### PR TITLE
feat(orchestration-mcp): add stdio MCP server for orchestration lifecycle

### DIFF
--- a/packages/cli/src/__tests__/cli-config.test.ts
+++ b/packages/cli/src/__tests__/cli-config.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for host-switch resolution and CLI-level configuration.
+ *
+ * The key invariants:
+ *   - SAPIOM_HOST env always wins
+ *   - --host flag beats --target flag
+ *   - --target local maps to localhost:3000, prod to api.sapiom.ai
+ *   - Persisted config (target / host) is the fallback before project host
+ *   - Project host from sapiom.json is the last fallback before default
+ *   - Default is the production backend
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// We test resolveHost by mocking XDG_CONFIG_HOME to point at a temp dir so
+// the test never touches the real ~/.sapiom/config.json.
+import { resolveHost } from '../lib/cli-config.js';
+
+const PROD = 'https://api.sapiom.ai';
+const LOCAL = 'http://localhost:3000';
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `sapiom-cli-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeConfigJson(xdgDir: string, content: object): void {
+  const sapiomDir = path.join(xdgDir, 'sapiom');
+  if (!existsSync(sapiomDir)) mkdirSync(sapiomDir, { recursive: true });
+  writeFileSync(path.join(sapiomDir, 'config.json'), JSON.stringify(content, null, 2) + '\n');
+}
+
+describe('resolveHost', () => {
+  let originalXdg: string | undefined;
+  let originalSapiomHost: string | undefined;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    originalSapiomHost = process.env.SAPIOM_HOST;
+    // Isolate each test from real user config
+    delete process.env.SAPIOM_HOST;
+  });
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+    if (originalSapiomHost === undefined) {
+      delete process.env.SAPIOM_HOST;
+    } else {
+      process.env.SAPIOM_HOST = originalSapiomHost;
+    }
+  });
+
+  it('returns prod host by default', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({})).toBe(PROD);
+  });
+
+  it('SAPIOM_HOST env wins over everything', () => {
+    process.env.SAPIOM_HOST = 'https://my-custom.example.com';
+    expect(resolveHost({ flagTarget: 'local', flagHost: 'http://other.example.com' })).toBe(
+      'https://my-custom.example.com',
+    );
+  });
+
+  it('--host flag wins over --target', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagHost: 'http://my-override.test', flagTarget: 'local' })).toBe(
+      'http://my-override.test',
+    );
+  });
+
+  it('--target local maps to localhost:3000', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagTarget: 'local' })).toBe(LOCAL);
+  });
+
+  it('--target prod maps to production host', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagTarget: 'prod' })).toBe(PROD);
+  });
+
+  it('persisted target=local in config.json is picked up when no flag is set', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { target: 'local' });
+    expect(resolveHost({})).toBe(LOCAL);
+  });
+
+  it('persisted host in config.json is picked up when no flag is set', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { host: 'https://staging.example.com' });
+    expect(resolveHost({})).toBe('https://staging.example.com');
+  });
+
+  it('persisted host takes precedence over persisted target', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { host: 'https://staging.example.com', target: 'local' });
+    expect(resolveHost({})).toBe('https://staging.example.com');
+  });
+
+  it('project host from sapiom.json is last fallback before default', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    // No config.json written — project host should apply
+    expect(resolveHost({ projectHost: 'https://project-host.example.com' })).toBe(
+      'https://project-host.example.com',
+    );
+  });
+
+  it('flag target beats persisted config', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { target: 'prod' });
+    expect(resolveHost({ flagTarget: 'local' })).toBe(LOCAL);
+  });
+
+  it('strips trailing slash from host values', () => {
+    process.env.SAPIOM_HOST = 'https://example.com/';
+    expect(resolveHost({})).toBe('https://example.com');
+  });
+});

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+
+import { action, json } from '../shared.js';
+import { runSetTarget } from './set-target.js';
+
+/**
+ * Mount the `sapiom config …` command group for machine-level CLI configuration.
+ * Project identity (`sapiom.json`) is handled separately by `orchestrations link`.
+ */
+export function registerConfigCommands(program: Command): void {
+  const group = program
+    .command('config')
+    .description('Manage machine-level CLI configuration.');
+
+  json(
+    group
+      .command('set-target <target>')
+      .description("Persist the default API target: 'prod' (default) or 'local'."),
+  ).action(action(runSetTarget));
+}

--- a/packages/cli/src/commands/config/set-target.ts
+++ b/packages/cli/src/commands/config/set-target.ts
@@ -1,0 +1,23 @@
+/**
+ * `sapiom config set-target <prod|local>` — persist the default API target to
+ * `~/.sapiom/config.json`. Individual commands can still override per-invocation
+ * with `--target` or `--host`.
+ */
+import { type CliTarget, writeCliConfig } from '../../lib/cli-config.js';
+import { CliError, ok } from '../../lib/output.js';
+
+const VALID_TARGETS = new Set<string>(['prod', 'local']);
+
+export async function runSetTarget(target: string): Promise<void> {
+  if (!VALID_TARGETS.has(target)) {
+    throw new CliError({
+      code: 'BAD_TARGET',
+      message: `Unknown target: '${target}'. Expected 'prod' or 'local'.`,
+    });
+  }
+
+  writeCliConfig({ target: target as CliTarget, host: undefined });
+
+  const description = target === 'local' ? 'http://localhost:3000' : 'https://api.sapiom.ai';
+  ok({ target }, [`✓ Default target set to '${target}' (${description}).`]);
+}

--- a/packages/cli/src/commands/orchestrations/deploy.ts
+++ b/packages/cli/src/commands/orchestrations/deploy.ts
@@ -1,18 +1,22 @@
 import { deploy, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations deploy` — mint push credentials, push the current
  * commit, trigger a build, and wait for it to finish.
+ *
+ * Note: the backend tenant deploy routes (POST definitions, push-credentials,
+ * builds) are being added in a parallel effort and are not yet merged. Until
+ * those land, deploy end-to-end will return 404 from the backend.
  */
