### PR TITLE
fix(examples): fail fast when demo server is unreachable

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -150,6 +150,12 @@ The Sapiom SDK handles all authorization and payment automatically - your code j
 **Connection refused / timeout**
 - Check that `DUMMY_SERVER_URL` is correct and the test server is running
 
+**403 from demo server / "Demo server unreachable"**
+- The examples check `GET /api/public/time` before running (plain `fetch`, no SDK)
+- Verify with: `curl -v https://x402-demo.sapiom.ai/api/public/time`
+- A Cloudflare block page (`server: cloudflare`) is an infrastructure issue — check [open issues](https://github.com/sapiom/sapiom-js/issues)
+- `http://localhost:3101` is not bundled in this repo; use the hosted demo URL unless you run your own server
+
 **AuthorizationDeniedError on first request**
 - Check your Rules in the dashboard - you may have a restrictive policy
 

--- a/examples/axios/index-free.ts
+++ b/examples/axios/index-free.ts
@@ -13,6 +13,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, config } from "./client";
 
 // ANSI colors for terminal output
@@ -77,6 +78,8 @@ async function main() {
   logInfo("• Free endpoints (no payment required)");
   logInfo("• Authorization-only endpoints");
   logInfo("• Usage tracking in Sapiom dashboard");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const client = createClient();

--- a/examples/axios/index.ts
+++ b/examples/axios/index.ts
@@ -8,6 +8,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, config } from "./client";
 
 // ANSI colors for terminal output
@@ -74,6 +75,8 @@ async function main() {
   logInfo("• Pre-emptive authorization before HTTP requests");
   logInfo("• Automatic payment handling on 402 responses");
   logInfo("• Drop-in replacement for existing Axios code");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const client = createClient();

--- a/examples/fetch/index-free.ts
+++ b/examples/fetch/index-free.ts
@@ -13,6 +13,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, baseUrl, config } from "./client";
 
 // ANSI colors for terminal output
@@ -77,6 +78,8 @@ async function main() {
   logInfo("• Free endpoints (no payment required)");
   logInfo("• Authorization-only endpoints");
   logInfo("• Usage tracking in Sapiom dashboard");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const safeFetch = createClient();

--- a/examples/fetch/index.ts
+++ b/examples/fetch/index.ts
@@ -8,6 +8,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, baseUrl, config } from "./client";
 
 // ANSI colors for terminal output
@@ -74,6 +75,8 @@ async function main() {
   logInfo("• Pre-emptive authorization before HTTP requests");
   logInfo("• Automatic payment handling on 402 responses");
   logInfo("• Drop-in replacement for native fetch()");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const safeFetch = createClient();

--- a/examples/node-http/index-free.ts
+++ b/examples/node-http/index-free.ts
@@ -13,6 +13,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, baseUrl, config } from "./client";
 
 // ANSI colors for terminal output
@@ -77,6 +78,8 @@ async function main() {
   logInfo("• Free endpoints (no payment required)");
   logInfo("• Authorization-only endpoints");
   logInfo("• Usage tracking in Sapiom dashboard");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const client = createClient();

--- a/examples/node-http/index.ts
+++ b/examples/node-http/index.ts
@@ -8,6 +8,7 @@
  *
  * Run: npm start
  */
+import { assertDemoServerReachable } from "../shared/check-demo-server";
 import { createClient, baseUrl, config } from "./client";
 
 // ANSI colors for terminal output
@@ -74,6 +75,8 @@ async function main() {
   logInfo("• Pre-emptive authorization before HTTP requests");
   logInfo("• Automatic payment handling on 402 responses");
   logInfo("• Native Node.js http/https module integration");
+
+  await assertDemoServerReachable(config.dummyServerUrl);
 
   // Create client
   const client = createClient();

--- a/examples/shared/check-demo-server.ts
+++ b/examples/shared/check-demo-server.ts
@@ -1,0 +1,109 @@
+const DEMO_HEALTH_PATH = "/api/public/time";
+
+export interface DemoServerCheckResult {
+  ok: boolean;
+  status?: number;
+  cloudflareBlocked?: boolean;
+  error?: string;
+}
+
+/**
+ * Probe the demo server with plain fetch (no Sapiom SDK) before running examples.
+ */
+export async function checkDemoServer(
+  baseUrl: string,
+): Promise<DemoServerCheckResult> {
+  const url = `${baseUrl.replace(/\/$/, "")}${DEMO_HEALTH_PATH}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (response.ok) {
+      return { ok: true, status: response.status };
+    }
+
+    const server = response.headers.get("server") ?? "";
+    let body = "";
+    try {
+      body = await response.text();
+    } catch {
+      // ignore body read errors
+    }
+
+    const cloudflareBlocked =
+      response.status === 403 &&
+      (server.toLowerCase().includes("cloudflare") ||
+        body.includes("Cloudflare") ||
+        body.includes("you have been blocked"));
+
+    return {
+      ok: false,
+      status: response.status,
+      cloudflareBlocked,
+      error: cloudflareBlocked
+        ? "Demo server blocked by Cloudflare (403)"
+        : `Demo server returned HTTP ${response.status}`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const unreachable =
+      message.includes("fetch failed") ||
+      message.includes("ECONNREFUSED") ||
+      message.includes("ENOTFOUND");
+
+    return {
+      ok: false,
+      error: unreachable
+        ? `Cannot reach demo server at ${baseUrl} (${message})`
+        : `Demo server health check failed: ${message}`,
+    };
+  }
+}
+
+export function printDemoServerUnreachable(
+  baseUrl: string,
+  result: DemoServerCheckResult,
+): void {
+  const healthUrl = `${baseUrl.replace(/\/$/, "")}${DEMO_HEALTH_PATH}`;
+
+  console.error("");
+  console.error("Demo server unreachable — skipping example.");
+  console.error(`  URL: ${healthUrl}`);
+  if (result.status !== undefined) {
+    console.error(`  HTTP: ${result.status}`);
+  }
+  if (result.error) {
+    console.error(`  Reason: ${result.error}`);
+  }
+  console.error("");
+
+  if (result.cloudflareBlocked) {
+    console.error(
+      "The hosted demo is blocked by Cloudflare, not the Sapiom SDK.",
+    );
+    console.error(
+      "Check open issues at https://github.com/sapiom/sapiom-js/issues",
+    );
+  } else {
+    console.error("Verify DUMMY_SERVER_URL in .env, or run:");
+    console.error(`  curl -v ${healthUrl}`);
+  }
+
+  console.error("");
+  console.error(
+    "Note: http://localhost:3101 is not bundled in this repo — examples expect the hosted demo.",
+  );
+  console.error("");
+}
+
+export async function assertDemoServerReachable(baseUrl: string): Promise<void> {
+  const result = await checkDemoServer(baseUrl);
+  if (!result.ok) {
+    printDemoServerUnreachable(baseUrl, result);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Add a startup health check for the HTTP examples (axios, fetch, node-http)
- Probe `/api/public/time` with plain `fetch` before the SDK runs
- Detect Cloudflare 403 blocks and exit with a clear error message
- Document troubleshooting in `examples/README.md`

Follow-up to #<your-issue-number>.

## Test plan
- [x] `npm start` in `examples/axios` — exits early with Cloudflare message when demo is blocked
- [ ] When demo server is restored, examples proceed past the health check