### PR TITLE
feat(mcp): deliver workflow-authoring guidance via server instructions (SAP-1040)

### DIFF
--- a/.changeset/sapiom-mcp-authoring-instructions.md
+++ b/.changeset/sapiom-mcp-authoring-instructions.md
@@ -2,4 +2,4 @@
 "@sapiom/mcp": minor
 ---
 
-Deliver the workflow-authoring primer via the MCP server `instructions` field. Capable clients (e.g. Claude Code) inject it into the agent's context on connect, so any agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically — no skill install or docs hand-off. The primer is concise and points to the full docs (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.
+Deliver the workflow-authoring primer through the MCP server `instructions` field. Capable MCP clients surface it to the model on connect, so an agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically. The primer is concise and points to the full documentation (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.

--- a/.changeset/sapiom-mcp-authoring-instructions.md
+++ b/.changeset/sapiom-mcp-authoring-instructions.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/mcp": minor
+---
+
+Deliver the workflow-authoring primer via the MCP server `instructions` field. Capable clients (e.g. Claude Code) inject it into the agent's context on connect, so any agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically — no skill install or docs hand-off. The primer is concise and points to the full docs (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,6 +6,7 @@ import { resolveEnvironment } from "./credentials.js";
 import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerOrchestrations } from "./tools/orchestrations.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
 
 async function main(): Promise<void> {
   // Resolve environment: SAPIOM_ENVIRONMENT env var > file > "production"
@@ -17,11 +18,19 @@ async function main(): Promise<void> {
     );
   }
 
-  const server = new McpServer({
-    // The local dev surface — distinct from the remote Sapiom capabilities MCP.
-    name: "sapiom-dev",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      // The local dev surface — distinct from the remote Sapiom capabilities MCP.
+      name: "sapiom-dev",
+      version: "0.1.0",
+    },
+    {
+      // Auto-delivered to capable clients on connect (the MCP `initialize` handshake),
+      // so any agent that adds this server gets the workflow-authoring primer with no
+      // skill install or docs hand-off. See ./instructions.ts.
+      instructions: AUTHORING_INSTRUCTIONS,
+    },
+  );
 
   // Register all tools
   registerAuthenticate(server, env);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,9 +25,9 @@ async function main(): Promise<void> {
       version: "0.1.0",
     },
     {
-      // Auto-delivered to capable clients on connect (the MCP `initialize` handshake),
-      // so any agent that adds this server gets the workflow-authoring primer with no
-      // skill install or docs hand-off. See ./instructions.ts.
+      // Returned in the MCP `initialize` handshake; capable clients surface it to the
+      // model on connect, so an agent that adds this server gets the authoring primer
+      // automatically. See ./instructions.ts.
       instructions: AUTHORING_INSTRUCTIONS,
     },
   );

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
+
+describe("server instructions", () => {
+  it("are delivered to a client over the initialize handshake", async () => {
+    const server = new McpServer(
+      { name: "sapiom-dev", version: "0.1.0" },
+      { instructions: AUTHORING_INSTRUCTIONS },
+    );
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    // This is the channel a capable client injects into the agent's context.
+    expect(client.getInstructions()).toBe(AUTHORING_INSTRUCTIONS);
+  });
+
+  it("primer covers the lifecycle, canonical rules, and points to the docs", () => {
+    // Lifecycle tools an agent must drive
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_authenticate");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_orchestrations_scaffold");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_orchestrations_run_local");
+    // Canonical naming (and the stale name it must steer away from)
+    expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/orchestration");
+    expect(AUTHORING_INSTRUCTIONS).toContain("defineOrchestration");
+    // the stale names appear only inside the explicit "NEVER use" warning
+    expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
+    // Single-source pointer to the full docs + the scaffold guide
+    expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
+    expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
+  });
+});

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -33,7 +33,7 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("defineOrchestration");
     // the stale names appear only inside the explicit "NEVER use" warning
     expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
