### PR TITLE
add running/dispatching orchestrations as a tool

### DIFF
--- a/.changeset/orchestration-zod-4.md
+++ b/.changeset/orchestration-zod-4.md
@@ -1,0 +1,18 @@
+---
+"@sapiom/orchestration": minor
+"@sapiom/orchestration-runtime": minor
+"@sapiom/orchestration-core": patch
+"@sapiom/create-orchestration": patch
+---
+
+Move the orchestration authoring SDK onto zod 4 via the bare `zod` import (no
+more `zod/v4` subpath), so installing is just:
+
+```sh
+npm install @sapiom/orchestration
+```
+
+`zod` is now a regular dependency rather than a peer. Author your step schemas
+with your own `import { z } from "zod"` as usual; a compatibility re-export
+(`import { z } from "@sapiom/orchestration"`) is available for projects pinned
+to an incompatible zod. Scaffolded projects now pin zod 4.

--- a/.changeset/orchestrations-run.md
+++ b/.changeset/orchestrations-run.md
@@ -1,0 +1,18 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `orchestrations` capability — run a deployed orchestration by slug, or dispatch one from a workflow step and pause on its result.
+
+```ts
+import { orchestrations } from "@sapiom/tools";
+
+// run inline:
+const result = await orchestrations.run({ definition: "enrich-lead", input });
+
+// or dispatch from a step and resume when it finishes:
+const child = await orchestrations.launch({ definition: "enrich-lead", input });
+return pauseUntilSignal(child, { resumeStep: "use-result" });
+```
+
+`launch` returns a handle usable with `pauseUntilSignal`; the resumed step receives an `OrchestrationRunResultPayload` (validate with `orchestrationResultSchema`). Also exports `ORCHESTRATIONS_RESULT_SIGNAL` for the static `pause` declaration on a step.

--- a/packages/create-orchestration/src/versions.ts
+++ b/packages/create-orchestration/src/versions.ts
@@ -17,8 +17,8 @@ const FALLBACK = {
   tools: '0.1.1',
 };
 
