### PR TITLE
add `@sapiom/tools` with sandbox ported

### DIFF
--- a/packages/tools/.eslintrc.js
+++ b/packages/tools/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,0 +1,71 @@
+# @sapiom/tools
+
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, and coding agents — authenticated to your tenant.
+
+These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
+
+```bash
+npm install @sapiom/tools
+# or
+pnpm add @sapiom/tools
+```
+
+## Quickstart
+
+```typescript
+import { createClient } from "@sapiom/tools";
+
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// Create a repo, have a coding agent build into it, then publish.
+const repo = await sapiom.repositories.create("landing-page");
+const run = await sapiom.agent.coding.run({
+  task: "Build a one-page marketing site in index.html.",
+  gitRepository: repo, // cloned into the run's sandbox at /workspace/landing-page
+});
+
+if (run.result?.success) {
+  const { sha } = await repo.pushFromSandbox(run.sandbox, { message: "build: landing" });
+  console.log("published", sha);
+}
+```
+
+## Authentication
+
+There are two ways to authenticate, both exposing the identical capability surface:
+
+- **Explicit** — pass a key to `createClient`. This is the standalone entry point:
+  ```typescript
+  const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+  await sapiom.sandboxes.create({ name: "demo" });
+  ```
+- **Ambient** — import the namespaces directly and they resolve credentials from `SAPIOM_API_KEY` (or, inside a Sapiom workflow step, from the client the runtime provides):
+  ```typescript
+  import { sandboxes, repositories, agent } from "@sapiom/tools";
+  await sandboxes.create({ name: "demo" });
+  ```
+
+## Capabilities
+
+Each capability is a namespace, importable from the barrel or its own subpath (e.g. `@sapiom/tools/sandboxes`). Every capability has its own README with usage details, preconditions, and gotchas the type signatures can't express — read it before first use.
+
+| Namespace | What it is | Docs |
+|---|---|---|
+| `sandboxes` | Isolated, ephemeral compute | [src/sandboxes](./src/sandboxes/README.md) |
+| `repositories` | Private, in-network git repos | [src/repositories](./src/repositories/README.md) |
+| `agent` | Coding agents (LLM execution) | [src/agent](./src/agent/README.md) |
+
+## Composing capabilities
+
+Capabilities are designed to work together. A coding `agent` run hands back the live `Sandbox` it executed in, and a `Repository` can publish a working tree straight from that sandbox:
+
+```typescript
+const run = await agent.coding.run({ task, gitRepository: repo });
+await repo.pushFromSandbox(run.sandbox);
+```
+
+A useful pattern: let the agent do the open-ended work (writing files) and perform exact, repeatable actions — committing, pushing, deploying — in your own code rather than in the agent's prompt. The agent produces the changes; `pushFromSandbox` publishes them deterministically.
+
+## License
+
+MIT

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -45,6 +45,22 @@ There are two ways to authenticate, both exposing the identical capability surfa
   await sandboxes.create({ name: "demo" });
   ```
 
+## Attribution
+
+Calls can be attributed to an agent and trace so they show up correctly in your transaction history. Attribution is set **once, on the client** — not per call:
+
+```typescript
+const sapiom = createClient({
+  apiKey: process.env.SAPIOM_API_KEY,
+  attribution: { agentName: "digest-bot", traceId },
+});
+// every call this client makes is now attributed to digest-bot / traceId
+```
+
+Inside a Sapiom workflow you don't set this at all — the runtime constructs the client with the running execution's attribution, so every tool call is attributed automatically.
+
+If a single process makes calls on behalf of more than one agent or trace, derive a client per context with `sapiom.withAttribution({ ... })`.
+
 ## Capabilities
 
 Each capability is a namespace, importable from the barrel or its own subpath (e.g. `@sapiom/tools/sandboxes`). Every capability has its own README with usage details, preconditions, and gotchas the type signatures can't express — read it before first use.

--- a/packages/tools/jest.config.js
+++ b/packages/tools/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: 'node',
+  passWithNoTests: true,
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.ts',
+    '!src/**/*.spec.ts',
+    '!src/index.ts',
+  ],
+};

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@sapiom/tools",
+  "version": "0.0.0",
+  "description": "Typed client for Sapiom capabilities (sandboxes, repositories, agent, …) — the same tools your agents call over MCP, callable from your code, auth'd to your tenant.",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./sandboxes": {
+      "types": "./dist/cjs/sandboxes/index.d.ts",
+      "import": "./dist/esm/sandboxes/index.js",
+      "require": "./dist/cjs/sandboxes/index.js"
+    },
+    "./repositories": {
+      "types": "./dist/cjs/repositories/index.d.ts",
+      "import": "./dist/esm/repositories/index.js",
+      "require": "./dist/cjs/repositories/index.js"
+    },
+    "./agent": {
+      "types": "./dist/cjs/agent/index.d.ts",
+      "import": "./dist/esm/agent/index.js",
+      "require": "./dist/cjs/agent/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src/**/README.md",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "npm run build:cjs && npm run build:esm && npm run build:esm-pkg",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build:esm-pkg": "echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc --watch --project tsconfig.cjs.json",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepublishOnly": "pnpm build"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Auth + transport core for `@sapiom/tools` — the private "runtime half" every
+ * capability namespace wraps. Capability modules call THIS; they never import each
+ * other's runtime, so the cross-capability mesh (`repo.pushFromSandbox(sandbox)`)
+ * has no package/module cycles. See docs/plans/capability-authoring-sdk.md.
+ *
+ * The credential resolves from one of two sources, same surface either way:
+ *   - explicit:  createClient({ apiKey })  — standalone / open-source use
+ *   - ambient:   SAPIOM_API_KEY (env), which the workflow engine injects per
+ *                execution so step authors write zero auth plumbing.
+ */
+
+export interface TransportConfig {
+  /** Explicit tenant API key. Omit inside a workflow step — the engine injects it ambiently. */
+  apiKey?: string;
+  /** Inject a fetch (tests / non-standard runtimes). Defaults to global fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export class Transport {
+  private readonly apiKey: string | undefined;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(config: TransportConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.SAPIOM_API_KEY ?? undefined;
+    this.fetchImpl = config.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Authenticated raw fetch — capabilities that need streaming or custom
+   * response handling (filesystem, log streams) use this and inspect the
+   * `Response` themselves. Injects the tenant credential; sets no content-type.
+   */
+  async fetch(url: string, init: RequestInit = {}): Promise<Response> {
+    if (!this.apiKey) {
+      throw new Error(
+        "@sapiom/tools: no tenant credential. Pass createClient({ apiKey }) for standalone use, " +
+          "or run inside a Sapiom workflow (the engine injects SAPIOM_API_KEY).",
+      );
+    }
+    return this.fetchImpl(url, {
+      ...init,
+      headers: { "x-sapiom-api-key": this.apiKey, ...(init.headers ?? {}) },
+    });
+  }
+
+  /** Authenticated JSON request — parses the body and throws on a non-2xx status. */
+  async request<T>(url: string, init: RequestInit = {}): Promise<T> {
+    const res = await this.fetch(url, {
+      ...init,
+      headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+    });
+    if (!res.ok) {
+      throw new Error(`${init.method ?? "GET"} ${url} → ${res.status} ${await res.text()}`);
+    }
+    return (await res.json()) as T;
+  }
+}
+
+/** The ambient default transport used by barrel-imported capabilities when no client is supplied. */
+let _default: Transport | undefined;
+export function defaultTransport(): Transport {
+  return (_default ??= new Transport());
+}

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -8,28 +8,99 @@
  *   - explicit:  createClient({ apiKey })  — standalone / open-source use
  *   - ambient:   SAPIOM_API_KEY (env), which the workflow engine injects per
  *                execution so step authors write zero auth plumbing.
+ *
+ * Attribution (which agent / trace a call belongs to) is execution context the
+ * runtime owns, NOT a parameter of any operation — so it lives here on the
+ * transport, set once and injected on every request, never threaded through
+ * capability methods. The engine sets it per execution by constructing the
+ * per-execution client; `withAttribution(...)` is a quiet escape hatch for the
+ * router / standalone cases. Capability method signatures deliberately have no
+ * attribution argument: that absence keeps LLM-authored step code from setting
+ * (and getting wrong) context it doesn't own.
  */
+
+/**
+ * Per-request attribution recorded with the gateway transaction. Every field is
+ * optional and maps 1:1 to an `x-sapiom-*` header the collapsed flow understands.
+ */
+export interface Attribution {
+  /** Human-readable agent name. Mutually exclusive with `agentId` (gateway-enforced). */
+  agentName?: string;
+  /** Agent UUID. Mutually exclusive with `agentName` (gateway-enforced). */
+  agentId?: string;
+  /** Sapiom trace id to attribute this call to. */
+  traceId?: string;
+  /** Your own external trace / correlation id. */
+  traceExternalId?: string;
+  /** Arbitrary JSON object stored with the transaction. Must be an object. */
+  metadata?: Record<string, unknown>;
+}
 
 export interface TransportConfig {
   /** Explicit tenant API key. Omit inside a workflow step — the engine injects it ambiently. */
   apiKey?: string;
   /** Inject a fetch (tests / non-standard runtimes). Defaults to global fetch. */
   fetch?: typeof globalThis.fetch;
+  /** Default attribution applied to every request this transport makes (see class doc). */
+  attribution?: Attribution;
+}
+
+function attributionToHeaders(a: Attribution): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (a.agentName) h["x-sapiom-agent-name"] = a.agentName;
+  if (a.agentId) h["x-sapiom-agent-id"] = a.agentId;
+  if (a.traceId) h["x-sapiom-trace-id"] = a.traceId;
+  if (a.traceExternalId) h["x-sapiom-trace-external-id"] = a.traceExternalId;
+  if (a.metadata) h["x-sapiom-metadata"] = JSON.stringify(a.metadata);
+  return h;
+}
+
+/**
+ * Standalone-only ambient attribution. Read once for the process-global default
+ * transport. NOT the engine's injection channel — `process.env` is process-wide,
+ * so it would bleed across step executions that share a worker. The engine sets
+ * attribution by constructing the per-execution client instead. Safe only for the
+ * one-execution-per-process case (CLI, scripts).
+ */
+function attributionFromEnv(): Attribution {
+  const a: Attribution = {};
+  if (process.env.SAPIOM_AGENT_ID) a.agentId = process.env.SAPIOM_AGENT_ID;
+  if (process.env.SAPIOM_AGENT_NAME) a.agentName = process.env.SAPIOM_AGENT_NAME;
+  if (process.env.SAPIOM_TRACE_ID) a.traceId = process.env.SAPIOM_TRACE_ID;
+  if (process.env.SAPIOM_TRACE_EXTERNAL_ID) a.traceExternalId = process.env.SAPIOM_TRACE_EXTERNAL_ID;
+  return a;
 }
 
 export class Transport {
   private readonly apiKey: string | undefined;
   private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly attribution: Attribution;
 
   constructor(config: TransportConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.SAPIOM_API_KEY ?? undefined;
     this.fetchImpl = config.fetch ?? globalThis.fetch;
+    this.attribution = config.attribution ?? {};
+  }
+
+  /**
+   * A new transport sharing this one's credential and fetch, with `attribution`
+   * merged over the current defaults. The escape hatch for the cases where one
+   * process attributes to many agents/traces (a router) — not something
+   * step-authoring code reaches for.
+   */
+  withAttribution(attribution: Attribution): Transport {
+    return new Transport({
+      apiKey: this.apiKey,
+      fetch: this.fetchImpl,
+      attribution: { ...this.attribution, ...attribution },
+    });
   }
 
   /**
    * Authenticated raw fetch — capabilities that need streaming or custom
    * response handling (filesystem, log streams) use this and inspect the
-   * `Response` themselves. Injects the tenant credential; sets no content-type.
+   * `Response` themselves. Injects the tenant credential + attribution headers;
+   * sets no content-type.
    */
   async fetch(url: string, init: RequestInit = {}): Promise<Response> {
     if (!this.apiKey) {
@@ -40,7 +111,11 @@ export class Transport {
     }
     return this.fetchImpl(url, {
       ...init,
-      headers: { "x-sapiom-api-key": this.apiKey, ...(init.headers ?? {}) },
+      headers: {
+        "x-sapiom-api-key": this.apiKey,
+        ...attributionToHeaders(this.attribution),
+        ...(init.headers ?? {}),
+      },
     });
   }
 
@@ -60,5 +135,5 @@ export class Transport {
 /** The ambient default transport used by barrel-imported capabilities when no client is supplied. */
 let _default: Transport | undefined;
 export function defaultTransport(): Transport {
-  return (_default ??= new Transport());
+  return (_default ??= new Transport({ attribution: attributionFromEnv() }));
 }

--- a/packages/tools/src/agent/README.md
+++ b/packages/tools/src/agent/README.md
@@ -1,0 +1,36 @@
+# agent
+
+Coding agents — give one a task in natural language and it edits a checkout inside a sandbox.
+
+```ts
+import { agent, repositories } from "@sapiom/tools";
+
+const repo = await repositories.create("api");
+const run = await agent.coding.run({
+  task: "Add a /health endpoint that returns 200 OK.",
+  gitRepository: repo, // cloned into the sandbox at /workspace/api with push access
+});
+if (run.result?.success) await repo.pushFromSandbox(run.sandbox, { message: "feat: health" });
+```
+
+## Things to know
+
+- **`run` blocks until the agent finishes; `launch` doesn't.** `run` polls to completion, which for a real task can take several minutes. Use `launch` when you'd rather kick off the run, do other work, and check on it yourself with `handle.status()` or `handle.wait()`.
+
+- **`gitRepository` sets up the checkout for you.** Passing a repository clones it into the sandbox at `/workspace/<slug>` with push access already configured — which is exactly what `repo.pushFromSandbox(run.sandbox)` needs afterward. Without it, the agent works in an empty sandbox and there's nothing to push.
+
+- **The sandbox stays alive after the run by default.** This lets a later step read files, run commands, or push from it. Pass `keepSandbox: false` to tear it down automatically when the run finishes (after which you can't push from it).
+
+- **The returned `sandbox` is a live handle.** Use it directly — `run.sandbox.readFile(...)`, `run.sandbox.exec(...)`, `repo.pushFromSandbox(run.sandbox)`. Pass it back as `spec.sandbox` on a follow-up run to chain agents in the same environment.
+
+- **Keep exact, repeatable steps out of the task.** Have the agent write code, and perform actions like git pushes or deploys in your own code (see `repositories.pushFromSandbox`). A `result.success` of `true` means the agent finished — not that anything was published.
+
+- **`workingDirectory` is relative to the run's workspace, not the filesystem root.** Leave it unset to default to the repo checkout (or a fresh per-run workspace); set it to point the agent at a subdirectory.
+
+- **Each run is billed.** Runs that fail or are aborted still cost. Check `run.result?.success` and `run.error` before relying on a run's output.
+
+## Reference
+
+`agent.coding.run(spec)` · `agent.coding.launch(spec)`
+
+See the exported types (`CodingRunSpec`, `CodingRunResult`, `RunHandle`) for full signatures.

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -1,0 +1,208 @@
+/**
+ * `agent` capability — LLM execution (coding agents). The fuzzy counterpart to a
+ * deterministic step: hand it a task in natural language, it edits a checkout in a
+ * sandbox.
+ *
+ *   import { agent, repositories } from "@sapiom/tools";
+ *   const repo = await repositories.create("landing");
+ *   const run = await agent.coding.run({
+ *     task: "Build a one-page landing site in index.html.",
+ *     gitRepository: repo,        // auto-cloned into the sandbox at /workspace/<slug>
+ *   });
+ *   await repo.pushFromSandbox(run.sandbox, { message: "build: landing" });
+ *
+ * `run` awaits completion; `launch` returns a handle to poll yourself. Both return
+ * a live `Sandbox` handle so a later step can read files, exec, or push from it.
+ * The cross-capability inputs (`gitRepository: Repository`, `sandbox: Sandbox`) are
+ * passed as instances and resolved here to their wire ids.
+ *
+ * The wire contract is the gateway's JSON:API-shaped envelope (`data.attributes` /
+ * `data.relationships.execution_environment`). Attributes are snake_case on the
+ * wire; this module maps them to the camelCase SDK surface below.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { Sandbox } from "../sandboxes/index.js";
+import type { Repository } from "../repositories/index.js";
+
+const DEFAULT_BASE_URL = process.env.SAPIOM_AGENTS_URL || "https://agents.services.sapiom.ai";
+
+/** Run lifecycle, mirrored from the gateway's `AgentsRunStatus`. */
+export type RunStatus = "pending" | "queued" | "running" | "completed" | "failed";
+const TERMINAL = new Set<RunStatus>(["completed", "failed"]);
+
+export interface CodingRunSpec {
+  /** Natural-language instruction for the coding agent. */
+  task: string;
+  /** Repo to clone into the sandbox at `/workspace/<slug>` and operate on. */
+  gitRepository?: Repository;
+  /** Reuse an existing sandbox instead of provisioning a fresh one. */
+  sandbox?: Sandbox;
+  /** Subdirectory (under the runner root) the agent SDK runs in. */
+  workingDirectory?: string;
+  /** Keep the sandbox alive after the run finishes. SDK default: true (the mesh needs it). */
+  keepSandbox?: boolean;
+  /** Override the model the agent runs on. */
+  model?: string;
+}
+
+export interface CodingRunUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  thinkingTokens: number;
+}
+
+export interface CodingRunOutcome {
+  success: boolean;
+  turns: number;
+  modelUsed: string | null;
+  durationMs: number;
+  toolCallCount: number;
+  usage: CodingRunUsage;
+}
+
+export interface CodingRunError {
+  /** `launch` (failed before the agent ran) vs `run` (failed mid-execution). */
+  stage: string;
+  message: string;
+}
+
+export interface CodingRunResult {
+  runId: string;
+  status: RunStatus;
+  summary: string | null;
+  result: CodingRunOutcome | null;
+  error: CodingRunError | null;
+  /** Live handle to the sandbox the run executed in. */
+  sandbox: Sandbox;
+}
+
+/** A launched-but-not-awaited run. */
+export interface RunHandle {
+  runId: string;
+  sandbox: Sandbox;
+  /** Fetch the current status without blocking. */
+  status(): Promise<RunStatus>;
+  /** Poll to a terminal state and resolve the full result. */
+  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<CodingRunResult>;
+}
+
+// --- wire shapes (snake_case, as served by the gateway serializer) ---
+
+interface WireResult {
+  success: boolean;
+  turns: number;
+  model_used: string | null;
+  duration_ms: number;
+  tool_call_count: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_tokens?: number;
+    cache_create_tokens?: number;
+    thinking_tokens?: number;
+  };
+}
+
+interface RunDoc {
+  data: {
+    id: string;
+    attributes: {
+      status: RunStatus;
+      summary?: string | null;
+      result?: WireResult | null;
+      error?: { stage: string; message: string } | null;
+    };
+    relationships?: { execution_environment?: { data?: { id: string } } };
+  };
+}
+
+function mapResult(r: WireResult | null | undefined): CodingRunOutcome | null {
+  if (!r) return null;
+  return {
+    success: r.success,
+    turns: r.turns,
+    modelUsed: r.model_used ?? null,
+    durationMs: r.duration_ms,
+    toolCallCount: r.tool_call_count,
+    usage: {
+      inputTokens: r.usage?.input_tokens ?? 0,
+      outputTokens: r.usage?.output_tokens ?? 0,
+      cacheReadTokens: r.usage?.cache_read_tokens ?? 0,
+      cacheCreateTokens: r.usage?.cache_create_tokens ?? 0,
+      thinkingTokens: r.usage?.thinking_tokens ?? 0,
+    },
+  };
+}
+
+function buildBody(spec: CodingRunSpec): Record<string, unknown> {
+  return {
+    task: spec.task,
+    git_repository: spec.gitRepository?.slug,
+    execution_environment_id: spec.sandbox?.name,
+    working_directory: spec.workingDirectory,
+    keep_sandbox: spec.keepSandbox ?? true,
+    model: spec.model,
+  };
+}
+
+export async function launch(
+  spec: CodingRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<RunHandle> {
+  // 202 + a launch document; the execution_environment relationship is always present.
+  const doc = await transport.request<RunDoc>(`${baseUrl}/v1/coding/runs`, {
+    method: "POST",
+    body: JSON.stringify(buildBody(spec)),
+  });
+  const runId = doc.data.id;
+  const envId = doc.data.relationships?.execution_environment?.data?.id;
+  // Reuse the caller's sandbox handle when they supplied one; otherwise adopt the
+  // environment the run provisioned (its id is the sandbox name) so later steps
+  // can act on it.
+  const sandbox = spec.sandbox ?? Sandbox.attach(envId ?? runId, {}, transport);
+
+  const fetchDoc = () => transport.request<RunDoc>(`${baseUrl}/v1/coding/runs/${encodeURIComponent(runId)}`);
+  const toResult = (d: RunDoc): CodingRunResult => ({
+    runId,
+    status: d.data.attributes.status,
+    summary: d.data.attributes.summary ?? null,
+    result: mapResult(d.data.attributes.result),
+    error: d.data.attributes.error ?? null,
+    sandbox,
+  });
+
+  return {
+    runId,
+    sandbox,
+    async status() {
+      return (await fetchDoc()).data.attributes.status;
+    },
+    async wait({ timeoutMs = 20 * 60_000, pollMs = 3_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (TERMINAL.has(d.data.attributes.status)) return toResult(d);
+        if (Date.now() > deadline) {
+          throw new Error(`coding run ${runId} timed out after ${timeoutMs}ms (last status: ${d.data.attributes.status})`);
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+export async function run(
+  spec: CodingRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<CodingRunResult> {
+  const handle = await launch(spec, transport, baseUrl);
+  return handle.wait();
+}
+
+/** Ambient-bound `agent.coding` namespace. */
+export const coding = { run, launch };

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -1,0 +1,62 @@
+/**
+ * `createClient` — builds a `Sapiom` client whose capability namespaces are bound
+ * to an explicit credential. This is the standalone / open-source entry point:
+ *
+ *   import { createClient } from "@sapiom/tools";
+ *   const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+ *   const box = await sapiom.sandboxes.create({ name: "demo" });
+ *
+ * Inside a workflow step the engine hands you an already-auth'd `sapiom` of this
+ * same shape; you can also barrel-import the ambient-bound namespaces directly
+ * (`import { sandbox } from "@sapiom/tools"`).
+ */
+import { Transport, type TransportConfig } from "./_client/index.js";
+import { Sandbox } from "./sandboxes/index.js";
+import type { SandboxCreateOptions } from "./sandboxes/index.js";
+import { Repository } from "./repositories/index.js";
+import { run as codingRun, launch as codingLaunch } from "./agent/index.js";
+import type { CodingRunSpec, CodingRunResult, RunHandle } from "./agent/index.js";
+
+export interface Sapiom {
+  readonly sandboxes: {
+    create(opts: SandboxCreateOptions): Promise<Sandbox>;
+    attach(name: string, opts?: { workspaceRoot?: string; baseUrl?: string }): Sandbox;
+  };
+  readonly repositories: {
+    create(slug: string): Promise<Repository>;
+    get(slug: string): Promise<Repository>;
+    list(): Promise<Repository[]>;
+    delete(slug: string): Promise<void>;
+    attach(slug: string, cloneUrl: string): Repository;
+  };
+  readonly agent: {
+    coding: {
+      run(spec: CodingRunSpec): Promise<CodingRunResult>;
+      launch(spec: CodingRunSpec): Promise<RunHandle>;
+    };
+  };
+  // domains, scrape, search, … land here as they're ported.
+}
+
+export function createClient(config?: TransportConfig): Sapiom {
+  const transport = new Transport(config);
+  return {
+    sandboxes: {
+      create: (opts) => Sandbox.create(opts, transport),
+      attach: (name, opts) => Sandbox.attach(name, opts, transport),
+    },
+    repositories: {
+      create: (slug) => Repository.create(slug, transport),
+      get: (slug) => Repository.get(slug, transport),
+      list: () => Repository.list(transport),
+      delete: (slug) => Repository.delete(slug, transport),
+      attach: (slug, cloneUrl) => Repository.attach(slug, cloneUrl, transport),
+    },
+    agent: {
+      coding: {
+        run: (spec) => codingRun(spec, transport),
+        launch: (spec) => codingLaunch(spec, transport),
+      },
+    },
+  };
+}

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -8,9 +8,13 @@
  *
  * Inside a workflow step the engine hands you an already-auth'd `sapiom` of this
  * same shape; you can also barrel-import the ambient-bound namespaces directly
- * (`import { sandbox } from "@sapiom/tools"`).
+ * (`import { sandboxes } from "@sapiom/tools"`).
+ *
+ * Attribution is set once (the engine constructs the per-execution client with
+ * it; standalone callers pass it to `createClient`), never per capability call.
+ * `withAttribution(...)` derives a client for the router case — see `_client`.
  */
-import { Transport, type TransportConfig } from "./_client/index.js";
+import { Transport, type TransportConfig, type Attribution } from "./_client/index.js";
 import { Sandbox } from "./sandboxes/index.js";
 import type { SandboxCreateOptions } from "./sandboxes/index.js";
 import { Repository } from "./repositories/index.js";
@@ -35,11 +39,17 @@ export interface Sapiom {
       launch(spec: CodingRunSpec): Promise<RunHandle>;
     };
   };
+  /**
+   * Derive a client that attributes its calls to a different agent/trace. For the
+   * router case (one process acting for many agents); step-authoring code doesn't
+   * need this — attribution is set once when the client is constructed.
+   */
+  withAttribution(attribution: Attribution): Sapiom;
   // domains, scrape, search, … land here as they're ported.
 }
 
-export function createClient(config?: TransportConfig): Sapiom {
-  const transport = new Transport(config);
+/** Bind every capability namespace to a transport. `withAttribution` rebinds to a derived one. */
+function bind(transport: Transport): Sapiom {
   return {
     sandboxes: {
       create: (opts) => Sandbox.create(opts, transport),
@@ -58,5 +68,10 @@ export function createClient(config?: TransportConfig): Sapiom {
         launch: (spec) => codingLaunch(spec, transport),
       },
     },
+    withAttribution: (attribution) => bind(transport.withAttribution(attribution)),
   };
+}
+
+export function createClient(config?: TransportConfig): Sapiom {
+  return bind(new Transport(config));
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `@sapiom/tools` — the typed Sapiom capability client.
+ *
+ * The same catalog your agents call over MCP, callable from code. Capabilities are
+ * namespaces (`sandboxes`, `repositories`, `agent`, … ), importable from the barrel
+ * or a subpath:
+ *
+ *   import { sandboxes } from "@sapiom/tools";
+ *   import { sandboxes } from "@sapiom/tools/sandboxes";
+ *
+ * Auth is implicit: ambient (engine-injected) inside a workflow step, or explicit
+ * via `createClient({ apiKey })` standalone.
+ */
+export { createClient } from "./client.js";
+export type { Sapiom } from "./client.js";
+export type { TransportConfig } from "./_client/index.js";
+
+export * as sandboxes from "./sandboxes/index.js";
+export { Sandbox } from "./sandboxes/index.js";
+
+export * as repositories from "./repositories/index.js";
+export { Repository } from "./repositories/index.js";
+
+export * as agent from "./agent/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,7 +13,7 @@
  */
 export { createClient } from "./client.js";
 export type { Sapiom } from "./client.js";
-export type { TransportConfig } from "./_client/index.js";
+export type { TransportConfig, Attribution } from "./_client/index.js";
 
 export * as sandboxes from "./sandboxes/index.js";
 export { Sandbox } from "./sandboxes/index.js";

--- a/packages/tools/src/repositories/README.md
+++ b/packages/tools/src/repositories/README.md
@@ -1,0 +1,29 @@
+# repositories
+
+Private, in-network git repositories — create, get, list, delete, and push a working tree straight from a sandbox.
+
+```ts
+import { repositories, agent } from "@sapiom/tools";
+
+const repo = await repositories.create("landing-page");
+const run = await agent.coding.run({ task: "Build index.html", gitRepository: repo });
+const { pushed, sha } = await repo.pushFromSandbox(run.sandbox, { message: "build: landing" });
+```
+
+## Things to know
+
+- **Repositories are hosted by Sapiom, not GitHub.** Clones and pushes are authenticated through the Sapiom git gateway using your tenant credentials — there are no personal access tokens or SSH keys to manage. The `cloneUrl` on a repository is the unauthenticated origin; the credentials to clone it yourself are returned when you create the repo.
+
+- **`pushFromSandbox` requires the repo to already be checked out in the sandbox.** It does not clone — it commits and pushes from the repo's checkout at `/workspace/<slug>`. The straightforward way to get that checkout is to run a coding agent with `gitRepository: repo`, which clones the repo into exactly that path with push access already configured. The two methods are meant to be used together; calling `pushFromSandbox` on a sandbox where the repo was never cloned will fail.
+
+- **`pushFromSandbox` is a no-op when there's nothing to commit.** It returns `{ pushed: false, sha: null }` rather than throwing on an empty diff. A non-null `sha` means a commit was actually created and pushed.
+
+- **Prefer pushing in code over asking the agent to push.** Have the coding agent write files, and use `pushFromSandbox` to commit and push afterward. This keeps publishing exact and repeatable instead of depending on the agent to run git correctly.
+
+- **`delete` is idempotent.** It does not throw if the repository is already gone, so it's safe to call unconditionally during cleanup.
+
+## Reference
+
+`create` · `get` · `list` · `delete` · `attach`, and on a repository instance: `pushFromSandbox` · `delete`.
+
+See the exported types for full signatures.

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -1,0 +1,144 @@
+/**
+ * `repositories` capability — in-network git repos: create, get, list, delete, and
+ * the first cross-capability mesh method, `repo.pushFromSandbox(sandbox)`.
+ *
+ *   import { repositories } from "@sapiom/tools";
+ *   const repo = await repositories.create("my-app");
+ *   // … an agent or your code writes files in a sandbox checkout of the repo …
+ *   await repo.pushFromSandbox(box, { message: "build: page" });
+ *
+ * `pushFromSandbox` is the deterministic counterpart to a fuzzy agent step: it
+ * composes the `sandboxes` capability (calls `sandbox.exec`) to commit + push the
+ * repo's working tree. It references the `Sandbox` TYPE only — no module cycle.
+ *
+ * Note: `cloneUrl` is the unauthenticated origin. The gateway authenticates clones
+ * via basic-auth (the `auth` block returned by create); inside an agent run the
+ * `gitRepository` auto-clone wires that credential into the in-sandbox origin, so
+ * `pushFromSandbox` doesn't need it.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import type { Sandbox } from "../sandboxes/index.js";
+
+const DEFAULT_BASE_URL = process.env.SAPIOM_GIT_URL || "https://git.services.sapiom.ai";
+
+/** Canonical in-sandbox checkout path (matches the agent's `gitRepository` auto-clone). */
+const checkoutDir = (slug: string) => `/workspace/${slug}`;
+
+/** `GET`/`list` shape from the git gateway. */
+interface RepoSummary {
+  slug: string;
+  cloneUrl: string;
+  status: string;
+  createdAt: string;
+}
+
+/** `POST` (create) shape — note: no `status`, and `cloneUrl` is unauthenticated. */
+interface CreateRepositoryResponse {
+  tenantId: string;
+  slug: string;
+  cloneUrl: string;
+  auth: { scheme: "basic"; username: string; password: string; example: string };
+}
+
+export interface PushResult {
+  /** False when there was nothing to commit. */
+  pushed: boolean;
+  sha: string | null;
+}
+
+/** A connected in-network repository. */
+export class Repository {
+  readonly slug: string;
+  /** Unauthenticated clone origin (see module note on auth). */
+  readonly cloneUrl: string;
+  readonly status: string;
+
+  private readonly transport: Transport;
+  private readonly baseUrl: string;
+
+  private constructor(
+    fields: { slug: string; cloneUrl: string; status: string },
+    transport: Transport,
+    baseUrl: string,
+  ) {
+    this.slug = fields.slug;
+    this.cloneUrl = fields.cloneUrl;
+    this.status = fields.status;
+    this.transport = transport;
+    this.baseUrl = baseUrl;
+  }
+
+  static async create(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository> {
+    const r = await transport.request<CreateRepositoryResponse>(`${baseUrl}/v1/git/repositories`, {
+      method: "POST",
+      body: JSON.stringify({ slug }),
+    });
+    // create doesn't return a status; a just-created repo is active.
+    return new Repository({ slug: r.slug, cloneUrl: r.cloneUrl, status: "active" }, transport, baseUrl);
+  }
+
+  static async get(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository> {
+    const r = await transport.request<RepoSummary>(`${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`);
+    return new Repository(r, transport, baseUrl);
+  }
+
+  static async list(transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository[]> {
+    const r = await transport.request<{ repositories: RepoSummary[] }>(`${baseUrl}/v1/git/repositories`);
+    return r.repositories.map((s) => new Repository(s, transport, baseUrl));
+  }
+
+  static async delete(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<void> {
+    await transport.request(`${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`, { method: "DELETE" }).catch(() => undefined);
+  }
+
+  /** Adopt a known repo without a round-trip (e.g. one returned from another step). */
+  static attach(slug: string, cloneUrl: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Repository {
+    return new Repository({ slug, cloneUrl, status: "active" }, transport, baseUrl);
+  }
+
+  /** Delete this repository. */
+  delete(): Promise<void> {
+    return Repository.delete(this.slug, this.transport, this.baseUrl);
+  }
+
+  /**
+   * Deterministically stage + commit + push this repo's working tree FROM a
+   * sandbox checkout (no LLM). Assumes the repo is checked out at the canonical
+   * `/workspace/<slug>` with an authenticated `origin` (which the agent's
+   * `gitRepository` auto-clone sets up). No-op when there's nothing to commit.
+   */
+  async pushFromSandbox(sandbox: Sandbox, opts: { message?: string } = {}): Promise<PushResult> {
+    const message = (opts.message ?? `update ${this.slug}`).replace(/'/g, ""); // single-quote-safe for sh -c
+    const script =
+      `cd ${checkoutDir(this.slug)} && git add -A && ` +
+      `if git diff --cached --quiet; then echo NO_CHANGES; else ` +
+      `git -c user.email=workflow@sapiom.ai -c user.name=sapiom-workflow commit -m "${message}" >/dev/null && ` +
+      `git push origin HEAD && printf "SHA:%s\\n" "$(git rev-parse HEAD)"; fi`;
+    const { stdout, stderr, exitCode } = await sandbox.exec(`sh -c '${script}'`);
+    const out = `${stdout}\n${stderr}`;
+    if (out.includes("NO_CHANGES")) return { pushed: false, sha: null };
+    const sha = out.match(/SHA:([0-9a-f]{7,40})/)?.[1] ?? null;
+    if (exitCode !== 0 || !sha) {
+      throw new Error(`pushFromSandbox(${this.slug}) failed (exit ${exitCode}): ${out.slice(-300)}`);
+    }
+    return { pushed: true, sha };
+  }
+}
+
+// Ambient-bound namespace functions.
+export function create(slug: string): Promise<Repository> {
+  return Repository.create(slug);
+}
+export function get(slug: string): Promise<Repository> {
+  return Repository.get(slug);
+}
+export function list(): Promise<Repository[]> {
+  return Repository.list();
+}
+export function attach(slug: string, cloneUrl: string): Repository {
+  return Repository.attach(slug, cloneUrl);
+}
+function deleteRepository(slug: string): Promise<void> {
+  return Repository.delete(slug);
+}
+export { deleteRepository as delete };

--- a/packages/tools/src/sandboxes/README.md
+++ b/packages/tools/src/sandboxes/README.md
@@ -1,0 +1,30 @@
+# sandboxes
+
+Isolated, ephemeral compute. Create a sandbox, write files, run commands, stream output, and tear it down.
+
+```ts
+import { sandboxes } from "@sapiom/tools";
+
+const box = await sandboxes.create({ name: "build-01", tier: "small" });
+await box.writeFile("/workspace/app.py", "print('hi')");
+const { stdout } = await box.exec("python /workspace/app.py");
+await box.destroy();
+```
+
+## Things to know
+
+- **Sandboxes are live and billed until you stop them.** A sandbox keeps running — and accruing cost — until you call `destroy()` or its `ttl` elapses. Destroy it in a `finally` block, or set a short `ttl`, unless a later step still needs it.
+
+- **`name` is how you find a sandbox again.** Use `attach(name)` to reconnect to an already-running sandbox — for example from another process, or one returned by a coding agent run — without provisioning a new one. `create` provisions a fresh sandbox; `attach` adopts an existing one.
+
+- **Credentials are not injected automatically.** The sandbox environment is empty by default. Pass anything your workload needs explicitly via `envs` when you create the sandbox.
+
+- **`exec` waits for the command to finish.** It returns once the command exits, with `{ exitCode, stdout, stderr }`. For commands that run longer than a single request, use `execStream` for live output, or start the process and poll it with `getProcess` / `waitForProcess`.
+
+- **`/workspace` is the conventional working directory.** Other capabilities assume it — the `agent` capability clones repos into `/workspace/<slug>`, and `repositories.pushFromSandbox` pushes from there. Keep your files under `/workspace` to stay compatible.
+
+## Reference
+
+`create` · `attach` · `exec` · `execStream` · `readFile` · `writeFile` · `getProcess` · `waitForProcess` · `destroy`
+
+See the exported types for full signatures and options.

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -1,0 +1,283 @@
+/**
+ * `sandbox` capability — an isolated, ephemeral compute instance for running code
+ * or agents securely: create, exec (sync / fire-and-forget / streaming), read &
+ * write files, then destroy. Ported from the legacy `@sapiom/sandbox` onto the
+ * `_client` transport, with the Blaxel specifics removed:
+ *   - auth comes from the transport (ambient or explicit), not per-call apiKey
+ *   - the host is a platform routing detail (overridable), not a "blaxel" concept
+ *   - custom image build (the Blaxel-runtime Dockerfile) is deferred, not exposed
+ *
+ *   import { sandbox } from "@sapiom/tools";          // ambient auth
+ *   const box = await sandbox.create({ name: "demo" });
+ *   const { stdout } = await box.exec("echo hi");
+ *   await box.destroy();
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import type {
+  CreateResponse,
+  ExecOptions,
+  ExecResult,
+  ExecStreamOptions,
+  OutputLine,
+  ProcessCreateResponse,
+  ProcessStatus,
+  SandboxCreateOptions,
+  StreamingExecResult,
+} from "./types.js";
+
+export type {
+  ExecOptions,
+  ExecResult,
+  ExecStreamOptions,
+  OutputLine,
+  PortSpec,
+  ProcessStatus,
+  SandboxCreateOptions,
+  SandboxTier,
+  StreamingExecResult,
+} from "./types.js";
+
+/** Platform sandbox service. Host routing is an internal detail — override via `baseUrl` or SAPIOM_SANDBOX_URL. */
+const DEFAULT_BASE_URL = process.env.SAPIOM_SANDBOX_URL || "https://blaxel.services.sapiom.ai";
+const DEFAULT_POLL_INTERVAL = 1000;
+const DEFAULT_EXEC_TIMEOUT = 60_000;
+
+function assertRelativePath(path: string): void {
+  if (path.split("/").some((seg) => seg === "..")) {
+    throw new Error(`Path must not contain '..' segments: ${path}`);
+  }
+}
+
+function encodePathSegments(path: string): string {
+  return path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+function parseOutputLine(line: string): OutputLine {
+  if (line.startsWith("stdout:")) return { stream: "stdout", data: line.slice(7) };
+  if (line.startsWith("stderr:")) return { stream: "stderr", data: line.slice(7) };
+  return { stream: "stdout", data: line }; // unrecognized framing — keep, don't drop
+}
+
+/** A live sandbox handle. Create via {@link create}; pass between steps to share state. */
+export class Sandbox {
+  /** Name / identifier of the sandbox. */
+  readonly name: string;
+  /** Absolute workspace root path inside the sandbox. */
+  readonly workspaceRoot: string;
+
+  private readonly transport: Transport;
+  private readonly baseUrl: string;
+
+  private constructor(name: string, workspaceRoot: string, transport: Transport, baseUrl: string) {
+    this.name = name;
+    this.workspaceRoot = workspaceRoot;
+    this.transport = transport;
+    this.baseUrl = baseUrl;
+  }
+
+  /** Create a sandbox and return a handle. Uses the ambient transport unless one is supplied. */
+  static async create(opts: SandboxCreateOptions, transport: Transport = defaultTransport()): Promise<Sandbox> {
+    if (opts.port !== undefined && opts.ports !== undefined) {
+      throw new Error("Cannot specify both 'port' and 'ports'");
+    }
+    const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+
+    const body: Record<string, unknown> = { name: opts.name };
+    if (opts.tier !== undefined) body.tier = opts.tier;
+    if (opts.ttl !== undefined) body.ttl = opts.ttl;
+    if (opts.envs !== undefined) body.envs = opts.envs;
+    if (opts.port !== undefined) body.port = opts.port;
+    if (opts.ports !== undefined) body.ports = opts.ports;
+    if (opts.image !== undefined) body.image = opts.image;
+
+    const res = await transport.fetch(`${baseUrl}/v1/sandboxes`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`Failed to create sandbox: ${res.status} ${await res.text()}`);
+
+    const data = (await res.json()) as CreateResponse;
+    return new Sandbox(data.name, data.workspaceRoot, transport, baseUrl);
+  }
+
+  /** Adopt an existing sandbox by name (e.g. one a prior step kept). */
+  static attach(name: string, opts: { workspaceRoot?: string; baseUrl?: string } = {}, transport: Transport = defaultTransport()): Sandbox {
+    return new Sandbox(name, opts.workspaceRoot ?? "/", transport, opts.baseUrl ?? DEFAULT_BASE_URL);
+  }
+
+  private fileUrl(path: string): string {
+    assertRelativePath(path);
+    const base = this.workspaceRoot.endsWith("/") ? this.workspaceRoot.slice(0, -1) : this.workspaceRoot;
+    const rel = path.startsWith("/") ? path.slice(1) : path;
+    const abs = `${base}/${rel}`.replace(/^\//, "");
+    return `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/filesystem/${encodePathSegments(abs)}`;
+  }
+
+  private procUrl(suffix = ""): string {
+    return `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/process${suffix}`;
+  }
+
+  /** Write a file (path relative to the workspace root). */
+  async writeFile(path: string, content: string): Promise<void> {
+    const res = await this.transport.fetch(this.fileUrl(path), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+    if (!res.ok) throw new Error(`Failed to write file '${path}': ${res.status} ${await res.text()}`);
+  }
+
+  /** Read a file (path relative to the workspace root). */
+  async readFile(path: string): Promise<string> {
+    const res = await this.transport.fetch(this.fileUrl(path));
+    if (!res.ok) throw new Error(`Failed to read file '${path}': ${res.status} ${await res.text()}`);
+    const data = (await res.json()) as { content: string };
+    return data.content;
+  }
+
+  /**
+   * Execute a command. Waits for completion by default; set `waitForCompletion:
+   * false` for fire-and-forget, or use {@link execStream} for real-time output.
+   */
+  async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
+    const proc = await this.createProcess(command, opts);
+    if (proc.status === "completed") {
+      return { pid: proc.pid, exitCode: proc.exitCode ?? 0, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
+    }
+    if (opts?.waitForCompletion === false) {
+      return { pid: proc.pid, exitCode: -1, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
+    }
+    return this.pollProcess(proc.pid, opts);
+  }
+
+  /** Execute a command and stream output lines in real time. `exitCode` populates after `output` drains. */
+  async execStream(command: string, opts?: ExecStreamOptions): Promise<StreamingExecResult> {
+    const proc = await this.createProcess(command, opts);
+
+    if (proc.status === "completed") {
+      const code = proc.exitCode ?? 0;
+      const stdout = proc.stdout ?? "";
+      const stderr = proc.stderr ?? "";
+      const output = (async function* (): AsyncGenerator<OutputLine> {
+        if (stdout) yield { stream: "stdout", data: stdout };
+        if (stderr) yield { stream: "stderr", data: stderr };
+      })();
+      return { pid: proc.pid, get exitCode() { return code; }, output };
+    }
+
+    let finalExitCode = -1;
+    const transport = this.transport;
+    const signal = opts?.signal;
+    const logsUrl = this.procUrl(`/${proc.pid}/logs/stream`);
+    const statusUrl = this.procUrl(`/${proc.pid}`);
+
+    async function* streamOutput(): AsyncGenerator<OutputLine> {
+      const res = await transport.fetch(logsUrl, { signal });
+      if (!res.ok) throw new Error(`Failed to stream process ${proc.pid}: ${res.status} ${await res.text()}`);
+      if (!res.body) throw new Error(`No response body for process ${proc.pid} log stream`);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop()!;
+          for (const line of lines) if (line) yield parseOutputLine(line);
+        }
+        buffer += decoder.decode();
+        if (buffer) yield parseOutputLine(buffer);
+      } finally {
+        reader.releaseLock();
+      }
+
+      let status = await readStatus();
+      while (status.status !== "completed") {
+        await new Promise((r) => setTimeout(r, 1000));
+        status = await readStatus();
+      }
+      finalExitCode = status.exitCode ?? 0;
+
+      async function readStatus(): Promise<ProcessStatus> {
+        const s = await transport.fetch(statusUrl, { signal });
+        if (!s.ok) throw new Error(`Failed to get final status for process ${proc.pid}: ${s.status} ${await s.text()}`);
+        return (await s.json()) as ProcessStatus;
+      }
+    }
+
+    return { pid: proc.pid, get exitCode() { return finalExitCode; }, output: streamOutput() };
+  }
+
+  /** Current status of a process by PID (useful for fire-and-forget execs). */
+  async getProcess(pid: string): Promise<ProcessStatus> {
+    const res = await this.transport.fetch(this.procUrl(`/${pid}`));
+    if (!res.ok) throw new Error(`Failed to get process ${pid}: ${res.status} ${await res.text()}`);
+    return (await res.json()) as ProcessStatus;
+  }
+
+  /** Wait for a process to finish by polling its status. */
+  async waitForProcess(pid: string, opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal }): Promise<ExecResult> {
+    return this.pollProcess(pid, opts);
+  }
+
+  /** Destroy the sandbox and release its resources. */
+  async destroy(): Promise<void> {
+    const res = await this.transport.fetch(`${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}`, { method: "DELETE" });
+    if (!res.ok) throw new Error(`Failed to destroy sandbox: ${res.status} ${await res.text()}`);
+  }
+
+  // --- internal ---
+
+  private async createProcess(command: string, opts?: ExecOptions): Promise<ProcessCreateResponse> {
+    const body: Record<string, unknown> = { command };
+    if (opts?.cwd !== undefined) {
+      assertRelativePath(opts.cwd);
+      const base = this.workspaceRoot.endsWith("/") ? this.workspaceRoot.slice(0, -1) : this.workspaceRoot;
+      body.cwd = `${base}/${opts.cwd.startsWith("/") ? opts.cwd.slice(1) : opts.cwd}`;
+    }
+    if (opts?.env !== undefined) body.env = opts.env;
+    if (opts?.keepAlive !== undefined) body.keepAlive = opts.keepAlive;
+    if (opts?.processTimeout !== undefined) body.timeout = opts.processTimeout;
+
+    const res = await this.transport.fetch(this.procUrl(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: opts?.signal,
+    });
+    if (!res.ok) throw new Error(`Failed to execute command: ${res.status} ${await res.text()}`);
+    return (await res.json()) as ProcessCreateResponse;
+  }
+
+  private async pollProcess(pid: string, opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal }): Promise<ExecResult> {
+    const pollInterval = opts?.pollInterval ?? DEFAULT_POLL_INTERVAL;
+    const deadline = Date.now() + (opts?.timeout ?? DEFAULT_EXEC_TIMEOUT);
+    while (Date.now() < deadline) {
+      const res = await this.transport.fetch(this.procUrl(`/${pid}`), { signal: opts?.signal });
+      if (!res.ok) throw new Error(`Failed to poll process ${pid}: ${res.status} ${await res.text()}`);
+      const status = (await res.json()) as ProcessStatus;
+      if (status.status === "completed") {
+        return { pid, exitCode: status.exitCode ?? 0, stdout: status.stdout ?? "", stderr: status.stderr ?? "" };
+      }
+      await new Promise((r) => setTimeout(r, pollInterval));
+    }
+    throw new Error(`Process ${pid} timed out after ${opts?.timeout ?? DEFAULT_EXEC_TIMEOUT}ms`);
+  }
+}
+
+/** Create a sandbox (ambient transport). The namespace's primary entry point. */
+export function create(opts: SandboxCreateOptions): Promise<Sandbox> {
+  return Sandbox.create(opts);
+}
+
+/** Adopt an existing sandbox by name (ambient transport). */
+export function attach(name: string, opts?: { workspaceRoot?: string; baseUrl?: string }): Sandbox {
+  return Sandbox.attach(name, opts);
+}

--- a/packages/tools/src/sandboxes/types.ts
+++ b/packages/tools/src/sandboxes/types.ts
@@ -1,0 +1,136 @@
+/** Memory tier for sandbox allocation. */
+export type SandboxTier = "xs" | "s" | "m" | "l" | "xl";
+
+/** Port specification for an exposed port. */
+export interface PortSpec {
+  port: number;
+  [key: string]: unknown;
+}
+
+/** Options for creating a sandbox. */
+export interface SandboxCreateOptions {
+  /** Sandbox name. Lowercase alphanumeric and hyphens, 2-63 characters. */
+  name: string;
+
+  /** Memory tier. @default 's' */
+  tier?: SandboxTier;
+
+  /** Time-to-live (e.g. '1h', '24h', '7d'). */
+  ttl?: string;
+
+  /** Environment variables to set in the sandbox. */
+  envs?: Record<string, string>;
+
+  /** Single port to expose. Mutually exclusive with `ports`. */
+  port?: number;
+
+  /** Ports to expose. Mutually exclusive with `port`. */
+  ports?: PortSpec[];
+
+  /**
+   * Pre-built image reference to launch from. The image must be reachable by the
+   * Sapiom sandbox service (e.g. a managed `sapiom/...` image or one your tenant
+   * has access to).
+   *
+   * NOTE: building a custom image from a Dockerfile is intentionally NOT exposed
+   * here yet — it requires the platform to inject the sandbox runtime agent, which
+   * shouldn't leak into the author's Dockerfile. It lands later as a properly
+   * abstracted capability. See docs/plans/capability-authoring-sdk.md.
+   */
+  image?: string;
+
+  /** Override the sandbox service base URL (platform routing detail; rarely needed). */
+  baseUrl?: string;
+}
+
+/** Options for executing a command (non-streaming). */
+export interface ExecOptions {
+  /** Working directory, resolved relative to the sandbox workspace root. */
+  cwd?: string;
+
+  /** Environment variables for the process. */
+  env?: Record<string, string>;
+
+  /**
+   * Wait for the process to finish before returning. When false, returns
+   * immediately after process creation (fire-and-forget). @default true
+   */
+  waitForCompletion?: boolean;
+
+  /** Polling interval in ms while waiting for completion. @default 1000 */
+  pollInterval?: number;
+
+  /** Timeout in ms while waiting for completion. @default 60000 */
+  timeout?: number;
+
+  /** Keep the sandbox awake (no standby) while this process runs. */
+  keepAlive?: boolean;
+
+  /** Auto-terminate the process after this many seconds (0 = no auto-termination). */
+  processTimeout?: number;
+
+  /** AbortSignal to cancel the operation. */
+  signal?: AbortSignal;
+}
+
+/** Options for streaming command execution. */
+export interface ExecStreamOptions {
+  /** Working directory, resolved relative to the sandbox workspace root. */
+  cwd?: string;
+  /** Environment variables for the process. */
+  env?: Record<string, string>;
+  /** AbortSignal to cancel the operation. */
+  signal?: AbortSignal;
+}
+
+/** A single line of process output from a streaming exec. */
+export interface OutputLine {
+  stream: "stdout" | "stderr";
+  data: string;
+}
+
+/** Result of a (non-streaming) process execution. */
+export interface ExecResult {
+  /** Process ID in the sandbox. */
+  pid: string;
+  /** Exit code. -1 when `waitForCompletion` is false and the process hasn't finished. */
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Result of a streaming process execution. Iterate `output`; `exitCode` populates after it drains. */
+export interface StreamingExecResult {
+  readonly pid: string;
+  readonly exitCode: number;
+  readonly output: AsyncIterable<OutputLine>;
+}
+
+/** Process status as reported by the sandbox service. */
+export interface ProcessStatus {
+  pid: string;
+  status: string;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  [key: string]: unknown;
+}
+
+// --- internal wire shapes (not part of the public surface) ---
+
+/** @internal Raw create response. */
+export interface CreateResponse {
+  name: string;
+  workspaceRoot: string;
+  [key: string]: unknown;
+}
+
+/** @internal Raw process-create response. */
+export interface ProcessCreateResponse {
+  pid: string;
+  status: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  [key: string]: unknown;
+}

--- a/packages/tools/tsconfig.cjs.json
+++ b/packages/tools/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/tools/tsconfig.esm.json
+++ b/packages/tools/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./dist/esm",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/tools/tsconfig.json
+++ b/packages/tools/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,36 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/tools:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.24
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.24)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.6.2
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.5(@babel/core@7.28.5)(jest@29.7.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
 packages:
 
   /@anthropic-ai/sdk@0.65.0(zod@4.1.12):


### PR DESCRIPTION
This pull request introduces the initial implementation of the `@sapiom/tools` package, providing a typed client for Sapiom capabilities. It establishes a modular structure for capability namespaces (starting with `sandbox` and `repositories`), a shared authenticated transport layer, and a unified client creation API. The package includes configuration for TypeScript, linting, and testing to support development and publishing workflows.

Key changes are grouped below:

### Core Package Infrastructure

* Added `package.json` for `@sapiom/tools`, defining entry points, build scripts (CJS/ESM), dependencies, and publishing configuration.
* Added ESLint (`.eslintrc.js`) and Jest (`jest.config.js`) configurations for code quality and testing. [[1]](diffhunk://#diff-78d15e62d85242af3d54f322ea875c2b9a0eb9e5b9b265d15b60fe3f43465bb0R1-R23) [[2]](diffhunk://#diff-5b1166ddda47ff66d51d52392e5bd02c48c2a490734751a6bfd9a376cac95e41R1-R20)

### Transport Layer

* Implemented the `Transport` class (`src/_client/index.ts`), providing authenticated HTTP requests with API key resolution (explicit or from environment), and a `defaultTransport` singleton for ambient use.

### Client API and Entry Point

* Added `createClient` function (`src/client.ts`) to instantiate a `Sapiom` client with capability namespaces bound to a credential, supporting both standalone and workflow-injected use cases.
* Created barrel export in `src/index.ts` for easy imports of the client, types, and capabilities.

### Capabilities

* Added the `repositories` capability (`src/repositories/index.ts`), supporting repository creation, retrieval, listing, deletion, and a cross-capability method `pushFromSandbox` to stage, commit, and push changes from a sandbox.

These changes lay the foundation for a modular, authenticated SDK for Sapiom capabilities, with robust developer tooling and a clear path for future capability expansion.