### PR TITLE
refactor(core): extract HttpClient to break circular dependency

### DIFF
--- a/packages/core/src/client/HttpClient.ts
+++ b/packages/core/src/client/HttpClient.ts
@@ -1,0 +1,205 @@
+/**
+ * Request configuration for the HTTP client
+ */
+export interface HttpRequestConfig {
+  method?: string;
+  url: string;
+  params?: Record<string, any>;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Configuration for creating an HttpClient
+ */
+export interface HttpClientConfig {
+  baseURL: string;
+  timeout: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Core HTTP client for making API requests.
+ * Uses native fetch for zero external dependencies.
+ */
+export class HttpClient {
+  private readonly baseURL: string;
+  private readonly timeout: number;
+  private headers: Record<string, string>;
+
+  constructor(config: HttpClientConfig) {
+    this.baseURL = config.baseURL;
+    this.timeout = config.timeout;
+    this.headers = { ...config.headers };
+  }
+
+  /**
+   * Update a header value
+   */
+  setHeader(key: string, value: string): void {
+    this.headers[key] = value;
+  }
+
+  /**
+   * Get client defaults (for testing and compatibility)
+   */
+  getDefaults(): {
+    baseURL: string;
+    timeout: number;
+    headers: Record<string, string>;
+  } {
+    return {
+      baseURL: this.baseURL,
+      timeout: this.timeout,
+      headers: this.headers,
+    };
+  }
+
+  /**
+   * Make a request using native fetch
+   */
+  async request<T = any>(config: HttpRequestConfig): Promise<T> {
+    const url = this.buildUrl(config.url, config.params);
+    const headers = { ...this.headers, ...config.headers };
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        method: config.method || "GET",
+        headers,
+        body: this.prepareRequestBody(config.body),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorData = await this.parseResponse(response);
+        throw new Error(
+          `Request failed with status ${response.status}: ${JSON.stringify(errorData)}`,
+        );
+      }
+
+      const responseData = await this.parseResponse(response);
+
+      return responseData as T;
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+      if (error.name === "AbortError") {
+        throw new Error(`Request timeout after ${this.timeout}ms`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Prepare request body for fetch
+   * Handles various body types without double-encoding
+   */
+  private prepareRequestBody(body: any): any {
+    if (body === null || body === undefined) {
+      return undefined;
+    }
+
+    // If already a string, use as-is (might be pre-stringified JSON)
+    if (typeof body === "string") {
+      return body;
+    }
+
+    // If it's FormData, Blob, ArrayBuffer, etc., pass as-is
+    if (
+      body instanceof FormData ||
+      body instanceof Blob ||
+      body instanceof ArrayBuffer ||
+      body instanceof URLSearchParams ||
+      (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
+    ) {
+      return body;
+    }
+
+    // For plain objects and arrays, stringify
+    return JSON.stringify(body);
+  }
+
+  /**
+   * Parse response based on content type
+   */
+  private async parseResponse(response: Response): Promise<any> {
+    const contentType = response.headers.get("content-type");
+
+    // Handle JSON responses
+    if (contentType?.includes("application/json")) {
+      try {
+        return await response.json();
+      } catch {
+        // Invalid JSON, return empty object
+        return {};
+      }
+    }
+
+    // Handle text responses
+    if (contentType?.includes("text/")) {
+      return await response.text();
+    }
+
+    // No content-type or unknown type - try text first, then fall back
+    const text = await response.text();
+
+    // Empty response
+    if (!text) {
+      return null;
+    }
+
+    // Try to parse as JSON if it looks like JSON
+    if (
+      (text.startsWith("{") || text.startsWith("[")) &&
+      (text.endsWith("}") || text.endsWith("]"))
+    ) {
+      try {
+        return JSON.parse(text);
+      } catch {
+        // Not valid JSON, return as text
+        return text;
+      }
+    }
+
+    // Return as text
+    return text;
+  }
+
+  /**
+   * Build full URL with query parameters
+   * Automatically prefixes paths with /v1/ for API versioning
+   */
+  private buildUrl(path: string, params?: Record<string, any>): string {
+    const base = this.baseURL.endsWith("/")
+      ? this.baseURL.slice(0, -1)
+      : this.baseURL;
+
+    // Ensure path starts with /
+    const pathname = path.startsWith("/") ? path : `/${path}`;
+
+    // Add /v1 prefix if not already present
+    const versionedPath = pathname.startsWith("/v1/")
+      ? pathname
+      : `/v1${pathname}`;
+
+    const url = `${base}${versionedPath}`;
+
+    if (!params || Object.keys(params).length === 0) {
+      return url;
+    }
+
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value));
+      }
+    });
+
+    const queryString = searchParams.toString();
+    return queryString ? `${url}?${queryString}` : url;
+  }
+}

