### PR TITLE
feat(orchestration): secrets/secretsRef for vault injection (SAP-786)

### DIFF
--- a/.changeset/orchestration-vault-secrets.md
+++ b/.changeset/orchestration-vault-secrets.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/orchestration": minor
+---
+
+Add optional `secrets` and `secretsRef` to orchestration definitions and the workflow manifest. An orchestration can declare the names of the vault secrets it needs (and, optionally, the secret-set ref to read them from); the engine reads these from the manifest to inject vault-stored secrets into a run's sandbox env at dispatch (SAP-786). Backward-compatible: both fields are optional, and the manifest schema defaults `secrets` to `[]`, so existing manifests keep parsing.

--- a/.changeset/orchestration-vault-secrets.md
+++ b/.changeset/orchestration-vault-secrets.md
@@ -2,4 +2,4 @@
 "@sapiom/orchestration": minor
 ---
 
-Add optional `secrets` and `secretsRef` to orchestration definitions and the workflow manifest. An orchestration can declare the names of the vault secrets it needs (and, optionally, the secret-set ref to read them from); the engine reads these from the manifest to inject vault-stored secrets into a run's sandbox env at dispatch (SAP-786). Backward-compatible: both fields are optional, and the manifest schema defaults `secrets` to `[]`, so existing manifests keep parsing.
+Add optional `secrets` to orchestration definitions and the workflow manifest: an array of bindings `{ ref, keys }`, each pulling the named `keys` (env-var names) from one vault secret-set (`ref`). A workflow can declare several to read from different sets. The engine reads these from the manifest to inject vault-stored secret values into a run's sandbox env at dispatch (SAP-786). Backward-compatible: optional, and the manifest schema defaults it to `[]`, so existing manifests keep parsing.

--- a/packages/orchestration/src/build-manifest.ts
+++ b/packages/orchestration/src/build-manifest.ts
@@ -53,6 +53,8 @@ export function buildManifest(
     sdkVersion: opts.sdkVersion,
     artifact: opts.artifact,
     steps,
+    secrets: def.secrets ?? [],
+    secretsRef: def.secretsRef,
   };
 }
 

--- a/packages/orchestration/src/build-manifest.ts
+++ b/packages/orchestration/src/build-manifest.ts
@@ -54,7 +54,6 @@ export function buildManifest(
     artifact: opts.artifact,
     steps,
     secrets: def.secrets ?? [],
-    secretsRef: def.secretsRef,
   };
 }
 

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -277,6 +277,36 @@ describe('buildManifest', () => {
     expect(parsed.steps.entry.inputSchema).not.toBeNull();
     expect(parsed.steps.exit.timeoutMs).toBe(5000);
   });
