### PR TITLE
relax step schema

### DIFF
--- a/.changeset/orchestration-relax-additional-properties.md
+++ b/.changeset/orchestration-relax-additional-properties.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/orchestration": patch
+---
+
+Generated step-input JSON Schemas no longer reject fields the schema doesn't declare.
+
+`z.toJSONSchema()` (Zod v4) marks every object as closed (`additionalProperties: false`), but a `z.object()` ignores keys it doesn't name when it parses, rather than rejecting them. `buildManifest` now strips the closed-object marker from the schemas it emits so the two behaviors match — a step keeps validating successfully when an input it receives carries extra fields the step's `inputSchema` doesn't name. Typed catchalls (`z.object().catchall(...)`) are preserved.
+
+Additive and non-breaking. If you previously added fields to a step's `inputSchema` only to admit extra incoming payload fields, that workaround is no longer required (though it remains harmless).

--- a/packages/orchestration/src/build-manifest.ts
+++ b/packages/orchestration/src/build-manifest.ts
@@ -1,21 +1,22 @@
-import { zodToJsonSchema } from './introspection.js';
-import { MANIFEST_PROTOCOL, type ManifestTransition, type WorkflowManifest } from './manifest.js';
-import type { StepDefinition } from './step.js';
-import type { OrchestrationDefinition } from './workflow.js';
+import { zodToJsonSchema } from "./introspection.js";
+import {
+  MANIFEST_PROTOCOL,
+  type ManifestTransition,
+  type WorkflowManifest,
+} from "./manifest.js";
+import type { StepDefinition } from "./step.js";
+import type { OrchestrationDefinition } from "./workflow.js";
 
 /**
  * Generate a WorkflowManifest from a workflow definition and build metadata.
  *
- * Called by the build phase (locally via `build-definition`, in CI via the
- * sandbox build-run). Runs in the build sandbox, never in the engine.
- *
  * - Walks def.steps; for each step:
- *   - timeoutMs: step.timeoutMs if declared, null otherwise (engine applies
- *     DEFAULT_DISPATCH_TIMEOUT_MS for null — timeout policy stays engine-side).
- *   - inputSchema: zod→JSON Schema if step.inputSchema is declared, null
- *     otherwise. Defaulted top-level fields are dropped from `required` so the
- *     engine's AJV pre-check is never stricter than the sandbox's Zod parse.
- *   - transitions: the tagged edge list, read from the step's DECLARED
+ *   - timeoutMs: step.timeoutMs if declared, null otherwise.
+ *   - inputSchema: the step's Zod schema converted to JSON Schema if declared,
+ *     null otherwise. The generated schema is normalized so it accepts the same
+ *     inputs the Zod schema parses: defaulted fields are not forced as required,
+ *     and objects are not closed to extra fields.
+ *   - transitions: the tagged edge list, read from the step's declared
  *     `next`/`terminal`/`canFail`/`pause` runtime properties (set by
  *     `defineStep`). This is a runtime-value read, exactly like inputSchema —
  *     no type reflection, no AST parsing.
@@ -30,14 +31,20 @@ export function buildManifest(
 ): WorkflowManifest {
   const steps: Record<
     string,
-    { timeoutMs: number | null; inputSchema: Record<string, unknown> | null; transitions: ManifestTransition[] }
+    {
+      timeoutMs: number | null;
+      inputSchema: Record<string, unknown> | null;
+      transitions: ManifestTransition[];
+    }
   > = {};
 
   for (const [stepName, step] of Object.entries(def.steps)) {
     let inputSchema: Record<string, unknown> | null = null;
     if (step.inputSchema) {
       const raw = zodToJsonSchema(step.inputSchema);
-      inputSchema = dropDefaultedFromRequired(raw);
+      inputSchema = relaxAdditionalProperties(
+        dropDefaultedFromRequired(raw),
+      ) as Record<string, unknown>;
     }
     steps[stepName] = {
       timeoutMs: step.timeoutMs ?? null,
@@ -63,19 +70,23 @@ export function buildManifest(
 function transitionsFor(step: StepDefinition): ManifestTransition[] {
   const transitions: ManifestTransition[] = [];
   for (const target of step.next ?? []) {
-    transitions.push({ kind: 'continue', target });
+    transitions.push({ kind: "continue", target });
   }
   if (step.pause) {
-    transitions.push({ kind: 'pause', signal: step.pause.signal, resumeStep: step.pause.resumeStep });
+    transitions.push({
+      kind: "pause",
+      signal: step.pause.signal,
+      resumeStep: step.pause.resumeStep,
+    });
   }
-  if (step.terminal) transitions.push({ kind: 'terminate' });
-  if (step.canFail) transitions.push({ kind: 'fail' });
+  if (step.terminal) transitions.push({ kind: "terminate" });
+  if (step.canFail) transitions.push({ kind: "fail" });
   return transitions;
 }
 
 // ---------------------------------------------------------------------------
-// Graph validation (build-time conformance — developer courtesy, NOT the trust
-// boundary; the engine's per-step completion check is the enforcement).
+// Graph validation (build-time conformance check — a developer-facing courtesy
+// that surfaces malformed graphs early; not an authoritative guarantee).
 // ---------------------------------------------------------------------------
 
 export interface GraphValidation {
@@ -111,7 +122,10 @@ export function validateGraph(manifest: WorkflowManifest): GraphValidation {
   if (names.has(manifest.entry)) {
     const reachable = bfs([manifest.entry], forward);
     for (const name of names) {
-      if (!reachable.has(name)) warnings.push(`step '${name}' is unreachable from entry '${manifest.entry}'`);
+      if (!reachable.has(name))
+        warnings.push(
+          `step '${name}' is unreachable from entry '${manifest.entry}'`,
+        );
     }
   }
   warnings.push(...terminalReachabilityWarnings(manifest, names, forward));
@@ -123,7 +137,9 @@ export function validateGraph(manifest: WorkflowManifest): GraphValidation {
 export function assertValidGraph(manifest: WorkflowManifest): string[] {
   const { errors, warnings } = validateGraph(manifest);
   if (errors.length > 0) {
-    throw new Error(`Invalid workflow graph for '${manifest.name}':\n  - ${errors.join('\n  - ')}`);
+    throw new Error(
+      `Invalid workflow graph for '${manifest.name}':\n  - ${errors.join("\n  - ")}`,
+    );
   }
   return warnings;
 }
@@ -133,20 +149,29 @@ export function assertValidGraph(manifest: WorkflowManifest): string[] {
  * a continue-target-missing error per unknown target and a dead-end error for a
  * step that declares no transitions at all.
  */
