### PR TITLE
feat(tools): add search.webSearch capability

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -67,15 +67,15 @@ If a single process makes calls on behalf of more than one agent or trace, deriv
 
 Each capability is a namespace, importable from the barrel or its own subpath (e.g. `@sapiom/tools/sandboxes`). Every capability has its own README with usage details, preconditions, and gotchas the type signatures can't express — read it before first use.
 
-| Namespace           | What it is                                                           | Docs                                                         |
-| ------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `sandboxes`         | Isolated, ephemeral compute                                          | [src/sandboxes](./src/sandboxes/README.md)                   |
-| `repositories`      | Private, in-network git repos                                        | [src/repositories](./src/repositories/README.md)             |
-| `agent`             | Coding agents (LLM execution)                                        | [src/agent](./src/agent/README.md)                           |
-| `fileStorage`       | Tenant-scoped object storage (presigned URLs)                        | [src/file-storage](./src/file-storage/README.md)             |
-| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage` | [src/content-generation](./src/content-generation/README.md) |
-| `search`            | Read a page with `scrape` (web search and email lookup landing soon) | [src/search](./src/search/README.md)                         |
-| `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result | [src/orchestrations](./src/orchestrations/README.md)   |
+| Namespace           | What it is                                                                             | Docs                                                         |
+| ------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `sandboxes`         | Isolated, ephemeral compute                                                            | [src/sandboxes](./src/sandboxes/README.md)                   |
+| `repositories`      | Private, in-network git repos                                                          | [src/repositories](./src/repositories/README.md)             |
+| `agent`             | Coding agents (LLM execution)                                                          | [src/agent](./src/agent/README.md)                           |
+| `fileStorage`       | Tenant-scoped object storage (presigned URLs)                                          | [src/file-storage](./src/file-storage/README.md)             |
+| `contentGeneration` | Media generation (images; video/audio soon), with optional `storage`                   | [src/content-generation](./src/content-generation/README.md) |
+| `search`            | Search the web with `webSearch`, read a page with `scrape` (email lookup landing soon) | [src/search](./src/search/README.md)                         |
+| `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result         | [src/orchestrations](./src/orchestrations/README.md)         |
 
 ## Composing capabilities
 

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -54,6 +54,26 @@ export interface TransportConfig {
   resumeToken?: string;
 }
 
+/**
+ * Which header carries the tenant credential. Sapiom has two authenticated
+ * surfaces with different conventions: most operations send `x-sapiom-api-key`
+ * (the default), while a few send `x-api-key`. A capability that targets the
+ * latter passes `authHeader: "x-api-key"`; everything else uses the default.
+ * The credential value is the same — the Transport holds it; callers never do.
+ */
+export type AuthHeader = "x-sapiom-api-key" | "x-api-key";
+
+const DEFAULT_AUTH_HEADER: AuthHeader = "x-sapiom-api-key";
+
+/** Per-request options the Transport understands, layered over a normal `RequestInit`. */
+export interface TransportRequestOptions {
+  /**
+   * Which header carries the tenant credential. Defaults to `x-sapiom-api-key`.
+   * A capability sets this only when its destination expects a different header.
+   */
+  authHeader?: AuthHeader;
+}
+
 function attributionToHeaders(a: Attribution): Record<string, string> {
   const h: Record<string, string> = {};
   if (a.agentName) h["x-sapiom-agent-name"] = a.agentName;
@@ -98,7 +118,9 @@ export class Transport {
     this.fetchImpl = config.fetch ?? globalThis.fetch;
     this.attribution = config.attribution ?? {};
     this.resumeToken =
-      config.resumeToken ?? process.env.SAPIOM_CAPABILITY_RESUME_TOKEN ?? undefined;
+      config.resumeToken ??
+      process.env.SAPIOM_CAPABILITY_RESUME_TOKEN ??
+      undefined;
   }
 
   /**
@@ -121,8 +143,16 @@ export class Transport {
    * response handling (filesystem, log streams) use this and inspect the
    * `Response` themselves. Injects the tenant credential + attribution headers;
    * sets no content-type.
+   *
+   * The credential rides `x-sapiom-api-key` by default; pass
+   * `{ authHeader: "x-api-key" }` for a destination that expects that header
+   * instead (the value is identical — the Transport owns the key either way).
    */
-  async fetch(url: string, init: RequestInit = {}): Promise<Response> {
+  async fetch(
+    url: string,
+    init: RequestInit = {},
+    options: TransportRequestOptions = {},
+  ): Promise<Response> {
     if (!this.apiKey) {
       throw new Error(
         "@sapiom/tools: no tenant credential. Pass createClient({ apiKey }) for standalone use, " +
@@ -132,7 +162,7 @@ export class Transport {
     return this.fetchImpl(url, {
       ...init,
       headers: {
-        "x-sapiom-api-key": this.apiKey,
+        [options.authHeader ?? DEFAULT_AUTH_HEADER]: this.apiKey,
         ...attributionToHeaders(this.attribution),
         ...(init.headers ?? {}),
       },
@@ -140,11 +170,22 @@ export class Transport {
   }
 
   /** Authenticated JSON request — parses the body and throws on a non-2xx status. */
-  async request<T>(url: string, init: RequestInit = {}): Promise<T> {
-    const res = await this.fetch(url, {
-      ...init,
-      headers: { "content-type": "application/json", ...(init.headers ?? {}) },
-    });
+  async request<T>(
+    url: string,
+    init: RequestInit = {},
+    options: TransportRequestOptions = {},
+  ): Promise<T> {
+    const res = await this.fetch(
+      url,
+      {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...(init.headers ?? {}),
+        },
+      },
+      options,
+    );
     if (!res.ok) {
       throw new Error(
         `${init.method ?? "GET"} ${url} → ${res.status} ${await res.text()}`,

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -52,8 +52,13 @@ import type {
   ImageCreateInput,
   ImageGenerationResult,
 } from "./content-generation/index.js";
-import { scrape } from "./search/index.js";
-import type { ScrapeInput, ScrapeResult } from "./search/index.js";
+import { scrape, webSearch } from "./search/index.js";
+import type {
+  ScrapeInput,
+  ScrapeResult,
+  WebSearchInput,
+  WebSearchResponse,
+} from "./search/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -108,6 +113,8 @@ export interface Sapiom {
   readonly search: {
     /** Read a page and return its content (markdown by default). */
     scrape(input: ScrapeInput): Promise<ScrapeResult>;
+    /** Search the web — a synthesized answer plus results by default. */
+    webSearch(input: WebSearchInput): Promise<WebSearchResponse>;
   };
   /**
    * Derive a client that attributes its calls to a different agent/trace. For the
@@ -157,6 +164,7 @@ function bind(transport: Transport): Sapiom {
     },
     search: {
       scrape: (input) => scrape(input, transport),
+      webSearch: (input) => webSearch(input, transport),
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/search/README.md
+++ b/packages/tools/src/search/README.md
@@ -2,7 +2,58 @@
 
 Find information across the web and beyond — searching the web, reading pages,
 and looking up professional emails. More operations land in this namespace as
-they ship; today it offers `scrape`.
+they ship; today it offers `webSearch` and `scrape`.
+
+## `webSearch` — search the web
+
+Search the web and get a synthesized answer plus supporting results:
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+const hits = await sapiom.search.webSearch({ query: "what is an LLM agent?" });
+hits.answer; // a synthesized answer
+hits.results; // supporting results: [{ title, url, snippet }]
+```
+
+Ambient import works too: `import { search } from "@sapiom/tools"`.
+
+### Choosing what you get back
+
+Pass `intent: "links"` for a list of relevant results instead of a synthesized
+answer, and `depth: "deep"` for a more thorough search:
+
+```typescript
+const hits = await sapiom.search.webSearch({
+  query: "best practices for prompt caching",
+  intent: "links",
+  depth: "deep",
+});
+hits.results; // [{ title, url, snippet }, …]
+```
+
+### Input
+
+- `query` (required) — what to search for.
+- `depth` (optional) — `"standard"` (default) or `"deep"` for a more thorough
+  search.
+- `intent` (optional) — `"answer"` (default) for a synthesized answer plus
+  supporting results, or `"links"` for a list of relevant results.
+
+### Result
+
+```typescript
+{
+  query: string;          // the query that was searched
+  answer?: string;        // a synthesized answer (present for intent: "answer")
+  results: Array<{
+    title: string;
+    url: string;
+    snippet: string;
+  }>;
+}
+```
 
 ## `scrape` — read a page
 

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -1,6 +1,6 @@
 import { createClient } from "../index.js";
 import { Transport } from "../_client/index.js";
