### PR TITLE
fix sandbox, workflow resume integration

### DIFF
--- a/.changeset/dispatch-pause-resume.md
+++ b/.changeset/dispatch-pause-resume.md
@@ -1,0 +1,16 @@
+---
+"@sapiom/tools": patch
+"@sapiom/orchestration": patch
+---
+
+Add the dispatch→pause→resume authoring surface for long-running capabilities.
+
+`@sapiom/tools`: new `DispatchHandle` contract + `CODING_RESULT_SIGNAL`; coding-run
+handles now carry a `dispatch` member, and `launch` forwards the engine-injected
+`SAPIOM_CAPABILITY_RESUME_TOKEN` as the `x-sapiom-workflow-token` header.
+
+`@sapiom/orchestration`: `pauseUntilSignal` accepts a `DispatchHandle |
+Promise<DispatchHandle>` so a step can pause on a launched capability with
+`pauseUntilSignal(ctx.sapiom.agent.coding.launch(...), { resumeStep })`.
+
+Additive and non-breaking — standalone `agent.coding.launch` is unchanged.

--- a/packages/orchestration/src/constructors.spec.ts
+++ b/packages/orchestration/src/constructors.spec.ts
@@ -4,6 +4,8 @@
  * engine then validates the directive against the pinned manifest.
  */
 
