### PR TITLE
feat(tools): forward workflow resume token via createClient({ resumeToken })

### DIFF
--- a/.changeset/mcp-run-coerce-input.md
+++ b/.changeset/mcp-run-coerce-input.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/mcp": patch
+---
+
+Fix `sapiom_dev_orchestrations_run` rejecting valid input as "input must be an object".
+
+The real-run tool passed the `input` argument straight through, but some MCP clients serialize object-valued args as a JSON string — so the execution API (which requires an object) received `"{}"` and returned HTTP 400. `run_local` already normalized this with `coerceJson`; the real-run path now does the same and defaults an absent input to `{}`. Brings the two paths into parity.

--- a/.changeset/tools-resume-token-option.md
+++ b/.changeset/tools-resume-token-option.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": patch
+---
+
+Forward the workflow resume token explicitly via `createClient({ resumeToken })`.
+
+`agent.coding.run`/`launch` send the per-execution resume token as the `x-sapiom-workflow-token` header so the gateway can resume the paused workflow step. Previously the token was read ONLY from `process.env.SAPIOM_CAPABILITY_RESUME_TOKEN` — fine for the sandbox runtime (which injects that env var) but invisible to the engine's in-process runtime, which must not set process-global env (it would bleed across concurrent step executions sharing the worker). `TransportConfig` now accepts an optional `resumeToken`; the client prefers it and falls back to the env var, so the sandbox path is unchanged and the in-process runtime can pass the token per-call. Additive and backward-compatible.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Thumbs.db
 .temp/
 .claude/commands/
 .trees
+
+# Local Verdaccio registry (SDK dev loop) — storage + runtime auth, never committed
+.verdaccio/storage/
+.verdaccio/.npmrc

