### PR TITLE
add `@sapiom/orchestration`, prep `@sapiom/tools`

### DIFF
--- a/packages/orchestration/.eslintrc.js
+++ b/packages/orchestration/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/orchestration/LICENSE
+++ b/packages/orchestration/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -1,0 +1,55 @@
+# @sapiom/orchestration
+
+The versioned public contract for authoring Sapiom orchestrations.
+
+A lean, dependency-light package (types + a small protocol runtime, with a single
+strictly-pinned `zod` peer) shared by three consumers:
+
+- **Customer orchestration definitions** — authored against this package's types and
+  compiled by the build.
+- **The sandbox step-runner** — reads a step's input, builds `ctx`, runs one step.
+- **The engine** — uses the directive guards + manifest schema; it never runs
+  customer code, only validates the pure-data completion payload.
+
+## Install
+
+```sh
+npm install @sapiom/orchestration zod
+```
+
+`zod` is a peer dependency, pinned to the `3.25.x` line (the SDK uses the `zod/v4`
+subpath).
+
+## Authoring surface
+
+```ts
+import { defineOrchestration, defineStep, goto, terminate } from '@sapiom/orchestration';
+
+const start = defineStep({
+  name: 'start',
+  next: ['finish'],
+  async run(input, ctx) {
+    return goto('finish', { greeting: `hello ${input.name}` });
+  },
+});
+
+const finish = defineStep({
+  name: 'finish',
+  next: [],
+  terminal: true,
+  async run() {
+    return terminate({ done: true });
+  },
+});
+
+export const hello = defineOrchestration({
+  name: 'hello',
+  entry: 'start',
+  steps: { start, finish },
+});
+```
+
+A step declares the transitions it may take (`next` / `terminal` / `canFail` /
+`pause`); the `run` return type is derived from those declarations, so an
+undeclared transition is a compile error. The build reads those same declarations
+to render the orchestration graph without executing anything.

--- a/packages/orchestration/jest.config.js
+++ b/packages/orchestration/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testEnvironment: 'node',
+  passWithNoTests: true,
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,7 +1,21 @@
 {
-  "name": "@sapiom/tools",
+  "name": "@sapiom/orchestration",
   "version": "0.1.0",
-  "description": "Typed client for Sapiom capabilities (sandboxes, repositories, agent, …) — the same tools your agents call over MCP, callable from your code, auth'd to your tenant.",
+  "description": "Versioned public contract for authoring Sapiom orchestrations: types, directive constructors/guards, defineOrchestration, defineStep, InMemoryContextStore. Shared by customer orchestration definitions, the sandbox step-runner, and the engine.",
+  "license": "MIT",
+  "author": "Sapiom",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/orchestration"
+  },
+  "keywords": [
+    "sapiom",
+    "orchestration",
+    "workflows",
+    "sdk",
+    "step-runner"
+  ],
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",
@@ -10,32 +24,17 @@
       "types": "./dist/cjs/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    },
-    "./sandboxes": {
-      "types": "./dist/cjs/sandboxes/index.d.ts",
-      "import": "./dist/esm/sandboxes/index.js",
-      "require": "./dist/cjs/sandboxes/index.js"
-    },
-    "./repositories": {
-      "types": "./dist/cjs/repositories/index.d.ts",
-      "import": "./dist/esm/repositories/index.js",
-      "require": "./dist/cjs/repositories/index.js"
-    },
-    "./agent": {
-      "types": "./dist/cjs/agent/index.d.ts",
-      "import": "./dist/esm/agent/index.js",
-      "require": "./dist/cjs/agent/index.js"
     }
   },
   "files": [
     "dist",
-    "src/**/README.md",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "scripts": {
-    "build": "npm run build:cjs && npm run build:esm && npm run build:esm-pkg",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run build:esm-pkg",
     "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:esm": "tsc --project tsconfig.esm.json",
     "build:esm-pkg": "echo '{\"type\": \"module\"}' > dist/esm/package.json",
@@ -49,6 +48,9 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "prepublishOnly": "pnpm build"
   },
+  "peerDependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^20.11.30",
@@ -58,13 +60,13 @@
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.2",
+    "zod": "^3.25.76"
   },
   "engines": {
     "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/orchestration/src/build-manifest.ts
+++ b/packages/orchestration/src/build-manifest.ts
@@ -1,0 +1,224 @@
+import { zodToJsonSchema } from './introspection.js';
+import { MANIFEST_PROTOCOL, type ManifestTransition, type WorkflowManifest } from './manifest.js';
+import type { StepDefinition } from './step.js';
+import type { OrchestrationDefinition } from './workflow.js';
+
+/**
+ * Generate a WorkflowManifest from a workflow definition and build metadata.
+ *
+ * Called by the build phase (locally via `build-definition`, in CI via the
+ * sandbox build-run). Runs in the build sandbox, never in the engine.
+ *
+ * - Walks def.steps; for each step:
+ *   - timeoutMs: step.timeoutMs if declared, null otherwise (engine applies
+ *     DEFAULT_DISPATCH_TIMEOUT_MS for null — timeout policy stays engine-side).
+ *   - inputSchema: zod→JSON Schema if step.inputSchema is declared, null
+ *     otherwise. Defaulted top-level fields are dropped from `required` so the
+ *     engine's AJV pre-check is never stricter than the sandbox's Zod parse.
+ *   - transitions: the tagged edge list, read from the step's DECLARED
+ *     `next`/`terminal`/`canFail`/`pause` runtime properties (set by
+ *     `defineStep`). This is a runtime-value read, exactly like inputSchema —
+ *     no type reflection, no AST parsing.
+ * - name/entry from def; protocol 1 (locked); sdkVersion/artifact from opts.
+ */
+export function buildManifest(
+  def: OrchestrationDefinition,
+  opts: {
+    sdkVersion: string;
+    artifact: { sha256: string; entryFile: string };
+  },
+): WorkflowManifest {
+  const steps: Record<
+    string,
+    { timeoutMs: number | null; inputSchema: Record<string, unknown> | null; transitions: ManifestTransition[] }
+  > = {};
+
+  for (const [stepName, step] of Object.entries(def.steps)) {
+    let inputSchema: Record<string, unknown> | null = null;
+    if (step.inputSchema) {
+      const raw = zodToJsonSchema(step.inputSchema);
+      inputSchema = dropDefaultedFromRequired(raw);
+    }
+    steps[stepName] = {
+      timeoutMs: step.timeoutMs ?? null,
+      inputSchema,
+      transitions: transitionsFor(step),
+    };
+  }
+
+  return {
+    protocol: MANIFEST_PROTOCOL,
+    name: def.name,
+    entry: def.entry,
+    sdkVersion: opts.sdkVersion,
+    artifact: opts.artifact,
+    steps,
+  };
+}
+
+/**
+ * Derive the tagged transition list from a step's declared capabilities. Order:
+ * one `continue` per `next` entry, then `pause`, then `terminate`, then `fail`.
+ */
+function transitionsFor(step: StepDefinition): ManifestTransition[] {
+  const transitions: ManifestTransition[] = [];
+  for (const target of step.next ?? []) {
+    transitions.push({ kind: 'continue', target });
+  }
+  if (step.pause) {
+    transitions.push({ kind: 'pause', signal: step.pause.signal, resumeStep: step.pause.resumeStep });
+  }
+  if (step.terminal) transitions.push({ kind: 'terminate' });
+  if (step.canFail) transitions.push({ kind: 'fail' });
+  return transitions;
+}
+
+// ---------------------------------------------------------------------------
+// Graph validation (build-time conformance — developer courtesy, NOT the trust
+// boundary; the engine's per-step completion check is the enforcement).
+// ---------------------------------------------------------------------------
+
+export interface GraphValidation {
+  /** Build-blocking problems (malformed graph). */
+  readonly errors: string[];
+  /** Non-blocking smells (unreachable steps, no path to a terminal). */
+  readonly warnings: string[];
+}
+
+/**
+ * Validate a manifest's graph. Errors (build should fail):
+ *   - entry step missing;
+ *   - a `continue` target that doesn't exist;
+ *   - a dead-end step (no transitions at all — can only retry, never progress).
+ * Warnings (best-effort):
+ *   - steps unreachable from entry;
+ *   - steps that cannot reach any `terminate`/`fail` (possible unbounded loop
+ *     or a missing terminal). A `pause` counts as a forward edge via resumeStep.
+ */
+export function validateGraph(manifest: WorkflowManifest): GraphValidation {
+  const errors: string[] = [];
+  const names = new Set(Object.keys(manifest.steps));
+
+  if (!names.has(manifest.entry)) {
+    errors.push(`entry step '${manifest.entry}' is not in the steps map`);
+  }
+
+  // Forward edges (continue targets + pause resumeStep); also records
+  // continue-target-missing + dead-end errors as a side effect.
+  const forward = buildForwardEdges(manifest, names, errors);
+
+  const warnings: string[] = [];
+  if (names.has(manifest.entry)) {
+    const reachable = bfs([manifest.entry], forward);
+    for (const name of names) {
+      if (!reachable.has(name)) warnings.push(`step '${name}' is unreachable from entry '${manifest.entry}'`);
+    }
+  }
+  warnings.push(...terminalReachabilityWarnings(manifest, names, forward));
+
+  return { errors, warnings };
+}
+
+/** Throw if the graph has errors; return warnings. Used by the build phase. */
+export function assertValidGraph(manifest: WorkflowManifest): string[] {
+  const { errors, warnings } = validateGraph(manifest);
+  if (errors.length > 0) {
+    throw new Error(`Invalid workflow graph for '${manifest.name}':\n  - ${errors.join('\n  - ')}`);
+  }
+  return warnings;
+}
+
+/**
+ * Build the forward adjacency map (continue targets + pause resumeStep). Pushes
+ * a continue-target-missing error per unknown target and a dead-end error for a
+ * step that declares no transitions at all.
+ */
+function buildForwardEdges(manifest: WorkflowManifest, names: Set<string>, errors: string[]): Map<string, Set<string>> {
+  const forward = new Map<string, Set<string>>();
+  for (const [name, step] of Object.entries(manifest.steps)) {
+    const targets = new Set<string>();
+    for (const t of step.transitions) {
+      if (t.kind === 'continue') {
+        if (names.has(t.target)) targets.add(t.target);
+        else errors.push(`step '${name}' has a continue target '${t.target}' that is not in the steps map`);
+      } else if (t.kind === 'pause' && names.has(t.resumeStep)) {
+        targets.add(t.resumeStep);
+      }
+    }
+    if (step.transitions.length === 0) {
+      errors.push(`step '${name}' is a dead-end: it declares no transitions (next/terminal/canFail/pause)`);
+    }
+    forward.set(name, targets);
+  }
+  return forward;
+}
+
+/**
+ * Warn about steps that cannot reach any `terminate`/`fail` sink (possible
+ * unbounded loop or missing terminal) — computed by reverse BFS from the sinks.
+ */
+function terminalReachabilityWarnings(
+  manifest: WorkflowManifest,
+  names: Set<string>,
+  forward: Map<string, Set<string>>,
+): string[] {
+  const sinks = Object.entries(manifest.steps)
+    .filter(([, s]) => s.transitions.some((t) => t.kind === 'terminate' || t.kind === 'fail'))
+    .map(([name]) => name);
+  if (sinks.length === 0) {
+    return ['no step can terminate or fail — the workflow has no terminal state'];
+  }
+
+  const reverse = new Map<string, Set<string>>();
+  for (const name of names) reverse.set(name, new Set());
+  for (const [name, targets] of forward) {
+    for (const t of targets) reverse.get(t)?.add(name);
+  }
+
+  const canReach = bfs(sinks, reverse);
+  const warnings: string[] = [];
+  for (const name of names) {
+    if (!canReach.has(name)) {
+      warnings.push(`step '${name}' cannot reach any terminate/fail (possible unbounded loop or missing terminal)`);
+    }
+  }
+  return warnings;
+}
+
+/** Multi-source BFS over an adjacency map; returns the set of reachable nodes. */
+function bfs(starts: readonly string[], edges: Map<string, Set<string>>): Set<string> {
+  const seen = new Set<string>();
+  const queue = [...starts];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    for (const next of edges.get(cur) ?? []) if (!seen.has(next)) queue.push(next);
+  }
+  return seen;
+}
+
+/**
+ * Remove from the JSON Schema's top-level `required` array any key that also
+ * appears in `properties` with a `default` value. This prevents the engine's
+ * AJV pre-check from falsely rejecting inputs where a caller omits a field
+ * that Zod would supply via its default. Operates only on the top level;
+ * nested objects are out of scope for v1.
+ */
+function dropDefaultedFromRequired(schema: Record<string, unknown>): Record<string, unknown> {
+  const required = schema.required;
+  const properties = schema.properties;
+  if (!Array.isArray(required) || !properties || typeof properties !== 'object') {
+    return schema;
+  }
+  const props = properties as Record<string, unknown>;
+  const filtered = required.filter((key) => {
+    if (typeof key !== 'string') return true;
+    const prop = props[key];
+    return !(prop && typeof prop === 'object' && 'default' in prop);
+  });
+  if (filtered.length === required.length) {
+    return schema;
+  }
+  return { ...schema, required: filtered };
+}