-import { scrape, SearchHttpError } from "./index.js";
+import { scrape, webSearch, SearchHttpError } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers — the capability fn is tested directly with a real Transport wired to
@@ -92,7 +92,10 @@ describe("search.scrape()", () => {
     });
     expect(calls[0]!.url).toBe(`${BASE}/v2/scrape`);
     expect(calls[0]!.init.method).toBe("POST");
+    // scrape sends the default credential header, NOT x-api-key (guards against
+    // regression from the per-destination auth-header change).
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
     // formats is omitted entirely when the caller didn't pass it.
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
@@ -356,6 +359,208 @@ describe("createClient().search.scrape", () => {
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       url: "https://example.com",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search.webSearch()
+// ---------------------------------------------------------------------------
+
+describe("search.webSearch()", () => {
+  it("POSTs query + default intent, sends x-api-key (not x-sapiom-api-key), and maps the result", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          query: "llm agents",
+          answer: "An LLM agent is …",
+          results: [
+            {
+              title: "Agents 101",
+              url: "https://example.com/a",
+              snippet: "intro",
+            },
+          ],
+        }),
+    ]);
+
+    const out = await webSearch({ query: "llm agents" }, transport, BASE);
+
+    expect(out).toEqual({
+      query: "llm agents",
+      answer: "An LLM agent is …",
+      results: [
+        { title: "Agents 101", url: "https://example.com/a", snippet: "intro" },
+      ],
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/web.search`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // This destination authenticates via x-api-key — the SDK must send that
+    // header here, and must NOT send the default x-sapiom-api-key for this call.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // intent defaults to "answer"; depth omitted when not provided.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "llm agents",
+      intent: "answer",
+    });
+  });
+
+  it("forwards depth and an explicit intent", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ query: "q", results: [] }),
+    ]);
+
+    await webSearch(
+      { query: "q", depth: "deep", intent: "links" },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      depth: "deep",
+      intent: "links",
+    });
+  });
+
+  it("defaults intent to answer even when depth is set", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ query: "q", results: [] }),
+    ]);
+
+    await webSearch({ query: "q", depth: "standard" }, transport, BASE);
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      depth: "standard",
+      intent: "answer",
+    });
+  });
+
+  it("treats a null depth (JS caller bypassing types) as absent in the body", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ query: "q", results: [] }),
+    ]);
+
+    await webSearch(
+      { query: "q", depth: null as unknown as undefined },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      intent: "answer",
+    });
+  });
+
+  it("omits answer when the wire has none (intent:'links') and defaults missing results to []", async () => {
+    const { transport } = makeTransport([() => jsonResponse({ query: "q" })]);
+
+    const out = await webSearch(
+      { query: "q", intent: "links" },
+      transport,
+      BASE,
+    );
+
+    expect(out).toEqual({ query: "q", results: [] });
+    expect(out).not.toHaveProperty("answer");
+  });
+
+  it("drops unknown extra fields from the response and result rows (defensive)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          query: "q",
+          answer: "a",
+          // an unexpected top-level field that must never reach a caller
+          extraTopLevel: "should-not-surface",
+          results: [
+            {
+              title: "T",
+              url: "https://example.com",
+              snippet: "s",
+              extraOnRow: "should-not-surface",
+            },
+          ],
+        }),
+    ]);
+
+    const out = await webSearch({ query: "q" }, transport, BASE);
+
+    // The result is built from known fields only, so any extra field is dropped.
+    expect(out).toEqual({
+      query: "q",
+      answer: "a",
+      results: [{ title: "T", url: "https://example.com", snippet: "s" }],
+    });
+    expect(out).not.toHaveProperty("extraTopLevel");
+    expect(out.results[0]).not.toHaveProperty("extraOnRow");
+  });
+
+  it("falls back to the input query when the wire omits it", async () => {
+    const { transport } = makeTransport([() => jsonResponse({ results: [] })]);
+
+    const out = await webSearch({ query: "fallback" }, transport, BASE);
+
+    expect(out.query).toBe("fallback");
+  });
+
+  it("throws SearchHttpError (with status + body) on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "Bad Request" }), {
+          status: 400,
+        }),
+    ]);
+
+    await expect(
+      webSearch({ query: "q" }, transport, BASE),
+    ).rejects.toMatchObject({
+      name: "SearchHttpError",
+      status: 400,
+      body: { error: "Bad Request" },
+    });
+    await expect(
+      webSearch({ query: "q" }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClient().search.webSearch — binding
+// ---------------------------------------------------------------------------
+
+describe("createClient().search.webSearch", () => {
+  it("binds to the client's credential + default host, sending x-api-key", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      calls.push({ url: String(input), init });
+      return jsonResponse({
+        query: "q",
+        answer: "a",
+        results: [{ title: "T", url: "https://example.com", snippet: "s" }],
+      });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
+    const out = await sapiom.search.webSearch({ query: "q" });
+
+    expect(out.answer).toBe("a");
+    expect(out.results[0]!.url).toBe("https://example.com");
+    expect(calls[0]!.url).toBe(
+      "https://api.sapiom.ai/v1/capabilities/web.search",
+    );
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      intent: "answer",
     });
   });
 });

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -2,15 +2,17 @@
  * `search` capability — find information across the web and beyond.
  *
  * This is the home for Sapiom's search primitives: searching the web, reading the
- * contents of a page, and looking up professional email addresses. The first
- * operation — `scrape`, which reads a page and returns its content — lands here;
- * more operations follow.
+ * contents of a page, and looking up professional email addresses. Today it
+ * offers `webSearch` (search the web) and `scrape` (read a page); more operations
+ * follow.
  *
  *   import { search } from "@sapiom/tools";        // ambient auth
+ *   const hits = await search.webSearch({ query: "what is an LLM agent?" });
+ *   hits.answer;     // a synthesized answer
  *   const page = await search.scrape({ url: "https://example.com" });
  *   page.markdown;   // the page content as markdown
  *
- * Or via an explicit client: `createClient({ apiKey }).search.scrape(...)`.
+ * Or via an explicit client: `createClient({ apiKey }).search.webSearch(...)`.
  *
  * Failed requests throw {@link SearchHttpError} (carries `status` + parsed `body`).
  */
@@ -21,6 +23,9 @@ export { SearchHttpError };
 
 const DEFAULT_BASE_URL =
   process.env.SAPIOM_SCRAPE_URL || "https://firecrawl.services.sapiom.ai";
+
+const DEFAULT_WEB_SEARCH_BASE_URL =
+  process.env.SAPIOM_SEARCH_URL || "https://api.sapiom.ai";
 
 // ----- Types -----
 
@@ -166,4 +171,110 @@ export async function scrape(
     "Failed to scrape",
   );
   return mapScrape(input.url, (await res.json()) as RawScrapeResponse);
+}
+
+// ----- search.webSearch -----
+
+export interface WebSearchInput {
+  /** What to search for. */
+  query: string;
+  /** How thoroughly to search. Defaults to `"standard"`. */
+  depth?: "standard" | "deep";
+  /**
+   * What you want back. `"answer"` (default) returns a synthesized answer plus
+   * supporting results; `"links"` returns a list of relevant results.
+   */
+  intent?: "answer" | "links";
+}
+
+export interface WebSearchResult {
+  /** Result title. */
+  title: string;
+  /** Result URL. */
+  url: string;
+  /** Short excerpt for the result. */
+  snippet: string;
+}
+
+export interface WebSearchResponse {
+  /** The query that was searched (echoes the input). */
+  query: string;
+  /** A synthesized answer, when `intent` is `"answer"`. */
+  answer?: string;
+  /** The results found for the query. */
+  results: WebSearchResult[];
+}
+
+interface RawWebSearchResult {
+  title?: string;
+  url?: string;
+  snippet?: string;
+  [key: string]: unknown;
+}
+
+interface RawWebSearchResponse {
+  query?: string;
+  answer?: string;
+  results?: RawWebSearchResult[];
+  [key: string]: unknown;
+}
+
+function mapWebSearchResult(raw: RawWebSearchResult): WebSearchResult {
+  return {
+    title: raw.title ?? "",
+    url: raw.url ?? "",
+    snippet: raw.snippet ?? "",
+  };
+}
+
+function mapWebSearch(
+  query: string,
+  raw: RawWebSearchResponse,
+): WebSearchResponse {
+  // Build the result from only the public fields. A defensive measure: any
+  // extra top-level field on the wire (e.g. bookkeeping not meant for callers)
+  // is dropped by construction rather than spread through.
+  const results = Array.isArray(raw.results)
+    ? raw.results.map(mapWebSearchResult)
+    : [];
+  return {
+    query: raw.query ?? query,
+    ...(raw.answer != null && { answer: raw.answer }),
+    results,
+  };
+}
+
+/**
+ * Search the web. By default you get a synthesized answer plus supporting
+ * results; pass `intent: "links"` for a list of relevant results, and
+ * `depth: "deep"` for a more thorough search.
+ *
+ * Failed requests throw {@link SearchHttpError}.
+ */
+export async function webSearch(
+  input: WebSearchInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_WEB_SEARCH_BASE_URL,
+): Promise<WebSearchResponse> {
+  // `!= null` so an optional explicitly passed as null (a JS caller bypassing the
+  // types) is treated as absent rather than forwarded as a null field.
+  const body: Record<string, unknown> = {
+    query: input.query,
+    intent: input.intent ?? "answer",
+  };
+  if (input.depth != null) body.depth = input.depth;
+
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/capabilities/web.search`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      { authHeader: "x-api-key" },
+    ),
+    "Failed to search the web",
+  );
+  return mapWebSearch(input.query, (await res.json()) as RawWebSearchResponse);
 }

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -35,7 +35,7 @@ import type {
   FileMetadata,
 } from "../file-storage/index.js";
 import type { ImageGenerationResult } from "../content-generation/index.js";
