### PR TITLE
feat(sandbox): multipart file upload (POL-886)

### DIFF
--- a/.changeset/multipart-uploads-for-sandbox.md
+++ b/.changeset/multipart-uploads-for-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/sandbox": minor
+---
+
+Add multipart file upload support. New `uploadFile(path, content, opts?)` handles the full initiate → parallel part uploads → complete lifecycle with auto-abort on failure. Accepts `Blob | Uint8Array | string`. Low-level `initiateMultipartUpload` / `uploadPart` / `completeMultipartUpload` / `abortMultipartUpload` / `listMultipartParts` primitives are also exposed for resumable or custom-retry use cases.

--- a/.changeset/multipart-uploads-for-sandbox.md
+++ b/.changeset/multipart-uploads-for-sandbox.md
@@ -2,4 +2,4 @@
 "@sapiom/sandbox": minor
 ---
 
-Add multipart file upload support. New `uploadFile(path, content, opts?)` handles the full initiate → parallel part uploads → complete lifecycle with auto-abort on failure. Accepts `Blob | Uint8Array | string`. Low-level `initiateMultipartUpload` / `uploadPart` / `completeMultipartUpload` / `abortMultipartUpload` / `listMultipartParts` primitives are also exposed for resumable or custom-retry use cases.
+Add multipart file upload support. New `uploadFile(path, content, opts?)` handles the full initiate → parallel part uploads → complete lifecycle with per-part retries (408/425/429/5xx + network errors, honors `Retry-After`) and auto-abort on failure. Accepts `Blob | Uint8Array | string`. Low-level `initiateMultipartUpload` / `uploadPart` / `completeMultipartUpload` / `abortMultipartUpload` / `listMultipartParts` primitives are exposed for resumable or custom-retry use cases, and a typed `SandboxHttpError` carries `status` + `retryAfterMs` for programmatic handling.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -106,11 +106,13 @@ await sandbox.uploadFile("big.bin", blob, { signal: ctrl.signal });
 
 | Option            | Type                    | Default         | Description                                                                 |
 |-------------------|-------------------------|-----------------|-----------------------------------------------------------------------------|
