### PR TITLE
add command to scaffold definitions locally

### DIFF
--- a/packages/create-orchestration/.eslintrc.js
+++ b/packages/create-orchestration/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  root: true,
+  env: {
+    node: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules', 'templates'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/create-orchestration/LICENSE
+++ b/packages/create-orchestration/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-orchestration/README.md
+++ b/packages/create-orchestration/README.md
@@ -1,0 +1,22 @@
+# @sapiom/create-orchestration
+
+Scaffold a new [Sapiom orchestration](https://www.npmjs.com/package/@sapiom/orchestration) project.
+
+```sh
+npm create @sapiom/orchestration my-agent
+# or
+npx @sapiom/create-orchestration my-agent
+```
+
+Creates a ready-to-edit project: `@sapiom/orchestration` + `@sapiom/tools` pinned to the current published versions, a `tsconfig.json` tuned for the SDK's subpath exports, and a stub `index.ts` defining a minimal orchestration.
+
+## Options
+
+```
+create-orchestration <dir> [--template <name>]
+```
+
+- `-t, --template <name>` — template to scaffold from (default: `default`). More pre-supplied templates can be added without upgrading this tool.
+- `-h, --help`
+
+Non-interactive by design — everything comes from arguments, so it scripts cleanly (including from a coding agent).

--- a/packages/create-orchestration/package.json
+++ b/packages/create-orchestration/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@sapiom/create-orchestration",
+  "version": "0.1.0",
+  "description": "Scaffold a new Sapiom orchestration project — `npm create @sapiom/orchestration my-app`.",
+  "license": "MIT",
+  "author": "Sapiom",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/create-orchestration"
+  },
+  "keywords": [
+    "sapiom",
+    "orchestration",
+    "scaffold",
+    "create",
+    "cli"
+  ],
+  "bin": {
+    "create-orchestration": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "templates",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc --watch -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/create-orchestration/src/index.ts
+++ b/packages/create-orchestration/src/index.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * `npm create @sapiom/orchestration <dir>` — scaffold a new Sapiom orchestration
+ * project. Non-interactive by design (agent-friendly): everything comes from
+ * argv, no prompts.
+ *
+ *   npm create @sapiom/orchestration my-agent
+ *   npx @sapiom/create-orchestration my-agent --template default
+ */
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { scaffold } from './scaffold';
+import { DEFAULT_TEMPLATE, listTemplates, resolveTemplate } from './templates';
+import { resolveVersions } from './versions';
+
+interface Args {
+  dir?: string;
+  template: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { template: DEFAULT_TEMPLATE, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--template' || a === '-t') args.template = argv[++i] ?? args.template;
+    else if (!a.startsWith('-') && args.dir === undefined) args.dir = a;
+  }
+  return args;
+}
+
+function printHelp(): void {
+  const templates = listTemplates();
+  console.log(
+    [
+      'Create a new Sapiom orchestration project.',
+      '',
+      'Usage:',
+      '  npm create @sapiom/orchestration <dir> [-- --template <name>]',
+      '  npx @sapiom/create-orchestration <dir> [--template <name>]',
+      '',
+      'Options:',
+      '  -t, --template <name>   Template to scaffold from' +
+        (templates.length ? ` (${templates.join(', ')})` : '') +
+        `. Default: ${DEFAULT_TEMPLATE}`,
+      '  -h, --help              Show this help',
+    ].join('\n'),
+  );
+}
+
+function printNextSteps(dir: string): void {
+  console.log(
+    [
+      '',
+      `✓ Created ${dir}`,
+      '',
+      'Next steps:',
+      `  cd ${dir}`,
+      '  npm install',
+      '  # edit index.ts — your orchestration is defined with defineOrchestration({ steps })',
+      '  # Sapiom capabilities are available pre-auth\'d on ctx.sapiom inside any step',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.dir) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  const targetDir = path.resolve(args.dir);
+  if (existsSync(targetDir) && readdirSync(targetDir).length > 0) {
+    console.error(`Error: target directory '${args.dir}' already exists and is not empty.`);
+    process.exit(1);
+  }
+
+  // Throws (clear message) on an unknown template — the resolver seam.
+  const templateDir = resolveTemplate(args.template);
+  const versions = await resolveVersions();
+
+  mkdirSync(targetDir, { recursive: true });
+  scaffold({
+    templateDir,
+    targetDir,
+    replacements: {
+      __PROJECT_NAME__: path.basename(targetDir),
+      __ORCHESTRATION_VERSION__: versions.orchestration,
+      __TOOLS_VERSION__: versions.tools,
+      __ZOD_VERSION__: versions.zod,
+    },
+  });
+
+  printNextSteps(args.dir);
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/packages/create-orchestration/src/scaffold.ts
+++ b/packages/create-orchestration/src/scaffold.ts
@@ -1,0 +1,62 @@
+/**
+ * Copy a template directory into the target, applying placeholder substitution
+ * and the dotfile-rename convention.
+ *
+ * Why `_gitignore` → `.gitignore`: npm strips/renames a literal `.gitignore`
+ * inside a published package, so templates store it as `_gitignore` and we
+ * restore the dot on scaffold. Same trick applies to any other dotfile.
+ */
+import { cpSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export interface ScaffoldOptions {
+  templateDir: string;
+  targetDir: string;
+  /** Literal `__TOKEN__` → value substitutions applied to every text file. */
+  replacements: Record<string, string>;
+}
+
+const DOTFILE_PREFIX = '_';
+const DOTFILE_NAMES = new Set(['_gitignore', '_npmrc']);
+
+export function scaffold({ templateDir, targetDir, replacements }: ScaffoldOptions): void {
+  cpSync(templateDir, targetDir, { recursive: true });
+  walk(targetDir, (file) => {
+    const base = path.basename(file);
+
+    // Restore dotfiles: _gitignore → .gitignore
+    if (DOTFILE_NAMES.has(base)) {
+      const dotted = path.join(path.dirname(file), '.' + base.slice(DOTFILE_PREFIX.length));
+      renameSync(file, dotted);
+      applyReplacements(dotted, replacements);
+      return;
+    }
+
+    applyReplacements(file, replacements);
+  });
+}
+
+function applyReplacements(file: string, replacements: Record<string, string>): void {
+  let content: string;
+  try {
+    content = readFileSync(file, 'utf8');
+  } catch {
+    return; // unreadable / binary — leave as-is
+  }
+  let changed = false;
+  for (const [token, value] of Object.entries(replacements)) {
+    if (content.includes(token)) {
+      content = content.split(token).join(value);
+      changed = true;
+    }
+  }
+  if (changed) writeFileSync(file, content);
+}
+
+function walk(dir: string, onFile: (file: string) => void): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, onFile);
+    else onFile(full);
+  }
+}

--- a/packages/create-orchestration/src/templates.ts
+++ b/packages/create-orchestration/src/templates.ts
@@ -1,0 +1,35 @@
+/**
+ * Template resolution — the extension seam.
+ *
+ * Today this resolves a directory bundled in the published package
+ * (`templates/<name>`). It is deliberately the ONLY place that knows where
+ * templates come from, so future work — a richer set of pre-supplied examples,
+ * or fetching a template from a remote manifest / git — slots in here without
+ * touching the CLI's arg-parsing or scaffold logic. `--template <name>` already
+ * flows through; adding examples is just dropping a dir under `templates/`.
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/** Bundled templates sit beside `dist/` at the package root (shipped via `files`). */
+const TEMPLATES_DIR = path.resolve(__dirname, '..', 'templates');
+
+export const DEFAULT_TEMPLATE = 'default';
+
+export function listTemplates(): string[] {
+  if (!existsSync(TEMPLATES_DIR)) return [];
+  return readdirSync(TEMPLATES_DIR).filter((name) => statSync(path.join(TEMPLATES_DIR, name)).isDirectory());
+}
+
+/** Absolute path to a bundled template directory. Throws on an unknown name. */
+export function resolveTemplate(name: string): string {
+  const dir = path.join(TEMPLATES_DIR, name);
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+    const available = listTemplates();
+    throw new Error(
+      `Unknown template '${name}'.` +
+        (available.length ? ` Available: ${available.join(', ')}.` : ' No templates are bundled.'),
+    );
+  }
+  return dir;
+}

--- a/packages/create-orchestration/src/versions.ts
+++ b/packages/create-orchestration/src/versions.ts
@@ -1,0 +1,52 @@
+/**
+ * Resolve the dependency versions stamped into a scaffolded project.
+ *
+ * We fetch the *current* published version of each Sapiom package from npm at
+ * scaffold time (with a pinned fallback if offline / the registry is slow), so a
+ * stale copy of this CLI still stamps up-to-date pins. This is the forward-compat
+ * hook: the CLI never needs republishing just to track new SDK releases.
+ *
+ * Pins are stamped EXACT (no caret) so a project's local typecheck matches what
+ * the build injects — see the SDK version drift-check in the build pipeline.
+ */
+const REGISTRY = 'https://registry.npmjs.org';
+
+/** Used when the registry is unreachable. Bump alongside notable SDK releases. */
+const FALLBACK = {
+  orchestration: '0.1.1',
+  tools: '0.1.1',
+};
+
+/** Pinned to the zod 3.25.x line the SDK's `zod/v4` subpath requires. */
+const ZOD_VERSION = '3.25.76';
+
+export interface ResolvedVersions {
+  orchestration: string;
+  tools: string;
+  zod: string;
+}
+
+async function latestVersion(pkg: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${REGISTRY}/${pkg.replace('/', '%2F')}/latest`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { version?: string };
+    return typeof json.version === 'string' ? json.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveVersions(): Promise<ResolvedVersions> {
+  const [orchestration, tools] = await Promise.all([
+    latestVersion('@sapiom/orchestration'),
+    latestVersion('@sapiom/tools'),
+  ]);
+  return {
+    orchestration: orchestration ?? FALLBACK.orchestration,
+    tools: tools ?? FALLBACK.tools,
+    zod: ZOD_VERSION,
+  };
+}

--- a/packages/create-orchestration/templates/default/README.md
+++ b/packages/create-orchestration/templates/default/README.md
@@ -1,0 +1,22 @@
+# __PROJECT_NAME__
+
+A Sapiom orchestration, authored as code against [`@sapiom/orchestration`](https://www.npmjs.com/package/@sapiom/orchestration).
+
+## Getting started
+
+```sh
+npm install
+```
+
+Then open `index.ts`. The orchestration is defined with `defineOrchestration({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
+
+```ts
+const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
+const repo = await ctx.sapiom.repositories.create('my-repo');
+```
+
+No credentials to wire — the engine injects a per-execution tenant credential when your orchestration runs.
+
+## How it runs
+
+Push this repo to Sapiom; the build bundles your definition, derives the step graph, and the engine executes it (pause/resume, retries, schedules, per-step cost — all built in). You author the steps; Sapiom runs them.

--- a/packages/create-orchestration/templates/default/_gitignore
+++ b/packages/create-orchestration/templates/default/_gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.tsbuildinfo

--- a/packages/create-orchestration/templates/default/index.ts
+++ b/packages/create-orchestration/templates/default/index.ts
@@ -1,0 +1,38 @@
+import { defineOrchestration, defineStep, goto, terminate } from '@sapiom/orchestration';
+
+/**
+ * A minimal Sapiom orchestration: two steps, `start → finish`.
+ *
+ * Each step declares its allowed transitions (`next` / `terminal` / `canFail` /
+ * `pause`); the return type is derived from them, so an undeclared transition is
+ * a compile error. Inside any step the full Sapiom tool catalog is available,
+ * pre-auth'd and tenant-scoped, on `ctx.sapiom` — no credentials to wire.
+ */
+const start = defineStep({
+  name: 'start',
+  next: ['finish'],
+  async run(input, ctx) {
+    ctx.logger.info('starting', { input });
+
+    // Sapiom capabilities are available on ctx.sapiom (metered + traced):
+    //   const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
+    //   const repo = await ctx.sapiom.repositories.create('my-repo');
+
+    return goto('finish', { greeting: 'hello from Sapiom' });
+  },
+});
+
+const finish = defineStep({
+  name: 'finish',
+  next: [],
+  terminal: true,
+  async run() {
+    return terminate({ done: true });
+  },
+});
+
+export const orchestration = defineOrchestration({
+  name: '__PROJECT_NAME__',
+  entry: 'start',
+  steps: { start, finish },
+});

--- a/packages/create-orchestration/templates/default/package.json
+++ b/packages/create-orchestration/templates/default/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "__PROJECT_NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@sapiom/orchestration": "__ORCHESTRATION_VERSION__",
+    "@sapiom/tools": "__TOOLS_VERSION__",
+    "zod": "__ZOD_VERSION__"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/packages/create-orchestration/templates/default/tsconfig.json
+++ b/packages/create-orchestration/templates/default/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/create-orchestration/tsconfig.json
+++ b/packages/create-orchestration/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "declarationMap": false,
+    "composite": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,27 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/create-orchestration:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      prettier:
+        specifier: ^3.2.5
+        version: 3.8.4
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
   packages/fetch:
     dependencies:
       '@sapiom/core':


### PR DESCRIPTION
This pull request introduces a new package, `@sapiom/create-orchestration`, which provides a CLI tool to scaffold new Sapiom orchestration projects. The package includes a non-interactive CLI, template management, dynamic dependency version resolution, and a default project template. The implementation ensures that generated projects are ready-to-edit, up-to-date with the latest dependencies, and agent/script friendly.

The most important changes are:

**New CLI Tool and Core Implementation**
- Added the main CLI entrypoint (`src/index.ts`) that parses arguments, handles help output, resolves templates and dependency versions, and invokes project scaffolding. The CLI is non-interactive and designed for scripting/agent use.

**Project Scaffolding and Template System**
- Implemented a flexible scaffolding system (`src/scaffold.ts`) that copies template files, applies placeholder substitutions, and restores dotfiles (like `.gitignore`) from template-safe names.
- Added a template resolution module (`src/templates.ts`) that supports listing and resolving bundled templates, enabling easy extension for new or remote templates in the future.

**Dynamic Dependency Version Resolution**
- Added logic to fetch the latest published versions of Sapiom dependencies from npm at scaffold time, with offline fallbacks, ensuring generated projects use current versions without needing CLI updates. (src/versions.ts)

**Default Project Template**
- Introduced a default template (`templates/default/`) including a minimal orchestration example (`index.ts`), a tailored `package.json` and `tsconfig.json`, a starter `README.md`, and standard dotfiles. Placeholders are used for project name and dependency versions. [[1]](diffhunk://#diff-c217771a62b9882167ebf4a08f0bf467014cc8143488283f1924286707295eeeR1-R38) [[2]](diffhunk://#diff-b88fea650fa44a7708a1ee36e41ac438ff243d7b5a4d94074993f15233656c45R1-R15) [[3]](diffhunk://#diff-d6c955e8643c26d5f734262e87227d9c2d4b3d504e3c393a7e39172aaf524c18R1-R12) [[4]](diffhunk://#diff-6fab77cbdb2c88a0e0476cbbb1eb05a458f35be838d42a42d2e92af74a7ca706R1-R22) [[5]](diffhunk://#diff-6f3ca799acf51ccbc765ed80576248bd067f112ff3a0df4365fb3a18fa73e281R1-R3)

**Tooling and Documentation**
- Added configuration files for TypeScript, ESLint, and Prettier, a package manifest, and a README describing CLI usage and options. [[1]](diffhunk://#diff-a9837e402f97d0214adcc0c289a902b9400b5392a3942328af971dc7f7b1ad28R1-R13) [[2]](diffhunk://#diff-965bf117e034e278b754c3f31365607883db19a69d5287cf3238bb110f829ff3R1-R19) [[3]](diffhunk://#diff-61bd7915d281dbc3f29213f6c703be0806523e4060c5300a2bf3b5cc96f31e3bR1-R50) [[4]](diffhunk://#diff-b29105cea7679f026e835c137d4866219914b5285b783cb62d0f0b8f1255a844R1-R22)
- Included an MIT license and updated the monorepo lockfile for new dev dependencies. [[1]](diffhunk://#diff-15106770890a8a753faf92a90542aad81c35ef9211e9644fb510c436b116d8c5R1-R21) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR103-R123)

This sets up a robust foundation for quickly bootstrapping new Sapiom orchestration projects with best practices and up-to-date dependencies.