### PR TITLE
feat(tools): search namespace + search.scrape

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, and content generation — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, and search — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -25,7 +25,9 @@ const run = await sapiom.agent.coding.run({
 });
 
 if (run.result?.success) {
-  const { sha } = await repo.pushFromSandbox(run.sandbox, { message: "build: landing" });
+  const { sha } = await repo.pushFromSandbox(run.sandbox, {
+    message: "build: landing",
+  });
   console.log("published", sha);
 }
 ```
@@ -65,13 +67,14 @@ If a single process makes calls on behalf of more than one agent or trace, deriv
 
 Each capability is a namespace, importable from the barrel or its own subpath (e.g. `@sapiom/tools/sandboxes`). Every capability has its own README with usage details, preconditions, and gotchas the type signatures can't express — read it before first use.
 
-| Namespace | What it is | Docs |
-|---|---|---|
-| `sandboxes` | Isolated, ephemeral compute | [src/sandboxes](./src/sandboxes/README.md) |
-| `repositories` | Private, in-network git repos | [src/repositories](./src/repositories/README.md) |
-| `agent` | Coding agents (LLM execution) | [src/agent](./src/agent/README.md) |
-| `fileStorage` | Tenant-scoped object storage (presigned URLs) | [src/file-storage](./src/file-storage/README.md) |
-| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
+| Namespace           | What it is                                                                        | Docs                                                         |
+| ------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `sandboxes`         | Isolated, ephemeral compute                                                       | [src/sandboxes](./src/sandboxes/README.md)                   |
+| `repositories`      | Private, in-network git repos                                                     | [src/repositories](./src/repositories/README.md)             |
+| `agent`             | Coding agents (LLM execution)                                                     | [src/agent](./src/agent/README.md)                           |
+| `fileStorage`       | Tenant-scoped object storage (presigned URLs)                                     | [src/file-storage](./src/file-storage/README.md)             |
+| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage`              | [src/content-generation](./src/content-generation/README.md) |
+| `search`            | Web search, page reading, and professional email lookup (operations landing soon) | `@sapiom/tools/search`                                       |
 
 ## Composing capabilities
 
@@ -91,7 +94,9 @@ const out = await contentGeneration.images.create({
   prompt: "a logo",
   storage: { visibility: "private" },
 });
-const { downloadUrl } = await fileStorage.getDownloadUrl(out.images![0].fileId!);
+const { downloadUrl } = await fileStorage.getDownloadUrl(
+  out.images![0].fileId!,
+);
 ```
 
 ## License

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -67,14 +67,14 @@ If a single process makes calls on behalf of more than one agent or trace, deriv
 
 Each capability is a namespace, importable from the barrel or its own subpath (e.g. `@sapiom/tools/sandboxes`). Every capability has its own README with usage details, preconditions, and gotchas the type signatures can't express — read it before first use.
 
-| Namespace           | What it is                                                                        | Docs                                                         |
-| ------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `sandboxes`         | Isolated, ephemeral compute                                                       | [src/sandboxes](./src/sandboxes/README.md)                   |
-| `repositories`      | Private, in-network git repos                                                     | [src/repositories](./src/repositories/README.md)             |
-| `agent`             | Coding agents (LLM execution)                                                     | [src/agent](./src/agent/README.md)                           |
-| `fileStorage`       | Tenant-scoped object storage (presigned URLs)                                     | [src/file-storage](./src/file-storage/README.md)             |
-| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage`              | [src/content-generation](./src/content-generation/README.md) |
-| `search`            | Web search, page reading, and professional email lookup (operations landing soon) | `@sapiom/tools/search`                                       |
+| Namespace           | What it is                                                           | Docs                                                         |
+| ------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `sandboxes`         | Isolated, ephemeral compute                                          | [src/sandboxes](./src/sandboxes/README.md)                   |
+| `repositories`      | Private, in-network git repos                                        | [src/repositories](./src/repositories/README.md)             |
+| `agent`             | Coding agents (LLM execution)                                        | [src/agent](./src/agent/README.md)                           |
+| `fileStorage`       | Tenant-scoped object storage (presigned URLs)                        | [src/file-storage](./src/file-storage/README.md)             |
+| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
+| `search`            | Read a page with `scrape` (web search and email lookup landing soon) | [src/search](./src/search/README.md)                         |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/esm/content-generation/index.js",
       "require": "./dist/cjs/content-generation/index.js"
     },
