### PR TITLE
fix(ci): surface real error from npm publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,13 +40,21 @@ jobs:
       - name: Publish to npm
         id: publish
         run: |
-          OUTPUT=$(pnpm changeset publish 2>&1)
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "@sapiom/mcp@"; then
+          # Stream output live and capture the real exit code. The previous
+          # `OUTPUT=$(...)` form ran under `set -e`, so a failed publish killed
+          # the step on the assignment before its output could be printed —
+          # hiding the actual error. `tee` keeps the log visible; PIPESTATUS
+          # preserves the publish exit code so we still fail on a real failure.
+          set +e
+          pnpm changeset publish 2>&1 | tee publish.log
+          STATUS=${PIPESTATUS[0]}
+          set -e
+          if grep -q "@sapiom/mcp@" publish.log; then
             echo "mcp-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mcp-changed=false" >> "$GITHUB_OUTPUT"
           fi
+          exit "$STATUS"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

When the **Publish** workflow's `Publish to npm` step fails, the log shows only `Process completed with exit code 1` — no actual error. This has masked the real cause of recent release failures.

Root cause: the step runs under `bash -e` and does
```bash
OUTPUT=$(pnpm changeset publish 2>&1)
echo "$OUTPUT"
```
When `pnpm changeset publish` fails, the **command substitution / assignment** inherits the non-zero exit code, and `set -e` terminates the step **before** `echo "$OUTPUT"` runs. The captured error is discarded.

## Fix

Stream the publish output through `tee` (so it's always in the log), capture the publish exit code via `PIPESTATUS`, still derive the `mcp-changed` output, then `exit` with the real status so genuine failures still fail the job.

```bash
set +e
pnpm changeset publish 2>&1 | tee publish.log
STATUS=${PIPESTATUS[0]}
set -e
if grep -q "@sapiom/mcp@" publish.log; then ... fi
exit "$STATUS"
```

## Note

This is a **visibility** fix — it does not change publish behavior. The underlying reason CI currently fails is that the `NPM_TOKEN` secret cannot satisfy npm's 2FA policy on publish; that needs a separate token rotation (granular access token with "Bypass 2FA" enabled). This PR ensures that error (and any future one) is actually printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)