-| `partSize`        | `number`                | `5 * 1024 * 1024` | Part size in bytes. The Sapiom ingress rejects uploads over ~8 MiB, so keep this ≤ 7 MiB. |
-| `concurrency`     | `number`                | `4`             | Number of parallel part uploads. Blaxel recommends 3–5.                      |
-| `permissions`     | `string`                | `"0644"`        | Unix file permissions.                                                      |
-| `signal`          | `AbortSignal`           | —               | Cancel the upload. Triggers an auto-abort of the server-side session.        |
-| `onPartUploaded`  | `(part, progress) => void` | —            | Fired after each part finishes (completion order — not `partNumber` order).  |
+| `partSize`          | `number`                | `5 * 1024 * 1024` | Part size in bytes. The Sapiom ingress rejects uploads over ~8 MiB, so keep this ≤ 7 MiB. |
+| `concurrency`       | `number`                | `4`               | Number of parallel part uploads. Blaxel recommends 3–5.                     |
+| `permissions`       | `string`                | `"0644"`          | Unix file permissions.                                                       |
+| `maxRetries`        | `number`                | `3`               | Retries per failed part on 408/425/429/5xx and network errors. `0` disables.  |
+| `retryBaseDelayMs`  | `number`                | `50`              | Initial backoff in ms. Doubles per attempt with jitter; honors `Retry-After`. |
+| `signal`            | `AbortSignal`           | —                 | Cancel the upload. Triggers an auto-abort of the server-side session.         |
+| `onPartUploaded`    | `(part, progress) => void` | —              | Fired after each part finishes (completion order — not `partNumber` order).   |
 
 The server accepts at most **10,000 parts per upload**. If `content.size / partSize > 10_000`, `uploadFile` throws before making any request and suggests a larger `partSize`.
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -75,6 +75,78 @@ Writes a file relative to the sandbox's workspace root.
 await sandbox.writeFile("src/index.ts", 'console.log("hi")');
 ```
 
+### `sandbox.uploadFile(path, content, opts?)`
+
+Uploads a file using multipart upload. Handles the full `initiate → upload parts → complete` lifecycle, with parallel part uploads and automatic abort on any failure. Prefer this over `writeFile` for binary content or files over a few MB.
+
+```typescript
+import { openAsBlob } from "node:fs";
+
+// From a buffer / Uint8Array
+await sandbox.uploadFile("data/snapshot.bin", new Uint8Array(bytes));
+
+// From a file on disk without slurping it into memory (Node 20+)
+const blob = await openAsBlob("./huge.parquet");
+await sandbox.uploadFile("datasets/huge.parquet", blob, {
+  partSize: 5 * 1024 * 1024,
+  concurrency: 4,
+  onPartUploaded: (part, progress) => {
+    const pct = ((progress.bytesUploaded / progress.totalBytes) * 100).toFixed(1);
+    console.log(`part ${part.partNumber} ok — ${pct}%`);
+  },
+});
+
+// Cancel a running upload — the server-side multipart session is auto-aborted
+const ctrl = new AbortController();
+setTimeout(() => ctrl.abort(), 10_000);
+await sandbox.uploadFile("big.bin", blob, { signal: ctrl.signal });
+```
+
+**Options:**
+
+| Option            | Type                    | Default         | Description                                                                 |
+|-------------------|-------------------------|-----------------|-----------------------------------------------------------------------------|
+| `partSize`        | `number`                | `5 * 1024 * 1024` | Part size in bytes. The Sapiom ingress rejects uploads over ~8 MiB, so keep this ≤ 7 MiB. |
+| `concurrency`     | `number`                | `4`             | Number of parallel part uploads. Blaxel recommends 3–5.                      |
+| `permissions`     | `string`                | `"0644"`        | Unix file permissions.                                                      |
+| `signal`          | `AbortSignal`           | —               | Cancel the upload. Triggers an auto-abort of the server-side session.        |
+| `onPartUploaded`  | `(part, progress) => void` | —            | Fired after each part finishes (completion order — not `partNumber` order).  |
+
+The server accepts at most **10,000 parts per upload**. If `content.size / partSize > 10_000`, `uploadFile` throws before making any request and suggests a larger `partSize`.
+
+### Low-level multipart API
+
+For resumable uploads or custom retry logic, drive the multipart lifecycle directly:
+
+```typescript
+const { uploadId } = await sandbox.initiateMultipartUpload("large.bin");
+
+try {
+  // ...upload parts as bytes become available
+  const part1 = await sandbox.uploadPart(uploadId, 1, chunk1);
+  const part2 = await sandbox.uploadPart(uploadId, 2, chunk2);
+
+  // Inspect server-side state (useful after a crash/reconnect)
+  const uploaded = await sandbox.listMultipartParts(uploadId);
+
+  await sandbox.completeMultipartUpload(uploadId, [
+    { partNumber: part1.partNumber, etag: part1.etag },
+    { partNumber: part2.partNumber, etag: part2.etag },
+  ]);
+} catch (err) {
+  await sandbox.abortMultipartUpload(uploadId);
+  throw err;
+}
+```
+
+| Method                                               | Description                                 |
+|------------------------------------------------------|---------------------------------------------|
+| `initiateMultipartUpload(path, opts?)`               | Start a session. Returns `{ uploadId, path }`. |
+| `uploadPart(uploadId, partNumber, bytes, opts?)`     | Upload one part (1-indexed, 1–10000).        |
+| `listMultipartParts(uploadId, opts?)`                | List parts already uploaded.                 |
+| `completeMultipartUpload(uploadId, parts, opts?)`    | Commit the upload.                           |
+| `abortMultipartUpload(uploadId, opts?)`              | Discard the session and clean up parts.      |
+
 ### `sandbox.readFile(path)`
 
 Reads a file relative to the sandbox's workspace root and returns its content as a string.

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,4 +1,5 @@
 export { SapiomSandbox } from "./sandbox.js";
+export { SandboxHttpError } from "./multipart.js";
 export type {
   SandboxCreateOptions,
   SandboxCreateResponse,

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -11,4 +11,9 @@ export type {
   OutputLine,
   ProcessCreateResponse,
   ProcessStatusResponse,
+  MultipartInitiateResponse,
+  MultipartUploadedPart,
+  MultipartPartInfo,
+  UploadFileOptions,
+  UploadProgress,
 } from "./types.js";

--- a/packages/sandbox/src/multipart.test.ts
+++ b/packages/sandbox/src/multipart.test.ts
@@ -1,8 +1,11 @@
 import {
   MAX_PARTS,
+  SandboxHttpError,
+  parseRetryAfter,
   planParts,
   runWithConcurrency,
   toBlob,
+  withRetry,
 } from "./multipart";
 
 describe("toBlob", () => {
@@ -113,5 +116,141 @@ describe("runWithConcurrency", () => {
     await expect(
       runWithConcurrency([1], 0, async (n) => n),
     ).rejects.toThrow(/concurrency must be >= 1/);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("returns undefined for null / empty", () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter("")).toBeUndefined();
+  });
+
+  it("parses delta-seconds integer form", () => {
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("30")).toBe(30_000);
+    expect(parseRetryAfter("0.5")).toBe(500);
+  });
+
+  it("parses HTTP-date form", () => {
+    const future = new Date(Date.now() + 5_000).toUTCString();
+    const parsed = parseRetryAfter(future);
+    expect(parsed).toBeGreaterThan(0);
+    // within a reasonable window of 5s
+    expect(parsed).toBeLessThanOrEqual(6_000);
+  });
+
+  it("clamps past HTTP-date to 0", () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(parseRetryAfter(past)).toBe(0);
+  });
+
+  it("returns undefined for unparseable input", () => {
+    expect(parseRetryAfter("soon")).toBeUndefined();
+  });
+});
+
+describe("withRetry", () => {
+  it("returns immediately on first success", async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+      calls += 1;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries on retryable HTTP errors and ultimately succeeds", async () => {
+    let attempts = 0;
+    const result = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) throw new SandboxHttpError("boom", 503);
+        return "done";
+      },
+      { retryBaseDelayMs: 1 }, // keep tests fast
+    );
+    expect(result).toBe("done");
+    expect(attempts).toBe(3);
+  });
+
+  it("does not retry non-retryable HTTP errors (e.g. 413)", async () => {
+    let attempts = 0;
+    await expect(
+      withRetry(
+        async () => {
+          attempts += 1;
+          throw new SandboxHttpError("too big", 413);
+        },
+        { retryBaseDelayMs: 1 },
+      ),
+    ).rejects.toThrow(/too big/);
+    expect(attempts).toBe(1);
+  });
+
+  it("gives up after maxRetries", async () => {
+    let attempts = 0;
+    await expect(
+      withRetry(
+        async () => {
+          attempts += 1;
+          throw new SandboxHttpError("nope", 500);
+        },
+        { maxRetries: 2, retryBaseDelayMs: 1 },
+      ),
+    ).rejects.toThrow(/nope/);
+    expect(attempts).toBe(3); // 1 initial + 2 retries
+  });
+
+  it("does not retry on AbortError", async () => {
+    let attempts = 0;
+    await expect(
+      withRetry(
+        async () => {
+          attempts += 1;
+          throw Object.assign(new Error("aborted"), { name: "AbortError" });
+        },
+        { retryBaseDelayMs: 1 },
+      ),
+    ).rejects.toThrow(/aborted/);
+    expect(attempts).toBe(1);
+  });
+
+  it("respects an aborted signal during backoff", async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+
+    const promise = withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          // schedule abort during the backoff between attempt 1 and 2
+          setTimeout(() => controller.abort(), 5);
+          throw new SandboxHttpError("retry me", 503);
+        }
+        return "never";
+      },
+      { retryBaseDelayMs: 100, signal: controller.signal },
+    );
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(attempts).toBe(1);
+  });
+
+  it("honors Retry-After from SandboxHttpError", async () => {
+    let attempts = 0;
+    const started = Date.now();
+    await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new SandboxHttpError("429", 429, 50);
+        return "ok";
+      },
+      { retryBaseDelayMs: 1 },
+    );
+    expect(attempts).toBe(2);
+    const elapsed = Date.now() - started;
+    // Should have waited ~50ms (the Retry-After), not the 1ms retryBaseDelayMs
+    expect(elapsed).toBeGreaterThanOrEqual(40);
   });
 });

--- a/packages/sandbox/src/multipart.test.ts
+++ b/packages/sandbox/src/multipart.test.ts
@@ -1,0 +1,117 @@
+import {
+  MAX_PARTS,
+  planParts,
+  runWithConcurrency,
+  toBlob,
+} from "./multipart";
+
+describe("toBlob", () => {
+  it("returns the same Blob when given a Blob", () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])]);
+    expect(toBlob(blob)).toBe(blob);
+  });
+
+  it("wraps a Uint8Array in a Blob", async () => {
+    const bytes = new Uint8Array([9, 8, 7, 6, 5]);
+    const blob = toBlob(bytes);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(5);
+    const roundtrip = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(roundtrip)).toEqual([9, 8, 7, 6, 5]);
+  });
+
+  it("UTF-8 encodes strings", async () => {
+    const blob = toBlob("héllo");
+    // 'h' 'é' (2 bytes) 'l' 'l' 'o' = 6 bytes
+    expect(blob.size).toBe(6);
+    const text = await blob.text();
+    expect(text).toBe("héllo");
+  });
+});
+
+describe("planParts", () => {
+  it("emits a single part for zero-byte input", () => {
+    const plans = planParts(0, 1024);
+    expect(plans).toEqual([{ partNumber: 1, start: 0, end: 0 }]);
+  });
+
+  it("emits one part when totalBytes < partSize", () => {
+    expect(planParts(500, 1024)).toEqual([{ partNumber: 1, start: 0, end: 500 }]);
+  });
+
+  it("emits a final short part when totalBytes is not a multiple of partSize", () => {
+    expect(planParts(2500, 1024)).toEqual([
+      { partNumber: 1, start: 0, end: 1024 },
+      { partNumber: 2, start: 1024, end: 2048 },
+      { partNumber: 3, start: 2048, end: 2500 },
+    ]);
+  });
+
+  it("emits exact parts when totalBytes is a multiple of partSize", () => {
+    expect(planParts(3072, 1024)).toEqual([
+      { partNumber: 1, start: 0, end: 1024 },
+      { partNumber: 2, start: 1024, end: 2048 },
+      { partNumber: 3, start: 2048, end: 3072 },
+    ]);
+  });
+
+  it("rejects non-positive partSize", () => {
+    expect(() => planParts(100, 0)).toThrow(/partSize must be a positive integer/);
+    expect(() => planParts(100, -1)).toThrow(/partSize must be a positive integer/);
+  });
+
+  it("rejects files that would exceed MAX_PARTS and suggests a larger partSize", () => {
+    const huge = MAX_PARTS * 5 + 1; // would need > MAX_PARTS at partSize 5
+    expect(() => planParts(huge, 5)).toThrow(
+      /Increase partSize to at least \d+/,
+    );
+  });
+});
+
+describe("runWithConcurrency", () => {
+  it("processes every item and preserves result order", async () => {
+    const items = [10, 20, 30, 40, 50];
+    const result = await runWithConcurrency(items, 2, async (n) => n * 2);
+    expect(result).toEqual([20, 40, 60, 80, 100]);
+  });
+
+  it("runs at most `concurrency` workers simultaneously", async () => {
+    const items = Array.from({ length: 8 }, (_, i) => i);
+    let inFlight = 0;
+    let peak = 0;
+    await runWithConcurrency(items, 3, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThanOrEqual(2);
+  });
+
+  it("rejects with the first error and stops scheduling new work", async () => {
+    const started: number[] = [];
+    await expect(
+      runWithConcurrency([1, 2, 3, 4, 5, 6], 2, async (n) => {
+        started.push(n);
+        if (n === 2) throw new Error("boom");
+        await new Promise((r) => setTimeout(r, 5));
+        return n;
+      }),
+    ).rejects.toThrow("boom");
+    // At most the initial two items should have been kicked off before failure
+    // halts scheduling; allow a couple more for the race window.
+    expect(started.length).toBeLessThanOrEqual(4);
+  });
+
+  it("handles empty input", async () => {
+    const result = await runWithConcurrency([], 3, async () => "x");
+    expect(result).toEqual([]);
+  });
+
+  it("rejects concurrency < 1", async () => {
+    await expect(
+      runWithConcurrency([1], 0, async (n) => n),
+    ).rejects.toThrow(/concurrency must be >= 1/);
+  });
+});

--- a/packages/sandbox/src/multipart.ts
+++ b/packages/sandbox/src/multipart.ts
@@ -1,0 +1,110 @@
+/** Max parts allowed per multipart upload (Blaxel constraint). */
+export const MAX_PARTS = 10_000;
+
+/**
+ * Default part size: 5 MiB. Bottom of Blaxel's recommended 5–10 MB range
+ * and well clear of the Sapiom ingress 8 MiB body-size ceiling (with
+ * room left for multipart form-data overhead).
+ */
+export const DEFAULT_PART_SIZE = 5 * 1024 * 1024;
+
+/** Default number of parallel part uploads. */
+export const DEFAULT_CONCURRENCY = 4;
+
+/** Default file permissions (Blaxel default). */
+export const DEFAULT_PERMISSIONS = "0644";
+
+/**
+ * Normalize any supported content type into a `Blob`.
+ * `Blob.slice()` gives us random-access + lazy reads, so large inputs don't
+ * have to sit materialized in memory.
+ */
+export function toBlob(content: Blob | Uint8Array | string): Blob {
+  if (content instanceof Blob) return content;
+  if (typeof content === "string") {
+    return new Blob([new TextEncoder().encode(content)]);
+  }
+  return new Blob([content]);
+}
+
+export interface PartPlan {
+  partNumber: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * Split a byte range into part plans.
+ * Always emits at least one part (even for zero-byte inputs) so the caller
+ * still goes through the initiate/upload/complete handshake.
+ */
+export function planParts(totalBytes: number, partSize: number): PartPlan[] {
+  if (!Number.isFinite(partSize) || partSize <= 0) {
+    throw new Error(`partSize must be a positive integer (got ${partSize})`);
+  }
+
+  const count = totalBytes === 0 ? 1 : Math.ceil(totalBytes / partSize);
+
+  if (count > MAX_PARTS) {
+    const minPartSize = Math.ceil(totalBytes / MAX_PARTS);
+    throw new Error(
+      `File of ${totalBytes} bytes would require ${count} parts at partSize=${partSize}, ` +
+        `but the server accepts at most ${MAX_PARTS}. Increase partSize to at least ${minPartSize}.`,
+    );
+  }
+
+  const plans: PartPlan[] = [];
+  for (let i = 0; i < count; i++) {
+    const start = i * partSize;
+    const end = Math.min(start + partSize, totalBytes);
+    plans.push({ partNumber: i + 1, start, end });
+  }
+  return plans;
+}
+
+/**
+ * Run `worker` over `items` with at most `concurrency` promises in flight.
+ * Rejects on the first worker failure (and stops scheduling further items).
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isFinite(concurrency) || concurrency < 1) {
+    throw new Error(`concurrency must be >= 1 (got ${concurrency})`);
+  }
+
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  let failed = false;
+  let firstError: unknown;
+
+  const limit = Math.min(concurrency, items.length);
+  const runners: Promise<void>[] = [];
+
+  for (let slot = 0; slot < limit; slot++) {
+    runners.push(
+      (async () => {
+        while (!failed) {
+          const i = next++;
+          if (i >= items.length) return;
+          try {
+            results[i] = await worker(items[i]!, i);
+          } catch (err) {
+            if (!failed) {
+              failed = true;
+              firstError = err;
+            }
+            return;
+          }
+        }
+      })(),
+    );
+  }
+
+  await Promise.all(runners);
+
+  if (failed) throw firstError;
+  return results;
+}

--- a/packages/sandbox/src/multipart.ts
+++ b/packages/sandbox/src/multipart.ts
@@ -1,6 +1,135 @@
 /** Max parts allowed per multipart upload (Blaxel constraint). */
 export const MAX_PARTS = 10_000;
 
+/** Default number of retries for a single failed part upload. */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/** Default initial retry backoff in milliseconds. */
+export const DEFAULT_RETRY_BASE_DELAY_MS = 50;
+
+/** HTTP status codes worth retrying. 4xx are user errors unless explicitly transient. */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/**
+ * Error thrown by multipart HTTP methods when the server returns a non-2xx.
+ * Exposes `status` + `retryAfterMs` (parsed from `Retry-After`) so callers
+ * and the retry loop can make informed decisions.
+ */
+export class SandboxHttpError extends Error {
+  readonly status: number;
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, status: number, retryAfterMs?: number) {
+    super(message);
+    this.name = "SandboxHttpError";
+    this.status = status;
+    if (retryAfterMs !== undefined) this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Parse a `Retry-After` header value. Supports both forms:
+ *  - delta-seconds integer (e.g. `"30"`)
+ *  - HTTP-date (e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`)
+ */
+export function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return undefined;
+}
+
+/**
+ * Wrap a `fetch` response: if non-2xx, throw a `SandboxHttpError` carrying
+ * the status + Retry-After, otherwise return the response for the caller to
+ * parse.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  const text = await response.text().catch(() => "");
+  const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"));
+  throw new SandboxHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    retryAfterMs,
+  );
+}
+
+export interface RetryOptions {
+  /** Max number of retry attempts after the initial try. @default 3 */
+  maxRetries?: number;
+
+  /** Initial backoff in ms. Doubles each retry with up to `base` ms jitter. @default 50 */
+  retryBaseDelayMs?: number;
+
+  /** AbortSignal to cancel the retry loop. */
+  signal?: AbortSignal;
+}
+
+/** Whether this error is worth retrying. */
+function isRetryable(err: unknown): boolean {
+  if (err instanceof SandboxHttpError) return RETRYABLE_STATUS.has(err.status);
+  // Network-level failures (fetch rejected): typically TypeError "fetch failed"
+  // or AbortError. Retry non-abort errors.
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Retry `fn` up to `maxRetries` times on retryable errors with jittered
+ * exponential backoff. Honors `Retry-After` when the server provides one.
+ * Respects `signal` for prompt cancellation during the backoff wait.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  opts?: RetryOptions,
+): Promise<T> {
+  const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const base = opts?.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const signal = opts?.signal;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      if (attempt >= maxRetries || !isRetryable(err) || signal?.aborted) {
+        throw err;
+      }
+      const backoff =
+        err instanceof SandboxHttpError && err.retryAfterMs !== undefined
+          ? err.retryAfterMs
+          : base * 2 ** attempt + Math.random() * base;
+      await sleepWithSignal(backoff, signal);
+    }
+  }
+}
+
+function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /**
  * Default part size: 5 MiB. Bottom of Blaxel's recommended 5–10 MB range
  * and well clear of the Sapiom ingress 8 MiB body-size ceiling (with

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -488,6 +488,105 @@ describe("SapiomSandbox — multipart methods", () => {
       expect(peak).toBeGreaterThanOrEqual(2);
     });
 
+    it("retries failed parts on retryable status codes", async () => {
+      const attemptsByPart: Record<number, number> = {};
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-retry", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const n = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            attemptsByPart[n] = (attemptsByPart[n] ?? 0) + 1;
+            // Part 2 fails twice with 503 before succeeding
+            if (n === 2 && attemptsByPart[n] < 3) {
+              return new Response("upstream hiccup", { status: 503 });
+            }
+            return jsonResponse({ partNumber: n, etag: `e${n}`, size: 1000 });
+          }
+          if (call.init.method === "POST" && call.url.includes("/complete")) {
+            return jsonResponse({ message: "ok", path: "p" });
+          }
+          return null;
+        },
+      ]);
+
+      await sandbox.uploadFile("p", new Uint8Array(3000), {
+        partSize: 1000,
+        concurrency: 1,
+        retryBaseDelayMs: 1,
+      });
+
+      expect(attemptsByPart).toEqual({ 1: 1, 2: 3, 3: 1 });
+    });
+
+    it("gives up and aborts after exhausting maxRetries", async () => {
+      let attempts = 0;
+      let abortCalled = false;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-x", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            attempts += 1;
+            return new Response("always broken", { status: 500 });
+          }
+          if (
+            call.init.method === "DELETE" &&
+            call.url.includes("/multipart/u-x")
+          ) {
+            abortCalled = true;
+            return jsonResponse({ message: "aborted" });
+          }
+          return null;
+        },
+      ]);
+
+      await expect(
+        sandbox.uploadFile("p", new Uint8Array(1000), {
+          partSize: 1000,
+          maxRetries: 2,
+          retryBaseDelayMs: 1,
+        }),
+      ).rejects.toThrow(/Failed to upload part 1/);
+
+      // 1 initial + 2 retries = 3
+      expect(attempts).toBe(3);
+      await new Promise((r) => setImmediate(r));
+      expect(abortCalled).toBe(true);
+    });
+
+    it("does not retry deterministic 4xx like 413", async () => {
+      let attempts = 0;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-413", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            attempts += 1;
+            return new Response("too big", { status: 413 });
+          }
+          if (call.init.method === "DELETE") {
+            return jsonResponse({ message: "aborted" });
+          }
+          return null;
+        },
+      ]);
+
+      await expect(
+        sandbox.uploadFile("p", new Uint8Array(1000), {
+          partSize: 1000,
+          retryBaseDelayMs: 1,
+        }),
+      ).rejects.toThrow(/413/);
+      // No retry — 413 is not retryable
+      expect(attempts).toBe(1);
+    });
+
     it("works with a string input (UTF-8 encoded)", async () => {
       let totalBytes = 0;
       const { sandbox } = await makeSandbox([

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -1,0 +1,515 @@
+import { SapiomSandbox } from "./sandbox";
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+/**
+ * Build a sandbox with a scripted fetch mock.
+ * Each request to the create endpoint returns the create response; subsequent
+ * calls are matched by `(method, url suffix)` against `handlers`.
+ */
+async function makeSandbox(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  createOverrides?: Partial<{ workspaceRoot: string }>,
+): Promise<{ sandbox: SapiomSandbox; calls: FetchCall[] }> {
+  const calls: FetchCall[] = [];
+  let createCalled = false;
+  const fetchMock = async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init?: Parameters<typeof globalThis.fetch>[1],
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const call: FetchCall = { url, init: init ?? {} };
+    calls.push(call);
+    if (!createCalled) {
+      createCalled = true;
+      return jsonResponse({
+        name: "test-sb",
+        source: "blaxel",
+        status: "running",
+        tier: "s",
+        url: "https://sandbox-url",
+        workspaceRoot: createOverrides?.workspaceRoot ?? "/blaxel/",
+        expiresAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+    for (const handler of handlers) {
+      const response = await handler(call);
+      if (response) return response;
+    }
+    throw new Error(
+      `Unmatched mock fetch: ${init?.method ?? "GET"} ${url}`,
+    );
+  };
+
+  const sandbox = await SapiomSandbox.create({
+    name: "test-sb",
+    fetch: fetchMock as typeof globalThis.fetch,
+    baseUrl: "https://api.test",
+  });
+
+  // Drop the create call so assertions only see operation calls.
+  calls.shift();
+
+  return { sandbox, calls };
+}
+
+describe("SapiomSandbox — multipart methods", () => {
+  describe("initiateMultipartUpload", () => {
+    it("POSTs to the correct URL with permissions in the body", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST") {
+            return jsonResponse({ uploadId: "u-1", path: "data/large.bin" });
+          }
+          return null;
+        },
+      ]);
+
+      const result = await sandbox.initiateMultipartUpload("data/large.bin", {
+        permissions: "0755",
+      });
+
+      expect(result).toEqual({ uploadId: "u-1", path: "data/large.bin" });
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/initiate/data/large.bin",
+      );
+      expect(calls[0]!.init.method).toBe("POST");
+      expect(calls[0]!.init.headers).toMatchObject({
+        "Content-Type": "application/json",
+      });
+      expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+        permissions: "0755",
+      });
+    });
+
+    it("omits permissions from the body when not provided", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ uploadId: "u-1", path: "x" }),
+      ]);
+      await sandbox.initiateMultipartUpload("x");
+      expect(JSON.parse(calls[0]!.init.body as string)).toEqual({});
+    });
+
+    it("encodes path segments", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ uploadId: "u", path: "with space" }),
+      ]);
+      await sandbox.initiateMultipartUpload("dir with space/file.bin");
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/initiate/dir%20with%20space/file.bin",
+      );
+    });
+
+    it("rejects paths containing '..'", async () => {
+      const { sandbox } = await makeSandbox([]);
+      await expect(
+        sandbox.initiateMultipartUpload("../escape"),
+      ).rejects.toThrow(/must not contain '\.\.'/);
+    });
+
+    it("throws with a useful message on non-2xx", async () => {
+      const { sandbox } = await makeSandbox([
+        () => new Response("boom", { status: 500 }),
+      ]);
+      await expect(sandbox.initiateMultipartUpload("x")).rejects.toThrow(
+        /Failed to initiate multipart upload for 'x': 500 boom/,
+      );
+    });
+  });
+
+  describe("uploadPart", () => {
+    it("PUTs multipart/form-data with `file` field and partNumber query param", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ partNumber: 3, etag: "etag-3", size: 100 }),
+      ]);
+
+      const ack = await sandbox.uploadPart(
+        "u-42",
+        3,
+        new Uint8Array([1, 2, 3, 4, 5]),
+      );
+      expect(ack).toEqual({ partNumber: 3, etag: "etag-3", size: 100 });
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/u-42/part?partNumber=3",
+      );
+      expect(calls[0]!.init.method).toBe("PUT");
+      expect(calls[0]!.init.body).toBeInstanceOf(FormData);
+      const form = calls[0]!.init.body as FormData;
+      expect(form.get("file")).toBeInstanceOf(Blob);
+      // Do not set Content-Type manually — fetch must set the boundary.
+      expect((calls[0]!.init.headers as Record<string, string> | undefined)?.[
+        "Content-Type"
+      ]).toBeUndefined();
+    });
+
+    it("accepts a Blob directly without double-wrapping", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ partNumber: 1, etag: "e", size: 3 }),
+      ]);
+      const blob = new Blob([new Uint8Array([1, 2, 3])]);
+      await sandbox.uploadPart("u", 1, blob);
+      // FormData promotes Blob entries to File per WHATWG spec, so identity
+      // won't hold; assert the content instead.
+      const form = calls[0]!.init.body as FormData;
+      const entry = form.get("file") as Blob;
+      expect(entry.size).toBe(3);
+      const roundtrip = new Uint8Array(await entry.arrayBuffer());
+      expect(Array.from(roundtrip)).toEqual([1, 2, 3]);
+    });
+
+    it("encodes uploadId in the URL", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ partNumber: 1, etag: "e", size: 1 }),
+      ]);
+      await sandbox.uploadPart("id/with slash", 1, new Uint8Array([0]));
+      expect(calls[0]!.url).toContain("/multipart/id%2Fwith%20slash/part");
+    });
+  });
+
+  describe("completeMultipartUpload", () => {
+    it("POSTs the parts array as JSON", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () =>
+          jsonResponse({
+            message: "Upload completed successfully",
+            path: "big.bin",
+          }),
+      ]);
+
+      const parts = [
+        { partNumber: 1, etag: "e1" },
+        { partNumber: 2, etag: "e2" },
+      ];
+      const result = await sandbox.completeMultipartUpload("u-1", parts);
+      expect(result).toEqual({
+        message: "Upload completed successfully",
+        path: "big.bin",
+      });
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/u-1/complete",
+      );
+      expect(calls[0]!.init.method).toBe("POST");
+      expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ parts });
+    });
+  });
+
+  describe("abortMultipartUpload", () => {
+    it("DELETEs the upload without an /abort suffix", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () => jsonResponse({ message: "aborted" }),
+      ]);
+      await sandbox.abortMultipartUpload("u-9");
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/u-9",
+      );
+      expect(calls[0]!.init.method).toBe("DELETE");
+    });
+  });
+
+  describe("listMultipartParts", () => {
+    it("GETs and returns the parts array", async () => {
+      const { sandbox, calls } = await makeSandbox([
+        () =>
+          jsonResponse({
+            uploadId: "u-1",
+            parts: [
+              {
+                partNumber: 1,
+                etag: "e1",
+                size: 1024,
+                uploadedAt: "2026-01-01T00:00:00Z",
+              },
+            ],
+          }),
+      ]);
+      const parts = await sandbox.listMultipartParts("u-1");
+      expect(parts).toHaveLength(1);
+      expect(parts[0]!.etag).toBe("e1");
+      expect(calls[0]!.url).toBe(
+        "https://api.test/v1/sandboxes/test-sb/filesystem/multipart/u-1/parts",
+      );
+    });
+  });
+
+  describe("uploadFile", () => {
+    it("single-part upload for content smaller than partSize", async () => {
+      const uploadedParts: number[] = [];
+      const { sandbox, calls } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-1", path: "small.bin" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const qp = new URL(call.url).searchParams.get("partNumber")!;
+            const partNumber = Number(qp);
+            uploadedParts.push(partNumber);
+            return jsonResponse({ partNumber, etag: `e${partNumber}`, size: 10 });
+          }
+          if (
+            call.init.method === "POST" &&
+            call.url.includes("/complete")
+          ) {
+            return jsonResponse({ message: "ok", path: "small.bin" });
+          }
+          return null;
+        },
+      ]);
+
+      await sandbox.uploadFile("small.bin", new Uint8Array(10), {
+        partSize: 1024,
+      });
+
+      expect(uploadedParts).toEqual([1]);
+      // 1 initiate + 1 upload + 1 complete
+      expect(calls).toHaveLength(3);
+    });
+
+    it("multi-part upload splits bytes correctly and sends parts sorted by partNumber on complete", async () => {
+      let completeBody: { parts: Array<{ partNumber: number; etag: string }> } | null =
+        null;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-1", path: "big.bin" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const partNumber = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            const form = call.init.body as FormData;
+            const file = form.get("file") as Blob;
+            return jsonResponse({
+              partNumber,
+              etag: `e${partNumber}`,
+              size: file.size,
+            });
+          }
+          if (call.init.method === "POST" && call.url.includes("/complete")) {
+            completeBody = JSON.parse(call.init.body as string);
+            return jsonResponse({ message: "ok", path: "big.bin" });
+          }
+          return null;
+        },
+      ]);
+
+      // 3 parts of size 1000, then one remainder of 500
+      const bytes = new Uint8Array(3500);
+      await sandbox.uploadFile("big.bin", bytes, { partSize: 1000, concurrency: 2 });
+
+      expect(completeBody!.parts).toEqual([
+        { partNumber: 1, etag: "e1" },
+        { partNumber: 2, etag: "e2" },
+        { partNumber: 3, etag: "e3" },
+        { partNumber: 4, etag: "e4" },
+      ]);
+    });
+
+    it("fires onPartUploaded with cumulative progress", async () => {
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u", path: "p" });
+          }
+          if (call.init.method === "PUT") {
+            const n = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            return jsonResponse({ partNumber: n, etag: `e${n}`, size: 1000 });
+          }
+          return jsonResponse({ message: "ok", path: "p" });
+        },
+      ]);
+
+      const events: Array<{ partsUploaded: number; bytesUploaded: number }> = [];
+      await sandbox.uploadFile("p", new Uint8Array(3000), {
+        partSize: 1000,
+        concurrency: 1, // sequential for deterministic event ordering
+        onPartUploaded: (_p, prog) => {
+          events.push({
+            partsUploaded: prog.partsUploaded,
+            bytesUploaded: prog.bytesUploaded,
+          });
+        },
+      });
+
+      expect(events).toEqual([
+        { partsUploaded: 1, bytesUploaded: 1000 },
+        { partsUploaded: 2, bytesUploaded: 2000 },
+        { partsUploaded: 3, bytesUploaded: 3000 },
+      ]);
+    });
+
+    it("aborts the upload when a part fails and re-throws the original error", async () => {
+      let abortCalled = false;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-abort", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const n = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            if (n === 2) {
+              return new Response("part 2 broke", { status: 500 });
+            }
+            return jsonResponse({ partNumber: n, etag: `e${n}`, size: 1000 });
+          }
+          if (
+            call.init.method === "DELETE" &&
+            call.url.includes("/multipart/u-abort")
+          ) {
+            abortCalled = true;
+            return jsonResponse({ message: "aborted" });
+          }
+          return null;
+        },
+      ]);
+
+      await expect(
+        sandbox.uploadFile("p", new Uint8Array(3000), {
+          partSize: 1000,
+          concurrency: 1,
+        }),
+      ).rejects.toThrow(/Failed to upload part 2/);
+
+      // Let the fire-and-forget abort() settle
+      await new Promise((r) => setImmediate(r));
+      expect(abortCalled).toBe(true);
+    });
+
+    it("aborts the upload when opts.signal aborts mid-flight", async () => {
+      let abortCalled = false;
+      const controller = new AbortController();
+
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u-sig", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            // The init from uploadPart should carry the signal through
+            const sig = call.init.signal as AbortSignal | undefined;
+            if (sig?.aborted) {
+              return Promise.reject(
+                Object.assign(new Error("aborted"), { name: "AbortError" }),
+              );
+            }
+            // Fire the abort before responding to part 1
+            controller.abort();
+            return Promise.reject(
+              Object.assign(new Error("aborted"), { name: "AbortError" }),
+            );
+          }
+          if (
+            call.init.method === "DELETE" &&
+            call.url.includes("/multipart/u-sig")
+          ) {
+            abortCalled = true;
+            return jsonResponse({ message: "aborted" });
+          }
+          return null;
+        },
+      ]);
+
+      await expect(
+        sandbox.uploadFile("p", new Uint8Array(3000), {
+          partSize: 1000,
+          concurrency: 1,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow();
+
+      await new Promise((r) => setImmediate(r));
+      expect(abortCalled).toBe(true);
+    });
+
+    it("rejects inputs that would exceed MAX_PARTS before making any HTTP call", async () => {
+      const { sandbox, calls } = await makeSandbox([]);
+      await expect(
+        sandbox.uploadFile("p", new Uint8Array(10_001), { partSize: 1 }),
+      ).rejects.toThrow(/Increase partSize to at least/);
+      expect(calls).toHaveLength(0);
+    });
+
+    it("respects concurrency by limiting in-flight part uploads", async () => {
+      let inFlight = 0;
+      let peak = 0;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u", path: "p" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const n = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            inFlight += 1;
+            peak = Math.max(peak, inFlight);
+            return new Promise<Response>((resolve) => {
+              setTimeout(() => {
+                inFlight -= 1;
+                resolve(
+                  jsonResponse({ partNumber: n, etag: `e${n}`, size: 1000 }),
+                );
+              }, 10);
+            });
+          }
+          return jsonResponse({ message: "ok", path: "p" });
+        },
+      ]);
+
+      await sandbox.uploadFile("p", new Uint8Array(8000), {
+        partSize: 1000,
+        concurrency: 3,
+      });
+
+      expect(peak).toBeLessThanOrEqual(3);
+      expect(peak).toBeGreaterThanOrEqual(2);
+    });
+
+    it("works with a string input (UTF-8 encoded)", async () => {
+      let totalBytes = 0;
+      const { sandbox } = await makeSandbox([
+        (call) => {
+          if (call.init.method === "POST" && call.url.includes("/initiate/")) {
+            return jsonResponse({ uploadId: "u", path: "s.txt" });
+          }
+          if (call.init.method === "PUT" && call.url.includes("/part")) {
+            const n = Number(
+              new URL(call.url).searchParams.get("partNumber")!,
+            );
+            const file = (call.init.body as FormData).get("file") as Blob;
+            totalBytes += file.size;
+            return jsonResponse({ partNumber: n, etag: `e${n}`, size: file.size });
+          }
+          return jsonResponse({ message: "ok", path: "s.txt" });
+        },
+      ]);
+
+      await sandbox.uploadFile("s.txt", "héllo", { partSize: 1024 });
+      // UTF-8 encoding of 'héllo' = 6 bytes
+      expect(totalBytes).toBe(6);
+    });
+  });
+});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,4 +1,11 @@
 import { createFetch } from "@sapiom/fetch";
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_PART_SIZE,
+  planParts,
+  runWithConcurrency,
+  toBlob,
+} from "./multipart.js";
 import type {
   SandboxCreateOptions,
   SandboxCreateResponse,
@@ -9,6 +16,10 @@ import type {
   OutputLine,
   ProcessCreateResponse,
   ProcessStatusResponse,
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadedPart,
+  UploadFileOptions,
 } from "./types.js";
 
 const DEFAULT_BASE_URL = "https://blaxel.services.sapiom.ai";
@@ -54,6 +65,14 @@ function fileUrl(
     ? absolutePath.slice(1)
     : absolutePath;
   return `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandboxName)}/filesystem/${encodePathSegments(cleanPath)}`;
+}
+
+function multipartUrl(
+  baseUrl: string,
+  sandboxName: string,
+  suffix: string,
+): string {
+  return `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandboxName)}/filesystem/multipart${suffix}`;
 }
 
 function parseOutputLine(line: string): OutputLine {
@@ -186,6 +205,248 @@ export class SapiomSandbox {
 
     const data = (await response.json()) as { content: string };
     return data.content;
+  }
+
+  /**
+   * Upload a file to the sandbox using multipart upload.
+   *
+   * Handles the full initiate → part upload → complete lifecycle, with
+   * parallel part uploads and automatic abort on any failure (including
+   * `signal` aborts).
+   *
+   * Prefer this over {@link writeFile} for binary content or any file over
+   * a few MB. `writeFile` stays available for small text files.
+   *
+   * @param path - File path relative to workspaceRoot.
+   * @param content - Blob, Uint8Array, or string. Strings are UTF-8 encoded.
+   * @param opts - Upload options.
+   */
+  async uploadFile(
+    path: string,
+    content: Blob | Uint8Array | string,
+    opts?: UploadFileOptions,
+  ): Promise<void> {
+    assertRelativePath(path);
+
+    const blob = toBlob(content);
+    const partSize = opts?.partSize ?? DEFAULT_PART_SIZE;
+    const concurrency = opts?.concurrency ?? DEFAULT_CONCURRENCY;
+    const totalBytes = blob.size;
+    const plans = planParts(totalBytes, partSize);
+
+    const { uploadId } = await this.initiateMultipartUpload(path, {
+      permissions: opts?.permissions,
+      signal: opts?.signal,
+    });
+
+    try {
+      let partsUploaded = 0;
+      let bytesUploaded = 0;
+
+      const uploaded = await runWithConcurrency(
+        plans,
+        concurrency,
+        async (plan) => {
+          const slice = blob.slice(plan.start, plan.end);
+          const ack = await this.uploadPart(uploadId, plan.partNumber, slice, {
+            signal: opts?.signal,
+          });
+          partsUploaded += 1;
+          bytesUploaded += ack.size;
+          opts?.onPartUploaded?.(ack, {
+            partsUploaded,
+            totalParts: plans.length,
+            bytesUploaded,
+            totalBytes,
+          });
+          return ack;
+        },
+      );
+
+      const parts = uploaded
+        .map(({ partNumber, etag }) => ({ partNumber, etag }))
+        .sort((a, b) => a.partNumber - b.partNumber);
+
+      await this.completeMultipartUpload(uploadId, parts, {
+        signal: opts?.signal,
+      });
+    } catch (err) {
+      // Best-effort cleanup; don't mask the original error.
+      this.abortMultipartUpload(uploadId).catch(() => {});
+      throw err;
+    }
+  }
+
+  /**
+   * Initiate a multipart upload for a file path.
+   *
+   * Low-level: prefer {@link uploadFile} for the full lifecycle. Use this
+   * when you need custom retry/progress/resumable behavior.
+   */
+  async initiateMultipartUpload(
+    path: string,
+    opts?: { permissions?: string; signal?: AbortSignal },
+  ): Promise<MultipartInitiateResponse> {
+    assertRelativePath(path);
+    const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+    const url = multipartUrl(
+      this._baseUrl,
+      this.name,
+      `/initiate/${encodePathSegments(cleanPath)}`,
+    );
+
+    const body: Record<string, unknown> = {};
+    if (opts?.permissions !== undefined) body.permissions = opts.permissions;
+
+    const response = await this._fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: opts?.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to initiate multipart upload for '${path}': ${response.status} ${text}`,
+      );
+    }
+
+    return (await response.json()) as MultipartInitiateResponse;
+  }
+
+  /**
+   * Upload a single part of a multipart upload.
+   *
+   * Low-level: prefer {@link uploadFile} for the full lifecycle.
+   *
+   * @param uploadId - Upload session ID from {@link initiateMultipartUpload}.
+   * @param partNumber - 1-indexed part number (1 to 10000).
+   * @param part - The part bytes.
+   */
+  async uploadPart(
+    uploadId: string,
+    partNumber: number,
+    part: Blob | Uint8Array,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MultipartUploadedPart> {
+    const url =
+      multipartUrl(
+        this._baseUrl,
+        this.name,
+        `/${encodeURIComponent(uploadId)}/part`,
+      ) + `?partNumber=${encodeURIComponent(String(partNumber))}`;
+
+    const form = new FormData();
+    form.append("file", part instanceof Blob ? part : new Blob([part]));
+
+    // Intentionally no Content-Type header — fetch sets the multipart
+    // boundary automatically.
+    const response = await this._fetch(url, {
+      method: "PUT",
+      body: form,
+      signal: opts?.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to upload part ${partNumber} for upload '${uploadId}': ${response.status} ${text}`,
+      );
+    }
+
+    return (await response.json()) as MultipartUploadedPart;
+  }
+
+  /**
+   * Complete a multipart upload by committing the uploaded parts.
+   *
+   * Low-level: prefer {@link uploadFile} for the full lifecycle.
+   */
+  async completeMultipartUpload(
+    uploadId: string,
+    parts: Array<{ partNumber: number; etag: string }>,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{ message: string; path: string }> {
+    const url = multipartUrl(
+      this._baseUrl,
+      this.name,
+      `/${encodeURIComponent(uploadId)}/complete`,
+    );
+
+    const response = await this._fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parts }),
+      signal: opts?.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to complete multipart upload '${uploadId}': ${response.status} ${text}`,
+      );
+    }
+
+    return (await response.json()) as { message: string; path: string };
+  }
+
+  /**
+   * Abort a multipart upload and clean up any uploaded parts on the server.
+   */
+  async abortMultipartUpload(
+    uploadId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const url = multipartUrl(
+      this._baseUrl,
+      this.name,
+      `/${encodeURIComponent(uploadId)}`,
+    );
+
+    const response = await this._fetch(url, {
+      method: "DELETE",
+      signal: opts?.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to abort multipart upload '${uploadId}': ${response.status} ${text}`,
+      );
+    }
+  }
+
+  /**
+   * List the parts already uploaded for a multipart upload.
+   *
+   * Useful for resumable uploads: after reconnecting, call this to see
+   * which part numbers you still need to upload.
+   */
+  async listMultipartParts(
+    uploadId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MultipartPartInfo[]> {
+    const url = multipartUrl(
+      this._baseUrl,
+      this.name,
+      `/${encodeURIComponent(uploadId)}/parts`,
+    );
+
+    const response = await this._fetch(url, { signal: opts?.signal });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to list parts for multipart upload '${uploadId}': ${response.status} ${text}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      uploadId: string;
+      parts: MultipartPartInfo[];
+    };
+    return data.parts;
   }
 
   /**

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,10 +1,14 @@
 import { createFetch } from "@sapiom/fetch";
 import {
   DEFAULT_CONCURRENCY,
+  DEFAULT_MAX_RETRIES,
   DEFAULT_PART_SIZE,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  ensureOk,
   planParts,
   runWithConcurrency,
   toBlob,
+  withRetry,
 } from "./multipart.js";
 import type {
   SandboxCreateOptions,
@@ -243,14 +247,22 @@ export class SapiomSandbox {
       let partsUploaded = 0;
       let bytesUploaded = 0;
 
+      const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+      const retryBaseDelayMs =
+        opts?.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+
       const uploaded = await runWithConcurrency(
         plans,
         concurrency,
         async (plan) => {
           const slice = blob.slice(plan.start, plan.end);
-          const ack = await this.uploadPart(uploadId, plan.partNumber, slice, {
-            signal: opts?.signal,
-          });
+          const ack = await withRetry(
+            () =>
+              this.uploadPart(uploadId, plan.partNumber, slice, {
+                signal: opts?.signal,
+              }),
+            { maxRetries, retryBaseDelayMs, signal: opts?.signal },
+          );
           partsUploaded += 1;
           bytesUploaded += ack.size;
           opts?.onPartUploaded?.(ack, {
@@ -298,19 +310,15 @@ export class SapiomSandbox {
     const body: Record<string, unknown> = {};
     if (opts?.permissions !== undefined) body.permissions = opts.permissions;
 
-    const response = await this._fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal: opts?.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(
-        `Failed to initiate multipart upload for '${path}': ${response.status} ${text}`,
-      );
-    }
+    const response = await ensureOk(
+      await this._fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: opts?.signal,
+      }),
+      `Failed to initiate multipart upload for '${path}'`,
+    );
 
     return (await response.json()) as MultipartInitiateResponse;
   }
@@ -342,18 +350,14 @@ export class SapiomSandbox {
 
     // Intentionally no Content-Type header — fetch sets the multipart
     // boundary automatically.
-    const response = await this._fetch(url, {
-      method: "PUT",
-      body: form,
-      signal: opts?.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(
-        `Failed to upload part ${partNumber} for upload '${uploadId}': ${response.status} ${text}`,
-      );
-    }
+    const response = await ensureOk(
+      await this._fetch(url, {
+        method: "PUT",
+        body: form,
+        signal: opts?.signal,
+      }),
+      `Failed to upload part ${partNumber} for upload '${uploadId}'`,
+    );
 
     return (await response.json()) as MultipartUploadedPart;
   }
@@ -374,19 +378,15 @@ export class SapiomSandbox {
       `/${encodeURIComponent(uploadId)}/complete`,
     );
 
-    const response = await this._fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ parts }),
-      signal: opts?.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(
-        `Failed to complete multipart upload '${uploadId}': ${response.status} ${text}`,
-      );
-    }
+    const response = await ensureOk(
+      await this._fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ parts }),
+        signal: opts?.signal,
+      }),
+      `Failed to complete multipart upload '${uploadId}'`,
+    );
 
     return (await response.json()) as { message: string; path: string };
   }
@@ -404,17 +404,13 @@ export class SapiomSandbox {
       `/${encodeURIComponent(uploadId)}`,
     );
 
-    const response = await this._fetch(url, {
-      method: "DELETE",
-      signal: opts?.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(
-        `Failed to abort multipart upload '${uploadId}': ${response.status} ${text}`,
-      );
-    }
+    await ensureOk(
+      await this._fetch(url, {
+        method: "DELETE",
+        signal: opts?.signal,
+      }),
+      `Failed to abort multipart upload '${uploadId}'`,
+    );
   }
 
   /**
@@ -433,14 +429,10 @@ export class SapiomSandbox {
       `/${encodeURIComponent(uploadId)}/parts`,
     );
 
-    const response = await this._fetch(url, { signal: opts?.signal });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(
-        `Failed to list parts for multipart upload '${uploadId}': ${response.status} ${text}`,
-      );
-    }
+    const response = await ensureOk(
+      await this._fetch(url, { signal: opts?.signal }),
+      `Failed to list parts for multipart upload '${uploadId}'`,
+    );
 
     const data = (await response.json()) as {
       uploadId: string;

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -202,3 +202,47 @@ export interface ProcessStatusResponse {
   stderr?: string;
   [key: string]: unknown;
 }
+
+/** Raw response from POST /v1/sandboxes/:name/filesystem/multipart/initiate/:path. */
+export interface MultipartInitiateResponse {
+  uploadId: string;
+  path: string;
+}
+
+/** Ack returned after a part upload or needed to complete an upload. */
+export interface MultipartUploadedPart {
+  partNumber: number;
+  etag: string;
+  size: number;
+}
+
+/** Full part record returned by GET .../multipart/:uploadId/parts. */
+export interface MultipartPartInfo extends MultipartUploadedPart {
+  uploadedAt: string;
+}
+
+/** Progress reported to {@link UploadFileOptions.onPartUploaded}. */
+export interface UploadProgress {
+  partsUploaded: number;
+  totalParts: number;
+  bytesUploaded: number;
+  totalBytes: number;
+}
+
+/** Options for {@link SapiomSandbox.uploadFile}. */
+export interface UploadFileOptions {
+  /** Part size in bytes. @default 5 * 1024 * 1024 (5 MiB) */
+  partSize?: number;
+
+  /** Number of parallel part uploads. @default 4 */
+  concurrency?: number;
+
+  /** File permissions string passed to initiate. @default "0644" */
+  permissions?: string;
+
+  /** AbortSignal to cancel the upload. Triggers an auto-abort of the multipart upload on the server. */
+  signal?: AbortSignal;
+
+  /** Invoked after each part finishes uploading (in completion order, not partNumber order). */
+  onPartUploaded?: (part: MultipartUploadedPart, progress: UploadProgress) => void;
+}

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -240,6 +240,20 @@ export interface UploadFileOptions {
   /** File permissions string passed to initiate. @default "0644" */
   permissions?: string;
 
+  /**
+   * Max retries per failed part upload. Retries on 408/425/429/5xx and
+   * network errors; honors `Retry-After`. Pass `0` to disable.
+   * @default 3
+   */
+  maxRetries?: number;
+
+  /**
+   * Initial retry backoff in ms. Doubles each attempt with up to `base` ms
+   * jitter, so 3 retries take ≤ ~400ms total at the default.
+   * @default 50
+   */
+  retryBaseDelayMs?: number;
+
   /** AbortSignal to cancel the upload. Triggers an auto-abort of the multipart upload on the server. */
   signal?: AbortSignal;
 


### PR DESCRIPTION
## Summary

- Adds `sandbox.uploadFile(path, content, opts?)` to `@sapiom/sandbox` — handles the full `initiate → parallel part uploads → complete` lifecycle with per-part retries (`408` / `425` / `429` / `5xx` + network errors, honors `Retry-After`) and auto-abort on failure. Accepts `Blob | Uint8Array | string`.
- Also exposes low-level primitives for resumable / custom-retry flows: `initiateMultipartUpload`, `uploadPart`, `completeMultipartUpload`, `abortMultipartUpload`, `listMultipartParts`.
- Introduces `SandboxHttpError` (exported) carrying `status` + `retryAfterMs` so callers can make typed retry/recovery decisions.
- `writeFile` is intentionally unchanged — still a string-only JSON PUT for small text files.
- Linear: [POL-886](https://linear.app/sapiom/issue/POL-886)

## Design decisions

| Question | Decision | Why |
|---|---|---|
| Replace or supplement `writeFile`? | **Supplement.** | No silent behavior change for existing callers. |
| API surface? | **Convenience + low-level escape hatches.** | `uploadFile` covers the 99% case; primitives unlock resumable uploads. |
| Content input type? | `Blob \| Uint8Array \| string` | Isomorphic (Node 20+ / browsers / Workers). `Blob.slice()` gives lazy reads for large files via `fs.openAsBlob(path)` without a stream abstraction, and keeps parallel + retry simple. |
| Default `partSize`? | **5 MiB** | Empirically verified: the Sapiom ingress 413s on ≥8 MiB (multipart/form-data overhead pushes an 8 MiB raw payload over the ceiling). 5 MiB sits at the bottom of Blaxel's recommended 5–10 MiB range with real headroom. |
| Default `concurrency`? | **4** | Middle of Blaxel's recommended 3–5. |
| Retry defaults? | **3 retries, 50 ms base + jitter, exponential x2, honor `Retry-After`.** | Fast recovery on transient flakes (≤ ~400 ms total dead time); server-driven pacing on real overload. Skip deterministic 4xx (400/403/413) — no point retrying. |

## Files

- `packages/sandbox/src/types.ts` — 5 new exported types + retry opts on `UploadFileOptions`.
- `packages/sandbox/src/multipart.ts` *(new)* — internal helpers: `toBlob`, `planParts` (with `MAX_PARTS=10_000` guard and a helpful error that suggests a larger `partSize`), bounded-concurrency executor, `withRetry`, `parseRetryAfter`, `ensureOk`, `SandboxHttpError`.
- `packages/sandbox/src/sandbox.ts` — 6 new methods + `multipartUrl` helper; all multipart methods throw typed `SandboxHttpError` via `ensureOk`.
- `packages/sandbox/src/index.ts` — re-export types + `SandboxHttpError`.
- `packages/sandbox/src/{multipart,sandbox}.test.ts` *(new)* — **first tests in this package** (48 in total).
- `packages/sandbox/README.md` — new `uploadFile` + low-level multipart sections, with a `fs.openAsBlob` worked example.
- `.changeset/multipart-uploads-for-sandbox.md` — minor bump.

## Test plan

- [x] `pnpm --filter @sapiom/sandbox typecheck` ✓
- [x] `pnpm --filter @sapiom/sandbox lint` ✓
- [x] `pnpm --filter @sapiom/sandbox test` — 48/48 ✓
- [x] `pnpm --filter @sapiom/sandbox build` ✓
- [x] **Prod smoke** (25 MiB multipart upload, `SAPIOM_API_KEY_PROD`): upload completes in ~25 s across 5 parts uploaded via `concurrency=4`; `wc -c` returns the right byte count; sha256 matches the source bytes exactly; `listMultipartParts` returns the expected part records. Re-verified after adding the retry code path.
- [ ] **Abort flow** blocked on [sapiom/Sapiom#1496](https://github.com/sapiom/Sapiom/pull/1496) — one-line Sapiom proxy fix (drops `/abort` suffix when forwarding to Blaxel). Once that ships, the SDK's `abortMultipartUpload` and `uploadFile`'s auto-abort-on-failure will both work end-to-end. The SDK code itself is already correct; `SandboxHttpError.status` surfaces the 404 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)