--- a/packages/orchestration/src/constructors.spec.ts
+++ b/packages/orchestration/src/constructors.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Transition constructor shapes — goto/terminate/fail/pauseUntilSignal/retry.
+ * The runner extracts `output` from these and rebuilds the wire directive; the
+ * engine then validates the directive against the pinned manifest.
+ */
+
+import { DIRECTIVE_KIND, fail, goto, pauseUntilSignal, retry, terminate } from './index.js';
+
+describe('goto', () => {
+  it('builds a continue directive carrying the payload as `input`', () => {
+    expect(goto('enrich', { topic: 't' })).toEqual({
+      kind: DIRECTIVE_KIND.CONTINUE,
+      stepName: 'enrich',
+      input: { topic: 't' },
+    });
+  });
+
+  it('omitted payload → input undefined', () => {
+    expect(goto('enrich')).toEqual({ kind: DIRECTIVE_KIND.CONTINUE, stepName: 'enrich', input: undefined });
+  });
+});
+
+describe('terminate', () => {
+  it('carries output and optional reason', () => {
+    expect(terminate({ ok: true })).toEqual({
+      kind: DIRECTIVE_KIND.TERMINATE,
+      output: { ok: true },
+      reason: undefined,
+    });
+    expect(terminate({ ok: true }, { reason: 'done' }).reason).toBe('done');
+  });
+});
+
+describe('fail', () => {
+  it('carries reason and optional structured output', () => {
+    expect(fail('rejected')).toEqual({ kind: DIRECTIVE_KIND.FAIL, reason: 'rejected', output: undefined });
+    expect(fail('rejected', { output: { code: 7 } }).output).toEqual({ code: 7 });
+  });
+});
+
+describe('pauseUntilSignal', () => {
+  it('wraps signal as { name } and carries resumeStep; correlationId left undefined for the runner', () => {
+    expect(pauseUntilSignal({ signal: 'demo.approval', resumeStep: 'finalize' })).toEqual({
+      kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+      signal: { name: 'demo.approval', correlationId: undefined },
+      resumeStep: 'finalize',
+      timeoutMs: undefined,
+      output: undefined,
+    });
+  });
+
+  it('passes through an explicit correlationId', () => {
+    const d = pauseUntilSignal({ signal: 's', resumeStep: 'r', correlationId: 'key-1' });
+    expect(d.signal.correlationId).toBe('key-1');
+  });
+});
+
+describe('retry', () => {
+  it('builds a retry directive with optional delay/reason', () => {
+    expect(retry()).toEqual({ kind: DIRECTIVE_KIND.RETRY, delayMs: undefined, reason: undefined });
+    expect(retry({ delayMs: 500, reason: 'transient' })).toEqual({
+      kind: DIRECTIVE_KIND.RETRY,
+      delayMs: 500,
+      reason: 'transient',
+    });
+  });
+});