+    "./search": {
+      "types": "./dist/cjs/search/index.d.ts",
+      "import": "./dist/esm/search/index.js",
+      "require": "./dist/cjs/search/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -52,7 +52,6 @@ import type {
   ImageCreateInput,
   ImageGenerationResult,
 } from "./content-generation/index.js";
-import { search } from "./search/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -104,7 +103,7 @@ export interface Sapiom {
    * Search the web, read pages, and look up professional emails. Operations are
    * added to this namespace as they ship.
    */
-  readonly search: typeof search;
+  readonly search: Record<string, never>;
   /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
@@ -151,7 +150,9 @@ function bind(transport: Transport): Sapiom {
         create: (input) => contentGeneration.createImage(input, transport),
       },
     },
-    search,
+    // search methods land in follow-up tickets — bind each as a transport-bound
+    // closure (cf. contentGeneration) so withAttribution works.
+    search: {},
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),
   };

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -52,6 +52,8 @@ import type {
   ImageCreateInput,
   ImageGenerationResult,
 } from "./content-generation/index.js";
+import { scrape } from "./search/index.js";
+import type { ScrapeInput, ScrapeResult } from "./search/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -100,10 +102,13 @@ export interface Sapiom {
     };
   };
   /**
-   * Search the web, read pages, and look up professional emails. Operations are
-   * added to this namespace as they ship.
+   * Search the web, read pages, and look up professional emails. More operations
+   * are added to this namespace as they ship.
    */
-  readonly search: Record<string, never>;
+  readonly search: {
+    /** Read a page and return its content (markdown by default). */
+    scrape(input: ScrapeInput): Promise<ScrapeResult>;
+  };
   /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
@@ -150,9 +155,9 @@ function bind(transport: Transport): Sapiom {
         create: (input) => contentGeneration.createImage(input, transport),
       },
     },
-    // search methods land in follow-up tickets — bind each as a transport-bound
-    // closure (cf. contentGeneration) so withAttribution works.
-    search: {},
+    search: {
+      scrape: (input) => scrape(input, transport),
+    },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),
   };

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -52,6 +52,7 @@ import type {
   ImageCreateInput,
   ImageGenerationResult,
 } from "./content-generation/index.js";
+import { search } from "./search/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -100,12 +101,17 @@ export interface Sapiom {
     };
   };
   /**
+   * Search the web, read pages, and look up professional emails. Operations are
+   * added to this namespace as they ship.
+   */
+  readonly search: typeof search;
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
    */
   withAttribution(attribution: Attribution): Sapiom;
-  // domains, scrape, search, … land here as they're ported.
+  // domains, … land here as they're ported.
 }
 
 /** Bind every capability namespace to a transport. `withAttribution` rebinds to a derived one. */
@@ -145,6 +151,7 @@ function bind(transport: Transport): Sapiom {
         create: (input) => contentGeneration.createImage(input, transport),
       },
     },
+    search,
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),
   };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -50,10 +50,16 @@ export { ORCHESTRATIONS_RESULT_SIGNAL } from "./orchestrations/index.js";
 // as input — annotate the resumed step with it instead of hand-rolling the shape.
 export type { OrchestrationRunResultPayload } from "./orchestrations/index.js";
 // Validate an OrchestrationRunResultPayload at the resume boundary.
-export { orchestrationResultSchema, OrchestrationResultSchemaError } from "./orchestrations/index.js";
+export {
+  orchestrationResultSchema,
+  OrchestrationResultSchemaError,
+} from "./orchestrations/index.js";
 
 export * as fileStorage from "./file-storage/index.js";
 export { FileStorageHttpError } from "./file-storage/index.js";
 
 export * as contentGeneration from "./content-generation/index.js";
 export { ContentGenerationHttpError } from "./content-generation/index.js";
+
+export * as search from "./search/index.js";
+export { SearchHttpError } from "./search/index.js";

