### PR TITLE
feat: SDK identity token lifecycle

### DIFF
--- a/packages/axios/src/axios.ts
+++ b/packages/axios/src/axios.ts
@@ -89,6 +89,28 @@ export function withSapiom(
 
   (axiosInstance as any).__sapiomFailureMode = failureMode;
 
+  // Identity header interceptor: attach Sapiom-Identity when target matches token audience
+  if (sapiomClient.identity) {
+    axiosInstance.interceptors.request.use(async (config) => {
+      const url = config.url
+        ? config.baseURL
+          ? `${config.baseURL}${config.url}`
+          : config.url
+        : undefined;
+      if (url) {
+        const identityHeaders =
+          await sapiomClient.identity.getHeaderIfMatch(url);
+        if (identityHeaders["Sapiom-Identity"]) {
+          config.headers.set(
+            "Sapiom-Identity",
+            identityHeaders["Sapiom-Identity"],
+          );
+        }
+      }
+      return config;
+    });
+  }
+
   addAuthorizationInterceptor(axiosInstance, { sapiomClient, failureMode });
   // IMPORTANT: Completion interceptor must be added BEFORE payment interceptor
   // because Axios response interceptors run in LIFO order (last added runs first).

--- a/packages/core/src/client/IdentityManager.test.ts
+++ b/packages/core/src/client/IdentityManager.test.ts
@@ -1,0 +1,447 @@
+import { IdentityManager } from "./IdentityManager";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+// Mock randomUUID (used by HttpClient for idempotency keys)
+jest.mock("node:crypto", () => ({
+  randomUUID: () => "test-uuid-1234",
+}));
+
+/**
+ * Helper: create a minimal HttpClient that uses mocked global fetch
+ */
+function createMockHttpClient(baseURL = "https://api.sapiom.ai") {
+  const { HttpClient } = require("./HttpClient");
+  return new HttpClient({
+    baseURL,
+    timeout: 5000,
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "sk_test_key",
+    },
+    retry: { maxAttempts: 1, baseDelayMs: 0 },
+  });
+}
+
+/**
+ * Helper: create a JWT with given payload (no signature verification needed)
+ */
+function createTestJWT(payload: Record<string, any>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "fake-signature";
+  return `${header}.${body}.${signature}`;
+}
+
+/**
+ * Helper: mock a successful token response
+ */
+function mockTokenResponse(
+  audiences: string | string[],
+  expiresInMs: number = 60 * 60 * 1000, // 1 hour
+) {
+  const expiresAt = new Date(Date.now() + expiresInMs).toISOString();
+  const jwt = createTestJWT({
+    sub: "org_123",
+    aud: audiences,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor((Date.now() + expiresInMs) / 1000),
+  });
+
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) =>
+        name === "content-type" ? "application/json" : null,
+    },
+    json: jest.fn().mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
+    text: jest.fn().mockResolvedValue(JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt })),
+  });
+
+  return { jwt, expiresAt };
+}
+
+describe("IdentityManager", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    jest.useRealTimers();
+  });
+
+  describe("lazy token fetch", () => {
+    it("should lazily fetch token on first getToken() call", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      const { jwt } = mockTokenResponse("services.sapiom.ai");
+
+      const token = await manager.getToken();
+
+      expect(token).not.toBeNull();
+      expect(token!.identity).toBe(jwt);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/auth/tokens"),
+        expect.objectContaining({ method: "POST" }),
+      );
+
+      manager.dispose();
+    });
+
+    it("should cache token and reuse on second call", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      mockTokenResponse("services.sapiom.ai");
+
+      const token1 = await manager.getToken();
+      const token2 = await manager.getToken();
+
+      expect(token1!.identity).toBe(token2!.identity);
+      expect(mockFetch).toHaveBeenCalledTimes(1); // Only one HTTP call
+
+      manager.dispose();
+    });
+  });
+
+  describe("token expiry and refresh", () => {
+    it("should block and re-fetch when token is expired", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      // First token expires immediately
+      mockTokenResponse("services.sapiom.ai", -1000);
+      await manager.getToken();
+
+      // Second call should fetch again since token is expired
+      const { jwt: newJwt } = mockTokenResponse("services.sapiom.ai");
+      const token = await manager.getToken();
+
+      expect(token!.identity).toBe(newJwt);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      manager.dispose();
+    });
+
+    it("should return current token and trigger async refresh when near expiry", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      // Token expires in 2 minutes (< 3 min threshold)
+      const { jwt: nearExpiryJwt } = mockTokenResponse(
+        "services.sapiom.ai",
+        2 * 60 * 1000,
+      );
+
+      const token = await manager.getToken();
+      expect(token!.identity).toBe(nearExpiryJwt);
+
+      // Mock for the background refresh
+      mockTokenResponse("services.sapiom.ai");
+
+      // Second call should return the near-expiry token immediately
+      // while triggering an async refresh
+      const token2 = await manager.getToken();
+      expect(token2!.identity).toBe(nearExpiryJwt);
+
+      // Wait for async refresh to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockFetch).toHaveBeenCalledTimes(2); // initial + async refresh
+
+      manager.dispose();
+    });
+  });
+
+  describe("audience matching", () => {
+    it("should attach header when hostname directly matches aud", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      const { jwt } = mockTokenResponse("services.sapiom.ai");
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+
+      expect(headers["Sapiom-Identity"]).toBe(jwt);
+
+      manager.dispose();
+    });
+
+    it("should attach header when hostname is subdomain of aud", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      const { jwt } = mockTokenResponse("services.sapiom.ai");
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://fal.services.sapiom.ai/v1/infer",
+      );
+
+      expect(headers["Sapiom-Identity"]).toBe(jwt);
+
+      manager.dispose();
+    });
+
+    it("should NOT attach header when hostname does not match aud", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      mockTokenResponse("services.sapiom.ai");
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://api.openai.com/v1/chat",
+      );
+
+      expect(headers["Sapiom-Identity"]).toBeUndefined();
+
+      manager.dispose();
+    });
+
+    it("should handle aud as array", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      const { jwt } = mockTokenResponse([
+        "services.sapiom.ai",
+        "tools.sapiom.ai",
+      ]);
+
+      const headers1 = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+      expect(headers1["Sapiom-Identity"]).toBe(jwt);
+
+      const headers2 = await manager.getHeaderIfMatch(
+        "https://tools.sapiom.ai/v1/search",
+      );
+      expect(headers2["Sapiom-Identity"]).toBe(jwt);
+
+      const headers3 = await manager.getHeaderIfMatch(
+        "https://api.external.com/data",
+      );
+      expect(headers3["Sapiom-Identity"]).toBeUndefined();
+
+      manager.dispose();
+    });
+
+    it("should be case-insensitive for audience matching", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      const { jwt } = mockTokenResponse("Services.Sapiom.AI");
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+      expect(headers["Sapiom-Identity"]).toBe(jwt);
+
+      manager.dispose();
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("should return null when facilitator is unreachable", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+      const token = await manager.getToken();
+      expect(token).toBeNull();
+
+      manager.dispose();
+    });
+
+    it("should return empty headers when facilitator is unreachable", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+      expect(headers).toEqual({});
+
+      manager.dispose();
+    });
+
+    it("should return empty headers for invalid URL", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      const headers = await manager.getHeaderIfMatch("not-a-valid-url");
+      expect(headers).toEqual({});
+
+      manager.dispose();
+    });
+  });
+
+  describe("mutex (concurrent request deduplication)", () => {
+    it("should only make one HTTP request for concurrent first calls", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      // Use a slow-resolving mock
+      const { jwt } = mockTokenResponse("services.sapiom.ai");
+
+      // Fire 5 concurrent requests
+      const results = await Promise.all([
+        manager.getToken(),
+        manager.getToken(),
+        manager.getToken(),
+        manager.getToken(),
+        manager.getToken(),
+      ]);
+
+      // All should get the same token
+      for (const result of results) {
+        expect(result!.identity).toBe(jwt);
+      }
+
+      // But only one HTTP request should have been made
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      manager.dispose();
+    });
+  });
+
+  describe("shouldAttachHeader", () => {
+    it("should return false when no token is cached", () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      expect(manager.shouldAttachHeader("services.sapiom.ai")).toBe(false);
+
+      manager.dispose();
+    });
+
+    it("should return true after token is fetched and hostname matches", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+      mockTokenResponse("services.sapiom.ai");
+
+      await manager.getToken();
+      expect(manager.shouldAttachHeader("services.sapiom.ai")).toBe(true);
+      expect(manager.shouldAttachHeader("fal.services.sapiom.ai")).toBe(true);
+      expect(manager.shouldAttachHeader("api.external.com")).toBe(false);
+
+      manager.dispose();
+    });
+  });
+
+  describe("backgroundRefresh", () => {
+    it("should start a timer that fires refresh for near-expiry tokens", async () => {
+      jest.useFakeTimers();
+      const httpClient = createMockHttpClient();
+
+      // Initial token near expiry (2 min left)
+      mockTokenResponse("services.sapiom.ai", 2 * 60 * 1000);
+
+      const manager = new IdentityManager(httpClient, {
+        backgroundRefresh: true,
+      });
+
+      // Trigger initial fetch
+      await manager.getToken();
+
+      // Mock for background refresh
+      mockTokenResponse("services.sapiom.ai", 60 * 60 * 1000);
+
+      // Advance timer to trigger background refresh check
+      jest.advanceTimersByTime(61 * 1000);
+
+      // Allow the promise to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      manager.dispose();
+      jest.useRealTimers();
+    });
+
+    it("should clean up timer on dispose", () => {
+      jest.useFakeTimers();
+      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient, {
+        backgroundRefresh: true,
+      });
+
+      manager.dispose();
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+
+      clearIntervalSpy.mockRestore();
+      jest.useRealTimers();
+    });
+
+    it("should not start timer when backgroundRefresh is false", () => {
+      jest.useFakeTimers();
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient, {
+        backgroundRefresh: false,
+      });
+
+      // setInterval may be called by other things, check it wasn't called for refresh
+      const callsBefore = setIntervalSpy.mock.calls.length;
+      expect(callsBefore).toBe(0);
+
+      manager.dispose();
+      setIntervalSpy.mockRestore();
+      jest.useRealTimers();
+    });
+  });
+
+  describe("JWT decoding edge cases", () => {
+    it("should handle JWT with no aud claim", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      const jwt = createTestJWT({ sub: "org_123" }); // no aud
+      const expiresAt = new Date(Date.now() + 3600000).toISOString();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) =>
+            name === "content-type" ? "application/json" : null,
+        },
+        json: jest.fn().mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
+        text: jest.fn().mockResolvedValue(JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt })),
+      });
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+      expect(headers["Sapiom-Identity"]).toBeUndefined();
+
+      manager.dispose();
+    });
+
+    it("should handle malformed JWT gracefully", async () => {
+      const httpClient = createMockHttpClient();
+      const manager = new IdentityManager(httpClient);
+
+      const expiresAt = new Date(Date.now() + 3600000).toISOString();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) =>
+            name === "content-type" ? "application/json" : null,
+        },
+        json: jest.fn().mockResolvedValue({ identity: "not-a-jwt", identityExpiresAt: expiresAt }),
+        text: jest.fn().mockResolvedValue(JSON.stringify({ identity: "not-a-jwt", identityExpiresAt: expiresAt })),
+      });
+
+      const headers = await manager.getHeaderIfMatch(
+        "https://services.sapiom.ai/v1/models",
+      );
+      expect(headers["Sapiom-Identity"]).toBeUndefined();
+
+      manager.dispose();
+    });
+  });
+});

