### PR TITLE
loosen orchestration -> tools version dep

### DIFF
--- a/.changeset/orchestration-tools-peer.md
+++ b/.changeset/orchestration-tools-peer.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/orchestration": patch
+---
+
+Depend on `@sapiom/tools` with a caret range (`^0.1`) instead of an exact
+version. The dependency was declared `workspace:*`, which publishes as the exact
+resolved version — so `@sapiom/orchestration@0.1.2` carried a hard `0.1.2` pin and
+forced a second copy of `@sapiom/tools` whenever a project used a newer patch
+(e.g. tools `0.1.3`), producing duplicate nominal types and `tsc` errors. A caret
+range lets the consumer's own `@sapiom/tools` (any `0.1.x`) satisfy and dedupe to
+a single copy, while still pulling tools in transitively so authoring types
+resolve out of the box.

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -49,7 +49,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@sapiom/tools": "workspace:*"
+    "@sapiom/tools": "workspace:^"
   },
   "peerDependencies": {
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
   packages/orchestration:
     dependencies:
       '@sapiom/tools':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tools
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
This pull request updates the way `@sapiom/orchestration` depends on `@sapiom/tools`, switching from an exact version pin to a caret (`^`) range. This change prevents duplicate installations of `@sapiom/tools` and resolves TypeScript errors caused by mismatched nominal types when multiple patch versions are present.

Dependency management improvements:

* Changed the `@sapiom/tools` dependency in `packages/orchestration/package.json` from `workspace:*` (exact version) to `workspace:^` (caret range), allowing deduplication and compatibility with any `0.1.x` version.
* Updated the dependency specifier for `@sapiom/tools` in `pnpm-lock.yaml` to use `workspace:^`, reflecting the new caret range.

Documentation:

* Added a changeset file explaining the motivation and impact of switching to a caret dependency range for `@sapiom/tools`.