+
+  it('secrets + secretsRef survive the buildManifest round-trip', () => {
+    const def = defineOrchestration({
+      name: 'secret-wf',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+      secrets: ['STRIPE_KEY', 'DB_PASSWORD'],
+      secretsRef: 'billing',
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.secrets).toEqual(['STRIPE_KEY', 'DB_PASSWORD']);
+    expect(manifest.secretsRef).toBe('billing');
+    const parsed = workflowManifestSchema.parse(manifest);
+    expect(parsed.secrets).toEqual(['STRIPE_KEY', 'DB_PASSWORD']);
+    expect(parsed.secretsRef).toBe('billing');
+  });
+
+  it('secrets defaults to [] and secretsRef is undefined when not declared', () => {
+    const def = defineOrchestration({
+      name: 'no-secrets-wf',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+    });
+    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    expect(manifest.secrets).toEqual([]);
+    expect(manifest.secretsRef).toBeUndefined();
+    // A manifest missing the field still parses (schema defaults to []).
+    const parsed = workflowManifestSchema.parse({ ...manifest, secrets: undefined });
+    expect(parsed.secrets).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -278,23 +278,26 @@ describe('buildManifest', () => {
     expect(parsed.steps.exit.timeoutMs).toBe(5000);
   });
 
-  it('secrets + secretsRef survive the buildManifest round-trip', () => {
+  it('secret bindings survive the buildManifest round-trip', () => {
     const def = defineOrchestration({
       name: 'secret-wf',
       entry: 'start',
       steps: { start: makeStep('start') },
-      secrets: ['STRIPE_KEY', 'DB_PASSWORD'],
-      secretsRef: 'billing',
+      secrets: [
+        { ref: 'billing', keys: ['STRIPE_KEY'] },
+        { ref: 'analytics', keys: ['POSTHOG_KEY'] },
+      ],
     });
     const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
-    expect(manifest.secrets).toEqual(['STRIPE_KEY', 'DB_PASSWORD']);
-    expect(manifest.secretsRef).toBe('billing');
-    const parsed = workflowManifestSchema.parse(manifest);
-    expect(parsed.secrets).toEqual(['STRIPE_KEY', 'DB_PASSWORD']);
-    expect(parsed.secretsRef).toBe('billing');
+    const expected = [
+      { ref: 'billing', keys: ['STRIPE_KEY'] },
+      { ref: 'analytics', keys: ['POSTHOG_KEY'] },
+    ];
+    expect(manifest.secrets).toEqual(expected);
+    expect(workflowManifestSchema.parse(manifest).secrets).toEqual(expected);
   });
 
-  it('secrets defaults to [] and secretsRef is undefined when not declared', () => {
+  it('secrets defaults to [] when not declared', () => {
     const def = defineOrchestration({
       name: 'no-secrets-wf',
       entry: 'start',
@@ -302,7 +305,6 @@ describe('buildManifest', () => {
     });
     const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
     expect(manifest.secrets).toEqual([]);
-    expect(manifest.secretsRef).toBeUndefined();
     // A manifest missing the field still parses (schema defaults to []).
     const parsed = workflowManifestSchema.parse({ ...manifest, secrets: undefined });
     expect(parsed.secrets).toEqual([]);

--- a/packages/orchestration/src/manifest.ts
+++ b/packages/orchestration/src/manifest.ts
@@ -71,13 +71,21 @@ export interface WorkflowManifest {
   /** Per-step metadata map (keyed by step name). */
   readonly steps: Readonly<Record<string, WorkflowStepManifest>>;
   /**
-   * Vault secret key names the orchestration declared; injected into step env at
-   * dispatch. Optional on the type (legacy/hand-built manifests omit it); the zod
-   * schema defaults it to `[]` and `buildManifest` always sets it.
+   * Vault secret bindings the orchestration declared; injected into step env at
+   * dispatch. Each binding pulls `keys` from one secret-set (`ref`). Optional on
+   * the type (legacy/hand-built manifests omit it); the zod schema defaults it to
+   * `[]` and `buildManifest` always sets it.
    */
-  readonly secrets?: readonly string[];
-  /** Vault secret-set ref the secrets live under; engine defaults to 'workflows' when absent. */
-  readonly secretsRef?: string;
+  readonly secrets?: readonly SecretBinding[];
+}
+
+/**
+ * A vault secret binding: pull `keys` (env-var names) from the secret-set `ref`.
+ * A workflow can declare several bindings to read from different sets.
+ */
+export interface SecretBinding {
+  readonly ref: string;
+  readonly keys: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +105,13 @@ const workflowStepManifestSchema = z.object({
   transitions: z.array(manifestTransitionSchema),
 });
 
+// Charset mirrors defineOrchestration's check so the engine enforces the trust
+// boundary where it parses — not just the producer (these flow into a vault URL).
+const secretBindingSchema = z.object({
+  ref: z.string().regex(/^[A-Za-z0-9._:-]+$/),
+  keys: z.array(z.string().regex(/^[A-Za-z0-9._-]+$/)),
+});
+
 /**
  * Zod schema that parses and validates a WorkflowManifest.
  * The engine uses this when it receives a manifest from the build phase.
@@ -111,11 +126,5 @@ export const workflowManifestSchema = z.object({
     entryFile: z.string().min(1),
   }),
   steps: z.record(z.string(), workflowStepManifestSchema),
-  // Charset mirrors defineOrchestration's check so the engine enforces the trust
-  // boundary where it parses — not just the producer (these flow into a vault URL).
-  secrets: z.array(z.string().regex(/^[A-Za-z0-9._-]+$/)).default([]),
-  secretsRef: z
-    .string()
-    .regex(/^[A-Za-z0-9._:-]+$/)
-    .optional(),
+  secrets: z.array(secretBindingSchema).default([]),
 });

--- a/packages/orchestration/src/manifest.ts
+++ b/packages/orchestration/src/manifest.ts
@@ -70,6 +70,14 @@ export interface WorkflowManifest {
   };
   /** Per-step metadata map (keyed by step name). */
   readonly steps: Readonly<Record<string, WorkflowStepManifest>>;
+  /**
+   * Vault secret key names the orchestration declared; injected into step env at
+   * dispatch. Optional on the type (legacy/hand-built manifests omit it); the zod
+   * schema defaults it to `[]` and `buildManifest` always sets it.
+   */
+  readonly secrets?: readonly string[];
+  /** Vault secret-set ref the secrets live under; engine defaults to 'workflows' when absent. */
+  readonly secretsRef?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,4 +111,11 @@ export const workflowManifestSchema = z.object({
     entryFile: z.string().min(1),
   }),
   steps: z.record(z.string(), workflowStepManifestSchema),
+  // Charset mirrors defineOrchestration's check so the engine enforces the trust
+  // boundary where it parses — not just the producer (these flow into a vault URL).
+  secrets: z.array(z.string().regex(/^[A-Za-z0-9._-]+$/)).default([]),
+  secretsRef: z
+    .string()
+    .regex(/^[A-Za-z0-9._:-]+$/)
+    .optional(),
 });

--- a/packages/orchestration/src/sdk.spec.ts
+++ b/packages/orchestration/src/sdk.spec.ts
@@ -130,6 +130,38 @@ describe('defineOrchestration', () => {
     expect(Object.keys(def.steps)).toHaveLength(3);
   });
 
+  it('accepts a valid secretsRef', () => {
+    const def = defineOrchestration({
+      name: 'wf',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+      secretsRef: 'billing',
+    });
+    expect(def.secretsRef).toBe('billing');
+  });
+
+  it('throws on an invalid secretsRef', () => {
+    expect(() =>
+      defineOrchestration({
+        name: 'wf',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secretsRef: 'bad ref!',
+      }),
+    ).toThrow('invalid secretsRef');
+  });
+
+  it('throws on an invalid secret key', () => {
+    expect(() =>
+      defineOrchestration({
+        name: 'wf',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets: ['BAD KEY!'],
+      }),
+    ).toThrow('invalid secret key');
+  });
+
   it('attaches a non-enumerable ORCHESTRATION_DEFINITION_BRAND symbol to the returned object', () => {
     const def = defineOrchestration({
       name: 'branded',

--- a/packages/orchestration/src/sdk.spec.ts
+++ b/packages/orchestration/src/sdk.spec.ts
@@ -130,25 +130,25 @@ describe('defineOrchestration', () => {
     expect(Object.keys(def.steps)).toHaveLength(3);
   });
 
-  it('accepts a valid secretsRef', () => {
+  it('accepts valid secret bindings', () => {
     const def = defineOrchestration({
       name: 'wf',
       entry: 'start',
       steps: { start: makeStep('start') },
-      secretsRef: 'billing',
+      secrets: [{ ref: 'billing', keys: ['STRIPE_KEY'] }],
     });
-    expect(def.secretsRef).toBe('billing');
+    expect(def.secrets?.[0].ref).toBe('billing');
   });
 
-  it('throws on an invalid secretsRef', () => {
+  it('throws on an invalid binding ref', () => {
     expect(() =>
       defineOrchestration({
         name: 'wf',
         entry: 'start',
         steps: { start: makeStep('start') },
-        secretsRef: 'bad ref!',
+        secrets: [{ ref: 'bad ref!', keys: ['STRIPE_KEY'] }],
       }),
-    ).toThrow('invalid secretsRef');
+    ).toThrow('invalid secret binding ref');
   });
 
   it('throws on an invalid secret key', () => {
@@ -157,7 +157,7 @@ describe('defineOrchestration', () => {
         name: 'wf',
         entry: 'start',
         steps: { start: makeStep('start') },
-        secrets: ['BAD KEY!'],
+        secrets: [{ ref: 'billing', keys: ['BAD KEY!'] }],
       }),
     ).toThrow('invalid secret key');
   });

--- a/packages/orchestration/src/workflow.ts
+++ b/packages/orchestration/src/workflow.ts
@@ -47,6 +47,13 @@ export interface OrchestrationDefinition<
   readonly name: string;
   readonly entry: string;
   readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
+  /** Vault secret keys the orchestration needs; injected into step env at dispatch. */
+  readonly secrets?: readonly string[];
+  /**
+   * Vault secret-set ref to read `secrets` from; engine defaults to 'workflows'
+   * when absent. May use `:` for namespacing (e.g. 'billing:prod').
+   */
+  readonly secretsRef?: string;
   /**
    * Phantom marker that carries the entry-step input type so `runner.run(def, input)`
    * can infer it (see TInput in the doc above). The steps map is deliberately
@@ -68,6 +75,29 @@ export interface OrchestrationDefinition<
 export function isOrchestrationDefinition(val: unknown): val is OrchestrationDefinition {
   if (val === null || typeof val !== 'object') return false;
   return (val as Record<symbol, unknown>)[ORCHESTRATION_DEFINITION_BRAND] === 1;
+}
+
+/**
+ * Validate an orchestration's optional secret declaration: each `secrets` key and
+ * the `secretsRef` must match the vault charset. Extracted from `defineOrchestration`
+ * to keep its cognitive complexity within bounds.
+ */
+function validateSecretsDeclaration(def: { name: string; secrets?: readonly string[]; secretsRef?: string }): void {
+  if (def.secrets !== undefined) {
+    const secretKeyPattern = /^[A-Za-z0-9._-]+$/;
+    for (const key of def.secrets) {
+      if (typeof key !== 'string' || key.length === 0 || !secretKeyPattern.test(key)) {
+        throw new Error(
+          `Workflow '${def.name}' has invalid secret key: '${key}' (must be non-empty, matching /^[A-Za-z0-9._-]+$/)`,
+        );
+      }
+    }
+  }
+  if (def.secretsRef !== undefined && !/^[A-Za-z0-9._:-]+$/.test(def.secretsRef)) {
+    throw new Error(
+      `Workflow '${def.name}' has invalid secretsRef: '${def.secretsRef}' (must be non-empty, matching /^[A-Za-z0-9._:-]+$/)`,
+    );
+  }
 }
 
 /**
@@ -104,6 +134,7 @@ export function defineOrchestration<TInput = unknown, TShared extends Record<str
       throw new Error(`Workflow '${def.name}' step name mismatch at key '${key}': step.name='${step.name}'`);
     }
   }
+  validateSecretsDeclaration(def);
   // Attach the brand as a non-enumerable property so it:
   //   - survives esbuild bundling (symbol properties pass through)
   //   - survives dynamic import (the imported object is the same reference)

--- a/packages/orchestration/src/workflow.ts
+++ b/packages/orchestration/src/workflow.ts
@@ -1,4 +1,5 @@
 import { UnknownStepError } from './errors.js';
+import type { SecretBinding } from './manifest.js';
 import type { StepDefinition } from './step.js';
 
 /**
@@ -47,13 +48,8 @@ export interface OrchestrationDefinition<
   readonly name: string;
   readonly entry: string;
   readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
-  /** Vault secret keys the orchestration needs; injected into step env at dispatch. */
-  readonly secrets?: readonly string[];
-  /**
-   * Vault secret-set ref to read `secrets` from; engine defaults to 'workflows'
-   * when absent. May use `:` for namespacing (e.g. 'billing:prod').
-   */
-  readonly secretsRef?: string;
+  /** Vault secret bindings the orchestration needs; injected into step env at dispatch. */
+  readonly secrets?: readonly SecretBinding[];
   /**
    * Phantom marker that carries the entry-step input type so `runner.run(def, input)`
    * can infer it (see TInput in the doc above). The steps map is deliberately
@@ -78,25 +74,27 @@ export function isOrchestrationDefinition(val: unknown): val is OrchestrationDef
 }
 
 /**
- * Validate an orchestration's optional secret declaration: each `secrets` key and
- * the `secretsRef` must match the vault charset. Extracted from `defineOrchestration`
- * to keep its cognitive complexity within bounds.
+ * Validate an orchestration's optional secret bindings: each binding's `ref` and
+ * every `keys` entry must match the vault charset. Extracted from
+ * `defineOrchestration` to keep its cognitive complexity within bounds.
  */
-function validateSecretsDeclaration(def: { name: string; secrets?: readonly string[]; secretsRef?: string }): void {
-  if (def.secrets !== undefined) {
-    const secretKeyPattern = /^[A-Za-z0-9._-]+$/;
-    for (const key of def.secrets) {
-      if (typeof key !== 'string' || key.length === 0 || !secretKeyPattern.test(key)) {
+function validateSecretsDeclaration(def: { name: string; secrets?: readonly SecretBinding[] }): void {
+  if (def.secrets === undefined) return;
+  const refPattern = /^[A-Za-z0-9._:-]+$/;
+  const keyPattern = /^[A-Za-z0-9._-]+$/;
+  for (const binding of def.secrets) {
+    if (!binding || typeof binding.ref !== 'string' || !refPattern.test(binding.ref)) {
+      throw new Error(
+        `Workflow '${def.name}' has an invalid secret binding ref: '${binding?.ref}' (must match /^[A-Za-z0-9._:-]+$/)`,
+      );
+    }
+    for (const key of binding.keys ?? []) {
+      if (typeof key !== 'string' || key.length === 0 || !keyPattern.test(key)) {
         throw new Error(
-          `Workflow '${def.name}' has invalid secret key: '${key}' (must be non-empty, matching /^[A-Za-z0-9._-]+$/)`,
+          `Workflow '${def.name}' has an invalid secret key '${key}' in ref '${binding.ref}' (must match /^[A-Za-z0-9._-]+$/)`,
         );
       }
     }
-  }
-  if (def.secretsRef !== undefined && !/^[A-Za-z0-9._:-]+$/.test(def.secretsRef)) {
-    throw new Error(
-      `Workflow '${def.name}' has invalid secretsRef: '${def.secretsRef}' (must be non-empty, matching /^[A-Za-z0-9._:-]+$/)`,
-    );
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `secrets` field to `@sapiom/orchestration` definitions + the workflow manifest — the **SDK half** of SAP-786 (vault secret injection into runs). Pairs with Sapiom engine PR #2413.

`secrets` is an array of **bindings** — each `{ ref, keys }` pulls the named env-var `keys` from one vault secret-set (`ref`). A workflow can declare several to read from different sets:
```ts
defineOrchestration({
  secrets: [
    { ref: 'billing',   keys: ['STRIPE_KEY'] },
    { ref: 'analytics', keys: ['POSTHOG_KEY'] },
  ],
  // ...
})
```
Only the **names** are declared here — the engine reads the values from the vault at dispatch and injects them into the run's sandbox env. Values never live in the definition.

## Changes
- `workflow.ts` — `secrets?: readonly SecretBinding[]` on `OrchestrationDefinition` + charset validation in `defineOrchestration` (ref `/^[A-Za-z0-9._:-]+$/`, keys `/^[A-Za-z0-9._-]+$/`).
- `manifest.ts` — `SecretBinding` type + `secrets?` on `WorkflowManifest` + `workflowManifestSchema` (mirrors the charset; defaults to `[]`).
- `build-manifest.ts` — copies `secrets` into the built manifest.
- tests (`sdk.spec.ts`, `manifest.spec.ts`) + a changeset (minor).

## Compatibility
Optional; the manifest schema defaults `secrets` to `[]`, so existing manifests keep parsing. No breaking change.

## Verification
`pnpm --filter @sapiom/orchestration` → typecheck ✅ · lint ✅ · test ✅ (5 suites, 74).

Needs a **manual publish** (0.1.2) after merge so the engine can bump `ORCHESTRATION_VERSION`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