-export async function runDeploy(opts: { branch?: string }): Promise<void> {
+export async function runDeploy(opts: { branch?: string; host?: string; target?: CliTarget }): Promise<void> {
   try {
     const dir = process.cwd();
     const cfg = requireConfig(dir);
-    const client = makeClient(cfg.host);
+    const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
 
     const result = await deploy({ projectDir: dir, definitionId: cfg.definitionId, branch: opts.branch }, client);
 

--- a/packages/cli/src/commands/orchestrations/index.ts
+++ b/packages/cli/src/commands/orchestrations/index.ts
@@ -9,6 +9,16 @@ import { runLogs } from './logs.js';
 import { runRun } from './run.js';
 import { runSignal } from './signal.js';
 
+/**
+ * Attach the shared --host / --target flags to a command. These override the
+ * machine-level config and sapiom.json host for a single invocation.
+ */
+function withHostFlags(cmd: Command): Command {
+  return cmd
+    .option('--host <url>', 'API host URL (overrides config and SAPIOM_HOST)')
+    .option('--target <target>', 'target environment: prod (default) or local');
+}
+
 /** Mount the `sapiom orchestrations …` command group. */
 export function registerOrchestrationsCommands(program: Command): void {
   const group = program
@@ -24,24 +34,26 @@ export function registerOrchestrationsCommands(program: Command): void {
     action(runCheck),
   );
 
-  json(group.command('link [name]').description('Link this project to its server-side orchestration.'))
+  withHostFlags(json(group.command('link [name]').description('Link this project to its server-side orchestration.')))
     .option('--create', 'create the orchestration if it does not exist')
     .action(action(runLink));
 
-  json(group.command('deploy').description('Push the current commit, build, and wait for it to finish.'))
-    .option('-b, --branch <branch>', 'branch to push to', 'main')
-    .action(action(runDeploy));
+  withHostFlags(
+    json(group.command('deploy').description('Push the current commit, build, and wait for it to finish.')),
+  ).option('-b, --branch <branch>', 'branch to push to', 'main').action(action(runDeploy));
 
-  json(group.command('run').description('Start an execution of the linked orchestration.'))
+  withHostFlags(json(group.command('run').description('Start an execution of the linked orchestration.')))
     .option('--input <json>', 'execution input as a JSON string')
     .option('--input-file <path>', 'read execution input from a JSON file')
     .action(action(runRun));
 
-  json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.'))
+  withHostFlags(
+    json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.')),
+  )
     .option('--build <buildRunId>', 'inspect a build instead of an execution')
     .action(action(runLogs));
 
-  json(group.command('signal <executionId>').description('Resume a paused execution.'))
+  withHostFlags(json(group.command('signal <executionId>').description('Resume a paused execution.')))
     .requiredOption('--name <name>', 'the signal name to deliver')
     .requiredOption('--correlation-id <id>', 'the signal correlation id')
     .option('--payload <json>', 'signal payload as a JSON string')

--- a/packages/cli/src/commands/orchestrations/link.ts
+++ b/packages/cli/src/commands/orchestrations/link.ts
@@ -2,21 +2,28 @@ import path from 'node:path';
 
 import { link, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { writeConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations link [name]` — resolve a server-side orchestration by
  * name (or create it with --create) and cache its id in sapiom.json.
+ *
+ * Note: the `--create` path (POST /definitions) depends on backend tenant
+ * deploy routes that are being added in a parallel effort and are not yet
+ * merged. Linking to an existing definition works today.
  */
-export async function runLink(name: string | undefined, opts: { create?: boolean }): Promise<void> {
+export async function runLink(
+  name: string | undefined,
+  opts: { create?: boolean; host?: string; target?: CliTarget },
+): Promise<void> {
   try {
     const dir = process.cwd();
-    const target = name ?? path.basename(dir);
-    const client = makeClient();
+    const linkTarget = name ?? path.basename(dir);
+    const client = makeClient({ flagHost: opts.host, flagTarget: opts.target });
 
-    const result = await link({ name: target, create: opts.create }, client);
+    const result = await link({ name: linkTarget, create: opts.create }, client);
 
     writeConfig(dir, { definitionId: result.definitionId, name: result.name });
     ok({ definitionId: result.definitionId, name: result.name }, [`✓ Linked to ${result.name} (${result.definitionId})`]);

--- a/packages/cli/src/commands/orchestrations/logs.ts
+++ b/packages/cli/src/commands/orchestrations/logs.ts
@@ -1,6 +1,6 @@
 import { inspect, inspectBuild, listExecutions, OrchestrationError } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { readConfig, requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
 
@@ -10,14 +10,14 @@ import { CliError, isJsonMode, ok } from '../../lib/output.js';
  */
 export async function runLogs(
   executionId: string | undefined,
-  opts: { build?: string },
+  opts: { build?: string; host?: string; target?: CliTarget },
 ): Promise<void> {
   try {
     const dir = process.cwd();
 
     if (opts.build) {
       const cfg = requireConfig(dir);
-      const client = makeClient(cfg.host);
+      const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
       const { build } = await inspectBuild({ definitionId: cfg.definitionId, buildRunId: opts.build }, client);
       if (isJsonMode()) ok({ build });
       else ok({}, [`build ${opts.build}: ${build.status ?? 'unknown'}`]);
@@ -25,7 +25,7 @@ export async function runLogs(
     }
 
     const cfg = readConfig(dir);
-    const client = makeClient(cfg?.host);
+    const client = makeClient({ projectHost: cfg?.host, flagHost: opts.host, flagTarget: opts.target });
 
     if (!executionId) {
       const { executions } = await listExecutions(client);

--- a/packages/cli/src/commands/orchestrations/run.ts
+++ b/packages/cli/src/commands/orchestrations/run.ts
@@ -2,18 +2,23 @@ import { readFileSync } from 'node:fs';
 
 import { OrchestrationError, parseJsonInput, run } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { requireConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
 /**
  * `sapiom orchestrations run` — start an execution of the linked orchestration.
  */
-export async function runRun(opts: { input?: string; inputFile?: string }): Promise<void> {
+export async function runRun(opts: {
+  input?: string;
+  inputFile?: string;
+  host?: string;
+  target?: CliTarget;
+}): Promise<void> {
   try {
     const dir = process.cwd();
     const cfg = requireConfig(dir);
-    const client = makeClient(cfg.host);
+    const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
     const input = resolveInput(opts);
 
     const result = await run({ definitionId: cfg.definitionId, input }, client);

--- a/packages/cli/src/commands/orchestrations/signal.ts
+++ b/packages/cli/src/commands/orchestrations/signal.ts
@@ -1,6 +1,6 @@
 import { OrchestrationError, parseSignalPayload, signal } from '@sapiom/orchestration-core';
 
-import { makeClient } from '../../lib/client.js';
+import { type CliTarget, makeClient } from '../../lib/client.js';
 import { readConfig } from '../../lib/config.js';
 import { CliError, ok } from '../../lib/output.js';
 
@@ -10,11 +10,11 @@ import { CliError, ok } from '../../lib/output.js';
  */
 export async function runSignal(
   executionId: string,
-  opts: { name: string; correlationId: string; payload?: string },
+  opts: { name: string; correlationId: string; payload?: string; host?: string; target?: CliTarget },
 ): Promise<void> {
   try {
     const cfg = readConfig(process.cwd());
-    const client = makeClient(cfg?.host);
+    const client = makeClient({ projectHost: cfg?.host, flagHost: opts.host, flagTarget: opts.target });
     const payload = opts.payload ? parseSignalPayload(opts.payload) : undefined;
 
     const result = await signal({ executionId, name: opts.name, correlationId: opts.correlationId, payload }, client);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 
 import { registerAuthCommands } from './commands/auth/index.js';
+import { registerConfigCommands } from './commands/config/index.js';
 import { registerOrchestrationsCommands } from './commands/orchestrations/index.js';
 
 /**
@@ -13,6 +14,7 @@ export function buildProgram(): Command {
   const program = new Command('sapiom').description('The Sapiom command-line interface.');
 
   registerAuthCommands(program);
+  registerConfigCommands(program);
   registerOrchestrationsCommands(program);
 
   return program;

--- a/packages/cli/src/lib/cli-config.ts
+++ b/packages/cli/src/lib/cli-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Machine-level CLI configuration persisted at `~/.sapiom/config.json`. Stores
+ * the active target (prod vs local) and any user-set host override. Project
+ * identity (`sapiom.json` / `definitionId`) is kept separate from this — the
+ * server stays the source of truth for what orchestrations exist.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+
+import { configDir, configFilePath } from './paths.js';
+
+export type CliTarget = 'prod' | 'local';
+
+export interface CliConfig {
+  /**
+   * Named target: `prod` routes to the production backend, `local` to the
+   * backend running on localhost:3000. A raw `host` override supersedes this.
+   */
+  target?: CliTarget;
+  /**
+   * Explicit host URL override. When present, takes precedence over `target`.
+   * Stored so `sapiom orchestrations run` remembers the host without requiring
+   * `--host` on every invocation.
+   */
+  host?: string;
+}
+
+const PROD_HOST = 'https://api.sapiom.ai';
+const LOCAL_HOST = 'http://localhost:3000';
+
+function load(): CliConfig {
+  const file = configFilePath();
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as CliConfig;
+  } catch {
+    return {};
+  }
+}
+
+function persist(cfg: CliConfig): void {
+  const dir = configDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(configFilePath(), JSON.stringify(cfg, null, 2) + '\n');
+}
+
+export function readCliConfig(): CliConfig {
+  return load();
+}
+
+export function writeCliConfig(patch: Partial<CliConfig>): void {
+  const current = load();
+  persist({ ...current, ...patch });
+}
+
+/**
+ * Resolve the effective API host from (in precedence order):
+ * 1. An explicit `SAPIOM_HOST` environment variable
+ * 2. An explicit `--host <url>` flag (passed as `flagHost`)
+ * 3. The `--target local|prod` flag (passed as `flagTarget`)
+ * 4. The `host` or `target` stored in `~/.sapiom/config.json`
+ * 5. The project-level `host` from `sapiom.json` (passed as `projectHost`)
+ * 6. Default: production backend
+ */
+export function resolveHost(opts: {
+  flagHost?: string;
+  flagTarget?: CliTarget;
+  projectHost?: string;
+}): string {
+  // Env var always wins
+  if (process.env.SAPIOM_HOST) return process.env.SAPIOM_HOST.replace(/\/$/, '');
+  // Explicit --host flag
+  if (opts.flagHost) return opts.flagHost.replace(/\/$/, '');
+  // --target flag
+  if (opts.flagTarget) return opts.flagTarget === 'local' ? LOCAL_HOST : PROD_HOST;
+
+  // Persisted CLI config
+  const cfg = load();
+  if (cfg.host) return cfg.host.replace(/\/$/, '');
+  if (cfg.target) return cfg.target === 'local' ? LOCAL_HOST : PROD_HOST;
+
+  // Project-level sapiom.json host
+  if (opts.projectHost) return opts.projectHost.replace(/\/$/, '');
+
+  return PROD_HOST;
+}

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,19 +1,19 @@
 /**
- * CLI-level client factory. Resolves host and API key from the environment and
- * stored session, then delegates to @sapiom/orchestration-core's GatewayClient.
+ * CLI-level client factory. Resolves host and API key from the environment,
+ * stored CLI config, and the optional project-level host — then delegates to
+ * @sapiom/orchestration-core's GatewayClient.
  *
  * Auth resolution stays here (in the CLI) because it reads process.env and the
  * local session store — both are CLI concerns. The core client itself is stateless.
  */
-import { createClient, DEFAULT_WORKFLOWS_HOST, GatewayClient } from '@sapiom/orchestration-core';
+import { createClient, GatewayClient } from '@sapiom/orchestration-core';
 
+import { type CliTarget, resolveHost } from './cli-config.js';
 import { CliError } from './output.js';
 import { readCredential } from './session.js';
 
-/** Host precedence: explicit env override → linked project's host → default. */
-export function resolveHost(configHost?: string): string {
-  return process.env.SAPIOM_WORKFLOWS_HOST ?? configHost ?? DEFAULT_WORKFLOWS_HOST;
-}
+export { resolveHost };
+export type { CliTarget };
 
 /**
  * Credential precedence: the environment always wins (CI / ephemeral /
@@ -25,6 +25,8 @@ function resolveApiKey(): string {
   if (env) return env;
 
   const stored = readCredential();
+  // accessToken from the device flow or a raw API key both work — the backend
+  // accepts either via `x-api-key` or `Authorization: Bearer` for `sk_` tokens.
   const token = stored?.accessToken ?? stored?.apiKey;
   if (token) return token;
 
@@ -36,9 +38,22 @@ function resolveApiKey(): string {
 }
 
 /**
- * Build a GatewayClient for a CLI command. Reads host and API key from the
- * environment / session; callers pass the optional project host override.
+ * Build a GatewayClient for a CLI command. Resolves host from env / CLI config /
+ * project override; resolves credentials from env or stored session.
+ *
+ * @param projectHost  Optional host stored in the project's `sapiom.json`.
+ * @param flagHost     Optional `--host <url>` flag value.
+ * @param flagTarget   Optional `--target local|prod` flag value.
  */
-export function makeClient(configHost?: string): GatewayClient {
-  return createClient({ host: resolveHost(configHost), apiKey: resolveApiKey() });
+export function makeClient(opts?: {
+  projectHost?: string;
+  flagHost?: string;
+  flagTarget?: CliTarget;
+}): GatewayClient {
+  const host = resolveHost({
+    flagHost: opts?.flagHost,
+    flagTarget: opts?.flagTarget,
+    projectHost: opts?.projectHost,
+  });
+  return createClient({ host, apiKey: resolveApiKey() });
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
-    "types": ["node"],
+    "types": ["node", "jest"],
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,

--- a/packages/orchestration-core/src/__tests__/client.test.ts
+++ b/packages/orchestration-core/src/__tests__/client.test.ts
@@ -41,7 +41,7 @@ afterEach(() => {
 // ── GatewayClient ─────────────────────────────────────────────────────────────
 
 describe('createClient / GatewayClient', () => {
-  it('sends x-sapiom-api-key header and targets /v1/workflows', async () => {
+  it('sends x-api-key header and targets /v1/workflows', async () => {
     const spy = mockFetch([{ status: 200, body: { ok: true } }]);
     const client = createClient({ host: 'https://example.com', apiKey: 'sk_test' });
     await client.get('/foo');
@@ -49,7 +49,7 @@ describe('createClient / GatewayClient', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://example.com/v1/workflows/foo');
-    expect((init.headers as Record<string, string>)['x-sapiom-api-key']).toBe('sk_test');
+    expect((init.headers as Record<string, string>)['x-api-key']).toBe('sk_test');
   });
 
   it('throws OrchestrationError with HTTP_4xx code on error status', async () => {
@@ -61,13 +61,13 @@ describe('createClient / GatewayClient', () => {
     });
   });
 
-  it('defaults to the production workflows host', () => {
+  it('defaults to the production backend host', () => {
     const client = new GatewayClient({ apiKey: 'sk_test' });
     // Access the private base via a GET call
     const spy = mockFetch([{ status: 200, body: {} }]);
     void client.get('/ping');
     const [url] = spy.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('workflows.services.sapiom.ai/v1/workflows/ping');
+    expect(url).toContain('api.sapiom.ai/v1/workflows/ping');
   });
 
   it('throws NETWORK error when fetch rejects', async () => {
@@ -82,11 +82,17 @@ describe('createClient / GatewayClient', () => {
 describe('run', () => {
   const client = createClient({ host: 'https://example.com', apiKey: 'sk' });
 
-  it('posts to /definitions/:id/execute and returns executionId (CLI-style)', async () => {
-    mockFetch([{ status: 200, body: { executionId: 'exec-1', status: 'running' } }]);
+  it('posts to /executions with definitionId in the body and returns executionId (CLI-style)', async () => {
+    const spy = mockFetch([{ status: 200, body: { executionId: 'exec-1', status: 'running' } }]);
     const result = await run({ definitionId: 'def-1', input: { foo: 'bar' } }, client);
     expect(result.executionId).toBe('exec-1');
     expect(result.raw).toMatchObject({ executionId: 'exec-1' });
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.com/v1/workflows/executions');
+    const body = JSON.parse(init.body as string);
+    expect(body.definitionId).toBe('def-1');
+    expect(body.input).toEqual({ foo: 'bar' });
   });
 
   it('accepts id field as fallback for executionId (MCP-style)', async () => {

--- a/packages/orchestration-core/src/client.ts
+++ b/packages/orchestration-core/src/client.ts
@@ -1,19 +1,20 @@
 /**
- * Configurable HTTP client for the Sapiom workflows gateway. All inputs are
+ * Configurable HTTP client for the Sapiom workflows backend API. All inputs are
  * passed explicitly (base URL + API key) — no process.env reads, no global
  * state — so the client is usable from a CLI, an MCP tool, or a test harness.
- *
- * The same endpoints as #85's CLI client are targeted; retargeting to a
- * different host is SAP-929 / SAP-927 and explicitly out of scope here.
  */
 import { OrchestrationError } from './errors.js';
 
-export const DEFAULT_WORKFLOWS_HOST = 'https://workflows.services.sapiom.ai';
+/**
+ * Production host for the Sapiom backend tenant API.
+ * The `/v1/workflows` path is appended internally.
+ */
+export const DEFAULT_WORKFLOWS_HOST = 'https://api.sapiom.ai';
 
 export interface ClientOptions {
-  /** Full host URL; defaults to the production workflows gateway. */
+  /** Full host URL; defaults to the production backend host. */
   host?: string;
-  /** API key sent as `x-sapiom-api-key`. */
+  /** API key sent as `x-api-key`. Must start with `sk_`. */
   apiKey: string;
 }
 
@@ -42,7 +43,7 @@ export class GatewayClient {
     try {
       res = await fetch(`${this.base}${path}`, {
         method,
-        headers: { 'x-sapiom-api-key': this.apiKey, 'content-type': 'application/json' },
+        headers: { 'x-api-key': this.apiKey, 'content-type': 'application/json' },
         body: body === undefined ? undefined : JSON.stringify(body),
       });
     } catch (err) {
@@ -61,7 +62,7 @@ export class GatewayClient {
         message: messageFrom(data) ?? `Request failed (${res.status} ${res.statusText}).`,
         hint:
           res.status === 401 || res.status === 403
-            ? 'Check your API key and that it has access to this orchestration.'
+            ? 'Check your API key (`sapiom login` or SAPIOM_API_KEY) and that it has access to this orchestration.'
             : undefined,
       });
     }

--- a/packages/orchestration-core/src/run.ts
+++ b/packages/orchestration-core/src/run.ts
@@ -3,6 +3,9 @@
  *
  * Networked operation: requires a GatewayClient. All inputs passed explicitly;
  * no file-system reads — the caller supplies the definition id and input.
+ *
+ * The backend route is `POST /v1/workflows/executions` and takes the definition
+ * id in the body alongside the execution input (not as a path segment).
  */
 import { GatewayClient } from './client.js';
 import { OrchestrationError } from './errors.js';
@@ -31,9 +34,12 @@ export interface RunResult {
 export async function run(opts: RunOptions, client: GatewayClient): Promise<RunResult> {
   const { definitionId, input = {} } = opts;
 
+  // Backend route: POST /v1/workflows/executions — definition id is in the body,
+  // not the path. The tenant scope is resolved server-side from the caller's
+  // authenticated API key; it cannot be overridden by the client.
   const res = await client.post<{ executionId?: string; id?: string } & Record<string, unknown>>(
-    `/definitions/${definitionId}/execute`,
-    { input },
+    '/executions',
+    { definitionId, input },
   );
   const executionId = res.executionId ?? res.id;
   if (!executionId) {

--- a/packages/orchestration-mcp/.eslintrc.cjs
+++ b/packages/orchestration-mcp/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+  },
+  ignorePatterns: ['.eslintrc.cjs', 'vitest.config.ts', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/orchestration-mcp/package.json
+++ b/packages/orchestration-mcp/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@sapiom/orchestration-mcp",
+  "version": "0.1.0",
+  "description": "Stdio MCP server that exposes Sapiom orchestration lifecycle tools — scaffold, check, deploy, run, inspect, and signal — for use with Claude Code and other MCP clients.",
+  "keywords": [
+    "sapiom",
+    "orchestration",
+    "workflows",
+    "mcp",
+    "claude"
+  ],
+  "homepage": "https://github.com/sapiom/sapiom-js/tree/main/packages/orchestration-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/sapiom/sapiom-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/orchestration-mcp"
+  },
+  "license": "MIT",
+  "author": "Sapiom",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "sapiom-orchestration-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@sapiom/orchestration-core": "workspace:^",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/orchestration-mcp/src/config.test.ts
+++ b/packages/orchestration-mcp/src/config.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for host and API key resolution in config.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We use environment variable control to exercise the resolution paths
+// without touching the real filesystem or ~/.sapiom/.
+
+describe("resolveHost", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    // Clear all sapiom-related env vars before each test
+    delete process.env.SAPIOM_HOST;
+    delete process.env.SAPIOM_TARGET;
+    delete process.env.SAPIOM_API_KEY;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, ORIGINAL_ENV);
+    // Remove keys that weren't in the original env
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIGINAL_ENV)) delete process.env[key];
+    }
+  });
+
+  it("SAPIOM_HOST wins over everything", async () => {
+    process.env.SAPIOM_HOST = "https://custom.example.com/";
+    const { resolveHost } = await import("./config.js");
+    expect(resolveHost()).toBe("https://custom.example.com");
+  });
+
+  it("strips trailing slash from SAPIOM_HOST", async () => {
+    process.env.SAPIOM_HOST = "https://custom.example.com/";
+    const { resolveHost } = await import("./config.js");
+    expect(resolveHost()).toBe("https://custom.example.com");
+  });
+
+  it("SAPIOM_TARGET=local maps to localhost:3000", async () => {
+    process.env.SAPIOM_TARGET = "local";
+    const { resolveHost } = await import("./config.js");
+    expect(resolveHost()).toBe("http://localhost:3000");
+  });
+
+  it("SAPIOM_TARGET=prod maps to production URL", async () => {
+    process.env.SAPIOM_TARGET = "prod";
+    const { resolveHost } = await import("./config.js");
+    expect(resolveHost()).toBe("https://api.sapiom.ai");
+  });
+
+  it("defaults to production when no env vars or config are set", async () => {
+    // Point XDG_CONFIG_HOME at an empty temp dir so we don't read real config
+    process.env.XDG_CONFIG_HOME = "/tmp/sapiom-mcp-test-nonexistent";
+    const { resolveHost } = await import("./config.js");
+    expect(resolveHost()).toBe("https://api.sapiom.ai");
+  });
+});
+
+describe("resolveApiKey", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.SAPIOM_API_KEY;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, ORIGINAL_ENV);
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIGINAL_ENV)) delete process.env[key];
+    }
+  });
+
+  it("returns SAPIOM_API_KEY when set", async () => {
+    process.env.SAPIOM_API_KEY = "sk_test_abc123";
+    const { resolveApiKey } = await import("./config.js");
+    expect(resolveApiKey()).toBe("sk_test_abc123");
+  });
+
+  it("throws a helpful error when no credentials exist", async () => {
+    // Point at a path with no credentials file
+    process.env.XDG_CONFIG_HOME = "/tmp/sapiom-mcp-test-nonexistent";
+    const { resolveApiKey } = await import("./config.js");
+    expect(() => resolveApiKey()).toThrow(/SAPIOM_API_KEY/);
+    expect(() => resolveApiKey()).toThrow(/sapiom login/);
+  });
+});

--- a/packages/orchestration-mcp/src/config.ts
+++ b/packages/orchestration-mcp/src/config.ts
@@ -1,0 +1,139 @@
+/**
+ * Host and API key resolution for the orchestration MCP server.
+ *
+ * Mirrors the CLI's resolution order exactly so that config written by
+ * `sapiom login` and `sapiom target` is shared with the MCP without
+ * duplication. The CLI's config helpers are in `@sapiom/cli` (a sibling
+ * package that we cannot import without creating a circular dep), so we
+ * replicate only the stateless resolution logic here and point at the same
+ * file paths under `~/.sapiom/`.
+ *
+ * Resolution order for host (highest priority first):
+ *   1. SAPIOM_HOST env var
+ *   2. SAPIOM_TARGET env var ("local" | "prod")
+ *   3. host stored in ~/.sapiom/config.json
+ *   4. target stored in ~/.sapiom/config.json
+ *   5. project-level host from sapiom.json in cwd
+ *   6. Production default
+ *
+ * Resolution order for API key (highest priority first):
+ *   1. SAPIOM_API_KEY env var
+ *   2. accessToken / apiKey stored in ~/.sapiom/credentials.json
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import {
+  createClient,
+  readConfig,
+  type GatewayClient,
+} from "@sapiom/orchestration-core";
+
+const PROD_HOST = "https://api.sapiom.ai";
+const LOCAL_HOST = "http://localhost:3000";
+
+// ── Path helpers (same conventions as @sapiom/cli) ───────────────────────────
+
+function configDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  return xdg ? path.join(xdg, "sapiom") : path.join(homedir(), ".sapiom");
+}
+
+function configFilePath(): string {
+  return path.join(configDir(), "config.json");
+}
+
+function credentialsPath(): string {
+  return path.join(configDir(), "credentials.json");
+}
+
+// ── Config / credentials file shapes ─────────────────────────────────────────
+
+interface CliConfig {
+  target?: "prod" | "local";
+  host?: string;
+}
+
+interface StoredCredential {
+  apiKey?: string;
+  accessToken?: string;
+}
+
+interface CredentialsFile {
+  profiles: Record<string, StoredCredential>;
+}
+
+function loadCliConfig(): CliConfig {
+  const file = configFilePath();
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as CliConfig;
+  } catch {
+    return {};
+  }
+}
+
+function loadStoredCredential(): StoredCredential | null {
+  const file = credentialsPath();
+  if (!existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as CredentialsFile;
+    return parsed.profiles?.["default"] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Public resolution helpers ─────────────────────────────────────────────────
+
+/**
+ * Resolve the effective API host. The optional `projectDir` lets callers pass a
+ * cwd so the project-level sapiom.json host can be considered.
+ */
+export function resolveHost(projectDir?: string): string {
+  if (process.env.SAPIOM_HOST)
+    return process.env.SAPIOM_HOST.replace(/\/$/, "");
+
+  if (process.env.SAPIOM_TARGET) {
+    return process.env.SAPIOM_TARGET === "local" ? LOCAL_HOST : PROD_HOST;
+  }
+
+  const cfg = loadCliConfig();
+  if (cfg.host) return cfg.host.replace(/\/$/, "");
+  if (cfg.target) return cfg.target === "local" ? LOCAL_HOST : PROD_HOST;
+
+  if (projectDir) {
+    const proj = readConfig(projectDir);
+    if (proj?.host) return proj.host.replace(/\/$/, "");
+  }
+
+  return PROD_HOST;
+}
+
+/**
+ * Resolve the API key from environment or stored credentials.
+ * Throws a descriptive error when neither source yields a key.
+ */
+export function resolveApiKey(): string {
+  if (process.env.SAPIOM_API_KEY) return process.env.SAPIOM_API_KEY;
+
+  const stored = loadStoredCredential();
+  const token = stored?.accessToken ?? stored?.apiKey;
+  if (token) return token;
+
+  throw new Error(
+    "No Sapiom credentials found. Set SAPIOM_API_KEY or run: sapiom login",
+  );
+}
+
+/**
+ * Build a GatewayClient from the resolved host and API key.
+ *
+ * @param projectDir  Optional project directory; used for sapiom.json host fallback.
+ */
+export function makeClient(projectDir?: string): GatewayClient {
+  const host = resolveHost(projectDir);
+  const apiKey = resolveApiKey();
+  return createClient({ host, apiKey });
+}

--- a/packages/orchestration-mcp/src/index.ts
+++ b/packages/orchestration-mcp/src/index.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * @sapiom/orchestration-mcp — stdio MCP server
+ *
+ * Exposes @sapiom/orchestration-core as MCP tools so that an MCP client
+ * (e.g. Claude Code) can scaffold, validate, link, deploy, run, inspect,
+ * and signal orchestrations without leaving the editor.
+ *
+ * Host and API key resolution mirrors the CLI: SAPIOM_HOST / SAPIOM_API_KEY
+ * env vars take precedence, then ~/.sapiom/config.json, then sapiom.json,
+ * then the production default. Credentials written by `sapiom login` are
+ * shared transparently.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { register as registerScaffold } from "./tools/scaffold.js";
+import { register as registerCheck } from "./tools/check.js";
+import { register as registerLink } from "./tools/link.js";
+import { register as registerDeploy } from "./tools/deploy.js";
+import { register as registerRun } from "./tools/run.js";
+import { register as registerStatus } from "./tools/status.js";
+import { register as registerLogs } from "./tools/logs.js";
+import { register as registerSignal } from "./tools/signal.js";
+
+async function main(): Promise<void> {
+  const server = new McpServer({
+    name: "sapiom-orchestration",
+    version: "0.1.0",
+  });
+
+  registerScaffold(server);
+  registerCheck(server);
+  registerLink(server);
+  registerDeploy(server);
+  registerRun(server);
+  registerStatus(server);
+  registerLogs(server);
+  registerSignal(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Sapiom orchestration MCP server running on stdio");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/packages/orchestration-mcp/src/tools/check.ts
+++ b/packages/orchestration-mcp/src/tools/check.ts
@@ -1,0 +1,68 @@
+/**
+ * check tool — local bundle + manifest + graph validation.
+ * No network required; validates the orchestration before deploying.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { check, OrchestrationError } from "@sapiom/orchestration-core";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_check",
+    "Validate an orchestration project locally: bundles index.ts with esbuild, " +
+      "loads the definition, parses the manifest, and checks the step graph. " +
+      "Run this before deploying to catch structural errors offline.",
+    {
+      sourceDir: z
+        .string()
+        .min(1)
+        .describe(
+          "Absolute path to the orchestration project directory containing index.ts.",
+        ),
+    },
+    async ({ sourceDir }) => {
+      try {
+        const result = await check({ sourceDir });
+
+        const warnings =
+          result.warnings.length > 0
+            ? `\nWarnings:\n${result.warnings.map((w) => `  - ${w}`).join("\n")}`
+            : "";
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Orchestration validation passed.`,
+                ``,
+                `Name: ${result.name}`,
+                `Steps: ${result.stepCount}`,
+                warnings,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `check failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/deploy.ts
+++ b/packages/orchestration-mcp/src/tools/deploy.ts
@@ -1,0 +1,98 @@
+/**
+ * deploy tool — push the current commit, trigger a server-side build, and poll
+ * until the build reaches a terminal state.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  deploy,
+  readConfig,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_deploy",
+    "Deploy an orchestration project to the server. Pushes the current git commit, " +
+      "triggers a server-side build, and polls until the build completes. " +
+      "The project must be a git repository and linked to a server-side definition " +
+      "(sapiom.json must contain a definitionId). " +
+      "Run orchestration_check first to validate locally.",
+    {
+      projectDir: z
+        .string()
+        .min(1)
+        .describe(
+          "Absolute path to the orchestration project directory. " +
+            "Must contain sapiom.json with a definitionId.",
+        ),
+      branch: z
+        .string()
+        .optional()
+        .describe("Git branch to push to. Defaults to 'main'."),
+    },
+    async ({ projectDir, branch }) => {
+      try {
+        const cfg = readConfig(projectDir);
+        if (!cfg?.definitionId) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  "This project is not linked to a server-side orchestration. " +
+                  "Run orchestration_link to link it first.",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const client = makeClient(projectDir);
+        const result = await deploy(
+          { projectDir, definitionId: cfg.definitionId, branch },
+          client,
+        );
+
+        const statusLine =
+          result.status === "ready"
+            ? "Build completed successfully."
+            : `Build finished with status: ${result.status}`;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                statusLine,
+                ``,
+                `Definition ID: ${result.definitionId}`,
+                `Build run ID:  ${result.buildRunId}`,
+                `Status:        ${result.status}`,
+              ].join("\n"),
+            },
+          ],
+          isError: result.status !== "ready",
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `deploy failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/link.ts
+++ b/packages/orchestration-mcp/src/tools/link.ts
@@ -1,0 +1,91 @@
+/**
+ * link tool — resolve or create a server-side orchestration definition and
+ * write its ID into the project's sapiom.json.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  link,
+  writeConfig,
+  readConfig,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_link",
+    "Link a local orchestration project to a server-side definition by name. " +
+      "Resolves the definition on the server and writes its ID into sapiom.json. " +
+      "Pass create=true to provision a new definition when one does not exist yet.",
+    {
+      projectDir: z
+        .string()
+        .min(1)
+        .describe(
+          "Absolute path to the orchestration project directory. " +
+            "sapiom.json will be updated with the resolved definitionId.",
+        ),
+      name: z
+        .string()
+        .min(1)
+        .describe(
+          "Name or slug of the server-side orchestration definition to link to.",
+        ),
+      create: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, create the definition on the server if it does not exist yet. " +
+            "Defaults to false.",
+        ),
+    },
+    async ({ projectDir, name, create }) => {
+      try {
+        const client = makeClient(projectDir);
+        const result = await link({ name, create }, client);
+
+        // Persist the resolved id alongside any existing config fields
+        const existing = readConfig(projectDir);
+        writeConfig(projectDir, {
+          ...(existing ?? {}),
+          definitionId: result.definitionId,
+          name: result.name,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Project linked to server-side definition.`,
+                ``,
+                `Name:          ${result.name}`,
+                `Definition ID: ${result.definitionId}`,
+                ``,
+                `sapiom.json updated. You can now run orchestration_deploy.`,
+              ].join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `link failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/logs.ts
+++ b/packages/orchestration-mcp/src/tools/logs.ts
@@ -1,0 +1,131 @@
+/**
+ * logs tool — list recent executions or inspect a build run.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  listExecutions,
+  inspectBuild,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  // List recent executions
+  server.tool(
+    "orchestration_logs",
+    "List recent executions across all definitions for the authenticated tenant. " +
+      "Returns execution IDs, statuses, and the current step for in-progress runs. " +
+      "Use orchestration_status for detailed step records on a single execution.",
+    {},
+    async () => {
+      try {
+        const client = makeClient();
+        const result = await listExecutions(client);
+
+        if (result.executions.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "No executions found for this definition.",
+              },
+            ],
+          };
+        }
+
+        const lines = result.executions.map(
+          (e) =>
+            `  ${e.id}  [${e.status}]${e.currentStep ? `  step: ${e.currentStep}` : ""}`,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Recent executions (${result.executions.length}):`,
+                ...lines,
+              ].join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `logs failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // Inspect a build run
+  server.tool(
+    "orchestration_build_status",
+    "Fetch the status of a specific build run. " +
+      "Useful for checking why a deploy failed.",
+    {
+      definitionId: z
+        .string()
+        .min(1)
+        .describe("Server-side definition ID the build belongs to."),
+      buildRunId: z
+        .string()
+        .min(1)
+        .describe("Build run ID returned by orchestration_deploy."),
+    },
+    async ({ definitionId, buildRunId }) => {
+      try {
+        const client = makeClient();
+        const result = await inspectBuild({ definitionId, buildRunId }, client);
+        const { build } = result;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Build run ID: ${build.id ?? buildRunId}`,
+                `Status:       ${build.status}`,
+                build.error != null
+                  ? `Error:        ${typeof build.error === "object" ? JSON.stringify(build.error) : build.error}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            },
+          ],
+          isError: build.status === "failed" ? true : undefined,
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `build_status failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/run.ts
+++ b/packages/orchestration-mcp/src/tools/run.ts
@@ -1,0 +1,104 @@
+/**
+ * run tool — start a new execution of a server-side orchestration definition.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  run,
+  parseJsonInput,
+  readConfig,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_run",
+    "Start a new execution of a server-side orchestration definition. " +
+      "Returns an executionId that you can poll with orchestration_status.",
+    {
+      definitionId: z
+        .string()
+        .optional()
+        .describe(
+          "Server-side definition ID. " +
+            "If omitted, the definitionId is read from sapiom.json in projectDir.",
+        ),
+      projectDir: z
+        .string()
+        .optional()
+        .describe(
+          "Absolute path to the orchestration project directory. " +
+            "Used to read definitionId from sapiom.json when definitionId is not provided. " +
+            "Also informs host resolution from sapiom.json.",
+        ),
+      input: z
+        .string()
+        .optional()
+        .describe(
+          "JSON-encoded execution input. Omit for orchestrations with no required input.",
+        ),
+    },
+    async ({ definitionId, projectDir, input }) => {
+      try {
+        let resolvedDefinitionId = definitionId;
+        if (!resolvedDefinitionId) {
+          const cfg = projectDir ? readConfig(projectDir) : null;
+          if (!cfg?.definitionId) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text:
+                    "No definitionId provided and none found in sapiom.json. " +
+                    "Pass definitionId or projectDir pointing to a linked project.",
+                },
+              ],
+              isError: true,
+            };
+          }
+          resolvedDefinitionId = cfg.definitionId;
+        }
+
+        const parsedInput = input ? parseJsonInput(input) : undefined;
+        const client = makeClient(projectDir);
+        const result = await run(
+          { definitionId: resolvedDefinitionId, input: parsedInput },
+          client,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Execution started.`,
+                ``,
+                `Execution ID: ${result.executionId}`,
+                ``,
+                `Use orchestration_status to check progress.`,
+              ].join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `run failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/scaffold.ts
+++ b/packages/orchestration-mcp/src/tools/scaffold.ts
@@ -1,0 +1,86 @@
+/**
+ * scaffold tool — initialize a new orchestration project locally from a
+ * bundled template. Pure local operation; no network call required.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  scaffold,
+  resolveVersions,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_scaffold",
+    "Initialize a new Sapiom orchestration project in a local directory. " +
+      "Creates the project skeleton (index.ts, package.json, tsconfig, sapiom.json placeholder) " +
+      "from the default template. After scaffolding, open the project directory and write your " +
+      "workflow definition, then use orchestration_check to validate it locally before deploying.",
+    {
+      targetDir: z
+        .string()
+        .min(1)
+        .describe(
+          "Absolute path to the directory where the project should be created. " +
+            "Must not already contain an index.ts or package.json.",
+        ),
+      projectName: z
+        .string()
+        .min(1)
+        .describe(
+          "Human-readable name for the orchestration (e.g. 'invoice-processor'). " +
+            "Stamped into package.json and sapiom.json.",
+        ),
+      template: z
+        .string()
+        .optional()
+        .describe(
+          "Template name to scaffold from. Omit to use the default template.",
+        ),
+    },
+    async ({ targetDir, projectName, template }) => {
+      try {
+        const versions = await resolveVersions();
+        const result = await scaffold({
+          targetDir,
+          projectName,
+          template,
+          versions,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Orchestration project scaffolded successfully.`,
+                ``,
+                `Directory: ${result.targetDir}`,
+                `Template: ${result.template}`,
+                `Project name: ${result.projectName}`,
+                ``,
+                `Next steps:`,
+                `  1. Open ${result.targetDir}/index.ts and write your workflow definition.`,
+                `  2. Run orchestration_check to validate the definition locally.`,
+                `  3. Run orchestration_deploy to link and deploy to the server.`,
+              ].join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [{ type: "text" as const, text: `scaffold failed: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/signal.ts
+++ b/packages/orchestration-mcp/src/tools/signal.ts
@@ -1,0 +1,87 @@
+/**
+ * signal tool — deliver a named signal to a paused execution.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  signal,
+  parseSignalPayload,
+  OrchestrationError,
+} from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_signal",
+    "Resume a paused execution by delivering a named signal. " +
+      "An orchestration pauses at a 'waitForSignal' step until the matching signal arrives. " +
+      "Returns the number of executions that received the signal.",
+    {
+      executionId: z
+        .string()
+        .min(1)
+        .describe("ID of the execution to signal."),
+      name: z
+        .string()
+        .min(1)
+        .describe(
+          "Signal name that the orchestration is waiting on (e.g. 'approval', 'payment-confirmed').",
+        ),
+      correlationId: z
+        .string()
+        .min(1)
+        .describe(
+          "Correlation ID used to match the signal to the correct execution branch.",
+        ),
+      payload: z
+        .string()
+        .optional()
+        .describe(
+          "JSON-encoded payload to pass to the orchestration when resuming. " +
+            "Omit if the signal carries no data.",
+        ),
+    },
+    async ({ executionId, name, correlationId, payload }) => {
+      try {
+        const parsedPayload = payload ? parseSignalPayload(payload) : undefined;
+        const client = makeClient();
+        const result = await signal(
+          { executionId, name, correlationId, payload: parsedPayload },
+          client,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Signal delivered.`,
+                ``,
+                `Signal name:    ${name}`,
+                `Execution ID:   ${executionId}`,
+                `Matched:        ${result.matched} execution(s)`,
+              ].join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `signal failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/status.ts
+++ b/packages/orchestration-mcp/src/tools/status.ts
@@ -1,0 +1,87 @@
+/**
+ * status tool — fetch the current state and step records for a single execution.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { inspect, OrchestrationError } from "@sapiom/orchestration-core";
+import { makeClient } from "../config.js";
+
+export function register(server: McpServer): void {
+  server.tool(
+    "orchestration_status",
+    "Fetch the current status and step records for a running or completed execution. " +
+      "Returns the execution status, the current step (if running), any error, " +
+      "and a per-step breakdown.",
+    {
+      executionId: z
+        .string()
+        .min(1)
+        .describe("Execution ID returned by orchestration_run."),
+    },
+    async ({ executionId }) => {
+      try {
+        const client = makeClient();
+        const result = await inspect({ executionId }, client);
+        const { execution } = result;
+
+        const stepLines =
+          execution.steps && execution.steps.length > 0
+            ? [
+                ``,
+                `Steps:`,
+                ...execution.steps.map(
+                  (s) =>
+                    `  [${s.status}] ${s.stepName}` +
+                    (s.attempt > 1 ? ` (attempt ${s.attempt})` : "") +
+                    (s.error?.message ? ` — ${s.error.message}` : ""),
+                ),
+              ]
+            : [];
+
+        const errorLine =
+          execution.error != null
+            ? [
+                ``,
+                `Error: ${typeof execution.error === "object" ? JSON.stringify(execution.error) : execution.error}`,
+              ]
+            : [];
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                `Execution ID: ${execution.id}`,
+                `Status:       ${execution.status}`,
+                execution.currentStep
+                  ? `Current step: ${execution.currentStep}`
+                  : null,
+                ...errorLine,
+                ...stepLines,
+              ]
+                .filter((l) => l !== null)
+                .join("\n"),
+            },
+          ],
+        };
+      } catch (err) {
+        const message =
+          err instanceof OrchestrationError
+            ? `${err.message}${err.hint ? `\nHint: ${err.hint}` : ""}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `status failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/orchestration-mcp/src/tools/tools.test.ts
+++ b/packages/orchestration-mcp/src/tools/tools.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Unit tests for orchestration MCP tool registration.
+ *
+ * Strategy: mock @sapiom/orchestration-core functions and verify that each
+ * tool (a) registers under the correct name, (b) calls the right core function,
+ * and (c) serializes the result into the expected text shape.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// ── Mock core ─────────────────────────────────────────────────────────────────
+
+vi.mock("@sapiom/orchestration-core", () => ({
+  scaffold: vi.fn(),
+  resolveVersions: vi.fn(),
+  check: vi.fn(),
+  link: vi.fn(),
+  deploy: vi.fn(),
+  run: vi.fn(),
+  parseJsonInput: vi.fn((s: string) => JSON.parse(s)),
+  inspect: vi.fn(),
+  listExecutions: vi.fn(),
+  inspectBuild: vi.fn(),
+  signal: vi.fn(),
+  parseSignalPayload: vi.fn((s: string) => JSON.parse(s)),
+  readConfig: vi.fn(),
+  writeConfig: vi.fn(),
+  createClient: vi.fn(),
+  OrchestrationError: class OrchestrationError extends Error {
+    code: string;
+    hint?: string;
+    constructor(opts: { code: string; message: string; hint?: string }) {
+      super(opts.message);
+      this.code = opts.code;
+      this.hint = opts.hint;
+    }
+  },
+}));
+
+// Mock config so we don't read real ~/.sapiom files
+vi.mock("../config.js", () => ({
+  makeClient: vi.fn(() => ({})),
+  resolveHost: vi.fn(() => "https://api.sapiom.ai"),
+  resolveApiKey: vi.fn(() => "sk_test"),
+}));
+
+import {
+  scaffold,
+  resolveVersions,
+  check,
+  link,
+  deploy,
+  run,
+  inspect,
+  listExecutions,
+  inspectBuild,
+  signal,
+  readConfig,
+  writeConfig,
+} from "@sapiom/orchestration-core";
+
+import { register as registerScaffold } from "./scaffold.js";
+import { register as registerCheck } from "./check.js";
+import { register as registerLink } from "./link.js";
+import { register as registerDeploy } from "./deploy.js";
+import { register as registerRun } from "./run.js";
+import { register as registerStatus } from "./status.js";
+import { register as registerLogs } from "./logs.js";
+import { register as registerSignal } from "./signal.js";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+function createMockServer(): {
+  server: McpServer;
+  handlers: Map<string, ToolHandler>;
+} {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: vi.fn(
+      (_name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+        handlers.set(_name, handler);
+      },
+    ),
+  } as unknown as McpServer;
+  return { server, handlers };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── scaffold ──────────────────────────────────────────────────────────────────
+
+describe("orchestration_scaffold", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerScaffold(server);
+    expect(handlers.has("orchestration_scaffold")).toBe(true);
+  });
+
+  it("calls scaffold with resolved versions and returns success text", async () => {
+    const { server, handlers } = createMockServer();
+    registerScaffold(server);
+
+    vi.mocked(resolveVersions).mockResolvedValue({
+      orchestration: "0.1.0",
+      tools: "0.1.0",
+      cli: "0.1.0",
+    });
+    vi.mocked(scaffold).mockResolvedValue({
+      targetDir: "/tmp/my-workflow",
+      template: "default",
+      projectName: "my-workflow",
+    });
+
+    const result = await handlers.get("orchestration_scaffold")!({
+      targetDir: "/tmp/my-workflow",
+      projectName: "my-workflow",
+    });
+
+    expect(scaffold).toHaveBeenCalledWith({
+      targetDir: "/tmp/my-workflow",
+      projectName: "my-workflow",
+      template: undefined,
+      versions: { orchestration: "0.1.0", tools: "0.1.0", cli: "0.1.0" },
+    });
+    expect(result.content[0].text).toContain("scaffolded successfully");
+    expect(result.content[0].text).toContain("/tmp/my-workflow");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns isError on failure", async () => {
+    const { server, handlers } = createMockServer();
+    registerScaffold(server);
+
+    vi.mocked(resolveVersions).mockResolvedValue({
+      orchestration: "0.1.0",
+      tools: "0.1.0",
+      cli: "0.1.0",
+    });
+    vi.mocked(scaffold).mockRejectedValue(new Error("Directory not empty"));
+
+    const result = await handlers.get("orchestration_scaffold")!({
+      targetDir: "/tmp/my-workflow",
+      projectName: "my-workflow",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Directory not empty");
+  });
+});
+
+// ── check ─────────────────────────────────────────────────────────────────────
+
+describe("orchestration_check", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerCheck(server);
+    expect(handlers.has("orchestration_check")).toBe(true);
+  });
+
+  it("calls check and returns step count", async () => {
+    const { server, handlers } = createMockServer();
+    registerCheck(server);
+
+    vi.mocked(check).mockResolvedValue({
+      name: "my-workflow",
+      stepCount: 3,
+      warnings: [],
+      manifest: {},
+    });
+
+    const result = await handlers.get("orchestration_check")!({
+      sourceDir: "/tmp/my-workflow",
+    });
+
+    expect(check).toHaveBeenCalledWith({ sourceDir: "/tmp/my-workflow" });
+    expect(result.content[0].text).toContain("validation passed");
+    expect(result.content[0].text).toContain("Steps: 3");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("includes warnings in output", async () => {
+    const { server, handlers } = createMockServer();
+    registerCheck(server);
+
+    vi.mocked(check).mockResolvedValue({
+      name: "my-workflow",
+      stepCount: 1,
+      warnings: ["Step 'slow' has no timeout"],
+      manifest: {},
+    });
+
+    const result = await handlers.get("orchestration_check")!({
+      sourceDir: "/tmp/my-workflow",
+    });
+
+    expect(result.content[0].text).toContain("Step 'slow' has no timeout");
+  });
+});
+
+// ── link ──────────────────────────────────────────────────────────────────────
+
+describe("orchestration_link", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerLink(server);
+    expect(handlers.has("orchestration_link")).toBe(true);
+  });
+
+  it("calls link, writes config, and returns definition id", async () => {
+    const { server, handlers } = createMockServer();
+    registerLink(server);
+
+    vi.mocked(link).mockResolvedValue({
+      definitionId: "def-123",
+      name: "my-workflow",
+    });
+    vi.mocked(readConfig).mockReturnValue(null);
+
+    const result = await handlers.get("orchestration_link")!({
+      projectDir: "/tmp/my-workflow",
+      name: "my-workflow",
+    });
+
+    expect(link).toHaveBeenCalledWith(
+      { name: "my-workflow", create: undefined },
+      expect.anything(),
+    );
+    expect(writeConfig).toHaveBeenCalledWith("/tmp/my-workflow", {
+      definitionId: "def-123",
+      name: "my-workflow",
+    });
+    expect(result.content[0].text).toContain("def-123");
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ── deploy ────────────────────────────────────────────────────────────────────
+
+describe("orchestration_deploy", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerDeploy(server);
+    expect(handlers.has("orchestration_deploy")).toBe(true);
+  });
+
+  it("calls deploy and returns build status", async () => {
+    const { server, handlers } = createMockServer();
+    registerDeploy(server);
+
+    vi.mocked(readConfig).mockReturnValue({
+      definitionId: "def-123",
+      name: "my-workflow",
+    });
+    vi.mocked(deploy).mockResolvedValue({
+      definitionId: "def-123",
+      buildRunId: "build-456",
+      status: "ready",
+    });
+
+    const result = await handlers.get("orchestration_deploy")!({
+      projectDir: "/tmp/my-workflow",
+    });
+
+    expect(deploy).toHaveBeenCalledWith(
+      { projectDir: "/tmp/my-workflow", definitionId: "def-123", branch: undefined },
+      expect.anything(),
+    );
+    expect(result.content[0].text).toContain("ready");
+    expect(result.content[0].text).toContain("build-456");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns error when project is not linked", async () => {
+    const { server, handlers } = createMockServer();
+    registerDeploy(server);
+
+    vi.mocked(readConfig).mockReturnValue(null);
+
+    const result = await handlers.get("orchestration_deploy")!({
+      projectDir: "/tmp/my-workflow",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("not linked");
+  });
+});
+
+// ── run ───────────────────────────────────────────────────────────────────────
+
+describe("orchestration_run", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerRun(server);
+    expect(handlers.has("orchestration_run")).toBe(true);
+  });
+
+  it("calls run with definitionId and returns executionId", async () => {
+    const { server, handlers } = createMockServer();
+    registerRun(server);
+
+    vi.mocked(run).mockResolvedValue({
+      executionId: "exec-789",
+      raw: {},
+    });
+
+    const result = await handlers.get("orchestration_run")!({
+      definitionId: "def-123",
+    });
+
+    expect(run).toHaveBeenCalledWith(
+      { definitionId: "def-123", input: undefined },
+      expect.anything(),
+    );
+    expect(result.content[0].text).toContain("exec-789");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("reads definitionId from sapiom.json when not provided", async () => {
+    const { server, handlers } = createMockServer();
+    registerRun(server);
+
+    vi.mocked(readConfig).mockReturnValue({
+      definitionId: "def-from-config",
+      name: "my-workflow",
+    });
+    vi.mocked(run).mockResolvedValue({ executionId: "exec-999", raw: {} });
+
+    const result = await handlers.get("orchestration_run")!({
+      projectDir: "/tmp/my-workflow",
+    });
+
+    expect(run).toHaveBeenCalledWith(
+      { definitionId: "def-from-config", input: undefined },
+      expect.anything(),
+    );
+    expect(result.content[0].text).toContain("exec-999");
+  });
+});
+
+// ── status ────────────────────────────────────────────────────────────────────
+
+describe("orchestration_status", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerStatus(server);
+    expect(handlers.has("orchestration_status")).toBe(true);
+  });
+
+  it("calls inspect and formats execution status", async () => {
+    const { server, handlers } = createMockServer();
+    registerStatus(server);
+
+    vi.mocked(inspect).mockResolvedValue({
+      execution: {
+        id: "exec-789",
+        status: "running",
+        currentStep: "step-2",
+        steps: [
+          { stepName: "step-1", attempt: 1, status: "completed" },
+          { stepName: "step-2", attempt: 1, status: "running" },
+        ],
+      },
+    });
+
+    const result = await handlers.get("orchestration_status")!({
+      executionId: "exec-789",
+    });
+
+    expect(inspect).toHaveBeenCalledWith({ executionId: "exec-789" }, expect.anything());
+    expect(result.content[0].text).toContain("exec-789");
+    expect(result.content[0].text).toContain("running");
+    expect(result.content[0].text).toContain("step-2");
+  });
+});
+
+// ── logs ──────────────────────────────────────────────────────────────────────
+
+describe("orchestration_logs and orchestration_build_status", () => {
+  it("registers both tools", () => {
+    const { server, handlers } = createMockServer();
+    registerLogs(server);
+    expect(handlers.has("orchestration_logs")).toBe(true);
+    expect(handlers.has("orchestration_build_status")).toBe(true);
+  });
+
+  it("calls listExecutions and formats list", async () => {
+    const { server, handlers } = createMockServer();
+    registerLogs(server);
+
+    vi.mocked(listExecutions).mockResolvedValue({
+      executions: [
+        { id: "exec-1", status: "completed" },
+        { id: "exec-2", status: "running", currentStep: "step-1" },
+      ],
+    });
+
+    const result = await handlers.get("orchestration_logs")!({});
+
+    expect(listExecutions).toHaveBeenCalledWith(expect.anything());
+    expect(result.content[0].text).toContain("exec-1");
+    expect(result.content[0].text).toContain("exec-2");
+    expect(result.content[0].text).toContain("step-1");
+  });
+
+  it("calls inspectBuild and returns build status", async () => {
+    const { server, handlers } = createMockServer();
+    registerLogs(server);
+
+    vi.mocked(inspectBuild).mockResolvedValue({
+      build: { id: "build-456", status: "ready" },
+    });
+
+    const result = await handlers.get("orchestration_build_status")!({
+      definitionId: "def-123",
+      buildRunId: "build-456",
+    });
+
+    expect(inspectBuild).toHaveBeenCalledWith(
+      { definitionId: "def-123", buildRunId: "build-456" },
+      expect.anything(),
+    );
+    expect(result.content[0].text).toContain("ready");
+  });
+});
+
+// ── signal ────────────────────────────────────────────────────────────────────
+
+describe("orchestration_signal", () => {
+  it("registers the tool", () => {
+    const { server, handlers } = createMockServer();
+    registerSignal(server);
+    expect(handlers.has("orchestration_signal")).toBe(true);
+  });
+
+  it("calls signal and returns matched count", async () => {
+    const { server, handlers } = createMockServer();
+    registerSignal(server);
+
+    vi.mocked(signal).mockResolvedValue({ matched: 1 });
+
+    const result = await handlers.get("orchestration_signal")!({
+      executionId: "exec-789",
+      name: "approval",
+      correlationId: "corr-abc",
+    });
+
+    expect(signal).toHaveBeenCalledWith(
+      {
+        executionId: "exec-789",
+        name: "approval",
+        correlationId: "corr-abc",
+        payload: undefined,
+      },
+      expect.anything(),
+    );
+    expect(result.content[0].text).toContain("Signal delivered");
+    expect(result.content[0].text).toContain("1 execution(s)");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("validates the input schema: correlationId is required", async () => {
+    // Schema validation happens before the handler; here we just confirm the
+    // handler receives and forwards correlationId when present
+    const { server, handlers } = createMockServer();
+    registerSignal(server);
+
+    vi.mocked(signal).mockResolvedValue({ matched: 1 });
+
+    const result = await handlers.get("orchestration_signal")!({
+      executionId: "exec-789",
+      name: "approval",
+      correlationId: "corr-xyz",
+      payload: '{"approved":true}',
+    });
+
+    expect(result.content[0].text).toContain("Signal delivered");
+  });
+});

--- a/packages/orchestration-mcp/src/tools/tools.test.ts
+++ b/packages/orchestration-mcp/src/tools/tools.test.ts
@@ -109,6 +109,7 @@ describe("orchestration_scaffold", () => {
     vi.mocked(resolveVersions).mockResolvedValue({
       orchestration: "0.1.0",
       tools: "0.1.0",
+      zod: "3.25.0",
       cli: "0.1.0",
     });
     vi.mocked(scaffold).mockResolvedValue({
@@ -126,7 +127,7 @@ describe("orchestration_scaffold", () => {
       targetDir: "/tmp/my-workflow",
       projectName: "my-workflow",
       template: undefined,
-      versions: { orchestration: "0.1.0", tools: "0.1.0", cli: "0.1.0" },
+      versions: { orchestration: "0.1.0", tools: "0.1.0", zod: "3.25.0", cli: "0.1.0" },
     });
     expect(result.content[0].text).toContain("scaffolded successfully");
     expect(result.content[0].text).toContain("/tmp/my-workflow");
@@ -140,6 +141,7 @@ describe("orchestration_scaffold", () => {
     vi.mocked(resolveVersions).mockResolvedValue({
       orchestration: "0.1.0",
       tools: "0.1.0",
+      zod: "3.25.0",
       cli: "0.1.0",
     });
     vi.mocked(scaffold).mockRejectedValue(new Error("Directory not empty"));

--- a/packages/orchestration-mcp/tsconfig.build.json
+++ b/packages/orchestration-mcp/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/orchestration-mcp/tsconfig.json
+++ b/packages/orchestration-mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/orchestration-mcp/vitest.config.ts
+++ b/packages/orchestration-mcp/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,40 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/orchestration-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.26.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@sapiom/orchestration-core':
+        specifier: workspace:^
+        version: link:../orchestration-core
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      prettier:
+        specifier: ^3.2.5
+        version: 3.8.4
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/node@20.19.43)
+
   packages/sandbox:
     dependencies:
       '@sapiom/fetch':


### PR DESCRIPTION
## Summary

- Adds a new package `@sapiom/orchestration-mcp` — a stdio MCP server that wraps `@sapiom/orchestration-core` as typed MCP tools
- An MCP client (e.g. Claude Code) can scaffold, validate, link, deploy, run, inspect, and signal orchestrations without leaving the editor
- Host and API key resolution mirrors the CLI exactly: env vars win, then `~/.sapiom/config.json`, then `sapiom.json`, then production default — credentials from `sapiom login` are shared transparently

## Tools exposed

| Tool | Maps to core function | Network? |
|---|---|---|
| `orchestration_scaffold` | `scaffold` + `resolveVersions` | No |
| `orchestration_check` | `check` | No |
| `orchestration_link` | `link` + `writeConfig` | Yes |
| `orchestration_deploy` | `deploy` | Yes |
| `orchestration_run` | `run` | Yes |
| `orchestration_status` | `inspect` | Yes |
| `orchestration_logs` | `listExecutions` | Yes |
| `orchestration_build_status` | `inspectBuild` | Yes |
| `orchestration_signal` | `signal` | Yes |

## Config sharing

`src/config.ts` implements `resolveHost` and `resolveApiKey` following the same precedence order as the CLI (`SAPIOM_HOST` env > `SAPIOM_TARGET` env > `~/.sapiom/config.json` > `sapiom.json` > prod default; `SAPIOM_API_KEY` env > `~/.sapiom/credentials.json` default profile). The CLI helper functions live in `@sapiom/cli` — importing that package here would create a circular dependency, so we replicate only the stateless resolution logic while pointing at the same file paths.

## Tests

- 22 tool unit tests covering registration, core-function delegation, and result serialization for all 9 tools
- 7 config unit tests covering host and API key resolution paths
- 29 tests total, all passing

## Test plan

- [x] `pnpm --filter @sapiom/orchestration-mcp build` — passes
- [x] `pnpm --filter @sapiom/orchestration-mcp test` — 29/29 pass
- [x] `pnpm --filter @sapiom/orchestration-mcp lint` — clean

Generated with [Claude Code](https://claude.com/claude-code)