### PR TITLE
docs: fix PUBLISHING.md for OIDC autopublish + make Publish failures legible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,12 +57,23 @@ jobs:
       - name: Publish to npm (OIDC trusted publishing — no token)
         id: publish
         run: |
-          OUTPUT=$(pnpm changeset publish 2>&1)
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "@sapiom/mcp@"; then
+          # Stream output live AND capture it. `set +e` + PIPESTATUS so a failing
+          # `changeset publish` doesn't kill the step before we've logged its
+          # output and recorded the real exit code — the old `OUTPUT=$(... 2>&1)`
+          # form died at the assignment under `set -e`, hiding the actual error
+          # (e.g. an E404 from a package with no trusted publisher configured).
+          set +e
+          pnpm changeset publish 2>&1 | tee publish-output.txt
+          STATUS=${PIPESTATUS[0]}
+          set -e
+          if grep -q "@sapiom/mcp@" publish-output.txt; then
             echo "mcp-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mcp-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::changeset publish failed (exit $STATUS) — see output above. A common cause is a new package missing its per-package Trusted Publisher on npmjs.com (E404)."
+            exit "$STATUS"
           fi
 
       # --- MCP registry publish (unchanged; already OIDC via github-oidc) ---

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,106 +1,141 @@
 # Publishing
 
