### PR TITLE
fix(node-http): handle undefined headers in request

### DIFF
--- a/packages/node-http/src/node-http.ts
+++ b/packages/node-http/src/node-http.ts
@@ -223,8 +223,11 @@ export function createClient(
         return makeRequest<T>(request);
       }
 
+      // Normalize request to ensure headers is always defined
+      const normalizedRequest = { ...request, headers: request.headers || {} };
+
       const modifiedRequest = await handleAuthorization(
-        request,
+        normalizedRequest,
         authConfig,
         defaultMetadata
       );


### PR DESCRIPTION
## Summary
- Normalizes `request.headers` to an empty object before passing to `handleAuthorization`
- Fixes `TypeError: Cannot convert undefined or null to object` when `client.request()` is called without a `headers` option

## Root Cause
The `handleAuthorization` function in `interceptors.ts` calls `Object.entries(request.headers)` without checking if headers is defined. When users call:

```typescript
await client.request({ method: "GET", url: "..." });
```

...without specifying headers, `request.headers` is `undefined`, causing the error.

## Test plan
- [ ] Run node-http example without headers: `await client.request({ method: "GET", url: "..." })`
- [ ] Verify requests with headers still work: `await client.request({ method: "GET", url: "...", headers: {} })`

🤖 Generated with [Claude Code](https://claude.com/claude-code)