### PR TITLE
make access public

### DIFF
--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -74,7 +74,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -71,7 +71,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }

--- a/packages/langchain-classic/CHANGELOG.md
+++ b/packages/langchain-classic/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @sapiom/langchain
+# @sapiom/langchain-classic
 
 ## 0.1.0
 

--- a/packages/langchain-classic/package.json
+++ b/packages/langchain-classic/package.json
@@ -80,7 +80,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @sapiom/langchain
+
+## 0.1.0
+
+### Initial Release
+
+- LangChain v1.x middleware integration
+- Automatic agent lifecycle tracking
+- Model call tracking with token estimation
+- Tool call pre-authorization support
+- Session-based cost tracking
+- Compatible with LangChain v1.0+

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -81,7 +81,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }

--- a/packages/node-http/package.json
+++ b/packages/node-http/package.json
@@ -72,7 +72,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
This pull request updates the publishing configuration for several packages to make them publicly accessible on npm, and adds changelog documentation for the new `@sapiom/langchain` package. The main changes are grouped below by theme.

**Package Publishing Configuration Updates:**

* Changed the `publishConfig.access` setting from `"restricted"` to `"public"` in the `package.json` files for the following packages: `axios`, `core`, `fetch`, `langchain-classic`, `langchain`, and `node-http`. This allows these packages to be published publicly to npm. [[1]](diffhunk://#diff-35d8c898b89d071a04d401786405facac7fb7aff2026e51c87ae28a9eb3c96dbL77-R77) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7L70-R70) [[3]](diffhunk://#diff-c31d56c6329adc9c47bdfaa4bb8c56a9894e395a02ee0d2e3a6809f45ea19d43L74-R74) [[4]](diffhunk://#diff-aa43e956b527e53263402a278fdfa096cc8f3c578caf1cab4563299ce3778eefL83-R83) [[5]](diffhunk://#diff-b04b890b40f07a3710d5e81a95f8c099b5dca6077f7748f19677c6039df741d7L84-R84) [[6]](diffhunk://#diff-2698e02a5d17533e550bf86b8f79a0386d3fec843f6a9ea5bd9f1930e537b09fL75-R75)

**Changelog and Documentation Updates:**

* Added a new changelog file for `@sapiom/langchain` describing its initial release, features, and compatibility.
* Updated the changelog header for `@sapiom/langchain-classic` to use the correct package name.