### PR TITLE
SDK / DX improvements

### DIFF
--- a/.changeset/coding-result-execution-environment.md
+++ b/.changeset/coding-result-execution-environment.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/tools": minor
+"@sapiom/orchestration-core": patch
+---
+
+**BREAKING (`@sapiom/tools`):** align the coding-run resume payload with the shape a resumed step actually receives. `CodingResultPayload` now carries `executionEnvironment: { type, id } | null` instead of `sandbox: { name, workspaceRoot }`. Re-attach a resumed run's sandbox with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (for a `blaxel_sandbox`).
+
+Adds `codingResultSchema` (runtime validation of the resume payload), `toResumePayload`, `ExecutionEnvironmentRef`, and `EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX`. The stub client now emits the same payload shape a resumed step receives, so a step written against the local loop runs identically once deployed.
+
+The `coding-pause` template and its guidance are updated to the new shape.

--- a/.changeset/scaffold-git-init-and-inspect-wait.md
+++ b/.changeset/scaffold-git-init-and-inspect-wait.md
@@ -6,3 +6,5 @@
 `scaffold` now initializes a git repository with an initial commit, so a freshly scaffolded project is immediately deployable (deploy requires a repo with at least one commit). Best-effort: if `git` is unavailable the project is left uninitialized. `ScaffoldResult` gains `gitInitialized`.
 
 Adds `waitForExecution` (and `isExecutionTerminal`) to poll an execution until it reaches a terminal state, settles on a pause that needs a signal, or a wait budget elapses — so callers don't hand-roll a poll loop. The `sapiom_dev_orchestrations_inspect` MCP tool gains opt-in `wait` / `maxWaitSeconds` options that use it and return `done` / `waiting` / `hint`; a non-blocking inspect of a still-running execution now also hints to use `wait`.
+
+Fixes `sapiom_dev_orchestrations_link`: omitting `name` no longer sends an empty name (which the gateway rejected). It now defaults to the orchestration's name read from `index.ts` (matching `defineOrchestration({ name })`), and returns a clear error if no name is available.

--- a/.changeset/scaffold-git-init-and-inspect-wait.md
+++ b/.changeset/scaffold-git-init-and-inspect-wait.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/orchestration-core": minor
+"@sapiom/mcp": minor
+---
+
+`scaffold` now initializes a git repository with an initial commit, so a freshly scaffolded project is immediately deployable (deploy requires a repo with at least one commit). Best-effort: if `git` is unavailable the project is left uninitialized. `ScaffoldResult` gains `gitInitialized`.
+
+Adds `waitForExecution` (and `isExecutionTerminal`) to poll an execution until it reaches a terminal state, settles on a pause that needs a signal, or a wait budget elapses — so callers don't hand-roll a poll loop. The `sapiom_dev_orchestrations_inspect` MCP tool gains opt-in `wait` / `maxWaitSeconds` options that use it and return `done` / `waiting` / `hint`; a non-blocking inspect of a still-running execution now also hints to use `wait`.

--- a/packages/mcp/src/tools/orchestrations.ts
+++ b/packages/mcp/src/tools/orchestrations.ts
@@ -266,7 +266,9 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       name: z
         .string()
         .optional()
-        .describe("Orchestration name. Defaults to the directory name."),
+        .describe(
+          "Orchestration name (matches defineOrchestration({ name })). Defaults to the orchestration's name read from index.ts.",
+        ),
       create: z
         .boolean()
         .optional()