-/** Pinned to the zod 3.25.x line the SDK's `zod/v4` subpath requires. */
-const ZOD_VERSION = '3.25.76';
+/** The zod major the authoring SDK is built against. */
+const ZOD_VERSION = '4.1.12';
 
 export interface ResolvedVersions {
   orchestration: string;

--- a/packages/orchestration-core/src/scaffold.ts
+++ b/packages/orchestration-core/src/scaffold.ts
@@ -80,8 +80,8 @@ const VERSION_FALLBACK = {
   tools: "0.1.1",
 };
 
-/** Pinned to the zod 3.25.x line the SDK requires. */
-const ZOD_VERSION = "3.25.76";
+/** The zod major the authoring SDK is built against. */
+const ZOD_VERSION = "4.1.12";
 
 export interface ResolvedVersions {
   orchestration: string;

--- a/packages/orchestration-runtime/package.json
+++ b/packages/orchestration-runtime/package.json
@@ -52,7 +52,7 @@
     "ajv": "^8.12.0"
   },
   "peerDependencies": {
-    "zod": "^3.25.76"
+    "zod": "^4.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -64,7 +64,7 @@
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.2",
-    "zod": "^3.25.76"
+    "zod": "^4.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/orchestration-runtime/src/completion-payload.ts
+++ b/packages/orchestration-runtime/src/completion-payload.ts
@@ -1,5 +1,4 @@
-// `zod/v4` subpath (zod 3.25.x) — matches the SDK's zod regime.
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 /**
  * The step-completion wire contract (protocol 1) — what an executor reports

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -2,8 +2,8 @@
 
 The versioned public contract for authoring Sapiom orchestrations.
 
-A lean, dependency-light package (types + a small protocol runtime, with a single
-strictly-pinned `zod` peer) shared by three consumers:
+A lean, dependency-light package (types + a small protocol runtime) shared by
+three consumers:
 
 - **Customer orchestration definitions** — authored against this package's types and
   compiled by the build.
@@ -14,11 +14,8 @@ strictly-pinned `zod` peer) shared by three consumers:
 ## Install
 
 ```sh
-npm install @sapiom/orchestration zod
+npm install @sapiom/orchestration
 ```
-
-`zod` is a peer dependency, pinned to the `3.25.x` line (the SDK uses the `zod/v4`
-subpath).
 
 ## Authoring surface
 
@@ -131,3 +128,25 @@ list grows as capabilities land:
 | Capability   | Launch                              | Pause signal                             |
 | ------------ | ----------------------------------- | ---------------------------------------- |
 | Coding agent | `ctx.sapiom.agent.coding.launch(…)` | `CODING_RESULT_SIGNAL` (`@sapiom/tools`) |
+
+## Compatibility: zod
+
+Author your step schemas with zod the way you normally would:
+
+```ts
+import { z } from "zod";
+```
+
+Step `inputSchema`s are zod schemas, and the build converts them to JSON Schema
+for the manifest — so your project's `zod` is the one to reach for.
+
+If your project is pinned to an older `zod` that the authoring types reject, you
+can import a known-good `z` directly from this package instead, without changing
+your own `zod`:
+
+```ts
+import { z } from "@sapiom/orchestration";
+```
+
+This is a compatibility shim, not the recommended import — prefer your own `zod`
+unless you hit a version conflict.

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -49,10 +49,8 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@sapiom/tools": "workspace:^"
-  },
-  "peerDependencies": {
-    "zod": "^3.25.76"
+    "@sapiom/tools": "workspace:^",
+    "zod": "^4.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -64,7 +62,7 @@
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.2",
-    "zod": "^3.25.76"
+    "zod": "^4.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/orchestration/src/errors.ts
+++ b/packages/orchestration/src/errors.ts
@@ -1,4 +1,4 @@
-import type { $ZodIssue } from 'zod/v4/core';
+import type { core } from 'zod';
 
 /** Base class for every error the primitive can throw. */
 export class WorkflowError extends Error {
@@ -18,8 +18,8 @@ export class WorkflowError extends Error {
  */
 export class StepInputValidationError extends WorkflowError {
   readonly stepName: string;
-  readonly issues: readonly $ZodIssue[];
-  constructor(stepName: string, issues: readonly $ZodIssue[]) {
+  readonly issues: readonly core.$ZodIssue[];
+  constructor(stepName: string, issues: readonly core.$ZodIssue[]) {
     super(`Input for step '${stepName}' failed validation: ${formatIssues(issues)}`);
     this.name = 'StepInputValidationError';
     this.stepName = stepName;
@@ -28,7 +28,7 @@ export class StepInputValidationError extends WorkflowError {
 }
 
 /** `path.to.field: message; other: message` — compact, human-readable. */
-function formatIssues(issues: readonly $ZodIssue[]): string {
+function formatIssues(issues: readonly core.$ZodIssue[]): string {
   if (issues.length === 0) return 'unknown validation error';
   return issues
     .map((issue) => {

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -6,9 +6,8 @@
  *   - The sandbox step-runner (reads input.json, builds ctx, runs one step)
  *   - The engine (uses types + directive guards; steps implement these interfaces)
  *
- * Design rule: LEAN. Types + ~100 lines of protocol runtime + one strictly-pinned
- * zod peer dep (`zod/v4` subpath on zod 3.25.x). No capability clients, no engine
- * internals, no NestJS imports.
+ * Design rule: LEAN. Types + ~100 lines of protocol runtime over zod. No
+ * capability clients, no engine internals, no NestJS imports.
  */
 
 // Directives — the load-bearing protocol contract
@@ -61,3 +60,10 @@ export type { WorkflowManifest, WorkflowStepManifest, ManifestTransition } from 
 // Manifest generator + graph validation — called by the build phase.
 export { buildManifest, validateGraph, assertValidGraph } from './build-manifest.js';
 export type { GraphValidation } from './build-manifest.js';
+
+// Compatibility re-export. Authoring code should `import { z } from "zod"` as
+// normal — this is only for projects pinned to a zod that's incompatible with
+// the authoring types, so they can pull a known-good `z` from here without
+// touching their own zod. See the README's "Compatibility" note.
+export { z } from 'zod';
+export type { ZodType } from 'zod';

--- a/packages/orchestration/src/introspection.ts
+++ b/packages/orchestration/src/introspection.ts
@@ -1,9 +1,4 @@
-// Use the Zod 4 API via the `zod/v4` subpath: the workspace pins zod at
-// 3.25.x (which ships v4 under this subpath), so we get `z.toJSONSchema`
-// without bumping the shared `zod` resolution to v4 for the rest of the
-// monorepo (wagmi/wallet peers). errors.ts uses `zod/v4/core` for the same
-// reason.
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 import type { OrchestrationDefinition } from './workflow.js';
 

--- a/packages/orchestration/src/manifest.spec.ts
+++ b/packages/orchestration/src/manifest.spec.ts
@@ -9,7 +9,7 @@
  *   5. buildManifest: step with timeoutMs → timeoutMs; without → null
  *   6. buildManifest: protocol is always 1, sdkVersion/artifact from opts
  */
-import { z } from "zod/v4";
+import { z } from "zod";
 
 import { buildManifest } from "./build-manifest.js";
 import { goto, pauseUntilSignal, terminate } from "./directives.js";

--- a/packages/orchestration/src/manifest.ts
+++ b/packages/orchestration/src/manifest.ts
@@ -1,6 +1,4 @@
-// `zod/v4` subpath (zod 3.25.x): keeps the shared `zod` resolution on v3
-// while this SDK uses the v4 type + API surface.
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 /**
  * Protocol version for the workflow manifest format. Bumped when the schema

--- a/packages/orchestration/src/step.ts
+++ b/packages/orchestration/src/step.ts
@@ -1,6 +1,4 @@
-// `zod/v4` subpath (zod 3.25.x): keeps the shared `zod` resolution on v3
-// while this engine uses the v4 type + API surface. See introspection.ts.
-import type { ZodType } from 'zod/v4';
+import type { ZodType } from 'zod';
 
 import type { OrchestrationExecutionContext } from './context.js';
 import type { Fail, Goto, NextStepDirective, Pause, Retry, Terminate } from './directives.js';

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -29,6 +29,15 @@ import type {
   CodingRunResult,
   RunHandle,
 } from "./agent/index.js";
+import {
+  run as orchestrationsRun,
+  launch as orchestrationsLaunch,
+} from "./orchestrations/index.js";
+import type {
+  OrchestrationRunSpec,
+  OrchestrationRunResult,
+  RunHandle as OrchestrationRunHandle,
+} from "./orchestrations/index.js";
 import * as fileStorage from "./file-storage/index.js";
 import type {
   UploadInput,
@@ -64,6 +73,12 @@ export interface Sapiom {
       run(spec: CodingRunSpec): Promise<CodingRunResult>;
       launch(spec: CodingRunSpec): Promise<RunHandle>;
     };
+  };
+  readonly orchestrations: {
+    /** Run a deployed orchestration by slug and await its terminal result. */
+    run(spec: OrchestrationRunSpec): Promise<OrchestrationRunResult>;
+    /** Launch a deployed orchestration; pass the handle to `pauseUntilSignal` to suspend on it. */
+    launch(spec: OrchestrationRunSpec): Promise<OrchestrationRunHandle>;
   };
   readonly fileStorage: {
     upload(input: UploadInput): Promise<UploadResponse>;
@@ -112,6 +127,10 @@ function bind(transport: Transport): Sapiom {
         run: (spec) => codingRun(spec, transport),
         launch: (spec) => codingLaunch(spec, transport),
       },
+    },
+    orchestrations: {
+      run: (spec) => orchestrationsRun(spec, transport),
+      launch: (spec) => orchestrationsLaunch(spec, transport),
     },
     fileStorage: {
       upload: (input) => fileStorage.upload(input, transport),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -43,6 +43,15 @@ export {
   EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
 } from "./agent/index.js";
 
+export * as orchestrations from "./orchestrations/index.js";
+// Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
+export { ORCHESTRATIONS_RESULT_SIGNAL } from "./orchestrations/index.js";
+// The shape a step resumed from `pauseUntilSignal(orchestrationHandle, …)` receives
+// as input — annotate the resumed step with it instead of hand-rolling the shape.
+export type { OrchestrationRunResultPayload } from "./orchestrations/index.js";
+// Validate an OrchestrationRunResultPayload at the resume boundary.
+export { orchestrationResultSchema, OrchestrationResultSchemaError } from "./orchestrations/index.js";
+
 export * as fileStorage from "./file-storage/index.js";
 export { FileStorageHttpError } from "./file-storage/index.js";
 

--- a/packages/tools/src/orchestrations/index.spec.ts
+++ b/packages/tools/src/orchestrations/index.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * orchestrations.launch — dispatch-handle shape, slug URL, resume-token forwarding —
+ * plus the resume-payload schema. Injects a fake fetch (no real network).
+ */
+import { createClient } from "../index.js";
+import {
+  ORCHESTRATIONS_RESULT_SIGNAL,
+  OrchestrationResultSchemaError,
+  orchestrationResultSchema,
+} from "./index.js";
+
+function fakeFetch(capture?: { headers?: Record<string, string>; url?: string }): typeof globalThis.fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    if (capture) {
+      capture.headers = init.headers as Record<string, string>;
+      capture.url = url;
+    }
+    return {
+      ok: true,
+      status: 201,
+      json: async () => ({ status: "enqueued", executionId: "exec-9" }),
+      text: async () => JSON.stringify({ status: "enqueued", executionId: "exec-9" }),
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("orchestrations.launch — dispatch handle", () => {
+  it("returns a handle satisfying DispatchHandle (correlationId = child execution id)", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch() });
+    const handle = await sapiom.orchestrations.launch({ definition: "enrich-lead", input: { a: 1 } });
+    expect(handle.executionId).toBe("exec-9");
+    expect(handle.dispatch).toEqual({
+      correlationId: "exec-9",
+      resultSignal: ORCHESTRATIONS_RESULT_SIGNAL,
+    });
+  });
+
+  it("POSTs to /v1/workflows/:slug/executions (by slug)", async () => {
+    const capture: { url?: string } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    await sapiom.orchestrations.launch({ definition: "enrich-lead" });
+    expect(capture.url).toContain("/v1/workflows/enrich-lead/executions");
+  });
+
+  it("ORCHESTRATIONS_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(ORCHESTRATIONS_RESULT_SIGNAL).toBe("orchestrations.result");
+  });
+});
+
+describe("orchestrations.launch — workflow resume token", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("forwards the env token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-abc";
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    await sapiom.orchestrations.launch({ definition: "d" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBe("tok-abc");
+  });
+
+  it("omits the header outside a workflow (no env token)", async () => {
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
+    await sapiom.orchestrations.launch({ definition: "d" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
+  });
+});
+
+describe("orchestrationResultSchema", () => {
+  const base = { executionId: "e", definition: "d", version: "1", startedAt: "t0", finishedAt: "t1" };
+
+  it("accepts a completed payload", () => {
+    const p = { ...base, status: "completed", output: { ok: true } };
+    expect(orchestrationResultSchema.parse(p)).toBe(p);
+  });
+
+  it("accepts a failed payload", () => {
+    const p = { ...base, status: "failed", error: { message: "x" } };
+    expect(orchestrationResultSchema.parse(p).status).toBe("failed");
+  });
+
+  it("rejects an unknown status", () => {
+    expect(() => orchestrationResultSchema.parse({ ...base, status: "weird" })).toThrow(
+      OrchestrationResultSchemaError,
+    );
+  });
+
+  it("rejects a completed payload missing output", () => {
+    expect(() => orchestrationResultSchema.parse({ ...base, status: "completed" })).toThrow(
+      OrchestrationResultSchemaError,
+    );
+  });
+});

--- a/packages/tools/src/orchestrations/index.ts
+++ b/packages/tools/src/orchestrations/index.ts
@@ -1,0 +1,217 @@
+/**
+ * `orchestrations` capability — run a deployed orchestration, and (the headline
+ * use) dispatch one FROM a step and pause until it finishes.
+ *
+ *   import { orchestrations } from "@sapiom/tools";
+ *   // dispatch another orchestration and pause this step on its result:
+ *   const child = await orchestrations.launch({ definition: "enrich-lead", input });
+ *   return pauseUntilSignal(child, { resumeStep: "use-result" });
+ *   // the resumed step receives an OrchestrationRunResultPayload
+ *
+ * `launch` returns a handle to pass straight to `pauseUntilSignal` (the waiting
+ * step resumes when the run finishes) or to `wait()` inline for standalone use.
+ * `run` is `launch` + `wait` — it blocks until the run reaches a terminal state, so
+ * use it for inline standalone calls, NOT to pause a step (it returns a result, not
+ * a pausable handle). An orchestration is addressed by its **slug** (its stable handle).
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import type { DispatchHandle } from "../dispatch.js";
+
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_WORKFLOWS_URL || "https://workflows.services.sapiom.ai";
+
+/**
+ * Signal a run fires when it reaches a terminal state (completed OR failed — the
+ * payload carries which, the resumed step branches). A step paused on an
+ * orchestration handle resumes on this; it is the value carried in the handle's
+ * `dispatch.resultSignal`.
+ */
+export const ORCHESTRATIONS_RESULT_SIGNAL = "orchestrations.result";
+
+/** Run lifecycle status. */
+export type ExecutionStatus =
+  | "running"
+  | "paused"
+  | "completed"
+  | "failed"
+  | "cancelled";
+const TERMINAL = new Set<ExecutionStatus>(["completed", "failed", "cancelled"]);
+
+export interface OrchestrationRunSpec {
+  /** Slug of the deployed orchestration to run (its stable handle). */
+  definition: string;
+  /** Input passed to the orchestration's entry step. */
+  input?: Record<string, unknown>;
+  /** Optional idempotency key — a repeat with the same key returns the existing run. */
+  idempotencyKey?: string;
+}
+
+/** A live, awaited run (the standalone `run()`/`wait()` result). */
+export interface OrchestrationRunResult {
+  executionId: string;
+  status: ExecutionStatus;
+  output: unknown;
+  error: unknown;
+}
+
+/**
+ * The typed result delivered to the step resumed from `pauseUntilSignal(handle, …)`
+ * — the payload that step receives as its `input`. Discriminated on `status` so a
+ * FAILURE is data the author branches on, not an exception.
+ *
+ *   const useResult = defineStep({
+ *     name: "use-result",
+ *     async run(result: OrchestrationRunResultPayload, ctx) {
+ *       if (result.status === "failed") { … }
+ *     },
+ *   });
+ */
+export type OrchestrationRunResultPayload<TOutput = unknown> =
+  | {
+      status: "completed";
+      executionId: string;
+      definition: string;
+      version: string;
+      output: TOutput;
+      startedAt: string;
+      finishedAt: string;
+    }
+  | {
+      status: "failed";
+      executionId: string;
+      definition: string;
+      version: string;
+      error: unknown;
+      startedAt: string;
+      finishedAt: string;
+    };
+
+/** Thrown by {@link orchestrationResultSchema}.parse on a malformed resume payload. */
+export class OrchestrationResultSchemaError extends Error {}
+
+/**
+ * Runtime validator for {@link OrchestrationRunResultPayload}. `parse` returns the
+ * value typed on success and throws an {@link OrchestrationResultSchemaError} on any
+ * divergence. Generic in the caller's expected `output` type — the shape of
+ * `output` itself is the child orchestration's contract, not validated here.
+ */
+export const orchestrationResultSchema = {
+  parse<TOutput = unknown>(value: unknown): OrchestrationRunResultPayload<TOutput> {
+    const fail = (msg: string): never => {
+      throw new OrchestrationResultSchemaError(
+        `invalid orchestration result payload: ${msg}`,
+      );
+    };
+    if (!value || typeof value !== "object") fail("not an object");
+    const v = value as Record<string, unknown>;
+
+    if (v.status !== "completed" && v.status !== "failed")
+      fail("status must be 'completed' or 'failed'");
+    if (typeof v.executionId !== "string") fail("executionId must be a string");
+    if (typeof v.definition !== "string") fail("definition must be a string");
+    if (typeof v.version !== "string") fail("version must be a string");
+    if (typeof v.startedAt !== "string") fail("startedAt must be a string");
+    if (typeof v.finishedAt !== "string") fail("finishedAt must be a string");
+    if (v.status === "completed" && !("output" in v))
+      fail("a completed result must carry `output`");
+    if (v.status === "failed" && !("error" in v))
+      fail("a failed result must carry `error`");
+
+    return value as OrchestrationRunResultPayload<TOutput>;
+  },
+};
+
+/**
+ * A launched-but-not-awaited child run. Satisfies {@link DispatchHandle}, so it can
+ * be handed straight to `pauseUntilSignal(handle, { resumeStep })` to suspend the
+ * step until the child finishes — or `wait()`-ed inline for standalone use.
+ */
+export interface RunHandle extends DispatchHandle {
+  executionId: string;
+  /** Fetch the current status without blocking. */
+  status(): Promise<ExecutionStatus>;
+  /** Poll to a terminal state and resolve the run result. */
+  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<OrchestrationRunResult>;
+}
+
+/**
+ * Inside a Sapiom workflow a resume token is provided via the environment;
+ * forwarding it (as a header, not a body field) lets the run resume the waiting
+ * step when it finishes. Outside a workflow there's no token, so nothing is sent.
+ */
+function workflowResumeHeaders(): Record<string, string> {
+  const token = process.env.SAPIOM_CAPABILITY_RESUME_TOKEN;
+  return token ? { "x-sapiom-workflow-token": token } : {};
+}
+
+// --- wire shapes ---
+
+/** Create-execution response. */
+interface StartResponse {
+  status: "enqueued" | "already_exists";
+  executionId: string;
+  existingStatus?: ExecutionStatus;
+}
+
+/** Execution status document — only the fields the handle reads. */
+interface ExecutionDoc {
+  status: ExecutionStatus;
+  output?: unknown;
+  error?: unknown;
+}
+
+export async function launch(
+  spec: OrchestrationRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<RunHandle> {
+  const res = await transport.request<StartResponse>(
+    `${baseUrl}/v1/workflows/${encodeURIComponent(spec.definition)}/executions`,
+    {
+      method: "POST",
+      body: JSON.stringify({ input: spec.input ?? {}, idempotencyKey: spec.idempotencyKey }),
+      headers: workflowResumeHeaders(),
+    },
+  );
+  const executionId = res.executionId;
+
+  const fetchDoc = () =>
+    transport.request<ExecutionDoc>(
+      `${baseUrl}/v1/workflows/executions/${encodeURIComponent(executionId)}`,
+    );
+
+  return {
+    executionId,
+    // Framework plumbing for `pauseUntilSignal` — see DispatchHandle. correlationId
+    // is this run's id (the resume's correlation key).
+    dispatch: { correlationId: executionId, resultSignal: ORCHESTRATIONS_RESULT_SIGNAL },
+    async status() {
+      return (await fetchDoc()).status;
+    },
+    async wait({ timeoutMs = 60 * 60_000, pollMs = 3_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (TERMINAL.has(d.status)) {
+          return { executionId, status: d.status, output: d.output ?? null, error: d.error ?? null };
+        }
+        if (Date.now() > deadline) {
+          throw new Error(
+            `orchestration ${executionId} timed out after ${timeoutMs}ms (last status: ${d.status})`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+export async function run(
+  spec: OrchestrationRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<OrchestrationRunResult> {
+  const handle = await launch(spec, transport, baseUrl);
+  return handle.wait();
+}

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -20,6 +20,11 @@
  */
 import { CODING_RESULT_SIGNAL, toResumePayload } from "../agent/index.js";
 import type { CodingRunResult, RunHandle, RunStatus } from "../agent/index.js";
+import { ORCHESTRATIONS_RESULT_SIGNAL } from "../orchestrations/index.js";
+import type {
+  OrchestrationRunResult,
+  RunHandle as OrchestrationRunHandle,
+} from "../orchestrations/index.js";
 import type { Sapiom } from "../client.js";
 import { Repository } from "../repositories/index.js";
 import { Sandbox } from "../sandboxes/index.js";
@@ -478,6 +483,43 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             () => toResumePayload(result),
           );
         },
+      },
+    },
+    orchestrations: {
+      run: (spec) =>
+        Promise.resolve(
+          r("orchestrations.run", [spec], () => ({
+            executionId: `stub-exec-${++launchSeq}`,
+            status: "completed" as const,
+            output: {},
+            error: null,
+          })) as OrchestrationRunResult,
+        ),
+      launch: (spec) => {
+        const executionId = `stub-exec-${++launchSeq}`;
+        const result: OrchestrationRunResult = {
+          executionId,
+          status: "completed",
+          output: {},
+          error: null,
+        };
+        const handle: OrchestrationRunHandle = {
+          executionId,
+          dispatch: { correlationId: executionId, resultSignal: ORCHESTRATIONS_RESULT_SIGNAL },
+          status: () => Promise.resolve("completed" as const),
+          wait: () => Promise.resolve(result),
+        };
+        // Register the resume payload so a local `pauseUntilSignal` on this handle
+        // resolves with an OrchestrationRunResultPayload.
+        return dispatchable(handle, opts.signals, () => ({
+          status: "completed" as const,
+          executionId,
+          definition: spec.definition,
+          version: "stub",
+          output: {},
+          startedAt: "2099-01-01T00:00:00.000Z",
+          finishedAt: "2099-01-01T00:00:00.000Z",
+        }));
       },
     },
     fileStorage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@sapiom/tools':
         specifier: workspace:^
         version: link:../tools
+      zod:
+        specifier: ^4.1.0
+        version: 4.4.3
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -317,9 +320,6 @@ importers:
       typescript:
         specifier: ^5.4.2
         version: 5.9.3
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
 
   packages/orchestration-core:
     dependencies:
@@ -401,8 +401,8 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.1.0
+        version: 4.4.3
 
   packages/sandbox:
     dependencies:
@@ -3285,6 +3285,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -6350,3 +6353,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
This pull request introduces a new `orchestrations` capability to the `@sapiom/tools` package, enabling users to run or dispatch orchestrations (workflows) by slug, either inline or from a workflow step with support for pausing and resuming. The changes include the main implementation, type definitions, runtime schema validation, client and stub integrations, and comprehensive tests.

**Key changes:**

### Orchestrations Capability Implementation

* Added `orchestrations` module with `run` (awaits terminal result) and `launch` (returns a handle for pausing/resuming) functions, including type definitions for run specs, results, and payloads, as well as runtime schema validation (`orchestrationResultSchema`) and a capability-stable terminal signal (`ORCHESTRATIONS_RESULT_SIGNAL`).
* Updated the main package export to surface the new orchestrations API, types, and schema validator at the top level for easy import and use.
* Documented the new orchestrations capability and its usage in a changeset.

### Sapiom Client and Stub Integration

* Integrated the orchestrations API into the main `Sapiom` client, exposing `orchestrations.run` and `orchestrations.launch` methods, and wired them to the transport layer. [[1]](diffhunk://#diff-6e2f33aad43ffeb8daa54875dcba4212199ca99aadc6f9b772d3211bf5acb4c8R32-R40) [[2]](diffhunk://#diff-6e2f33aad43ffeb8daa54875dcba4212199ca99aadc6f9b772d3211bf5acb4c8R77-R82) [[3]](diffhunk://#diff-6e2f33aad43ffeb8daa54875dcba4212199ca99aadc6f9b772d3211bf5acb4c8R131-R134)
* Added orchestrations support to the stub client for testing, including simulated run and launch behavior with resume payload registration for `pauseUntilSignal`. [[1]](diffhunk://#diff-16f7671e59baf9c254e69e34b54764bac88507133389bb9c2783e8255de929d8R23-R27) [[2]](diffhunk://#diff-16f7671e59baf9c254e69e34b54764bac88507133389bb9c2783e8255de929d8R488-R524)

### Testing

* Added comprehensive tests for the orchestrations module, covering launch handle shape, slug URL construction, resume token forwarding, terminal signal, and schema validation for result payloads.