--- a/packages/core/src/client/IdentityManager.test.ts
+++ b/packages/core/src/client/IdentityManager.test.ts
@@ -1,4 +1,5 @@
 import { IdentityManager } from "./IdentityManager";
+import { HttpClient } from "./HttpClient";
 
 // Mock global fetch
 const mockFetch = jest.fn();
@@ -13,7 +14,6 @@ jest.mock("node:crypto", () => ({
  * Helper: create a minimal HttpClient that uses mocked global fetch
  */
 function createMockHttpClient(baseURL = "https://api.sapiom.ai") {
-  const { HttpClient } = require("./HttpClient");
   return new HttpClient({
     baseURL,
     timeout: 5000,
@@ -29,7 +29,9 @@ function createMockHttpClient(baseURL = "https://api.sapiom.ai") {
  * Helper: create a JWT with given payload (no signature verification needed)
  */
 function createTestJWT(payload: Record<string, any>): string {
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const signature = "fake-signature";
   return `${header}.${body}.${signature}`;
@@ -57,8 +59,14 @@ function mockTokenResponse(
       get: (name: string) =>
         name === "content-type" ? "application/json" : null,
     },
-    json: jest.fn().mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
-    text: jest.fn().mockResolvedValue(JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt })),
+    json: jest
+      .fn()
+      .mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
+    text: jest
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt }),
+      ),
   });
 
   return { jwt, expiresAt };
@@ -407,8 +415,14 @@ describe("IdentityManager", () => {
           get: (name: string) =>
             name === "content-type" ? "application/json" : null,
         },
-        json: jest.fn().mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
-        text: jest.fn().mockResolvedValue(JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt })),
+        json: jest
+          .fn()
+          .mockResolvedValue({ identity: jwt, identityExpiresAt: expiresAt }),
+        text: jest
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({ identity: jwt, identityExpiresAt: expiresAt }),
+          ),
       });
 
       const headers = await manager.getHeaderIfMatch(
@@ -432,8 +446,20 @@ describe("IdentityManager", () => {
           get: (name: string) =>
             name === "content-type" ? "application/json" : null,
         },
-        json: jest.fn().mockResolvedValue({ identity: "not-a-jwt", identityExpiresAt: expiresAt }),
-        text: jest.fn().mockResolvedValue(JSON.stringify({ identity: "not-a-jwt", identityExpiresAt: expiresAt })),
+        json: jest
+          .fn()
+          .mockResolvedValue({
+            identity: "not-a-jwt",
+            identityExpiresAt: expiresAt,
+          }),
+        text: jest
+          .fn()
+          .mockResolvedValue(
+            JSON.stringify({
+              identity: "not-a-jwt",
+              identityExpiresAt: expiresAt,
+            }),
+          ),
       });
 
       const headers = await manager.getHeaderIfMatch(

--- a/packages/core/src/client/IdentityManager.ts
+++ b/packages/core/src/client/IdentityManager.ts
@@ -55,10 +55,16 @@ export class IdentityManager {
    * Get the current identity token, fetching lazily if needed.
    * Returns null if the facilitator is unreachable.
    */
-  async getToken(): Promise<{ identity: string; identityExpiresAt: string } | null> {
+  async getToken(): Promise<{
+    identity: string;
+    identityExpiresAt: string;
+  } | null> {
     const token = await this.resolveToken();
     if (!token) return null;
-    return { identity: token.jwt, identityExpiresAt: token.expiresAt.toISOString() };
+    return {
+      identity: token.jwt,
+      identityExpiresAt: token.expiresAt.toISOString(),
+    };
   }
 
   /**
@@ -173,7 +179,11 @@ export class IdentityManager {
     }, BACKGROUND_REFRESH_INTERVAL_MS);
 
     // unref() so the timer doesn't prevent clean process exit
-    if (this.refreshTimer && typeof this.refreshTimer === "object" && "unref" in this.refreshTimer) {
+    if (
+      this.refreshTimer &&
+      typeof this.refreshTimer === "object" &&
+      "unref" in this.refreshTimer
+    ) {
       (this.refreshTimer as NodeJS.Timeout).unref();
     }
   }
@@ -202,7 +212,8 @@ export class IdentityManager {
       const aud = payload.aud;
       if (!aud) return [];
       if (typeof aud === "string") return [aud];
-      if (Array.isArray(aud)) return aud.filter((a: unknown) => typeof a === "string");
+      if (Array.isArray(aud))
+        return aud.filter((a: unknown) => typeof a === "string");
       return [];
     } catch {
       return [];

--- a/packages/core/src/client/IdentityManager.ts
+++ b/packages/core/src/client/IdentityManager.ts
@@ -1,0 +1,234 @@
+import { HttpClient } from "./HttpClient.js";
+
+/**
+ * Options for configuring the IdentityManager
+ */
+export interface IdentityManagerOptions {
+  /**
+   * Enable proactive timer-based token refresh for long-running servers.
+   * When enabled, a background timer periodically refreshes the token
+   * before it expires, using `unref()` to avoid preventing clean process exit.
+   * Default: false (optimistic refresh on each request)
+   */
+  backgroundRefresh?: boolean;
+}
+
+interface CachedToken {
+  jwt: string;
+  expiresAt: Date;
+  audiences: string[];
+}
+
+/** Minimum remaining TTL before triggering an async background refresh */
+const REFRESH_THRESHOLD_MS = 3 * 60 * 1000; // 3 minutes
+
+/** How often the background timer checks for refresh (when backgroundRefresh is enabled) */
+const BACKGROUND_REFRESH_INTERVAL_MS = 60 * 1000; // 1 minute
+
+/**
+ * Manages identity token lifecycle for Sapiom SDK.
+ *
+ * - Lazily fetches tokens from `POST /v1/auth/tokens`
+ * - Caches in-memory with expiry tracking
+ * - Audience matching: direct hostname match + subdomain match
+ * - Refresh: blocks if expired, async if near-expiry (< 3min)
+ * - Graceful degradation: proceeds without identity if facilitator is unreachable
+ */
+export class IdentityManager {
+  private readonly httpClient: HttpClient;
+  private readonly backgroundRefresh: boolean;
+
+  private cached: CachedToken | null = null;
+  private inFlightFetch: Promise<CachedToken | null> | null = null;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(httpClient: HttpClient, options?: IdentityManagerOptions) {
+    this.httpClient = httpClient;
+    this.backgroundRefresh = options?.backgroundRefresh ?? false;
+
+    if (this.backgroundRefresh) {
+      this.startBackgroundRefresh();
+    }
+  }
+
+  /**
+   * Get the current identity token, fetching lazily if needed.
+   * Returns null if the facilitator is unreachable.
+   */
+  async getToken(): Promise<{ identity: string; identityExpiresAt: string } | null> {
+    const token = await this.resolveToken();
+    if (!token) return null;
+    return { identity: token.jwt, identityExpiresAt: token.expiresAt.toISOString() };
+  }
+
+  /**
+   * Check if the identity header should be attached for the given hostname.
+   * Performs direct match and subdomain match against token `aud` entries.
+   */
+  shouldAttachHeader(targetHostname: string): boolean {
+    if (!this.cached) return false;
+    return this.matchesAudience(targetHostname, this.cached.audiences);
+  }
+
+  /**
+   * Convenience method: resolves the token and returns the `Sapiom-Identity` header
+   * if the target URL's hostname matches the token audience. Returns empty object otherwise.
+   */
+  async getHeaderIfMatch(targetUrl: string): Promise<Record<string, string>> {
+    const hostname = this.extractHostname(targetUrl);
+    if (!hostname) return {};
+
+    const token = await this.resolveToken();
+    if (!token) return {};
+
+    if (this.matchesAudience(hostname, token.audiences)) {
+      return { "Sapiom-Identity": token.jwt };
+    }
+
+    return {};
+  }
+
+  /**
+   * Clean up background refresh timer. Call when done with the manager.
+   */
+  dispose(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async resolveToken(): Promise<CachedToken | null> {
+    // Healthy cached token
+    if (this.cached && !this.isExpired(this.cached)) {
+      // Near-expiry: return current but trigger async refresh
+      if (this.isNearExpiry(this.cached)) {
+        this.triggerAsyncRefresh();
+      }
+      return this.cached;
+    }
+
+    // Expired or no token — block and fetch
+    return this.fetchToken();
+  }
+
+  private async fetchToken(): Promise<CachedToken | null> {
+    // Mutex: reuse in-flight fetch if one exists
+    if (this.inFlightFetch) {
+      return this.inFlightFetch;
+    }
+
+    this.inFlightFetch = this.doFetchToken();
+
+    try {
+      return await this.inFlightFetch;
+    } finally {
+      this.inFlightFetch = null;
+    }
+  }
+
+  private async doFetchToken(): Promise<CachedToken | null> {
+    try {
+      const response = await this.httpClient.request<{
+        identity: string;
+        identityExpiresAt: string;
+      }>({
+        method: "POST",
+        url: "/auth/tokens",
+      });
+
+      const audiences = this.decodeAudiences(response.identity);
+      const cached: CachedToken = {
+        jwt: response.identity,
+        expiresAt: new Date(response.identityExpiresAt),
+        audiences,
+      };
+
+      this.cached = cached;
+      return cached;
+    } catch {
+      // Graceful degradation: facilitator unreachable → proceed without identity
+      return null;
+    }
+  }
+
+  private triggerAsyncRefresh(): void {
+    // Fire-and-forget — don't block the caller
+    if (this.inFlightFetch) return; // already refreshing
+    this.inFlightFetch = this.doFetchToken();
+    this.inFlightFetch.finally(() => {
+      this.inFlightFetch = null;
+    });
+  }
+
+  private startBackgroundRefresh(): void {
+    this.refreshTimer = setInterval(() => {
+      if (this.cached && this.isNearExpiry(this.cached)) {
+        this.triggerAsyncRefresh();
+      }
+    }, BACKGROUND_REFRESH_INTERVAL_MS);
+
+    // unref() so the timer doesn't prevent clean process exit
+    if (this.refreshTimer && typeof this.refreshTimer === "object" && "unref" in this.refreshTimer) {
+      (this.refreshTimer as NodeJS.Timeout).unref();
+    }
+  }
+
+  private isExpired(token: CachedToken): boolean {
+    return Date.now() >= token.expiresAt.getTime();
+  }
+
+  private isNearExpiry(token: CachedToken): boolean {
+    return token.expiresAt.getTime() - Date.now() < REFRESH_THRESHOLD_MS;
+  }
+
+  /**
+   * Decode `aud` claim from JWT payload without crypto verification.
+   * Handles both string and string[] `aud` formats.
+   */
+  private decodeAudiences(jwt: string): string[] {
+    try {
+      const parts = jwt.split(".");
+      if (parts.length !== 3) return [];
+
+      const payload = JSON.parse(
+        Buffer.from(parts[1]!, "base64url").toString("utf-8"),
+      );
+
+      const aud = payload.aud;
+      if (!aud) return [];
+      if (typeof aud === "string") return [aud];
+      if (Array.isArray(aud)) return aud.filter((a: unknown) => typeof a === "string");
+      return [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Match hostname against audience entries.
+   * Supports direct match and subdomain match
+   * (e.g., `fal.services.sapiom.ai` matches `aud` entry `services.sapiom.ai`).
+   */
+  private matchesAudience(hostname: string, audiences: string[]): boolean {
+    const lower = hostname.toLowerCase();
+    for (const aud of audiences) {
+      const audLower = aud.toLowerCase();
+      if (lower === audLower) return true;
+      if (lower.endsWith(`.${audLower}`)) return true;
+    }
+    return false;
+  }
+
+  private extractHostname(url: string): string | null {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/core/src/client/SapiomClient.ts
+++ b/packages/core/src/client/SapiomClient.ts
@@ -2,7 +2,6 @@ import { ApiKeyAPI } from "./ApiKeyAPI.js";
 import { HttpClient, HttpRequestConfig } from "./HttpClient.js";
 import type { RetryConfig } from "./HttpClient.js";
 import { IdentityManager } from "./IdentityManager.js";
-import type { IdentityManagerOptions } from "./IdentityManager.js";
 import { TransactionAPI } from "./TransactionAPI.js";
 
 /**

--- a/packages/core/src/client/SapiomClient.ts
+++ b/packages/core/src/client/SapiomClient.ts
@@ -1,6 +1,8 @@
 import { ApiKeyAPI } from "./ApiKeyAPI.js";
 import { HttpClient, HttpRequestConfig } from "./HttpClient.js";
 import type { RetryConfig } from "./HttpClient.js";
+import { IdentityManager } from "./IdentityManager.js";
+import type { IdentityManagerOptions } from "./IdentityManager.js";
 import { TransactionAPI } from "./TransactionAPI.js";
 
 /**
@@ -34,6 +36,12 @@ export interface SapiomClientConfig {
    * Default: 3 attempts with 200ms base delay (exponential backoff).
    */
   retry?: RetryConfig;
+
+  /**
+   * Enable proactive timer-based identity token refresh for long-running servers.
+   * @see IdentityManagerOptions.backgroundRefresh
+   */
+  backgroundRefresh?: boolean;
 }
 
 /**
@@ -72,6 +80,7 @@ export interface SapiomClientConfig {
 export class SapiomClient {
   private readonly httpClient: HttpClient;
   public readonly apiKeys: ApiKeyAPI;
+  public readonly identity: IdentityManager;
   public readonly transactions: TransactionAPI;
 
   constructor(config: SapiomClientConfig) {
@@ -92,6 +101,9 @@ export class SapiomClient {
 
     // Initialize API modules
     this.apiKeys = new ApiKeyAPI(this.httpClient);
+    this.identity = new IdentityManager(this.httpClient, {
+      backgroundRefresh: config.backgroundRefresh,
+    });
     this.transactions = new TransactionAPI(this.httpClient);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,8 @@
 export { SapiomClient } from "./client/SapiomClient.js";
 export type { SapiomClientConfig } from "./client/SapiomClient.js";
 export type { RetryConfig } from "./client/HttpClient.js";
+export { IdentityManager } from "./client/IdentityManager.js";
+export type { IdentityManagerOptions } from "./client/IdentityManager.js";
 export { ApiKeyAPI } from "./client/ApiKeyAPI.js";
 export { TransactionAPI } from "./client/TransactionAPI.js";
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -97,6 +97,13 @@ export interface BaseSapiomIntegrationConfig {
    * Default: 3 attempts with 200ms base delay (exponential backoff).
    */
   retry?: RetryConfig;
+
+  /**
+   * Enable proactive timer-based identity token refresh for long-running servers.
+   * When true, the SDK periodically refreshes the identity token before it expires.
+   * Default: false (optimistic refresh triggered by requests near token expiry)
+   */
+  backgroundRefresh?: boolean;
 }
 
 /**
@@ -152,5 +159,6 @@ export function initializeSapiomClient(
         : undefined),
     headers: config?.headers,
     retry: config?.retry,
+    backgroundRefresh: config?.backgroundRefresh,
   });
 }

--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -129,6 +129,18 @@ export function createFetch(config?: SapiomFetchConfig): typeof fetch {
       return globalThis.fetch(request);
     }
 
+    // Attach identity header if target matches token audience
+    if (sapiomClient.identity) {
+      const identityHeaders = await sapiomClient.identity.getHeaderIfMatch(
+        request.url,
+      );
+      if (identityHeaders["Sapiom-Identity"]) {
+        const headers = new Headers(request.headers);
+        headers.set("Sapiom-Identity", identityHeaders["Sapiom-Identity"]);
+        request = new Request(request, { headers });
+      }
+    }
+
     request = await handleAuthorization(request, authConfig, defaultMetadata);
 
     const startTime = Date.now();

--- a/packages/node-http/src/node-http.ts
+++ b/packages/node-http/src/node-http.ts
@@ -225,8 +225,8 @@ export function createClient(
         return makeRequest<T>(request);
       }
 
-      // Normalize request to ensure headers is always defined
-      const normalizedRequest = { ...request, headers: request.headers || {} };
+      // Normalize request: shallow-copy headers to avoid mutating caller's object
+      const normalizedRequest = { ...request, headers: { ...request.headers } };
 
       // Attach identity header if target matches token audience
       if (sapiomClient.identity) {

--- a/packages/node-http/src/node-http.ts
+++ b/packages/node-http/src/node-http.ts
@@ -228,6 +228,17 @@ export function createClient(
       // Normalize request to ensure headers is always defined
       const normalizedRequest = { ...request, headers: request.headers || {} };
 
+      // Attach identity header if target matches token audience
+      if (sapiomClient.identity) {
+        const identityHeaders = await sapiomClient.identity.getHeaderIfMatch(
+          normalizedRequest.url,
+        );
+        if (identityHeaders["Sapiom-Identity"]) {
+          normalizedRequest.headers["Sapiom-Identity"] =
+            identityHeaders["Sapiom-Identity"];
+        }
+      }
+
       const modifiedRequest = await handleAuthorization(
         normalizedRequest,
         authConfig,


### PR DESCRIPTION
## Summary

Adds automatic `Sapiom-Identity` JWT management across all SDK packages. The SDK lazily fetches identity tokens from `POST /v1/auth/tokens`, caches them in-memory, and attaches the `Sapiom-Identity` header to requests whose target hostname matches the token's `aud` claim (direct or subdomain match).

- **Lazy acquisition** — no fetch at init, first request triggers token retrieval
- **Smart refresh** — blocks if expired, async background refresh if < 3min remaining
- **Optional `backgroundRefresh: true`** — proactive timer-based refresh for long-running servers
- **Graceful degradation** — proceeds without identity if facilitator is unreachable
- **Concurrent deduplication** — mutex prevents parallel token fetches
- **Integrated across `@sapiom/axios`, `@sapiom/fetch`, and `@sapiom/node-http`**

Implements [GAT-32](https://linear.app/sapiom/issue/GAT-32/sdk-token-lifecycle)

## Packages (all minor)

| Package | Change |
|---------|--------|
| `@sapiom/core` | New `IdentityManager` class, `backgroundRefresh` config option |
| `@sapiom/axios` | Identity header via request interceptor |
| `@sapiom/fetch` | Identity header before authorization |
| `@sapiom/node-http` | Identity header before authorization + fix header mutation by reference |

## Test plan

- [x] 20 unit tests for `IdentityManager` (lazy fetch, cache, expiry, refresh, audience matching, degradation, mutex, background timer, JWT edge cases)
- [x] All existing tests pass: core (118), axios (33), fetch (43), node-http (33), langchain (21), langchain-classic (167)
- [x] Adversarial GPT review — found and fixed header object mutation leak in node-http
- [ ] Manual verification with live facilitator after GAT-30 deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)