### PR TITLE
feat(orchestration): let a step declare the capability it calls

### DIFF
--- a/.changeset/step-capability-declaration.md
+++ b/.changeset/step-capability-declaration.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/orchestration": minor
+---
+
+Let a workflow step declare the capability it calls.
+
+`defineStep` accepts an optional `capability` — the canonical dotted capability id the step invokes (`web.search`, `agent.coding.run`). A step's `run` calls capabilities dynamically via `ctx.sapiom.*`, so the binding can't be inferred; declaring it lets `buildManifest` emit it into the step manifest as `capabilityId`. Steps that declare nothing emit `capabilityId: null` (the step runs in-process). The manifest schema (`workflowManifestSchema`) carries `capabilityId` as an optional, non-empty string or null, so manifests built before this field existed still validate.

--- a/packages/orchestration/src/build-manifest.ts
+++ b/packages/orchestration/src/build-manifest.ts
@@ -20,6 +20,9 @@ import type { OrchestrationDefinition } from "./workflow.js";
  *     `next`/`terminal`/`canFail`/`pause` runtime properties (set by
  *     `defineStep`). This is a runtime-value read, exactly like inputSchema —
  *     no type reflection, no AST parsing.
+ *   - capabilityId: the step's declared `capability` (the canonical dotted id),
+ *     or null when undeclared (the step runs in-process). Another runtime-value
+ *     read; the platform validates the id against its capability registry.
  * - name/entry from def; protocol 1 (locked); sdkVersion/artifact from opts.
  */
 export function buildManifest(
@@ -34,6 +37,7 @@ export function buildManifest(
     {
       timeoutMs: number | null;
       inputSchema: Record<string, unknown> | null;
+      capabilityId: string | null;
       transitions: ManifestTransition[];
     }
   > = {};
@@ -49,6 +53,7 @@ export function buildManifest(
     steps[stepName] = {
       timeoutMs: step.timeoutMs ?? null,
       inputSchema,
+      capabilityId: step.capability ?? null,
       transitions: transitionsFor(step),
     };
   }

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -28,7 +28,7 @@ import { defineOrchestration } from "./workflow.js";
 /** A terminal step (declares `terminal: true`) for the schema/inputSchema/timeout tests. */
 function makeStep(
   name: string,
-  opts: { inputSchema?: z.ZodType; timeoutMs?: number } = {},
+  opts: { inputSchema?: z.ZodType; timeoutMs?: number; capability?: string } = {},
 ) {
   return defineStep({
     name,
@@ -36,6 +36,7 @@ function makeStep(
     terminal: true,
     inputSchema: opts.inputSchema,
     timeoutMs: opts.timeoutMs,
+    capability: opts.capability,
     async run() {
       return terminate(null);
     },
@@ -448,5 +449,111 @@ describe("buildManifest transitions", () => {
 
   it("produces a manifest that validates against the schema", () => {
     expect(() => workflowManifestSchema.parse(manifest)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildManifest — capability binding (the declared step→capability id)
+// ---------------------------------------------------------------------------
+
+describe("buildManifest capability binding", () => {
+  it("emits the declared capability as the step's canonical dotted capabilityId", () => {
+    const def = defineOrchestration({
+      name: "wf",
+      entry: "search",
+      steps: { search: makeStep("search", { capability: "web.search" }) },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.steps.search.capabilityId).toBe("web.search");
+  });
+
+  it("emits capabilityId: null for a step that declares no capability (runs in-process)", () => {
+    const def = defineOrchestration({
+      name: "wf",
+      entry: "plain",
+      steps: { plain: makeStep("plain") },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.steps.plain.capabilityId).toBeNull();
+  });
+
+  it("maps each step's capability independently across a multi-step definition", () => {
+    const def = defineOrchestration({
+      name: "multi",
+      entry: "search",
+      steps: {
+        search: defineStep({
+          name: "search",
+          next: ["code"],
+          capability: "web.search",
+          async run() {
+            return goto("code");
+          },
+        }),
+        code: defineStep({
+          name: "code",
+          next: ["done"],
+          capability: "agent.coding.run",
+          async run() {
+            return goto("done");
+          },
+        }),
+        done: makeStep("done"),
+      },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.steps.search.capabilityId).toBe("web.search");
+    expect(manifest.steps.code.capabilityId).toBe("agent.coding.run");
+    expect(manifest.steps.done.capabilityId).toBeNull();
+  });
+
+  it("a manifest carrying a capabilityId validates against the schema", () => {
+    const def = defineOrchestration({
+      name: "wf",
+      entry: "search",
+      steps: { search: makeStep("search", { capability: "web.search" }) },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    const parsed = workflowManifestSchema.parse(manifest);
+    expect(parsed.steps.search.capabilityId).toBe("web.search");
+  });
+
+  it("schema accepts a step manifest that omits capabilityId (back-compat)", () => {
+    const legacy = {
+      protocol: MANIFEST_PROTOCOL,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      // no capabilityId on the step — a manifest built before the field existed
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
+    };
+    expect(() => workflowManifestSchema.parse(legacy)).not.toThrow();
+  });
+
+  it("schema rejects an empty-string capabilityId (declared ids are non-empty)", () => {
+    const bad = {
+      protocol: MANIFEST_PROTOCOL,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: { timeoutMs: null, inputSchema: null, capabilityId: "", transitions: [] },
+      },
+    };
+    expect(() => workflowManifestSchema.parse(bad)).toThrow();
   });
 });

--- a/packages/orchestration/src/manifest.ts
+++ b/packages/orchestration/src/manifest.ts
@@ -41,6 +41,19 @@ export interface WorkflowStepManifest {
    */
   readonly inputSchema: Record<string, unknown> | null;
   /**
+   * The canonical dotted capability id this step declares it calls
+   * (`web.search`, `agent.coding.run`), or null when the step runs in-process and
+   * invokes no capability. A step's `run` invokes capabilities dynamically
+   * (`ctx.sapiom.*`), so the binding cannot be inferred — it is declared via
+   * `defineStep({ capability })` and emitted here by the build phase. The engine
+   * indexes it per step and validates it against the capability registry.
+   *
+   * Optional for back-compat: manifests built before this field existed omit it
+   * (read as null). When declared, it is always the canonical dotted id — the
+   * registry key — never a per-surface rendering.
+   */
+  readonly capabilityId?: string | null;
+  /**
    * The declared transitions out of this step (the graph edges). Built from the
    * step's `next`/`terminal`/`canFail`/`pause` declarations. The engine
    * validates every completion's directive against this set (per-step,
@@ -86,6 +99,9 @@ const manifestTransitionSchema = z.discriminatedUnion('kind', [
 const workflowStepManifestSchema = z.object({
   timeoutMs: z.union([z.number().int().positive(), z.null()]),
   inputSchema: z.union([z.record(z.string(), z.unknown()), z.null()]),
+  // Optional so manifests built before this field existed still validate; a
+  // declared id is a non-empty canonical dotted string, otherwise null.
+  capabilityId: z.union([z.string().min(1), z.null()]).optional(),
   transitions: z.array(manifestTransitionSchema),
 });
 

--- a/packages/orchestration/src/step.ts
+++ b/packages/orchestration/src/step.ts
@@ -79,6 +79,14 @@ export interface StepDefinition<TShared extends Record<string, unknown> = Record
   readonly canFail: boolean;
   /** Declared pause edge, if any. */
   readonly pause?: { readonly signal: string; readonly resumeStep: string };
+  /**
+   * The canonical dotted capability id this step calls (`web.search`,
+   * `agent.coding.run`), if declared. A step invokes capabilities dynamically
+   * via `ctx.sapiom.*`, so the binding can't be inferred — declaring it lets
+   * `buildManifest` emit it into the step manifest (`capabilityId`). Undeclared
+   * → the step is treated as running in-process (manifest `capabilityId: null`).
+   */
+  readonly capability?: string;
   readonly inputSchema?: ZodType<unknown>;
   readonly timeoutMs?: number;
   run(input: unknown, ctx: OrchestrationExecutionContext<TShared>): Promise<NextStepDirective>;
@@ -94,6 +102,12 @@ export interface StepDefinition<TShared extends Record<string, unknown> = Record
  * (`ctx: OrchestrationExecutionContext<MyShared>`); `TIn` from `inputSchema` or the
  * `input` annotation. `next`/`terminal`/`canFail`/`pause` are inferred as
  * literals (`const` type params), so no `as const` is needed.
+ *
+ * `capability` optionally declares the canonical dotted capability id this step
+ * calls (`web.search`). It is metadata only — it does not constrain `run` — and
+ * is stored as a runtime property for `buildManifest` to emit (exactly like
+ * `inputSchema`). The platform validates the declared id against its capability
+ * registry; an undeclared step is treated as running in-process.
  */
 export function defineStep<
   TIn = unknown,
@@ -111,6 +125,8 @@ export function defineStep<
   terminal?: Term;
   canFail?: CanFail;
   pause?: PauseDecl;
+  /** Canonical dotted capability id this step calls (`web.search`), if any. */
+  capability?: string;
   inputSchema?: ZodType<TIn>;
   timeoutMs?: number;
   // Arrow-property (not method) type so `def.run` can be read as a value below
@@ -126,6 +142,9 @@ export function defineStep<
     terminal: def.terminal ?? false,
     canFail: def.canFail ?? false,
     ...(def.pause ? { pause: def.pause } : {}),
+    // Omit when falsy (undefined / empty) so an undeclared capability emits a
+    // manifest `capabilityId: null` rather than an empty string.
+    ...(def.capability ? { capability: def.capability } : {}),
     ...(def.inputSchema ? { inputSchema: def.inputSchema as ZodType<unknown> } : {}),
     ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
     run: def.run as unknown as (input: unknown, ctx: OrchestrationExecutionContext<TShared>) => Promise<NextStepDirective>,


### PR DESCRIPTION
## What

A workflow step invokes capabilities dynamically via `ctx.sapiom.*`, so which capability a step calls can't be inferred statically. This adds an optional `capability` to `defineStep` — the canonical dotted capability id the step calls (`web.search`, `agent.coding.run`) — and has `buildManifest` emit it onto the step manifest as `capabilityId`.

```ts
defineStep({
  name: "search",
  next: ["summarize"],
  capability: "web.search", // ← declared; emitted as the step's capabilityId
  async run(input, ctx) { /* ctx.sapiom.web.search(...) */ },
});
```

Steps that declare nothing emit `capabilityId: null` (the step runs in-process).

## Changes

- **`defineStep` / `StepDefinition`** — optional `capability`, stored as a runtime property and read by `buildManifest` exactly like `inputSchema`. It is metadata only and does not constrain `run`'s return type. Empty/undefined is omitted.
- **`WorkflowStepManifest.capabilityId` + `workflowManifestSchema`** — an optional, non-empty string or null. **Optional** so manifests built before this field existed still validate.
- **`buildManifest`** — emits `capabilityId: step.capability ?? null` per step.

## Tests

`manifest.spec.ts` covers: emit when declared / null when undeclared / independent per step in a multi-step definition; a manifest carrying a `capabilityId` validates against the schema; the schema accepts a step that omits the field (back-compat) and rejects an empty-string id.

`pnpm typecheck`, `pnpm lint`, `pnpm test` (79 tests), and `pnpm build` all pass.

## Notes

This package only **declares + emits** the id; the platform validates it against its capability registry. A changeset (`@sapiom/orchestration` minor) is included.