--- a/packages/tools/src/search/README.md
+++ b/packages/tools/src/search/README.md
@@ -1,0 +1,75 @@
+# search
+
+Find information across the web and beyond — searching the web, reading pages,
+and looking up professional emails. More operations land in this namespace as
+they ship; today it offers `scrape`.
+
+## `scrape` — read a page
+
+Read a page and return its content. By default you get markdown:
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+const page = await sapiom.search.scrape({ url: "https://example.com" });
+page.markdown; // the page content as markdown
+page.metadata.title; // the page title
+```
+
+Ambient import works too: `import { search } from "@sapiom/tools"`.
+
+### Choosing formats
+
+Pass `formats` to get HTML, raw HTML, a screenshot, or the page's links — alone
+or alongside markdown:
+
+```typescript
+const page = await sapiom.search.scrape({
+  url: "https://example.com",
+  formats: ["markdown", "html", "links"],
+});
+page.html; // cleaned HTML
+page.links; // string[] of links found on the page
+```
+
+Each requested format is returned as its own field; a field is present only when
+that format was requested.
+
+### Input
+
+- `url` (required) — the page to read.
+- `formats` (optional) — any of `"markdown" | "html" | "rawHtml" | "screenshot" |
+"links"`. Defaults to `["markdown"]`.
+- `onlyMainContent` (optional) — return only the main content, dropping
+  navigation, headers, footers, and ads.
+- `waitFor` (optional) — milliseconds to wait before reading, for content
+  rendered by JavaScript.
+
+### Result
+
+```typescript
+{
+  url: string;            // the URL that was read
+  markdown?: string;
+  html?: string;
+  rawHtml?: string;
+  screenshot?: string;
+  links?: string[];
+  metadata: {
+    title?: string;
+    description?: string;
+    language?: string;
+    sourceUrl?: string;
+    statusCode?: number;
+  };
+}
+```
+
+`scrape` works on HTML pages and common documents (PDF, DOCX, TXT). It is not
+meant for images, video, or archives.
+
+## Gotchas
+
+- **Failed requests throw `SearchHttpError`** (carries `status` + parsed `body`),
+  exported from `@sapiom/tools`.

--- a/packages/tools/src/search/errors.ts
+++ b/packages/tools/src/search/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error thrown by the `search` capability when a request fails (non-2xx
+ * response). Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ */
+export class SearchHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "SearchHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link SearchHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new SearchHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -1,0 +1,361 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import { scrape, SearchHttpError } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — the capability fn is tested directly with a real Transport wired to
+// a scripted fetch mock, so URL/method/header/body assertions are exact and we
+// verify the Transport injects the tenant credential.
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+// ---------------------------------------------------------------------------
+// search.scrape()
+// ---------------------------------------------------------------------------
+
+describe("search.scrape()", () => {
+  it("POSTs just the url + credential (default formats omitted) and maps the wire result", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          data: {
+            markdown: "# Hello\n\nworld",
+            metadata: {
+              title: "Hello",
+              description: "a page",
+              language: "en",
+              sourceURL: "https://example.com",
+              statusCode: 200,
+              error: null,
+            },
+          },
+        }),
+    ]);
+
+    const out = await scrape({ url: "https://example.com" }, transport, BASE);
+
+    // metadata.sourceURL → sourceUrl; the {success} wrapper is dropped; url echoes input.
+    expect(out).toEqual({
+      url: "https://example.com",
+      markdown: "# Hello\n\nworld",
+      metadata: {
+        title: "Hello",
+        description: "a page",
+        language: "en",
+        sourceUrl: "https://example.com",
+        statusCode: 200,
+      },
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v2/scrape`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // formats is omitted entirely when the caller didn't pass it.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("forwards formats, onlyMainContent, and waitFor when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ success: true, data: { metadata: {} } }),
+    ]);
+
+    await scrape(
+      {
+        url: "https://example.com",
+        formats: ["markdown", "html", "links"],
+        onlyMainContent: true,
+        waitFor: 1500,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+      formats: ["markdown", "html", "links"],
+      onlyMainContent: true,
+      waitFor: 1500,
+    });
+  });
+
+  it("forwards onlyMainContent: false (a meaningful value, not dropped)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ success: true, data: { metadata: {} } }),
+    ]);
+
+    await scrape(
+      { url: "https://example.com", onlyMainContent: false },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+      onlyMainContent: false,
+    });
+  });
+
+  it("treats null optionals (JS caller bypassing types) as absent in the body", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ success: true, data: { metadata: {} } }),
+    ]);
+
+    await scrape(
+      {
+        url: "https://example.com",
+        formats: null as unknown as undefined,
+        onlyMainContent: null as unknown as undefined,
+        waitFor: null as unknown as undefined,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("maps every requested format and the page links", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          data: {
+            markdown: "md",
+            html: "<p>h</p>",
+            rawHtml: "<html>raw</html>",
+            screenshot: "https://shots/x.png",
+            links: ["https://a", "https://b"],
+            metadata: { title: "T", sourceURL: "https://example.com" },
+          },
+        }),
+    ]);
+
+    const out = await scrape(
+      {
+        url: "https://example.com",
+        formats: ["markdown", "html", "rawHtml", "screenshot", "links"],
+      },
+      transport,
+      BASE,
+    );
+
+    expect(out.html).toBe("<p>h</p>");
+    expect(out.rawHtml).toBe("<html>raw</html>");
+    expect(out.screenshot).toBe("https://shots/x.png");
+    expect(out.links).toEqual(["https://a", "https://b"]);
+  });
+
+  it("collapses array-valued title/description to a single string", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          data: {
+            markdown: "x",
+            metadata: {
+              title: ["First Title", "Second Title"],
+              description: ["First desc", "Second desc"],
+              sourceURL: "https://example.com",
+            },
+          },
+        }),
+    ]);
+
+    const out = await scrape({ url: "https://example.com" }, transport, BASE);
+
+    expect(out.metadata.title).toBe("First Title");
+    expect(out.metadata.description).toBe("First desc");
+  });
+
+  it("drops the success wrapper and extra fields; omits absent metadata fields", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          data: {
+            markdown: "x",
+            // extra fields that must not surface on the result
+            branding: { foo: "bar" },
+            changeTracking: null,
+            warning: null,
+            actions: null,
+            metadata: { sourceURL: "https://example.com", statusCode: 200 },
+          },
+        }),
+    ]);
+
+    const out = await scrape({ url: "https://example.com" }, transport, BASE);
+
+    expect(out).toEqual({
+      url: "https://example.com",
+      markdown: "x",
+      metadata: { sourceUrl: "https://example.com", statusCode: 200 },
+    });
+    // no leaked extras and no `success` key on the result.
+    expect(out).not.toHaveProperty("success");
+    expect(out).not.toHaveProperty("branding");
+    expect(out).not.toHaveProperty("changeTracking");
+    // title/description were absent on the wire → absent on the surface.
+    expect(out.metadata).not.toHaveProperty("title");
+    expect(out.metadata).not.toHaveProperty("description");
+  });
+
+  it("returns an empty metadata object when the wire omits data/metadata entirely", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ success: true }),
+    ]);
+
+    const out = await scrape({ url: "https://example.com" }, transport, BASE);
+
+    expect(out).toEqual({
+      url: "https://example.com",
+      metadata: {},
+    });
+  });
+
+  it("treats null fields (unrequested formats / empty metadata) as absent, not null", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          data: {
+            markdown: "# Hello",
+            // unrequested formats arrive explicitly null
+            html: null,
+            rawHtml: null,
+            screenshot: null,
+            links: null,
+            metadata: {
+              title: "Hello",
+              description: null,
+              language: null,
+              sourceURL: "https://example.com",
+              statusCode: 200,
+              error: null,
+            },
+          },
+        }),
+    ]);
+
+    const out = await scrape({ url: "https://example.com" }, transport, BASE);
+
+    // null formats are omitted, not surfaced as `field: null`.
+    expect(out).toEqual({
+      url: "https://example.com",
+      markdown: "# Hello",
+      metadata: {
+        title: "Hello",
+        sourceUrl: "https://example.com",
+        statusCode: 200,
+      },
+    });
+    expect(out).not.toHaveProperty("html");
+    expect(out).not.toHaveProperty("links");
+    expect(out.metadata).not.toHaveProperty("description");
+    expect(out.metadata).not.toHaveProperty("language");
+  });
+
+  it("throws SearchHttpError (with status + body) on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ success: false, error: "Bad Request" }), {
+          status: 400,
+        }),
+    ]);
+
+    await expect(
+      scrape({ url: "https://example.com" }, transport, BASE),
+    ).rejects.toMatchObject({
+      name: "SearchHttpError",
+      status: 400,
+      body: { error: "Bad Request" },
+    });
+    await expect(
+      scrape({ url: "https://example.com" }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClient().search.scrape — binding
+// ---------------------------------------------------------------------------
+
+describe("createClient().search.scrape", () => {
+  it("binds to the client's credential + default host, mapping the result", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      calls.push({ url: String(input), init });
+      return jsonResponse({
+        success: true,
+        data: {
+          markdown: "ok",
+          metadata: { sourceURL: "https://example.com" },
+        },
+      });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
+    const out = await sapiom.search.scrape({ url: "https://example.com" });
+
+    expect(out.markdown).toBe("ok");
+    expect(out.metadata.sourceUrl).toBe("https://example.com");
+    expect(calls[0]!.url).toBe(
+      "https://firecrawl.services.sapiom.ai/v2/scrape",
+    );
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+    });
+  });
+});

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -1,0 +1,22 @@
+/**
+ * `search` capability — find information across the web and beyond.
+ *
+ * This is the home for Sapiom's search primitives: searching the web, reading the
+ * contents of a page, and looking up professional email addresses. The first
+ * operations land here shortly; for now this namespace is intentionally empty.
+ *
+ *   import { search } from "@sapiom/tools";        // ambient auth
+ *
+ * Or via an explicit client: `createClient({ apiKey }).search`.
+ *
+ * Failed requests throw {@link SearchHttpError} (carries `status` + parsed `body`).
+ */
+import { SearchHttpError } from "./errors.js";
+
+export { SearchHttpError };
+
+/**
+ * The `search` namespace. Operations (web search, page reading, email lookup) are
+ * added here as they ship.
+ */
+export const search = {};

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -15,8 +15,6 @@ import { SearchHttpError } from "./errors.js";
 
 export { SearchHttpError };
 
