### PR TITLE
support sandbox keepalive and processtimeout

### DIFF
--- a/.changeset/polite-turtles-cough.md
+++ b/.changeset/polite-turtles-cough.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/sandbox": minor
+---
+
+support keepAlive and processTimeout opts

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -423,13 +423,15 @@ export class SapiomSandbox {
 
   private async _createProcess(
     command: string,
-    opts?: ExecStreamOptions,
+    opts?: ExecStreamOptions & { keepAlive?: boolean; processTimeout?: number },
   ): Promise<ProcessCreateResponse> {
     const body: Record<string, unknown> = { command };
     if (opts?.cwd !== undefined) {
       body.cwd = resolvePath(this.workspaceRoot, opts.cwd);
     }
     if (opts?.env !== undefined) body.env = opts.env;
+    if (opts?.keepAlive !== undefined) body.keepAlive = opts.keepAlive;
+    if (opts?.processTimeout !== undefined) body.timeout = opts.processTimeout;
 
     const response = await this._fetch(
       `${this._baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/process`,

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -104,6 +104,18 @@ export interface ExecOptions {
   /** Timeout in ms when waiting for completion. @default 60000 */
   timeout?: number;
 
+  /**
+   * Prevent the sandbox from entering standby while this process runs.
+   * Passed through to the Blaxel process API.
+   */
+  keepAlive?: boolean;
+
+  /**
+   * Auto-terminate the process after this many seconds.
+   * 0 means no auto-termination. Passed through to the Blaxel process API.
+   */
+  processTimeout?: number;
+
   /** AbortSignal to cancel the operation. */
   signal?: AbortSignal;
 }


### PR DESCRIPTION
This pull request introduces support for two new options, `keepAlive` and `processTimeout`, to the sandbox process API. These options allow finer control over process lifecycle and resource management when running commands in the sandbox.

Enhancements to process options:

* Added `keepAlive` and `processTimeout` options to the `ExecOptions` interface in `packages/sandbox/src/types.ts`, enabling prevention of standby and auto-termination of processes.
* Updated the `_createProcess` method in `packages/sandbox/src/sandbox.ts` to accept and forward `keepAlive` and `processTimeout` options when creating sandbox processes.

Documentation:

* Added a changeset describing the new minor version and summarizing the added support for `keepAlive` and `processTimeout` options. (.changeset/polite-turtles-cough.md)