-> **Scope:** Right now only **`@sapiom/sandbox`** is actively maintained and
-> published. The other packages are not in use. This is a **temporary manual
-> process** until we have a universal release fix (see
-> [Reviving automation](#reviving-automated-publishing-future)).
+Publishing is **automated**. The `Publish` workflow
+(`.github/workflows/publish.yml`) runs on every push to `main` and publishes to
+npm via **OIDC Trusted Publishing** — no long-lived `NPM_TOKEN`, no interactive
+2FA in CI. You normally never run a publish command by hand.
 
-## Why publishing is manual
+The one exception is the **first-ever publish of a brand-new package**, which
+CI cannot do (see [Bootstrapping a new package](#bootstrapping-a-new-package)).
 
-The npm `@sapiom` org requires **two-factor auth to publish**. CI can't perform
-2FA, so the `Publish` GitHub workflow is disabled (manual-dispatch only) and
-releases are published from a maintainer's machine with a one-time password.
+> The `@sapiom/langchain` and `@sapiom/langchain-classic` packages are
+> quarantined out of the workspace (see `pnpm-workspace.yaml`) and are not
+> published by this flow.
 
-## One-time setup (per maintainer)
+## The normal flow (automated)
 
-To publish you need **both** of these on your npm account
-(npmjs.com → Account → Two-Factor Authentication):
+1. **In your change PR, add a changeset** describing the bump:
+   ```bash
+   pnpm changeset        # pick package(s) + bump type, write summary
+   ```
+   Commit it and merge the PR.
+2. Merging to `main` makes the `Release PR` workflow open (or update) a
+   **"chore: version packages"** PR that applies the changeset: bumps
+   `package.json` versions, updates `CHANGELOG.md`, and deletes the changeset
+   file.
+3. **Merge that "version packages" PR.** The push to `main` triggers the
+   `Publish` workflow, which runs `pnpm changeset publish`. Because it goes
+   through pnpm it resolves `workspace:*` to real version ranges, and it only
+   publishes versions not already on npm — so it's a safe no-op on any push that
+   isn't a version bump.
 
-1. A **TOTP authenticator app** enrolled (Authy, 1Password, Google
-   Authenticator, …). A security key alone is **not** enough — it only works in
-   the browser, and the publish flow needs a typed 6-digit code.
-2. 2FA level set to **"Authorization and writes"** (not "Authorization only").
+That's it. npm generates provenance attestations automatically under trusted
+publishing.
 
-> Why both: `changeset publish` runs `npm profile get` and only asks for an OTP
-> when `tfa.mode === "auth-and-writes"`. If it's "authorization only", it
-> publishes **without** an OTP and npm rejects it with a confusing
-> `404`/`E401` — this is the failure we chased down. Passing `--otp=` explicitly
-> (below) sidesteps the detection entirely.
+### Prerequisites (already configured; here for reference)
 
-## Release steps
+- **A Trusted Publisher configured PER PACKAGE on npmjs.com**, pointing at repo
+  `sapiom/sapiom-js` and workflow file `publish.yml` (environment left blank). A
+  missing or mismatched trusted publisher is the usual cause of a publish
+  **E404** — and the reason a brand-new package needs a manual first publish.
+- Toolchain in the workflow: Node 24 and npm >= 11.5 (OIDC support) + pnpm 10+.
+  `packageManager` in the root `package.json` must stay in sync.
+- The job grants `id-token: write` so the runner can mint the short-lived OIDC
+  token npm trades for publish auth.
 
-### 1. Bump the version (normal changeset flow)
+## Bootstrapping a new package
 
-In your change PR, add a changeset and merge it:
+OIDC trusted publishing has a catch-22: you can't configure a trusted publisher
+for a package until the package exists on npm, but CI can only publish packages
+that already have one. So the **first** publish of a new package is manual;
+every publish after that is automated.
+
+Symptom you'll see if you skip this: the `Publish` job fails on the new package
+with an **E404**, *after* successfully publishing the already-configured ones
+(so the run is red but partially published).
+
+### 1. Make sure the version-bump flow has run
+
+The new package should already be versioned on `main` (its changeset merged and
+the "version packages" PR merged), so its `package.json` has the version you
+want to ship and `dist/` is buildable. Be on the merged commit:
 
 ```bash
-pnpm changeset        # pick @sapiom/sandbox + bump type, write summary
-```
-
-Merging to `main` opens a **"chore: version packages"** PR that bumps
-`package.json` + updates the changelog. **Merge that PR** so `main` has the new
-version.
-
-### 2. Publish
-
-```bash
-git checkout main && git pull              # be on the merged version bump
+git checkout main && git pull
 pnpm install --frozen-lockfile
 pnpm build
-pnpm changeset publish --otp=<6-digit code>
 ```
 
-`changeset publish` publishes via `pnpm`, so it **resolves `workspace:*`** to a
-real version range, and only publishes packages whose version isn't already on
-npm. The `--otp` code authenticates the publish — grab a **fresh** code right
-before running (they rotate every ~30s); if it expires, changeset re-prompts.
+### 2. Pack with pnpm, then publish the tarball
 
-> Running `pnpm release` (build + `changeset publish`) also works and will
-> **interactively prompt** `Enter one-time password:` — but only if your 2FA
-> level is "auth-and-writes". The explicit `--otp=` form above is the reliable
-> one and doesn't depend on that detection.
-
-### 3. Verify
+**Always pack with `pnpm`** — it rewrites `workspace:*` deps to real version
+ranges in the tarball. A bare `npm publish` from source does **not**, and ships
+an uninstallable package (this is what broke `@sapiom/sandbox@0.8.1`).
 
 ```bash
-npm view @sapiom/sandbox@<version> dependencies   # @sapiom/fetch must be a real version, NOT workspace:*
-npm view @sapiom/sandbox dist-tags                # latest -> <version>
-npm install @sapiom/sandbox@<version>             # clean install must resolve (no EUNSUPPORTEDPROTOCOL)
+cd packages/<new-package>
+pnpm pack                         # produces sapiom-<name>-<version>.tgz with deps resolved
+npm publish sapiom-<name>-<version>.tgz --access public
 ```
 
-### 4. If a broken version slipped out
+Publish in **dependency order** if several new packages depend on each other
+(a dependency must be on npm before the package that needs it is installable).
+
+#### Authenticating the manual publish
+
+The `@sapiom` org requires 2FA to publish. Pick whichever you have:
+
+- **Security key only (no authenticator app):** run `npm publish` **without**
+  `--otp`. npm prints a browser link (`Authenticate your account at: …`);
+  open it and approve with your security key. The `--otp=` flag does **not**
+  apply — you have no way to type a TOTP code.
+- **TOTP authenticator app (Authy/1Password/etc.):** pass a fresh 6-digit code
+  with `--otp=<code>` (they rotate ~30s; if it expires, npm re-prompts).
+
+> A successful publish prints `+ @sapiom/<name>@<version>`. In the npm debug log
+> the authoritative signal is `http fetch PUT 200 …/@sapiom%2f<name>`. A
+> brand-new package can take **several minutes** to become readable on the
+> public registry (`npm view` / a registry GET returns 404 in the meantime) even
+> though the `PUT 200` means it's committed — that read lag is normal and not a
+> failure.
+
+### 3. Configure the Trusted Publisher (so CI takes over)
+
+Now that the package exists, on npmjs.com → the package → **Settings → Trusted
+Publisher → Add**:
+
+- Provider: **GitHub Actions**
+- Repository: `sapiom/sapiom-js`
+- Workflow filename: `publish.yml`
+- Environment: *(leave blank)*
+
+From here on, the package publishes automatically via the normal flow.
+
+### 4. Verify
+
+```bash
+npm view @sapiom/<name>@<version> dependencies   # @sapiom/* deps must be real ranges, NOT workspace:*
+npm view @sapiom/<name> dist-tags                # latest -> <version>
+
+# clean-room install (the real test — catches unresolved workspace deps):
+mkdir /tmp/itest && cd /tmp/itest && npm init -y >/dev/null
+npm install @sapiom/<name>@<version>             # must resolve with no EUNSUPPORTEDPROTOCOL / UNMET
+```
+
+## If a broken version slipped out
 
 npm versions are immutable and unpublishing locks the number for 24h, so the fix
 is to publish the next patch correctly and deprecate the bad one:
 
 ```bash
-npm deprecate @sapiom/sandbox@<bad-version> "Broken: unresolved workspace dependency. Use <good-version>+"
+npm deprecate @sapiom/<name>@<bad-version> "Broken: unresolved workspace dependency. Use <good-version>+"
 ```
 
-## Fallback: publishing with only a security key
+## Manually re-running the Publish workflow
 
-If you can't add an authenticator app and only have a security key, you can't
-produce a typed OTP. Pack with pnpm (resolves `workspace:*`) and publish the
-prebuilt tarball with an **interactive** `npm publish`, which opens the browser
-2FA flow:
+Safe at any time — `changeset publish` only ships versions not already on npm,
+so a re-run is a no-op for everything currently published:
 
 ```bash
-cd packages/sandbox
-pnpm pack                                  # rewrites workspace:* -> real version
-npm publish sapiom-sandbox-<version>.tgz --access public
-# ^ opens a browser link for 2FA — approve with your security key
+gh workflow run publish.yml --ref main
 ```
-
-Never use a bare `npm publish` from source — npm won't rewrite `workspace:*` and
-you'll ship a broken, uninstallable package (this is what happened to `0.8.1`).
-
-## Reviving automated publishing (future)
-
-Re-enable the `Publish` workflow's `push` trigger (currently `workflow_dispatch`
-only) and give CI a credential that doesn't need interactive 2FA — either:
-
-- a **granular access token with "Bypass two-factor authentication"** enabled,
-  scoped to `@sapiom` read+write, stored as the `NPM_TOKEN` secret; or
-- **OIDC trusted publishing** (no token): configure the package's trusted
-  publisher on npmjs.com and publish from CI with a modern npm. The workflow
-  already requests `id-token: write`.


### PR DESCRIPTION
## What

Two related fixes uncovered while bootstrapping three new packages that CI couldn't publish.

### 1. Rewrite `PUBLISHING.md` to match reality
The old doc described a **manual, `@sapiom/sandbox`-only, 2FA/OTP** process. That's no longer how it works. The new doc documents:
- **Automated OIDC trusted publishing** on push to `main` via the normal changeset → "version packages" PR → merge flow (no `NPM_TOKEN`, no OTP in CI).
- The **new-package bootstrap** procedure — the catch-22 where OIDC can't do a package's *first* publish: `pnpm pack` → publish the tarball (security-key web-auth **or** TOTP `--otp`) → add a **per-package Trusted Publisher** on npmjs.com, in dependency order.
- The `PUT 200` (committed) vs. read-propagation-lag (transient 404) distinction, and a clean-room install check.

### 2. Make the `Publish` step show its errors
The publish step captured output into a var under `set -e`:
```bash
OUTPUT=$(pnpm changeset publish 2>&1)
echo "$OUTPUT"
```
On failure the script exited **at the assignment**, before `echo` — so the real error never reached the log. It now streams via `tee`, captures the true exit code from `PIPESTATUS`, still sets `mcp-changed`, and prints a hint pointing at the usual cause (a new package with no trusted publisher → E404).

## Why now
The `Publish` job had been **red on every push since Jun 21**: it published the packages that already had trusted publishers (`tools`, `orchestration`), then died with an invisible E404 on the first new one. `@sapiom/cli`, `@sapiom/orchestration-core`, and `@sapiom/orchestration-runtime` were silently never published. They've since been bootstrapped manually and verified installing cleanly from npm.

## Follow-up (not in this PR)
Add the per-package Trusted Publisher on npmjs.com for the three new packages so the next push goes green — documented in the new `PUBLISHING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYoBzvogzBW5GcpusgK2ne