@@ -277,7 +279,27 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       if (!client) return NOT_AUTHED;
       try {
         const projectDir = dir ?? process.cwd();
-        const result = await link({ name: name ?? "", create }, client);
+        // Default the link name to the orchestration's own name (from index.ts)
+        // so the link matches what deploy ships — the directory name can drift
+        // from defineOrchestration({ name }).
+        let linkName = name;
+        if (!linkName) {
+          try {
+            linkName = (await check({ sourceDir: projectDir })).name;
+          } catch {
+            // Couldn't read the manifest — fall through to the explicit error.
+          }
+        }
+        if (!linkName) {
+          return fail(
+            new OrchestrationError({
+              code: "NAME_REQUIRED",
+              message: "No orchestration name to link.",
+              hint: "Pass name, or ensure index.ts bundles (run check) so the name can be read from defineOrchestration({ name }).",
+            }),
+          );
+        }
+        const result = await link({ name: linkName, create }, client);
         writeConfig(projectDir, {
           definitionId: result.definitionId,
           name: result.name,

--- a/packages/mcp/src/tools/orchestrations.ts
+++ b/packages/mcp/src/tools/orchestrations.ts
@@ -20,6 +20,7 @@ import {
   GatewayClient,
   inspect,
   inspectBuild,
+  isExecutionTerminal,
   link,
   listExecutions,
   OrchestrationError,
@@ -29,6 +30,7 @@ import {
   runLocalFromDir,
   scaffold,
   signal,
+  waitForExecution,
   writeConfig,
   type StubFile,
 } from "@sapiom/orchestration-core";
@@ -349,7 +351,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
 
   server.tool(
     "sapiom_dev_orchestrations_inspect",
-    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local.",
+    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
     {
       dir: z
         .string()
@@ -362,8 +364,20 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         .string()
         .optional()
         .describe("Build to inspect (requires a linked project)."),
+      wait: z
+        .boolean()
+        .optional()
+        .describe(
+          "When inspecting an executionId, block until it reaches a terminal state (or settles on a pause needing a signal) instead of returning the current snapshot. Lets the tool own the polling so you don't have to.",
+        ),
+      maxWaitSeconds: z
+        .number()
+        .optional()
+        .describe(
+          "Max seconds to wait when wait:true (default 45, capped at 55). On timeout it returns the latest snapshot with waiting:true — call again to keep waiting.",
+        ),
     },
-    async ({ dir, executionId, buildRunId }) => {
+    async ({ dir, executionId, buildRunId, wait, maxWaitSeconds }) => {
       const client = await gatewayClient(env);
       if (!client) return NOT_AUTHED;
       try {
@@ -376,7 +390,35 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
             ),
           );
         }
-        if (executionId) return ok(await inspect({ executionId }, client));
+        if (executionId) {
+          if (wait) {
+            const maxWaitMs =
+              Math.min(Math.max(maxWaitSeconds ?? 45, 1), 55) * 1000;
+            const { execution, reason, done } = await waitForExecution(
+              { executionId, maxWaitMs },
+              client,
+            );
+            const hint =
+              reason === "timeout"
+                ? "Still running after the wait window — call inspect again with wait:true to keep waiting."
+                : reason === "needs-signal"
+                  ? `Paused on signal '${execution.pausedSignalName ?? "?"}' — deliver it with sapiom_dev_orchestrations_signal to resume.`
+                  : undefined;
+            return ok({
+              execution,
+              done,
+              waiting: !done,
+              ...(hint ? { hint } : {}),
+            });
+          }
+          const { execution } = await inspect({ executionId }, client);
+          // Self-correcting nudge: on a non-terminal snapshot, point at wait:true
+          // so a caller reaches for the tool's loop instead of polling by hand.
+          const hint = isExecutionTerminal(execution.status)
+            ? undefined
+            : `Execution is '${execution.status}', not terminal — call inspect with wait:true to block until it finishes instead of polling manually.`;
+          return ok({ execution, ...(hint ? { hint } : {}) });
+        }
         return ok(await listExecutions(client));
       } catch (err) {
         return fail(err);

--- a/packages/orchestration-core/src/__tests__/scaffold.test.ts
+++ b/packages/orchestration-core/src/__tests__/scaffold.test.ts
@@ -4,16 +4,23 @@
  * These tests are fully local — no network calls. They use a temp directory
  * for the target so the filesystem is the only external dependency.
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { OrchestrationError } from '../errors';
-import { scaffold } from '../scaffold';
+import { OrchestrationError } from "../errors";
+import { scaffold } from "../scaffold";
 
 // Point template resolution at the bundled templates dir (two levels up from
 // src/), bypassing the dist/ path that TEMPLATES_DIR normally expects.
-const FIXTURE_TEMPLATES = path.resolve(__dirname, '..', '..', 'templates');
+const FIXTURE_TEMPLATES = path.resolve(__dirname, "..", "..", "templates");
 
 beforeEach(() => {
   process.env.SAPIOM_TEMPLATES_DIR = FIXTURE_TEMPLATES;
@@ -24,93 +31,132 @@ afterEach(() => {
 });
 
 function makeTmp(): string {
-  return mkdtempSync(path.join(tmpdir(), 'sapiom-scaffold-test-'));
+  return mkdtempSync(path.join(tmpdir(), "sapiom-scaffold-test-"));
 }
 
-describe('scaffold', () => {
-  it('creates the target directory and applies replacements', async () => {
+describe("scaffold", () => {
+  it("creates the target directory and applies replacements", async () => {
     const base = makeTmp();
-    const targetDir = path.join(base, 'my-orch');
+    const targetDir = path.join(base, "my-orch");
     try {
       const result = await scaffold({
         targetDir,
-        template: 'default',
-        projectName: 'my-orch',
-        versions: { orchestration: '1.0.0', tools: '1.0.0', zod: '3.0.0' },
+        template: "default",
+        projectName: "my-orch",
+        versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
       });
 
       expect(result.targetDir).toBe(targetDir);
-      expect(result.projectName).toBe('my-orch');
-      expect(result.template).toBe('default');
-      expect(existsSync(path.join(targetDir, 'index.ts'))).toBe(true);
+      expect(result.projectName).toBe("my-orch");
+      expect(result.template).toBe("default");
+      expect(existsSync(path.join(targetDir, "index.ts"))).toBe(true);
 
       // Replacements applied: __PROJECT_NAME__ → my-orch in package.json
-      const pkg = JSON.parse(readFileSync(path.join(targetDir, 'package.json'), 'utf8'));
-      expect(pkg.name).toBe('my-orch');
+      const pkg = JSON.parse(
+        readFileSync(path.join(targetDir, "package.json"), "utf8"),
+      );
+      expect(pkg.name).toBe("my-orch");
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
   });
 
-  it('defaults projectName to path.basename(targetDir)', async () => {
+  it("initializes a git repository with an initial commit (so the project is deployable)", async () => {
     const base = makeTmp();
-    const targetDir = path.join(base, 'auto-named');
+    const targetDir = path.join(base, "git-init");
     try {
       const result = await scaffold({
         targetDir,
-        versions: { orchestration: '1.0.0', tools: '1.0.0', zod: '3.0.0' },
+        versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
       });
-      expect(result.projectName).toBe('auto-named');
+
+      expect(result.gitInitialized).toBe(true);
+      expect(existsSync(path.join(targetDir, ".git"))).toBe(true);
+      // A commit exists — deploy's assertDeployable requires at least one.
+      const head = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: targetDir,
+        encoding: "utf8",
+      }).trim();
+      expect(head).toMatch(/^[0-9a-f]{7,}$/);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
   });
 
-  it('throws DIR_NOT_EMPTY when target exists and is non-empty', async () => {
+  it("defaults projectName to path.basename(targetDir)", async () => {
+    const base = makeTmp();
+    const targetDir = path.join(base, "auto-named");
+    try {
+      const result = await scaffold({
+        targetDir,
+        versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+      });
+      expect(result.projectName).toBe("auto-named");
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("throws DIR_NOT_EMPTY when target exists and is non-empty", async () => {
     const targetDir = makeTmp();
     // mkdtempSync creates a non-empty-ish dir — add a file to be sure
-    writeFileSync(path.join(targetDir, 'existing.txt'), 'x');
+    writeFileSync(path.join(targetDir, "existing.txt"), "x");
     try {
       await expect(
-        scaffold({ targetDir, versions: { orchestration: '1.0.0', tools: '1.0.0', zod: '3.0.0' } }),
-      ).rejects.toMatchObject({ code: 'DIR_NOT_EMPTY' });
+        scaffold({
+          targetDir,
+          versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+        }),
+      ).rejects.toMatchObject({ code: "DIR_NOT_EMPTY" });
     } finally {
       rmSync(targetDir, { recursive: true, force: true });
     }
   });
 
-  it('throws UNKNOWN_TEMPLATE for a non-existent template', async () => {
+  it("throws UNKNOWN_TEMPLATE for a non-existent template", async () => {
     const base = makeTmp();
-    const targetDir = path.join(base, 'no-template');
+    const targetDir = path.join(base, "no-template");
     try {
       await expect(
-        scaffold({ targetDir, template: 'does-not-exist', versions: { orchestration: '1.0.0', tools: '1.0.0', zod: '3.0.0' } }),
-      ).rejects.toMatchObject({ code: 'UNKNOWN_TEMPLATE' });
+        scaffold({
+          targetDir,
+          template: "does-not-exist",
+          versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+        }),
+      ).rejects.toMatchObject({ code: "UNKNOWN_TEMPLATE" });
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
   });
 
-  it('renames _gitignore to .gitignore', async () => {
+  it("renames _gitignore to .gitignore", async () => {
     const base = makeTmp();
-    const targetDir = path.join(base, 'dotfile-test');
+    const targetDir = path.join(base, "dotfile-test");
     try {
       await scaffold({
         targetDir,
-        versions: { orchestration: '1.0.0', tools: '1.0.0', zod: '3.0.0' },
+        versions: { orchestration: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
       });
-      expect(existsSync(path.join(targetDir, '.gitignore'))).toBe(true);
-      expect(existsSync(path.join(targetDir, '_gitignore'))).toBe(false);
+      expect(existsSync(path.join(targetDir, ".gitignore"))).toBe(true);
+      expect(existsSync(path.join(targetDir, "_gitignore"))).toBe(false);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
   });
 });
 
-describe('OrchestrationError', () => {
-  it('serialises to a StructuredError shape', () => {
-    const err = new OrchestrationError({ code: 'TEST', message: 'msg', hint: 'fix it' });
-    expect(err.toStructured()).toEqual({ code: 'TEST', message: 'msg', hint: 'fix it' });
-    expect(err.name).toBe('OrchestrationError');
+describe("OrchestrationError", () => {
+  it("serialises to a StructuredError shape", () => {
+    const err = new OrchestrationError({
+      code: "TEST",
+      message: "msg",
+      hint: "fix it",
+    });
+    expect(err.toStructured()).toEqual({
+      code: "TEST",
+      message: "msg",
+      hint: "fix it",
+    });
+    expect(err.name).toBe("OrchestrationError");
   });
 });

--- a/packages/orchestration-core/src/index.ts
+++ b/packages/orchestration-core/src/index.ts
@@ -12,39 +12,64 @@
  */
 
 // Errors
-export { OrchestrationError } from './errors.js';
-export type { StructuredError } from './errors.js';
+export { OrchestrationError } from "./errors.js";
+export type { StructuredError } from "./errors.js";
 
 // HTTP client factory
-export { GatewayClient, createClient, DEFAULT_WORKFLOWS_HOST } from './client.js';
-export type { ClientOptions, GatewayErrorBody } from './client.js';
+export {
+  GatewayClient,
+  createClient,
+  DEFAULT_WORKFLOWS_HOST,
+} from "./client.js";
+export type { ClientOptions, GatewayErrorBody } from "./client.js";
 
 // Config (sapiom.json)
-export { readConfig, requireConfig, writeConfig, CONFIG_FILE } from './config.js';
-export type { SapiomConfig } from './config.js';
+export {
+  readConfig,
+  requireConfig,
+  writeConfig,
+  CONFIG_FILE,
+} from "./config.js";
+export type { SapiomConfig } from "./config.js";
 
 // scaffold (local, no network)
-export { scaffold, resolveVersions, resolveTemplate, listTemplates, DEFAULT_TEMPLATE } from './scaffold.js';
-export type { ScaffoldOptions, ScaffoldResult, ResolvedVersions } from './scaffold.js';
+export {
+  scaffold,
+  resolveVersions,
+  resolveTemplate,
+  listTemplates,
+  DEFAULT_TEMPLATE,
+} from "./scaffold.js";
+export type {
+  ScaffoldOptions,
+  ScaffoldResult,
+  ResolvedVersions,
+} from "./scaffold.js";
 
 // check (local, no network)
-export { check } from './check.js';
-export type { CheckOptions, CheckResult } from './check.js';
+export { check } from "./check.js";
+export type { CheckOptions, CheckResult } from "./check.js";
 
 // link (networked)
-export { link } from './link.js';
-export type { LinkOptions, LinkResult, DefinitionSummary } from './link.js';
+export { link } from "./link.js";
+export type { LinkOptions, LinkResult, DefinitionSummary } from "./link.js";
 
 // deploy (networked)
-export { deploy } from './deploy.js';
-export type { DeployOptions, DeployResult } from './deploy.js';
+export { deploy } from "./deploy.js";
+export type { DeployOptions, DeployResult } from "./deploy.js";
 
 // run (networked)
-export { run, parseJsonInput } from './run.js';
-export type { RunOptions, RunResult } from './run.js';
+export { run, parseJsonInput } from "./run.js";
+export type { RunOptions, RunResult } from "./run.js";
 
 // inspect / logs (networked)
-export { inspect, listExecutions, inspectBuild } from './inspect.js';
+export {
+  inspect,
+  listExecutions,
+  inspectBuild,
+  waitForExecution,
+  isExecutionTerminal,
+} from "./inspect.js";
 export type {
   InspectOptions,
   InspectResult,
@@ -54,23 +79,30 @@ export type {
   ExecutionDetail,
   StepRecord,
   BuildDetail,
-} from './inspect.js';
+  WaitForExecutionOptions,
+  WaitForExecutionResult,
+  WaitStopReason,
+} from "./inspect.js";
 
 // signal (networked)
-export { signal, parseSignalPayload } from './signal.js';
-export type { SignalOptions, SignalResult } from './signal.js';
+export { signal, parseSignalPayload } from "./signal.js";
+export type { SignalOptions, SignalResult } from "./signal.js";
 
 // git helpers (used by deploy; exported for consumers that need them directly)
-export { assertDeployable, pushHead } from './git.js';
+export { assertDeployable, pushHead } from "./git.js";
 
 // local stub file model (per-step capability overrides for run_local)
-export { parseStubFile, STUB_FILE_VERSION } from './local/stubs.js';
-export type { StubFile, StepStubs, StubResponse } from './local/stubs.js';
+export { parseStubFile, STUB_FILE_VERSION } from "./local/stubs.js";
+export type { StubFile, StepStubs, StubResponse } from "./local/stubs.js";
 
 // local execution (runs step bodies in-process against stub capabilities)
-export { runLocal, runLocalFromDir, STUBS_FILE } from './local/run-local.js';
-export type { RunLocalOptions, LocalRunResult, LocalRunOutcome } from './local/run-local.js';
-export { loadDefinition } from './local/load.js';
-export type { LoadedDefinition } from './local/load.js';
-export { LocalStubDispatcher } from './local/dispatcher.js';
-export type { LocalStepTrace, LogEntry } from './local/dispatcher.js';
+export { runLocal, runLocalFromDir, STUBS_FILE } from "./local/run-local.js";
+export type {
+  RunLocalOptions,
+  LocalRunResult,
+  LocalRunOutcome,
+} from "./local/run-local.js";
+export { loadDefinition } from "./local/load.js";
+export type { LoadedDefinition } from "./local/load.js";
+export { LocalStubDispatcher } from "./local/dispatcher.js";
+export type { LocalStepTrace, LogEntry } from "./local/dispatcher.js";

--- a/packages/orchestration-core/src/inspect.spec.ts
+++ b/packages/orchestration-core/src/inspect.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * waitForExecution — the bounded poll loop the inspect tool uses so callers
+ * never hand-roll a sleep loop. Uses injected sleep/now for determinism.
+ */
+import type { GatewayClient } from "./client.js";
+import {
+  isExecutionTerminal,
+  waitForExecution,
+  type ExecutionDetail,
+} from "./inspect.js";
+
+/** A GatewayClient whose `get` returns the queued snapshots (last one repeats). */
+function fakeClient(snapshots: Partial<ExecutionDetail>[]): {
+  client: GatewayClient;
+  calls: () => number;
+} {
+  let i = 0;
+  const client = {
+    get: async () => {
+      const snap = snapshots[Math.min(i, snapshots.length - 1)];
+      i += 1;
+      return { id: "e1", status: "running", ...snap } as ExecutionDetail;
+    },
+  } as unknown as GatewayClient;
+  return { client, calls: () => i };
+}
+
+const noopSleep = () => Promise.resolve();
+
+describe("isExecutionTerminal", () => {
+  it("treats completed/failed as terminal and running/paused as not", () => {
+    expect(isExecutionTerminal("completed")).toBe(true);
+    expect(isExecutionTerminal("failed")).toBe(true);
+    expect(isExecutionTerminal("running")).toBe(false);
+    expect(isExecutionTerminal("paused")).toBe(false);
+  });
+});
+
+describe("waitForExecution", () => {
+  it("polls until a terminal status, then resolves done", async () => {
+    const { client, calls } = fakeClient([
+      { status: "running" },
+      { status: "running" },
+      { status: "completed" },
+    ]);
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0 },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+    expect(res.execution.status).toBe("completed");
+    expect(calls()).toBe(3);
+  });
+
+  it("keeps waiting through an auto-resuming (coding) pause", async () => {
+    const { client } = fakeClient([
+      { status: "paused", pausedSignalName: "agent.coding.result" },
+      { status: "completed" },
+    ]);
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0 },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+  });
+
+  it("returns needs-signal on a pause that won't auto-resume", async () => {
+    const { client, calls } = fakeClient([
+      { status: "paused", pausedSignalName: "await-approval" },
+    ]);
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0 },
+      client,
+    );
+
+    expect(res.reason).toBe("needs-signal");
+    expect(res.done).toBe(false);
+    expect(calls()).toBe(1); // returns immediately, no further polling
+  });
+
+  it("returns timeout (not done) when the budget elapses before terminal", async () => {
+    const { client } = fakeClient([{ status: "running" }]);
+    // now() advances 600ms per call; with a 1000ms budget the deadline passes
+    // after the first sleep.
+    let t = 0;
+    const now = () => {
+      const v = t;
+      t += 600;
+      return v;
+    };
+
+    const res = await waitForExecution(
+      { executionId: "e1", maxWaitMs: 1000, sleep: noopSleep, now },
+      client,
+    );
+
+    expect(res.reason).toBe("timeout");
+    expect(res.done).toBe(false);
+    expect(res.execution.status).toBe("running");
+  });
+});

--- a/packages/orchestration-core/src/inspect.ts
+++ b/packages/orchestration-core/src/inspect.ts
@@ -5,7 +5,7 @@
  * The function named `inspect` (vs `logs`) makes the intent clear for
  * programmatic consumers; the CLI alias these as "logs" on its command surface.
  */
-import { GatewayClient } from './client.js';
+import { GatewayClient } from "./client.js";
 
 export interface StepRecord {
   stepName: string;
@@ -18,6 +18,7 @@ export interface ExecutionDetail {
   id: string;
   status: string;
   currentStep?: string | null;
+  pausedSignalName?: string | null;
   error?: unknown;
   steps?: StepRecord[];
 }
@@ -43,9 +44,108 @@ export interface InspectResult {
  *
  * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
  */
-export async function inspect(opts: InspectOptions, client: GatewayClient): Promise<InspectResult> {
-  const execution = await client.get<ExecutionDetail>(`/executions/${opts.executionId}`);
+export async function inspect(
+  opts: InspectOptions,
+  client: GatewayClient,
+): Promise<InspectResult> {
+  const execution = await client.get<ExecutionDetail>(
+    `/executions/${opts.executionId}`,
+  );
   return { execution };
+}
+
+// ── Wait for an execution to settle ────────────────────────────────────────────
+
+/** Statuses an execution will not advance from. */
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "canceled",
+]);
+
+/** True when an execution has reached a state it won't advance from on its own. */
+export function isExecutionTerminal(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * Pause signals the engine resumes on its own (a dispatched capability reports
+ * completion via a callback), so a wait should keep polling through them.
+ * Mirrors `CODING_RESULT_SIGNAL` from `@sapiom/tools`; extend as more dispatched
+ * capabilities land.
+ */
+const AUTO_RESUME_PAUSE_SIGNALS = ["agent.coding.result"];
+
+export type WaitStopReason = "terminal" | "needs-signal" | "timeout";
+
+export interface WaitForExecutionOptions {
+  executionId: string;
+  /** Max wall-clock to poll before returning the latest snapshot. Default 45_000. */
+  maxWaitMs?: number;
+  /** First poll interval; backs off (×1.5, capped at 5s) between reads. Default 1_000. */
+  pollMs?: number;
+  /** Paused signals that auto-resume — keep waiting through them rather than returning. */
+  autoResumeSignals?: string[];
+  /** Injectable for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+export interface WaitForExecutionResult {
+  execution: ExecutionDetail;
+  /** Why polling stopped. */
+  reason: WaitStopReason;
+  /** True only when the execution reached a terminal status. */
+  done: boolean;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll an execution until it reaches a terminal status, settles on a pause that
+ * needs an external signal, or the wait budget elapses — so callers (and the
+ * tool that wraps this) never hand-roll a sleep loop and can't misjudge elapsed
+ * time. Reads at least once; returns the latest snapshot and why it stopped.
+ *
+ * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
+ */
+export async function waitForExecution(
+  opts: WaitForExecutionOptions,
+  client: GatewayClient,
+): Promise<WaitForExecutionResult> {
+  const maxWaitMs = opts.maxWaitMs ?? 45_000;
+  const autoResume = opts.autoResumeSignals ?? AUTO_RESUME_PAUSE_SIGNALS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const now = opts.now ?? Date.now;
+
+  const deadline = now() + maxWaitMs;
+  let interval = opts.pollMs ?? 1_000;
+
+  for (;;) {
+    const { execution } = await inspect(
+      { executionId: opts.executionId },
+      client,
+    );
+
+    if (isExecutionTerminal(execution.status)) {
+      return { execution, reason: "terminal", done: true };
+    }
+    if (execution.status === "paused") {
+      const signal = execution.pausedSignalName ?? null;
+      if (!signal || !autoResume.includes(signal)) {
+        // Won't progress on its own — an external signal is required.
+        return { execution, reason: "needs-signal", done: false };
+      }
+    }
+
+    const remaining = deadline - now();
+    if (remaining <= 0) return { execution, reason: "timeout", done: false };
+
+    await sleep(Math.min(interval, remaining));
+    interval = Math.min(interval * 1.5, 5_000);
+  }
 }
 
 // ── List recent executions ────────────────────────────────────────────────────
@@ -58,8 +158,10 @@ export interface ListExecutionsResult {
  * List recent executions (no filter — the gateway decides the page size and
  * ordering). Callers can pass a definitionId in opts if the gateway supports it.
  */
-export async function listExecutions(client: GatewayClient): Promise<ListExecutionsResult> {
-  const executions = await client.get<ExecutionDetail[]>('/executions');
+export async function listExecutions(
+  client: GatewayClient,
+): Promise<ListExecutionsResult> {
+  const executions = await client.get<ExecutionDetail[]>("/executions");
   return { executions };
 }
 
@@ -79,7 +181,10 @@ export interface InspectBuildResult {
  *
  * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
  */
-export async function inspectBuild(opts: InspectBuildOptions, client: GatewayClient): Promise<InspectBuildResult> {
+export async function inspectBuild(
+  opts: InspectBuildOptions,
+  client: GatewayClient,
+): Promise<InspectBuildResult> {
   const build = await client.get<BuildDetail>(
     `/definitions/${opts.definitionId}/builds/${opts.buildRunId}`,
   );

--- a/packages/orchestration-core/src/local/run-local.spec.ts
+++ b/packages/orchestration-core/src/local/run-local.spec.ts
@@ -222,10 +222,9 @@ describe("runLocal", () => {
     expect(result.steps.map((s) => s.step)).toEqual(["launch", "review"]);
   });
 
-  // Regression for the opaque `'sandbox.toJSON' is not a method or field` crash:
-  // the resume payload must reach the resumed step as plain JSON (a wire-faithful
-  // shape), so the whole result — trace included — serializes cleanly and the
-  // step re-attaches the sandbox by name exactly as it would in production.
+  // The resume payload must reach the resumed step as plain JSON (a wire-faithful
+  // shape), so the whole result — trace included — serializes cleanly and the step
+  // re-attaches the sandbox from `executionEnvironment` exactly as in production.
   it("delivers a JSON-faithful resume payload and the full result serializes", async () => {
     const launch = defineStep({
       name: "launch",
@@ -241,11 +240,11 @@ describe("runLocal", () => {
       name: "finish",
       next: [],
       terminal: true,
-      async run(input: { sandbox?: { name?: string } }, ctx) {
-        // Production-faithful: the signal payload is plain JSON, so reconstruct a
-        // live sandbox handle by name before pushing.
+      async run(input: { executionEnvironment?: { id?: string } | null }, ctx) {
+        // The signal payload is plain JSON, so reconstruct a live sandbox handle
+        // from the executionEnvironment id before pushing.
         const sandbox = ctx.sapiom.sandboxes.attach(
-          input.sandbox?.name ?? "unknown",
+          input.executionEnvironment?.id ?? "unknown",
         );
         const repo = ctx.sapiom.repositories.attach(
           "demo",
@@ -253,7 +252,7 @@ describe("runLocal", () => {
         );
         const push = await repo.pushFromSandbox(sandbox);
         return terminate({
-          sandboxName: input.sandbox?.name,
+          sandboxName: input.executionEnvironment?.id,
           pushed: push.pushed,
         });
       },
@@ -275,11 +274,11 @@ describe("runLocal", () => {
       sandboxName: "stub-sandbox",
       pushed: true,
     });
-    // The resumed step's recorded input is plain data — a stub Sandbox *handle*
-    // here used to throw when the trace was JSON.stringify'd at the MCP boundary.
+    // The resumed step's recorded input is plain data and serializes cleanly at
+    // the MCP boundary (no live handles).
     const finishTrace = result.steps.find((s) => s.step === "finish");
     expect(finishTrace?.input).toMatchObject({
-      sandbox: { name: "stub-sandbox" },
+      executionEnvironment: { type: "blaxel_sandbox", id: "stub-sandbox" },
     });
     expect(() => JSON.stringify(result)).not.toThrow();
   });

--- a/packages/orchestration-core/src/scaffold.ts
+++ b/packages/orchestration-core/src/scaffold.ts
@@ -9,11 +9,21 @@
  * remote-fetch or richer template registries can slot in without touching the
  * function signature.
  */
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { OrchestrationError } from './errors.js';
+import { OrchestrationError } from "./errors.js";
 
 /**
  * Directory of this compiled module, resolved for BOTH build formats so the
@@ -28,15 +38,16 @@ import { OrchestrationError } from './errors.js';
  * resolving it at runtime inside the ESM module scope. Node-targeted only.
  */
 function resolveModuleDir(): string {
-  if (typeof __dirname !== 'undefined') return __dirname;
+  if (typeof __dirname !== "undefined") return __dirname;
   try {
     // eslint-disable-next-line no-eval
-    const metaUrl = eval('import.meta.url') as string | undefined;
-    if (typeof metaUrl === 'string') return path.dirname(fileURLToPath(metaUrl));
+    const metaUrl = eval("import.meta.url") as string | undefined;
+    if (typeof metaUrl === "string")
+      return path.dirname(fileURLToPath(metaUrl));
   } catch {
     // Not an ESM runtime — fall through to the empty default.
   }
-  return '';
+  return "";
 }
 
 const moduleDir: string = resolveModuleDir();
@@ -48,25 +59,29 @@ const moduleDir: string = resolveModuleDir();
  * override can be set after module load.
  */
 function getTemplatesDir(override?: string): string {
-  return override ?? process.env.SAPIOM_TEMPLATES_DIR ?? path.resolve(moduleDir, '..', '..', 'templates');
+  return (
+    override ??
+    process.env.SAPIOM_TEMPLATES_DIR ??
+    path.resolve(moduleDir, "..", "..", "templates")
+  );
 }
 
-export const DEFAULT_TEMPLATE = 'default';
+export const DEFAULT_TEMPLATE = "default";
 
-const DOTFILE_NAMES = new Set(['_gitignore', '_npmrc']);
+const DOTFILE_NAMES = new Set(["_gitignore", "_npmrc"]);
 
 // ── Version resolution ────────────────────────────────────────────────────────
 
-const REGISTRY = 'https://registry.npmjs.org';
+const REGISTRY = "https://registry.npmjs.org";
 
 /** Offline fallbacks — bump alongside notable releases. */
 const VERSION_FALLBACK = {
-  orchestration: '0.1.1',
-  tools: '0.1.1',
+  orchestration: "0.1.1",
+  tools: "0.1.1",
 };
 
 /** Pinned to the zod 3.25.x line the SDK requires. */
-const ZOD_VERSION = '3.25.76';
+const ZOD_VERSION = "3.25.76";
 
 export interface ResolvedVersions {
   orchestration: string;
@@ -81,7 +96,7 @@ async function latestNpmVersion(pkg: string): Promise<string | null> {
     });
     if (!res.ok) return null;
     const json = (await res.json()) as { version?: string };
-    return typeof json.version === 'string' ? json.version : null;
+    return typeof json.version === "string" ? json.version : null;
   } catch {
     return null;
   }
@@ -94,8 +109,8 @@ async function latestNpmVersion(pkg: string): Promise<string | null> {
  */
 export async function resolveVersions(): Promise<ResolvedVersions> {
   const [orchestration, tools] = await Promise.all([
-    latestNpmVersion('@sapiom/orchestration'),
-    latestNpmVersion('@sapiom/tools'),
+    latestNpmVersion("@sapiom/orchestration"),
+    latestNpmVersion("@sapiom/tools"),
   ]);
   return {
     orchestration: orchestration ?? VERSION_FALLBACK.orchestration,
@@ -109,7 +124,9 @@ export async function resolveVersions(): Promise<ResolvedVersions> {
 export function listTemplates(templatesDir?: string): string[] {
   const root = getTemplatesDir(templatesDir);
   if (!existsSync(root)) return [];
-  return readdirSync(root).filter((name) => statSync(path.join(root, name)).isDirectory());
+  return readdirSync(root).filter((name) =>
+    statSync(path.join(root, name)).isDirectory(),
+  );
 }
 
 /** Absolute path to a bundled template directory. Throws on an unknown name. */
@@ -118,19 +135,24 @@ export function resolveTemplate(name: string, templatesDir?: string): string {
   if (!existsSync(dir) || !statSync(dir).isDirectory()) {
     const available = listTemplates(templatesDir);
     throw new OrchestrationError({
-      code: 'UNKNOWN_TEMPLATE',
+      code: "UNKNOWN_TEMPLATE",
       message:
         `Unknown template '${name}'.` +
-        (available.length ? ` Available: ${available.join(', ')}.` : ' No templates are bundled.'),
+        (available.length
+          ? ` Available: ${available.join(", ")}.`
+          : " No templates are bundled."),
     });
   }
   return dir;
 }
 
-function applyReplacements(file: string, replacements: Record<string, string>): void {
+function applyReplacements(
+  file: string,
+  replacements: Record<string, string>,
+): void {
   let content: string;
   try {
-    content = readFileSync(file, 'utf8');
+    content = readFileSync(file, "utf8");
   } catch {
     return; // unreadable / binary — leave as-is
   }
@@ -152,19 +174,59 @@ function walk(dir: string, onFile: (file: string) => void): void {
   }
 }
 
-function copyTemplate(templateDir: string, targetDir: string, replacements: Record<string, string>): void {
+function copyTemplate(
+  templateDir: string,
+  targetDir: string,
+  replacements: Record<string, string>,
+): void {
   cpSync(templateDir, targetDir, { recursive: true });
   walk(targetDir, (file) => {
     const base = path.basename(file);
     // Restore dotfiles: _gitignore → .gitignore (npm strips literal .gitignore from published packages)
     if (DOTFILE_NAMES.has(base)) {
-      const dotted = path.join(path.dirname(file), '.' + base.slice(1));
+      const dotted = path.join(path.dirname(file), "." + base.slice(1));
       renameSync(file, dotted);
       applyReplacements(dotted, replacements);
       return;
     }
     applyReplacements(file, replacements);
   });
+}
+
+/**
+ * Best-effort: initialize a git repository with a single commit so the project
+ * is immediately deployable (`deploy` requires a repo with at least one commit).
+ * Each scaffolded project is a self-contained, independently deployable unit, so
+ * it always gets its own repo — including when scaffolded inside another repo (a
+ * nested repo is the deployable unit). Never throws: if `git` is unavailable the
+ * project is simply left uninitialized for the author to `git init` themselves.
+ */
+function initGitRepo(dir: string): boolean {
+  const tryGit = (args: string[]): boolean => {
+    try {
+      execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (!tryGit(["init"])) return false;
+  tryGit(["add", "-A"]);
+  // Commit with the author's configured identity; fall back to a neutral one so
+  // the initial commit (and therefore deploy) succeeds even with no git identity
+  // configured. The `-c` flags apply only to this invocation.
+  return (
+    tryGit(["commit", "-m", "Initial commit"]) ||
+    tryGit([
+      "-c",
+      "user.name=Sapiom",
+      "-c",
+      "user.email=noreply@sapiom.ai",
+      "commit",
+      "-m",
+      "Initial commit",
+    ])
+  );
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -193,6 +255,8 @@ export interface ScaffoldResult {
   targetDir: string;
   template: string;
   projectName: string;
+  /** Whether a git repo with an initial commit was created (false if `git` was unavailable). */
+  gitInitialized: boolean;
 }
 
 /**
@@ -208,7 +272,7 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
 
   if (existsSync(targetDir) && readdirSync(targetDir).length > 0) {
     throw new OrchestrationError({
-      code: 'DIR_NOT_EMPTY',
+      code: "DIR_NOT_EMPTY",
       message: `Target directory '${targetDir}' already exists and is not empty.`,
     });
   }
@@ -227,9 +291,14 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   // Seed the committed stub file for the local-run loop. Created here (not
   // shipped in the template) so it doesn't depend on how the registry treats
   // dotfiles in a published package.
-  const devDir = path.join(targetDir, '.sapiom-dev');
+  const devDir = path.join(targetDir, ".sapiom-dev");
   mkdirSync(devDir, { recursive: true });
-  writeFileSync(path.join(devDir, 'stubs.json'), JSON.stringify({ version: 1, steps: {} }, null, 2) + '\n');
+  writeFileSync(
+    path.join(devDir, "stubs.json"),
+    JSON.stringify({ version: 1, steps: {} }, null, 2) + "\n",
+  );
 
-  return { targetDir, template, projectName };
+  const gitInitialized = initGitRepo(targetDir);
+
+  return { targetDir, template, projectName, gitInitialized };
 }

--- a/packages/orchestration-core/templates/coding-pause/AGENTS.md
+++ b/packages/orchestration-core/templates/coding-pause/AGENTS.md
@@ -40,7 +40,7 @@ return pauseUntilSignal(run, { resumeStep: "finalize" });                       
 ```
 
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
-- That payload crossed a wire boundary, so **`sandbox` is plain `{ name, workspaceRoot }`, not a live handle** — re-attach with `ctx.sapiom.sandboxes.attach(name)` to act on it. Anything else the resumed step needs, stash in `ctx.shared` before pausing.
+- That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `agent.coding.run` *in the launching step* — that one value is both the `run()` result and the payload the paused step resumes with. `agent.coding.launch` is accepted there too.
 
 ## Determinism

--- a/packages/orchestration-core/templates/coding-pause/index.ts
+++ b/packages/orchestration-core/templates/coding-pause/index.ts
@@ -19,9 +19,10 @@ import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
  * the engine resumes `finalize` with the run result as its input.
  *
  * Key idea: the resumed step's `input` IS the signal payload (typed here as
- * `CodingResultPayload`). It crossed a wire boundary, so `sandbox` arrives as
- * plain data — re-attach a live handle with `ctx.sapiom.sandboxes.attach(name)`.
- * Anything else the resumed step needs is stashed in `ctx.shared` before pausing.
+ * `CodingResultPayload`). It crossed a wire boundary, so there are no live
+ * handles — re-attach the run's sandbox from `executionEnvironment` with
+ * `ctx.sapiom.sandboxes.attach(executionEnvironment.id)`. Anything else the
+ * resumed step needs is stashed in `ctx.shared` before pausing.
  */
 
 const REPO_SLUG = "__PROJECT_NAME__-notes";
@@ -84,7 +85,11 @@ const finalize = defineStep({
       ctx.shared.get("slug") as string,
       ctx.shared.get("cloneUrl") as string,
     );
-    const sandbox = ctx.sapiom.sandboxes.attach(run.sandbox.name);
+    const env = run.executionEnvironment;
+    if (!env) {
+      return fail("coding run did not provision an execution environment");
+    }
+    const sandbox = ctx.sapiom.sandboxes.attach(env.id);
     const push = await repo.pushFromSandbox(sandbox, {
       message: "chore: automated change",
     });

--- a/packages/orchestration-core/templates/default/AGENTS.md
+++ b/packages/orchestration-core/templates/default/AGENTS.md
@@ -40,7 +40,7 @@ return pauseUntilSignal(run, { resumeStep: "finalize" });                       
 ```
 
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
-- That payload crossed a wire boundary, so **`sandbox` is plain `{ name, workspaceRoot }`, not a live handle** — re-attach with `ctx.sapiom.sandboxes.attach(name)` to act on it. Anything else the resumed step needs, stash in `ctx.shared` before pausing.
+- That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `agent.coding.run` *in the launching step* — that one value is both the `run()` result and the payload the paused step resumes with. `agent.coding.launch` is accepted there too.
 
 ## Determinism

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -93,13 +93,28 @@ export interface CodingRunResult {
   sandbox: Sandbox;
 }
 
+/** Execution-environment `type` for a remote cloud sandbox; its `id` is the sandbox name. */
+export const EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX = "blaxel_sandbox";
+
+/**
+ * The execution environment a coding run used. For a `"blaxel_sandbox"`, `id` is
+ * the sandbox NAME — the value `ctx.sapiom.sandboxes.attach(id)` takes.
+ */
+export interface ExecutionEnvironmentRef {
+  /** Environment kind (today: `"blaxel_sandbox"` | `"local_host"`). */
+  type: string;
+  /** Type-specific id; for `"blaxel_sandbox"`, the sandbox name. */
+  id: string;
+}
+
 /**
  * The coding run's terminal result as it arrives at a step **resumed** from
- * `pauseUntilSignal(runHandle, { resumeStep })`. It is exactly the signal
- * payload the engine delivers as that step's `input`, and — because it crossed
- * the pause/resume (wire) boundary — `sandbox` is the plain `{ name,
- * workspaceRoot }` it serialized to, not a live handle. Re-attach it with
- * `ctx.sapiom.sandboxes.attach(name)` to act on it.
+ * `pauseUntilSignal(runHandle, { resumeStep })` — the signal payload delivered as
+ * that step's `input`. It crossed a wire boundary, so there are no live handles:
+ * to act on the run's sandbox, re-attach one from `executionEnvironment` —
+ * `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (when its `type`
+ * is `"blaxel_sandbox"`). `executionEnvironment` is `null` when the run never
+ * provisioned one (e.g. a launch-stage failure).
  *
  * Annotate a resumed step's input with this so you don't have to hand-roll the
  * shape:
@@ -109,9 +124,107 @@ export interface CodingRunResult {
  *     async run(result: CodingResultPayload, ctx) { … },
  *   });
  */
-export interface CodingResultPayload extends Omit<CodingRunResult, "sandbox"> {
-  sandbox: { name: string; workspaceRoot: string };
+export interface CodingResultPayload {
+  runId: string;
+  status: RunStatus;
+  summary: string | null;
+  result: CodingRunOutcome | null;
+  error: CodingRunError | null;
+  executionEnvironment: ExecutionEnvironmentRef | null;
 }
+
+/**
+ * Map a live, awaited {@link CodingRunResult} to the plain {@link CodingResultPayload}
+ * a resumed step receives across the wire boundary (live handles become an
+ * `executionEnvironment` reference).
+ */
+export function toResumePayload(run: CodingRunResult): CodingResultPayload {
+  return {
+    runId: run.runId,
+    status: run.status,
+    summary: run.summary,
+    result: run.result,
+    error: run.error,
+    executionEnvironment: {
+      type: EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+      id: run.sandbox.name,
+    },
+  };
+}
+
+/** Thrown by {@link codingResultSchema}.parse on a malformed resume payload. */
+export class CodingResultSchemaError extends Error {}
+
+const RUN_STATUSES: readonly RunStatus[] = [
+  "pending",
+  "queued",
+  "running",
+  "completed",
+  "failed",
+];
+
+/**
+ * Runtime validator for {@link CodingResultPayload}. `parse` returns the value typed
+ * on success and throws a {@link CodingResultSchemaError} on any divergence. The
+ * `executionEnvironment` key is required (use `null` when no environment was
+ * provisioned).
+ */
+export const codingResultSchema = {
+  parse(value: unknown): CodingResultPayload {
+    const fail = (msg: string): never => {
+      throw new CodingResultSchemaError(
+        `invalid coding result payload: ${msg}`,
+      );
+    };
+    if (!value || typeof value !== "object") fail("not an object");
+    const v = value as Record<string, unknown>;
+
+    if (typeof v.runId !== "string") fail("runId must be a string");
+    if (!RUN_STATUSES.includes(v.status as RunStatus))
+      fail(`status must be one of ${RUN_STATUSES.join(", ")}`);
+    if (v.summary !== null && typeof v.summary !== "string")
+      fail("summary must be a string or null");
+
+    if (v.result !== null) {
+      const r = v.result as Record<string, unknown>;
+      if (!r || typeof r !== "object") fail("result must be an object or null");
+      if (typeof r.success !== "boolean")
+        fail("result.success must be a boolean");
+      if (typeof r.turns !== "number") fail("result.turns must be a number");
+      if (r.modelUsed !== null && typeof r.modelUsed !== "string")
+        fail("result.modelUsed must be a string or null");
+      if (typeof r.durationMs !== "number")
+        fail("result.durationMs must be a number");
+      if (typeof r.toolCallCount !== "number")
+        fail("result.toolCallCount must be a number");
+      if (!r.usage || typeof r.usage !== "object")
+        fail("result.usage must be an object");
+    }
+
+    if (v.error !== null) {
+      const e = v.error as Record<string, unknown>;
+      if (!e || typeof e !== "object") fail("error must be an object or null");
+      if (typeof e.stage !== "string") fail("error.stage must be a string");
+      if (typeof e.message !== "string") fail("error.message must be a string");
+    }
+
+    if (!("executionEnvironment" in v))
+      fail(
+        "executionEnvironment is required (use null when no environment was provisioned)",
+      );
+    if (v.executionEnvironment !== null) {
+      const env = v.executionEnvironment as Record<string, unknown>;
+      if (!env || typeof env !== "object")
+        fail("executionEnvironment must be an object or null");
+      if (typeof env.type !== "string")
+        fail("executionEnvironment.type must be a string");
+      if (typeof env.id !== "string")
+        fail("executionEnvironment.id must be a string");
+    }
+
+    return value as CodingResultPayload;
+  },
+};
 
 /**
  * A launched-but-not-awaited run. Satisfies {@link DispatchHandle}, so it can be

--- a/packages/tools/src/agent/resume-payload.spec.ts
+++ b/packages/tools/src/agent/resume-payload.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * The coding-run resume-payload contract: the shape a step resumed from
+ * `pauseUntilSignal(codingHandle, …)` receives as input.
+ *
+ * Pins three things to one shape so they can't drift apart silently:
+ *   - `codingResultSchema` accepts a real resume payload and rejects a payload
+ *     missing `executionEnvironment`.
+ *   - `toResumePayload` maps a live result to that shape (no live handles).
+ *   - the stub client registers exactly that shape for a paused step to resume on.
+ */
+import {
+  codingResultSchema,
+  CodingResultSchemaError,
+  toResumePayload,
+  EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+  type CodingResultPayload,
+  type CodingRunResult,
+} from "./index.js";
+import { createStubClient } from "../stub/index.js";
+
+/** A representative payload as delivered to a resumed step. */
+const RESUME_PAYLOAD: CodingResultPayload = {
+  runId: "run-1",
+  status: "completed",
+  summary: "Created CHANGELOG.md with a dated section and committed it.",
+  result: {
+    success: true,
+    turns: 5,
+    modelUsed: null,
+    durationMs: 25442,
+    toolCallCount: 4,
+    usage: {
+      inputTokens: 7,
+      outputTokens: 581,
+      cacheReadTokens: 522283,
+      cacheCreateTokens: 8566,
+      thinkingTokens: 0,
+    },
+  },
+  error: null,
+  executionEnvironment: {
+    type: EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+    id: "agents-run-1",
+  },
+};
+
+describe("codingResultSchema", () => {
+  it("accepts a well-formed resume payload and returns it", () => {
+    expect(codingResultSchema.parse(RESUME_PAYLOAD)).toEqual(RESUME_PAYLOAD);
+  });
+
+  it("accepts a null executionEnvironment (no environment provisioned)", () => {
+    expect(() =>
+      codingResultSchema.parse({
+        ...RESUME_PAYLOAD,
+        executionEnvironment: null,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a payload missing executionEnvironment", () => {
+    const withoutEnv: Record<string, unknown> = { ...RESUME_PAYLOAD };
+    delete withoutEnv.executionEnvironment;
+    expect(() => codingResultSchema.parse(withoutEnv)).toThrow(
+      CodingResultSchemaError,
+    );
+  });
+
+  it("rejects a payload carrying a sandbox handle shape instead of executionEnvironment", () => {
+    const sandboxShape = {
+      runId: "run-1",
+      status: "completed",
+      summary: null,
+      result: null,
+      error: null,
+      sandbox: { name: "agents-run-1", workspaceRoot: "/workspace" },
+    };
+    expect(() => codingResultSchema.parse(sandboxShape)).toThrow(
+      CodingResultSchemaError,
+    );
+  });
+
+  it("rejects an unknown status", () => {
+    expect(() =>
+      codingResultSchema.parse({ ...RESUME_PAYLOAD, status: "done" }),
+    ).toThrow(CodingResultSchemaError);
+  });
+});
+
+describe("toResumePayload", () => {
+  it("maps a live result to the wire shape (executionEnvironment, no live handle)", () => {
+    const live = {
+      runId: "r",
+      status: "completed",
+      summary: "s",
+      result: null,
+      error: null,
+      sandbox: { name: "sb-1" },
+    } as unknown as CodingRunResult;
+
+    const payload = toResumePayload(live);
+
+    expect(payload.executionEnvironment).toEqual({
+      type: EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+      id: "sb-1",
+    });
+    expect(
+      (payload as unknown as Record<string, unknown>).sandbox,
+    ).toBeUndefined();
+    expect(() => codingResultSchema.parse(payload)).not.toThrow();
+  });
+});
+
+describe("stub client resume payload", () => {
+  it("registers a payload matching the schema for a paused step to resume on", async () => {
+    const signals = new Map<string, unknown>();
+    const client = createStubClient({ signals });
+
+    const handle = await client.agent.coding.launch({ task: "do a thing" });
+    const payload = signals.get(handle.dispatch.correlationId);
+
+    // The stub must hand back exactly the wire shape — schema-valid, an
+    // executionEnvironment reference, and no live sandbox handle.
+    const parsed = codingResultSchema.parse(payload);
+    expect(parsed.executionEnvironment).not.toBeNull();
+    expect(parsed.executionEnvironment?.type).toBe(
+      EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+    );
+    expect((payload as Record<string, unknown>).sandbox).toBeUndefined();
+  });
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -30,7 +30,18 @@ export * as agent from "./agent/index.js";
 export { CODING_RESULT_SIGNAL } from "./agent/index.js";
 // The shape a step resumed from `pauseUntilSignal(codingHandle, …)` receives as
 // input — annotate the resumed step with it instead of hand-rolling the shape.
-export type { CodingResultPayload } from "./agent/index.js";
+export type {
+  CodingResultPayload,
+  ExecutionEnvironmentRef,
+} from "./agent/index.js";
+// Validate / build a `CodingResultPayload`, and the env `type` whose `id` is a
+// sandbox name for `sandboxes.attach(id)`.
+export {
+  codingResultSchema,
+  CodingResultSchemaError,
+  toResumePayload,
+  EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
+} from "./agent/index.js";
 
 export * as fileStorage from "./file-storage/index.js";
 export { FileStorageHttpError } from "./file-storage/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -18,7 +18,7 @@
  * replaces that capability's default; a function `(…args) => value` computes it
  * from the call arguments.
  */
-import { CODING_RESULT_SIGNAL } from "../agent/index.js";
+import { CODING_RESULT_SIGNAL, toResumePayload } from "../agent/index.js";
 import type { CodingRunResult, RunHandle, RunStatus } from "../agent/index.js";
 import type { Sapiom } from "../client.js";
 import { Repository } from "../repositories/index.js";
@@ -86,19 +86,16 @@ function isDispatchHandle(
 async function dispatchable<T>(
   handle: T,
   signals?: Map<string, unknown>,
+  resumePayload?: () => unknown | Promise<unknown>,
 ): Promise<T> {
   if (signals && isDispatchHandle(handle)) {
-    // The resume payload is delivered as the dispatched run's terminal signal,
-    // which in production crosses a wire boundary — it reaches the resumed step
-    // as plain JSON, never a live handle. Round-trip it here so a local run sees
-    // exactly that shape (e.g. `result.sandbox` is plain data, so the author
-    // re-attaches it with `sandboxes.attach(name)` just as they would in prod —
-    // no local-only handle methods to lean on). Relies on stub handles being
-    // JSON-safe (see `makeHandle`).
-    signals.set(
-      handle.dispatch.correlationId,
-      toPlainJson(await handle.wait()),
-    );
+    // The resume payload crosses a wire boundary — it reaches the resumed step as
+    // plain JSON, never a live handle. A capability may supply `resumePayload` to
+    // produce that wire shape; absent, the awaited result IS the payload. Round-trip
+    // it either way so a local run sees exactly the wire shape — no local-only
+    // handle methods to lean on.
+    const payload = resumePayload ? await resumePayload() : await handle.wait();
+    signals.set(handle.dispatch.correlationId, toPlainJson(payload));
   }
   return handle;
 }
@@ -464,17 +461,20 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           Promise.resolve(resolveCodingResult(spec, "agent.coding.run")),
         launch: (spec) => {
           const correlationId = `stub-run-${++launchSeq}`;
-          // The resume payload IS the run result. `launch()` honors the key
-          // matching the call the author wrote (`agent.coding.launch`) first,
-          // then the shared `agent.coding.run` that controls both paths.
+          // `launch()` honors the key matching the call the author wrote
+          // (`agent.coding.launch`) first, then the shared `agent.coding.run`
+          // that controls both paths.
           const result = {
             ...resolveCodingResult(spec, dispatchedKeys("agent.coding")),
             runId: correlationId,
           };
-          // Generic: any dispatch-able handle registers itself for pause-resume.
+          // Register for pause-resume with the wire shape a resumed step receives:
+          // `toResumePayload` maps the live result to a `CodingResultPayload` (an
+          // `executionEnvironment` reference, not a live sandbox handle).
           return dispatchable(
             stubRunHandle(overrides, correlationId, result),
             opts.signals,
+            () => toResumePayload(result),
           );
         },
       },


### PR DESCRIPTION
This pull request introduces several improvements and new features to the orchestration core and related packages. The most significant changes include making scaffolded projects immediately deployable by initializing a git repository with an initial commit, and adding a robust polling mechanism (`waitForExecution`) to inspect executions until they reach a terminal state or require a signal. These changes are accompanied by updates to the MCP tool, expanded test coverage, and improved type exports.

**Project scaffolding and deployability:**
- The `scaffold` function now initializes a git repository with an initial commit, ensuring that newly scaffolded projects are immediately deployable. The result object includes a `gitInitialized` flag. If `git` is unavailable, the project remains uninitialized.
- Tests for `scaffold` have been expanded to verify git initialization, initial commit creation, and other behaviors.

**Execution inspection and polling:**
- Added `waitForExecution` and `isExecutionTerminal` utilities to poll an execution until it reaches a terminal state, pauses for a signal, or a timeout occurs. These are exported from `@sapiom/orchestration-core`. [[1]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L15-R72) [[2]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L57-R108) [[3]](diffhunk://#diff-276ac1a08572bee75364dc00b4969304175b5f62c5052203bb465d9aafd8ee5fL8-R8) [[4]](diffhunk://#diff-276ac1a08572bee75364dc00b4969304175b5f62c5052203bb465d9aafd8ee5fR21)
- The MCP tool `sapiom_dev_orchestrations_inspect` now supports `wait` and `maxWaitSeconds` options, allowing users to block until an execution finishes or needs a signal, and returns hints for further action. [[1]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR23) [[2]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR33) [[3]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfL352-R354) [[4]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR367-R380) [[5]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfL379-R421)
- Comprehensive tests for `waitForExecution` and terminal state detection have been added.

**Coding result execution environment (breaking change):**
- The `CodingResultPayload` now carries `executionEnvironment: { type, id } | null` instead of `sandbox: { name, workspaceRoot }`. This aligns the resume payload with the shape received by a resumed step, and requires resuming sandboxes using `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)`.
- Introduces `codingResultSchema`, `toResumePayload`, `ExecutionEnvironmentRef`, and `EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX`. Updates the stub client and `coding-pause` template to the new shape.

**Type and export improvements:**
- The main `@sapiom/orchestration-core` index now exports new types and functions, including those for execution polling and inspection. [[1]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L15-R72) [[2]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L57-R108)

**Summary of most important changes:**

**Project scaffolding and deployability:**
- `scaffold` now initializes a git repository with an initial commit, making projects deployable out of the box; result includes `gitInitialized`.
- Expanded and improved tests for scaffolding, including git initialization checks.

**Execution inspection and polling:**
- Added `waitForExecution` and `isExecutionTerminal` utilities for robust execution polling, with corresponding type exports. [[1]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L15-R72) [[2]](diffhunk://#diff-dd2013f2d9ccada8744678b32f9c68b918441972b869d03470819dd99b0eec38L57-R108) [[3]](diffhunk://#diff-276ac1a08572bee75364dc00b4969304175b5f62c5052203bb465d9aafd8ee5fL8-R8) [[4]](diffhunk://#diff-276ac1a08572bee75364dc00b4969304175b5f62c5052203bb465d9aafd8ee5fR21)
- MCP inspect tool (`sapiom_dev_orchestrations_inspect`) supports `wait` and `maxWaitSeconds` options for blocking until executions finish or pause, and provides actionable hints. [[1]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR23) [[2]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR33) [[3]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfL352-R354) [[4]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR367-R380) [[5]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfL379-R421)
- Added tests for execution polling and terminal state logic.

**Coding result execution environment:**
- **BREAKING:** `CodingResultPayload` now uses `executionEnvironment` instead of `sandbox`, requiring updated resume logic and schema.