--- a/packages/orchestration/src/context.ts
+++ b/packages/orchestration/src/context.ts
@@ -1,0 +1,144 @@
+import type { NextStepDirective } from './directives.js';
+
+/**
+ * Minimal structural logger interface for step code.
+ *
+ * WHY a separate interface rather than importing from the engine:
+ * The SDK is a public contract package — it must not depend on
+ * `apps/workflows-engine` or any of its internal modules. At the same
+ * time, the engine needs to pass its own `Logger` (from
+ * `src/observability/index.ts`) through `ctx.logger` to steps.
+ *
+ * Solution: define `StepLogger` here with EXACTLY the four methods that
+ * step code actually calls (`info`, `warn`, `error`, `debug`). The engine's
+ * `Logger` type is structurally identical — same four method signatures —
+ * so it satisfies `StepLogger` with zero engine changes. No cast, no
+ * wrapper, no coupling. If the engine ever adds methods to `Logger`,
+ * those additions are invisible to step code (structural compatibility
+ * still holds). If step code ever needs a new log level, add it here
+ * and the engine's richer Logger still satisfies the widened interface.
+ */
+export interface StepLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+  debug(message: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * The set of finished-step status values a StepExecutionRecord can carry.
+ * Mirrors `Exclude<StepStatus, 'running'>` from the engine entity — defined
+ * here as a literal union so the SDK does not depend on the engine's TypeORM
+ * entity. The engine assigns values from its own `STEP_STATUS` constant which
+ * has the same string literals, so the types are mutually assignable.
+ */
+export type FinishedStepStatus = 'dispatched' | 'succeeded' | 'failed';
+
+/**
+ * What every step sees on each `run()` call. Read-only from the step's
+ * perspective except for `shared.set(...)` and any side effects the step
+ * chooses to perform.
+ *
+ * The two channels for state, with different semantics:
+ *   - `input` (the first arg to run) and the step's return `output` —
+ *     the audit trail. Every (input, output) pair is persisted to
+ *     workflow_step_executions and becomes the answer to "what did this
+ *     step do?"
+ *   - `ctx.shared` — the named cross-step value bus. Typed via the
+ *     workflow definition's TShared generic. Persisted to
+ *     workflow_executions.shared_state after every step.
+ *
+ * Don't double-thread the same value through both channels — pick the
+ * one whose semantics match. Rule of thumb: if the next step needs it,
+ * pass it through `output → input`. If something three steps downstream
+ * needs it, put it in `shared`.
+ */
+export interface OrchestrationExecutionContext<TShared extends Record<string, unknown> = Record<string, unknown>> {
+  /** Stable id; the workflow_executions row primary key. */
+  readonly executionId: string;
+  readonly workflowName: string;
+
+  /**
+   * Tenant scope, stamped on the execution at creation and immutable for
+   * the lifetime of the run. Both null for admin / cross-tenant workflows.
+   *
+   * Polsia's mid-flight `bindCompany` (for onboarding's
+   * create-company-then-bind shape) is intentionally NOT ported: Sapiom
+   * callers supply `organizationId` + `tenantId` to `createExecution`
+   * upfront, so the scope never changes after the row is written.
+   */
+  readonly organizationId: string | null;
+  readonly tenantId: string | null;
+
+  /** The value passed to the workflow's entry step. Unchanged across the run. */
+  readonly input: unknown;
+
+  /** Typed named-slot store; persisted to shared_state after each step. */
+  readonly shared: TypedContextStore<TShared>;
+
+  /** Completed step executions in this run, oldest first. */
+  readonly history: readonly StepExecutionRecord[];
+
+  /** 0-based attempt counter for the current step. */
+  readonly attempts: number;
+
+  readonly logger: StepLogger;
+}
+
+export interface TypedContextStore<TShared extends Record<string, unknown>> {
+  get<K extends keyof TShared>(key: K): TShared[K] | undefined;
+  set<K extends keyof TShared>(key: K, value: TShared[K]): void;
+  has<K extends keyof TShared>(key: K): boolean;
+  snapshot(): Partial<TShared>;
+}
+
+/**
+ * History entry exposed to steps via ctx.history. Matches the shape of
+ * a finished workflow_step_executions row.
+ *
+ * `sharedStateAfter` is the snapshot of ctx.shared at the moment this
+ * step's run() resolved/threw — useful for steps that compare current
+ * shared with what an earlier step left, or for debugging the evolution
+ * of cross-step values.
+ */
+export interface StepExecutionRecord {
+  readonly stepName: string;
+  readonly attempt: number;
+  readonly status: FinishedStepStatus;
+  readonly input: unknown;
+  readonly output: unknown;
+  readonly error: unknown;
+  readonly nextDirective: NextStepDirective | null;
+  readonly sharedStateAfter: Record<string, unknown> | null;
+  readonly startedAt: Date;
+  readonly finishedAt: Date;
+}
+
+/**
+ * Internal: in-memory ContextStore backed by a plain object. The runner
+ * builds one of these per advance() call, seeded from the execution row's
+ * shared_state, and writes the mutated snapshot back after the step runs.
+ */
+export class InMemoryContextStore<TShared extends Record<string, unknown>> implements TypedContextStore<TShared> {
+  private state: Partial<TShared>;
+
+  constructor(initial: Partial<TShared> = {}) {
+    this.state = { ...initial };
+  }
+
+  get<K extends keyof TShared>(key: K): TShared[K] | undefined {
+    return this.state[key];
+  }
+
+  set<K extends keyof TShared>(key: K, value: TShared[K]): void {
+    this.state[key] = value;
+  }
+
+  has<K extends keyof TShared>(key: K): boolean {
+    return key in this.state;
+  }
+
+  snapshot(): Partial<TShared> {
+    return { ...this.state };
+  }
+}

--- a/packages/orchestration/src/directives.ts
+++ b/packages/orchestration/src/directives.ts
@@ -1,0 +1,241 @@
+/**
+ * The five ways a step can tell the runner what to do next.
+ *
+ * The shape of this union is the load-bearing contract of the primitive.
+ * Adding new kinds is additive (existing steps that don't return them are
+ * unaffected); changing the shape of an existing kind breaks every step
+ * that uses it.
+ *
+ * `pause_until_signal.signal` is a structured { name, correlationId } pair —
+ * NOT a bare string. Even though webhook-routed resume is deferred for v1
+ * (only resume is implemented), step authors can already write
+ * pause directives in the shape the routing layer will consume.
+ */
+
+/**
+ * Single source of truth for directive `kind` values.
+ *
+ * Step authors and framework code reference these constants instead of
+ * hardcoding `'continue'`, `'retry'`, etc. The directive interfaces below
+ * derive their `kind` literal type from this object, so a rename here
+ * propagates everywhere through the type system.
+ */
+export const DIRECTIVE_KIND = {
+  CONTINUE: 'continue',
+  RETRY: 'retry',
+  PAUSE_UNTIL_SIGNAL: 'pause_until_signal',
+  TERMINATE: 'terminate',
+  FAIL: 'fail',
+} as const;
+
+export type DirectiveKind = (typeof DIRECTIVE_KIND)[keyof typeof DIRECTIVE_KIND];
+
+export type NextStepDirective =
+  | ContinueDirective
+  | RetryDirective
+  | PauseUntilSignalDirective
+  | TerminateDirective
+  | FailDirective;
+
+/** Run the named step next. If `input` is omitted, the next step receives the current step's output. */
+export interface ContinueDirective {
+  readonly kind: typeof DIRECTIVE_KIND.CONTINUE;
+  readonly stepName: string;
+  readonly input?: unknown;
+}
+
+/**
+ * Run this step again. The runner caps attempts at `maxAttemptsPerStep`
+ * (default 3); exceeding the cap throws RetryLimitExceededError and
+ * finalizes the workflow as failed.
+ */
+export interface RetryDirective {
+  readonly kind: typeof DIRECTIVE_KIND.RETRY;
+  readonly delayMs?: number;
+  readonly reason?: string;
+}
+
+/**
+ * Pause until an external signal arrives. The runner records the pause
+ * (status='paused', signal name + correlationId stored on the execution row)
+ * and the inline runner exits via WorkflowPausedError.
+ *
+ * Signal-routed resume is implemented in `signals.service.ts`:
+ * `WorkflowSignals.fireSignal(name, correlationId, payload)` looks up paused
+ * executions by (signal.name, correlationId) and wakes each one with the
+ * payload as the resume step's input. Operator-driven resume also works.
+ */
+export interface PauseUntilSignalDirective {
+  readonly kind: typeof DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL;
+  readonly signal: {
+    readonly name: string;
+    readonly correlationId?: string;
+  };
+  readonly timeoutMs?: number;
+  /** Step to run when the signal arrives. Defaults to the paused step. */
+  readonly resumeStep?: string;
+}
+
+/** Finalize the workflow as completed. `output` (already on the StepResult) is the workflow's final output. */
+export interface TerminateDirective {
+  readonly kind: typeof DIRECTIVE_KIND.TERMINATE;
+  readonly reason?: string;
+}
+
+/**
+ * Finalize the workflow as failed — deterministically, without burning the
+ * retry cap. Sets `status='failed'` on the row in one shot. The step's
+ * `output` (on the `StepResult`) is preserved so callers can read structured
+ * failure context (which sub-task failed, why, what was produced before the
+ * abort). The `reason` is a short human-readable label for logs / dashboards.
+ *
+ * **When to use this vs throwing:**
+ *   - FAIL is for KNOWN-TERMINAL failures the step has already diagnosed
+ *     (e.g. "the coding agent reported `success: false`"). One CAS write,
+ *     one log line, one failure event.
+ *   - Throwing is for UNEXPECTED errors that may be transient (network
+ *     blip, race condition). The retry-up-to-cap mechanism gives those a
+ *     self-heal path before terminal failure.
+ *
+ * Mis-using throw for terminal failures wastes `maxAttemptsPerStep` cycles
+ * and produces misleading "retry" log noise. Mis-using FAIL for transient
+ * errors removes the self-heal safety net. Pick the one whose semantics
+ * match the failure mode you're handling.
+ *
+ * **Workflow-level cleanup pattern:** FAIL ends the execution immediately —
+ * any cleanup steps the workflow wants to run (sandbox teardown, file
+ * cleanup, etc.) must happen BEFORE the FAIL directive fires. The standard
+ * shape is: an earlier step stashes a "this run failed" flag in `ctx.shared`,
+ * cleanup steps run unconditionally, and the FINAL step inspects the flag
+ * and emits TERMINATE or FAIL (the single FAIL emit site).
+ *
+ * **Forward-compatible for hooks / recovery:** when a workflow-level
+ * `onFailure` hook surface lands, it fires off this directive's terminal
+ * state. The hook can read the row's `output` + `error` + `sharedState`
+ * to drive retry-with-different-input, escalation, or compensating
+ * transactions.
+ */
+export interface FailDirective {
+  readonly kind: typeof DIRECTIVE_KIND.FAIL;
+  /** Short human label for the failure (logs, dashboards). Distinct from `output` which carries structured caller data. */
+  readonly reason?: string;
+}
+
+export function isContinue(d: NextStepDirective): d is ContinueDirective {
+  return d.kind === DIRECTIVE_KIND.CONTINUE;
+}
+
+export function isRetry(d: NextStepDirective): d is RetryDirective {
+  return d.kind === DIRECTIVE_KIND.RETRY;
+}
+
+export function isPause(d: NextStepDirective): d is PauseUntilSignalDirective {
+  return d.kind === DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL;
+}
+
+export function isTerminate(d: NextStepDirective): d is TerminateDirective {
+  return d.kind === DIRECTIVE_KIND.TERMINATE;
+}
+
+export function isFail(d: NextStepDirective): d is FailDirective {
+  return d.kind === DIRECTIVE_KIND.FAIL;
+}
+
+// ---------------------------------------------------------------------------
+// Branded transition constructors (the authoring surface)
+// ---------------------------------------------------------------------------
+//
+// `defineStep` derives a step's `run` return type from its declared `next` /
+// `terminal` / `canFail` / `pause` via `Allowed<…>` (see step.ts). The branded
+// types below are what make that enforcement possible: `Goto<Target>` and
+// `Pause<Resume>` carry the target step name as a *type parameter*, so the
+// declared edge set can constrain which targets are expressible.
+//
+// They are PURE value constructors — no runtime context, importable anywhere.
+// Each is assignable to its corresponding wire interface above (Goto → Continue,
+// etc.), so a returned directive is still a `NextStepDirective`. The output
+// payload each carries is extracted by the runner into the completion's
+// `result.output`; the runner rebuilds the clean wire directive it POSTs (see
+// the runner's output-extraction). `goto`'s payload is BOTH this step's audit
+// output and the next step's input (unifying the old StepResult.output +
+// ContinueDirective.input).
+
+/** A `continue` to `Target`, carrying `Target` at the type level so `Allowed<…>` can gate it. */
+export interface Goto<Target extends string> {
+  readonly kind: typeof DIRECTIVE_KIND.CONTINUE;
+  readonly stepName: Target;
+  /** This step's output AND the next step's input. Omitted → next step receives `undefined`. */
+  readonly input?: unknown;
+}
+
+/** Finalize the workflow as completed. `output` becomes the workflow's final output. */
+export interface Terminate {
+  readonly kind: typeof DIRECTIVE_KIND.TERMINATE;
+  readonly output?: unknown;
+  readonly reason?: string;
+}
+
+/** Finalize the workflow as failed (deterministic, no retry). `output` carries structured failure context. */
+export interface Fail {
+  readonly kind: typeof DIRECTIVE_KIND.FAIL;
+  readonly reason?: string;
+  readonly output?: unknown;
+}
+
+/** Pause until a signal, resuming at `Resume` (type-level so `Allowed<…>` can gate it). */
+export interface Pause<Resume extends string> {
+  readonly kind: typeof DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL;
+  readonly signal: { readonly name: string; readonly correlationId?: string };
+  readonly resumeStep?: Resume;
+  readonly timeoutMs?: number;
+  /** Optional audit output recorded for the pausing step. */
+  readonly output?: unknown;
+}
+
+/** Re-run this step. Universal (not a declared edge); engine caps attempts at `maxAttemptsPerStep`. */
+export interface Retry {
+  readonly kind: typeof DIRECTIVE_KIND.RETRY;
+  readonly delayMs?: number;
+  readonly reason?: string;
+}
+
+/** Route to `target` (must be in the step's declared `next`), passing `output` as its input. */
+export function goto<const Target extends string>(target: Target, output?: unknown): Goto<Target> {
+  return { kind: DIRECTIVE_KIND.CONTINUE, stepName: target, input: output };
+}
+
+/** Finalize as completed with `output` as the workflow's final output. Requires `terminal: true`. */
+export function terminate(output?: unknown, opts?: { reason?: string }): Terminate {
+  return { kind: DIRECTIVE_KIND.TERMINATE, output, reason: opts?.reason };
+}
+
+/** Finalize as failed with a `reason` label and optional structured `output`. Requires `canFail: true`. */
+export function fail(reason?: string, opts?: { output?: unknown }): Fail {
+  return { kind: DIRECTIVE_KIND.FAIL, reason, output: opts?.output };
+}
+
+/**
+ * Pause until `signal` arrives, then resume at `resumeStep`. `correlationId`
+ * defaults to the ambient `executionId` (filled by the runner) when omitted.
+ * Requires a matching `pause: { signal, resumeStep }` declaration on the step.
+ */
+export function pauseUntilSignal<const Resume extends string>(args: {
+  signal: string;
+  resumeStep?: Resume;
+  correlationId?: string;
+  timeoutMs?: number;
+  output?: unknown;
+}): Pause<Resume> {
+  return {
+    kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+    signal: { name: args.signal, correlationId: args.correlationId },
+    resumeStep: args.resumeStep,
+    timeoutMs: args.timeoutMs,
+    output: args.output,
+  };
+}
+
+/** Re-run this step (optionally after `delayMs`). Always allowed; capped by `maxAttemptsPerStep`. */
+export function retry(opts?: { delayMs?: number; reason?: string }): Retry {
+  return { kind: DIRECTIVE_KIND.RETRY, delayMs: opts?.delayMs, reason: opts?.reason };
+}

--- a/packages/orchestration/src/errors.ts
+++ b/packages/orchestration/src/errors.ts
@@ -1,0 +1,75 @@
+import type { $ZodIssue } from 'zod/v4/core';
+
+/** Base class for every error the primitive can throw. */
+export class WorkflowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkflowError';
+  }
+}
+
+/**
+ * A step's input failed its declared `inputSchema`. Thrown both
+ * synchronously by `createExecution` (entry input rejected before any
+ * row is written) and at advance time by the runner (which fails the
+ * execution terminally — bad input is deterministic, so retrying is
+ * pure waste). Carries the raw Zod issues so callers (the admin tool)
+ * can surface field-level detail.
+ */
+export class StepInputValidationError extends WorkflowError {
+  readonly stepName: string;
+  readonly issues: readonly $ZodIssue[];
+  constructor(stepName: string, issues: readonly $ZodIssue[]) {
+    super(`Input for step '${stepName}' failed validation: ${formatIssues(issues)}`);
+    this.name = 'StepInputValidationError';
+    this.stepName = stepName;
+    this.issues = issues;
+  }
+}
+
+/** `path.to.field: message; other: message` — compact, human-readable. */
+function formatIssues(issues: readonly $ZodIssue[]): string {
+  if (issues.length === 0) return 'unknown validation error';
+  return issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+/** Definition references a step name that isn't in the steps map. */
+export class UnknownStepError extends WorkflowError {
+  readonly stepName: string;
+  constructor(stepName: string) {
+    super(`Unknown step: ${stepName}`);
+    this.name = 'UnknownStepError';
+    this.stepName = stepName;
+  }
+}
+
+/**
+ * A step's completion returned a directive the step did not declare — a
+ * `continue` to a target outside its `next`, a `terminate`/`fail` it didn't
+ * declare (`terminal`/`canFail`), or a `pause` with no matching declaration.
+ * The engine raises this at the trust boundary (validating the directive against
+ * the pinned manifest's per-step transitions) and fails the execution
+ * terminally — untrusted code cannot route outside the declared graph. `retry`
+ * is exempt (universal, capped by `maxAttemptsPerStep`).
+ */
+export class DisallowedTransitionError extends WorkflowError {
+  readonly stepName: string;
+  readonly directiveKind: string;
+  readonly target?: string;
+  constructor(stepName: string, directiveKind: string, target?: string) {
+    super(
+      `Step '${stepName}' returned a '${directiveKind}' directive` +
+        (target ? ` to '${target}'` : '') +
+        ` that is not in its declared transitions`,
+    );
+    this.name = 'DisallowedTransitionError';
+    this.stepName = stepName;
+    this.directiveKind = directiveKind;
+    this.target = target;
+  }
+}

--- a/packages/orchestration/src/graph.spec.ts
+++ b/packages/orchestration/src/graph.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * validateGraph — build-time conformance over the manifest's transitions.
+ */
+
+import { assertValidGraph, buildManifest, validateGraph } from './build-manifest.js';
+import { goto, pauseUntilSignal, terminate } from './directives.js';
+import { defineStep } from './step.js';
+import { defineOrchestration } from './workflow.js';
+
+const ARTIFACT = { sha256: 'x', entryFile: 'f.mjs' };
+const manifestOf = (def: Parameters<typeof buildManifest>[0]) =>
+  buildManifest(def, { sdkVersion: '0.1.0', artifact: ARTIFACT });
+
+describe('validateGraph', () => {
+  it('passes a well-formed linear graph', () => {
+    const def = defineOrchestration({
+      name: 'ok',
+      entry: 'a',
+      steps: {
+        a: defineStep({
+          name: 'a',
+          next: ['b'],
+          async run() {
+            return goto('b');
+          },
+        }),
+        b: defineStep({
+          name: 'b',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+      },
+    });
+    const { errors, warnings } = validateGraph(manifestOf(def));
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('errors on a continue target that does not exist', () => {
+    // Build a manifest then tamper to simulate an over-declared/garbage target
+    // (defineStep itself cannot express a non-string target; the engine/build
+    // guard against manifests, so we validate at the manifest layer).
+    const manifest = {
+      protocol: 1 as const,
+      name: 'bad',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: ARTIFACT,
+      steps: {
+        a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'continue' as const, target: 'ghost' }] },
+      },
+    };
+    const { errors } = validateGraph(manifest);
+    expect(errors.some((e) => e.includes("'ghost'"))).toBe(true);
+  });
+
+  it('errors on a dead-end step (no transitions at all)', () => {
+    const manifest = {
+      protocol: 1 as const,
+      name: 'dead',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: ARTIFACT,
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
+    };
+    const { errors } = validateGraph(manifest);
+    expect(errors.some((e) => e.includes('dead-end'))).toBe(true);
+  });
+
+  it('warns on an unreachable step', () => {
+    const def = defineOrchestration({
+      name: 'island',
+      entry: 'a',
+      steps: {
+        a: defineStep({
+          name: 'a',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+        orphan: defineStep({
+          name: 'orphan',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+      },
+    });
+    const { errors, warnings } = validateGraph(manifestOf(def));
+    expect(errors).toEqual([]);
+    expect(warnings.some((w) => w.includes("'orphan'") && w.includes('unreachable'))).toBe(true);
+  });
+
+  it('warns when a step cannot reach any terminal (unbounded loop)', () => {
+    // a <-> b continue loop, no terminate anywhere.
+    const manifest = {
+      protocol: 1 as const,
+      name: 'loop',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: ARTIFACT,
+      steps: {
+        a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'continue' as const, target: 'b' }] },
+        b: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'continue' as const, target: 'a' }] },
+      },
+    };
+    const { warnings } = validateGraph(manifest);
+    expect(warnings.some((w) => w.includes('unbounded') || w.includes('no step can terminate'))).toBe(true);
+  });
+
+  it('accepts a pause self-loop reaching a terminal (the repo-lock barrier shape)', () => {
+    const def = defineOrchestration({
+      name: 'barrier',
+      entry: 'await_lock',
+      steps: {
+        await_lock: defineStep({
+          name: 'await_lock',
+          next: ['provision'],
+          canFail: true,
+          pause: { signal: 'repo-free', resumeStep: 'await_lock' },
+          async run() {
+            return pauseUntilSignal({ signal: 'repo-free', resumeStep: 'await_lock' });
+          },
+        }),
+        provision: defineStep({
+          name: 'provision',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+      },
+    });
+    const { errors, warnings } = validateGraph(manifestOf(def));
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('assertValidGraph throws on errors and returns warnings otherwise', () => {
+    const bad = {
+      protocol: 1 as const,
+      name: 'x',
+      entry: 'missing',
+      sdkVersion: '0.1.0',
+      artifact: ARTIFACT,
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' as const }] } },
+    };
+    expect(() => assertValidGraph(bad)).toThrow(/Invalid workflow graph/);
+  });
+});

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @sapiom/workflow-sdk — the versioned public contract for Sapiom workflow authoring.
+ *
+ * Shared by:
+ *   - Customer workflow definitions (compiled against this package's types)
+ *   - The sandbox step-runner (reads input.json, builds ctx, runs one step)
+ *   - The engine (uses types + directive guards; steps implement these interfaces)
+ *
+ * Design rule: LEAN. Types + ~100 lines of protocol runtime + one strictly-pinned
+ * zod peer dep (`zod/v4` subpath on zod 3.25.x). No capability clients, no engine
+ * internals, no NestJS imports.
+ */
+
+// Directives — the load-bearing protocol contract
+export { DIRECTIVE_KIND, isContinue, isRetry, isPause, isTerminate, isFail } from './directives.js';
+export type {
+  DirectiveKind,
+  NextStepDirective,
+  ContinueDirective,
+  RetryDirective,
+  PauseUntilSignalDirective,
+  TerminateDirective,
+  FailDirective,
+} from './directives.js';
+
+// Transition constructors + their branded types (the authoring surface)
+export { goto, terminate, fail, pauseUntilSignal, retry } from './directives.js';
+export type { Goto, Terminate, Fail, Pause, Retry } from './directives.js';
+
+// Step authoring: defineStep + the derived `Allowed` return type + StepDefinition.
+// Step + StepResult are retained for the engine (deprecated for authoring).
+export { defineStep } from './step.js';
+export type { Step, StepResult, StepDefinition, Allowed } from './step.js';
+
+// Execution context — what a step's `run` receives (metadata + shared store + logger)
+export type {
+  OrchestrationExecutionContext,
+  TypedContextStore,
+  StepExecutionRecord,
+  StepLogger,
+  FinishedStepStatus,
+} from './context.js';
+export { InMemoryContextStore } from './context.js';
+
+// Workflow definition + defineOrchestration factory + brand guard
+export type { OrchestrationDefinition } from './workflow.js';
+export { defineOrchestration, isOrchestrationDefinition, ORCHESTRATION_DEFINITION_BRAND } from './workflow.js';
+
+// Errors that are part of the public contract surface
+export { WorkflowError, UnknownStepError, StepInputValidationError, DisallowedTransitionError } from './errors.js';
+
+// Introspection — zod→JSON-Schema conversion + step/workflow input contracts.
+// Shared by engine tooling and the build phase (runs outside the engine).
+export { zodToJsonSchema, exampleFromJsonSchema, stepInputContract, workflowInputContract } from './introspection.js';
+export type { StepInputContract, WorkflowInputContract } from './introspection.js';
+
+// Manifest types, Zod schema, and generator — the build→engine contract.
+export { MANIFEST_PROTOCOL, workflowManifestSchema } from './manifest.js';
+export type { WorkflowManifest, WorkflowStepManifest, ManifestTransition } from './manifest.js';
+
+// Manifest generator + graph validation — called by the build phase.
+export { buildManifest, validateGraph, assertValidGraph } from './build-manifest.js';
+export type { GraphValidation } from './build-manifest.js';

--- a/packages/orchestration/src/introspection.ts
+++ b/packages/orchestration/src/introspection.ts
@@ -1,0 +1,133 @@
+// Use the Zod 4 API via the `zod/v4` subpath: the workspace pins zod at
+// 3.25.x (which ships v4 under this subpath), so we get `z.toJSONSchema`
+// without bumping the shared `zod` resolution to v4 for the rest of the
+// monorepo (wagmi/wallet peers). errors.ts uses `zod/v4/core` for the same
+// reason.
+import { z } from 'zod/v4';
+
+import type { OrchestrationDefinition } from './workflow.js';
+
+/**
+ * The input contract of a step, derived from its `inputSchema`. For the entry
+ * step this is the whole workflow's input contract (the admin "start a
+ * workflow" form consumes it); for a `pause_until_signal` resume step it's the
+ * contract of the resume payload (the admin "resume" form consumes it). Both
+ * pre-fill + validate an otherwise-opaque JSON editor.
+ */
+export interface StepInputContract {
+  /** JSON Schema (draft 2020-12) of the step's input. */
+  readonly jsonSchema: Record<string, unknown>;
+  /**
+   * A prefill value for the input editor. Prefers an author-provided
+   * runnable example (`schema.meta({ examples: [{ … }] })`) so the
+   * operator can start it as-is; falls back to a type-correct skeleton
+   * (`""` / `0` / `false` / first-enum-value / `[]`) when the schema
+   * declares no example — that gives the right SHAPE but its placeholder
+   * values may not satisfy refinements like `.positive()`, so the
+   * operator edits before running.
+   */
+  readonly example: unknown;
+}
+
+/**
+ * @deprecated Use {@link StepInputContract}. Retained as an alias because the
+ * entry-step contract and a resume-step contract are the same shape.
+ */
+export type WorkflowInputContract = StepInputContract;
+
+/**
+ * Convert a Zod schema to its JSON Schema representation.
+ * Used by the manifest generator (build phase, sandbox) and by engine tooling.
+ */
+export function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  return z.toJSONSchema(schema) as Record<string, unknown>;
+}
+
+/**
+ * Describe a named step's input contract for tooling. Returns null when the
+ * step doesn't exist or declares no schema (the step accepts opaque input; the
+ * form falls back to a free editor).
+ */
+export function stepInputContract(
+  def: OrchestrationDefinition<unknown, Record<string, unknown>>,
+  stepName: string,
+): StepInputContract | null {
+  const schema = def.steps[stepName]?.inputSchema;
+  if (!schema) return null;
+
+  const jsonSchema = zodToJsonSchema(schema);
+  return { jsonSchema, example: exampleFromJsonSchema(jsonSchema) };
+}
+
+/**
+ * Describe a workflow's input contract for tooling.
+ *
+ * The entry step's `inputSchema` IS the workflow's input contract — the
+ * entry step receives whatever the caller passes to `run`/`createExecution`.
+ * Returns null when the entry step declares no schema (the workflow
+ * accepts opaque input; the form falls back to a free editor).
+ */
+export function workflowInputContract(
+  def: OrchestrationDefinition<unknown, Record<string, unknown>>,
+): StepInputContract | null {
+  return stepInputContract(def, def.entry);
+}
+
+/**
+ * Prefer an author-declared example (`.meta({ examples: [...] })` →
+ * JSON Schema `examples`, or singular `example`) — it's meant to be
+ * runnable as-is. Fall back to a generated type-skeleton otherwise.
+ *
+ * Exported so engine/tooling can call it after converting a schema with
+ * their own `z.toJSONSchema` (avoiding cross-module-instance issues).
+ */
+export function exampleFromJsonSchema(jsonSchema: Record<string, unknown>): unknown {
+  const examples = jsonSchema.examples;
+  if (Array.isArray(examples) && examples.length > 0) {
+    return examples[0];
+  }
+  if ('example' in jsonSchema && jsonSchema.example !== undefined) {
+    return jsonSchema.example;
+  }
+  return skeletonFromJsonSchema(jsonSchema);
+}
+
+/**
+ * Walk a JSON Schema and emit a placeholder value of the right type.
+ * Covers the shapes our input schemas produce (flat objects of scalars +
+ * enums + nested objects/arrays). Unknown shapes fall back to null —
+ * a placeholder the operator edits, never a crash.
+ */
+function skeletonFromJsonSchema(schema: Record<string, unknown>): unknown {
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  const branches = (schema.anyOf ?? schema.oneOf) as Record<string, unknown>[] | undefined;
+  if (Array.isArray(branches) && branches.length > 0) {
+    return skeletonFromJsonSchema(branches[0]);
+  }
+
+  switch (schema.type) {
+    case 'object': {
+      const props = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(props)) {
+        out[key] = skeletonFromJsonSchema(value);
+      }
+      return out;
+    }
+    case 'array':
+      return [];
+    case 'string':
+      return '';
+    case 'number':
+    case 'integer':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'null':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for manifest types, schema validation, and buildManifest generator.
+ *
+ * Proves:
+ *   1. workflowManifestSchema validates a well-formed manifest
+ *   2. workflowManifestSchema rejects invalid manifests (wrong protocol, missing fields)
+ *   3. buildManifest emits the correct manifest shape from a definition
+ *   4. buildManifest: step with inputSchema → JSON Schema; without → null
+ *   5. buildManifest: step with timeoutMs → timeoutMs; without → null
+ *   6. buildManifest: protocol is always 1, sdkVersion/artifact from opts
+ */
+import { z } from 'zod/v4';
+
+import { buildManifest } from './build-manifest.js';
+import { goto, pauseUntilSignal, terminate } from './directives.js';
+import { MANIFEST_PROTOCOL, type WorkflowManifest, workflowManifestSchema } from './manifest.js';
+import { defineStep } from './step.js';
+import { defineOrchestration } from './workflow.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A terminal step (declares `terminal: true`) for the schema/inputSchema/timeout tests. */
+function makeStep(name: string, opts: { inputSchema?: z.ZodType; timeoutMs?: number } = {}) {
+  return defineStep({
+    name,
+    next: [],
+    terminal: true,
+    inputSchema: opts.inputSchema,
+    timeoutMs: opts.timeoutMs,
+    async run() {
+      return terminate(null);
+    },
+  });
+}
+
+const DUMMY_ARTIFACT = { sha256: 'abc123', entryFile: 'dist/workflow.mjs' };
+const DUMMY_SDK_VERSION = '0.1.0';
+
+// ---------------------------------------------------------------------------
+// 1 + 2. workflowManifestSchema
+// ---------------------------------------------------------------------------
+
+describe('workflowManifestSchema', () => {
+  it('accepts a well-formed manifest', () => {
+    const manifest: WorkflowManifest = {
+      protocol: MANIFEST_PROTOCOL,
+      name: 'my-workflow',
+      entry: 'step-a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'deadbeef', entryFile: 'dist/my-workflow.mjs' },
+      steps: {
+        'step-a': {
+          timeoutMs: 5000,
+          inputSchema: { type: 'object' },
+          transitions: [{ kind: 'continue', target: 'step-b' }],
+        },
+        'step-b': { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+      },
+    };
+    expect(() => workflowManifestSchema.parse(manifest)).not.toThrow();
+    const parsed = workflowManifestSchema.parse(manifest);
+    expect(parsed.protocol).toBe(1);
+    expect(parsed.steps['step-a'].timeoutMs).toBe(5000);
+    expect(parsed.steps['step-b'].inputSchema).toBeNull();
+    expect(parsed.steps['step-a'].transitions).toEqual([{ kind: 'continue', target: 'step-b' }]);
+  });
+
+  it('rejects a manifest with wrong protocol', () => {
+    const bad = {
+      protocol: 2,
+      name: 'wf',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      steps: {},
+    };
+    expect(() => workflowManifestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects a manifest missing required fields', () => {
+    const missing = {
+      protocol: 1,
+      name: 'wf',
+      // missing entry, sdkVersion, artifact, steps
+    };
+    expect(() => workflowManifestSchema.parse(missing)).toThrow();
+  });
+
+  it('rejects a manifest with empty name', () => {
+    const empty = {
+      protocol: 1,
+      name: '',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      steps: {},
+    };
+    expect(() => workflowManifestSchema.parse(empty)).toThrow();
+  });
+
+  it('rejects a non-positive timeoutMs', () => {
+    const bad = {
+      protocol: 1,
+      name: 'wf',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      steps: { a: { timeoutMs: -100, inputSchema: null, transitions: [] } },
+    };
+    expect(() => workflowManifestSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects a step with an unknown transition kind', () => {
+    const bad = {
+      protocol: 1,
+      name: 'wf',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'teleport' }] } },
+    };
+    expect(() => workflowManifestSchema.parse(bad)).toThrow();
+  });
+
+  it('accepts null timeoutMs (engine default)', () => {
+    const good = {
+      protocol: 1,
+      name: 'wf',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
+    };
+    expect(() => workflowManifestSchema.parse(good)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 + 4 + 5 + 6. buildManifest
+// ---------------------------------------------------------------------------
+
+describe('buildManifest', () => {
+  it('emits protocol=1 and passes through sdkVersion and artifact', () => {
+    const def = defineOrchestration({
+      name: 'simple',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.protocol).toBe(1);
+    expect(manifest.sdkVersion).toBe(DUMMY_SDK_VERSION);
+    expect(manifest.artifact).toEqual(DUMMY_ARTIFACT);
+  });
+
+  it('carries name and entry from the definition', () => {
+    const def = defineOrchestration({
+      name: 'my-wf',
+      entry: 'alpha',
+      steps: { alpha: makeStep('alpha') },
+    });
+    const manifest = buildManifest(def, { sdkVersion: '1.0.0', artifact: DUMMY_ARTIFACT });
+    expect(manifest.name).toBe('my-wf');
+    expect(manifest.entry).toBe('alpha');
+  });
+
+  it('step without inputSchema → inputSchema: null in manifest', () => {
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'plain',
+      steps: { plain: makeStep('plain') },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.steps.plain.inputSchema).toBeNull();
+  });
+
+  it('step without timeoutMs → timeoutMs: null in manifest', () => {
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'plain',
+      steps: { plain: makeStep('plain') },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.steps.plain.timeoutMs).toBeNull();
+  });
+
+  it('step with inputSchema → schema converted to JSON Schema', () => {
+    const schema = z.object({ userId: z.string(), count: z.number() });
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'validated',
+      steps: { validated: makeStep('validated', { inputSchema: schema }) },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const stepSchema = manifest.steps.validated.inputSchema;
+    expect(stepSchema).not.toBeNull();
+    expect(stepSchema?.type).toBe('object');
+    expect((stepSchema?.properties as Record<string, unknown>)?.userId).toBeDefined();
+    expect((stepSchema?.properties as Record<string, unknown>)?.count).toBeDefined();
+  });
+
+  it('step with timeoutMs → timeoutMs carried through', () => {
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'slow',
+      steps: { slow: makeStep('slow', { timeoutMs: 30_000 }) },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.steps.slow.timeoutMs).toBe(30_000);
+  });
+
+  it('multi-step definition: each step independently mapped', () => {
+    const inputSchema = z.object({ topic: z.string() });
+    const def = defineOrchestration({
+      name: 'multi',
+      entry: 'gather',
+      steps: {
+        gather: makeStep('gather', { inputSchema, timeoutMs: 10_000 }),
+        summarize: makeStep('summarize', { timeoutMs: 20_000 }),
+        finalize: makeStep('finalize'),
+      },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+
+    // gather: has both schema and timeout
+    expect(manifest.steps.gather.timeoutMs).toBe(10_000);
+    expect(manifest.steps.gather.inputSchema).not.toBeNull();
+    expect(manifest.steps.gather.inputSchema?.type).toBe('object');
+
+    // summarize: timeout but no schema
+    expect(manifest.steps.summarize.timeoutMs).toBe(20_000);
+    expect(manifest.steps.summarize.inputSchema).toBeNull();
+
+    // finalize: neither
+    expect(manifest.steps.finalize.timeoutMs).toBeNull();
+    expect(manifest.steps.finalize.inputSchema).toBeNull();
+  });
+
+  it('defaulted field is NOT in required in the manifest JSON Schema (AJV pre-check must not be stricter than Zod)', () => {
+    // `count` has a Zod default → zod.toJSONSchema marks it required; buildManifest
+    // must strip it so a caller that omits `count` passes AJV pre-check.
+    // Only top-level `required` entries are treated (nested objects out of scope for v1).
+    const schema = z.object({
+      name: z.string(),
+      count: z.number().default(0),
+    });
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'step',
+      steps: { step: makeStep('step', { inputSchema: schema }) },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const stepSchema = manifest.steps.step.inputSchema!;
+    const required = stepSchema.required as string[] | undefined;
+    // `name` (no default) must still be required; `count` (has default) must not be.
+    expect(required).toBeDefined();
+    expect(required).toContain('name');
+    expect(required).not.toContain('count');
+  });
+
+  it('manifest validates against workflowManifestSchema', () => {
+    const inputSchema = z.object({ input: z.string() });
+    const def = defineOrchestration({
+      name: 'validated-wf',
+      entry: 'entry',
+      steps: {
+        entry: makeStep('entry', { inputSchema }),
+        exit: makeStep('exit', { timeoutMs: 5000 }),
+      },
+    });
+    const manifest = buildManifest(def, { sdkVersion: '0.1.0', artifact: DUMMY_ARTIFACT });
+
+    // Parse with the zod schema — must not throw
+    const parsed = workflowManifestSchema.parse(manifest);
+    expect(parsed.name).toBe('validated-wf');
+    expect(parsed.steps.entry.inputSchema).not.toBeNull();
+    expect(parsed.steps.exit.timeoutMs).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildManifest — transitions emission (the build-derivable graph edges)
+// ---------------------------------------------------------------------------
+
+describe('buildManifest transitions', () => {
+  // A four-step graph exercising every transition kind:
+  //   prep -> enrich -> approval (pause→finalize) -> finalize (terminate|fail)
+  const def = defineOrchestration({
+    name: 'graph',
+    entry: 'prep',
+    steps: {
+      prep: defineStep({
+        name: 'prep',
+        next: ['enrich'],
+        async run() {
+          return goto('enrich');
+        },
+      }),
+      enrich: defineStep({
+        name: 'enrich',
+        next: ['approval', 'finalize'],
+        async run() {
+          return goto('approval');
+        },
+      }),
+      approval: defineStep({
+        name: 'approval',
+        next: ['finalize'],
+        pause: { signal: 'demo.approval', resumeStep: 'finalize' },
+        async run() {
+          return pauseUntilSignal({ signal: 'demo.approval', resumeStep: 'finalize' });
+        },
+      }),
+      finalize: defineStep({
+        name: 'finalize',
+        next: [],
+        terminal: true,
+        canFail: true,
+        async run() {
+          return terminate({ done: true });
+        },
+      }),
+    },
+  });
+  const manifest = buildManifest(def, { sdkVersion: '0.1.0', artifact: DUMMY_ARTIFACT });
+
+  it('emits one continue transition per next entry', () => {
+    expect(manifest.steps.prep.transitions).toEqual([{ kind: 'continue', target: 'enrich' }]);
+    expect(manifest.steps.enrich.transitions).toEqual([
+      { kind: 'continue', target: 'approval' },
+      { kind: 'continue', target: 'finalize' },
+    ]);
+  });
+
+  it('emits a pause transition with signal + resumeStep', () => {
+    expect(manifest.steps.approval.transitions).toContainEqual({
+      kind: 'pause',
+      signal: 'demo.approval',
+      resumeStep: 'finalize',
+    });
+  });
+
+  it('emits terminate and fail transitions for a terminal+canFail step', () => {
+    expect(manifest.steps.finalize.transitions).toEqual([{ kind: 'terminate' }, { kind: 'fail' }]);
+  });
+
+  it('does NOT emit a retry transition (retry is a universal badge, not an edge)', () => {
+    for (const step of Object.values(manifest.steps)) {
+      expect(step.transitions.some((t) => (t as { kind: string }).kind === 'retry')).toBe(false);
+    }
+  });
+
+  it('produces a manifest that validates against the schema', () => {
+    expect(() => workflowManifestSchema.parse(manifest)).not.toThrow();
+  });
+});

--- a/packages/orchestration/src/manifest.ts
+++ b/packages/orchestration/src/manifest.ts
@@ -1,0 +1,106 @@
+// `zod/v4` subpath (zod 3.25.x): keeps the shared `zod` resolution on v3
+// while this SDK uses the v4 type + API surface.
+import { z } from 'zod/v4';
+
+/**
+ * Protocol version for the workflow manifest format. Bumped when the schema
+ * changes in a way that requires the engine to handle both versions.
+ */
+export const MANIFEST_PROTOCOL = 1 as const;
+
+/**
+ * A declared transition a step may take — the build-derivable graph edge set.
+ * Tagged + versioned (NOT a bare `next: string[]`) so future edge kinds
+ * (sub-workflow, fan-out) slot in as additive `kind`s without a schema break.
+ * `retry` is intentionally NOT a transition kind — it is a universal badge the
+ * engine always permits, not a topology edge.
+ */
+export type ManifestTransition =
+  | { readonly kind: 'continue'; readonly target: string }
+  | { readonly kind: 'terminate' }
+  | { readonly kind: 'fail' }
+  | { readonly kind: 'pause'; readonly signal: string; readonly resumeStep: string };
+
+/**
+ * Per-step metadata emitted by the build phase and consumed by the engine.
+ * The engine uses this to pre-validate inputs and enforce dispatch deadlines
+ * without importing any customer definition code.
+ */
+export interface WorkflowStepManifest {
+  /**
+   * Dispatch deadline for one attempt (ms).
+   * null → engine applies its own default (DEFAULT_DISPATCH_TIMEOUT_MS).
+   * Populated from step.timeoutMs when declared; null when undeclared.
+   * Timeout policy lives in the engine, not the SDK — manifest carries null.
+   */
+  readonly timeoutMs: number | null;
+  /**
+   * JSON Schema (draft 2020-12) for the step input, or null if the step
+   * declares no inputSchema. The engine pre-validates against this before
+   * dispatching; the sandbox runner does the authoritative Zod parse.
+   */
+  readonly inputSchema: Record<string, unknown> | null;
+  /**
+   * The declared transitions out of this step (the graph edges). Built from the
+   * step's `next`/`terminal`/`canFail`/`pause` declarations. The engine
+   * validates every completion's directive against this set (per-step,
+   * per-kind); the renderer draws one edge per entry. `reachable ⊆ declared`.
+   */
+  readonly transitions: readonly ManifestTransition[];
+}
+
+/**
+ * The workflow manifest — pure data the engine consumes to drive execution
+ * without importing customer code. Produced by the build phase (locally via
+ * `build-definition`, in CI via the sandbox build-run). Protocol 1.
+ */
+export interface WorkflowManifest {
+  /** Schema version. Engine rejects unknown protocols. */
+  readonly protocol: typeof MANIFEST_PROTOCOL;
+  /** Workflow name (matches OrchestrationDefinition.name). */
+  readonly name: string;
+  /** Entry step name (matches OrchestrationDefinition.entry). */
+  readonly entry: string;
+  /** Version of @sapiom/workflow-sdk used to build the definition. */
+  readonly sdkVersion: string;
+  /** Bundle artifact metadata for integrity checks. */
+  readonly artifact: {
+    readonly sha256: string;
+    readonly entryFile: string;
+  };
+  /** Per-step metadata map (keyed by step name). */
+  readonly steps: Readonly<Record<string, WorkflowStepManifest>>;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema — used by the engine to validate manifests it receives
+// ---------------------------------------------------------------------------
+
+const manifestTransitionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('continue'), target: z.string().min(1) }),
+  z.object({ kind: z.literal('terminate') }),
+  z.object({ kind: z.literal('fail') }),
+  z.object({ kind: z.literal('pause'), signal: z.string().min(1), resumeStep: z.string().min(1) }),
+]);
+
+const workflowStepManifestSchema = z.object({
+  timeoutMs: z.union([z.number().int().positive(), z.null()]),
+  inputSchema: z.union([z.record(z.string(), z.unknown()), z.null()]),
+  transitions: z.array(manifestTransitionSchema),
+});
+
+/**
+ * Zod schema that parses and validates a WorkflowManifest.
+ * The engine uses this when it receives a manifest from the build phase.
+ */
+export const workflowManifestSchema = z.object({
+  protocol: z.literal(MANIFEST_PROTOCOL),
+  name: z.string().min(1),
+  entry: z.string().min(1),
+  sdkVersion: z.string().min(1),
+  artifact: z.object({
+    sha256: z.string().min(1),
+    entryFile: z.string().min(1),
+  }),
+  steps: z.record(z.string(), workflowStepManifestSchema),
+});

--- a/packages/orchestration/src/sdk.spec.ts
+++ b/packages/orchestration/src/sdk.spec.ts
@@ -1,0 +1,393 @@
+/**
+ * @sapiom/workflow-sdk — own-package tests.
+ *
+ * Proves:
+ *   1. defineOrchestration validation (name, entry, step map checks)
+ *   2. Directive guard functions (isContinue, isRetry, isPause, isTerminate, isFail)
+ *   3. InMemoryContextStore round-trip (get/set/has/snapshot)
+ *   4. UnknownStepError is thrown by defineOrchestration for missing entry
+ *   5. StepLogger structural compatibility: a plain object matching the
+ *      StepLogger interface is accepted (validates the structural design)
+ */
+
+import {
+  DIRECTIVE_KIND,
+  InMemoryContextStore,
+  StepInputValidationError,
+  UnknownStepError,
+  ORCHESTRATION_DEFINITION_BRAND,
+  WorkflowError,
+  defineStep,
+  defineOrchestration,
+  isContinue,
+  isFail,
+  isPause,
+  isRetry,
+  isTerminate,
+  isOrchestrationDefinition,
+  terminate,
+} from './index.js';
+import type {
+  ContinueDirective,
+  FailDirective,
+  NextStepDirective,
+  PauseUntilSignalDirective,
+  RetryDirective,
+  StepLogger,
+  TerminateDirective,
+} from './index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal terminal step suitable for use in defineOrchestration test fixtures. */
+function makeStep(name: string) {
+  return defineStep({
+    name,
+    next: [],
+    terminal: true,
+    async run() {
+      return terminate(null);
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. defineOrchestration validation
+// ---------------------------------------------------------------------------
+
+describe('defineOrchestration', () => {
+  it('returns the definition unchanged when valid', () => {
+    const entry = makeStep('start');
+    const def = defineOrchestration({
+      name: 'my-workflow',
+      entry: 'start',
+      steps: { start: entry },
+    });
+    expect(def.name).toBe('my-workflow');
+    expect(def.entry).toBe('start');
+    expect(def.steps.start).toBe(entry);
+  });
+
+  it('throws when name is empty', () => {
+    expect(() =>
+      defineOrchestration({
+        name: '',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+      }),
+    ).toThrow('Workflow definition must have a non-empty name');
+  });
+
+  it('throws when entry is empty string', () => {
+    expect(() =>
+      defineOrchestration({
+        name: 'wf',
+        entry: '',
+        steps: { start: makeStep('start') },
+      }),
+    ).toThrow("Workflow 'wf' must declare an entry step");
+  });
+
+  it('throws UnknownStepError when entry is not in steps', () => {
+    expect(() =>
+      defineOrchestration({
+        name: 'wf',
+        entry: 'missing',
+        steps: { start: makeStep('start') },
+      }),
+    ).toThrow(UnknownStepError);
+  });
+
+  it('UnknownStepError carries the step name', () => {
+    let thrown: unknown;
+    try {
+      defineOrchestration({ name: 'wf', entry: 'missing', steps: { start: makeStep('start') } });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(UnknownStepError);
+    expect((thrown as UnknownStepError).stepName).toBe('missing');
+  });
+
+  it('throws when a step key does not match step.name', () => {
+    expect(() =>
+      defineOrchestration({
+        name: 'wf',
+        entry: 'start',
+        steps: { start: makeStep('wrong-name') },
+      }),
+    ).toThrow("step name mismatch at key 'start'");
+  });
+
+  it('accepts multiple steps with correct names', () => {
+    const def = defineOrchestration({
+      name: 'multi',
+      entry: 'a',
+      steps: { a: makeStep('a'), b: makeStep('b'), c: makeStep('c') },
+    });
+    expect(Object.keys(def.steps)).toHaveLength(3);
+  });
+
+  it('attaches a non-enumerable ORCHESTRATION_DEFINITION_BRAND symbol to the returned object', () => {
+    const def = defineOrchestration({
+      name: 'branded',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+    });
+    // The brand must be present with value 1.
+    const brand = (def as unknown as Record<symbol, unknown>)[ORCHESTRATION_DEFINITION_BRAND];
+    expect(brand).toBe(1);
+    // Non-enumerable: must not appear in Object.keys or for...in.
+    expect(Object.keys(def)).not.toContain(ORCHESTRATION_DEFINITION_BRAND.toString());
+    const enumKeys: string[] = [];
+    for (const k in def) enumKeys.push(k);
+    expect(enumKeys).not.toContain(ORCHESTRATION_DEFINITION_BRAND.toString());
+  });
+
+  it('brand survives a JSON round-trip by being on the live object (not on a parsed copy)', () => {
+    const def = defineOrchestration({
+      name: 'json-round-trip',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+    });
+    // The brand is on the live definition object.
+    expect(isOrchestrationDefinition(def)).toBe(true);
+    // A plain-JSON copy (simulating what JSON.stringify/parse produces) lacks the brand.
+    const copy = JSON.parse(JSON.stringify({ name: def.name, entry: def.entry, steps: {} }));
+    expect(isOrchestrationDefinition(copy)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOrchestrationDefinition type guard
+// ---------------------------------------------------------------------------
+
+describe('isOrchestrationDefinition', () => {
+  it('returns true for a value produced by defineOrchestration', () => {
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+    });
+    expect(isOrchestrationDefinition(def)).toBe(true);
+  });
+
+  it('returns false for a plain object with name/entry/steps (duck-type trap)', () => {
+    const plain = { name: 'wf', entry: 'start', steps: {} };
+    expect(isOrchestrationDefinition(plain)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isOrchestrationDefinition(null)).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isOrchestrationDefinition('workflow')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isOrchestrationDefinition(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(isOrchestrationDefinition({})).toBe(false);
+  });
+
+  it('narrows the type: TypeScript accepts it as OrchestrationDefinition after guard', () => {
+    const val: unknown = defineOrchestration({
+      name: 'narrowed',
+      entry: 's',
+      steps: { s: makeStep('s') },
+    });
+    if (isOrchestrationDefinition(val)) {
+      // If this compiles, the type narrowing works.
+      expect(val.name).toBe('narrowed');
+    } else {
+      throw new Error('expected isOrchestrationDefinition to return true');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Directive guard functions
+// ---------------------------------------------------------------------------
+
+describe('directive guards', () => {
+  const continueD: ContinueDirective = { kind: DIRECTIVE_KIND.CONTINUE, stepName: 'next' };
+  const retryD: RetryDirective = { kind: DIRECTIVE_KIND.RETRY };
+  const pauseD: PauseUntilSignalDirective = { kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL, signal: { name: 'sig' } };
+  const terminateD: TerminateDirective = { kind: DIRECTIVE_KIND.TERMINATE };
+  const failD: FailDirective = { kind: DIRECTIVE_KIND.FAIL };
+
+  const all: NextStepDirective[] = [continueD, retryD, pauseD, terminateD, failD];
+
+  it('isContinue identifies only continue', () => {
+    expect(all.filter(isContinue)).toEqual([continueD]);
+  });
+
+  it('isRetry identifies only retry', () => {
+    expect(all.filter(isRetry)).toEqual([retryD]);
+  });
+
+  it('isPause identifies only pause_until_signal', () => {
+    expect(all.filter(isPause)).toEqual([pauseD]);
+  });
+
+  it('isTerminate identifies only terminate', () => {
+    expect(all.filter(isTerminate)).toEqual([terminateD]);
+  });
+
+  it('isFail identifies only fail', () => {
+    expect(all.filter(isFail)).toEqual([failD]);
+  });
+
+  it('isContinue narrows type: stepName is accessible', () => {
+    const d: NextStepDirective = continueD;
+    if (isContinue(d)) {
+      // TypeScript should allow d.stepName here
+      expect(d.stepName).toBe('next');
+    } else {
+      throw new Error('isContinue should have returned true');
+    }
+  });
+
+  it('isPause carries signal name and correlationId', () => {
+    const d: PauseUntilSignalDirective = {
+      kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+      signal: { name: 'approval', correlationId: 'run-1' },
+      resumeStep: 'finalize',
+    };
+    expect(isPause(d)).toBe(true);
+    if (isPause(d)) {
+      expect(d.signal.correlationId).toBe('run-1');
+      expect(d.resumeStep).toBe('finalize');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. InMemoryContextStore round-trip
+// ---------------------------------------------------------------------------
+
+describe('InMemoryContextStore', () => {
+  // Extends `Record<string, unknown>` so it satisfies `InMemoryContextStore`'s
+  // `TShared extends Record<string, unknown>` constraint. A bare interface (or a
+  // plain object) lacks the index signature the constraint needs; `extends`
+  // gives it one while keeping the named keys' specific types for get/set. (A
+  // `type` alias would also satisfy the constraint via its implicit index
+  // signature, but the lint rule auto-rewrites `type`→`interface`, which would
+  // then fail the constraint — so the interface form is the stable one.)
+  interface TestShared extends Record<string, unknown> {
+    count: number;
+    label: string;
+    nested: { x: number };
+  }
+
+  it('starts empty and has returns false for unknown keys', () => {
+    const store = new InMemoryContextStore<TestShared>();
+    expect(store.has('count')).toBe(false);
+    expect(store.get('count')).toBeUndefined();
+  });
+
+  it('set/get round-trips scalar values', () => {
+    const store = new InMemoryContextStore<TestShared>();
+    store.set('count', 42);
+    expect(store.get('count')).toBe(42);
+    expect(store.has('count')).toBe(true);
+  });
+
+  it('set/get round-trips object values', () => {
+    const store = new InMemoryContextStore<TestShared>();
+    store.set('nested', { x: 7 });
+    expect(store.get('nested')).toEqual({ x: 7 });
+  });
+
+  it('snapshot returns a copy with all set keys', () => {
+    const store = new InMemoryContextStore<TestShared>({ count: 1 });
+    store.set('label', 'hello');
+    const snap = store.snapshot();
+    expect(snap).toEqual({ count: 1, label: 'hello' });
+  });
+
+  it('snapshot is a shallow copy — mutation does not affect store', () => {
+    const store = new InMemoryContextStore<TestShared>({ count: 5 });
+    const snap = store.snapshot();
+    (snap as { count?: number }).count = 99;
+    expect(store.get('count')).toBe(5);
+  });
+
+  it('initialises from a partial initial state', () => {
+    const store = new InMemoryContextStore<TestShared>({ count: 10 });
+    expect(store.get('count')).toBe(10);
+    expect(store.get('label')).toBeUndefined();
+  });
+
+  it('overwrites previous value on repeated set', () => {
+    const store = new InMemoryContextStore<TestShared>();
+    store.set('count', 1);
+    // intentional: asserts a repeated set overwrites the prior value
+    store.set('count', 2);
+    expect(store.get('count')).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Error hierarchy
+// ---------------------------------------------------------------------------
+
+describe('error hierarchy', () => {
+  it('UnknownStepError is a WorkflowError', () => {
+    const e = new UnknownStepError('foo');
+    expect(e).toBeInstanceOf(WorkflowError);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('UnknownStepError');
+    expect(e.stepName).toBe('foo');
+    expect(e.message).toContain('foo');
+  });
+
+  it('StepInputValidationError is a WorkflowError and carries issues', () => {
+    // Use a minimal $ZodIssue-compatible object cast to the constructor's expected type
+    const fakeIssues = [
+      { path: ['name'], message: 'Required', code: 'invalid_type' },
+    ] as unknown as ConstructorParameters<typeof StepInputValidationError>[1];
+    const e = new StepInputValidationError('myStep', fakeIssues);
+    expect(e).toBeInstanceOf(WorkflowError);
+    expect(e.name).toBe('StepInputValidationError');
+    expect(e.stepName).toBe('myStep');
+    expect(e.issues).toBe(fakeIssues);
+    expect(e.message).toContain('myStep');
+    expect(e.message).toContain('name');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. StepLogger structural compatibility
+// ---------------------------------------------------------------------------
+
+describe('StepLogger structural interface', () => {
+  it('a plain object with the four methods satisfies StepLogger', () => {
+    const logs: string[] = [];
+    // If this assignment compiles, the structural interface is correct.
+    const logger: StepLogger = {
+      info: (msg) => {
+        logs.push(`info:${msg}`);
+      },
+      warn: (msg) => {
+        logs.push(`warn:${msg}`);
+      },
+      error: (msg) => {
+        logs.push(`error:${msg}`);
+      },
+      debug: (msg) => {
+        logs.push(`debug:${msg}`);
+      },
+    };
+    logger.info('hello');
+    logger.warn('careful', { key: 'val' });
+    logger.error('boom');
+    logger.debug('trace');
+    expect(logs).toEqual(['info:hello', 'warn:careful', 'error:boom', 'debug:trace']);
+  });
+});

--- a/packages/orchestration/src/step.ts
+++ b/packages/orchestration/src/step.ts
@@ -1,0 +1,133 @@
+// `zod/v4` subpath (zod 3.25.x): keeps the shared `zod` resolution on v3
+// while this engine uses the v4 type + API surface. See introspection.ts.
+import type { ZodType } from 'zod/v4';
+
+import type { OrchestrationExecutionContext } from './context.js';
+import type { Fail, Goto, NextStepDirective, Pause, Retry, Terminate } from './directives.js';
+
+/**
+ * @deprecated Authoring uses {@link defineStep}/{@link StepDefinition}. This
+ * interface + {@link StepResult} are retained because the engine re-exports them
+ * (`apps/workflows-engine/src/workflows/_core/step.ts`) and uses `StepResult`
+ * as the internal shape it reconstructs from a completion payload — they are NOT
+ * the customer authoring surface anymore.
+ *
+ * A workflow step: consumes typed input + ctx, returns an output + a directive.
+ */
+export interface Step<
+  TIn = unknown,
+  TOut = unknown,
+  TShared extends Record<string, unknown> = Record<string, unknown>,
+> {
+  readonly name: string;
+  readonly inputSchema?: ZodType<TIn>;
+  readonly timeoutMs?: number;
+  run(input: TIn, ctx: OrchestrationExecutionContext<TShared>): Promise<StepResult<TOut>>;
+}
+
+/**
+ * The engine's internal per-step shape: the audit `output` + the `next`
+ * directive. The runner reconstructs this from a completion payload (extracting
+ * `output` from the returned directive — see the runner's output-extraction).
+ */
+export interface StepResult<TOut = unknown> {
+  /** Persisted to the step's audit row. Default input for the next step. */
+  readonly output: TOut;
+  readonly next: NextStepDirective;
+}
+
+// ---------------------------------------------------------------------------
+// Declared-edge authoring: defineStep + Allowed
+// ---------------------------------------------------------------------------
+
+/**
+ * The set of transitions a step's `run` may return, derived from its declared
+ * routing capabilities. This is the load-bearing type: `goto` to a target not
+ * in `Next` (or `terminate`/`fail`/`pause` a step that didn't declare it) is not
+ * assignable to this union → a compile error at the `run` return.
+ *
+ * `Retry` is always present (universal badge, not a declared edge — the engine
+ * caps it by `maxAttemptsPerStep`). A step with `next: []` and no
+ * terminal/canFail/pause can therefore still only `retry` (and is flagged as a
+ * dead-end by `validateGraph`).
+ */
+export type Allowed<
+  Next extends readonly string[],
+  Term extends boolean,
+  CanFail extends boolean,
+  PauseTo extends string,
+> =
+  | Goto<Next[number]>
+  | (Term extends true ? Terminate : never)
+  | (CanFail extends true ? Fail : never)
+  | ([PauseTo] extends [never] ? never : Pause<PauseTo>)
+  | Retry;
+
+/**
+ * A step as stored in a workflow's `steps` map — type-erased over routing. The
+ * declared routing capabilities (`next`/`terminal`/`canFail`/`pause`) are
+ * **runtime properties** `defineStep` always writes, which is what
+ * `buildManifest` reads to emit the graph (exactly as it reads `inputSchema`).
+ */
+export interface StepDefinition<TShared extends Record<string, unknown> = Record<string, unknown>> {
+  readonly name: string;
+  /** Declared `continue` targets (the graph's outgoing edges from this step). */
+  readonly next: readonly string[];
+  /** May `terminate`. */
+  readonly terminal: boolean;
+  /** May `fail`. */
+  readonly canFail: boolean;
+  /** Declared pause edge, if any. */
+  readonly pause?: { readonly signal: string; readonly resumeStep: string };
+  readonly inputSchema?: ZodType<unknown>;
+  readonly timeoutMs?: number;
+  run(input: unknown, ctx: OrchestrationExecutionContext<TShared>): Promise<NextStepDirective>;
+}
+
+/**
+ * Define a step. `defineStep` derives the `run` return type from the declared
+ * `next`/`terminal`/`canFail`/`pause` (via {@link Allowed}) — making undeclared
+ * transitions a compile error — and stores those declarations as runtime
+ * properties for `buildManifest` to read.
+ *
+ * `TShared` is inferred from the `ctx` annotation in `run`
+ * (`ctx: OrchestrationExecutionContext<MyShared>`); `TIn` from `inputSchema` or the
+ * `input` annotation. `next`/`terminal`/`canFail`/`pause` are inferred as
+ * literals (`const` type params), so no `as const` is needed.
+ */
+export function defineStep<
+  TIn = unknown,
+  TShared extends Record<string, unknown> = Record<string, unknown>,
+  const Next extends readonly string[] = readonly [],
+  const Term extends boolean = false,
+  const CanFail extends boolean = false,
+  // Capture the whole pause object as a `const` type param (not a nested
+  // property of a fixed-shape param) so its `resumeStep` literal is preserved —
+  // a nested `resumeStep: PauseTo` widens to `string` and defeats enforcement.
+  const PauseDecl extends { signal: string; resumeStep: string } | undefined = undefined,
+>(def: {
+  name: string;
+  next?: Next;
+  terminal?: Term;
+  canFail?: CanFail;
+  pause?: PauseDecl;
+  inputSchema?: ZodType<TIn>;
+  timeoutMs?: number;
+  // Arrow-property (not method) type so `def.run` can be read as a value below
+  // without tripping @typescript-eslint/unbound-method.
+  run: (
+    input: TIn,
+    ctx: OrchestrationExecutionContext<TShared>,
+  ) => Promise<Allowed<Next, Term, CanFail, PauseDecl extends { resumeStep: infer R extends string } ? R : never>>;
+}): StepDefinition<TShared> {
+  return {
+    name: def.name,
+    next: def.next ?? [],
+    terminal: def.terminal ?? false,
+    canFail: def.canFail ?? false,
+    ...(def.pause ? { pause: def.pause } : {}),
+    ...(def.inputSchema ? { inputSchema: def.inputSchema as ZodType<unknown> } : {}),
+    ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+    run: def.run as unknown as (input: unknown, ctx: OrchestrationExecutionContext<TShared>) => Promise<NextStepDirective>,
+  };
+}

--- a/packages/orchestration/src/type-enforcement.spec.ts
+++ b/packages/orchestration/src/type-enforcement.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * TYPE-LEVEL enforcement — the load-bearing claim of the declared-edge model.
+ *
+ * These assertions are checked by `tsc --noEmit` (the package `typecheck`
+ * script), NOT by the test runner's runtime (esbuild erases types). Jest just
+ * imports the file; the single runtime `it` keeps the suite non-empty.
+ *
+ * Two layers:
+ *  1. An `Allowed<…>` assignability TABLE — robust, no `@ts-expect-error`
+ *     placement fragility: a wrong answer makes `= true/false` fail to compile.
+ *  2. `defineStep` smoke checks proving the inference wires `next`/`terminal`/…
+ *     through to the `run` return constraint end-to-end.
+ */
+
+import { defineStep, fail, goto, pauseUntilSignal, retry, terminate } from './index.js';
+import type { Allowed, Goto, Pause, Retry, Terminate } from './index.js';
+
+type Extends<A, B> = A extends B ? true : false;
+
+// ---- 1. Allowed<…> assignability table ----------------------------------
+
+// goto: assignable iff the target ∈ next
+const _gotoDeclared: Extends<Goto<'b'>, Allowed<['b'], false, false, never>> = true;
+const _gotoUndeclared: Extends<Goto<'c'>, Allowed<['b'], false, false, never>> = false;
+// dynamic goto(cond ? 'a' : 'b') — assignable iff BOTH ∈ next
+const _gotoUnionOk: Extends<Goto<'a' | 'b'>, Allowed<['a', 'b'], false, false, never>> = true;
+const _gotoUnionPartial: Extends<Goto<'a' | 'c'>, Allowed<['a', 'b'], false, false, never>> = false;
+// terminate: only when terminal:true
+const _terminateNoDecl: Extends<Terminate, Allowed<[], false, false, never>> = false;
+const _terminateDecl: Extends<Terminate, Allowed<[], true, false, never>> = true;
+// pause: only with a matching resumeStep declaration
+const _pauseNoDecl: Extends<Pause<'r'>, Allowed<[], false, false, never>> = false;
+const _pauseDecl: Extends<Pause<'r'>, Allowed<[], false, false, 'r'>> = true;
+// retry: always allowed
+const _retryAlways: Extends<Retry, Allowed<[], false, false, never>> = true;
+
+const TABLE = [
+  _gotoDeclared,
+  _gotoUndeclared,
+  _gotoUnionOk,
+  _gotoUnionPartial,
+  _terminateNoDecl,
+  _terminateDecl,
+  _pauseNoDecl,
+  _pauseDecl,
+  _retryAlways,
+];
+
+// ---- 2. defineStep end-to-end inference smoke checks ---------------------
+// Never invoked; tsc checks the bodies. Each `@ts-expect-error` asserts the
+// constraint fires — an unused directive (i.e. it compiled) is itself a tsc error.
+
+function _smoke() {
+  // valid: goto to a declared target
+  defineStep({ name: 's', next: ['b'], run: async () => goto('b') });
+  // valid: retry is always allowed
+  defineStep({ name: 's', next: ['b'], run: async () => retry() });
+  // valid: terminate with terminal:true
+  defineStep({ name: 's', next: [], terminal: true, run: async () => terminate({ ok: 1 }) });
+  // valid: fail with canFail:true
+  defineStep({ name: 's', next: [], canFail: true, run: async () => fail('x') });
+  // valid: pause with a matching declaration
+  defineStep({
+    name: 's',
+    next: [],
+    pause: { signal: 'sig', resumeStep: 'b' },
+    run: async () => pauseUntilSignal({ signal: 'sig', resumeStep: 'b' }),
+  });
+
+  // INVALID: goto to an undeclared target
+  defineStep({
+    name: 's',
+    next: ['b'],
+    run: async () =>
+      // @ts-expect-error 'c' is not in next: ['b']
+      goto('c'),
+  });
+  // INVALID: terminate without terminal:true
+  defineStep({
+    name: 's',
+    next: [],
+    run: async () =>
+      // @ts-expect-error step did not declare terminal: true
+      terminate(),
+  });
+  // INVALID: fail without canFail:true
+  defineStep({
+    name: 's',
+    next: [],
+    run: async () =>
+      // @ts-expect-error step did not declare canFail: true
+      fail('x'),
+  });
+  // INVALID: pause to an undeclared resumeStep
+  defineStep({
+    name: 's',
+    next: [],
+    pause: { signal: 'sig', resumeStep: 'b' },
+    run: async () =>
+      // @ts-expect-error resumeStep 'c' does not match the declared 'b'
+      pauseUntilSignal({ signal: 'sig', resumeStep: 'c' }),
+  });
+}
+
+describe('type enforcement', () => {
+  it('assignability table + defineStep smoke checks are validated by tsc --noEmit', () => {
+    expect(TABLE).toHaveLength(9);
+    expect(typeof _smoke).toBe('function');
+  });
+});

--- a/packages/orchestration/src/workflow.ts
+++ b/packages/orchestration/src/workflow.ts
@@ -1,0 +1,118 @@
+import { UnknownStepError } from './errors.js';
+import type { StepDefinition } from './step.js';
+
+/**
+ * Brand symbol for OrchestrationDefinition objects produced by `defineOrchestration`.
+ *
+ * Attached as a non-enumerable property so it survives bundling + dynamic
+ * import without polluting the object's visible shape. The value is the
+ * protocol version (1); bump if the definition contract changes.
+ *
+ * Use `isOrchestrationDefinition(val)` to check the brand — never duck-type on
+ * name/entry/steps because those keys are also valid plain data objects.
+ */
+export const ORCHESTRATION_DEFINITION_BRAND = Symbol.for('sapiom.orchestration.definition');
+
+/**
+ * A workflow definition: a name, an entry step, and a name → step map.
+ *
+ * Generics:
+ *   - TInput:  the type of the value passed to the entry step on `runner.run(def, input, ...)`
+ *   - TShared: the named-slots shape for cross-step values; ctx.shared is typed by this
+ *
+ * Workflow authors write:
+ *
+ *   interface CycleShared {
+ *     summary: SummaryOutput;
+ *     monitoring: MonitoringSnapshot;
+ *   }
+ *
+ *   export const cycleWorkflow = defineOrchestration<{ companyId: number }, CycleShared>({
+ *     name: 'cycle',
+ *     entry: 'gather',
+ *     steps: { gather, summarize, ... },
+ *   });
+ *
+ * Steps inside `steps` are typed Step<unknown, unknown, TShared>. The
+ * primitive doesn't (and can't) statically enforce that each step's TIn
+ * matches its predecessor's TOut — that's a design tradeoff for the
+ * "dynamic next directive" capability. Step authors maintain the chain
+ * by convention; runtime mismatches surface as the step's own TS
+ * narrowing at the top of run().
+ */
+export interface OrchestrationDefinition<
+  TInput = unknown,
+  TShared extends Record<string, unknown> = Record<string, unknown>,
+> {
+  readonly name: string;
+  readonly entry: string;
+  readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
+  /**
+   * Phantom marker that carries the entry-step input type so `runner.run(def, input)`
+   * can infer it (see TInput in the doc above). The steps map is deliberately
+   * type-erased, leaving TInput no structural home — this is its anchor. Never
+   * assigned at runtime; do not read it.
+   */
+  readonly __inputType?: TInput;
+}
+
+/**
+ * Type guard that checks the `ORCHESTRATION_DEFINITION_BRAND` symbol set by
+ * `defineOrchestration`. Use this (not duck-typing on name/entry/steps) to
+ * detect workflow definitions among module exports.
+ *
+ * Example:
+ *   const mod = await import(bundleUrl);
+ *   const defs = Object.values(mod).filter(isOrchestrationDefinition);
+ */
+export function isOrchestrationDefinition(val: unknown): val is OrchestrationDefinition {
+  if (val === null || typeof val !== 'object') return false;
+  return (val as Record<symbol, unknown>)[ORCHESTRATION_DEFINITION_BRAND] === 1;
+}
+
+/**
+ * Validate and return a workflow definition. Checks done here:
+ *   1. `name` is non-empty
+ *   2. `entry` exists in `steps`
+ *   3. Every step in `steps` is non-null and the map key matches `step.name`
+ *
+ * Attaches a non-enumerable brand symbol (`ORCHESTRATION_DEFINITION_BRAND`) so
+ * the object can be detected by `isOrchestrationDefinition` after bundling +
+ * dynamic import without relying on duck-typed property names.
+ *
+ * Static validation of every `continue` target is intentionally NOT
+ * done — most are computed at runtime inside `run()`. PR review is the
+ * gate for "did you reference a step that doesn't exist."
+ */
+export function defineOrchestration<TInput = unknown, TShared extends Record<string, unknown> = Record<string, unknown>>(
+  def: OrchestrationDefinition<TInput, TShared>,
+): OrchestrationDefinition<TInput, TShared> {
+  if (!def.name) {
+    throw new Error('Workflow definition must have a non-empty name');
+  }
+  if (!def.entry) {
+    throw new Error(`Workflow '${def.name}' must declare an entry step`);
+  }
+  if (!def.steps[def.entry]) {
+    throw new UnknownStepError(def.entry);
+  }
+  for (const [key, step] of Object.entries(def.steps)) {
+    if (!step) {
+      throw new Error(`Workflow '${def.name}' has null/undefined step at key '${key}'`);
+    }
+    if (step.name !== key) {
+      throw new Error(`Workflow '${def.name}' step name mismatch at key '${key}': step.name='${step.name}'`);
+    }
+  }
+  // Attach the brand as a non-enumerable property so it:
+  //   - survives esbuild bundling (symbol properties pass through)
+  //   - survives dynamic import (the imported object is the same reference)
+  //   - doesn't pollute JSON.stringify or for...in iteration
+  Object.defineProperty(def, ORCHESTRATION_DEFINITION_BRAND, {
+    value: 1,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return def;
+}

--- a/packages/orchestration/tsconfig.cjs.json
+++ b/packages/orchestration/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/orchestration/tsconfig.esm.json
+++ b/packages/orchestration/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./dist/esm",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/orchestration/tsconfig.json
+++ b/packages/orchestration/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node", "jest"],
+    "removeComments": true,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/LICENSE
+++ b/packages/tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Public-surface smoke test for @sapiom/tools.
+ *
+ * Asserts the package's exported surface is wired and importable — `createClient`
+ * builds a `Sapiom` with the expected capability namespaces, `withAttribution`
+ * derives a same-shaped client, and the barrel re-exports the namespaces +
+ * resource classes. It makes NO network calls: `createClient` only binds a
+ * transport (the missing-credential error fires on a request, not at
+ * construction), so constructing + shape-checking is side-effect-free.
+ */
+import { createClient, sandboxes, repositories, agent, Sandbox, Repository } from './index.js';
+
+describe('@sapiom/tools public surface', () => {
+  it('exposes createClient as a function', () => {
+    expect(typeof createClient).toBe('function');
+  });
+
+  it('createClient builds a Sapiom with the expected capability namespaces', () => {
+    const sapiom = createClient({ apiKey: 'test-key' });
+
+    expect(typeof sapiom.sandboxes.create).toBe('function');
+    expect(typeof sapiom.sandboxes.attach).toBe('function');
+
+    expect(typeof sapiom.repositories.create).toBe('function');
+    expect(typeof sapiom.repositories.get).toBe('function');
+    expect(typeof sapiom.repositories.list).toBe('function');
+    expect(typeof sapiom.repositories.delete).toBe('function');
+    expect(typeof sapiom.repositories.attach).toBe('function');
+
+    expect(typeof sapiom.agent.coding.run).toBe('function');
+    expect(typeof sapiom.agent.coding.launch).toBe('function');
+
+    expect(typeof sapiom.withAttribution).toBe('function');
+  });
+
+  it('withAttribution derives a client of the same shape', () => {
+    const derived = createClient({ apiKey: 'test-key' }).withAttribution({});
+    expect(typeof derived.sandboxes.create).toBe('function');
+    expect(typeof derived.agent.coding.run).toBe('function');
+    expect(typeof derived.withAttribution).toBe('function');
+  });
+
+  it('barrel re-exports the capability namespaces and resource classes', () => {
+    expect(typeof sandboxes).toBe('object');
+    expect(typeof repositories).toBe('object');
+    expect(typeof agent).toBe('object');
+    expect(typeof Sandbox).toBe('function'); // class constructor
+    expect(typeof Repository).toBe('function');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,39 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/orchestration:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.24
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.24)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.6.2
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.5(@babel/core@7.28.5)(jest@29.7.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
   packages/sandbox:
     dependencies:
       '@sapiom/fetch':


### PR DESCRIPTION
This pull request introduces the initial implementation of the `@sapiom/orchestration` package, establishing the foundation for authoring and running orchestrations within the Sapiom ecosystem. It includes project setup, documentation, licensing, configuration, and the core TypeScript source files that define the orchestration contract, manifest builder, context, and directive constructors. The package is designed to be dependency-light, with a strictly-pinned `zod` peer dependency, and is shared across orchestration authors, the sandbox step-runner, and the engine.

The most important changes are:

**Project Setup and Documentation**
- Added `package.json` with project metadata, scripts, dependencies, and build/test configuration for the `@sapiom/orchestration` package.
- Included a comprehensive `README.md` describing the package's purpose, usage, and authoring interface for orchestrations.
- Added `LICENSE` file with the MIT License for open source compliance.
- Added `jest.config.js` to configure testing with Jest and TypeScript.

**Core Orchestration Functionality**
- Implemented `build-manifest.ts` to generate workflow manifests from orchestration definitions, including build-time graph validation and schema handling.
- Added `context.ts` defining the orchestration execution context, step logger interface, context store, and step execution record types, as well as an in-memory context store implementation.

**Testing and Validation**
- Added `constructors.spec.ts` with tests for directive constructors (`goto`, `terminate`, `fail`, `pauseUntilSignal`, `retry`) to ensure correct directive shapes and payload handling.