### PR TITLE
feat(cli): resolve a staging environment in host resolution

### DIFF
--- a/.changeset/staging-environment.md
+++ b/.changeset/staging-environment.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/cli": minor
+"@sapiom/mcp": minor
+---
+
+Add a `staging` environment to host resolution. `resolveHost` maps the `staging` target (alias `dev`) to the staging API host, and the MCP server resolves `SAPIOM_ENVIRONMENT=staging`/`dev`/`prod` from built-in presets without requiring a `~/.sapiom/credentials.json` entry. A file-defined environment still takes precedence.

--- a/packages/cli/src/__tests__/cli-config.test.ts
+++ b/packages/cli/src/__tests__/cli-config.test.ts
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { resolveHost } from '../lib/cli-config.js';
 
 const PROD = 'https://api.sapiom.ai';
+const STAGING = 'https://api.sapiom.dev';
 const LOCAL = 'http://localhost:3000';
 
 function makeTmpDir(): string {
@@ -87,6 +88,19 @@ describe('resolveHost', () => {
     const tmp = makeTmpDir();
     process.env.XDG_CONFIG_HOME = tmp;
     expect(resolveHost({ flagTarget: 'prod' })).toBe(PROD);
+  });
+
+  it('--target staging maps to api.sapiom.dev', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    expect(resolveHost({ flagTarget: 'staging' })).toBe(STAGING);
+  });
+
+  it('persisted target=staging in config.json is picked up when no flag is set', () => {
+    const tmp = makeTmpDir();
+    process.env.XDG_CONFIG_HOME = tmp;
+    writeConfigJson(tmp, { target: 'staging' });
+    expect(resolveHost({})).toBe(STAGING);
   });
 
   it('persisted target=local in config.json is picked up when no flag is set', () => {

--- a/packages/cli/src/commands/config/set-target.test.ts
+++ b/packages/cli/src/commands/config/set-target.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for `sapiom config set-target`. Verifies the accepted targets, the
+ * `dev` → `staging` alias, rejection of unknown targets, and that the resolved
+ * target persists to `~/.sapiom/config.json` (redirected via XDG_CONFIG_HOME).
+ */
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { readCliConfig } from '../../lib/cli-config.js';
+import { CliError } from '../../lib/output.js';
+import { runSetTarget } from './set-target.js';
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `sapiom-set-target-test-${process.pid}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('runSetTarget', () => {
+  let originalXdg: string | undefined;
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = makeTmpDir();
+    // Keep the success line out of the test runner's output.
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdg;
+  });
+
+  it.each(['prod', 'staging', 'local'] as const)('persists target %s', async (target) => {
+    await runSetTarget(target);
+    expect(readCliConfig().target).toBe(target);
+  });
+
+  it("treats 'dev' as an alias for 'staging'", async () => {
+    await runSetTarget('dev');
+    expect(readCliConfig().target).toBe('staging');
+  });
+
+  it('clears any persisted host override when setting a target', async () => {
+    await runSetTarget('staging');
+    expect(readCliConfig().host).toBeUndefined();
+  });
+
+  it('rejects an unknown target', async () => {
+    await expect(runSetTarget('production')).rejects.toBeInstanceOf(CliError);
+    await expect(runSetTarget('production')).rejects.toThrow(/Unknown target/);
+  });
+});

--- a/packages/cli/src/commands/config/set-target.ts
+++ b/packages/cli/src/commands/config/set-target.ts
@@ -1,23 +1,30 @@
 /**
- * `sapiom config set-target <prod|local>` — persist the default API target to
- * `~/.sapiom/config.json`. Individual commands can still override per-invocation
- * with `--target` or `--host`.
+ * `sapiom config set-target <prod|staging|local>` — persist the default API
+ * target to `~/.sapiom/config.json`. `dev` is accepted as an alias for
+ * `staging`. Individual commands can still override per-invocation with
+ * `--target` or `--host`.
  */
-import { type CliTarget, writeCliConfig } from '../../lib/cli-config.js';
+import { type CliTarget, hostForTarget, writeCliConfig } from '../../lib/cli-config.js';
 import { CliError, ok } from '../../lib/output.js';
 
-const VALID_TARGETS = new Set<string>(['prod', 'local']);
+/** Accepted user input → canonical target. `dev` is a friendly alias for `staging`. */
+const TARGET_ALIASES: Record<string, CliTarget> = {
+  prod: 'prod',
+  staging: 'staging',
+  dev: 'staging',
+  local: 'local',
+};
 
-export async function runSetTarget(target: string): Promise<void> {
-  if (!VALID_TARGETS.has(target)) {
+export async function runSetTarget(input: string): Promise<void> {
+  const target = TARGET_ALIASES[input];
+  if (!target) {
     throw new CliError({
       code: 'BAD_TARGET',
-      message: `Unknown target: '${target}'. Expected 'prod' or 'local'.`,
+      message: `Unknown target: '${input}'. Expected 'prod', 'staging' (alias 'dev'), or 'local'.`,
     });
   }
 
-  writeCliConfig({ target: target as CliTarget, host: undefined });
+  writeCliConfig({ target, host: undefined });
 
-  const description = target === 'local' ? 'http://localhost:3000' : 'https://api.sapiom.ai';
-  ok({ target }, [`✓ Default target set to '${target}' (${description}).`]);
+  ok({ target }, [`✓ Default target set to '${target}' (${hostForTarget(target)}).`]);
 }

--- a/packages/cli/src/lib/cli-config.ts
+++ b/packages/cli/src/lib/cli-config.ts
@@ -1,20 +1,21 @@
 /**
  * Machine-level CLI configuration persisted at `~/.sapiom/config.json`. Stores
- * the active target (prod vs local) and any user-set host override. Project
- * identity (`sapiom.json` / `definitionId`) is kept separate from this — the
- * server stays the source of truth for what orchestrations exist.
+ * the active target (prod / staging / local) and any user-set host override.
+ * Project identity (`sapiom.json` / `definitionId`) is kept separate from this —
+ * the server stays the source of truth for what orchestrations exist.
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdirSync } from 'node:fs';
 
 import { configDir, configFilePath } from './paths.js';
 
-export type CliTarget = 'prod' | 'local';
+export type CliTarget = 'prod' | 'staging' | 'local';
 
 export interface CliConfig {
   /**
-   * Named target: `prod` routes to the production backend, `local` to the
-   * backend running on localhost:3000. A raw `host` override supersedes this.
+   * Named target: `prod` routes to the production backend, `staging` to the
+   * staging backend (`api.sapiom.dev`), `local` to the backend running on
+   * localhost:3000. A raw `host` override supersedes this.
    */
   target?: CliTarget;
   /**
@@ -26,7 +27,20 @@ export interface CliConfig {
 }
 
 const PROD_HOST = 'https://api.sapiom.ai';
+const STAGING_HOST = 'https://api.sapiom.dev';
 const LOCAL_HOST = 'http://localhost:3000';
+
+/** The API host a named target routes to. */
+export function hostForTarget(target: CliTarget): string {
+  switch (target) {
+    case 'local':
+      return LOCAL_HOST;
+    case 'staging':
+      return STAGING_HOST;
+    default:
+      return PROD_HOST;
+  }
+}
 
 function load(): CliConfig {
   const file = configFilePath();
@@ -57,7 +71,7 @@ export function writeCliConfig(patch: Partial<CliConfig>): void {
  * Resolve the effective API host from (in precedence order):
  * 1. An explicit `SAPIOM_HOST` environment variable
  * 2. An explicit `--host <url>` flag (passed as `flagHost`)
- * 3. The `--target local|prod` flag (passed as `flagTarget`)
+ * 3. The `--target local|staging|prod` flag (passed as `flagTarget`)
  * 4. The `host` or `target` stored in `~/.sapiom/config.json`
  * 5. The project-level `host` from `sapiom.json` (passed as `projectHost`)
  * 6. Default: production backend
@@ -72,12 +86,12 @@ export function resolveHost(opts: {
   // Explicit --host flag
   if (opts.flagHost) return opts.flagHost.replace(/\/$/, '');
   // --target flag
-  if (opts.flagTarget) return opts.flagTarget === 'local' ? LOCAL_HOST : PROD_HOST;
+  if (opts.flagTarget) return hostForTarget(opts.flagTarget);
 
   // Persisted CLI config
   const cfg = load();
   if (cfg.host) return cfg.host.replace(/\/$/, '');
-  if (cfg.target) return cfg.target === 'local' ? LOCAL_HOST : PROD_HOST;
+  if (cfg.target) return hostForTarget(cfg.target);
 
   // Project-level sapiom.json host
   if (opts.projectHost) return opts.projectHost.replace(/\/$/, '');

--- a/packages/mcp/src/credentials.test.ts
+++ b/packages/mcp/src/credentials.test.ts
@@ -76,9 +76,34 @@ describe("resolveEnvironment", () => {
     });
   });
 
+  it("should resolve staging from the built-in preset without a file", async () => {
+    const env = await resolveEnvironment("staging");
+    expect(env).toEqual({
+      name: "staging",
+      appURL: "https://app.sapiom.dev",
+      apiURL: "https://api.sapiom.dev",
+      services: {},
+      credentials: null,
+    });
+  });
+
+  it("should treat 'dev' as an alias for staging", async () => {
+    const env = await resolveEnvironment("dev");
+    expect(env.name).toBe("staging");
+    expect(env.apiURL).toBe("https://api.sapiom.dev");
+  });
+
+  it("should treat 'prod' as an alias for production", async () => {
+    const env = await resolveEnvironment("prod");
+    expect(env.name).toBe("production");
+    expect(env.apiURL).toBe("https://api.sapiom.ai");
+  });
+
   it("should use env override over file's currentEnvironment", async () => {
     vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(sampleFile));
 
+    // sampleFile defines a staging env with *.sapiom.ai URLs, so the file entry
+    // takes precedence over the built-in *.sapiom.dev preset.
     const env = await resolveEnvironment("staging");
     expect(env.name).toBe("staging");
     expect(env.appURL).toBe("https://staging.app.sapiom.ai");

--- a/packages/mcp/src/credentials.ts
+++ b/packages/mcp/src/credentials.ts
@@ -2,9 +2,28 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 
-const DEFAULT_APP_URL = "https://app.sapiom.ai";
-const DEFAULT_API_URL = "https://api.sapiom.ai";
 const DEFAULT_ENVIRONMENT = "production";
+
+/** Friendly aliases → canonical environment name. */
+const ENVIRONMENT_ALIASES: Record<string, string> = {
+  prod: "production",
+  dev: "staging",
+};
+
+/**
+ * Built-in environment presets, so the common targets resolve to the right URLs
+ * without anyone hand-editing `~/.sapiom/credentials.json`. A matching
+ * environment defined in the file always takes precedence over a preset (so a
+ * custom override, or one carrying credentials, still wins).
+ */
+const ENVIRONMENT_PRESETS: Record<string, { appURL: string; apiURL: string }> = {
+  production: { appURL: "https://app.sapiom.ai", apiURL: "https://api.sapiom.ai" },
+  staging: { appURL: "https://app.sapiom.dev", apiURL: "https://api.sapiom.dev" },
+};
+
+function canonicalEnvironmentName(name: string): string {
+  return ENVIRONMENT_ALIASES[name] ?? name;
+}
 
 export interface CredentialEntry {
   apiKey: string;
@@ -57,20 +76,25 @@ async function writeCredentialsFile(file: CredentialsFile): Promise<void> {
 /**
  * Resolve the active environment configuration.
  *
- * Priority: SAPIOM_ENVIRONMENT env var > file's currentEnvironment > "production"
+ * Priority: SAPIOM_ENVIRONMENT env var > file's currentEnvironment > "production".
+ * The names `prod` and `dev` are accepted as aliases for `production` and
+ * `staging`.
  *
- * If the file doesn't exist and environment is "production", returns hardcoded defaults.
- * If the file doesn't exist and environment is custom, throws (file must define custom envs).
+ * Resolution order for the chosen environment:
+ *   1. A matching entry in `~/.sapiom/credentials.json` (carries URLs + creds).
+ *   2. A built-in preset (`production`, `staging`) — no file edit required.
+ *   3. Otherwise throws (a custom environment must be defined in the file).
  */
 export async function resolveEnvironment(
   envOverride?: string,
 ): Promise<ResolvedEnvironment> {
   const file = await readCredentialsFile();
-  const name = envOverride ?? file?.currentEnvironment ?? DEFAULT_ENVIRONMENT;
+  const name = canonicalEnvironmentName(
+    envOverride ?? file?.currentEnvironment ?? DEFAULT_ENVIRONMENT,
+  );
 
-  // Look up in file
+  // A matching environment in the file always wins.
   const envConfig = file?.environments[name];
-
   if (envConfig) {
     return {
       name,
@@ -81,12 +105,13 @@ export async function resolveEnvironment(
     };
   }
 
-  // Environment not in file — use production defaults or error
-  if (name === DEFAULT_ENVIRONMENT) {
+  // Otherwise fall back to a built-in preset (no creds file needed).
+  const preset = ENVIRONMENT_PRESETS[name];
+  if (preset) {
     return {
       name,
-      appURL: DEFAULT_APP_URL,
-      apiURL: DEFAULT_API_URL,
+      appURL: preset.appURL,
+      apiURL: preset.apiURL,
       services: {},
       credentials: null,
     };


### PR DESCRIPTION
## Summary

Add a `staging` environment to host resolution in `@sapiom/cli` and `@sapiom/mcp`.

- **CLI** (`packages/cli`): `set-target` accepts `staging` (alias `dev`); `resolveHost` maps it to `https://api.sapiom.dev`, within the existing precedence (`SAPIOM_HOST` → `--host` → `--target` → persisted config → project host → prod default).
- **MCP** (`packages/mcp`): `SAPIOM_ENVIRONMENT=staging` (and `dev`/`prod` aliases) resolves from built-in presets without a `~/.sapiom/credentials.json` entry. A file-defined environment still takes precedence.
- Tests for both; changeset included.

## Test plan
- `@sapiom/cli`: typecheck + lint + jest
- `@sapiom/mcp`: typecheck + lint + vitest