### PR TITLE
feat(cli): host-switch + auth hardening, retarget to backend tenant API

### DIFF
--- a/packages/cli/src/__tests__/cli-config.test.ts
+++ b/packages/cli/src/__tests__/cli-config.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for host-switch resolution and CLI-level configuration.
+ *
+ * The key invariants:
+ *   - SAPIOM_HOST env always wins
+ *   - --host flag beats --target flag
+ *   - --target local maps to localhost:3000, prod to api.sapiom.ai
+ *   - Persisted config (target / host) is the fallback before project host
+ *   - Project host from sapiom.json is the last fallback before default
+ *   - Default is the production backend
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// We test resolveHost by mocking XDG_CONFIG_HOME to point at a temp dir so
+// the test never touches the real ~/.sapiom/config.json.
+import { resolveHost } from '../lib/cli-config.js';
+
+const PROD = 'https://api.sapiom.ai';
+const LOCAL = 'http://localhost:3000';
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `sapiom-cli-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeConfigJson(xdgDir: string, content: object): void {
+  const sapiomDir = path.join(xdgDir, 'sapiom');
+  if (!existsSync(sapiomDir)) mkdirSync(sapiomDir, { recursive: true });
+  writeFileSync(path.join(sapiomDir, 'config.json'), JSON.stringify(content, null, 2) + '\n');
+}
+
+describe('resolveHost', () => {
+  let originalXdg: string | undefined;
+  let originalSapiomHost: string | undefined;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    originalSapiomHost = process.env.SAPIOM_HOST;
+    // Isolate each test from real user config
+    delete process.env.SAPIOM_HOST;
+  });
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+    if (originalSapiomHost === undefined) {
+      delete process.env.SAPIOM_HOST;
+    } else {
+      process.env.SAPIOM_HOST = originalSapiomHost;
+    }
+  });
+
+  it('returns prod host by default', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({})).toBe(PROD);
+  });
+
+  it('SAPIOM_HOST env wins over everything', () => {
+    process.env.SAPIOM_HOST = 'https://my-custom.example.com';
+    expect(resolveHost({ flagTarget: 'local', flagHost: 'http://other.example.com' })).toBe(
+      'https://my-custom.example.com',
+    );
+  });
+
+  it('--host flag wins over --target', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagHost: 'http://my-override.test', flagTarget: 'local' })).toBe(
+      'http://my-override.test',
+    );
+  });
+
+  it('--target local maps to localhost:3000', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagTarget: 'local' })).toBe(LOCAL);
+  });
+
+  it('--target prod maps to production host', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagTarget: 'prod' })).toBe(PROD);
+  });
+
+  it('persisted target=local in config.json is picked up when no flag is set', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { target: 'local' });
+    expect(resolveHost({})).toBe(LOCAL);
+  });
+
+  it('persisted host in config.json is picked up when no flag is set', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { host: 'https://staging.example.com' });
+    expect(resolveHost({})).toBe('https://staging.example.com');
+  });
+
+  it('persisted host takes precedence over persisted target', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { host: 'https://staging.example.com', target: 'local' });
+    expect(resolveHost({})).toBe('https://staging.example.com');
+  });
+
+  it('project host from sapiom.json is last fallback before default', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    // No config.json written — project host should apply
+    expect(resolveHost({ projectHost: 'https://project-host.example.com' })).toBe(
+      'https://project-host.example.com',
+    );
+  });
+
+  it('flag target beats persisted config', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { target: 'prod' });
+    expect(resolveHost({ flagTarget: 'local' })).toBe(LOCAL);
+  });
+
+  it('strips trailing slash from host values', () => {
+    process.env.SAPIOM_HOST = 'https://example.com/';
+    expect(resolveHost({})).toBe('https://example.com');
+  });
+});

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+
+import { action, json } from '../shared.js';
+import { runSetTarget } from './set-target.js';
+
+/**
+ * Mount the `sapiom config …` command group for machine-level CLI configuration.
+ * Project identity (`sapiom.json`) is handled separately by `orchestrations link`.
+ */
+export function registerConfigCommands(program: Command): void {
+  const group = program
+    .command('config')
+    .description('Manage machine-level CLI configuration.');
+
+  json(
+    group
+      .command('set-target <target>')
+      .description("Persist the default API target: 'prod' (default) or 'local'."),
+  ).action(action(runSetTarget));
+}

--- a/packages/cli/src/commands/config/set-target.ts
+++ b/packages/cli/src/commands/config/set-target.ts
@@ -1,0 +1,23 @@
+/**
+ * `sapiom config set-target <prod|local>` — persist the default API target to
+ * `~/.sapiom/config.json`. Individual commands can still override per-invocation
+ * with `--target` or `--host`.
+ */
+import { type CliTarget, writeCliConfig } from '../../lib/cli-config.js';
+import { CliError, ok } from '../../lib/output.js';
+
+const VALID_TARGETS = new Set<string>(['prod', 'local']);
+
+export async function runSetTarget(target: string): Promise<void> {
+  if (!VALID_TARGETS.has(target)) {
+    throw new CliError({
+      code: 'BAD_TARGET',
+      message: `Unknown target: '${target}'. Expected 'prod' or 'local'.`,
+    });
+  }
+
+  writeCliConfig({ target: target as CliTarget, host: undefined });
+
+  const description = target === 'local' ? 'http://localhost:3000' : 'https://api.sapiom.ai';
+  ok({ target }, [`✓ Default target set to '${target}' (${description}).`]);
+}

--- a/packages/cli/src/commands/orchestrations/deploy.ts
+++ b/packages/cli/src/commands/orchestrations/deploy.ts
@@ -1,18 +1,22 @@
 import { deploy, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations deploy` — mint push credentials, push the current
  * commit, trigger a build, and wait for it to finish.