-/**
- * The `search` namespace. Operations (web search, page reading, email lookup) are
- * added here as they ship.
- */
-export const search = {};
+// Operations (web search, page reading, email lookup) are added here as they
+// ship. Each becomes a named export and the barrel re-exports this module as the
+// `search` namespace, so a method reads as `search.webSearch(...)`.

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -3,18 +3,167 @@
  *
  * This is the home for Sapiom's search primitives: searching the web, reading the
  * contents of a page, and looking up professional email addresses. The first
- * operations land here shortly; for now this namespace is intentionally empty.
+ * operation — `scrape`, which reads a page and returns its content — lands here;
+ * more operations follow.
  *
  *   import { search } from "@sapiom/tools";        // ambient auth
+ *   const page = await search.scrape({ url: "https://example.com" });
+ *   page.markdown;   // the page content as markdown
  *
- * Or via an explicit client: `createClient({ apiKey }).search`.
+ * Or via an explicit client: `createClient({ apiKey }).search.scrape(...)`.
  *
  * Failed requests throw {@link SearchHttpError} (carries `status` + parsed `body`).
  */
-import { SearchHttpError } from "./errors.js";
+import { Transport, defaultTransport } from "../_client/index.js";
+import { SearchHttpError, ensureOk } from "./errors.js";
 
 export { SearchHttpError };
 
