### PR TITLE
fix(sandbox): treat all terminal process statuses as done when polling

### DIFF
--- a/.changeset/sandbox-poll-terminal-status.md
+++ b/.changeset/sandbox-poll-terminal-status.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/sandbox": patch
+---
+
+Fix process polling treating only `"completed"` as terminal. Non-zero exits (status `"failed"`) and `"killed"`/`"stopped"` are now recognized as finished, so `exec`/`execStream`/`waitForProcess` return promptly with the real exit code instead of hanging until the timeout. Terminal statuses that omit an exit code now report a non-zero code instead of falsely reporting success.

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -73,6 +73,40 @@ async function makeSandbox(
   return { sandbox, calls };
 }
 
+interface ProcessBody {
+  status: string;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Build fetch handlers for an `exec`/`execStream` call: the POST to `/process`
+ * returns `createResponse`; each subsequent GET `/process/:pid` returns the next
+ * entry of `pollStatuses` (the last entry repeats so a "running" poll can loop).
+ */
+function execHandlers(
+  pollStatuses: ProcessBody[],
+  createResponse: ProcessBody = { status: "running" },
+): Array<(call: FetchCall) => Response | null> {
+  let i = 0;
+  return [
+    (call: FetchCall) => {
+      if (/\/process$/.test(call.url)) {
+        return jsonResponse({ pid: "p1", ...createResponse });
+      }
+      if (/\/process\/[^/]+$/.test(call.url)) {
+        const body = pollStatuses[Math.min(i, pollStatuses.length - 1)] ?? {
+          status: "running",
+        };
+        i += 1;
+        return jsonResponse({ pid: "p1", ...body });
+      }
+      return null;
+    },
+  ];
+}
+
 describe("SapiomSandbox — multipart methods", () => {
   describe("initiateMultipartUpload", () => {
     it("POSTs to the correct URL with permissions in the body", async () => {
@@ -610,5 +644,150 @@ describe("SapiomSandbox — multipart methods", () => {
       // UTF-8 encoding of 'héllo' = 6 bytes
       expect(totalBytes).toBe(6);
     });
+  });
+});
+
+describe("SapiomSandbox — exec process polling", () => {
+  // Regression: a non-zero exit is reported as status "failed", not
+  // "completed". exec must recognize it as finished and return promptly
+  // instead of polling until the timeout and throwing.
+  it("resolves a non-zero exit (status 'failed') instead of hanging", async () => {
+    const { sandbox } = await makeSandbox(
+      execHandlers([{ status: "failed", exitCode: 1, stdout: "", stderr: "boom" }]),
+    );
+
+    const result = await sandbox.exec("[ -d node_modules ]", {
+      pollInterval: 1,
+      timeout: 1000,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("boom");
+  });
+
+  it("resolves a 'killed' process with its exit code", async () => {
+    const { sandbox } = await makeSandbox(
+      execHandlers([{ status: "killed", exitCode: 137 }]),
+    );
+
+    const result = await sandbox.exec("sleep 999", {
+      pollInterval: 1,
+      timeout: 1000,
+    });
+
+    expect(result.exitCode).toBe(137);
+  });
+
+  it("resolves a 'stopped' process and honors exit code 0", async () => {
+    const { sandbox } = await makeSandbox(
+      execHandlers([{ status: "stopped", exitCode: 0 }]),
+    );
+
+    const result = await sandbox.exec("true", { pollInterval: 1, timeout: 1000 });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps polling while 'running' then returns on 'completed'", async () => {
+    const { sandbox, calls } = await makeSandbox(
+      execHandlers([
+        { status: "running" },
+        { status: "completed", exitCode: 0, stdout: "hi" },
+      ]),
+    );
+
+    const result = await sandbox.exec("echo hi", {
+      pollInterval: 1,
+      timeout: 1000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hi");
+    const polls = calls.filter((c) => /\/process\/[^/]+$/.test(c.url));
+    expect(polls.length).toBe(2);
+  });
+
+  it("defaults a non-completed terminal status with no exitCode to non-zero", async () => {
+    const { sandbox } = await makeSandbox(execHandlers([{ status: "failed" }]));
+
+    const result = await sandbox.exec("x", { pollInterval: 1, timeout: 1000 });
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("defaults a 'completed' status with no exitCode to 0", async () => {
+    const { sandbox } = await makeSandbox(execHandlers([{ status: "completed" }]));
+
+    const result = await sandbox.exec("x", { pollInterval: 1, timeout: 1000 });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still times out when the process never reaches a terminal status", async () => {
+    const { sandbox } = await makeSandbox(execHandlers([{ status: "running" }]));
+
+    await expect(
+      sandbox.exec("sleep 999", { pollInterval: 5, timeout: 40 }),
+    ).rejects.toThrow(/timed out after 40ms/);
+  });
+
+  it("short-circuits when the create response is already terminal (no poll)", async () => {
+    const { sandbox, calls } = await makeSandbox(
+      execHandlers([], { status: "failed", exitCode: 1, stderr: "nope" }),
+    );
+
+    const result = await sandbox.exec("false", {
+      pollInterval: 1,
+      timeout: 1000,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("nope");
+    // Only the create POST happened — no GET /process/:pid poll round-trip.
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.init.method).toBe("POST");
+  });
+
+  it("waitForProcess resolves a 'failed' status with its exit code", async () => {
+    const { sandbox } = await makeSandbox([
+      (call) => {
+        if (/\/process\/p1$/.test(call.url)) {
+          return jsonResponse({ pid: "p1", status: "failed", exitCode: 2 });
+        }
+        return null;
+      },
+    ]);
+
+    const result = await sandbox.waitForProcess("p1", {
+      pollInterval: 1,
+      timeout: 1000,
+    });
+
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("execStream short-circuits a synchronously failed process without streaming", async () => {
+    const { sandbox, calls } = await makeSandbox(
+      execHandlers([], {
+        status: "failed",
+        exitCode: 1,
+        stdout: "out",
+        stderr: "err",
+      }),
+    );
+
+    const stream = await sandbox.execStream("false");
+    const lines: Array<{ stream: string; data: string }> = [];
+    for await (const line of stream.output) {
+      lines.push(line);
+    }
+
+    expect(stream.exitCode).toBe(1);
+    expect(lines).toEqual([
+      { stream: "stdout", data: "out" },
+      { stream: "stderr", data: "err" },
+    ]);
+    // The log stream endpoint was never opened for an already-finished process.
+    expect(calls.some((c) => c.url.includes("/logs/stream"))).toBe(false);
   });
 });

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -30,6 +30,45 @@ const DEFAULT_BASE_URL = "https://blaxel.services.sapiom.ai";
 const DEFAULT_POLL_INTERVAL = 1000;
 const DEFAULT_EXEC_TIMEOUT = 60_000;
 
+/**
+ * Process statuses that mean the process has finished. The Blaxel sandbox-api
+ * reports a non-zero exit as `"failed"` (enum: running/completed/failed/killed/
+ * stopped), so polling must treat all of these — not just `"completed"` — as
+ * done. Any unrecognized status keeps polling and ultimately hits the exec
+ * timeout, which is a loud, debuggable failure rather than a silent wrong result.
+ */
+const TERMINAL_PROCESS_STATUSES = new Set([
+  "completed",
+  "failed",
+  "killed",
+  "stopped",
+]);
+
+function isProcessTerminal(status: string | undefined): boolean {
+  return status !== undefined && TERMINAL_PROCESS_STATUSES.has(status);
+}
+
+/**
+ * Resolve a process exit code. A non-`"completed"` terminal status
+ * (failed/killed/stopped) that omits `exitCode` must not report success, so it
+ * defaults to a non-zero code.
+ */
+function terminalExitCode(s: { status: string; exitCode?: number }): number {
+  return s.exitCode ?? (s.status === "completed" ? 0 : 1);
+}
+
+function toExecResult(
+  pid: string,
+  s: { status: string; exitCode?: number; stdout?: string; stderr?: string },
+): ExecResult {
+  return {
+    pid,
+    exitCode: terminalExitCode(s),
+    stdout: s.stdout ?? "",
+    stderr: s.stderr ?? "",
+  };
+}
+
 function assertRelativePath(path: string): void {
   const segments = path.split("/");
   for (const seg of segments) {
@@ -454,14 +493,9 @@ export class SapiomSandbox {
   async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
     const proc = await this._createProcess(command, opts);
 
-    // If the process already completed synchronously, return immediately
-    if (proc.status === "completed") {
-      return {
-        pid: proc.pid,
-        exitCode: proc.exitCode ?? 0,
-        stdout: proc.stdout ?? "",
-        stderr: proc.stderr ?? "",
-      };
+    // If the process already finished synchronously, return immediately
+    if (isProcessTerminal(proc.status)) {
+      return toExecResult(proc.pid, proc);
     }
 
     const waitForCompletion = opts?.waitForCompletion ?? true;
@@ -493,11 +527,11 @@ export class SapiomSandbox {
   ): Promise<StreamingExecResult> {
     const proc = await this._createProcess(command, opts);
 
-    // If the process already completed synchronously, return without
+    // If the process already finished synchronously, return without
     // opening the log stream — yield the stdout/stderr from the create
     // response directly.
-    if (proc.status === "completed") {
-      const code = proc.exitCode ?? 0;
+    if (isProcessTerminal(proc.status)) {
+      const code = terminalExitCode(proc);
       const stdout = proc.stdout ?? "";
       const stderr = proc.stderr ?? "";
       const output = (async function* (): AsyncGenerator<OutputLine> {
@@ -585,9 +619,9 @@ export class SapiomSandbox {
       let status =
         (await statusResponse.json()) as ProcessStatusResponse;
 
-      // If the process hasn't completed yet (e.g. stream disconnected
+      // If the process hasn't finished yet (e.g. stream disconnected
       // before the process finished), poll until it does.
-      while (status.status !== "completed") {
+      while (!isProcessTerminal(status.status)) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const retry = await fetchFn(
           `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandboxName)}/process/${proc.pid}`,
@@ -602,7 +636,7 @@ export class SapiomSandbox {
         status = (await retry.json()) as ProcessStatusResponse;
       }
 
-      finalExitCode = status.exitCode ?? 0;
+      finalExitCode = terminalExitCode(status);
     }
 
     return {
@@ -729,13 +763,8 @@ export class SapiomSandbox {
 
       const status = (await response.json()) as ProcessStatusResponse;
 
-      if (status.status === "completed") {
-        return {
-          pid,
-          exitCode: status.exitCode ?? 0,
-          stdout: status.stdout ?? "",
-          stderr: status.stderr ?? "",
-        };
+      if (isProcessTerminal(status.status)) {
+        return toExecResult(pid, status);
       }
 
       await new Promise((resolve) => setTimeout(resolve, pollInterval));


### PR DESCRIPTION
The sandbox SDK's process polling only treated `status === "completed"` as finished, so any command that exited non-zero (reported by the sandbox-api as `"failed"`) was never recognized as done — `exec`/`execStream`/`waitForProcess` kept polling until the exec timeout and then threw, even though the command had finished in ~1s. This change makes all terminal statuses (`completed`, `failed`, `killed`, `stopped`) resolve with the real exit code, and defaults a terminal status that omits an exit code to non-zero so a failure can't be silently read as success. It adds 10 unit tests covering the regression, each terminal status, the polling/timeout backstop, and the synchronous short-circuit paths, plus a patch changeset for `@sapiom/sandbox`. This is the durable SDK-side fix for a process-hang that a downstream workflow was previously mitigating with a client-side workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)