--- a/.verdaccio/config.yaml
+++ b/.verdaccio/config.yaml
@@ -1,0 +1,39 @@
+# Local-only Verdaccio registry for Sapiom SDK development.
+#
+# Serves @sapiom/* from your LOCAL publishes (`pnpm publish:local`) and proxies
+# everything else from npmjs. This is the supported way to develop the public
+# SDKs against a local Sapiom stack and a customer-like MCP session without a real
+# npm publish on every change. See docs/guides/workflows-authoring-quickstart.md §4.
+#
+# NOT for production: anonymous publish, no auth. Local machine only.
+
+storage: ./storage
+# No web UI plugin / no auth plugin needed for local dev. Anonymous everything.
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    # Cache upstream tarballs so the local stack still installs npm deps offline-ish.
+    cache: true
+
+packages:
+  # First-party scope: NEVER proxy to npm — local publishes are authoritative, so a
+  # locally-published 0.5.x always wins over the real-npm version of the same name.
+  "@sapiom/*":
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  # Everything else proxies through npmjs (so non-@sapiom deps resolve normally).
+  "@*/*":
+    access: $all
+    publish: $all
+    proxy: npmjs
+  "**":
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+log: { type: stdout, format: pretty, level: warn }
+
+listen: 0.0.0.0:4873

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
-    "dev:watch": "pnpm -r --filter='./packages/*' --parallel run dev"
+    "dev:watch": "pnpm -r --filter='./packages/*' --parallel run dev",
+    "registry:local": "npx -y verdaccio@6 --config .verdaccio/config.yaml",
+    "publish:local": "node scripts/publish-local.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/packages/mcp/src/tools/orchestrations.ts
+++ b/packages/mcp/src/tools/orchestrations.ts
@@ -364,7 +364,16 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       if (!client) return NOT_AUTHED;
       try {
         const cfg = requireConfig(dir ?? process.cwd());
-        return ok(await run({ definitionId: cfg.definitionId, input }, client));
+        // Coerce a string-serialized input back to JSON (some MCP clients
+        // stringify object-valued args), mirroring run_local — the execution API
+        // requires an object, so a raw `"{}"` string would be rejected. Default an
+        // absent input to {} (the entry step's empty input).
+        return ok(
+          await run(
+            { definitionId: cfg.definitionId, input: coerceJson(input) ?? {} },
+            client,
+          ),
+        );
       } catch (err) {
         return fail(err);
       }

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -43,6 +43,15 @@ export interface TransportConfig {
   fetch?: typeof globalThis.fetch;
   /** Default attribution applied to every request this transport makes (see class doc). */
   attribution?: Attribution;
+  /**
+   * Opaque per-execution workflow resume token. Forwarded as the
+   * `x-sapiom-workflow-token` header on a coding launch so the gateway can resume
+   * the paused step. The SANDBOX runtime injects it ambiently
+   * (`SAPIOM_CAPABILITY_RESUME_TOKEN`) and this is left unset; the IN-PROCESS
+   * runtime — which must not touch process-global env — passes it explicitly here.
+   * When omitted, falls back to the env var, so both runtimes work.
+   */
+  resumeToken?: string;
 }
 
 function attributionToHeaders(a: Attribution): Record<string, string> {
@@ -77,17 +86,25 @@ export class Transport {
   private readonly apiKey: string | undefined;
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly attribution: Attribution;
+  /**
+   * The workflow resume token to forward (see {@link TransportConfig.resumeToken}).
+   * Explicit config wins; otherwise the ambient env var, so the sandbox runtime —
+   * which injects `SAPIOM_CAPABILITY_RESUME_TOKEN` — keeps working unchanged.
+   */
+  readonly resumeToken: string | undefined;
 
   constructor(config: TransportConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.SAPIOM_API_KEY ?? undefined;
     this.fetchImpl = config.fetch ?? globalThis.fetch;
     this.attribution = config.attribution ?? {};
+    this.resumeToken =
+      config.resumeToken ?? process.env.SAPIOM_CAPABILITY_RESUME_TOKEN ?? undefined;
   }
 
   /**
-   * A new transport sharing this one's credential and fetch, with `attribution`
-   * merged over the current defaults. The escape hatch for the cases where one
-   * process attributes to many agents/traces (a router) — not something
+   * A new transport sharing this one's credential, fetch, and resume token, with
+   * `attribution` merged over the current defaults. The escape hatch for the cases
+   * where one process attributes to many agents/traces (a router) — not something
    * step-authoring code reaches for.
    */
   withAttribution(attribution: Attribution): Transport {
@@ -95,6 +112,7 @@ export class Transport {
       apiKey: this.apiKey,
       fetch: this.fetchImpl,
       attribution: { ...this.attribution, ...attribution },
+      resumeToken: this.resumeToken,
     });
   }
 

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -250,8 +250,7 @@ export interface RunHandle extends DispatchHandle {
  * gateway call back into the engine to resume the paused workflow when the run
  * finishes. Absent outside a workflow → no header, no behavior change.
  */
-function workflowResumeHeaders(): Record<string, string> {
-  const token = process.env.SAPIOM_CAPABILITY_RESUME_TOKEN;
+function workflowResumeHeaders(token: string | undefined): Record<string, string> {
   return token ? { "x-sapiom-workflow-token": token } : {};
 }
 
@@ -323,7 +322,7 @@ export async function launch(
   const doc = await transport.request<RunDoc>(`${baseUrl}/v1/coding/runs`, {
     method: "POST",
     body: JSON.stringify(buildBody(spec)),
-    headers: workflowResumeHeaders(),
+    headers: workflowResumeHeaders(transport.resumeToken),
   });
   const runId = doc.data.id;
   const envId = doc.data.relationships?.execution_environment?.data?.id;

--- a/packages/tools/src/agent/launch.spec.ts
+++ b/packages/tools/src/agent/launch.spec.ts
@@ -71,4 +71,27 @@ describe("agent.coding.launch — workflow resume token", () => {
     await sapiom.agent.coding.launch({ task: "t" });
     expect(capture.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
   });
+
+  it("forwards an explicit createClient({ resumeToken }) — the in-process runtime path", async () => {
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      resumeToken: "tok-explicit",
+      fetch: fakeLaunchFetch(capture),
+    });
+    await sapiom.agent.coding.launch({ task: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBe("tok-explicit");
+  });
+
+  it("explicit resumeToken wins over the ambient env token", async () => {
+    process.env[KEY] = "tok-env";
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      resumeToken: "tok-explicit",
+      fetch: fakeLaunchFetch(capture),
+    });
+    await sapiom.agent.coding.launch({ task: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBe("tok-explicit");
+  });
 });

--- a/scripts/publish-local.mjs
+++ b/scripts/publish-local.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// =============================================================================
+// scripts/publish-local.mjs
+//
+// Publish all public @sapiom/* packages to the LOCAL Verdaccio registry
+// (http://localhost:4873) so the Sapiom monorepo + a customer-like MCP session
+// can consume local SDK edits without a real npm publish. See
+// docs/guides/workflows-authoring-quickstart.md §4.
+//
+// Each run stamps a FRESH version (patch-bump beyond whatever the local registry
+// already has, and beyond the source version so it never collides with real npm):
+//   - a REAL patch (not a prerelease) so the monorepo's `^0.5.0`-style ranges
+//     still match it, AND it becomes the `latest` tag the scaffold exact-pins.
+//   - a new version each run → cache-safe (no pnpm integrity collisions).
+// Internal `workspace:^` deps are rewritten to the stamped versions by pnpm at
+// publish time. Source package.json version bumps are REVERTED at the end so git
+// stays clean — the registry, not the working tree, tracks the local version.
+//
+// Usage:  node scripts/publish-local.mjs [--skip-build]
+// Prereq: the registry must be running — `pnpm registry:local` in another shell.
+// =============================================================================
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REGISTRY = "http://localhost:4873";
+
+// Publish set in dependency (topological) order. Skips the quarantined langchain*.
+const PACKAGES = [
+  "core",
+  "fetch",
+  "tools",
+  "orchestration",
+  "orchestration-runtime",
+  "orchestration-core",
+  "sandbox",
+  "cli",
+  "mcp",
+];
+
+function pkgJsonPath(dir) {
+  return path.join(ROOT, "packages", dir, "package.json");
+}
+function readPkg(dir) {
+  return JSON.parse(readFileSync(pkgJsonPath(dir), "utf8"));
+}
+
+/** Bump the patch of an x.y.z version, stripping any prerelease/build suffix. */
+function bumpPatch(version) {
+  const [core] = version.split(/[-+]/);
+  const [major, minor, patch] = core.split(".").map((n) => parseInt(n, 10));
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+/** Highest version currently on the local registry, or null if never published. */
+function localRegistryVersion(name) {
+  try {
+    return (
+      execFileSync("npm", ["view", name, "version", "--registry", REGISTRY], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+// A Verdaccio-scoped userconfig: anonymous publish still needs *a* token line, and
+// the registry pointer. Gitignored (.verdaccio/.npmrc) — never the real npm config.
+function writeAuthNpmrc() {
+  const npmrc = path.join(ROOT, ".verdaccio", ".npmrc");
+  mkdirSync(path.dirname(npmrc), { recursive: true });
+  writeFileSync(
+    npmrc,
+    `registry=${REGISTRY}/\n//localhost:4873/:_authToken=local-dev\n`,
+  );
+  return npmrc;
+}
+
+function run(cmd, args, extraEnv = {}) {
+  execFileSync(cmd, args, {
+    cwd: ROOT,
+    stdio: "inherit",
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+// --- preflight: registry reachable? ---
+try {
+  execFileSync("curl", ["-sf", "-o", "/dev/null", `${REGISTRY}/-/ping`], {
+    stdio: "ignore",
+  });
+} catch {
+  console.error(
+    `\n✗ Local registry not reachable at ${REGISTRY}.\n  Start it first:  pnpm registry:local\n`,
+  );
+  process.exit(1);
+}
+
+const skipBuild = process.argv.includes("--skip-build");
+if (!skipBuild) {
+  console.log("• Building all packages…");
+  run("pnpm", ["-r", "--filter=./packages/*", "build"]);
+}
+
+// 1. Compute the next version for each package (bump beyond source AND registry).
+const versions = {};
+const originals = {};
+for (const dir of PACKAGES) {
+  const pkg = readPkg(dir);
+  originals[dir] = pkg.version;
+  const local = localRegistryVersion(pkg.name);
+  // Take the higher of source/local as the floor, then patch-bump it.
+  const floor = local && cmp(local, pkg.version) >= 0 ? local : pkg.version;
+  versions[dir] = bumpPatch(floor);
+}
+
+// 2. Write the stamped versions (so pnpm rewrites workspace:^ → ^<new version>).
+for (const dir of PACKAGES) {
+  const pkg = readPkg(dir);
+  pkg.version = versions[dir];
+  writeFileSync(pkgJsonPath(dir), JSON.stringify(pkg, null, 2) + "\n");
+}
+
+const authNpmrc = writeAuthNpmrc();
+const failed = [];
+try {
+  for (const dir of PACKAGES) {
+    const { name } = readPkg(dir);
+    console.log(`• Publishing ${name}@${versions[dir]} → ${REGISTRY}`);
+    try {
+      run(
+        "pnpm",
+        [
+          "--filter",
+          name,
+          "publish",
+          "--registry",
+          REGISTRY,
+          "--no-git-checks",
+          "--tag",
+          "latest",
+        ],
+        {
+          npm_config_userconfig: authNpmrc,
+        },
+      );
+    } catch {
+      failed.push(name);
+    }
+  }
+} finally {
+  // 3. Revert source version bumps so the working tree stays clean.
+  run("git", [
+    "checkout",
+    "--",
+    ...PACKAGES.map((d) => path.join("packages", d, "package.json")),
+  ]);
+}
+
+if (failed.length) {
+  console.error(`\n✗ Failed to publish: ${failed.join(", ")}`);
+  process.exit(1);
+}
+console.log(
+  `\n✓ Published ${PACKAGES.length} @sapiom/* packages to ${REGISTRY} (latest patch stamped).`,
+);
+console.log(
+  "  Monorepo:  pnpm install --registry http://localhost:4873  (then restart pnpm dev)",
+);
+console.log(
+  "  Author session / MCP:  npm install / npx with npm_config_registry=http://localhost:4873",
+);
+
+/** Compare two x.y.z versions (ignoring prerelease): -1 / 0 / 1. */
+function cmp(a, b) {
+  const pa = a.split(/[-+]/)[0].split(".").map(Number);
+  const pb = b.split(/[-+]/)[0].split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0))
+      return (pa[i] || 0) > (pb[i] || 0) ? 1 : -1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
This PR carries two small, independent SDK fixes uncovered while running workflows end-to-end on a local stack, plus the local dev tooling that made that possible.

**1. `@sapiom/tools` — forward the workflow resume token explicitly.** `agent.coding.run`/`launch` send the per-execution resume token as the `x-sapiom-workflow-token` header so the gateway can resume a paused workflow step — but they only read it from `process.env.SAPIOM_CAPABILITY_RESUME_TOKEN`. That works for the sandbox runtime (which injects the env var) but not for an in-process runtime, which must not set process-global env (it would bleed across concurrent step executions). Adds an optional `resumeToken` to the transport config: `createClient({ resumeToken })`, preferring the explicit token and falling back to the env var. Additive and backward-compatible.

**2. `@sapiom/mcp` — `sapiom_dev_orchestrations_run` rejected valid object input.** Some MCP clients serialize object-valued tool args as a JSON string, so the real-run path forwarded `"{}"` to the execution API (which requires an object) and got a 400. `run_local` already coerced this with `coerceJson`; the run path now does the same and defaults an absent input to `{}`. Brings the two paths into parity.

Also adds a local **Verdaccio** dev loop (`pnpm registry:local` / `pnpm publish:local`) so the SDK can be edited and consumed locally across services without a real publish — which is how both fixes above were caught.

## Changes
- `@sapiom/tools`: `resumeToken` on the transport config; `agent.coding` forwards explicit-over-env (tests in `agent/launch.spec.ts`). Changeset: patch.
- `@sapiom/mcp`: coerce stringified `input` on the real-run tool, default absent input to `{}`. Changeset: patch.
- `.verdaccio/config.yaml` + `scripts/publish-local.mjs` + `registry:local`/`publish:local` scripts.

## Testing
- [x] `@sapiom/tools` unit tests pass (incl. new resume-token cases).
- [x] Validated end-to-end against a local stack: a coding-pause workflow auto-resumed past the coding step; the run tool now accepts object input (real execution launched, vs HTTP 400 before).

## Checklist
- [x] Self-reviewed
- [x] Changesets included (`@sapiom/tools`, `@sapiom/mcp`)