-// Operations (web search, page reading, email lookup) are added here as they
-// ship. Each becomes a named export and the barrel re-exports this module as the
-// `search` namespace, so a method reads as `search.webSearch(...)`.
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_SCRAPE_URL || "https://firecrawl.services.sapiom.ai";
+
+// ----- Types -----
+
+/** Output formats `scrape` can return. Defaults to `["markdown"]`. */
+export type ScrapeFormat =
+  | "markdown"
+  | "html"
+  | "rawHtml"
+  | "screenshot"
+  | "links";
+
+export interface ScrapeInput {
+  /** URL of the page to read. */
+  url: string;
+  /** Which content formats to return. Defaults to `["markdown"]`. */
+  formats?: ScrapeFormat[];
+  /** Return only the main content, dropping nav/header/footer/ads. */
+  onlyMainContent?: boolean;
+  /** Milliseconds to wait before reading (for content rendered by JavaScript). */
+  waitFor?: number;
+}
+
+export interface ScrapeMetadata {
+  /** Page title. */
+  title?: string;
+  /** Page description. */
+  description?: string;
+  /** Detected page language. */
+  language?: string;
+  /** The URL the content was read from. */
+  sourceUrl?: string;
+  /** HTTP status code returned while reading the page. */
+  statusCode?: number;
+}
+
+export interface ScrapeResult {
+  /** The URL that was read (echoes the input). */
+  url: string;
+  /** Page content as markdown (present when "markdown" was requested). */
+  markdown?: string;
+  /** Cleaned HTML (present when "html" was requested). */
+  html?: string;
+  /** Raw HTML (present when "rawHtml" was requested). */
+  rawHtml?: string;
+  /** Screenshot URL (present when "screenshot" was requested). */
+  screenshot?: string;
+  /** Links found on the page (present when "links" was requested). */
+  links?: string[];
+  /** Page metadata (title, description, language, status, …). */
+  metadata: ScrapeMetadata;
+}
+
+// ----- Internal request/response shapes -----
+
+interface RawMetadata {
+  // May arrive as an array on some pages; normalized to a single string.
+  title?: string | string[];
+  description?: string | string[];
+  language?: string;
+  sourceURL?: string;
+  statusCode?: number;
+  [key: string]: unknown;
+}
+
+interface RawScrapeData {
+  markdown?: string;
+  html?: string;
+  rawHtml?: string;
+  screenshot?: string;
+  links?: string[];
+  metadata?: RawMetadata;
+  [key: string]: unknown;
+}
+
+interface RawScrapeResponse {
+  success?: boolean;
+  data?: RawScrapeData;
+}
+
+/** Collapse a field that may be a single value or an array down to one value. */
+function firstOf<T>(value: T | T[] | undefined): T | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function mapMetadata(raw: RawMetadata | undefined): ScrapeMetadata {
+  const meta = raw ?? {};
+  const title = firstOf(meta.title);
+  const description = firstOf(meta.description);
+  // A field a caller didn't ask for comes back null — treat null as absent (`!=`)
+  // so the result only carries fields that were actually populated.
+  return {
+    ...(title != null && { title }),
+    ...(description != null && { description }),
+    ...(meta.language != null && { language: meta.language }),
+    ...(meta.sourceURL != null && { sourceUrl: meta.sourceURL }),
+    ...(meta.statusCode != null && { statusCode: meta.statusCode }),
+  };
+}
+
+function mapScrape(url: string, raw: RawScrapeResponse): ScrapeResult {
+  const data = raw.data ?? {};
+  // Unrequested formats come back null; treat null as absent (`!=`) so each
+  // format field is present only when it was actually returned.
+  return {
+    url,
+    ...(data.markdown != null && { markdown: data.markdown }),
+    ...(data.html != null && { html: data.html }),
+    ...(data.rawHtml != null && { rawHtml: data.rawHtml }),
+    ...(data.screenshot != null && { screenshot: data.screenshot }),
+    ...(data.links != null && { links: data.links }),
+    metadata: mapMetadata(data.metadata),
+  };
+}
+
+// ----- Capability operations -----
+
+/**
+ * Read a page and return its content. By default you get markdown; pass `formats`
+ * to also (or instead) get HTML, raw HTML, a screenshot, or the page's links.
+ *
+ * Works on HTML pages and common documents (PDF, DOCX, TXT). Failed requests throw
+ * {@link SearchHttpError}.
+ */
+export async function scrape(
+  input: ScrapeInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<ScrapeResult> {
+  // `!= null` so an optional explicitly passed as null (a JS caller bypassing the
+  // types) is treated as absent rather than forwarded as a null field.
+  const body: Record<string, unknown> = { url: input.url };
+  if (input.formats != null) body.formats = input.formats;
+  if (input.onlyMainContent != null)
+    body.onlyMainContent = input.onlyMainContent;
+  if (input.waitFor != null) body.waitFor = input.waitFor;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v2/scrape`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to scrape",
+  );
+  return mapScrape(input.url, (await res.json()) as RawScrapeResponse);
+}

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -40,6 +40,7 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.agent.coding.launch).toBe("function");
 
     expect(typeof sapiom.search).toBe("object");
+    expect(typeof sapiom.search.scrape).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -13,8 +13,10 @@ import {
   sandboxes,
   repositories,
   agent,
+  search,
   Sandbox,
   Repository,
+  SearchHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -37,6 +39,8 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.agent.coding.run).toBe("function");
     expect(typeof sapiom.agent.coding.launch).toBe("function");
 
+    expect(typeof sapiom.search).toBe("object");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -51,7 +55,16 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sandboxes).toBe("object");
     expect(typeof repositories).toBe("object");
     expect(typeof agent).toBe("object");
+    expect(typeof search).toBe("object");
+    expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
+  });
+
+  it("the search namespace has no self-named nested key", () => {
+    // The barrel creates the `search` namespace via `export * as search`; the
+    // module itself must not export a const named after itself, or methods would
+    // read as `search.search.webSearch()`.
+    expect("search" in search).toBe(false);
   });
 });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -35,6 +35,7 @@ import type {
   FileMetadata,
 } from "../file-storage/index.js";
 import type { ImageGenerationResult } from "../content-generation/index.js";
+import type { ScrapeResult } from "../search/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -586,9 +587,20 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           ),
       },
     },
-    // The `search` namespace is empty for now; operations gain stub defaults as
-    // they ship.
-    search: {},
+    search: {
+      scrape: (input) =>
+        Promise.resolve(
+          r("search.scrape", [input], () => ({
+            url: input.url,
+            markdown: `# ${input.url}\n\n(stub) scraped content`,
+            metadata: {
+              title: "Stub Page",
+              sourceUrl: input.url,
+              statusCode: 200,
+            },
+          })) as ScrapeResult,
+        ),
+    },
     withAttribution: () => client,
   };
 

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -505,7 +505,10 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         };
         const handle: OrchestrationRunHandle = {
           executionId,
-          dispatch: { correlationId: executionId, resultSignal: ORCHESTRATIONS_RESULT_SIGNAL },
+          dispatch: {
+            correlationId: executionId,
+            resultSignal: ORCHESTRATIONS_RESULT_SIGNAL,
+          },
           status: () => Promise.resolve("completed" as const),
           wait: () => Promise.resolve(result),
         };