-function buildForwardEdges(manifest: WorkflowManifest, names: Set<string>, errors: string[]): Map<string, Set<string>> {
+function buildForwardEdges(
+  manifest: WorkflowManifest,
+  names: Set<string>,
+  errors: string[],
+): Map<string, Set<string>> {
   const forward = new Map<string, Set<string>>();
   for (const [name, step] of Object.entries(manifest.steps)) {
     const targets = new Set<string>();
     for (const t of step.transitions) {
-      if (t.kind === 'continue') {
+      if (t.kind === "continue") {
         if (names.has(t.target)) targets.add(t.target);
-        else errors.push(`step '${name}' has a continue target '${t.target}' that is not in the steps map`);
-      } else if (t.kind === 'pause' && names.has(t.resumeStep)) {
+        else
+          errors.push(
+            `step '${name}' has a continue target '${t.target}' that is not in the steps map`,
+          );
+      } else if (t.kind === "pause" && names.has(t.resumeStep)) {
         targets.add(t.resumeStep);
       }
     }
     if (step.transitions.length === 0) {
-      errors.push(`step '${name}' is a dead-end: it declares no transitions (next/terminal/canFail/pause)`);
+      errors.push(
+        `step '${name}' is a dead-end: it declares no transitions (next/terminal/canFail/pause)`,
+      );
     }
     forward.set(name, targets);
   }
@@ -163,10 +188,14 @@ function terminalReachabilityWarnings(
   forward: Map<string, Set<string>>,
 ): string[] {
   const sinks = Object.entries(manifest.steps)
-    .filter(([, s]) => s.transitions.some((t) => t.kind === 'terminate' || t.kind === 'fail'))
+    .filter(([, s]) =>
+      s.transitions.some((t) => t.kind === "terminate" || t.kind === "fail"),
+    )
     .map(([name]) => name);
   if (sinks.length === 0) {
-    return ['no step can terminate or fail — the workflow has no terminal state'];
+    return [
+      "no step can terminate or fail — the workflow has no terminal state",
+    ];
   }
 
   const reverse = new Map<string, Set<string>>();
@@ -179,43 +208,85 @@ function terminalReachabilityWarnings(
   const warnings: string[] = [];
   for (const name of names) {
     if (!canReach.has(name)) {
-      warnings.push(`step '${name}' cannot reach any terminate/fail (possible unbounded loop or missing terminal)`);
+      warnings.push(
+        `step '${name}' cannot reach any terminate/fail (possible unbounded loop or missing terminal)`,
+      );
     }
   }
   return warnings;
 }
 
 /** Multi-source BFS over an adjacency map; returns the set of reachable nodes. */
-function bfs(starts: readonly string[], edges: Map<string, Set<string>>): Set<string> {
+function bfs(
+  starts: readonly string[],
+  edges: Map<string, Set<string>>,
+): Set<string> {
   const seen = new Set<string>();
   const queue = [...starts];
   while (queue.length > 0) {
     const cur = queue.shift()!;
     if (seen.has(cur)) continue;
     seen.add(cur);
-    for (const next of edges.get(cur) ?? []) if (!seen.has(next)) queue.push(next);
+    for (const next of edges.get(cur) ?? [])
+      if (!seen.has(next)) queue.push(next);
   }
   return seen;
 }
 
 /**
- * Remove from the JSON Schema's top-level `required` array any key that also
- * appears in `properties` with a `default` value. This prevents the engine's
- * AJV pre-check from falsely rejecting inputs where a caller omits a field
- * that Zod would supply via its default. Operates only on the top level;
- * nested objects are out of scope for v1.
+ * Recursively remove `additionalProperties: false` from a generated JSON Schema.
+ *
+ * `z.toJSONSchema()` (Zod v4) marks every converted object as closed
+ * (`additionalProperties: false`), top-level and nested. A plain `z.object()`
+ * ignores keys it doesn't name when it parses, rather than rejecting them, so a
+ * step input that carries extra fields should still be accepted. Removing the
+ * closed-object marker keeps the generated schema forward-compatible with inputs
+ * that gain fields over time.
+ *
+ * Only the closed form (`additionalProperties: false`) is removed; a typed
+ * catchall (`additionalProperties: { ... }`) is preserved. A property literally
+ * named `additionalProperties` is never the boolean `false`, so it is untouched.
  */
-function dropDefaultedFromRequired(schema: Record<string, unknown>): Record<string, unknown> {
+function relaxAdditionalProperties(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(relaxAdditionalProperties);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "additionalProperties" && v === false) {
+        continue;
+      }
+      out[key] = relaxAdditionalProperties(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Remove from the JSON Schema's top-level `required` array any key whose
+ * `properties` entry declares a `default`. A caller may omit such a field — Zod
+ * supplies the default on parse — so it should not be reported as missing.
+ * Operates only on the top level; nested objects are out of scope.
+ */
+function dropDefaultedFromRequired(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
   const required = schema.required;
   const properties = schema.properties;
-  if (!Array.isArray(required) || !properties || typeof properties !== 'object') {
+  if (
+    !Array.isArray(required) ||
+    !properties ||
+    typeof properties !== "object"
+  ) {
     return schema;
   }
   const props = properties as Record<string, unknown>;
   const filtered = required.filter((key) => {
-    if (typeof key !== 'string') return true;
+    if (typeof key !== "string") return true;
     const prop = props[key];
-    return !(prop && typeof prop === 'object' && 'default' in prop);
+    return !(prop && typeof prop === "object" && "default" in prop);
   });
   if (filtered.length === required.length) {
     return schema;

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -9,20 +9,27 @@
  *   5. buildManifest: step with timeoutMs → timeoutMs; without → null
  *   6. buildManifest: protocol is always 1, sdkVersion/artifact from opts
  */
-import { z } from 'zod/v4';
+import { z } from "zod/v4";
 
-import { buildManifest } from './build-manifest.js';
-import { goto, pauseUntilSignal, terminate } from './directives.js';
-import { MANIFEST_PROTOCOL, type WorkflowManifest, workflowManifestSchema } from './manifest.js';
-import { defineStep } from './step.js';
-import { defineOrchestration } from './workflow.js';
+import { buildManifest } from "./build-manifest.js";
+import { goto, pauseUntilSignal, terminate } from "./directives.js";
+import {
+  MANIFEST_PROTOCOL,
+  type WorkflowManifest,
+  workflowManifestSchema,
+} from "./manifest.js";
+import { defineStep } from "./step.js";
+import { defineOrchestration } from "./workflow.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** A terminal step (declares `terminal: true`) for the schema/inputSchema/timeout tests. */
-function makeStep(name: string, opts: { inputSchema?: z.ZodType; timeoutMs?: number } = {}) {
+function makeStep(
+  name: string,
+  opts: { inputSchema?: z.ZodType; timeoutMs?: number } = {},
+) {
   return defineStep({
     name,
     next: [],
@@ -35,102 +42,114 @@ function makeStep(name: string, opts: { inputSchema?: z.ZodType; timeoutMs?: num
   });
 }
 
-const DUMMY_ARTIFACT = { sha256: 'abc123', entryFile: 'dist/workflow.mjs' };
-const DUMMY_SDK_VERSION = '0.1.0';
+const DUMMY_ARTIFACT = { sha256: "abc123", entryFile: "dist/workflow.mjs" };
+const DUMMY_SDK_VERSION = "0.1.0";
 
 // ---------------------------------------------------------------------------
 // 1 + 2. workflowManifestSchema
 // ---------------------------------------------------------------------------
 
-describe('workflowManifestSchema', () => {
-  it('accepts a well-formed manifest', () => {
+describe("workflowManifestSchema", () => {
+  it("accepts a well-formed manifest", () => {
     const manifest: WorkflowManifest = {
       protocol: MANIFEST_PROTOCOL,
-      name: 'my-workflow',
-      entry: 'step-a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'deadbeef', entryFile: 'dist/my-workflow.mjs' },
+      name: "my-workflow",
+      entry: "step-a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "deadbeef", entryFile: "dist/my-workflow.mjs" },
       steps: {
-        'step-a': {
+        "step-a": {
           timeoutMs: 5000,
-          inputSchema: { type: 'object' },
-          transitions: [{ kind: 'continue', target: 'step-b' }],
+          inputSchema: { type: "object" },
+          transitions: [{ kind: "continue", target: "step-b" }],
         },
-        'step-b': { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+        "step-b": {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: "terminate" }],
+        },
       },
     };
     expect(() => workflowManifestSchema.parse(manifest)).not.toThrow();
     const parsed = workflowManifestSchema.parse(manifest);
     expect(parsed.protocol).toBe(1);
-    expect(parsed.steps['step-a'].timeoutMs).toBe(5000);
-    expect(parsed.steps['step-b'].inputSchema).toBeNull();
-    expect(parsed.steps['step-a'].transitions).toEqual([{ kind: 'continue', target: 'step-b' }]);
+    expect(parsed.steps["step-a"].timeoutMs).toBe(5000);
+    expect(parsed.steps["step-b"].inputSchema).toBeNull();
+    expect(parsed.steps["step-a"].transitions).toEqual([
+      { kind: "continue", target: "step-b" },
+    ]);
   });
 
-  it('rejects a manifest with wrong protocol', () => {
+  it("rejects a manifest with wrong protocol", () => {
     const bad = {
       protocol: 2,
-      name: 'wf',
-      entry: 'a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
       steps: {},
     };
     expect(() => workflowManifestSchema.parse(bad)).toThrow();
   });
 
-  it('rejects a manifest missing required fields', () => {
+  it("rejects a manifest missing required fields", () => {
     const missing = {
       protocol: 1,
-      name: 'wf',
+      name: "wf",
       // missing entry, sdkVersion, artifact, steps
     };
     expect(() => workflowManifestSchema.parse(missing)).toThrow();
   });
 
-  it('rejects a manifest with empty name', () => {
+  it("rejects a manifest with empty name", () => {
     const empty = {
       protocol: 1,
-      name: '',
-      entry: 'a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      name: "",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
       steps: {},
     };
     expect(() => workflowManifestSchema.parse(empty)).toThrow();
   });
 
-  it('rejects a non-positive timeoutMs', () => {
+  it("rejects a non-positive timeoutMs", () => {
     const bad = {
       protocol: 1,
-      name: 'wf',
-      entry: 'a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
       steps: { a: { timeoutMs: -100, inputSchema: null, transitions: [] } },
     };
     expect(() => workflowManifestSchema.parse(bad)).toThrow();
   });
 
-  it('rejects a step with an unknown transition kind', () => {
+  it("rejects a step with an unknown transition kind", () => {
     const bad = {
       protocol: 1,
-      name: 'wf',
-      entry: 'a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'x', entryFile: 'f.mjs' },
-      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'teleport' }] } },
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: "teleport" }],
+        },
+      },
     };
     expect(() => workflowManifestSchema.parse(bad)).toThrow();
   });
 
-  it('accepts null timeoutMs (engine default)', () => {
+  it("accepts null timeoutMs (engine default)", () => {
     const good = {
       protocol: 1,
-      name: 'wf',
-      entry: 'a',
-      sdkVersion: '0.1.0',
-      artifact: { sha256: 'x', entryFile: 'f.mjs' },
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
       steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
     };
     expect(() => workflowManifestSchema.parse(good)).not.toThrow();
@@ -141,92 +160,117 @@ describe('workflowManifestSchema', () => {
 // 3 + 4 + 5 + 6. buildManifest
 // ---------------------------------------------------------------------------
 
-describe('buildManifest', () => {
-  it('emits protocol=1 and passes through sdkVersion and artifact', () => {
+describe("buildManifest", () => {
+  it("emits protocol=1 and passes through sdkVersion and artifact", () => {
     const def = defineOrchestration({
-      name: 'simple',
-      entry: 'start',
-      steps: { start: makeStep('start') },
+      name: "simple",
+      entry: "start",
+      steps: { start: makeStep("start") },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     expect(manifest.protocol).toBe(1);
     expect(manifest.sdkVersion).toBe(DUMMY_SDK_VERSION);
     expect(manifest.artifact).toEqual(DUMMY_ARTIFACT);
   });
 
-  it('carries name and entry from the definition', () => {
+  it("carries name and entry from the definition", () => {
     const def = defineOrchestration({
-      name: 'my-wf',
-      entry: 'alpha',
-      steps: { alpha: makeStep('alpha') },
+      name: "my-wf",
+      entry: "alpha",
+      steps: { alpha: makeStep("alpha") },
     });
-    const manifest = buildManifest(def, { sdkVersion: '1.0.0', artifact: DUMMY_ARTIFACT });
-    expect(manifest.name).toBe('my-wf');
-    expect(manifest.entry).toBe('alpha');
+    const manifest = buildManifest(def, {
+      sdkVersion: "1.0.0",
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.name).toBe("my-wf");
+    expect(manifest.entry).toBe("alpha");
   });
 
-  it('step without inputSchema → inputSchema: null in manifest', () => {
+  it("step without inputSchema → inputSchema: null in manifest", () => {
     const def = defineOrchestration({
-      name: 'wf',
-      entry: 'plain',
-      steps: { plain: makeStep('plain') },
+      name: "wf",
+      entry: "plain",
+      steps: { plain: makeStep("plain") },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     expect(manifest.steps.plain.inputSchema).toBeNull();
   });
 
-  it('step without timeoutMs → timeoutMs: null in manifest', () => {
+  it("step without timeoutMs → timeoutMs: null in manifest", () => {
     const def = defineOrchestration({
-      name: 'wf',
-      entry: 'plain',
-      steps: { plain: makeStep('plain') },
+      name: "wf",
+      entry: "plain",
+      steps: { plain: makeStep("plain") },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     expect(manifest.steps.plain.timeoutMs).toBeNull();
   });
 
-  it('step with inputSchema → schema converted to JSON Schema', () => {
+  it("step with inputSchema → schema converted to JSON Schema", () => {
     const schema = z.object({ userId: z.string(), count: z.number() });
     const def = defineOrchestration({
-      name: 'wf',
-      entry: 'validated',
-      steps: { validated: makeStep('validated', { inputSchema: schema }) },
+      name: "wf",
+      entry: "validated",
+      steps: { validated: makeStep("validated", { inputSchema: schema }) },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     const stepSchema = manifest.steps.validated.inputSchema;
     expect(stepSchema).not.toBeNull();
-    expect(stepSchema?.type).toBe('object');
-    expect((stepSchema?.properties as Record<string, unknown>)?.userId).toBeDefined();
-    expect((stepSchema?.properties as Record<string, unknown>)?.count).toBeDefined();
+    expect(stepSchema?.type).toBe("object");
+    expect(
+      (stepSchema?.properties as Record<string, unknown>)?.userId,
+    ).toBeDefined();
+    expect(
+      (stepSchema?.properties as Record<string, unknown>)?.count,
+    ).toBeDefined();
   });
 
-  it('step with timeoutMs → timeoutMs carried through', () => {
+  it("step with timeoutMs → timeoutMs carried through", () => {
     const def = defineOrchestration({
-      name: 'wf',
-      entry: 'slow',
-      steps: { slow: makeStep('slow', { timeoutMs: 30_000 }) },
+      name: "wf",
+      entry: "slow",
+      steps: { slow: makeStep("slow", { timeoutMs: 30_000 }) },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     expect(manifest.steps.slow.timeoutMs).toBe(30_000);
   });
 
-  it('multi-step definition: each step independently mapped', () => {
+  it("multi-step definition: each step independently mapped", () => {
     const inputSchema = z.object({ topic: z.string() });
     const def = defineOrchestration({
-      name: 'multi',
-      entry: 'gather',
+      name: "multi",
+      entry: "gather",
       steps: {
-        gather: makeStep('gather', { inputSchema, timeoutMs: 10_000 }),
-        summarize: makeStep('summarize', { timeoutMs: 20_000 }),
-        finalize: makeStep('finalize'),
+        gather: makeStep("gather", { inputSchema, timeoutMs: 10_000 }),
+        summarize: makeStep("summarize", { timeoutMs: 20_000 }),
+        finalize: makeStep("finalize"),
       },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
 
     // gather: has both schema and timeout
     expect(manifest.steps.gather.timeoutMs).toBe(10_000);
     expect(manifest.steps.gather.inputSchema).not.toBeNull();
-    expect(manifest.steps.gather.inputSchema?.type).toBe('object');
+    expect(manifest.steps.gather.inputSchema?.type).toBe("object");
 
     // summarize: timeout but no schema
     expect(manifest.steps.summarize.timeoutMs).toBe(20_000);
@@ -237,7 +281,7 @@ describe('buildManifest', () => {
     expect(manifest.steps.finalize.inputSchema).toBeNull();
   });
 
-  it('defaulted field is NOT in required in the manifest JSON Schema (AJV pre-check must not be stricter than Zod)', () => {
+  it("defaulted field is NOT in required in the manifest JSON Schema (AJV pre-check must not be stricter than Zod)", () => {
     // `count` has a Zod default → zod.toJSONSchema marks it required; buildManifest
     // must strip it so a caller that omits `count` passes AJV pre-check.
     // Only top-level `required` entries are treated (nested objects out of scope for v1).
@@ -246,34 +290,72 @@ describe('buildManifest', () => {
       count: z.number().default(0),
     });
     const def = defineOrchestration({
-      name: 'wf',
-      entry: 'step',
-      steps: { step: makeStep('step', { inputSchema: schema }) },
+      name: "wf",
+      entry: "step",
+      steps: { step: makeStep("step", { inputSchema: schema }) },
     });
-    const manifest = buildManifest(def, { sdkVersion: DUMMY_SDK_VERSION, artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
     const stepSchema = manifest.steps.step.inputSchema!;
     const required = stepSchema.required as string[] | undefined;
     // `name` (no default) must still be required; `count` (has default) must not be.
     expect(required).toBeDefined();
-    expect(required).toContain('name');
-    expect(required).not.toContain('count');
+    expect(required).toContain("name");
+    expect(required).not.toContain("count");
   });
 
-  it('manifest validates against workflowManifestSchema', () => {
+  it("strips additionalProperties:false from the schema (top-level AND nested) so inputs with extra fields are accepted", () => {
+    // z.toJSONSchema marks every object as closed (additionalProperties:false).
+    // A plain z.object() parse ignores extra keys rather than rejecting them, so
+    // buildManifest relaxes the generated schema to match — keeping it
+    // forward-compatible with inputs that gain fields over time.
+    const schema = z.object({
+      runId: z.string(),
+      result: z.object({ success: z.boolean() }).nullable(),
+    });
+    const def = defineOrchestration({
+      name: "wf",
+      entry: "review",
+      steps: { review: makeStep("review", { inputSchema: schema }) },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    const stepSchema = manifest.steps.review.inputSchema!;
+
+    // No `additionalProperties: false` anywhere in the emitted schema.
+    const hasStrict = JSON.stringify(stepSchema).includes(
+      '"additionalProperties":false',
+    );
+    expect(hasStrict).toBe(false);
+    // Sanity: the schema is otherwise intact (named properties + required preserved).
+    expect(
+      (stepSchema.properties as Record<string, unknown>).runId,
+    ).toBeDefined();
+    expect(stepSchema.required).toContain("runId");
+  });
+
+  it("manifest validates against workflowManifestSchema", () => {
     const inputSchema = z.object({ input: z.string() });
     const def = defineOrchestration({
-      name: 'validated-wf',
-      entry: 'entry',
+      name: "validated-wf",
+      entry: "entry",
       steps: {
-        entry: makeStep('entry', { inputSchema }),
-        exit: makeStep('exit', { timeoutMs: 5000 }),
+        entry: makeStep("entry", { inputSchema }),
+        exit: makeStep("exit", { timeoutMs: 5000 }),
       },
     });
-    const manifest = buildManifest(def, { sdkVersion: '0.1.0', artifact: DUMMY_ARTIFACT });
+    const manifest = buildManifest(def, {
+      sdkVersion: "0.1.0",
+      artifact: DUMMY_ARTIFACT,
+    });
 
     // Parse with the zod schema — must not throw
     const parsed = workflowManifestSchema.parse(manifest);
-    expect(parsed.name).toBe('validated-wf');
+    expect(parsed.name).toBe("validated-wf");
     expect(parsed.steps.entry.inputSchema).not.toBeNull();
     expect(parsed.steps.exit.timeoutMs).toBe(5000);
   });
@@ -283,37 +365,40 @@ describe('buildManifest', () => {
 // buildManifest — transitions emission (the build-derivable graph edges)
 // ---------------------------------------------------------------------------
 
-describe('buildManifest transitions', () => {
+describe("buildManifest transitions", () => {
   // A four-step graph exercising every transition kind:
   //   prep -> enrich -> approval (pause→finalize) -> finalize (terminate|fail)
   const def = defineOrchestration({
-    name: 'graph',
-    entry: 'prep',
+    name: "graph",
+    entry: "prep",
     steps: {
       prep: defineStep({
-        name: 'prep',
-        next: ['enrich'],
+        name: "prep",
+        next: ["enrich"],
         async run() {
-          return goto('enrich');
+          return goto("enrich");
         },
       }),
       enrich: defineStep({
-        name: 'enrich',
-        next: ['approval', 'finalize'],
+        name: "enrich",
+        next: ["approval", "finalize"],
         async run() {
-          return goto('approval');
+          return goto("approval");
         },
       }),
       approval: defineStep({
-        name: 'approval',
-        next: ['finalize'],
-        pause: { signal: 'demo.approval', resumeStep: 'finalize' },
+        name: "approval",
+        next: ["finalize"],
+        pause: { signal: "demo.approval", resumeStep: "finalize" },
         async run() {
-          return pauseUntilSignal({ signal: 'demo.approval', resumeStep: 'finalize' });
+          return pauseUntilSignal({
+            signal: "demo.approval",
+            resumeStep: "finalize",
+          });
         },
       }),
       finalize: defineStep({
-        name: 'finalize',
+        name: "finalize",
         next: [],
         terminal: true,
         canFail: true,
@@ -323,35 +408,45 @@ describe('buildManifest transitions', () => {
       }),
     },
   });
-  const manifest = buildManifest(def, { sdkVersion: '0.1.0', artifact: DUMMY_ARTIFACT });
+  const manifest = buildManifest(def, {
+    sdkVersion: "0.1.0",
+    artifact: DUMMY_ARTIFACT,
+  });
 
-  it('emits one continue transition per next entry', () => {
-    expect(manifest.steps.prep.transitions).toEqual([{ kind: 'continue', target: 'enrich' }]);
+  it("emits one continue transition per next entry", () => {
+    expect(manifest.steps.prep.transitions).toEqual([
+      { kind: "continue", target: "enrich" },
+    ]);
     expect(manifest.steps.enrich.transitions).toEqual([
-      { kind: 'continue', target: 'approval' },
-      { kind: 'continue', target: 'finalize' },
+      { kind: "continue", target: "approval" },
+      { kind: "continue", target: "finalize" },
     ]);
   });
 
-  it('emits a pause transition with signal + resumeStep', () => {
+  it("emits a pause transition with signal + resumeStep", () => {
     expect(manifest.steps.approval.transitions).toContainEqual({
-      kind: 'pause',
-      signal: 'demo.approval',
-      resumeStep: 'finalize',
+      kind: "pause",
+      signal: "demo.approval",
+      resumeStep: "finalize",
     });
   });
 
-  it('emits terminate and fail transitions for a terminal+canFail step', () => {
-    expect(manifest.steps.finalize.transitions).toEqual([{ kind: 'terminate' }, { kind: 'fail' }]);
+  it("emits terminate and fail transitions for a terminal+canFail step", () => {
+    expect(manifest.steps.finalize.transitions).toEqual([
+      { kind: "terminate" },
+      { kind: "fail" },
+    ]);
   });
 
-  it('does NOT emit a retry transition (retry is a universal badge, not an edge)', () => {
+  it("does NOT emit a retry transition (retry is a universal badge, not an edge)", () => {
     for (const step of Object.values(manifest.steps)) {
-      expect(step.transitions.some((t) => (t as { kind: string }).kind === 'retry')).toBe(false);
+      expect(
+        step.transitions.some((t) => (t as { kind: string }).kind === "retry"),
+      ).toBe(false);
     }
   });
 
-  it('produces a manifest that validates against the schema', () => {
+  it("produces a manifest that validates against the schema", () => {
     expect(() => workflowManifestSchema.parse(manifest)).not.toThrow();
   });
 });


### PR DESCRIPTION
This pull request updates the orchestration package to ensure that step input JSON Schemas are more permissive and accurately reflect the behavior of Zod schemas. Now, generated schemas will no longer reject extra fields not declared in the schema, aligning JSON Schema validation with Zod's parsing logic. The changes also include some code cleanup, improved error/warning formatting, and test updates.

Key changes include:

### Schema Generation and Validation

* The `buildManifest` function now uses a new `relaxAdditionalProperties` helper to remove `additionalProperties: false` from generated JSON Schemas, ensuring that extra fields in step inputs are not rejected unless explicitly disallowed. This makes the JSON Schema behavior match Zod's, where undeclared keys are ignored rather than rejected. Typed catchalls (`z.object().catchall(...)`) are still respected. [[1]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL33-R47) [[2]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL182-R289)
* The top-level `required` fields in JSON Schemas are filtered to exclude fields that have a default value, so the engine's pre-check does not falsely reject valid inputs that Zod would accept by supplying defaults.

### Documentation

* A new changeset explains the schema relaxation and its impact, clarifying that developers no longer need to add dummy fields to schemas to accept extra input fields.

### Code Quality and Consistency

* Improved formatting and consistency in error and warning messages, and code style updates (e.g., consistent quote usage, multi-line formatting for clarity). [[1]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL66-R89) [[2]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL114-R128) [[3]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL126-R142) [[4]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL136-R174) [[5]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL166-R198)

### Test Updates

* Refactored test files for consistency in style and updated test cases to match the new schema behavior and formatting. [[1]](diffhunk://#diff-4e0d53f2775864fa9e110ac03ecdb7e8314f9614670d12a896b63ad5bfb65accL12-R32) [[2]](diffhunk://#diff-4e0d53f2775864fa9e110ac03ecdb7e8314f9614670d12a896b63ad5bfb65accL38-R152)

---

**References:**  
Schema Generation and Validation: [[1]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL33-R47) [[2]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL182-R289)  
Documentation:  
Code Quality and Consistency: [[1]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL66-R89) [[2]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL114-R128) [[3]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL126-R142) [[4]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL136-R174) [[5]](diffhunk://#diff-eed18427b232b13cb47ab646f48ba01234c44980c81fe34c9048c6c7b7d7f2aeL166-R198)  
Test Updates: [[1]](diffhunk://#diff-4e0d53f2775864fa9e110ac03ecdb7e8314f9614670d12a896b63ad5bfb65accL12-R32) [[2]](diffhunk://#diff-4e0d53f2775864fa9e110ac03ecdb7e8314f9614670d12a896b63ad5bfb65accL38-R152)