+ *
+ * Note: the backend tenant deploy routes (POST definitions, push-credentials,
+ * builds) are being added in a parallel effort and are not yet merged. Until
+ * those land, deploy end-to-end will return 404 from the backend.
  */
-export async function runDeploy(opts: { branch?: string }): Promise<void> {
+export async function runDeploy(opts: { branch?: string; host?: string; target?: CliTarget }): Promise<void> {
   try {
     const dir = process.cwd();
     const cfg = requireConfig(dir);
-    const client = makeClient(cfg.host);
+    const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
 
     const result = await deploy({ projectDir: dir, definitionId: cfg.definitionId, branch: opts.branch }, client);
 

--- a/packages/cli/src/commands/orchestrations/index.ts
+++ b/packages/cli/src/commands/orchestrations/index.ts
@@ -9,6 +9,16 @@ import { runLogs } from './logs.js';
 import { runRun } from './run.js';
 import { runSignal } from './signal.js';
 
+/**
+ * Attach the shared --host / --target flags to a command. These override the
+ * machine-level config and sapiom.json host for a single invocation.
+ */
+function withHostFlags(cmd: Command): Command {
+  return cmd
+    .option('--host <url>', 'API host URL (overrides config and SAPIOM_HOST)')
+    .option('--target <target>', 'target environment: prod (default) or local');
+}
+
 /** Mount the `sapiom orchestrations …` command group. */
 export function registerOrchestrationsCommands(program: Command): void {
   const group = program
@@ -24,24 +34,26 @@ export function registerOrchestrationsCommands(program: Command): void {
     action(runCheck),
   );
 
-  json(group.command('link [name]').description('Link this project to its server-side orchestration.'))
+  withHostFlags(json(group.command('link [name]').description('Link this project to its server-side orchestration.')))
     .option('--create', 'create the orchestration if it does not exist')
     .action(action(runLink));
 
-  json(group.command('deploy').description('Push the current commit, build, and wait for it to finish.'))
-    .option('-b, --branch <branch>', 'branch to push to', 'main')
-    .action(action(runDeploy));
+  withHostFlags(
+    json(group.command('deploy').description('Push the current commit, build, and wait for it to finish.')),
+  ).option('-b, --branch <branch>', 'branch to push to', 'main').action(action(runDeploy));
 
-  json(group.command('run').description('Start an execution of the linked orchestration.'))
+  withHostFlags(json(group.command('run').description('Start an execution of the linked orchestration.')))
     .option('--input <json>', 'execution input as a JSON string')
     .option('--input-file <path>', 'read execution input from a JSON file')
     .action(action(runRun));
 
-  json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.'))
+  withHostFlags(
+    json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.')),
+  )
     .option('--build <buildRunId>', 'inspect a build instead of an execution')
     .action(action(runLogs));
 
-  json(group.command('signal <executionId>').description('Resume a paused execution.'))
+  withHostFlags(json(group.command('signal <executionId>').description('Resume a paused execution.')))
     .requiredOption('--name <name>', 'the signal name to deliver')
     .requiredOption('--correlation-id <id>', 'the signal correlation id')
     .option('--payload <json>', 'signal payload as a JSON string')

--- a/packages/cli/src/commands/orchestrations/link.ts
+++ b/packages/cli/src/commands/orchestrations/link.ts
@@ -2,21 +2,28 @@ import path from 'node:path';
 
 import { link, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { writeConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations link [name]` — resolve a server-side orchestration by
  * name (or create it with --create) and cache its id in sapiom.json.
+ *
+ * Note: the `--create` path (POST /definitions) depends on backend tenant
+ * deploy routes that are being added in a parallel effort and are not yet
+ * merged. Linking to an existing definition works today.
  */
-export async function runLink(name: string | undefined, opts: { create?: boolean }): Promise<void> {
+export async function runLink(
+  name: string | undefined,
+  opts: { create?: boolean; host?: string; target?: CliTarget },
+): Promise<void> {
   try {
     const dir = process.cwd();
-    const target = name ?? path.basename(dir);
-    const client = makeClient();
+    const linkTarget = name ?? path.basename(dir);
+    const client = makeClient({ flagHost: opts.host, flagTarget: opts.target });
 
-    const result = await link({ name: target, create: opts.create }, client);
+    const result = await link({ name: linkTarget, create: opts.create }, client);
 
     writeConfig(dir, { definitionId: result.definitionId, name: result.name });
     ok({ definitionId: result.definitionId, name: result.name }, [`✓ Linked to ${result.name} (${result.definitionId})`]);

--- a/packages/cli/src/commands/orchestrations/logs.ts
+++ b/packages/cli/src/commands/orchestrations/logs.ts
@@ -1,6 +1,6 @@
 import { inspect, inspectBuild, listExecutions, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { readConfig, requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
 
@@ -10,14 +10,14 @@ import { CliError, isJsonMode, ok } from '../../lib/output.js';
  */
 export async function runLogs(
   executionId: string | undefined,
-  opts: { build?: string },
+  opts: { build?: string; host?: string; target?: CliTarget },
 ): Promise<void> {
   try {
     const dir = process.cwd();
 
     if (opts.build) {
       const cfg = requireConfig(dir);
-      const client = makeClient(cfg.host);
+      const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
       const { build } = await inspectBuild({ definitionId: cfg.definitionId, buildRunId: opts.build }, client);
       if (isJsonMode()) ok({ build });
       else ok({}, [`build ${opts.build}: ${build.status ?? 'unknown'}`]);
@@ -25,7 +25,7 @@ export async function runLogs(
     }
 
     const cfg = readConfig(dir);
-    const client = makeClient(cfg?.host);
+    const client = makeClient({ projectHost: cfg?.host, flagHost: opts.host, flagTarget: opts.target });
 
     if (!executionId) {
       const { executions } = await listExecutions(client);

--- a/packages/cli/src/commands/orchestrations/run.ts
+++ b/packages/cli/src/commands/orchestrations/run.ts
@@ -2,18 +2,23 @@ import { readFileSync } from 'node:fs';
 
 import { OrchestrationError, parseJsonInput, run } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { requireConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations run` — start an execution of the linked orchestration.
  */
-export async function runRun(opts: { input?: string; inputFile?: string }): Promise<void> {
+export async function runRun(opts: {
+  input?: string;
+  inputFile?: string;
+  host?: string;
+  target?: CliTarget;
+}): Promise<void> {
   try {
     const dir = process.cwd();
     const cfg = requireConfig(dir);
-    const client = makeClient(cfg.host);
+    const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
     const input = resolveInput(opts);
 
     const result = await run({ definitionId: cfg.definitionId, input }, client);

--- a/packages/cli/src/commands/orchestrations/signal.ts
+++ b/packages/cli/src/commands/orchestrations/signal.ts
@@ -1,6 +1,6 @@
 import { OrchestrationError, parseSignalPayload, signal } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { readConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
@@ -10,11 +10,11 @@ import { CliError, ok } from '../../lib/output.js';
  */
 export async function runSignal(
   executionId: string,
-  opts: { name: string; correlationId: string; payload?: string },
+  opts: { name: string; correlationId: string; payload?: string; host?: string; target?: CliTarget },
 ): Promise<void> {
   try {
     const cfg = readConfig(process.cwd());
-    const client = makeClient(cfg?.host);
+    const client = makeClient({ projectHost: cfg?.host, flagHost: opts.host, flagTarget: opts.target });
     const payload = opts.payload ? parseSignalPayload(opts.payload) : undefined;
 
     const result = await signal({ executionId, name: opts.name, correlationId: opts.correlationId, payload }, client);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 
 import { registerAuthCommands } from './commands/auth/index.js';
+import { registerConfigCommands } from './commands/config/index.js';
 import { registerOrchestrationsCommands } from './commands/orchestrations/index.js';
 
 /**
@@ -13,6 +14,7 @@ export function buildProgram(): Command {
   const program = new Command('sapiom').description('The Sapiom command-line interface.');
 
   registerAuthCommands(program);
+  registerConfigCommands(program);
   registerOrchestrationsCommands(program);
 
   return program;

--- a/packages/cli/src/lib/cli-config.ts
+++ b/packages/cli/src/lib/cli-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Machine-level CLI configuration persisted at `~/.sapiom/config.json`. Stores
+ * the active target (prod vs local) and any user-set host override. Project
+ * identity (`sapiom.json` / `definitionId`) is kept separate from this — the
+ * server stays the source of truth for what orchestrations exist.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+
+import { configDir, configFilePath } from './paths.js';
+
+export type CliTarget = 'prod' | 'local';
+
+export interface CliConfig {
+  /**
+   * Named target: `prod` routes to the production backend, `local` to the
+   * backend running on localhost:3000. A raw `host` override supersedes this.
+   */
+  target?: CliTarget;
+  /**
+   * Explicit host URL override. When present, takes precedence over `target`.
+   * Stored so `sapiom orchestrations run` remembers the host without requiring
+   * `--host` on every invocation.
+   */
+  host?: string;
+}
+
+const PROD_HOST = 'https://api.sapiom.ai';
+const LOCAL_HOST = 'http://localhost:3000';
+
+function load(): CliConfig {
+  const file = configFilePath();
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as CliConfig;
+  } catch {
+    return {};
+  }
+}
+
+function persist(cfg: CliConfig): void {
+  const dir = configDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(configFilePath(), JSON.stringify(cfg, null, 2) + '\n');
+}
+
+export function readCliConfig(): CliConfig {
+  return load();
+}
+
+export function writeCliConfig(patch: Partial<CliConfig>): void {
+  const current = load();
+  persist({ ...current, ...patch });
+}
+
+/**
+ * Resolve the effective API host from (in precedence order):
+ * 1. An explicit `SAPIOM_HOST` environment variable
+ * 2. An explicit `--host <url>` flag (passed as `flagHost`)
+ * 3. The `--target local|prod` flag (passed as `flagTarget`)
+ * 4. The `host` or `target` stored in `~/.sapiom/config.json`
+ * 5. The project-level `host` from `sapiom.json` (passed as `projectHost`)
+ * 6. Default: production backend
+ */
+export function resolveHost(opts: {
+  flagHost?: string;
+  flagTarget?: CliTarget;
+  projectHost?: string;
+}): string {
+  // Env var always wins
+  if (process.env.SAPIOM_HOST) return process.env.SAPIOM_HOST.replace(/\/$/, '');
+  // Explicit --host flag
+  if (opts.flagHost) return opts.flagHost.replace(/\/$/, '');
+  // --target flag
+  if (opts.flagTarget) return opts.flagTarget === 'local' ? LOCAL_HOST : PROD_HOST;
+
+  // Persisted CLI config
+  const cfg = load();
+  if (cfg.host) return cfg.host.replace(/\/$/, '');
+  if (cfg.target) return cfg.target === 'local' ? LOCAL_HOST : PROD_HOST;
+
+  // Project-level sapiom.json host
+  if (opts.projectHost) return opts.projectHost.replace(/\/$/, '');
+
+  return PROD_HOST;
+}

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,19 +1,19 @@
 /**
- * CLI-level client factory. Resolves host and API key from the environment and
- * stored session, then delegates to @sapiom/orchestration-core's GatewayClient.
+ * CLI-level client factory. Resolves host and API key from the environment,
+ * stored CLI config, and the optional project-level host — then delegates to
+ * @sapiom/orchestration-core's GatewayClient.
  *
  * Auth resolution stays here (in the CLI) because it reads process.env and the
  * local session store — both are CLI concerns. The core client itself is stateless.
  */
-import { createClient, DEFAULT_WORKFLOWS_HOST, GatewayClient } from '@sapiom/orchestration-core';
+import { createClient, GatewayClient } from '@sapiom/orchestration-core';
 
+import { type CliTarget, resolveHost } from './cli-config.js';
 import { CliError } from './output.js';
 import { readCredential } from './session.js';
 
-/** Host precedence: explicit env override → linked project's host → default. */
-export function resolveHost(configHost?: string): string {
-  return process.env.SAPIOM_WORKFLOWS_HOST ?? configHost ?? DEFAULT_WORKFLOWS_HOST;
-}
+export { resolveHost };
+export type { CliTarget };
 
 /**
  * Credential precedence: the environment always wins (CI / ephemeral /
@@ -25,6 +25,8 @@ function resolveApiKey(): string {
   if (env) return env;
 
   const stored = readCredential();
+  // accessToken from the device flow or a raw API key both work — the backend
+  // accepts either via `x-api-key` or `Authorization: Bearer` for `sk_` tokens.
   const token = stored?.accessToken ?? stored?.apiKey;
   if (token) return token;
 
@@ -36,9 +38,22 @@ function resolveApiKey(): string {
 }
 
 /**
- * Build a GatewayClient for a CLI command. Reads host and API key from the
- * environment / session; callers pass the optional project host override.
+ * Build a GatewayClient for a CLI command. Resolves host from env / CLI config /
+ * project override; resolves credentials from env or stored session.
+ *
+ * @param projectHost  Optional host stored in the project's `sapiom.json`.
+ * @param flagHost     Optional `--host <url>` flag value.
+ * @param flagTarget   Optional `--target local|prod` flag value.
  */
-export function makeClient(configHost?: string): GatewayClient {
-  return createClient({ host: resolveHost(configHost), apiKey: resolveApiKey() });
+export function makeClient(opts?: {
+  projectHost?: string;
+  flagHost?: string;
+  flagTarget?: CliTarget;
+}): GatewayClient {
+  const host = resolveHost({
+    flagHost: opts?.flagHost,
+    flagTarget: opts?.flagTarget,
+    projectHost: opts?.projectHost,
+  });
+  return createClient({ host, apiKey: resolveApiKey() });
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
-    "types": ["node"],
+    "types": ["node", "jest"],
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,

--- a/packages/orchestration-core/src/__tests__/client.test.ts
+++ b/packages/orchestration-core/src/__tests__/client.test.ts
@@ -41,7 +41,7 @@ afterEach(() => {
 // ── GatewayClient ─────────────────────────────────────────────────────────────
 
 describe('createClient / GatewayClient', () => {
-  it('sends x-sapiom-api-key header and targets /v1/workflows', async () => {
+  it('sends x-api-key header and targets /v1/workflows', async () => {
     const spy = mockFetch([{ status: 200, body: { ok: true } }]);
     const client = createClient({ host: 'https://example.com', apiKey: 'sk_test' });
     await client.get('/foo');
@@ -49,7 +49,7 @@ describe('createClient / GatewayClient', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.com/v1/workflows/foo');
-    expect((init.headers as Record<string, string>)['x-sapiom-api-key']).toBe('sk_test');
+    expect((init.headers as Record<string, string>)['x-api-key']).toBe('sk_test');
   });
 
   it('throws OrchestrationError with HTTP_4xx code on error status', async () => {
@@ -61,13 +61,13 @@ describe('createClient / GatewayClient', () => {
     });
   });
 
-  it('defaults to the production workflows host', () => {
+  it('defaults to the production backend host', () => {
     const client = new GatewayClient({ apiKey: 'sk_test' });
     // Access the private base via a GET call
     const spy = mockFetch([{ status: 200, body: {} }]);
     void client.get('/ping');
     const [url] = spy.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('workflows.services.sapiom.ai/v1/workflows/ping');
+    expect(url).toContain('api.sapiom.ai/v1/workflows/ping');
   });
 
   it('throws NETWORK error when fetch rejects', async () => {
@@ -82,11 +82,17 @@ describe('createClient / GatewayClient', () => {
 describe('run', () => {
   const client = createClient({ host: 'https://example.com', apiKey: 'sk' });
 
-  it('posts to /definitions/:id/execute and returns executionId (CLI-style)', async () => {
-    mockFetch([{ status: 200, body: { executionId: 'exec-1', status: 'running' } }]);
+  it('posts to /executions with definitionId in the body and returns executionId (CLI-style)', async () => {
+    const spy = mockFetch([{ status: 200, body: { executionId: 'exec-1', status: 'running' } }]);
     const result = await run({ definitionId: 'def-1', input: { foo: 'bar' } }, client);
     expect(result.executionId).toBe('exec-1');
     expect(result.raw).toMatchObject({ executionId: 'exec-1' });
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.com/v1/workflows/executions');
+    const body = JSON.parse(init.body as string);
+    expect(body.definitionId).toBe('def-1');
+    expect(body.input).toEqual({ foo: 'bar' });
   });
 
   it('accepts id field as fallback for executionId (MCP-style)', async () => {

--- a/packages/orchestration-core/src/client.ts
+++ b/packages/orchestration-core/src/client.ts
@@ -1,19 +1,20 @@
 /**
- * Configurable HTTP client for the Sapiom workflows gateway. All inputs are
+ * Configurable HTTP client for the Sapiom workflows backend API. All inputs are
  * passed explicitly (base URL + API key) — no process.env reads, no global
  * state — so the client is usable from a CLI, an MCP tool, or a test harness.
- *
- * The same endpoints as #85's CLI client are targeted; retargeting to a
- * different host is SAP-929 / SAP-927 and explicitly out of scope here.
  */
 import { OrchestrationError } from './errors.js';
 
-export const DEFAULT_WORKFLOWS_HOST = 'https://workflows.services.sapiom.ai';
+/**
+ * Production host for the Sapiom backend tenant API.
+ * The `/v1/workflows` path is appended internally.
+ */
+export const DEFAULT_WORKFLOWS_HOST = 'https://api.sapiom.ai';
 
 export interface ClientOptions {
-  /** Full host URL; defaults to the production workflows gateway. */
+  /** Full host URL; defaults to the production backend host. */
   host?: string;
-  /** API key sent as `x-sapiom-api-key`. */
+  /** API key sent as `x-api-key`. Must start with `sk_`. */
   apiKey: string;
 }
 
@@ -42,7 +43,7 @@ export class GatewayClient {
     try {
       res = await fetch(`${this.base}${path}`, {
         method,
-        headers: { 'x-sapiom-api-key': this.apiKey, 'content-type': 'application/json' },
+        headers: { 'x-api-key': this.apiKey, 'content-type': 'application/json' },
         body: body === undefined ? undefined : JSON.stringify(body),
       });
     } catch (err) {
@@ -61,7 +62,7 @@ export class GatewayClient {
         message: messageFrom(data) ?? `Request failed (${res.status} ${res.statusText}).`,
         hint:
           res.status === 401 || res.status === 403
-            ? 'Check your API key and that it has access to this orchestration.'
+            ? 'Check your API key (`sapiom login` or SAPIOM_API_KEY) and that it has access to this orchestration.'
             : undefined,
       });
     }

--- a/packages/orchestration-core/src/run.ts
+++ b/packages/orchestration-core/src/run.ts
@@ -3,6 +3,9 @@
  *
  * Networked operation: requires a GatewayClient. All inputs passed explicitly;
  * no file-system reads — the caller supplies the definition id and input.
+ *
+ * The backend route is `POST /v1/workflows/executions` and takes the definition
+ * id in the body alongside the execution input (not as a path segment).
  */
 import { GatewayClient } from './client.js';
 import { OrchestrationError } from './errors.js';
@@ -31,9 +34,12 @@ export interface RunResult {
 export async function run(opts: RunOptions, client: GatewayClient): Promise<RunResult> {
   const { definitionId, input = {} } = opts;
 
+  // Backend route: POST /v1/workflows/executions — definition id is in the body,
+  // not the path. The tenant scope is resolved server-side from the caller's
+  // authenticated API key; it cannot be overridden by the client.
   const res = await client.post<{ executionId?: string; id?: string } & Record<string, unknown>>(
-    `/definitions/${definitionId}/execute`,
-    { input },
+    '/executions',
+    { definitionId, input },
   );
   const executionId = res.executionId ?? res.id;
   if (!executionId) {


### PR DESCRIPTION
## Summary

- **Auth header fix**: `GatewayClient` now sends `x-api-key` (the header the backend `UnifiedAuthGuard`'s `ApiKeyStrategy` reads) instead of the old `x-sapiom-api-key` that the engine gateway accepted.
- **Retarget to backend**: default host changed to `https://api.sapiom.ai`; `run` now POSTs to `POST /executions` with `{definitionId, input}` in the body instead of `POST /definitions/:id/execute` (matching the backend tenant controller).
- **Host switch**: every networked command (`run`, `deploy`, `link`, `logs`, `signal`) gains `--target local|prod` and `--host <url>` flags. `local` resolves to `http://localhost:3000`.
- **Persisted target**: `sapiom config set-target <local|prod>` writes to `~/.sapiom/config.json`. Host resolution order: `SAPIOM_HOST` env > `--host` > `--target` > persisted config > project `sapiom.json` host > prod default.
- **CLI stays thin**: all logic changes are in `@sapiom/orchestration-core`; CLI adds flag-parsing and resolution only.

## Auth header confirmed

The backend `ApiKeyStrategy` in `UnifiedAuthGuard` extracts the key from `x-api-key` header or `Authorization: Bearer sk_*`. The old header `x-sapiom-api-key` is not recognized by the backend. `sapiom login` stores the device-flow token as `apiKey` in credentials; `resolveApiKey()` reads it and the core client sends it as `x-api-key`.

## Commands now targeting backend tenant API

| Command | Backend route | Status |
|---------|--------------|--------|
| `run` | `POST /v1/workflows/executions` | Working |
| `logs` (execution) | `GET /v1/workflows/executions/:id` | Working |
| `logs` (list) | `GET /v1/workflows/executions` | Working |
| `signal` | `POST /v1/workflows/executions/:id/signals` | Working |
| `link` (list) | `GET /v1/workflows/definitions` | Working |
| `deploy` / `link --create` | `POST /v1/workflows/definitions`, push-credentials, builds | Pending backend deploy routes (separate effort) |

## Test plan

- [x] `pnpm --filter @sapiom/orchestration-core build` passes
- [x] `pnpm --filter @sapiom/cli build` passes  
- [x] `pnpm --filter @sapiom/orchestration-core test` — 28 tests pass (updated for new host/header/endpoint)
- [x] `pnpm --filter @sapiom/cli test` — 11 new tests pass (resolveHost precedence)
- [x] `pnpm --filter @sapiom/cli lint` clean
- [x] `pnpm --filter @sapiom/orchestration-core lint` clean

Generated with Claude Code