@@ -583,6 +586,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           ),
       },
     },
+    // The `search` namespace is empty for now; operations gain stub defaults as
+    // they ship.
+    search: {},
     withAttribution: () => client,
   };
 


### PR DESCRIPTION
## What

Adds a new `search` capability namespace to `@sapiom/tools` — the home for search primitives (page reading, web search, and professional email lookup) — together with its first operation, `search.scrape`, which reads a page and returns its content.

This PR covers two things:
1. **The namespace scaffold + wiring** — the `search` surface, its error type, and every integration point.
2. **The first real tool — `search.scrape`** — a typed, tested operation on that surface.

## `search.scrape`

```typescript
import { createClient } from "@sapiom/tools";
const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });

const page = await sapiom.search.scrape({ url: "https://example.com" });
page.markdown;        // page content as markdown
page.metadata.title;  // page metadata

// Other formats on request:
await sapiom.search.scrape({
  url: "https://example.com",
  formats: ["markdown", "html", "links"],
});
```

- **Input**: `url` (required); optional `formats` (`"markdown" | "html" | "rawHtml" | "screenshot" | "links"`, default `["markdown"]`), `onlyMainContent`, `waitFor`. Optionals are sent only when set.
- **Result**: `{ url, markdown?, html?, rawHtml?, screenshot?, links?, metadata: { title?, description?, language?, sourceUrl?, statusCode? } }`. Normalized to camelCase; only populated fields are included (unrequested formats / empty metadata are omitted rather than surfaced as `null`).
- **Errors**: any non-2xx throws `SearchHttpError` (carries `status` + parsed `body`).

