### PR TITLE
push from sandbox resolved in backend

### DIFF
--- a/.changeset/push-from-sandbox-relay.md
+++ b/.changeset/push-from-sandbox-relay.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": patch
+---
+
+`repositories.pushFromSandbox` now always publishes the agent's work — it
+commits any pending changes and pushes the current commit, so your work reaches
+the repo whether the agent left changes uncommitted, already committed them, or
+both. (Previously it skipped the push when there were no uncommitted changes.)
+The result now includes `branch` alongside `pushed` and `sha`.

--- a/packages/tools/src/repositories/README.md
+++ b/packages/tools/src/repositories/README.md
@@ -14,9 +14,9 @@ const { pushed, sha } = await repo.pushFromSandbox(run.sandbox, { message: "buil
 
 - **Repositories are hosted by Sapiom, not GitHub.** Clones and pushes are authenticated through the Sapiom git gateway using your tenant credentials — there are no personal access tokens or SSH keys to manage. The `cloneUrl` on a repository is the unauthenticated origin; the credentials to clone it yourself are returned when you create the repo.
 
-- **`pushFromSandbox` requires the repo to already be checked out in the sandbox.** It does not clone — it commits and pushes from the repo's checkout at `/workspace/<slug>`. The straightforward way to get that checkout is to run a coding agent with `gitRepository: repo`, which clones the repo into exactly that path with push access already configured. The two methods are meant to be used together; calling `pushFromSandbox` on a sandbox where the repo was never cloned will fail.
+- **`pushFromSandbox` requires the repo to already be checked out in the sandbox.** It does not clone — it commits and pushes from the repo's checkout at `/workspace/<slug>`. The straightforward way to get that checkout is to run a coding agent with `gitRepository: repo`, which clones the repo into exactly that path. The two methods are meant to be used together; calling `pushFromSandbox` on a sandbox where the repo was never cloned will fail.
 
-- **`pushFromSandbox` is a no-op when there's nothing to commit.** It returns `{ pushed: false, sha: null }` rather than throwing on an empty diff. A non-null `sha` means a commit was actually created and pushed.
+- **`pushFromSandbox` publishes the agent's work.** It commits any pending changes and pushes the current commit, so your work reaches the repo whether the agent left changes uncommitted, already committed them, or both. It returns `{ pushed, sha, branch }`; a failed push (e.g. the repo was never cloned into the sandbox) throws.
 
 - **Prefer pushing in code over asking the agent to push.** Have the coding agent write files, and use `pushFromSandbox` to commit and push afterward. This keeps publishing exact and repeatable instead of depending on the agent to run git correctly.
 

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -1,29 +1,17 @@
 /**
  * `repositories` capability — in-network git repos: create, get, list, delete, and
- * the first cross-capability mesh method, `repo.pushFromSandbox(sandbox)`.
+ * `repo.pushFromSandbox(sandbox)` to commit + push a sandbox checkout.
  *
  *   import { repositories } from "@sapiom/tools";
  *   const repo = await repositories.create("my-app");
  *   // … an agent or your code writes files in a sandbox checkout of the repo …
  *   await repo.pushFromSandbox(box, { message: "build: page" });
- *
- * `pushFromSandbox` is the deterministic counterpart to a fuzzy agent step: it
- * composes the `sandboxes` capability (calls `sandbox.exec`) to commit + push the
- * repo's working tree. It references the `Sandbox` TYPE only — no module cycle.
- *
- * Note: `cloneUrl` is the unauthenticated origin. The gateway authenticates clones
- * via basic-auth (the `auth` block returned by create); inside an agent run the
- * `gitRepository` auto-clone wires that credential into the in-sandbox origin, so
- * `pushFromSandbox` doesn't need it.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
 import type { Sandbox } from "../sandboxes/index.js";
 
 const DEFAULT_BASE_URL =
   process.env.SAPIOM_GIT_URL || "https://git.services.sapiom.ai";
-
-/** Canonical in-sandbox checkout path (matches the agent's `gitRepository` auto-clone). */
-const checkoutDir = (slug: string) => `/workspace/${slug}`;
 
 /** `GET`/`list` shape from the git gateway. */
 interface RepoSummary {
@@ -47,9 +35,12 @@ interface CreateRepositoryResponse {
 }
 
 export interface PushResult {
-  /** False when there was nothing to commit. */
+  /** True once your work has been pushed to the repo. */
   pushed: boolean;
+  /** The pushed commit SHA, when available. */
   sha: string | null;
+  /** The branch it was pushed to, when available. */
+  branch?: string | null;
 }
 
 /** A connected in-network repository. */
@@ -147,33 +138,31 @@ export class Repository {
   }
 
   /**
-   * Deterministically stage + commit + push this repo's working tree FROM a
-   * sandbox checkout (no LLM). Assumes the repo is checked out at the canonical
-   * `/workspace/<slug>` with an authenticated `origin` (which the agent's
-   * `gitRepository` auto-clone sets up). No-op when there's nothing to commit.
+   * Commit and push this repo's working tree from a sandbox checkout. Commits any
+   * pending changes and pushes the current commit, so the agent's work is
+   * published whether it left changes uncommitted, already committed them, or
+   * both. Returns `{ pushed, sha, branch }`; throws if the push fails.
+   *
+   * `workingDirectory` defaults to the repo's checkout at `/workspace/<slug>`
+   * (where a coding agent run with `gitRepository: repo` clones it).
    */
   async pushFromSandbox(
     sandbox: Sandbox,
-    opts: { message?: string } = {},
+    opts: { message?: string; workingDirectory?: string } = {},
   ): Promise<PushResult> {
-    const message = (opts.message ?? `update ${this.slug}`).replace(/'/g, ""); // single-quote-safe for sh -c
-    const script =
-      `cd ${checkoutDir(this.slug)} && git add -A && ` +
-      `if git diff --cached --quiet; then echo NO_CHANGES; else ` +
-      `git -c user.email=workflow@sapiom.ai -c user.name=sapiom-workflow commit -m "${message}" >/dev/null && ` +
-      `git push origin HEAD && printf "SHA:%s\\n" "$(git rev-parse HEAD)"; fi`;
-    const { stdout, stderr, exitCode } = await sandbox.exec(
-      `sh -c '${script}'`,
+    return this.transport.request<PushResult>(
+      `${this.baseUrl}/v1/git/repositories/${encodeURIComponent(this.slug)}/push-from-sandbox`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          executionEnvironmentId: sandbox.name,
+          ...(opts.workingDirectory
+            ? { workingDirectory: opts.workingDirectory }
+            : {}),
+          ...(opts.message ? { message: opts.message } : {}),
+        }),
+      },
     );
-    const out = `${stdout}\n${stderr}`;
-    if (out.includes("NO_CHANGES")) return { pushed: false, sha: null };
-    const sha = out.match(/SHA:([0-9a-f]{7,40})/)?.[1] ?? null;
-    if (exitCode !== 0 || !sha) {
-      throw new Error(
-        `pushFromSandbox(${this.slug}) failed (exit ${exitCode}): ${out.slice(-300)}`,
-      );
-    }
-    return { pushed: true, sha };
   }
 }
 

--- a/packages/tools/src/repositories/push-from-sandbox.spec.ts
+++ b/packages/tools/src/repositories/push-from-sandbox.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * pushFromSandbox() — request shape + result passthrough.
+ *
+ * Injects a fake fetch (no real network) to assert it POSTs the sandbox name and
+ * options, and returns the `{ pushed, sha, branch }` response verbatim.
+ */
+import { createClient } from "../index.js";
+
+interface Captured {
+  url?: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+function fakeFetch(
+  capture: Captured,
+  response: unknown = { pushed: true, sha: "abc1234", branch: "main" },
+): typeof globalThis.fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    capture.url = url;
+    capture.method = init.method;
+    capture.body = init.body ? JSON.parse(init.body as string) : undefined;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => response,
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("repositories.pushFromSandbox", () => {
+  it("POSTs the sandbox name as executionEnvironmentId and returns the gateway result", async () => {
+    const capture: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    const repo = sapiom.repositories.attach("my-app", "https://git/x/my-app");
+    const sandbox = sapiom.sandboxes.attach("coding-abc");
+
+    const result = await repo.pushFromSandbox(sandbox, { message: "build: page" });
+
+    expect(capture.method).toBe("POST");
+    expect(capture.url).toContain("/v1/git/repositories/my-app/push-from-sandbox");
+    expect(capture.body).toEqual({
+      executionEnvironmentId: "coding-abc",
+      message: "build: page",
+    });
+    expect(result).toEqual({ pushed: true, sha: "abc1234", branch: "main" });
+  });
+
+  it("omits message/workingDirectory when not provided", async () => {
+    const capture: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    const repo = sapiom.repositories.attach("my-app", "https://git/x/my-app");
+    const sandbox = sapiom.sandboxes.attach("coding-abc");
+
+    await repo.pushFromSandbox(sandbox);
+
+    expect(capture.body).toEqual({ executionEnvironmentId: "coding-abc" });
+  });
+
+  it("forwards an explicit workingDirectory", async () => {
+    const capture: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    const repo = sapiom.repositories.attach("my-app", "https://git/x/my-app");
+    const sandbox = sapiom.sandboxes.attach("coding-abc");
+
+    await repo.pushFromSandbox(sandbox, { workingDirectory: "/workspace/sub" });
+
+    expect(capture.body).toEqual({
+      executionEnvironmentId: "coding-abc",
+      workingDirectory: "/workspace/sub",
+    });
+  });
+});


### PR DESCRIPTION
This pull request updates the `repositories.pushFromSandbox` method in the `@sapiom/tools` package to always publish the agent's work by committing and pushing any changes from a sandbox checkout, regardless of whether there are uncommitted changes. The API now consistently returns the pushed commit's SHA and branch, and the implementation has been refactored to use a network request to the git gateway rather than running shell commands directly in the sandbox. Documentation and tests have been updated to reflect these changes.

**Enhancements to `pushFromSandbox` behavior and API:**

* `pushFromSandbox` now always commits and pushes the current state of the repo in the sandbox, ensuring the agent's work is published whether changes were uncommitted, already committed, or both. The method now returns an object containing `pushed`, `sha`, and `branch`. [[1]](diffhunk://#diff-6bd4c4fbaaad298fbd40ded4bd7812df74720acc034bacc12d9f084e3282224fR1-R9) [[2]](diffhunk://#diff-f6f05a9895fa9673a2cfed87dcbf1e1adc59cd6a6b9b4ffe1efe29a29d939fb9L50-R43) [[3]](diffhunk://#diff-f6f05a9895fa9673a2cfed87dcbf1e1adc59cd6a6b9b4ffe1efe29a29d939fb9L150-L177)

**Implementation and interface changes:**

* The implementation of `pushFromSandbox` in `Repository` has been refactored to make a POST request to the git gateway, passing the sandbox name and options, instead of running shell commands in the sandbox.
* The `PushResult` interface has been updated to include the `branch` property and clarify the meaning of `pushed` and `sha`.

**Documentation updates:**

* The README for `repositories` has been updated to describe the new behavior of `pushFromSandbox`, removing references to the old no-op behavior and clarifying its purpose.
* The docstring for `pushFromSandbox` has been revised to reflect the new, more robust publishing behavior.

**Testing improvements:**

* Added a new test suite (`push-from-sandbox.spec.ts`) to verify the request shape and result passthrough for `pushFromSandbox`, ensuring it POSTs the correct data and returns the expected result.