### PR TITLE
update readme

### DIFF
--- a/.changeset/tools-orchestrations-docs.md
+++ b/.changeset/tools-orchestrations-docs.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+Document the `orchestrations` capability: add it to the README's Capabilities table + intro, and add a per-capability `src/orchestrations/README.md` (run a deployed orchestration, or dispatch one from a step and pause on its result).

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, and content generation — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, and orchestrations — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -72,6 +72,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `agent` | Coding agents (LLM execution) | [src/agent](./src/agent/README.md) |
 | `fileStorage` | Tenant-scoped object storage (presigned URLs) | [src/file-storage](./src/file-storage/README.md) |
 | `contentGeneration` | Media generation (images; video/audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
+| `orchestrations` | Run a deployed orchestration, or dispatch one from a step and await its result | [src/orchestrations](./src/orchestrations/README.md) |
 
 ## Composing capabilities
 

--- a/packages/tools/src/orchestrations/README.md
+++ b/packages/tools/src/orchestrations/README.md
@@ -1,0 +1,50 @@
+# orchestrations
+
+Run a deployed orchestration and await its result — or, from inside a step, dispatch one and pause until it finishes. An orchestration is addressed by its **slug** (its stable handle).
+
+```ts
+import { orchestrations } from "@sapiom/tools";
+
+// Standalone: run a deployed orchestration and wait for its result.
+const result = await orchestrations.run({ definition: "enrich-lead", input: { id } });
+if (result.status === "completed") {
+  // result.output
+}
+```
+
+From inside a step, dispatch another orchestration and suspend until it finishes — the step you name in `resumeStep` receives the typed result as its input:
+
+```ts
+import { orchestrations } from "@sapiom/tools";
+import { defineStep, pauseUntilSignal } from "@sapiom/orchestration";
+
+const enrich = defineStep({
+  name: "enrich",
+  pause: { signal: orchestrations.ORCHESTRATIONS_RESULT_SIGNAL, resumeStep: "use-result" },
+  async run(input, ctx) {
+    const child = await orchestrations.launch({ definition: "enrich-lead", input });
+    return pauseUntilSignal(child, { resumeStep: "use-result" });
+  },
+});
+
+const useResult = defineStep({
+  name: "use-result",
+  terminal: true,
+  async run(result: orchestrations.OrchestrationRunResultPayload, ctx) {
+    if (result.status === "failed") {
+      // result.error — failure is data you branch on, not a thrown exception
+    }
+    // result.output (when completed)
+  },
+});
+```
+
+## Things to know
+
+- **`run` blocks; `launch` returns a pausable handle.** `run` polls until the run reaches a terminal state and returns its result — use it for standalone, inline calls. `launch` returns immediately with a handle you hand to `pauseUntilSignal(handle, { resumeStep })` to suspend the step until the run finishes. Don't use `run` to pause a step — it returns a result, not a handle.
+
+- **Failure is data, not an exception.** The result is discriminated on `status` (`"completed" | "failed"`). A failed run resumes your step with `status: "failed"` and an `error` to branch on — it does not throw. Validate an incoming payload with `orchestrations.orchestrationResultSchema.parse(value)` if you want a runtime check.
+
+- **Addressed by slug.** `definition` is the deployed orchestration's slug — its stable handle. `input` is passed to its entry step.
+
+- **`idempotencyKey` deduplicates.** Repeating a launch with the same key returns the existing run instead of starting a new one.


### PR DESCRIPTION
This pull request adds documentation for the new `orchestrations` capability in the `@sapiom/tools` package. The updates include adding `orchestrations` to the main README's capabilities table and introduction, as well as providing a dedicated README explaining how to use the orchestration features.

**Documentation updates for orchestrations:**

* Added `orchestrations` to the capabilities list and table in `packages/tools/README.md`, describing its purpose and linking to its documentation. [[1]](diffhunk://#diff-82f1f6deb52933d1bc80b74d29daec29bbb32dc776c13c41ab9803ca89c0d6adL3-R3) [[2]](diffhunk://#diff-82f1f6deb52933d1bc80b74d29daec29bbb32dc776c13c41ab9803ca89c0d6adR75)
* Created `packages/tools/src/orchestrations/README.md` with usage examples, key concepts (such as the difference between `run` and `launch`, handling failures, addressing by slug, and idempotency), and best practices for using orchestrations.
* Added a changeset `.changeset/tools-orchestrations-docs.md` to track these documentation improvements.