### PR TITLE
chore: add changeset for SDK identity token lifecycle

### DIFF
--- a/.changeset/public-results-relax.md
+++ b/.changeset/public-results-relax.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/axios": minor
+"@sapiom/core": minor
+"@sapiom/fetch": minor
+"@sapiom/langchain": minor
+"@sapiom/langchain-classic": minor
+"@sapiom/mcp": minor
+"@sapiom/node-http": minor
+"@sapiom/sandbox": minor
+---
+
+New: SDK Identity Token Lifecycle. Adds automatic Sapiom-Identity JWT management across all SDK packages. The SDK lazily fetches identity tokens from POST /v1/auth/tokens, caches them in-memory, and attaches the Sapiom-Identity header to requests whose target hostname matches the token's aud claim (direct or subdomain match).


### PR DESCRIPTION
## Summary
- Adds changeset (`public-results-relax.md`) for the SDK Identity Token Lifecycle feature
- Covers minor bumps for all affected packages: `@sapiom/axios`, `@sapiom/core`, `@sapiom/fetch`, `@sapiom/langchain`, `@sapiom/langchain-classic`, `@sapiom/mcp`, `@sapiom/node-http`, `@sapiom/sandbox`
- Describes automatic Sapiom-Identity JWT management (lazy fetch, in-memory cache, audience-based header attachment)

## Test plan
- [ ] CI passes (changeset bot validates format)
- [ ] Version bumps are correct (minor for all listed packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)