### PR TITLE
update README to document integrated pauses

### DIFF
--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -23,18 +23,23 @@ subpath).
 ## Authoring surface
 
 ```ts
-import { defineOrchestration, defineStep, goto, terminate } from '@sapiom/orchestration';
+import {
+  defineOrchestration,
+  defineStep,
+  goto,
+  terminate,
+} from "@sapiom/orchestration";
 
 const start = defineStep({
-  name: 'start',
-  next: ['finish'],
+  name: "start",
+  next: ["finish"],
   async run(input, ctx) {
-    return goto('finish', { greeting: `hello ${input.name}` });
+    return goto("finish", { greeting: `hello ${input.name}` });
   },
 });
 
 const finish = defineStep({
-  name: 'finish',
+  name: "finish",
   next: [],
   terminal: true,
   async run() {
@@ -43,8 +48,8 @@ const finish = defineStep({
 });
 
 export const hello = defineOrchestration({
-  name: 'hello',
-  entry: 'start',
+  name: "hello",
+  entry: "start",
   steps: { start, finish },
 });
 ```
@@ -53,3 +58,76 @@ A step declares the transitions it may take (`next` / `terminal` / `canFail` /
 `pause`); the `run` return type is derived from those declarations, so an
 undeclared transition is a compile error. The build reads those same declarations
 to render the orchestration graph without executing anything.
+
+## Pausing on a long-running capability
+
+Some `ctx.sapiom` capabilities are **dispatched**: you launch them, they run far
+past one step's budget, and they report back when they finish (a coding agent
+today; more below). A step can't inline-`await` one — it pauses, and a later step
+resumes with the result. `pauseUntilSignal` accepts the launch handle (or the
+launch promise itself) and reads everything it needs off it:
+
+```ts
+import { defineStep, pauseUntilSignal, terminate } from "@sapiom/orchestration";
+import { CODING_RESULT_SIGNAL } from "@sapiom/tools";
+
+const code = defineStep({
+  name: "code",
+  next: ["review"],
+  // capability's exported signal constant so the decl can't drift from the handle.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "review" },
+  async run(input, ctx) {
+    // launch returns immediately; hand it straight to pauseUntilSignal. The run
+    // parks at status='paused' and the dispatch loop exits.
+    return pauseUntilSignal(
+      ctx.sapiom.agent.coding.launch({ task: input.task }),
+      {
+        resumeStep: "review",
+      },
+    );
+  },
+});
+
+const review = defineStep({
+  name: "review",
+  next: [],
+  terminal: true,
+  // Give this step an `inputSchema` (a zod schema for the capability's result
+  // shape) to type + validate what it receives.
+  async run(result, ctx) {
+    // Fires on success OR failure — branch on the terminal result.
+    return terminate({ ok: result.status === "completed" });
+  },
+});
+```
+
+Things to know:
+
+- **The pause is a real suspend across processes**, so the launch and the resume
+  are two steps — you can't fold them into one inline `await`.
+- **The resumed step receives the capability's result as its input.** Declare its
+  `inputSchema` to type + validate it (each capability documents its result shape).
+- **Pass the launch promise directly** for the one-liner above, or `await` it first
+  when you need the handle — to stash the run id in `ctx.shared`, or to `try/catch`
+  a launch failure and route somewhere other than a retry. Awaiting doesn't lose
+  the pause; the resolved handle still flows into `pauseUntilSignal`:
+
+  ```ts
+  async run(input, ctx) {
+    const run = await ctx.sapiom.agent.coding.launch({ task: input.task });
+    ctx.shared.set("codingRunId", run.runId); // readable from the resumed step
+    return pauseUntilSignal(run, { resumeStep: "review" });
+  }
+  ```
+- **Outside a workflow nothing changes** — `await launch().wait()` the capability as
+  usual; the pause wiring only engages when a step pauses on the handle.
+
+### Compatible capabilities
+
+Any capability whose `launch` returns a `DispatchHandle` (a `dispatch` member) is
+pausable; each ships a stable result-signal constant for the `pause` decl. This
+list grows as capabilities land:
+
+| Capability   | Launch                              | Pause signal                             |
+| ------------ | ----------------------------------- | ---------------------------------------- |
+| Coding agent | `ctx.sapiom.agent.coding.launch(…)` | `CODING_RESULT_SIGNAL` (`@sapiom/tools`) |


### PR DESCRIPTION
This pull request updates the `packages/orchestration/README.md` to improve code style consistency and add comprehensive documentation for pausing orchestration steps on long-running capabilities. The most significant change is the addition of a new section explaining how to use `pauseUntilSignal` with dispatched capabilities, including a detailed example and best practices.

Documentation improvements:

* Added a new section, "Pausing on a long-running capability," explaining how to use `pauseUntilSignal` to pause orchestration steps and resume them when a dispatched capability (like a coding agent) completes. This includes a detailed code example, important usage notes, and a compatibility table for current capabilities.

Code style and readability:

* Updated code examples throughout the README to use consistent double quotes and improved formatting for imports and object properties. [[1]](diffhunk://#diff-e1da710877e6703f565b368ec215f2c074692b5ba6e4b058e8de99f480f64e7aL26-R42) [[2]](diffhunk://#diff-e1da710877e6703f565b368ec215f2c074692b5ba6e4b058e8de99f480f64e7aL46-R52)