--- a/packages/core/src/client/SapiomClient.ts
+++ b/packages/core/src/client/SapiomClient.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpRequestConfig } from "./HttpClient";
 import { TransactionAPI } from "./TransactionAPI";
 
 export interface SapiomClientConfig {
@@ -7,22 +8,8 @@ export interface SapiomClientConfig {
   headers?: Record<string, string>;
 }
 
-/**
- * Internal HTTP client interface for SapiomClient
- * Uses native fetch for zero external dependencies
- */
-interface FetchConfig {
-  method?: string;
-  url: string;
-  params?: Record<string, any>;
-  body?: any;
-  headers?: Record<string, string>;
-}
-
 export class SapiomClient {
-  private readonly baseURL: string;
-  private readonly timeout: number;
-  private defaultHeaders: Record<string, string>;
+  private readonly httpClient: HttpClient;
   public readonly transactions: TransactionAPI;
 
   constructor(config: SapiomClientConfig) {
@@ -30,23 +17,25 @@ export class SapiomClient {
       throw new Error("API key is required");
     }
 
-    this.baseURL = config.baseURL || "https://api.sapiom.ai";
-    this.timeout = config.timeout || 30000;
-    this.defaultHeaders = {
-      "Content-Type": "application/json",
-      "x-api-key": config.apiKey,
-      ...config.headers,
-    };
+    this.httpClient = new HttpClient({
+      baseURL: config.baseURL || "https://api.sapiom.ai",
+      timeout: config.timeout || 30000,
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": config.apiKey,
+        ...config.headers,
+      },
+    });
 
     // Initialize API modules
-    this.transactions = new TransactionAPI(this);
+    this.transactions = new TransactionAPI(this.httpClient);
   }
 
   /**
    * Update the API key
    */
   setApiKey(apiKey: string): void {
-    this.defaultHeaders["x-api-key"] = apiKey;
+    this.httpClient.setHeader("x-api-key", apiKey);
   }
 
   /**
@@ -61,159 +50,14 @@ export class SapiomClient {
     };
   } {
     return {
-      defaults: {
-        baseURL: this.baseURL,
-        timeout: this.timeout,
-        headers: this.defaultHeaders,
-      },
+      defaults: this.httpClient.getDefaults(),
     };
   }
 
   /**
    * Make a custom request using native fetch
    */
-  async request<T = any>(config: FetchConfig): Promise<T> {
-    const url = this.buildUrl(config.url, config.params);
-    const headers = { ...this.defaultHeaders, ...config.headers };
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
-
-    try {
-      const response = await fetch(url, {
-        method: config.method || "GET",
-        headers,
-        body: this.prepareRequestBody(config.body),
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errorData = await this.parseResponse(response);
-        throw new Error(
-          `Request failed with status ${response.status}: ${JSON.stringify(errorData)}`,
-        );
-      }
-
-      const responseData = await this.parseResponse(response);
-
-      return responseData as T;
-    } catch (error: any) {
-      clearTimeout(timeoutId);
-      if (error.name === "AbortError") {
-        throw new Error(`Request timeout after ${this.timeout}ms`);
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Prepare request body for fetch
-   * Handles various body types without double-encoding
-   */
-  private prepareRequestBody(body: any): any {
-    if (body === null || body === undefined) {
-      return undefined;
-    }
-
-    // If already a string, use as-is (might be pre-stringified JSON)
-    if (typeof body === "string") {
-      return body;
-    }
-
-    // If it's FormData, Blob, ArrayBuffer, etc., pass as-is
-    if (
-      body instanceof FormData ||
-      body instanceof Blob ||
-      body instanceof ArrayBuffer ||
-      body instanceof URLSearchParams ||
-      (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
-    ) {
-      return body;
-    }
-
-    // For plain objects and arrays, stringify
-    return JSON.stringify(body);
-  }
-
-  /**
-   * Parse response based on content type
-   */
-  private async parseResponse(response: Response): Promise<any> {
-    const contentType = response.headers.get("content-type");
-
-    // Handle JSON responses
-    if (contentType?.includes("application/json")) {
-      try {
-        return await response.json();
-      } catch {
-        // Invalid JSON, return empty object
-        return {};
-      }
-    }
-
-    // Handle text responses
-    if (contentType?.includes("text/")) {
-      return await response.text();
-    }
-
-    // No content-type or unknown type - try text first, then fall back
-    const text = await response.text();
-
-    // Empty response
-    if (!text) {
-      return null;
-    }
-
-    // Try to parse as JSON if it looks like JSON
-    if (
-      (text.startsWith("{") || text.startsWith("[")) &&
-      (text.endsWith("}") || text.endsWith("]"))
-    ) {
-      try {
-        return JSON.parse(text);
-      } catch {
-        // Not valid JSON, return as text
-        return text;
-      }
-    }
-
-    // Return as text
-    return text;
-  }
-
-  /**
-   * Build full URL with query parameters
-   * Automatically prefixes paths with /v1/ for API versioning
-   */
-  private buildUrl(path: string, params?: Record<string, any>): string {
-    const base = this.baseURL.endsWith("/")
-      ? this.baseURL.slice(0, -1)
-      : this.baseURL;
-
-    // Ensure path starts with /
-    const pathname = path.startsWith("/") ? path : `/${path}`;
-
-    // Add /v1 prefix if not already present
-    const versionedPath = pathname.startsWith("/v1/")
-      ? pathname
-      : `/v1${pathname}`;
-
-    const url = `${base}${versionedPath}`;
-
-    if (!params || Object.keys(params).length === 0) {
-      return url;
-    }
-
-    const searchParams = new URLSearchParams();
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined && value !== null) {
-        searchParams.append(key, String(value));
-      }
-    });
-
-    const queryString = searchParams.toString();
-    return queryString ? `${url}?${queryString}` : url;
+  async request<T = any>(config: HttpRequestConfig): Promise<T> {
+    return this.httpClient.request<T>(config);
   }
 }

--- a/packages/core/src/client/TransactionAPI.ts
+++ b/packages/core/src/client/TransactionAPI.ts
@@ -9,10 +9,10 @@ import {
   TransactionCostInput,
   TransactionCostResponse,
 } from "../types/transaction";
-import type { SapiomClient } from "./SapiomClient";
+import type { HttpClient } from "./HttpClient";
 
 export class TransactionAPI {
-  constructor(private readonly client: SapiomClient) {}
+  constructor(private readonly httpClient: HttpClient) {}
 
   /**
    * Create a new transaction
@@ -20,7 +20,7 @@ export class TransactionAPI {
    * @returns The created transaction response
    */
   async create(data: CreateTransactionRequest): Promise<TransactionResponse> {
-    return await this.client.request<TransactionResponse>({
+    return await this.httpClient.request<TransactionResponse>({
       method: "POST",
       url: "/transactions",
       body: data,
@@ -33,7 +33,7 @@ export class TransactionAPI {
    * @returns The transaction details
    */
   async get(transactionId: string): Promise<TransactionResponse> {
-    return await this.client.request<TransactionResponse>({
+    return await this.httpClient.request<TransactionResponse>({
       method: "GET",
       url: `/transactions/${transactionId}`,
     });
@@ -80,7 +80,7 @@ export class TransactionAPI {
     transactionId: string,
     data: PaymentProtocolData,
   ): Promise<TransactionResponse> {
-    return await this.client.request<TransactionResponse>({
+    return await this.httpClient.request<TransactionResponse>({
       method: "POST",
       url: `/transactions/${transactionId}/reauthorize`,
       body: data,
@@ -112,7 +112,7 @@ export class TransactionAPI {
     transactionId: string,
     cost: TransactionCostInput & { supersedesCostId?: string },
   ): Promise<TransactionCostResponse> {
-    return await this.client.request<TransactionCostResponse>({
+    return await this.httpClient.request<TransactionCostResponse>({
       method: "POST",
       url: `/transactions/${transactionId}/costs`,
       body: cost,
@@ -159,7 +159,7 @@ export class TransactionAPI {
       facts: Record<string, any>;
     },
   ): Promise<{ success: boolean; factId: string; costId?: string }> {
-    return await this.client.request({
+    return await this.httpClient.request({
       method: "POST",
       url: `/transactions/${transactionId}/facts`,
       body: data,
@@ -209,7 +209,7 @@ export class TransactionAPI {
     transactionId: string,
     data: CompleteTransactionRequest,
   ): Promise<CompleteTransactionResult> {
-    return await this.client.request<CompleteTransactionResult>({
+    return await this.httpClient.request<CompleteTransactionResult>({
       method: "POST",
       url: `/transactions/${transactionId}/complete`,
       body: data,


### PR DESCRIPTION
## Summary
- Extract standalone `HttpClient` class with all HTTP request logic
- Update `TransactionAPI` to depend on `HttpClient` instead of `SapiomClient`
- Simplify `SapiomClient` to delegate HTTP operations to `HttpClient`

This breaks the circular dependency where `SapiomClient` imported `TransactionAPI` and `TransactionAPI` imported `SapiomClient`.

## Test plan
- [x] Typecheck passes
- [x] All 60 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)