### PR TITLE
add prepublish command for scaffolder package

### DIFF
--- a/packages/create-orchestration/package.json
+++ b/packages/create-orchestration/package.json
@@ -31,7 +31,8 @@
     "dev": "tsc --watch -p tsconfig.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",


### PR DESCRIPTION
This pull request introduces a minor but important change to the `packages/create-orchestration/package.json` file. The update ensures that the package is always built before it is published.

Build process improvement:

* Added a `prepublishOnly` script to run `pnpm build` before publishing the package, ensuring the latest build artifacts are always included.