### PR TITLE
publish changes for local DX

### DIFF
--- a/.changeset/local-runner-dispatch-pause.md
+++ b/.changeset/local-runner-dispatch-pause.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/tools": minor
+"@sapiom/orchestration-core": minor
+"@sapiom/mcp": patch
+---
+
+Make the local development loop (`run_local`) production-faithful and trustworthy for the dispatch/pause pattern (`agent.coding.launch` + `pauseUntilSignal`).
+
+- Stub capability handles now survive JSON serialization, so a paused/resumed coding workflow runs end-to-end locally instead of failing with an opaque `'sandbox.toJSON' is not a method or field` error.
+- The payload a paused step resumes with is delivered as plain JSON — the same shape production sends over the wire — so authors re-attach handles by name (`sandboxes.attach(...)`) locally exactly as they would in prod.
+- `@sapiom/tools` exports `CodingResultPayload`: the shape a step resumed from `pauseUntilSignal(codingHandle, …)` receives, so resumed steps can be annotated instead of hand-rolling the type.
+- Stubbing a handle-returning capability with plain JSON no longer strips the handle's instance methods (e.g. `repo.pushFromSandbox`), and `repositories.list` stubs are coerced and shape-checked.
+- A dispatched `launch()` accepts the `agent.coding.launch` stub key as well as the shared `agent.coding.run` (ordered candidate resolution), so the stub key matching the call the author wrote takes effect.
+- `run_local` now reports `unusedStubs` (a supplied key that matched no call) and `stubWarnings` (a key that matched but carried the wrong shape), surfacing stubs that silently didn't take effect; the MCP `run_local` also serializes its result defensively.
+- New `coding-pause` scaffold template for the launch + pause + resume pattern, and AGENTS docs documenting the resume-input contract, list stub item shape, failure-branch stubbing, and step determinism under replay.


### PR DESCRIPTION
This pull request focuses on making the local development workflow (`run_local`) more closely match production behavior for the dispatch/pause pattern used in coding agents. The changes improve the reliability and accuracy of local testing, especially when using `agent.coding.launch` and `pauseUntilSignal`. Key enhancements include better handle serialization, improved stub matching, and new documentation and templates for the pause/resume workflow.

Improvements to local development and stubbing:

* Stub capability handles now persist through JSON serialization, enabling end-to-end local runs of paused/resumed coding workflows without serialization errors.
* The payload for resumed steps is now plain JSON, matching production, so authors can re-attach handles by name locally as in production.
* Stubbing a handle-returning capability with plain JSON no longer strips instance methods, and `repositories.list` stubs are now coerced and shape-checked.
* Dispatched `launch()` now accepts both `agent.coding.launch` and `agent.coding.run` stub keys, improving stub matching to the author’s code.
* `run_local` now reports `unusedStubs` and `stubWarnings` to surface ineffective stubs, and the MCP `run_local` serializes its result defensively.

Developer experience and documentation:

* `@sapiom/tools` exports