-import type { ScrapeResult } from "../search/index.js";
+import type { ScrapeResult, WebSearchResponse } from "../search/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -599,6 +599,23 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               statusCode: 200,
             },
           })) as ScrapeResult,
+        ),
+      webSearch: (input) =>
+        Promise.resolve(
+          r("search.webSearch", [input], () => ({
+            query: input.query,
+            // mirror the real shape: an answer for the default intent, omitted for "links".
+            ...(input.intent === "links"
+              ? {}
+              : { answer: `(stub) answer for "${input.query}"` }),
+            results: [
+              {
+                title: "Stub Result",
+                url: "https://example.com",
+                snippet: `(stub) result for "${input.query}"`,
+              },
+            ],
+          })) as WebSearchResponse,
         ),
     },
     withAttribution: () => client,


### PR DESCRIPTION
## What

Adds a typed `webSearch` operation to the `search` namespace in `@sapiom/tools`:

```ts
const hits = await sapiom.search.webSearch({ query: "what is an LLM agent?" });
hits.answer;   // a synthesized answer
hits.results;  // [{ title, url, snippet }, …]
```

- `intent: "answer"` (default) returns a synthesized answer plus supporting results; `intent: "links"` returns a list of relevant results.
- `depth: "deep"` runs a more thorough search (`"standard"` by default).
- Failed requests throw `SearchHttpError` (carries `status` + parsed `body`), consistent with the rest of the namespace.

## How

- `src/search/index.ts` — `WebSearchInput` / `WebSearchResult` / `WebSearchResponse` types, private `Raw*` wire shapes, a `mapWebSearch` mapper that builds the result from known fields only (so any unexpected field is dropped by construction), and the `webSearch(input, transport, baseUrl)` operation.
- `src/_client/index.ts` — the `Transport` gains a small per-destination auth-header option: a capability can send the tenant credential under `x-api-key` for a destination that expects that header, while every other capability keeps the existing default unchanged. The credential value is identical either way — the Transport holds it; callers never do.
- Wired through `client.ts` (interface + binding), the `stub` (deterministic `search.webSearch` default for local runs), and documented in `src/search/README.md` + the root capabilities table.

## Tests

Scripted-fetch unit tests assert exact URL/method/headers/body, the wire→surface mapping, the `intent` default, the unknown-extra-field strip, null-optional handling, and the typed-error path. Includes a regression test confirming the existing `scrape` operation still sends its default credential header (no fallout from the Transport change). Full suite green (typecheck / test / lint / build).