+import type { DispatchHandle } from '@sapiom/tools';
+
 import { DIRECTIVE_KIND, fail, goto, pauseUntilSignal, retry, terminate } from './index.js';
 
 describe('goto', () => {
@@ -52,6 +54,35 @@ describe('pauseUntilSignal', () => {
   it('passes through an explicit correlationId', () => {
     const d = pauseUntilSignal({ signal: 's', resumeStep: 'r', correlationId: 'key-1' });
     expect(d.signal.correlationId).toBe('key-1');
+  });
+});
+
+describe('pauseUntilSignal — dispatch handle overload', () => {
+  const handle: DispatchHandle = { dispatch: { correlationId: 'run-9', resultSignal: 'agent.coding.result' } };
+
+  it('builds a Pause from a resolved handle, reading signal + correlationId off it', async () => {
+    const d = await pauseUntilSignal(handle, { resumeStep: 'review' });
+    expect(d).toEqual({
+      kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+      signal: { name: 'agent.coding.result', correlationId: 'run-9' },
+      resumeStep: 'review',
+      timeoutMs: undefined,
+      output: undefined,
+    });
+  });
+
+  it('awaits a launch promise and builds the identical Pause directive', async () => {
+    const d = await pauseUntilSignal(Promise.resolve(handle), { resumeStep: 'review', timeoutMs: 1000 });
+    expect(d.signal).toEqual({ name: 'agent.coding.result', correlationId: 'run-9' });
+    expect(d.resumeStep).toBe('review');
+    expect(d.timeoutMs).toBe(1000);
+  });
+
+  it('leaves the explicit-args form synchronous and unchanged', () => {
+    const d = pauseUntilSignal({ signal: 's', resumeStep: 'r' });
+    // Not a promise — the args form returns the directive directly.
+    expect((d as { then?: unknown }).then).toBeUndefined();
+    expect(d.signal).toEqual({ name: 's', correlationId: undefined });
   });
 });
 

--- a/packages/orchestration/src/directives.ts
+++ b/packages/orchestration/src/directives.ts
@@ -12,6 +12,8 @@
  * pause directives in the shape the routing layer will consume.
  */
 
+import type { DispatchHandle } from '@sapiom/tools';
+
 /**
  * Single source of truth for directive `kind` values.
  *
@@ -215,9 +217,26 @@ export function fail(reason?: string, opts?: { output?: unknown }): Fail {
 }
 
 /**
- * Pause until `signal` arrives, then resume at `resumeStep`. `correlationId`
- * defaults to the ambient `executionId` (filled by the runner) when omitted.
- * Requires a matching `pause: { signal, resumeStep }` declaration on the step.
+ * Pause until a signal arrives, then resume at `resumeStep`. Two ways to specify
+ * the wait — both still require a matching `pause: { signal, resumeStep }`
+ * declaration on the step (the build-time graph edge):
+ *
+ *   1. Explicit args (synchronous). For human approval or any external webhook
+ *      that isn't a dispatched Sapiom capability. `correlationId` defaults to the
+ *      ambient `executionId` (filled by the runner) when omitted.
+ *
+ *        return pauseUntilSignal({ signal: 'demo.approval', resumeStep: 'finalize' });
+ *
+ *   2. A dispatched-capability handle, or the launch promise itself (async — it
+ *      awaits the launch). Reads the `signal` + `correlationId` off the handle's
+ *      `dispatch` member, so the author writes neither. Erases to the identical
+ *      `Pause` directive as form (1).
+ *
+ *        return pauseUntilSignal(ctx.sapiom.agent.coding.launch({ task }), { resumeStep: 'review' });
+ *
+ * Both are consumed as `return pauseUntilSignal(...)` from an async `run()`, so
+ * async-return flattening makes the sync/async distinction invisible at the call
+ * site.
  */
 export function pauseUntilSignal<const Resume extends string>(args: {
   signal: string;
@@ -225,13 +244,50 @@ export function pauseUntilSignal<const Resume extends string>(args: {
   correlationId?: string;
   timeoutMs?: number;
   output?: unknown;
-}): Pause<Resume> {
+}): Pause<Resume>;
+export function pauseUntilSignal<const Resume extends string>(
+  handle: DispatchHandle | Promise<DispatchHandle>,
+  opts?: { resumeStep?: Resume; timeoutMs?: number; output?: unknown },
+): Promise<Pause<Resume>>;
+export function pauseUntilSignal<const Resume extends string>(
+  argOrHandle:
+    | { signal: string; resumeStep?: Resume; correlationId?: string; timeoutMs?: number; output?: unknown }
+    | DispatchHandle
+    | Promise<DispatchHandle>,
+  opts?: { resumeStep?: Resume; timeoutMs?: number; output?: unknown },
+): Pause<Resume> | Promise<Pause<Resume>> {
+  // The launch promise — await it, then build from the resolved handle.
+  if (isThenable(argOrHandle)) {
+    return Promise.resolve(argOrHandle).then((handle) => pauseFromHandle(handle, opts));
+  }
+  // A resolved dispatch handle — async for a uniform handle-form contract.
+  if ('dispatch' in argOrHandle) {
+    return Promise.resolve(pauseFromHandle(argOrHandle, opts));
+  }
+  // Explicit args — synchronous.
   return {
     kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
-    signal: { name: args.signal, correlationId: args.correlationId },
-    resumeStep: args.resumeStep,
-    timeoutMs: args.timeoutMs,
-    output: args.output,
+    signal: { name: argOrHandle.signal, correlationId: argOrHandle.correlationId },
+    resumeStep: argOrHandle.resumeStep,
+    timeoutMs: argOrHandle.timeoutMs,
+    output: argOrHandle.output,
+  };
+}
+
+function isThenable(x: unknown): x is Promise<DispatchHandle> {
+  return x != null && typeof (x as { then?: unknown }).then === 'function';
+}
+
+function pauseFromHandle<Resume extends string>(
+  handle: DispatchHandle,
+  opts: { resumeStep?: Resume; timeoutMs?: number; output?: unknown } | undefined,
+): Pause<Resume> {
+  return {
+    kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+    signal: { name: handle.dispatch.resultSignal, correlationId: handle.dispatch.correlationId },
+    resumeStep: opts?.resumeStep,
+    timeoutMs: opts?.timeoutMs,
+    output: opts?.output,
   };
 }
 

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -65,9 +65,11 @@ function attributionToHeaders(a: Attribution): Record<string, string> {
 export function attributionFromEnv(): Attribution {
   const a: Attribution = {};
   if (process.env.SAPIOM_AGENT_ID) a.agentId = process.env.SAPIOM_AGENT_ID;
-  if (process.env.SAPIOM_AGENT_NAME) a.agentName = process.env.SAPIOM_AGENT_NAME;
+  if (process.env.SAPIOM_AGENT_NAME)
+    a.agentName = process.env.SAPIOM_AGENT_NAME;
   if (process.env.SAPIOM_TRACE_ID) a.traceId = process.env.SAPIOM_TRACE_ID;
-  if (process.env.SAPIOM_TRACE_EXTERNAL_ID) a.traceExternalId = process.env.SAPIOM_TRACE_EXTERNAL_ID;
+  if (process.env.SAPIOM_TRACE_EXTERNAL_ID)
+    a.traceExternalId = process.env.SAPIOM_TRACE_EXTERNAL_ID;
   return a;
 }
 
@@ -126,7 +128,9 @@ export class Transport {
       headers: { "content-type": "application/json", ...(init.headers ?? {}) },
     });
     if (!res.ok) {
-      throw new Error(`${init.method ?? "GET"} ${url} → ${res.status} ${await res.text()}`);
+      throw new Error(
+        `${init.method ?? "GET"} ${url} → ${res.status} ${await res.text()}`,
+      );
     }
     return (await res.json()) as T;
   }

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -21,13 +21,28 @@
  * wire; this module maps them to the camelCase SDK surface below.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import type { DispatchHandle } from "../dispatch.js";
 import { Sandbox } from "../sandboxes/index.js";
 import type { Repository } from "../repositories/index.js";
 
-const DEFAULT_BASE_URL = process.env.SAPIOM_AGENTS_URL || "https://agents.services.sapiom.ai";
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_AGENTS_URL || "https://agents.services.sapiom.ai";
+
+/**
+ * Capability-stable signal a coding run fires when it reaches a terminal state
+ * (completed OR failed — it carries the result either way, the resumed step
+ * branches). A workflow step paused on a coding-run handle resumes on this; it is
+ * the value carried in the handle's `dispatch.resultSignal`.
+ */
+export const CODING_RESULT_SIGNAL = "agent.coding.result";
 
 /** Run lifecycle, mirrored from the gateway's `AgentsRunStatus`. */
-export type RunStatus = "pending" | "queued" | "running" | "completed" | "failed";
+export type RunStatus =
+  | "pending"
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed";
 const TERMINAL = new Set<RunStatus>(["completed", "failed"]);
 
 export interface CodingRunSpec {
@@ -78,14 +93,33 @@ export interface CodingRunResult {
   sandbox: Sandbox;
 }
 
-/** A launched-but-not-awaited run. */
-export interface RunHandle {
+/**
+ * A launched-but-not-awaited run. Satisfies {@link DispatchHandle}, so it can be
+ * handed straight to `pauseUntilSignal(handle, { resumeStep })` to suspend a
+ * workflow step until the run finishes — or `wait()`-ed inline for standalone use.
+ */
+export interface RunHandle extends DispatchHandle {
   runId: string;
   sandbox: Sandbox;
   /** Fetch the current status without blocking. */
   status(): Promise<RunStatus>;
   /** Poll to a terminal state and resolve the full result. */
-  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<CodingRunResult>;
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<CodingRunResult>;
+}
+
+/**
+ * When launched from inside a Sapiom workflow step, the engine injects an opaque
+ * per-execution resume token into the sandbox env. Forwarding it as a header — NOT
+ * a body field, so author-supplied request fields can't clobber it — lets the
+ * gateway call back into the engine to resume the paused workflow when the run
+ * finishes. Absent outside a workflow → no header, no behavior change.
+ */
+function workflowResumeHeaders(): Record<string, string> {
+  const token = process.env.SAPIOM_CAPABILITY_RESUME_TOKEN;
+  return token ? { "x-sapiom-workflow-token": token } : {};
 }
 
 // --- wire shapes (snake_case, as served by the gateway serializer) ---
@@ -156,6 +190,7 @@ export async function launch(
   const doc = await transport.request<RunDoc>(`${baseUrl}/v1/coding/runs`, {
     method: "POST",
     body: JSON.stringify(buildBody(spec)),
+    headers: workflowResumeHeaders(),
   });
   const runId = doc.data.id;
   const envId = doc.data.relationships?.execution_environment?.data?.id;
@@ -164,7 +199,10 @@ export async function launch(
   // can act on it.
   const sandbox = spec.sandbox ?? Sandbox.attach(envId ?? runId, {}, transport);
 
-  const fetchDoc = () => transport.request<RunDoc>(`${baseUrl}/v1/coding/runs/${encodeURIComponent(runId)}`);
+  const fetchDoc = () =>
+    transport.request<RunDoc>(
+      `${baseUrl}/v1/coding/runs/${encodeURIComponent(runId)}`,
+    );
   const toResult = (d: RunDoc): CodingRunResult => ({
     runId,
     status: d.data.attributes.status,
@@ -177,6 +215,9 @@ export async function launch(
   return {
     runId,
     sandbox,
+    // Framework plumbing for `pauseUntilSignal` — see DispatchHandle. correlationId
+    // is the run id (the join key x402 echoes back when it forwards completion).
+    dispatch: { correlationId: runId, resultSignal: CODING_RESULT_SIGNAL },
     async status() {
       return (await fetchDoc()).data.attributes.status;
     },
@@ -187,7 +228,9 @@ export async function launch(
         const d = await fetchDoc();
         if (TERMINAL.has(d.data.attributes.status)) return toResult(d);
         if (Date.now() > deadline) {
-          throw new Error(`coding run ${runId} timed out after ${timeoutMs}ms (last status: ${d.data.attributes.status})`);
+          throw new Error(
+            `coding run ${runId} timed out after ${timeoutMs}ms (last status: ${d.data.attributes.status})`,
+          );
         }
         await new Promise((r) => setTimeout(r, pollMs));
       }

--- a/packages/tools/src/agent/launch.spec.ts
+++ b/packages/tools/src/agent/launch.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * launch() — dispatch-handle shape + workflow resume-token forwarding.
+ *
+ * Injects a fake fetch (no real network) to assert the launched RunHandle
+ * satisfies DispatchHandle, and that the engine-injected resume token rides as a
+ * header (never the body) only when present in the env — so standalone use is
+ * unaffected.
+ */
+import { createClient } from "../index.js";
+import { CODING_RESULT_SIGNAL } from "./index.js";
+
+function fakeLaunchFetch(capture?: {
+  headers?: Record<string, string>;
+}): typeof globalThis.fetch {
+  return (async (_url: string, init: RequestInit = {}) => {
+    if (capture) capture.headers = init.headers as Record<string, string>;
+    return {
+      ok: true,
+      status: 202,
+      json: async () => ({
+        data: {
+          id: "run-123",
+          attributes: { status: "pending" },
+          relationships: { execution_environment: { data: { id: "env-1" } } },
+        },
+      }),
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("agent.coding.launch — dispatch handle", () => {
+  it("returns a handle that satisfies DispatchHandle", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeLaunchFetch() });
+    const handle = await sapiom.agent.coding.launch({ task: "do a thing" });
+    expect(handle.runId).toBe("run-123");
+    expect(handle.dispatch).toEqual({
+      correlationId: "run-123",
+      resultSignal: CODING_RESULT_SIGNAL,
+    });
+  });
+
+  it("CODING_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(CODING_RESULT_SIGNAL).toBe("agent.coding.result");
+  });
+});
+
+describe("agent.coding.launch — workflow resume token", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("forwards the env token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-abc";
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeLaunchFetch(capture),
+    });
+    await sapiom.agent.coding.launch({ task: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBe("tok-abc");
+  });
+
+  it("omits the header outside a workflow (no env token)", async () => {
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeLaunchFetch(capture),
+    });
+    await sapiom.agent.coding.launch({ task: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
+  });
+});

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -14,17 +14,29 @@
  * it; standalone callers pass it to `createClient`), never per capability call.
  * `withAttribution(...)` derives a client for the router case — see `_client`.
  */
-import { Transport, attributionFromEnv, type TransportConfig, type Attribution } from "./_client/index.js";
+import {
+  Transport,
+  attributionFromEnv,
+  type TransportConfig,
+  type Attribution,
+} from "./_client/index.js";
 import { Sandbox } from "./sandboxes/index.js";
 import type { SandboxCreateOptions } from "./sandboxes/index.js";
 import { Repository } from "./repositories/index.js";
 import { run as codingRun, launch as codingLaunch } from "./agent/index.js";
-import type { CodingRunSpec, CodingRunResult, RunHandle } from "./agent/index.js";
+import type {
+  CodingRunSpec,
+  CodingRunResult,
+  RunHandle,
+} from "./agent/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
     create(opts: SandboxCreateOptions): Promise<Sandbox>;
-    attach(name: string, opts?: { workspaceRoot?: string; baseUrl?: string }): Sandbox;
+    attach(
+      name: string,
+      opts?: { workspaceRoot?: string; baseUrl?: string },
+    ): Sandbox;
   };
   readonly repositories: {
     create(slug: string): Promise<Repository>;
@@ -68,7 +80,8 @@ function bind(transport: Transport): Sapiom {
         launch: (spec) => codingLaunch(spec, transport),
       },
     },
-    withAttribution: (attribution) => bind(transport.withAttribution(attribution)),
+    withAttribution: (attribution) =>
+      bind(transport.withAttribution(attribution)),
   };
 }
 

--- a/packages/tools/src/dispatch.ts
+++ b/packages/tools/src/dispatch.ts
@@ -1,0 +1,26 @@
+/**
+ * `DispatchHandle` — the structural contract a long-running capability's launch
+ * handle satisfies so a workflow step can pause on it and resume when it finishes.
+ *
+ * A "dispatched" capability (the coding agent today; deep research, sub-workflows,
+ * browser sessions later) is launched fire-and-forget and reports completion via a
+ * Sapiom-internal callback. Its launch handle carries the two facts the engine
+ * needs to pause-then-resume: a `correlationId` (the join key for this specific
+ * run) and the `resultSignal` it fires on terminal.
+ *
+ * Authors never read `dispatch` directly — they pass the whole handle to
+ * `pauseUntilSignal(handle, { resumeStep })`, which reads these off it. The member
+ * is framework plumbing (marked `@internal`); the callback / secret / correlation
+ * wiring beneath it is owned and injected by the engine + gateway. Any capability
+ * whose handle exposes a `dispatch` member is automatically pausable — the
+ * orchestration layer is blind to which capability produced it.
+ */
+export interface DispatchHandle {
+  /** @internal Framework plumbing consumed by `pauseUntilSignal`; not a supported author field. */
+  readonly dispatch: {
+    /** Join key for this dispatched run; the engine matches the resume on it. */
+    readonly correlationId: string;
+    /** Capability-stable signal fired when the run reaches a terminal state. */
+    readonly resultSignal: string;
+  };
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -15,6 +15,10 @@ export { createClient, createClientFromEnv } from "./client.js";
 export type { Sapiom } from "./client.js";
 export type { TransportConfig, Attribution } from "./_client/index.js";
 
+// The generic dispatch contract: any capability handle that carries a `dispatch`
+// member is pausable via `pauseUntilSignal` in @sapiom/orchestration.
+export type { DispatchHandle } from "./dispatch.js";
+
 export * as sandboxes from "./sandboxes/index.js";
 export { Sandbox } from "./sandboxes/index.js";
 
@@ -22,3 +26,5 @@ export * as repositories from "./repositories/index.js";
 export { Repository } from "./repositories/index.js";
 
 export * as agent from "./agent/index.js";
+// Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
+export { CODING_RESULT_SIGNAL } from "./agent/index.js";

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -19,7 +19,8 @@
 import { Transport, defaultTransport } from "../_client/index.js";
 import type { Sandbox } from "../sandboxes/index.js";
 
-const DEFAULT_BASE_URL = process.env.SAPIOM_GIT_URL || "https://git.services.sapiom.ai";
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_GIT_URL || "https://git.services.sapiom.ai";
 
 /** Canonical in-sandbox checkout path (matches the agent's `gitRepository` auto-clone). */
 const checkoutDir = (slug: string) => `/workspace/${slug}`;
@@ -37,7 +38,12 @@ interface CreateRepositoryResponse {
   tenantId: string;
   slug: string;
   cloneUrl: string;
-  auth: { scheme: "basic"; username: string; password: string; example: string };
+  auth: {
+    scheme: "basic";
+    username: string;
+    password: string;
+    example: string;
+  };
 }
 
 export interface PushResult {
@@ -68,32 +74,71 @@ export class Repository {
     this.baseUrl = baseUrl;
   }
 
-  static async create(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository> {
-    const r = await transport.request<CreateRepositoryResponse>(`${baseUrl}/v1/git/repositories`, {
-      method: "POST",
-      body: JSON.stringify({ slug }),
-    });
+  static async create(
+    slug: string,
+    transport: Transport = defaultTransport(),
+    baseUrl = DEFAULT_BASE_URL,
+  ): Promise<Repository> {
+    const r = await transport.request<CreateRepositoryResponse>(
+      `${baseUrl}/v1/git/repositories`,
+      {
+        method: "POST",
+        body: JSON.stringify({ slug }),
+      },
+    );
     // create doesn't return a status; a just-created repo is active.
-    return new Repository({ slug: r.slug, cloneUrl: r.cloneUrl, status: "active" }, transport, baseUrl);
+    return new Repository(
+      { slug: r.slug, cloneUrl: r.cloneUrl, status: "active" },
+      transport,
+      baseUrl,
+    );
   }
 
-  static async get(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository> {
-    const r = await transport.request<RepoSummary>(`${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`);
+  static async get(
+    slug: string,
+    transport: Transport = defaultTransport(),
+    baseUrl = DEFAULT_BASE_URL,
+  ): Promise<Repository> {
+    const r = await transport.request<RepoSummary>(
+      `${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`,
+    );
     return new Repository(r, transport, baseUrl);
   }
 
-  static async list(transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<Repository[]> {
-    const r = await transport.request<{ repositories: RepoSummary[] }>(`${baseUrl}/v1/git/repositories`);
+  static async list(
+    transport: Transport = defaultTransport(),
+    baseUrl = DEFAULT_BASE_URL,
+  ): Promise<Repository[]> {
+    const r = await transport.request<{ repositories: RepoSummary[] }>(
+      `${baseUrl}/v1/git/repositories`,
+    );
     return r.repositories.map((s) => new Repository(s, transport, baseUrl));
   }
 
-  static async delete(slug: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Promise<void> {
-    await transport.request(`${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`, { method: "DELETE" }).catch(() => undefined);
+  static async delete(
+    slug: string,
+    transport: Transport = defaultTransport(),
+    baseUrl = DEFAULT_BASE_URL,
+  ): Promise<void> {
+    await transport
+      .request(`${baseUrl}/v1/git/repositories/${encodeURIComponent(slug)}`, {
+        method: "DELETE",
+      })
+      .catch(() => undefined);
   }
 
   /** Adopt a known repo without a round-trip (e.g. one returned from another step). */
-  static attach(slug: string, cloneUrl: string, transport: Transport = defaultTransport(), baseUrl = DEFAULT_BASE_URL): Repository {
-    return new Repository({ slug, cloneUrl, status: "active" }, transport, baseUrl);
+  static attach(
+    slug: string,
+    cloneUrl: string,
+    transport: Transport = defaultTransport(),
+    baseUrl = DEFAULT_BASE_URL,
+  ): Repository {
+    return new Repository(
+      { slug, cloneUrl, status: "active" },
+      transport,
+      baseUrl,
+    );
   }
 
   /** Delete this repository. */
@@ -107,19 +152,26 @@ export class Repository {
    * `/workspace/<slug>` with an authenticated `origin` (which the agent's
    * `gitRepository` auto-clone sets up). No-op when there's nothing to commit.
    */
-  async pushFromSandbox(sandbox: Sandbox, opts: { message?: string } = {}): Promise<PushResult> {
+  async pushFromSandbox(
+    sandbox: Sandbox,
+    opts: { message?: string } = {},
+  ): Promise<PushResult> {
     const message = (opts.message ?? `update ${this.slug}`).replace(/'/g, ""); // single-quote-safe for sh -c
     const script =
       `cd ${checkoutDir(this.slug)} && git add -A && ` +
       `if git diff --cached --quiet; then echo NO_CHANGES; else ` +
       `git -c user.email=workflow@sapiom.ai -c user.name=sapiom-workflow commit -m "${message}" >/dev/null && ` +
       `git push origin HEAD && printf "SHA:%s\\n" "$(git rev-parse HEAD)"; fi`;
-    const { stdout, stderr, exitCode } = await sandbox.exec(`sh -c '${script}'`);
+    const { stdout, stderr, exitCode } = await sandbox.exec(
+      `sh -c '${script}'`,
+    );
     const out = `${stdout}\n${stderr}`;
     if (out.includes("NO_CHANGES")) return { pushed: false, sha: null };
     const sha = out.match(/SHA:([0-9a-f]{7,40})/)?.[1] ?? null;
     if (exitCode !== 0 || !sha) {
-      throw new Error(`pushFromSandbox(${this.slug}) failed (exit ${exitCode}): ${out.slice(-300)}`);
+      throw new Error(
+        `pushFromSandbox(${this.slug}) failed (exit ${exitCode}): ${out.slice(-300)}`,
+      );
     }
     return { pushed: true, sha };
   }

--- a/packages/tools/src/sandboxes/README.md
+++ b/packages/tools/src/sandboxes/README.md
@@ -19,12 +19,14 @@ await box.destroy();
 
 - **Credentials are not injected automatically.** The sandbox environment is empty by default. Pass anything your workload needs explicitly via `envs` when you create the sandbox.
 
-- **`exec` waits for the command to finish.** It returns once the command exits, with `{ exitCode, stdout, stderr }`. For commands that run longer than a single request, use `execStream` for live output, or start the process and poll it with `getProcess` / `waitForProcess`.
+- **`exec` waits for the command to finish.** It returns once the command exits, with `{ exitCode, stdout, stderr }` — including non-zero exits (a failed command resolves with its real `exitCode`; it does not throw). For commands that run longer than a single request, use `execStream` for live output, or start the process and poll it with `getProcess` / `waitForProcess`.
+
+- **Use `uploadFile` for binary or large files.** `writeFile` sends the whole body in one JSON request and is bounded by the ingress body-size ceiling. `uploadFile(path, content, opts?)` runs a chunked multipart upload (parallel parts, retries, auto-abort on failure) and accepts a `Blob`, `Uint8Array`, or string.
 
 - **`/workspace` is the conventional working directory.** Other capabilities assume it — the `agent` capability clones repos into `/workspace/<slug>`, and `repositories.pushFromSandbox` pushes from there. Keep your files under `/workspace` to stay compatible.
 
 ## Reference
 
-`create` · `attach` · `exec` · `execStream` · `readFile` · `writeFile` · `getProcess` · `waitForProcess` · `destroy`
+`create` · `attach` · `exec` · `execStream` · `readFile` · `writeFile` · `uploadFile` · `getProcess` · `waitForProcess` · `destroy`
 
 See the exported types for full signatures and options.

--- a/packages/tools/src/sandboxes/index.spec.ts
+++ b/packages/tools/src/sandboxes/index.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Sandbox exec/poll terminal-status handling + multipart upload lifecycle.
+ *
+ * The terminal-status tests are the regression guard for the bug that hung
+ * workflow execution 7: the sandbox process API reports a non-zero exit as
+ * status `"failed"` (not `"completed"`), and the client must surface that as an
+ * `ExecResult` with the real exit code rather than polling to the timeout.
+ *
+ * All tests inject a routed fake fetch — no real network.
+ */
+import { Transport } from "../_client/index.js";
+import { Sandbox } from "./index.js";
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+  headers: { get: (k: string) => string | null };
+}
+
+function ok(body: unknown): FakeResponse {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: { get: () => null },
+  };
+}
+
+function err(status: number, text = ""): FakeResponse {
+  return {
+    ok: false,
+    status,
+    json: async () => ({}),
+    text: async () => text,
+    headers: { get: () => null },
+  };
+}
+
+/** Build a Sandbox whose transport routes through `route(url, init)`. */
+function sandboxWith(
+  route: (url: string, init: RequestInit) => FakeResponse,
+): Sandbox {
+  const fetchFn = (async (url: string, init: RequestInit = {}) =>
+    route(
+      url,
+      init,
+    ) as unknown as Response) as unknown as typeof globalThis.fetch;
+  const transport = new Transport({ apiKey: "k", fetch: fetchFn });
+  return Sandbox.attach("box", {}, transport);
+}
+
+describe("Sandbox.exec — terminal status handling", () => {
+  it("returns the real exit code when the process polls to status 'failed' (regression: exec-7 hang)", async () => {
+    let polls = 0;
+    const box = sandboxWith((url, init) => {
+      if ((init.method ?? "GET") === "POST" && url.endsWith("/process")) {
+        return ok({ pid: "p1", status: "running" });
+      }
+      // GET status: running once, then failed with a non-zero exit code.
+      polls += 1;
+      return ok(
+        polls < 2
+          ? { pid: "p1", status: "running" }
+          : { pid: "p1", status: "failed", exitCode: 1, stderr: "boom" },
+      );
+    });
+
+    const res = await box.exec("cat /nope", { pollInterval: 1 });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toBe("boom");
+  });
+
+  it("treats a synchronous 'failed' create response as terminal (no polling)", async () => {
+    const box = sandboxWith((url, init) => {
+      if ((init.method ?? "GET") === "POST" && url.endsWith("/process")) {
+        return ok({ pid: "p2", status: "failed", exitCode: 2, stdout: "" });
+      }
+      throw new Error("should not poll a synchronously-terminal process");
+    });
+
+    const res = await box.exec("false");
+    expect(res.exitCode).toBe(2);
+  });
+
+  it("defaults a terminal non-'completed' status with no exitCode to 1", async () => {
+    const box = sandboxWith((url, init) => {
+      if ((init.method ?? "GET") === "POST" && url.endsWith("/process"))
+        return ok({ pid: "p3", status: "running" });
+      return ok({ pid: "p3", status: "killed" }); // no exitCode field
+    });
+    const res = await box.exec("sleep 999", { pollInterval: 1 });
+    expect(res.exitCode).toBe(1);
+  });
+
+  it("returns exitCode 0 on a clean completion", async () => {
+    const box = sandboxWith((url, init) => {
+      if ((init.method ?? "GET") === "POST" && url.endsWith("/process"))
+        return ok({ pid: "p4", status: "running" });
+      return ok({ pid: "p4", status: "completed", exitCode: 0, stdout: "hi" });
+    });
+    const res = await box.exec("echo hi", { pollInterval: 1 });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe("hi");
+  });
+});
+
+describe("Sandbox.uploadFile — multipart lifecycle", () => {
+  it("initiates, uploads each part, and completes", async () => {
+    const calls: string[] = [];
+    const box = sandboxWith((url, init) => {
+      const method = (init.method ?? "GET") as string;
+      if (url.includes("/multipart/initiate/")) {
+        calls.push("initiate");
+        return ok({ uploadId: "u1", path: "big.bin" });
+      }
+      if (url.includes("/multipart/u1/part") && method === "PUT") {
+        const partNumber = Number(new URL(url).searchParams.get("partNumber"));
+        calls.push(`part:${partNumber}`);
+        return ok({ partNumber, etag: `e${partNumber}`, size: 5 });
+      }
+      if (url.endsWith("/multipart/u1/complete") && method === "POST") {
+        calls.push("complete");
+        return ok({ message: "ok", path: "big.bin" });
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    });
+
+    // 12 bytes at a 5-byte part size → 3 parts.
+    await box.uploadFile("big.bin", new Uint8Array(12), { partSize: 5 });
+
+    expect(calls).toEqual([
+      "initiate",
+      "part:1",
+      "part:2",
+      "part:3",
+      "complete",
+    ]);
+  });
+
+  it("aborts the upload when a part fails", async () => {
+    const calls: string[] = [];
+    const box = sandboxWith((url, init) => {
+      const method = (init.method ?? "GET") as string;
+      if (url.includes("/multipart/initiate/"))
+        return ok({ uploadId: "u2", path: "f" });
+      if (url.includes("/multipart/u2/part") && method === "PUT")
+        return err(400, "bad part");
+      if (url.endsWith("/multipart/u2") && method === "DELETE") {
+        calls.push("abort");
+        return ok({});
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    });
+
+    await expect(
+      box.uploadFile("f", new Uint8Array(3), { partSize: 5, maxRetries: 0 }),
+    ).rejects.toThrow();
+    // Abort is best-effort/fire-and-forget; let the microtask flush.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls).toContain("abort");
+  });
+});

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -13,32 +13,55 @@
  *   await box.destroy();
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_PART_SIZE,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  ensureOk,
+  planParts,
+  runWithConcurrency,
+  toBlob,
+  withRetry,
+} from "./multipart.js";
 import type {
   CreateResponse,
   ExecOptions,
   ExecResult,
   ExecStreamOptions,
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadedPart,
   OutputLine,
   ProcessCreateResponse,
   ProcessStatus,
   SandboxCreateOptions,
   StreamingExecResult,
+  UploadFileOptions,
 } from "./types.js";
+
+export { SandboxHttpError } from "./multipart.js";
 
 export type {
   ExecOptions,
   ExecResult,
   ExecStreamOptions,
+  MultipartInitiateResponse,
+  MultipartPartInfo,
+  MultipartUploadedPart,
   OutputLine,
   PortSpec,
   ProcessStatus,
   SandboxCreateOptions,
   SandboxTier,
   StreamingExecResult,
+  UploadFileOptions,
+  UploadProgress,
 } from "./types.js";
 
 /** Platform sandbox service. Host routing is an internal detail — override via `baseUrl` or SAPIOM_SANDBOX_URL. */
-const DEFAULT_BASE_URL = process.env.SAPIOM_SANDBOX_URL || "https://blaxel.services.sapiom.ai";
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_SANDBOX_URL || "https://blaxel.services.sapiom.ai";
 const DEFAULT_POLL_INTERVAL = 1000;
 const DEFAULT_EXEC_TIMEOUT = 60_000;
 
@@ -56,9 +79,50 @@ function encodePathSegments(path: string): string {
 }
 
 function parseOutputLine(line: string): OutputLine {
-  if (line.startsWith("stdout:")) return { stream: "stdout", data: line.slice(7) };
-  if (line.startsWith("stderr:")) return { stream: "stderr", data: line.slice(7) };
+  if (line.startsWith("stdout:"))
+    return { stream: "stdout", data: line.slice(7) };
+  if (line.startsWith("stderr:"))
+    return { stream: "stderr", data: line.slice(7) };
   return { stream: "stdout", data: line }; // unrecognized framing — keep, don't drop
+}
+
+/**
+ * Process statuses that mean the process has finished. The Blaxel sandbox-api
+ * reports a non-zero exit as `"failed"` (enum: running/completed/failed/killed/
+ * stopped), so polling must treat all of these — not just `"completed"` — as
+ * done. Any unrecognized status keeps polling and ultimately hits the exec
+ * timeout, which is a loud, debuggable failure rather than a silent wrong result.
+ */
+const TERMINAL_PROCESS_STATUSES = new Set([
+  "completed",
+  "failed",
+  "killed",
+  "stopped",
+]);
+
+function isProcessTerminal(status: string | undefined): boolean {
+  return status !== undefined && TERMINAL_PROCESS_STATUSES.has(status);
+}
+
+/**
+ * Resolve a process exit code. A non-`"completed"` terminal status
+ * (failed/killed/stopped) that omits `exitCode` must not report success, so it
+ * defaults to a non-zero code.
+ */
+function terminalExitCode(s: { status: string; exitCode?: number }): number {
+  return s.exitCode ?? (s.status === "completed" ? 0 : 1);
+}
+
+function toExecResult(
+  pid: string,
+  s: { status: string; exitCode?: number; stdout?: string; stderr?: string },
+): ExecResult {
+  return {
+    pid,
+    exitCode: terminalExitCode(s),
+    stdout: s.stdout ?? "",
+    stderr: s.stderr ?? "",
+  };
 }
 
 /** A live sandbox handle. Create via {@link create}; pass between steps to share state. */
@@ -71,7 +135,12 @@ export class Sandbox {
   private readonly transport: Transport;
   private readonly baseUrl: string;
 
-  private constructor(name: string, workspaceRoot: string, transport: Transport, baseUrl: string) {
+  private constructor(
+    name: string,
+    workspaceRoot: string,
+    transport: Transport,
+    baseUrl: string,
+  ) {
     this.name = name;
     this.workspaceRoot = workspaceRoot;
     this.transport = transport;
@@ -79,7 +148,10 @@ export class Sandbox {
   }
 
   /** Create a sandbox and return a handle. Uses the ambient transport unless one is supplied. */
-  static async create(opts: SandboxCreateOptions, transport: Transport = defaultTransport()): Promise<Sandbox> {
+  static async create(
+    opts: SandboxCreateOptions,
+    transport: Transport = defaultTransport(),
+  ): Promise<Sandbox> {
     if (opts.port !== undefined && opts.ports !== undefined) {
       throw new Error("Cannot specify both 'port' and 'ports'");
     }
@@ -98,20 +170,34 @@ export class Sandbox {
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
     });
-    if (!res.ok) throw new Error(`Failed to create sandbox: ${res.status} ${await res.text()}`);
+    if (!res.ok)
+      throw new Error(
+        `Failed to create sandbox: ${res.status} ${await res.text()}`,
+      );
 
     const data = (await res.json()) as CreateResponse;
     return new Sandbox(data.name, data.workspaceRoot, transport, baseUrl);
   }
 
   /** Adopt an existing sandbox by name (e.g. one a prior step kept). */
-  static attach(name: string, opts: { workspaceRoot?: string; baseUrl?: string } = {}, transport: Transport = defaultTransport()): Sandbox {
-    return new Sandbox(name, opts.workspaceRoot ?? "/", transport, opts.baseUrl ?? DEFAULT_BASE_URL);
+  static attach(
+    name: string,
+    opts: { workspaceRoot?: string; baseUrl?: string } = {},
+    transport: Transport = defaultTransport(),
+  ): Sandbox {
+    return new Sandbox(
+      name,
+      opts.workspaceRoot ?? "/",
+      transport,
+      opts.baseUrl ?? DEFAULT_BASE_URL,
+    );
   }
 
   private fileUrl(path: string): string {
     assertRelativePath(path);
-    const base = this.workspaceRoot.endsWith("/") ? this.workspaceRoot.slice(0, -1) : this.workspaceRoot;
+    const base = this.workspaceRoot.endsWith("/")
+      ? this.workspaceRoot.slice(0, -1)
+      : this.workspaceRoot;
     const rel = path.startsWith("/") ? path.slice(1) : path;
     const abs = `${base}/${rel}`.replace(/^\//, "");
     return `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/filesystem/${encodePathSegments(abs)}`;
@@ -121,6 +207,10 @@ export class Sandbox {
     return `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/process${suffix}`;
   }
 
+  private multipartUrl(suffix: string): string {
+    return `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/filesystem/multipart${suffix}`;
+  }
+
   /** Write a file (path relative to the workspace root). */
   async writeFile(path: string, content: string): Promise<void> {
     const res = await this.transport.fetch(this.fileUrl(path), {
@@ -128,15 +218,212 @@ export class Sandbox {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ content }),
     });
-    if (!res.ok) throw new Error(`Failed to write file '${path}': ${res.status} ${await res.text()}`);
+    if (!res.ok)
+      throw new Error(
+        `Failed to write file '${path}': ${res.status} ${await res.text()}`,
+      );
   }
 
   /** Read a file (path relative to the workspace root). */
   async readFile(path: string): Promise<string> {
     const res = await this.transport.fetch(this.fileUrl(path));
-    if (!res.ok) throw new Error(`Failed to read file '${path}': ${res.status} ${await res.text()}`);
+    if (!res.ok)
+      throw new Error(
+        `Failed to read file '${path}': ${res.status} ${await res.text()}`,
+      );
     const data = (await res.json()) as { content: string };
     return data.content;
+  }
+
+  /**
+   * Upload a file using multipart upload. Handles the full initiate → part
+   * upload → complete lifecycle, with parallel part uploads and automatic abort
+   * on any failure (including `signal` aborts).
+   *
+   * Prefer this over {@link writeFile} for binary content or any file over a few
+   * MB — `writeFile` sends the whole body in one request and is bounded by the
+   * ingress body-size ceiling. `content` may be a Blob, Uint8Array, or string
+   * (strings are UTF-8 encoded).
+   */
+  async uploadFile(
+    path: string,
+    content: Blob | Uint8Array | string,
+    opts?: UploadFileOptions,
+  ): Promise<void> {
+    assertRelativePath(path);
+
+    const blob = toBlob(content);
+    const partSize = opts?.partSize ?? DEFAULT_PART_SIZE;
+    const concurrency = opts?.concurrency ?? DEFAULT_CONCURRENCY;
+    const totalBytes = blob.size;
+    const plans = planParts(totalBytes, partSize);
+
+    const { uploadId } = await this.initiateMultipartUpload(path, {
+      permissions: opts?.permissions,
+      signal: opts?.signal,
+    });
+
+    try {
+      let partsUploaded = 0;
+      let bytesUploaded = 0;
+
+      const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+      const retryBaseDelayMs =
+        opts?.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+
+      const uploaded = await runWithConcurrency(
+        plans,
+        concurrency,
+        async (plan) => {
+          const slice = blob.slice(plan.start, plan.end);
+          const ack = await withRetry(
+            () =>
+              this.uploadPart(uploadId, plan.partNumber, slice, {
+                signal: opts?.signal,
+              }),
+            {
+              maxRetries,
+              retryBaseDelayMs,
+              signal: opts?.signal,
+            },
+          );
+          partsUploaded += 1;
+          bytesUploaded += ack.size;
+          opts?.onPartUploaded?.(ack, {
+            partsUploaded,
+            totalParts: plans.length,
+            bytesUploaded,
+            totalBytes,
+          });
+          return ack;
+        },
+      );
+
+      const parts = uploaded
+        .map(({ partNumber, etag }) => ({ partNumber, etag }))
+        .sort((a, b) => a.partNumber - b.partNumber);
+
+      await this.completeMultipartUpload(uploadId, parts, {
+        signal: opts?.signal,
+      });
+    } catch (err) {
+      // Best-effort cleanup; don't mask the original error.
+      this.abortMultipartUpload(uploadId).catch(() => {});
+      throw err;
+    }
+  }
+
+  /**
+   * Initiate a multipart upload for a file path. Low-level: prefer
+   * {@link uploadFile} for the full lifecycle.
+   */
+  async initiateMultipartUpload(
+    path: string,
+    opts?: { permissions?: string; signal?: AbortSignal },
+  ): Promise<MultipartInitiateResponse> {
+    assertRelativePath(path);
+    const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+    const url = this.multipartUrl(`/initiate/${encodePathSegments(cleanPath)}`);
+
+    const body: Record<string, unknown> = {};
+    if (opts?.permissions !== undefined) body.permissions = opts.permissions;
+
+    const res = await ensureOk(
+      await this.transport.fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: opts?.signal,
+      }),
+      `Failed to initiate multipart upload for '${path}'`,
+    );
+    return (await res.json()) as MultipartInitiateResponse;
+  }
+
+  /**
+   * Upload a single part of a multipart upload. Low-level: prefer
+   * {@link uploadFile} for the full lifecycle.
+   */
+  async uploadPart(
+    uploadId: string,
+    partNumber: number,
+    part: Blob | Uint8Array,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MultipartUploadedPart> {
+    const url =
+      this.multipartUrl(`/${encodeURIComponent(uploadId)}/part`) +
+      `?partNumber=${encodeURIComponent(String(partNumber))}`;
+
+    const form = new FormData();
+    form.append("file", part instanceof Blob ? part : new Blob([part]));
+
+    // Intentionally no Content-Type header — fetch sets the multipart boundary.
+    const res = await ensureOk(
+      await this.transport.fetch(url, {
+        method: "PUT",
+        body: form,
+        signal: opts?.signal,
+      }),
+      `Failed to upload part ${partNumber} for upload '${uploadId}'`,
+    );
+    return (await res.json()) as MultipartUploadedPart;
+  }
+
+  /**
+   * Complete a multipart upload by committing the uploaded parts. Low-level:
+   * prefer {@link uploadFile} for the full lifecycle.
+   */
+  async completeMultipartUpload(
+    uploadId: string,
+    parts: Array<{ partNumber: number; etag: string }>,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{ message: string; path: string }> {
+    const url = this.multipartUrl(`/${encodeURIComponent(uploadId)}/complete`);
+    const res = await ensureOk(
+      await this.transport.fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ parts }),
+        signal: opts?.signal,
+      }),
+      `Failed to complete multipart upload '${uploadId}'`,
+    );
+    return (await res.json()) as { message: string; path: string };
+  }
+
+  /** Abort a multipart upload and clean up any uploaded parts on the server. */
+  async abortMultipartUpload(
+    uploadId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    const url = this.multipartUrl(`/${encodeURIComponent(uploadId)}`);
+    await ensureOk(
+      await this.transport.fetch(url, {
+        method: "DELETE",
+        signal: opts?.signal,
+      }),
+      `Failed to abort multipart upload '${uploadId}'`,
+    );
+  }
+
+  /**
+   * List the parts already uploaded for a multipart upload. Useful for resumable
+   * uploads: after reconnecting, call this to see which part numbers remain.
+   */
+  async listMultipartParts(
+    uploadId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MultipartPartInfo[]> {
+    const url = this.multipartUrl(`/${encodeURIComponent(uploadId)}/parts`);
+    const res = await ensureOk(
+      await this.transport.fetch(url, { signal: opts?.signal }),
+      `Failed to list parts for multipart upload '${uploadId}'`,
+    );
+    const data = (await res.json()) as {
+      uploadId: string;
+      parts: MultipartPartInfo[];
+    };
+    return data.parts;
   }
 
   /**
@@ -145,28 +432,43 @@ export class Sandbox {
    */
   async exec(command: string, opts?: ExecOptions): Promise<ExecResult> {
     const proc = await this.createProcess(command, opts);
-    if (proc.status === "completed") {
-      return { pid: proc.pid, exitCode: proc.exitCode ?? 0, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
+    // Process finished synchronously (any terminal status, incl. a non-zero exit).
+    if (isProcessTerminal(proc.status)) {
+      return toExecResult(proc.pid, proc);
     }
     if (opts?.waitForCompletion === false) {
-      return { pid: proc.pid, exitCode: -1, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
+      return {
+        pid: proc.pid,
+        exitCode: -1,
+        stdout: proc.stdout ?? "",
+        stderr: proc.stderr ?? "",
+      };
     }
     return this.pollProcess(proc.pid, opts);
   }
 
   /** Execute a command and stream output lines in real time. `exitCode` populates after `output` drains. */
-  async execStream(command: string, opts?: ExecStreamOptions): Promise<StreamingExecResult> {
+  async execStream(
+    command: string,
+    opts?: ExecStreamOptions,
+  ): Promise<StreamingExecResult> {
     const proc = await this.createProcess(command, opts);
 
-    if (proc.status === "completed") {
-      const code = proc.exitCode ?? 0;
+    if (isProcessTerminal(proc.status)) {
+      const code = terminalExitCode(proc);
       const stdout = proc.stdout ?? "";
       const stderr = proc.stderr ?? "";
       const output = (async function* (): AsyncGenerator<OutputLine> {
         if (stdout) yield { stream: "stdout", data: stdout };
         if (stderr) yield { stream: "stderr", data: stderr };
       })();
-      return { pid: proc.pid, get exitCode() { return code; }, output };
+      return {
+        pid: proc.pid,
+        get exitCode() {
+          return code;
+        },
+        output,
+      };
     }
 
     let finalExitCode = -1;
@@ -177,8 +479,12 @@ export class Sandbox {
 
     async function* streamOutput(): AsyncGenerator<OutputLine> {
       const res = await transport.fetch(logsUrl, { signal });
-      if (!res.ok) throw new Error(`Failed to stream process ${proc.pid}: ${res.status} ${await res.text()}`);
-      if (!res.body) throw new Error(`No response body for process ${proc.pid} log stream`);
+      if (!res.ok)
+        throw new Error(
+          `Failed to stream process ${proc.pid}: ${res.status} ${await res.text()}`,
+        );
+      if (!res.body)
+        throw new Error(`No response body for process ${proc.pid} log stream`);
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
@@ -199,47 +505,73 @@ export class Sandbox {
       }
 
       let status = await readStatus();
-      while (status.status !== "completed") {
+      while (!isProcessTerminal(status.status)) {
         await new Promise((r) => setTimeout(r, 1000));
         status = await readStatus();
       }
-      finalExitCode = status.exitCode ?? 0;
+      finalExitCode = terminalExitCode(status);
 
       async function readStatus(): Promise<ProcessStatus> {
         const s = await transport.fetch(statusUrl, { signal });
-        if (!s.ok) throw new Error(`Failed to get final status for process ${proc.pid}: ${s.status} ${await s.text()}`);
+        if (!s.ok)
+          throw new Error(
+            `Failed to get final status for process ${proc.pid}: ${s.status} ${await s.text()}`,
+          );
         return (await s.json()) as ProcessStatus;
       }
     }
 
-    return { pid: proc.pid, get exitCode() { return finalExitCode; }, output: streamOutput() };
+    return {
+      pid: proc.pid,
+      get exitCode() {
+        return finalExitCode;
+      },
+      output: streamOutput(),
+    };
   }
 
   /** Current status of a process by PID (useful for fire-and-forget execs). */
   async getProcess(pid: string): Promise<ProcessStatus> {
     const res = await this.transport.fetch(this.procUrl(`/${pid}`));
-    if (!res.ok) throw new Error(`Failed to get process ${pid}: ${res.status} ${await res.text()}`);
+    if (!res.ok)
+      throw new Error(
+        `Failed to get process ${pid}: ${res.status} ${await res.text()}`,
+      );
     return (await res.json()) as ProcessStatus;
   }
 
   /** Wait for a process to finish by polling its status. */
-  async waitForProcess(pid: string, opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal }): Promise<ExecResult> {
+  async waitForProcess(
+    pid: string,
+    opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal },
+  ): Promise<ExecResult> {
     return this.pollProcess(pid, opts);
   }
 
   /** Destroy the sandbox and release its resources. */
   async destroy(): Promise<void> {
-    const res = await this.transport.fetch(`${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}`, { method: "DELETE" });
-    if (!res.ok) throw new Error(`Failed to destroy sandbox: ${res.status} ${await res.text()}`);
+    const res = await this.transport.fetch(
+      `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok)
+      throw new Error(
+        `Failed to destroy sandbox: ${res.status} ${await res.text()}`,
+      );
   }
 
   // --- internal ---
 
-  private async createProcess(command: string, opts?: ExecOptions): Promise<ProcessCreateResponse> {
+  private async createProcess(
+    command: string,
+    opts?: ExecOptions,
+  ): Promise<ProcessCreateResponse> {
     const body: Record<string, unknown> = { command };
     if (opts?.cwd !== undefined) {
       assertRelativePath(opts.cwd);
-      const base = this.workspaceRoot.endsWith("/") ? this.workspaceRoot.slice(0, -1) : this.workspaceRoot;
+      const base = this.workspaceRoot.endsWith("/")
+        ? this.workspaceRoot.slice(0, -1)
+        : this.workspaceRoot;
       body.cwd = `${base}/${opts.cwd.startsWith("/") ? opts.cwd.slice(1) : opts.cwd}`;
     }
     if (opts?.env !== undefined) body.env = opts.env;
@@ -252,23 +584,36 @@ export class Sandbox {
       body: JSON.stringify(body),
       signal: opts?.signal,
     });
-    if (!res.ok) throw new Error(`Failed to execute command: ${res.status} ${await res.text()}`);
+    if (!res.ok)
+      throw new Error(
+        `Failed to execute command: ${res.status} ${await res.text()}`,
+      );
     return (await res.json()) as ProcessCreateResponse;
   }
 
-  private async pollProcess(pid: string, opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal }): Promise<ExecResult> {
+  private async pollProcess(
+    pid: string,
+    opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal },
+  ): Promise<ExecResult> {
     const pollInterval = opts?.pollInterval ?? DEFAULT_POLL_INTERVAL;
     const deadline = Date.now() + (opts?.timeout ?? DEFAULT_EXEC_TIMEOUT);
     while (Date.now() < deadline) {
-      const res = await this.transport.fetch(this.procUrl(`/${pid}`), { signal: opts?.signal });
-      if (!res.ok) throw new Error(`Failed to poll process ${pid}: ${res.status} ${await res.text()}`);
+      const res = await this.transport.fetch(this.procUrl(`/${pid}`), {
+        signal: opts?.signal,
+      });
+      if (!res.ok)
+        throw new Error(
+          `Failed to poll process ${pid}: ${res.status} ${await res.text()}`,
+        );
       const status = (await res.json()) as ProcessStatus;
-      if (status.status === "completed") {
-        return { pid, exitCode: status.exitCode ?? 0, stdout: status.stdout ?? "", stderr: status.stderr ?? "" };
+      if (isProcessTerminal(status.status)) {
+        return toExecResult(pid, status);
       }
       await new Promise((r) => setTimeout(r, pollInterval));
     }
-    throw new Error(`Process ${pid} timed out after ${opts?.timeout ?? DEFAULT_EXEC_TIMEOUT}ms`);
+    throw new Error(
+      `Process ${pid} timed out after ${opts?.timeout ?? DEFAULT_EXEC_TIMEOUT}ms`,
+    );
   }
 }
 
@@ -278,6 +623,9 @@ export function create(opts: SandboxCreateOptions): Promise<Sandbox> {
 }
 
 /** Adopt an existing sandbox by name (ambient transport). */
-export function attach(name: string, opts?: { workspaceRoot?: string; baseUrl?: string }): Sandbox {
+export function attach(
+  name: string,
+  opts?: { workspaceRoot?: string; baseUrl?: string },
+): Sandbox {
   return Sandbox.attach(name, opts);
 }

--- a/packages/tools/src/sandboxes/multipart.ts
+++ b/packages/tools/src/sandboxes/multipart.ts
@@ -1,0 +1,247 @@
+/**
+ * Multipart-upload helpers for the sandbox filesystem. Transport-agnostic pure
+ * functions (part planning, bounded concurrency, retry/backoff) plus the
+ * `SandboxHttpError` carried out of HTTP calls so the retry loop can read the
+ * status + `Retry-After`. Ported verbatim from the legacy `@sapiom/sandbox`;
+ * the `Sandbox` methods that use these call through the `_client` transport.
+ */
+
+/** Max parts allowed per multipart upload (Blaxel constraint). */
+export const MAX_PARTS = 10_000;
+
+/** Default number of retries for a single failed part upload. */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/** Default initial retry backoff in milliseconds. */
+export const DEFAULT_RETRY_BASE_DELAY_MS = 50;
+
+/** HTTP status codes worth retrying. 4xx are user errors unless explicitly transient. */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/**
+ * Error thrown by multipart HTTP methods when the server returns a non-2xx.
+ * Exposes `status` + `retryAfterMs` (parsed from `Retry-After`) so callers
+ * and the retry loop can make informed decisions.
+ */
+export class SandboxHttpError extends Error {
+  readonly status: number;
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, status: number, retryAfterMs?: number) {
+    super(message);
+    this.name = "SandboxHttpError";
+    this.status = status;
+    if (retryAfterMs !== undefined) this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Parse a `Retry-After` header value. Supports both forms:
+ *  - delta-seconds integer (e.g. `"30"`)
+ *  - HTTP-date (e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`)
+ */
+export function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return undefined;
+}
+
+/**
+ * Wrap a `fetch` response: if non-2xx, throw a `SandboxHttpError` carrying
+ * the status + Retry-After, otherwise return the response for the caller to
+ * parse.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  const text = await response.text().catch(() => "");
+  const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"));
+  throw new SandboxHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    retryAfterMs,
+  );
+}
+
+export interface RetryOptions {
+  /** Max number of retry attempts after the initial try. @default 3 */
+  maxRetries?: number;
+
+  /** Initial backoff in ms. Doubles each retry with up to `base` ms jitter. @default 50 */
+  retryBaseDelayMs?: number;
+
+  /** AbortSignal to cancel the retry loop. */
+  signal?: AbortSignal;
+}
+
+/** Whether this error is worth retrying. */
+function isRetryable(err: unknown): boolean {
+  if (err instanceof SandboxHttpError) return RETRYABLE_STATUS.has(err.status);
+  // Network-level failures (fetch rejected): typically TypeError "fetch failed"
+  // or AbortError. Retry non-abort errors.
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Retry `fn` up to `maxRetries` times on retryable errors with jittered
+ * exponential backoff. Honors `Retry-After` when the server provides one.
+ * Respects `signal` for prompt cancellation during the backoff wait.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  opts?: RetryOptions,
+): Promise<T> {
+  const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const base = opts?.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const signal = opts?.signal;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      if (attempt >= maxRetries || !isRetryable(err) || signal?.aborted) {
+        throw err;
+      }
+      const backoff =
+        err instanceof SandboxHttpError && err.retryAfterMs !== undefined
+          ? err.retryAfterMs
+          : base * 2 ** attempt + Math.random() * base;
+      await sleepWithSignal(backoff, signal);
+    }
+  }
+}
+
+function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Default part size: 5 MiB. Bottom of Blaxel's recommended 5–10 MB range
+ * and well clear of the Sapiom ingress 8 MiB body-size ceiling (with
+ * room left for multipart form-data overhead).
+ */
+export const DEFAULT_PART_SIZE = 5 * 1024 * 1024;
+
+/** Default number of parallel part uploads. */
+export const DEFAULT_CONCURRENCY = 4;
+
+/** Default file permissions (Blaxel default). */
+export const DEFAULT_PERMISSIONS = "0644";
+
+/**
+ * Normalize any supported content type into a `Blob`.
+ * `Blob.slice()` gives us random-access + lazy reads, so large inputs don't
+ * have to sit materialized in memory.
+ */
+export function toBlob(content: Blob | Uint8Array | string): Blob {
+  if (content instanceof Blob) return content;
+  if (typeof content === "string") {
+    return new Blob([new TextEncoder().encode(content)]);
+  }
+  return new Blob([content]);
+}
+
+export interface PartPlan {
+  partNumber: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * Split a byte range into part plans.
+ * Always emits at least one part (even for zero-byte inputs) so the caller
+ * still goes through the initiate/upload/complete handshake.
+ */
+export function planParts(totalBytes: number, partSize: number): PartPlan[] {
+  if (!Number.isFinite(partSize) || partSize <= 0) {
+    throw new Error(`partSize must be a positive integer (got ${partSize})`);
+  }
+
+  const count = totalBytes === 0 ? 1 : Math.ceil(totalBytes / partSize);
+
+  if (count > MAX_PARTS) {
+    const minPartSize = Math.ceil(totalBytes / MAX_PARTS);
+    throw new Error(
+      `File of ${totalBytes} bytes would require ${count} parts at partSize=${partSize}, ` +
+        `but the server accepts at most ${MAX_PARTS}. Increase partSize to at least ${minPartSize}.`,
+    );
+  }
+
+  const plans: PartPlan[] = [];
+  for (let i = 0; i < count; i++) {
+    const start = i * partSize;
+    const end = Math.min(start + partSize, totalBytes);
+    plans.push({ partNumber: i + 1, start, end });
+  }
+  return plans;
+}
+
+/**
+ * Run `worker` over `items` with at most `concurrency` promises in flight.
+ * Rejects on the first worker failure (and stops scheduling further items).
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isFinite(concurrency) || concurrency < 1) {
+    throw new Error(`concurrency must be >= 1 (got ${concurrency})`);
+  }
+
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  let failed = false;
+  let firstError: unknown;
+
+  const limit = Math.min(concurrency, items.length);
+  const runners: Promise<void>[] = [];
+
+  for (let slot = 0; slot < limit; slot++) {
+    runners.push(
+      (async () => {
+        while (!failed) {
+          const i = next++;
+          if (i >= items.length) return;
+          try {
+            results[i] = await worker(items[i]!, i);
+          } catch (err) {
+            if (!failed) {
+              failed = true;
+              firstError = err;
+            }
+            return;
+          }
+        }
+      })(),
+    );
+  }
+
+  await Promise.all(runners);
+
+  if (failed) throw firstError;
+  return results;
+}

--- a/packages/tools/src/sandboxes/types.ts
+++ b/packages/tools/src/sandboxes/types.ts
@@ -116,6 +116,67 @@ export interface ProcessStatus {
   [key: string]: unknown;
 }
 
+/** Raw response from POST /v1/sandboxes/:name/filesystem/multipart/initiate/:path. */
+export interface MultipartInitiateResponse {
+  uploadId: string;
+  path: string;
+}
+
+/** Ack returned after a part upload or needed to complete an upload. */
+export interface MultipartUploadedPart {
+  partNumber: number;
+  etag: string;
+  size: number;
+}
+
+/** Full part record returned by GET .../multipart/:uploadId/parts. */
+export interface MultipartPartInfo extends MultipartUploadedPart {
+  uploadedAt: string;
+}
+
+/** Progress reported to {@link UploadFileOptions.onPartUploaded}. */
+export interface UploadProgress {
+  partsUploaded: number;
+  totalParts: number;
+  bytesUploaded: number;
+  totalBytes: number;
+}
+
+/** Options for {@link Sandbox.uploadFile}. */
+export interface UploadFileOptions {
+  /** Part size in bytes. @default 5 * 1024 * 1024 (5 MiB) */
+  partSize?: number;
+
+  /** Number of parallel part uploads. @default 4 */
+  concurrency?: number;
+
+  /** File permissions string passed to initiate. @default "0644" */
+  permissions?: string;
+
+  /**
+   * Max retries per failed part upload. Retries on 408/425/429/5xx and
+   * network errors; honors `Retry-After`. Pass `0` to disable.
+   * @default 3
+   */
+  maxRetries?: number;
+
+  /**
+   * Initial retry backoff in ms. Doubles each attempt with up to `base` ms
+   * jitter, so 3 retries take ≤ ~400ms total at the default.
+   * @default 50
+   */
+  retryBaseDelayMs?: number;
+
+  /** AbortSignal to cancel the upload. Triggers an auto-abort of the multipart upload on the server. */
+  signal?: AbortSignal;
+
+  /** Invoked after each part finishes uploading (in completion order, not partNumber order). */
+  onPartUploaded?: (
+    part: MultipartUploadedPart,
+    progress: UploadProgress,
+  ) => void;
+}
+
 // --- internal wire shapes (not part of the public surface) ---
 
 /** @internal Raw create response. */

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -8,43 +8,50 @@
  * transport (the missing-credential error fires on a request, not at
  * construction), so constructing + shape-checking is side-effect-free.
  */
-import { createClient, sandboxes, repositories, agent, Sandbox, Repository } from './index.js';
+import {
+  createClient,
+  sandboxes,
+  repositories,
+  agent,
+  Sandbox,
+  Repository,
+} from "./index.js";
 
-describe('@sapiom/tools public surface', () => {
-  it('exposes createClient as a function', () => {
-    expect(typeof createClient).toBe('function');
+describe("@sapiom/tools public surface", () => {
+  it("exposes createClient as a function", () => {
+    expect(typeof createClient).toBe("function");
   });
 
-  it('createClient builds a Sapiom with the expected capability namespaces', () => {
-    const sapiom = createClient({ apiKey: 'test-key' });
+  it("createClient builds a Sapiom with the expected capability namespaces", () => {
+    const sapiom = createClient({ apiKey: "test-key" });
 
-    expect(typeof sapiom.sandboxes.create).toBe('function');
-    expect(typeof sapiom.sandboxes.attach).toBe('function');
+    expect(typeof sapiom.sandboxes.create).toBe("function");
+    expect(typeof sapiom.sandboxes.attach).toBe("function");
 
-    expect(typeof sapiom.repositories.create).toBe('function');
-    expect(typeof sapiom.repositories.get).toBe('function');
-    expect(typeof sapiom.repositories.list).toBe('function');
-    expect(typeof sapiom.repositories.delete).toBe('function');
-    expect(typeof sapiom.repositories.attach).toBe('function');
+    expect(typeof sapiom.repositories.create).toBe("function");
+    expect(typeof sapiom.repositories.get).toBe("function");
+    expect(typeof sapiom.repositories.list).toBe("function");
+    expect(typeof sapiom.repositories.delete).toBe("function");
+    expect(typeof sapiom.repositories.attach).toBe("function");
 
-    expect(typeof sapiom.agent.coding.run).toBe('function');
-    expect(typeof sapiom.agent.coding.launch).toBe('function');
+    expect(typeof sapiom.agent.coding.run).toBe("function");
+    expect(typeof sapiom.agent.coding.launch).toBe("function");
 
-    expect(typeof sapiom.withAttribution).toBe('function');
+    expect(typeof sapiom.withAttribution).toBe("function");
   });
 
-  it('withAttribution derives a client of the same shape', () => {
-    const derived = createClient({ apiKey: 'test-key' }).withAttribution({});
-    expect(typeof derived.sandboxes.create).toBe('function');
-    expect(typeof derived.agent.coding.run).toBe('function');
-    expect(typeof derived.withAttribution).toBe('function');
+  it("withAttribution derives a client of the same shape", () => {
+    const derived = createClient({ apiKey: "test-key" }).withAttribution({});
+    expect(typeof derived.sandboxes.create).toBe("function");
+    expect(typeof derived.agent.coding.run).toBe("function");
+    expect(typeof derived.withAttribution).toBe("function");
   });
 
-  it('barrel re-exports the capability namespaces and resource classes', () => {
-    expect(typeof sandboxes).toBe('object');
-    expect(typeof repositories).toBe('object');
-    expect(typeof agent).toBe('object');
-    expect(typeof Sandbox).toBe('function'); // class constructor
-    expect(typeof Repository).toBe('function');
+  it("barrel re-exports the capability namespaces and resource classes", () => {
+    expect(typeof sandboxes).toBe("object");
+    expect(typeof repositories).toBe("object");
+    expect(typeof agent).toBe("object");
+    expect(typeof Sandbox).toBe("function"); // class constructor
+    expect(typeof Repository).toBe("function");
   });
 });


### PR DESCRIPTION
This pull request introduces a new "dispatch → pause → resume" authoring surface for long-running capabilities, enabling workflow steps to pause on a capability (like a coding run) and resume when it completes. The main focus is on adding a generic `DispatchHandle` contract, updating the orchestration layer to pause on these handles, and ensuring that capability launches forward workflow resume tokens as headers for proper engine integration. The changes are additive and maintain backward compatibility.

**Key changes:**

**Orchestration & Workflow Pause/Resume:**
- Added support in `@sapiom/orchestration` for pausing workflow steps on a `DispatchHandle` or its promise, allowing steps to easily wait for long-running capabilities and resume when they finish. The `pauseUntilSignal` function now accepts a handle or promise and extracts the correct signal and correlation ID from it. [[1]](diffhunk://#diff-5db8b6e074ab4e1f1576b2767a58df9a96368f9546711be76419ec25e5d6d4c1L218-R290) [[2]](diffhunk://#diff-5db8b6e074ab4e1f1576b2767a58df9a96368f9546711be76419ec25e5d6d4c1R15-R16) [[3]](diffhunk://#diff-ce1a414fde5889293c97bf0d6049743fd2a74d19ed4f740d3e37e48e793c2a4bR7-R8) [[4]](diffhunk://#diff-ce1a414fde5889293c97bf0d6049743fd2a74d19ed4f740d3e37e48e793c2a4bR60-R88)
- Comprehensive tests were added to verify the new overloads and behaviors of `pauseUntilSignal`.

**DispatchHandle Contract & Coding Agent Integration:**
- Introduced the `DispatchHandle` interface in `@sapiom/tools`, which standardizes how long-running capability handles expose their dispatch information. [[1]](diffhunk://#diff-44a8e0472a1b83572f61dc82751668e54bc74da3bdbf7dfe6e4ab428d8037b9cR1-R26) [[2]](diffhunk://#diff-ed22786a9d71840b9374de8c2514769eabcea946787a1f0ada894d2a27ae0a6dR18-R30)
- Coding run handles (`RunHandle`) now implement `DispatchHandle` and include a `dispatch` member with the `correlationId` and a new capability-stable `CODING_RESULT_SIGNAL`. [[1]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L81-R122) [[2]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426R218-R220) [[3]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426R24-R45)
- The `CODING_RESULT_SIGNAL` constant is now exported for static workflow step declarations. [[1]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426R24-R45) [[2]](diffhunk://#diff-ed22786a9d71840b9374de8c2514769eabcea946787a1f0ada894d2a27ae0a6dR18-R30)

**Workflow Resume Token Forwarding:**
- When launching a coding run inside a workflow, the engine-injected resume token (`SAPIOM_CAPABILITY_RESUME_TOKEN`) is forwarded as the `x-sapiom-workflow-token` header. This enables the gateway to resume the paused workflow step when the capability completes. The header is omitted for standalone use. [[1]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L81-R122) [[2]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426R193) [[3]](diffhunk://#diff-754d80e7b4bdd1febd60b10154eae473620c8ea246135c74b34b4203ddf3d9edR1-R74)
- Tests were added to verify correct header forwarding behavior.

**Documentation & Authoring Surface:**
- Updated documentation and the changeset to describe the new authoring surface, usage patterns, and non-breaking nature of the changes.

**Formatting & Minor Cleanups:**
- Various files were reformatted for readability, and some minor code cleanups were performed. [[1]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL68-R72) [[2]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL129-R133) [[3]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L167-R205) [[4]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L190-R233) [[5]](diffhunk://#diff-6e2f33aad43ffeb8daa54875dcba4212199ca99aadc6f9b772d3211bf5acb4c8L17-R39) [[6]](diffhunk://#diff-6e2f33aad43ffeb8daa54875dcba4212199ca99aadc6f9b772d3211bf5acb4c8L71-R84) [[7]](diffhunk://#diff-f6f05a9895fa9673a2cfed87dcbf1e1adc59cd6a6b9b4ffe1efe29a29d939fb9L22-R23) [[8]](diffhunk://#diff-f6f05a9895fa9673a2cfed87dcbf1e1adc59cd6a6b9b4ffe1efe29a29d939fb9L40-R46)

These changes make it much simpler and more robust to author long-running, pausable workflow steps in Sapiom, and lay the groundwork for further capability integrations.