-    // Single-source pointer to the full docs + the scaffold guide
+    // Pointer to the full docs + the scaffold guide
     expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
   });

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -31,8 +31,9 @@ step's \`run(input, ctx)\` does work and returns a directive. All from the termi
   \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\` target
   must be listed in \`next[]\`. TypeScript enforces all of these.
 - Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
-- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent.coding, fileStorage,
-  contentGeneration.images) — a typed subset of the gateway catalog; use autocomplete/typecheck.
+- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent(+coding), orchestrations,
+  fileStorage, contentGeneration.{images,video}, search, database) — a typed subset of the gateway
+  catalog; use autocomplete/typecheck.
 
 Full reference: https://docs.sapiom.ai/workflows (authoring · capabilities · reference · examples)
 and the \`AGENTS.md\` inside your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -1,12 +1,11 @@
 /**
- * MCP server `instructions` — returned in the `initialize` handshake. Capable clients
- * (e.g. Claude Code) inject this into the agent's context on connect, so any coding agent
- * that adds this MCP gets the workflow-authoring primer automatically — no skill to install,
- * no docs to hand over.
+ * The MCP server `instructions` string, returned during the `initialize` handshake.
+ * Capable MCP clients surface it to the model on connect, so an agent that adds this
+ * server gets a workflow-authoring primer without any extra setup.
  *
- * Keep this CONCISE: it is always in context while the server is connected. It POINTS to the
- * single-source full docs (https://docs.sapiom.ai/workflows) and the `AGENTS.md` the scaffold
- * writes into every project, rather than restating them — so it rarely needs to change.
+ * Kept intentionally short — it stays in the model's context for the whole session, and
+ * points to the full documentation and the `AGENTS.md` generated into each scaffolded
+ * project rather than restating them.
  */
 export const AUTHORING_INSTRUCTIONS = `# Sapiom Workflow Authoring
 

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -1,0 +1,39 @@
+/**
+ * MCP server `instructions` — returned in the `initialize` handshake. Capable clients
+ * (e.g. Claude Code) inject this into the agent's context on connect, so any coding agent
+ * that adds this MCP gets the workflow-authoring primer automatically — no skill to install,
+ * no docs to hand over.
+ *
+ * Keep this CONCISE: it is always in context while the server is connected. It POINTS to the
+ * single-source full docs (https://docs.sapiom.ai/workflows) and the `AGENTS.md` the scaffold
+ * writes into every project, rather than restating them — so it rarely needs to change.
+ */
+export const AUTHORING_INSTRUCTIONS = `# Sapiom Workflow Authoring
+
+These tools let a coding agent build, test, and deploy a Sapiom workflow — a
+\`defineOrchestration({ name, entry, steps })\` (from \`@sapiom/orchestration\`) where each
+step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
+
+## Lifecycle (in order)
+1. \`sapiom_authenticate\` — browser login; caches an API key (makes you an API-key principal,
+   required for deploy/run). Confirm with \`sapiom_status\`.
+2. \`sapiom_dev_orchestrations_scaffold\` — writes a project. READ its \`AGENTS.md\` first; it is
+   the full authoring guide, shipped inside every scaffold. Then \`npm install\`.
+3. Test for free: \`npm run typecheck\` → \`sapiom_dev_orchestrations_check\` (validates the step
+   graph, offline) → \`sapiom_dev_orchestrations_run_local\` (capabilities are stubbed; zero spend).
+4. Ship: \`sapiom_dev_orchestrations_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.
+
+## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
+- Import \`defineOrchestration\`, \`defineStep\`, and the directives
+  (\`goto\` / \`terminate\` / \`fail\` / \`retry\` / \`pauseUntilSignal\`) from \`@sapiom/orchestration\`.
+  NEVER \`defineWorkflow\` or \`@sapiom/workflow-sdk\` (they do not exist). Import Zod from \`zod/v4\`.
+- \`defineStep({ name, next, terminal?, canFail?, pause?, inputSchema?, run })\`:
+  \`terminate()\` requires \`terminal: true\`; \`fail()\` requires \`canFail: true\`;
+  \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\` target
+  must be listed in \`next[]\`. TypeScript enforces all of these.
+- Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
+- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent.coding, fileStorage,
+  contentGeneration.images) — a typed subset of the gateway catalog; use autocomplete/typecheck.
+
+Full reference: https://docs.sapiom.ai/workflows (authoring · capabilities · reference · examples)
+and the \`AGENTS.md\` inside your scaffolded project.`;


### PR DESCRIPTION
## What (SAP-1040)
Delivers the workflow-authoring guidance through the **MCP server `instructions` field**, so any agent that connects `@sapiom/mcp` gets the authoring lifecycle + canonical rules **automatically on connect** — no skill to install, no docs to hand over.

- **NEW** `packages/mcp/src/instructions.ts` — a concise `AUTHORING_INSTRUCTIONS` primer: the lifecycle (`authenticate → scaffold → check/run_local → deploy/run`), the canonical `@sapiom/orchestration` rules (incl. the `terminal`/`canFail`/`pause` constraints and the "never `defineWorkflow`/`@sapiom/workflow-sdk`" steer), and `zod/v4`.
- `index.ts` — pass it via `new McpServer(serverInfo, { instructions })`.
- **NEW** `instructions.test.ts` — a real in-memory `Client`↔`Server` handshake asserting `client.getInstructions()` returns the primer, plus content checks.
- Changeset (`@sapiom/mcp` minor).

## Why
Today `@sapiom/mcp` returns no `instructions`, so nothing in the MCP itself points an agent at the docs — guidance only reaches agents via the scaffold's `AGENTS.md` (post-scaffold) or a separately-installed skill. `instructions` is the always-on, client-agnostic channel (the same one the Datadog/Chrome MCP servers use). It's kept **concise and single-sourced** — it points to docs.sapiom.ai/workflows and the scaffold's `AGENTS.md` rather than restating them, so it rarely needs to change.

## Test plan
- `pnpm --filter @sapiom/mcp test` → **55/55 pass** (incl. the new delivery test).
- `pnpm --filter @sapiom/mcp build` → **clean**.
- Not from this PR (untouched files, pre-existing on `main`): `@sapiom/orchestration-core`'s build is red, and the strict `typecheck` script trips on `orchestrations.ts:91` (`err: unknown`) — the publishable `build` config tolerates it. The three files in this PR compile + test green.

Closes: SAP-1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
