### PR TITLE
feat(tools): add contentGeneration.video.create (async video + optional storage)

### DIFF
--- a/.changeset/content-generation-video.md
+++ b/.changeset/content-generation-video.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add `contentGeneration.video.create` — generate a video from a prompt, with an optional `storage` param. Video generation is asynchronous: `create` submits the job and polls until the result is ready (configurable `pollIntervalMs` / `timeoutMs`), then resolves — so you `await` it just like `images.create`. When `storage` is passed, the output is persisted and the returned `video` carries a `fileId`. camelCase surface, mapped from the wire.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -71,7 +71,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `repositories` | Private, in-network git repos | [src/repositories](./src/repositories/README.md) |
 | `agent` | Coding agents (LLM execution) | [src/agent](./src/agent/README.md) |
 | `fileStorage` | Tenant-scoped object storage (presigned URLs) | [src/file-storage](./src/file-storage/README.md) |
-| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
+| `contentGeneration` | Media generation (images + video; audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
 
 ## Composing capabilities
 

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -42,6 +42,8 @@ import * as contentGeneration from "./content-generation/index.js";
 import type {
   ImageCreateInput,
   ImageGenerationResult,
+  VideoCreateInput,
+  VideoGenerationResult,
 } from "./content-generation/index.js";
 
 export interface Sapiom {
@@ -82,6 +84,14 @@ export interface Sapiom {
        * file-storage (the returned images then carry `file_id`).
        */
       create(input: ImageCreateInput): Promise<ImageGenerationResult>;
+    };
+    video: {
+      /**
+       * Generate a video from a prompt — async (submits, then polls until ready, then
+       * returns it). Pass `storage` to persist the output (the returned video carries
+       * `fileId`).
+       */
+      create(input: VideoCreateInput): Promise<VideoGenerationResult>;
     };
   };
   /**
@@ -124,6 +134,9 @@ function bind(transport: Transport): Sapiom {
     contentGeneration: {
       images: {
         create: (input) => contentGeneration.createImage(input, transport),
+      },
+      video: {
+        create: (input) => contentGeneration.createVideo(input, transport),
       },
     },
     withAttribution: (attribution) =>

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -1,6 +1,6 @@
 # contentGeneration
 
-Generate media — images today (video and audio to come) — with an optional
+Generate media — images and video today (audio to come) — with an optional
 `storage` param that persists each output to Sapiom file storage, so you get a
 durable `fileId` back inline.
 
@@ -41,7 +41,28 @@ for (const img of out.images ?? []) {
 Persisting is best-effort per image: if one fails, that image carries a
 `storageError` string instead of a `fileId` while the others still succeed.
 
-## Input
+## Video (async)
+
+Video generation is **asynchronous** — `create` submits the job, polls for the
+result, and resolves once it's ready, so you `await` it like an image (it just
+takes longer). `storage` works the same way — the output comes back with a `fileId`.
+
+```typescript
+const out = await sapiom.contentGeneration.video.create({
+  prompt: "a calm ocean wave at sunset",
+  storage: { visibility: "private" }, // optional — persist the output
+});
+
+out.video?.url; // hosted URL of the generated video
+out.video?.fileId; // present when `storage` was passed — use with `fileStorage`
+```
+
+Video input takes `prompt`, plus optional `storage`, `model`, and `params` (as with
+images), and two async controls: `pollIntervalMs` (poll cadence, default 5s) and
+`timeoutMs` (give up and throw if it isn't ready in time, default 5 min). The
+returned `video` is `{ url, contentType?, fileId?, storageError? }`.
+
+## Image input
 
 - `prompt` (required) — the text prompt.
 - `numImages` (optional) — how many images to generate.

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -392,6 +392,31 @@ describe("contentGeneration.video.create()", () => {
       ),
     ).rejects.toThrow(/did not complete within/);
   });
+
+  it("tolerates a transient non-ok poll, then returns once the result is ready", async () => {
+    let polls = 0;
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ request_id: "req-5", response_url: `${BASE}/queue/req-5` })
+          : null,
+      (c) => {
+        if (c.init.method !== "GET") return null;
+        polls += 1;
+        return polls < 2
+          ? jsonResponse({ error: "upstream hiccup" }, { status: 503 })
+          : jsonResponse({ video: { url: "https://media/v5.mp4" } });
+      },
+    ]);
+
+    const out = await createVideo(
+      { prompt: "x", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out.video?.url).toBe("https://media/v5.mp4");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -1,6 +1,11 @@
 import { createClient } from "../index.js";
 import { Transport } from "../_client/index.js";
-import { images, createImage, ContentGenerationHttpError } from "./index.js";
+import {
+  images,
+  createImage,
+  createVideo,
+  ContentGenerationHttpError,
+} from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers — the capability fn is tested directly with a real Transport wired to
@@ -237,5 +242,194 @@ describe("createClient().contentGeneration.images.create", () => {
       prompt: "x",
       storage: { visibility: "private" },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contentGeneration.video.create()  — async: submit, then poll until ready
+// ---------------------------------------------------------------------------
+
+describe("contentGeneration.video.create()", () => {
+  it("submits the default video model, polls until ready, and maps the result to camelCase", async () => {
+    let polls = 0;
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              request_id: "req-1",
+              response_url: `${BASE}/queue/fal-ai/veo3/requests/req-1`,
+              status_url: `${BASE}/queue/fal-ai/veo3/requests/req-1/status`,
+            })
+          : null,
+      (c) => {
+        if (c.init.method !== "GET") return null;
+        polls += 1;
+        // pending first, completed result second
+        return polls < 2
+          ? jsonResponse({ status: "IN_PROGRESS" })
+          : jsonResponse({
+              video: { url: "https://media/v.mp4", content_type: "video/mp4" },
+              seed: 9,
+            });
+      },
+    ]);
+
+    const out = await createVideo(
+      { prompt: "a wave", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    // wire snake (content_type) → camelCase (contentType); top-level extras pass through.
+    expect(out).toEqual({
+      video: { url: "https://media/v.mp4", contentType: "video/mp4" },
+      seed: 9,
+    });
+    // submit: default model, prompt only (no provider named, no storage).
+    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ prompt: "a wave" });
+    // polled the rewritten result URL until it carried output.
+    expect(
+      calls.filter(
+        (c) =>
+          c.init.method === "GET" &&
+          c.url === `${BASE}/queue/fal-ai/veo3/requests/req-1`,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("sends storage on submit and surfaces fileId on the polled result", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              request_id: "req-2",
+              response_url: `${BASE}/queue/req-2`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({
+              video: {
+                url: "https://media/v2.mp4",
+                content_type: "video/mp4",
+                file_id: "vid-file-1",
+              },
+            })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "x", storage: { visibility: "private" }, pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out.video).toEqual({
+      url: "https://media/v2.mp4",
+      contentType: "video/mp4",
+      fileId: "vid-file-1",
+    });
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      storage: { visibility: "private" },
+    });
+  });
+
+  it("maps a per-output storage_error to camelCase", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ request_id: "req-4", response_url: `${BASE}/queue/req-4` })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({
+              video: { url: "https://media/v4.mp4", storage_error: "nope" },
+            })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "x", storage: {}, pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out.video).toEqual({
+      url: "https://media/v4.mp4",
+      storageError: "nope",
+    });
+  });
+
+  it("throws ContentGenerationHttpError when the submit fails — never polls", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ error: "bad model" }, { status: 422 }),
+    ]);
+
+    await expect(
+      createVideo({ prompt: "x", pollIntervalMs: 1 }, transport, BASE),
+    ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+    expect(calls).toHaveLength(1); // submit only
+  });
+
+  it("throws if the result isn't ready before the timeout", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ request_id: "req-3", response_url: `${BASE}/queue/req-3` })
+          : null,
+      (c) =>
+        c.init.method === "GET" ? jsonResponse({ status: "IN_PROGRESS" }) : null,
+    ]);
+
+    await expect(
+      createVideo(
+        { prompt: "x", pollIntervalMs: 1, timeoutMs: 20 },
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow(/did not complete within/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClient().contentGeneration.video — binding
+// ---------------------------------------------------------------------------
+
+describe("createClient().contentGeneration.video.create", () => {
+  it("binds to the client credential + default host, submits then polls to the result", async () => {
+    let polls = 0;
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      calls.push({ url: String(input), init });
+      if (init.method === "POST") {
+        return jsonResponse({
+          request_id: "r",
+          response_url: "https://fal.services.sapiom.ai/queue/r",
+        });
+      }
+      polls += 1;
+      return polls < 2
+        ? jsonResponse({ status: "IN_PROGRESS" })
+        : jsonResponse({ video: { url: "u", file_id: "f" } });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
+    const out = await sapiom.contentGeneration.video.create({
+      prompt: "x",
+      storage: { visibility: "private" },
+      pollIntervalMs: 1,
+    });
+
+    expect(out.video?.fileId).toBe("f");
+    expect(calls[0]!.url).toBe(
+      "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+    );
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
   });
 });

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -295,6 +295,15 @@ export async function createVideo(
     if (res.ok) {
       const raw = (await res.json()) as RawVideoResult;
       if (raw.video?.url) return mapVideoResult(raw);
+    } else {
+      // Still generating, or a transient error. Drain the unread body so the
+      // connection can be reused, then keep polling — `timeoutMs` is the backstop
+      // for a result that never arrives.
+      try {
+        await res.body?.cancel();
+      } catch {
+        // best-effort drain
+      }
     }
     await sleep(intervalMs);
   }

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -1,5 +1,5 @@
 /**
- * `contentGeneration` capability — generate media (images today; video and audio
+ * `contentGeneration` capability — generate media (images and video today; audio
  * to come), with an optional `storage` param that persists each output to Sapiom
  * file storage so you get a durable `fileId` back inline.
  *
@@ -159,7 +159,149 @@ export async function createImage(
 
 /**
  * The `images` sub-namespace, so `contentGeneration.images.create(...)` reads the
- * same whether imported from the barrel or used on a client. Video and audio will
- * land here as sibling sub-namespaces.
+ * same whether imported from the barrel or used on a client.
  */
 export const images = { create: createImage };
+
+// ----- Video (async) -----
+
+/** Default video model when the caller doesn't pick one. */
+const DEFAULT_VIDEO_MODEL = "fal-ai/veo3/fast";
+/** How often to poll for the async result, and when to give up. Caller-overridable. */
+const DEFAULT_VIDEO_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_VIDEO_TIMEOUT_MS = 5 * 60_000;
+
+export interface VideoCreateInput {
+  /** Text prompt describing the video to generate. */
+  prompt: string;
+  /**
+   * Optional model selector. Defaults to a standard video model; most callers omit it.
+   * (Model identifiers are an advanced, evolving surface.)
+   */
+  model?: string;
+  /**
+   * Optional: persist the generated output to Sapiom file storage. When set, the
+   * returned `video` comes back annotated with `fileId` (or `storageError` if
+   * persisting failed).
+   */
+  storage?: StorageOptions;
+  /** Advanced: extra model-specific parameters, forwarded verbatim. */
+  params?: Record<string, unknown>;
+  /** How often to poll while the video generates (default 5s). */
+  pollIntervalMs?: number;
+  /** Give up and throw if the result isn't ready within this window (default 5 min). */
+  timeoutMs?: number;
+}
+
+export interface GeneratedVideo {
+  /** Hosted URL of the generated video. */
+  url: string;
+  /** MIME type, when reported. */
+  contentType?: string;
+  /**
+   * Present when `storage` was requested and the output was persisted — pass to
+   * `fileStorage.getDownloadUrl(fileId)` to retrieve it.
+   */
+  fileId?: string;
+  /** Present when `storage` was requested but persisting the output failed. */
+  storageError?: string;
+}
+
+export interface VideoGenerationResult {
+  /** The generated video. */
+  video?: GeneratedVideo;
+  /** Additional model-specific fields (e.g. `seed`, `timings`), returned as-is. */
+  [key: string]: unknown;
+}
+
+// ----- Internal request/response shapes -----
+
+interface RawMedia {
+  url: string;
+  content_type?: string;
+  file_id?: string;
+  storage_error?: string;
+}
+
+interface RawVideoResult {
+  video?: RawMedia;
+  [key: string]: unknown;
+}
+
+/** The async submit handle: a queue id + the Sapiom URL to poll for the result. */
+interface QueueHandle {
+  request_id?: string;
+  response_url?: string;
+  status_url?: string;
+}
+
+function mapVideo(raw: RawMedia): GeneratedVideo {
+  return {
+    url: raw.url,
+    ...(raw.content_type !== undefined && { contentType: raw.content_type }),
+    ...(raw.file_id !== undefined && { fileId: raw.file_id }),
+    ...(raw.storage_error !== undefined && { storageError: raw.storage_error }),
+  };
+}
+
+function mapVideoResult(raw: RawVideoResult): VideoGenerationResult {
+  const { video, ...rest } = raw;
+  return video === undefined ? { ...rest } : { ...rest, video: mapVideo(video) };
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Generate a video from a prompt. Video generation is asynchronous: this submits the
+ * job, then polls the result through Sapiom until it's ready and returns it — so you
+ * `await` it just like {@link createImage}, it just takes longer. Pass `storage` to
+ * persist the output (the returned `video` then carries `fileId`). Throws
+ * {@link ContentGenerationHttpError} on a failed submit, or an `Error` if the result
+ * isn't ready within `timeoutMs`.
+ */
+export async function createVideo(
+  input: VideoCreateInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<VideoGenerationResult> {
+  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
+
+  const body: Record<string, unknown> = { prompt: input.prompt, ...input.params };
+  // Truthy check (not `!== undefined`) so `storage: null` is treated as "no storage".
+  if (input.storage) body.storage = input.storage;
+
+  // Submit — for an async model Sapiom returns a queue handle, not the result.
+  const submitRes = await ensureOk(
+    await transport.fetch(`${baseUrl}/run/${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to submit video generation",
+  );
+  const handle = (await submitRes.json()) as QueueHandle;
+  if (!handle.response_url) {
+    throw new Error("Video submit did not return a result URL to poll");
+  }
+
+  // Poll the result THROUGH Sapiom until it's ready. The poll is what persists the
+  // output when `storage` was requested, so `fileId` is filled in by the time it returns.
+  const intervalMs = input.pollIntervalMs ?? DEFAULT_VIDEO_POLL_INTERVAL_MS;
+  const timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await transport.fetch(handle.response_url, { method: "GET" });
+    if (res.ok) {
+      const raw = (await res.json()) as RawVideoResult;
+      if (raw.video?.url) return mapVideoResult(raw);
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `Video generation did not complete within ${timeoutMs}ms (request id: ${handle.request_id ?? "unknown"})`,
+  );
+}
+
+/** The `video` sub-namespace: `contentGeneration.video.create(...)`. Async (submit + poll). */
+export const video = { create: createVideo };

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -29,7 +29,10 @@ import type {
   ListResponse,
   FileMetadata,
 } from "../file-storage/index.js";
-import type { ImageGenerationResult } from "../content-generation/index.js";
+import type {
+  ImageGenerationResult,
+  VideoGenerationResult,
+} from "../content-generation/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -538,6 +541,19 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 },
               ],
             })) as ImageGenerationResult,
+          ),
+      },
+      video: {
+        create: (input) =>
+          Promise.resolve(
+            r("contentGeneration.video.create", [input], () => ({
+              video: {
+                url: "https://content.local/stub-video.mp4",
+                contentType: "video/mp4",
+                // mirror the real stitch: a fileId only when storage was requested.
+                ...(input.storage ? { fileId: "stub-file" } : {}),
+              },
+            })) as VideoGenerationResult,
           ),
       },
     },


### PR DESCRIPTION
## Summary
Adds `contentGeneration.video.create` to `@sapiom/tools` — the async sibling of `images.create`. Video generation submits the job and polls until the result is ready, then resolves, so callers `await` it just like an image. An optional `storage` param persists the output and the returned `video` carries a `fileId`.

```typescript
const out = await contentGeneration.video.create({
  prompt: "a calm ocean wave at sunset",
  storage: { visibility: "private" }, // optional — persist the output
});
out.video?.url;     // hosted URL
out.video?.fileId;  // present when `storage` was passed → use with fileStorage
```

## Changes
- **`createVideo` / `contentGeneration.video.create`** — submit → poll until ready → return the result. Configurable `pollIntervalMs` (default 5s) / `timeoutMs` (default 5min). Throws `ContentGenerationHttpError` on a failed submit; an `Error` on timeout.
- camelCase surface mapped from the snake_case wire (`content_type→contentType`, `file_id→fileId`, `storage_error→storageError`); `params` forwarded verbatim; `storage` truthy-checked — mirrors `images.create`.
- Wired into `createClient().contentGeneration.video` + the `stub` client.
- README (capability + per-dir) + changeset (minor).

## Testing
- [x] 6 new unit tests (submit+poll+map, storage→fileId, storage_error mapping, submit-failure-never-polls, timeout, client binding) — **15/15 content-generation tests pass**
- [x] typecheck + lint clean

## Notes
- Async by design: the video isn't in the submit response, so `create` polls until ready (the poll also persists the output when `storage` is set — no extra call).
- Scope: video only; audio is a trivial follow-up (same path, different default model).

## Related
- Closes: SAP-1048
- Refs: SAP-892 (images)

## Checklist
- [x] Conventional commit
- [x] Tests pass; typecheck + lint clean
- [x] No breaking changes
- [x] Changeset included
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
