### PR TITLE
feat: add poll interval param to interceptor's configs

### DIFF
--- a/packages/axios/src/axios.ts
+++ b/packages/axios/src/axios.ts
@@ -4,6 +4,7 @@ import {
   BaseSapiomIntegrationConfig,
   initializeSapiomClient,
 } from "@sapiom/core";
+import type { TransactionPollingConfig } from "@sapiom/core";
 import {
   addAuthorizationInterceptor,
   addPaymentInterceptor,
@@ -13,7 +14,13 @@ import {
 /**
  * Configuration for Sapiom-enabled Axios client
  */
-export interface SapiomAxiosConfig extends BaseSapiomIntegrationConfig {}
+export interface SapiomAxiosConfig extends BaseSapiomIntegrationConfig {
+  /**
+   * Polling configuration for transaction authorization.
+   * Overrides default timeout (30s) and poll interval (1s).
+   */
+  polling?: TransactionPollingConfig;
+}
 
 /**
  * Creates a Sapiom-enabled Axios client with automatic authorization and payment handling
@@ -111,12 +118,12 @@ export function withSapiom(
     });
   }
 
-  addAuthorizationInterceptor(axiosInstance, { sapiomClient, failureMode });
+  addAuthorizationInterceptor(axiosInstance, { sapiomClient, failureMode, polling: config?.polling });
   // IMPORTANT: Completion interceptor must be added BEFORE payment interceptor
   // because Axios response interceptors run in LIFO order (last added runs first).
   // We want: request -> payment handling (retry on 402) -> completion
   addCompletionInterceptor(axiosInstance, { sapiomClient });
-  addPaymentInterceptor(axiosInstance, { sapiomClient, failureMode });
+  addPaymentInterceptor(axiosInstance, { sapiomClient, failureMode, polling: config?.polling });
 
   (axiosInstance as any).__sapiomClient = sapiomClient;
 

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -21,6 +21,7 @@ export type {
   SapiomClient,
   SapiomClientConfig,
   BaseSapiomIntegrationConfig,
+  TransactionPollingConfig,
   TransactionResponse,
   PaymentTransactionResponse,
   TransactionStatus,

--- a/packages/axios/src/interceptors.ts
+++ b/packages/axios/src/interceptors.ts
@@ -19,12 +19,15 @@ import {
   FailureMode,
 } from "@sapiom/core";
 
+import type { TransactionPollingConfig } from "@sapiom/core";
+
 /**
  * Authorization interceptor configuration
  */
 export interface AuthorizationInterceptorConfig {
   sapiomClient: SapiomClient;
   failureMode: FailureMode;
+  polling?: TransactionPollingConfig;
 }
 
 /**
@@ -33,11 +36,15 @@ export interface AuthorizationInterceptorConfig {
 export interface PaymentInterceptorConfig {
   sapiomClient: SapiomClient;
   failureMode: FailureMode;
+  polling?: TransactionPollingConfig;
 }
 
 const SDK_VERSION = "1.0.0";
-const AUTHORIZATION_TIMEOUT = 30000;
-const POLL_INTERVAL = 1000;
+
+const DEFAULT_POLLING: Required<TransactionPollingConfig> = {
+  timeout: 30000,
+  pollInterval: 1000,
+};
 
 /**
  * Custom error classes
@@ -247,10 +254,8 @@ export function addAuthorizationInterceptor(
   axiosInstance: AxiosInstance,
   config: AuthorizationInterceptorConfig,
 ): () => void {
-  const poller = new TransactionPoller(config.sapiomClient, {
-    timeout: AUTHORIZATION_TIMEOUT,
-    pollInterval: POLL_INTERVAL,
-  });
+  const polling = { ...DEFAULT_POLLING, ...config.polling };
+  const poller = new TransactionPoller(config.sapiomClient, polling);
 
   const interceptorId = axiosInstance.interceptors.request.use(
     async (axiosConfig: InternalAxiosRequestConfig) => {
@@ -329,7 +334,7 @@ export function addAuthorizationInterceptor(
               throw new AuthorizationTimeoutError(
                 existingTransactionId,
                 axiosConfig.url || "",
-                AUTHORIZATION_TIMEOUT,
+                polling.timeout,
               );
             }
           }
@@ -516,7 +521,7 @@ export function addAuthorizationInterceptor(
         throw new AuthorizationTimeoutError(
           transaction.id,
           endpoint,
-          AUTHORIZATION_TIMEOUT,
+          polling.timeout,
         );
       }
     },
@@ -559,10 +564,8 @@ export function addPaymentInterceptor(
   axiosInstance: AxiosInstance,
   config: PaymentInterceptorConfig,
 ): () => void {
-  const poller = new TransactionPoller(config.sapiomClient, {
-    timeout: AUTHORIZATION_TIMEOUT,
-    pollInterval: POLL_INTERVAL,
-  });
+  const polling = { ...DEFAULT_POLLING, ...config.polling };
+  const poller = new TransactionPoller(config.sapiomClient, polling);
 
   const interceptorId = axiosInstance.interceptors.response.use(
     (response: AxiosResponse) => response,

--- a/packages/node-http/src/index.ts
+++ b/packages/node-http/src/index.ts
@@ -13,3 +13,6 @@ export {
   AuthorizationTimeoutError,
 } from "./node-http.js";
 export type { SapiomNodeHttpConfig } from "./node-http.js";
+
+// Re-export commonly used types from core
+export type { TransactionPollingConfig } from "@sapiom/core";

--- a/packages/node-http/src/interceptors.ts
+++ b/packages/node-http/src/interceptors.ts
@@ -14,12 +14,15 @@ import {
   FailureMode,
 } from "@sapiom/core";
 
+import type { TransactionPollingConfig } from "@sapiom/core";
+
 /**
  * Authorization configuration
  */
 export interface AuthorizationConfig {
   sapiomClient: SapiomClient;
   failureMode: FailureMode;
+  polling?: TransactionPollingConfig;
 }
 
 /**
@@ -28,11 +31,15 @@ export interface AuthorizationConfig {
 export interface PaymentConfig {
   sapiomClient: SapiomClient;
   failureMode: FailureMode;
+  polling?: TransactionPollingConfig;
 }
 
 const SDK_VERSION = "1.0.0";
-const AUTHORIZATION_TIMEOUT = 30000;
-const POLL_INTERVAL = 1000;
+
+const DEFAULT_POLLING: Required<TransactionPollingConfig> = {
+  timeout: 30000,
+  pollInterval: 1000,
+};
 
 /**
  * Custom error classes
@@ -107,16 +114,15 @@ export async function handleAuthorization(
   config: AuthorizationConfig,
   defaultMetadata?: Record<string, any>,
 ): Promise<HttpRequest> {
+  const polling = { ...DEFAULT_POLLING, ...config.polling };
+
   const existingTransactionId = getHeader(
     request.headers,
     "X-Sapiom-Transaction-Id",
   );
 
   if (existingTransactionId) {
-    const poller = new TransactionPoller(config.sapiomClient, {
-      timeout: AUTHORIZATION_TIMEOUT,
-      pollInterval: POLL_INTERVAL,
-    });
+    const poller = new TransactionPoller(config.sapiomClient, polling);
 
     let transaction;
     try {
@@ -160,7 +166,7 @@ export async function handleAuthorization(
           throw new AuthorizationTimeoutError(
             existingTransactionId,
             endpoint,
-            AUTHORIZATION_TIMEOUT,
+            polling.timeout,
           );
         }
       }
@@ -275,10 +281,7 @@ export async function handleAuthorization(
 
   let result;
   try {
-    const poller = new TransactionPoller(config.sapiomClient, {
-      timeout: AUTHORIZATION_TIMEOUT,
-      pollInterval: POLL_INTERVAL,
-    });
+    const poller = new TransactionPoller(config.sapiomClient, polling);
     result = await poller.waitForAuthorization(transaction.id);
   } catch (error) {
     if (config.failureMode === "closed") throw error;
@@ -304,7 +307,7 @@ export async function handleAuthorization(
     throw new AuthorizationTimeoutError(
       transaction.id,
       endpoint,
-      AUTHORIZATION_TIMEOUT,
+      polling.timeout,
     );
   }
 }
@@ -380,12 +383,10 @@ export async function handlePayment(
   }
 
   if (transaction.status !== TransactionStatus.AUTHORIZED) {
+    const polling = { ...DEFAULT_POLLING, ...config.polling };
     let authResult;
     try {
-      const poller = new TransactionPoller(config.sapiomClient, {
-        timeout: AUTHORIZATION_TIMEOUT,
-        pollInterval: POLL_INTERVAL,
-      });
+      const poller = new TransactionPoller(config.sapiomClient, polling);
       authResult = await poller.waitForAuthorization(transaction.id);
     } catch (pollError) {
       if (config.failureMode === "closed") throw pollError;

--- a/packages/node-http/src/node-http.ts
+++ b/packages/node-http/src/node-http.ts
@@ -11,6 +11,7 @@ import {
   BaseSapiomIntegrationConfig,
   initializeSapiomClient,
 } from "@sapiom/core";
+import type { TransactionPollingConfig } from "@sapiom/core";
 import {
   handleAuthorization,
   handlePayment,
@@ -23,7 +24,13 @@ import {
 /**
  * Configuration for Sapiom-enabled Node.js HTTP client
  */
-export interface SapiomNodeHttpConfig extends BaseSapiomIntegrationConfig {}
+export interface SapiomNodeHttpConfig extends BaseSapiomIntegrationConfig {
+  /**
+   * Polling configuration for transaction authorization.
+   * Overrides default timeout (30s) and poll interval (1s).
+   */
+  polling?: TransactionPollingConfig;
+}
 
 /**
  * Creates a Sapiom-enabled Node.js HTTP client with automatic authorization and payment handling
@@ -120,8 +127,8 @@ export function createClient(
 
   const failureMode = config?.failureMode ?? "open";
 
-  const authConfig: AuthorizationConfig = { sapiomClient, failureMode };
-  const paymentConfig: PaymentConfig = { sapiomClient, failureMode };
+  const authConfig: AuthorizationConfig = { sapiomClient, failureMode, polling: config?.polling };
+  const paymentConfig: PaymentConfig = { sapiomClient, failureMode, polling: config?.polling };
   const completionConfig: CompletionConfig = { sapiomClient };
 
   async function makeRequest<T = any>(


### PR DESCRIPTION
The fetch package already supported user-configurable polling via TransactionPollingConfig, but axios and node-http hardcoded AUTHORIZATION_TIMEOUT (30s) and POLL_INTERVAL (1s) with no way to override them.

Apply the same pattern: accept an optional `polling` config, merge with defaults, and re-export TransactionPollingConfig.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is additive and defaults preserve existing 30s timeout/1s poll interval, but it does alter interceptor/client behavior when callers provide custom polling values.
> 
> **Overview**
> **Adds configurable polling for transaction authorization/payment flows.** `withSapiom` (Axios) and `createClient` (node-http) now accept an optional `polling` config (`TransactionPollingConfig`) and pass it through to authorization/payment interceptors.
> 
> Interceptors replace hardcoded `AUTHORIZATION_TIMEOUT`/`POLL_INTERVAL` with a `DEFAULT_POLLING` merged with the provided overrides, and the packages re-export `TransactionPollingConfig` for consumer use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452b6ba5a13cb86a34e3eb120067ecd158cce8b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->