## Changes

- **`src/search/errors.ts`** — `SearchHttpError` (`status` + `body`) and an `ensureOk` helper, matching the other capabilities' error pattern. *(scaffold)*
- **`src/search/index.ts`** — the `search` namespace with the `scrape` operation, its types, and the internal mapper (camelCase normalization).
- **`src/search/index.spec.ts`** — unit tests: request shape (default-formats omitted vs provided, `onlyMainContent: false`, null-optional handling), format/link mapping, `sourceURL → sourceUrl`, array→single-value title/description normalization, null-as-absent, error path, and the `createClient().search.scrape` binding.
- **`src/search/README.md`** — capability docs.
- **Wiring** so the namespace is reachable everywhere a capability should be:
  - `src/client.ts` — `search.scrape` on the `Sapiom` interface and in `bind()`.
  - `src/index.ts` — barrel exports (`export * as search` + `SearchHttpError`). *(scaffold)*
  - `src/stub/index.ts` — a deterministic `search.scrape` stub so local workflow runs need no network.
  - `package.json` — a `./search` subpath in `exports`. *(scaffold)*
  - `README.md` — the `search` row in the Capabilities table.

## Verification

- `build` (CJS + ESM) — emits `dist/{cjs,esm}/search/*` including `.d.ts`
- `typecheck` — the stub typechecks against the `Sapiom` interface
- `test` — 73 tests across 9 suites pass
- `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)