### PR TITLE
make zod peer dep

### DIFF
--- a/.changeset/orchestration-zod-peer.md
+++ b/.changeset/orchestration-zod-peer.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/orchestration": minor
+---
+
+Declare `zod` as a `peerDependency` (`^4.0.0`) instead of a direct dependency, and remove the `z` / `ZodType` compatibility re-exports from the package entry.
+
+Step `inputSchema`s are zod schemas authored in the consumer's project and passed into this package, so there must be a single shared `zod` instance — bundling our own copy could otherwise cause type and `instanceof` mismatches against the consumer's `zod`. zod 4 is required; npm 7+ and pnpm install the peer automatically (consumers on older package managers should add `zod` alongside this package).
+
+The previous `export { z } from "zod"` shim only worked because the package bundled its own `zod`; with `zod` as a peer it would just re-export the consumer's own instance, so it has been removed. Import `z` from `zod` directly.

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -138,15 +138,5 @@ import { z } from "zod";
 ```
 
 Step `inputSchema`s are zod schemas, and the build converts them to JSON Schema
-for the manifest — so your project's `zod` is the one to reach for.
-
-If your project is pinned to an older `zod` that the authoring types reject, you
-can import a known-good `z` directly from this package instead, without changing
-your own `zod`:
-
-```ts
-import { z } from "@sapiom/orchestration";
-```
-
-This is a compatibility shim, not the recommended import — prefer your own `zod`
-unless you hit a version conflict.
+for the manifest — so your project's `zod` is the one to reach for. `zod` is a
+peer dependency (`^4.0.0`); install it alongside this package.

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -49,8 +49,10 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@sapiom/tools": "workspace:^",
-    "zod": "^4.1.0"
+    "@sapiom/tools": "workspace:^"
+  },
+  "peerDependencies": {
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -60,10 +60,3 @@ export type { WorkflowManifest, WorkflowStepManifest, ManifestTransition } from 
 // Manifest generator + graph validation — called by the build phase.
 export { buildManifest, validateGraph, assertValidGraph } from './build-manifest.js';
 export type { GraphValidation } from './build-manifest.js';
-
-// Compatibility re-export. Authoring code should `import { z } from "zod"` as
-// normal — this is only for projects pinned to a zod that's incompatible with
-// the authoring types, so they can pull a known-good `z` from here without
-// touching their own zod. See the README's "Compatibility" note.
-export { z } from 'zod';
-export type { ZodType } from 'zod';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       '@sapiom/tools':
         specifier: workspace:^
         version: link:../tools
-      zod:
-        specifier: ^4.1.0
-        version: 4.4.3
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -320,6 +317,9 @@ importers:
       typescript:
         specifier: ^5.4.2
         version: 5.9.3
+      zod:
+        specifier: ^4.1.0
+        version: 4.4.3
 
   packages/orchestration-core:
     dependencies:


### PR DESCRIPTION
This pull request updates the `@sapiom/orchestration` package to declare `zod` as a peer dependency instead of a direct dependency. This change ensures that consumers of the package use a single shared instance of `zod`, preventing type mismatches and issues with `instanceof` checks. The change also updates the relevant configuration and lock files to reflect this dependency shift.

**Dependency management improvements:**

* Declared `zod` as a `peerDependency` (`^4.0.0`) in `packages/orchestration/package.json` instead of a direct dependency, and updated the `.changeset/orchestration-zod-peer.md` file to explain the rationale and migration guidance. [[1]](diffhunk://#diff-7783a5e26ba6c080486022b91b02160b9e7c079183b5cf8171f057abb29ff77bL52-R55) [[2]](diffhunk://#diff-315bebfa0de43a208e8d182036873f07cd0ba24d466ba09f5e6fec2fdd889561R1-R5)
* Removed `zod` from the dependencies section of `packages/orchestration/package.json` and updated `pnpm-lock.yaml` to reflect that `zod` is no longer installed directly for the orchestration package, but remains as a devDependency for tooling. [[1]](diffhunk://#diff-7783a5e26ba6c080486022b91b02160b9e7c079183b5cf8171f057abb29ff77bL52-R55) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL292-L294) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR320-R322)