### PR TITLE
fix(sandbox): republish 0.8.2 to resolve workspace dependency

### DIFF
--- a/.changeset/sandbox-republish-workspace-dep.md
+++ b/.changeset/sandbox-republish-workspace-dep.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/sandbox": patch
+---
+
+Republish to fix the `@sapiom/fetch` dependency. The `0.8.1` artifact shipped with the unresolved `workspace:*` specifier, making it uninstallable; this release ships it resolved to a real version range.


### PR DESCRIPTION
## What

Adds a patch changeset for `@sapiom/sandbox` to cut **0.8.2**.

## Why

`@sapiom/sandbox@0.8.1` was published with its dependency left as `"@sapiom/fetch": "workspace:*"` — the unresolved monorepo specifier leaked into the published artifact, so `npm install @sapiom/sandbox@0.8.1` fails with `EUNSUPPORTEDPROTOCOL`. `0.8.0` correctly shipped `"@sapiom/fetch": "0.5.0"`.

The source spec (`workspace:*`) is correct; the publish step is what resolves it. This bump republishes via the normal `pnpm changeset publish` path, which rewrites the workspace protocol to a real version range.

## Verify after publish

```
npm view @sapiom/sandbox@0.8.2 dependencies   # should show @sapiom/fetch: 0.5.0, not workspace:*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)