### PR TITLE
feat(tools): add contentGeneration.video.launch (dispatchable video generation)

### DIFF
--- a/.changeset/tools-video-launch.md
+++ b/.changeset/tools-video-launch.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/tools": minor
+---
+
+Add `contentGeneration.video.launch()` — the dispatchable surface for video generation.
+
+- `contentGeneration.video.launch(input)` submits a video generation job and returns a `VideoLaunchHandle` immediately. Pass the handle to `pauseUntilSignal(handle, { resumeStep })` to suspend a workflow step until the video is ready, or call `handle.wait()` to block inline.
+- `VideoLaunchHandle` satisfies `DispatchHandle` — `dispatch.correlationId` and `dispatch.resultSignal` are the join keys the orchestration engine uses to resume a paused step.
+- `VIDEO_RESULT_SIGNAL` (`"contentGeneration.video.result"`) is the capability-stable signal constant; use it in the static `pause: { signal }` declaration of a workflow step.
+- `VideoResultPayload` and `toVideoResumePayload` describe the payload a resumed step receives across the wire boundary (plain JSON with `outputs[].fileId` / `outputs[].storageError`).
+- Prompt-guard hardening: `images.create`, `video.create`, and `video.launch` now throw a typed error immediately when `prompt` is null, empty, or not a string — before any network request is made.
+- `createStubClient()` wires `contentGeneration.video.launch` as a dispatchable stub that auto-registers a resume payload when `signals` is provided, enabling local workflow testing.

--- a/packages/orchestration-core/src/inspect.spec.ts
+++ b/packages/orchestration-core/src/inspect.spec.ts
@@ -70,6 +70,21 @@ describe("waitForExecution", () => {
     expect(res.done).toBe(true);
   });
 
+  it("keeps waiting through a video generation pause (auto-resume signal)", async () => {
+    const { client } = fakeClient([
+      { status: "paused", pausedSignalName: "contentGeneration.video.result" },
+      { status: "completed" },
+    ]);
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0 },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+  });
+
   it("returns needs-signal on a pause that won't auto-resume", async () => {
     const { client, calls } = fakeClient([
       { status: "paused", pausedSignalName: "await-approval" },

--- a/packages/orchestration-core/src/inspect.ts
+++ b/packages/orchestration-core/src/inspect.ts
@@ -72,10 +72,12 @@ export function isExecutionTerminal(status: string): boolean {
 /**
  * Pause signals the engine resumes on its own (a dispatched capability reports
  * completion via a callback), so a wait should keep polling through them.
- * Mirrors `CODING_RESULT_SIGNAL` from `@sapiom/tools`; extend as more dispatched
- * capabilities land.
+ * Extend as more dispatched capabilities land.
  */
-const AUTO_RESUME_PAUSE_SIGNALS = ["agent.coding.result"];
+const AUTO_RESUME_PAUSE_SIGNALS = [
+  "agent.coding.result",
+  "contentGeneration.video.result",
+];
 
 export type WaitStopReason = "terminal" | "needs-signal" | "timeout";
 

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -53,6 +53,7 @@ import type {
   ImageGenerationResult,
   VideoCreateInput,
   VideoGenerationResult,
+  VideoLaunchHandle,
 } from "./content-generation/index.js";
 import {
   scrape,
@@ -126,6 +127,13 @@ export interface Sapiom {
        * `fileId`).
        */
       create(input: VideoCreateInput): Promise<VideoGenerationResult>;
+      /**
+       * Submit a video generation job and return a dispatchable handle immediately.
+       * Pass the handle to `pauseUntilSignal(handle, { resumeStep })` to suspend the
+       * workflow step until the video is ready, or call `handle.wait()` to block
+       * inline (equivalent to `video.create`). Pass `storage` to persist the output.
+       */
+      launch(input: VideoCreateInput): Promise<VideoLaunchHandle>;
     };
   };
   /**
@@ -194,6 +202,7 @@ function bind(transport: Transport): Sapiom {
       },
       video: {
         create: (input) => contentGeneration.createVideo(input, transport),
+        launch: (input) => contentGeneration.launchVideo(input, transport),
       },
     },
     search: {

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -62,6 +62,73 @@ images), and two async controls: `pollIntervalMs` (poll cadence, default 5s) and
 `timeoutMs` (give up and throw if it isn't ready in time, default 5 min). The
 returned `video` is `{ url, contentType?, fileId?, storageError? }`.
 
+## Dispatchable video: `video.launch`
+
+`video.launch` is the dispatchable surface for video generation. It submits the
+job and returns a handle immediately, so you decide when (or whether) to wait for
+the result.
+
+```typescript
+import { createClient, VIDEO_RESULT_SIGNAL } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// Option A — block inline (same result as `video.create`, useful when you want
+// a handle for tracking but still `await` in the same step):
+const handle = await sapiom.contentGeneration.video.launch({
+  prompt: "a calm ocean wave at sunset",
+  storage: { visibility: "private" }, // optional — persist the output
+});
+const out = await handle.wait(); // polls until ready
+out.video?.fileId;
+
+// Option B — suspend a workflow step until the video is ready, then resume:
+// (Inside a Sapiom workflow step; the orchestration engine handles the rest.)
+const handle = await sapiom.contentGeneration.video.launch({
+  prompt: "a calm ocean wave at sunset",
+});
+return pauseUntilSignal(handle, { resumeStep: finalize });
+// `finalize` receives a VideoResultPayload: { outputs: [{ fileId?, storageError? }] }
+```
+
+`handle.wait()` accepts the same `timeoutMs` and `pollMs` overrides as
+`video.create`'s input fields. `input.timeoutMs` / `input.pollIntervalMs` are the
+defaults when `wait()` is called without arguments, so the two APIs stay in sync.
+
+### `VIDEO_RESULT_SIGNAL`
+
+The capability-stable signal constant — use it in the static `pause: { signal }`
+declaration on a workflow step so the engine knows which signal to listen for:
+
+```typescript
+import { VIDEO_RESULT_SIGNAL } from "@sapiom/tools";
+
+const finalize = defineStep({
+  name: "finalize",
+  pause: { signal: VIDEO_RESULT_SIGNAL },
+  terminal: true,
+  async run(result: VideoResultPayload, ctx) {
+    result.outputs[0]?.fileId; // the persisted file, if storage was requested
+  },
+});
+```
+
+### `VideoResultPayload`
+
+The shape delivered to a step resumed from `pauseUntilSignal`:
+
+```typescript
+interface VideoResultPayload {
+  outputs: Array<{
+    fileId?: string; // present when storage was requested and succeeded
+    storageError?: string; // present when storage was requested but failed
+  }>;
+}
+```
+
+Import `VideoResultPayload` from `@sapiom/tools` to annotate the resumed step's
+`input` type; import `toVideoResumePayload` to map a live `VideoGenerationResult`
+to this shape when wiring local tests.
+
 ## Image input
 
 - `prompt` (required) — the text prompt.

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -4,6 +4,9 @@ import {
   images,
   createImage,
   createVideo,
+  launchVideo,
+  toVideoResumePayload,
+  VIDEO_RESULT_SIGNAL,
   ContentGenerationHttpError,
 } from "./index.js";
 
@@ -457,4 +460,324 @@ describe("createClient().contentGeneration.video.create", () => {
     );
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
   });
+});
+
+// ---------------------------------------------------------------------------
+// contentGeneration.video.launch() — dispatch handle + workflow resume token
+// ---------------------------------------------------------------------------
+
+function makeLaunchTransport(
+  submitResponse: unknown,
+  pollResponse: unknown,
+  resumeToken?: string,
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    if (init.method === "POST") return jsonResponse(submitResponse);
+    return jsonResponse(pollResponse);
+  }) as typeof globalThis.fetch;
+  return {
+    transport: new Transport({ apiKey: "test-key", fetch: fetchMock, resumeToken }),
+    calls,
+  };
+}
+
+describe("contentGeneration.video.launch()", () => {
+  it("submits to the right URL and method, returns a handle with requestId and dispatch", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { request_id: "req-launch-1", response_url: `${BASE}/queue/req-launch-1` },
+      { video: { url: "https://media/v.mp4" } },
+    );
+
+    const handle = await launchVideo({ prompt: "a wave" }, transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(handle.requestId).toBe("req-launch-1");
+  });
+
+  it("dispatch.correlationId equals requestId and dispatch.resultSignal equals VIDEO_RESULT_SIGNAL", async () => {
+    const { transport } = makeLaunchTransport(
+      { request_id: "req-dispatch", response_url: `${BASE}/queue/req-dispatch` },
+      { video: { url: "https://media/v.mp4" } },
+    );
+
+    const handle = await launchVideo({ prompt: "a wave" }, transport, BASE);
+
+    expect(handle.dispatch.correlationId).toBe("req-dispatch");
+    expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
+  });
+
+  it("VIDEO_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(VIDEO_RESULT_SIGNAL).toBe("contentGeneration.video.result");
+  });
+
+  it("includes x-sapiom-workflow-token when transport.resumeToken is set", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { request_id: "req-tok", response_url: `${BASE}/queue/req-tok` },
+      { video: { url: "u" } },
+      "tok-workflow-abc",
+    );
+
+    await launchVideo({ prompt: "x" }, transport, BASE);
+
+    expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
+      "tok-workflow-abc",
+    );
+  });
+
+  it("omits x-sapiom-workflow-token when resumeToken is not set", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { request_id: "req-notok", response_url: `${BASE}/queue/req-notok` },
+      { video: { url: "u" } },
+    );
+
+    await launchVideo({ prompt: "x" }, transport, BASE);
+
+    expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBeUndefined();
+  });
+
+  it("forwards the env token as x-sapiom-workflow-token", async () => {
+    const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+    process.env[KEY] = "tok-env-video";
+    try {
+      const calls: FetchCall[] = [];
+      const fetchMock = (async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        init: RequestInit = {},
+      ): Promise<Response> => {
+        calls.push({ url: String(input), init });
+        return jsonResponse({ request_id: "req-env", response_url: `${BASE}/queue/req-env` });
+      }) as typeof globalThis.fetch;
+      // Transport reads env var when resumeToken is not explicitly set
+      const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+      await launchVideo({ prompt: "x" }, transport, BASE);
+      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe("tok-env-video");
+    } finally {
+      delete process.env[KEY];
+    }
+  });
+
+  it("wait() polls the response_url and returns the mapped result", async () => {
+    let polls = 0;
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (init.method === "POST") {
+        return jsonResponse({
+          request_id: "req-wait",
+          response_url: `${BASE}/queue/req-wait`,
+        });
+      }
+      polls += 1;
+      return polls < 2
+        ? jsonResponse({ status: "IN_PROGRESS" })
+        : jsonResponse({ video: { url: "https://media/v.mp4", content_type: "video/mp4" } });
+    }) as typeof globalThis.fetch;
+    const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+
+    const handle = await launchVideo({ prompt: "a wave", pollIntervalMs: 1 } as Parameters<typeof launchVideo>[0], transport, BASE);
+    const result = await handle.wait({ pollMs: 1 });
+
+    expect(result.video).toEqual({
+      url: "https://media/v.mp4",
+      contentType: "video/mp4",
+    });
+    expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(2);
+  });
+
+  it("wait() maps fileId and passes storage on submit", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { request_id: "req-store", response_url: `${BASE}/queue/req-store` },
+      { video: { url: "https://media/v.mp4", file_id: "f-store" } },
+    );
+
+    const handle = await launchVideo(
+      { prompt: "x", storage: { visibility: "private" } },
+      transport,
+      BASE,
+    );
+    const result = await handle.wait({ pollMs: 1 });
+
+    expect(result.video?.fileId).toBe("f-store");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      storage: { visibility: "private" },
+    });
+  });
+
+  it("throws ContentGenerationHttpError when the submit fails — never polls", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ error: "bad model" }, { status: 422 }),
+    ]);
+
+    await expect(
+      launchVideo({ prompt: "x" }, transport, BASE),
+    ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClient().contentGeneration.video.launch — binding
+// ---------------------------------------------------------------------------
+
+describe("createClient().contentGeneration.video.launch", () => {
+  it("binds to the client credential, includes the workflow token header, and returns a handle", async () => {
+    const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+    process.env[KEY] = "tok-client-bind";
+    try {
+      const calls: FetchCall[] = [];
+      const fetchMock = (async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        init: RequestInit = {},
+      ): Promise<Response> => {
+        calls.push({ url: String(input), init });
+        return jsonResponse({
+          request_id: "r-client",
+          response_url: "https://fal.services.sapiom.ai/queue/r-client",
+        });
+      }) as typeof globalThis.fetch;
+
+      const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
+      const handle = await sapiom.contentGeneration.video.launch({ prompt: "x" });
+
+      expect(handle.requestId).toBe("r-client");
+      expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
+      expect(calls[0]!.url).toBe(
+        "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+      );
+      expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe("tok-client-bind");
+    } finally {
+      delete process.env[KEY];
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toVideoResumePayload()
+// ---------------------------------------------------------------------------
+
+describe("toVideoResumePayload()", () => {
+  it("maps a video with fileId to outputs[0].fileId", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "https://media/v.mp4", fileId: "f-1" },
+    });
+    expect(payload).toEqual({ outputs: [{ fileId: "f-1" }] });
+  });
+
+  it("maps a video with storageError to outputs[0].storageError", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "https://media/v.mp4", storageError: "quota exceeded" },
+    });
+    expect(payload).toEqual({ outputs: [{ storageError: "quota exceeded" }] });
+  });
+
+  it("maps a video with neither fileId nor storageError to an empty-field outputs[0]", () => {
+    const payload = toVideoResumePayload({ video: { url: "https://media/v.mp4" } });
+    expect(payload).toEqual({ outputs: [{}] });
+  });
+
+  it("returns empty outputs when there is no video", () => {
+    const payload = toVideoResumePayload({});
+    expect(payload).toEqual({ outputs: [] });
+  });
+
+  it("includes both fileId and storageError when both are present", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "u", fileId: "f-2", storageError: "partial" },
+    });
+    expect(payload).toEqual({
+      outputs: [{ fileId: "f-2", storageError: "partial" }],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prompt-guard: null / empty / non-string prompt throws before any fetch
+// ---------------------------------------------------------------------------
+
+describe("prompt-guard — createImage, createVideo, launchVideo throw on invalid prompt", () => {
+  const noFetch = (): never => {
+    throw new Error("fetch should not be called with an invalid prompt");
+  };
+  const noFetchTransport = new Transport({
+    apiKey: "test-key",
+    fetch: noFetch as unknown as typeof globalThis.fetch,
+  });
+
+  for (const [label, prompt] of [
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+    ["whitespace-only", "   "],
+    ["number", 42],
+    ["object", {}],
+  ] as const) {
+    it(`createImage throws ContentGenerationHttpError(400) for prompt = ${label}`, async () => {
+      await expect(
+        createImage(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+      await expect(
+        createImage(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it(`createVideo throws ContentGenerationHttpError(400) for prompt = ${label}`, async () => {
+      await expect(
+        createVideo(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+      await expect(
+        createVideo(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it(`launchVideo throws ContentGenerationHttpError(400) for prompt = ${label}`, async () => {
+      await expect(
+        launchVideo(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+      await expect(
+        launchVideo(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+  }
 });

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -291,7 +291,9 @@ describe("contentGeneration.video.create()", () => {
     // submit: default model, prompt only (no provider named, no storage).
     expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
     expect(calls[0]!.init.method).toBe("POST");
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ prompt: "a wave" });
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "a wave",
+    });
     // polled the rewritten result URL until it carried output.
     expect(
       calls.filter(
@@ -344,7 +346,10 @@ describe("contentGeneration.video.create()", () => {
     const { transport } = makeTransport([
       (c) =>
         c.init.method === "POST"
-          ? jsonResponse({ request_id: "req-4", response_url: `${BASE}/queue/req-4` })
+          ? jsonResponse({
+              request_id: "req-4",
+              response_url: `${BASE}/queue/req-4`,
+            })
           : null,
       (c) =>
         c.init.method === "GET"
@@ -381,10 +386,15 @@ describe("contentGeneration.video.create()", () => {
     const { transport } = makeTransport([
       (c) =>
         c.init.method === "POST"
-          ? jsonResponse({ request_id: "req-3", response_url: `${BASE}/queue/req-3` })
+          ? jsonResponse({
+              request_id: "req-3",
+              response_url: `${BASE}/queue/req-3`,
+            })
           : null,
       (c) =>
-        c.init.method === "GET" ? jsonResponse({ status: "IN_PROGRESS" }) : null,
+        c.init.method === "GET"
+          ? jsonResponse({ status: "IN_PROGRESS" })
+          : null,
     ]);
 
     await expect(
@@ -401,7 +411,10 @@ describe("contentGeneration.video.create()", () => {
     const { transport } = makeTransport([
       (c) =>
         c.init.method === "POST"
-          ? jsonResponse({ request_id: "req-5", response_url: `${BASE}/queue/req-5` })
+          ? jsonResponse({
+              request_id: "req-5",
+              response_url: `${BASE}/queue/req-5`,
+            })
           : null,
       (c) => {
         if (c.init.method !== "GET") return null;
@@ -487,7 +500,11 @@ function makeLaunchTransport(
     return jsonResponse(pollResponse);
   }) as typeof globalThis.fetch;
   return {
-    transport: new Transport({ apiKey: "test-key", fetch: fetchMock, resumeToken }),
+    transport: new Transport({
+      apiKey: "test-key",
+      fetch: fetchMock,
+      resumeToken,
+    }),
     calls,
   };
 }
@@ -495,7 +512,10 @@ function makeLaunchTransport(
 describe("contentGeneration.video.launch()", () => {
   it("submits to the right URL and method, returns a handle with requestId and dispatch", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-launch-1", response_url: `${BASE}/queue/req-launch-1` },
+      {
+        request_id: "req-launch-1",
+        response_url: `${BASE}/queue/req-launch-1`,
+      },
       { video: { url: "https://media/v.mp4" } },
     );
 
@@ -508,7 +528,10 @@ describe("contentGeneration.video.launch()", () => {
 
   it("dispatch.correlationId equals requestId and dispatch.resultSignal equals VIDEO_RESULT_SIGNAL", async () => {
     const { transport } = makeLaunchTransport(
-      { request_id: "req-dispatch", response_url: `${BASE}/queue/req-dispatch` },
+      {
+        request_id: "req-dispatch",
+        response_url: `${BASE}/queue/req-dispatch`,
+      },
       { video: { url: "https://media/v.mp4" } },
     );
 
@@ -557,12 +580,17 @@ describe("contentGeneration.video.launch()", () => {
         init: RequestInit = {},
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
-        return jsonResponse({ request_id: "req-env", response_url: `${BASE}/queue/req-env` });
+        return jsonResponse({
+          request_id: "req-env",
+          response_url: `${BASE}/queue/req-env`,
+        });
       }) as typeof globalThis.fetch;
       // Transport reads env var when resumeToken is not explicitly set
       const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
       await launchVideo({ prompt: "x" }, transport, BASE);
-      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe("tok-env-video");
+      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
+        "tok-env-video",
+      );
     } finally {
       delete process.env[KEY];
     }
@@ -586,11 +614,19 @@ describe("contentGeneration.video.launch()", () => {
       polls += 1;
       return polls < 2
         ? jsonResponse({ status: "IN_PROGRESS" })
-        : jsonResponse({ video: { url: "https://media/v.mp4", content_type: "video/mp4" } });
+        : jsonResponse({
+            video: { url: "https://media/v.mp4", content_type: "video/mp4" },
+          });
     }) as typeof globalThis.fetch;
     const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
 
-    const handle = await launchVideo({ prompt: "a wave", pollIntervalMs: 1 } as Parameters<typeof launchVideo>[0], transport, BASE);
+    const handle = await launchVideo(
+      { prompt: "a wave", pollIntervalMs: 1 } as Parameters<
+        typeof launchVideo
+      >[0],
+      transport,
+      BASE,
+    );
     const result = await handle.wait({ pollMs: 1 });
 
     expect(result.video).toEqual({
@@ -654,7 +690,9 @@ describe("createClient().contentGeneration.video.launch", () => {
       }) as typeof globalThis.fetch;
 
       const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
-      const handle = await sapiom.contentGeneration.video.launch({ prompt: "x" });
+      const handle = await sapiom.contentGeneration.video.launch({
+        prompt: "x",
+      });
 
       expect(handle.requestId).toBe("r-client");
       expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
@@ -662,7 +700,9 @@ describe("createClient().contentGeneration.video.launch", () => {
         "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
       );
       expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
-      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe("tok-client-bind");
+      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
+        "tok-client-bind",
+      );
     } finally {
       delete process.env[KEY];
     }
@@ -689,7 +729,9 @@ describe("toVideoResumePayload()", () => {
   });
 
   it("maps a video with neither fileId nor storageError to an empty-field outputs[0]", () => {
-    const payload = toVideoResumePayload({ video: { url: "https://media/v.mp4" } });
+    const payload = toVideoResumePayload({
+      video: { url: "https://media/v.mp4" },
+    });
     expect(payload).toEqual({ outputs: [{}] });
   });
 

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -621,9 +621,7 @@ describe("contentGeneration.video.launch()", () => {
     const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
 
     const handle = await launchVideo(
-      { prompt: "a wave", pollIntervalMs: 1 } as Parameters<
-        typeof launchVideo
-      >[0],
+      { prompt: "a wave", pollIntervalMs: 1 },
       transport,
       BASE,
     );
@@ -665,6 +663,47 @@ describe("contentGeneration.video.launch()", () => {
       launchVideo({ prompt: "x" }, transport, BASE),
     ).rejects.toBeInstanceOf(ContentGenerationHttpError);
     expect(calls).toHaveLength(1);
+  });
+
+  it("wait() throws if the result isn't ready before the timeout", async () => {
+    const { transport } = makeLaunchTransport(
+      { request_id: "req-timeout", response_url: `${BASE}/queue/req-timeout` },
+      { status: "IN_PROGRESS" },
+    );
+
+    const handle = await launchVideo({ prompt: "x" }, transport, BASE);
+    await expect(handle.wait({ timeoutMs: 20, pollMs: 1 })).rejects.toThrow(
+      /did not complete within/,
+    );
+  });
+
+  it("explicit resumeToken wins over the ambient env token", async () => {
+    const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+    process.env[KEY] = "tok-env-should-lose";
+    try {
+      const calls: FetchCall[] = [];
+      const fetchMock = (async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        init: RequestInit = {},
+      ): Promise<Response> => {
+        calls.push({ url: String(input), init });
+        return jsonResponse({
+          request_id: "req-explicit",
+          response_url: `${BASE}/queue/req-explicit`,
+        });
+      }) as typeof globalThis.fetch;
+      const transport = new Transport({
+        apiKey: "test-key",
+        resumeToken: "tok-explicit",
+        fetch: fetchMock,
+      });
+      await launchVideo({ prompt: "x" }, transport, BASE);
+      expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
+        "tok-explicit",
+      );
+    } finally {
+      delete process.env[KEY];
+    }
   });
 });
 

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -465,8 +465,8 @@ export async function launchVideo(
   const responseUrl = handle.response_url;
 
   const wait = async ({
-    timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
-    pollMs = DEFAULT_VIDEO_POLL_INTERVAL_MS,
+    timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS,
+    pollMs = input.pollIntervalMs ?? DEFAULT_VIDEO_POLL_INTERVAL_MS,
   }: {
     timeoutMs?: number;
     pollMs?: number;

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -12,14 +12,29 @@
  *   out.images[0].fileId;    // present when `storage` was passed → use with fileStorage
  *
  * Or via an explicit client: `createClient({ apiKey }).contentGeneration.images.create(...)`.
+ *
+ * `video.launch` is the dispatchable surface: it submits the job and returns a
+ * handle immediately. Pass the handle to `pauseUntilSignal(handle, { resumeStep })`
+ * to suspend the workflow step until the video is ready, or call `handle.wait()`
+ * inline to block until done — same as `video.create` but with the ability to
+ * pause a running workflow.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
 import { ensureOk, ContentGenerationHttpError } from "./errors.js";
+import type { DispatchHandle } from "../dispatch.js";
 
 export { ContentGenerationHttpError };
 
 const DEFAULT_BASE_URL =
   process.env.SAPIOM_CONTENT_GENERATION_URL || "https://fal.services.sapiom.ai";
+
+/**
+ * Capability-stable signal a video launch fires when the video reaches a terminal
+ * state (ready OR failed — it carries the result either way, the resumed step
+ * branches). A workflow step paused on a launch handle resumes on this; it is the
+ * value carried in the handle's `dispatch.resultSignal`.
+ */
+export const VIDEO_RESULT_SIGNAL = "contentGeneration.video.result";
 
 /** Default image model when the caller doesn't pick one — a fast, low-cost model. */
 const DEFAULT_IMAGE_MODEL = "fal-ai/flux/schnell";
@@ -126,6 +141,35 @@ function modelToPath(model: string): string {
 }
 
 /**
+ * Guard a prompt value: throw a clear error before a paid job is submitted when
+ * the prompt is absent, empty, or not a string. A JS caller passing `null`,
+ * `undefined`, or `""` gets an immediate, actionable error instead of a silent
+ * paid request with a blank prompt.
+ */
+function assertPrompt(prompt: unknown): void {
+  if (typeof prompt !== "string" || prompt.trim() === "") {
+    throw new ContentGenerationHttpError(
+      "prompt is required and must be a non-empty string",
+      400,
+      { error: "invalid_prompt" },
+    );
+  }
+}
+
+/**
+ * When launched from inside a Sapiom workflow step, the engine injects an opaque
+ * per-execution resume token into the transport. Forwarding it as a header — NOT
+ * a body field, so author-supplied request fields can't clobber it — lets the
+ * service call back into the engine to resume the paused workflow when the job
+ * finishes. Absent outside a workflow → no header, no behavior change.
+ */
+function workflowResumeHeaders(
+  token: string | undefined,
+): Record<string, string> {
+  return token ? { "x-sapiom-workflow-token": token } : {};
+}
+
+/**
  * Generate one or more images from a prompt. Pass `storage` to persist each output
  * (the returned images then carry `fileId`). Failed requests throw
  * {@link ContentGenerationHttpError}.
@@ -135,6 +179,7 @@ export async function createImage(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<ImageGenerationResult> {
+  assertPrompt(input.prompt);
   const path = modelToPath(input.model || DEFAULT_IMAGE_MODEL);
 
   const body: Record<string, unknown> = {
@@ -246,7 +291,9 @@ function mapVideo(raw: RawMedia): GeneratedVideo {
 
 function mapVideoResult(raw: RawVideoResult): VideoGenerationResult {
   const { video, ...rest } = raw;
-  return video === undefined ? { ...rest } : { ...rest, video: mapVideo(video) };
+  return video === undefined
+    ? { ...rest }
+    : { ...rest, video: mapVideo(video) };
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -265,9 +312,13 @@ export async function createVideo(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<VideoGenerationResult> {
+  assertPrompt(input.prompt);
   const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
 
-  const body: Record<string, unknown> = { prompt: input.prompt, ...input.params };
+  const body: Record<string, unknown> = {
+    prompt: input.prompt,
+    ...input.params,
+  };
   // Truthy check (not `!== undefined`) so `storage: null` is treated as "no storage".
   if (input.storage) body.storage = input.storage;
 
@@ -312,5 +363,140 @@ export async function createVideo(
   );
 }
 
-/** The `video` sub-namespace: `contentGeneration.video.create(...)`. Async (submit + poll). */
-export const video = { create: createVideo };
+/**
+ * A launched-but-not-awaited video generation job. Satisfies {@link DispatchHandle},
+ * so it can be handed straight to `pauseUntilSignal(handle, { resumeStep })` to
+ * suspend a workflow step until the video is ready — or `wait()`-ed inline for
+ * standalone use (same as `video.create`, but with the dispatchable surface).
+ */
+export interface VideoLaunchHandle extends DispatchHandle {
+  /** The queue request id for this job. */
+  requestId: string;
+  /** Poll to completion and resolve the full result. */
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<VideoGenerationResult>;
+}
+
+/**
+ * The video job's terminal result as it arrives at a step **resumed** from
+ * `pauseUntilSignal(launchHandle, { resumeStep })`. It crossed a wire boundary,
+ * so the shape is plain JSON. Annotate a resumed step's input with this type.
+ *
+ *   const finalize = defineStep({
+ *     name: "finalize", terminal: true,
+ *     async run(result: VideoResultPayload, ctx) { … },
+ *   });
+ */
+export interface VideoResultPayload {
+  outputs: Array<{
+    /** Present when the output was persisted to file storage. */
+    fileId?: string;
+    /** Present when storage was requested but persisting this output failed. */
+    storageError?: string;
+  }>;
+}
+
+/**
+ * Map a live, awaited {@link VideoGenerationResult} to the plain
+ * {@link VideoResultPayload} a resumed step receives across the wire boundary.
+ */
+export function toVideoResumePayload(
+  result: VideoGenerationResult,
+): VideoResultPayload {
+  if (!result.video) return { outputs: [] };
+  return {
+    outputs: [
+      {
+        ...(result.video.fileId !== undefined && {
+          fileId: result.video.fileId,
+        }),
+        ...(result.video.storageError !== undefined && {
+          storageError: result.video.storageError,
+        }),
+      },
+    ],
+  };
+}
+
+/**
+ * Submit a video generation job and return a dispatchable handle immediately.
+ * The handle's `dispatch` member lets a workflow step pause until the video
+ * is ready; `handle.wait()` blocks inline instead — same as `video.create` but
+ * with the ability to suspend a running workflow.
+ *
+ * Pass `storage` to persist the output (the result then carries `fileId`).
+ * Throws {@link ContentGenerationHttpError} when the submit fails.
+ */
+export async function launchVideo(
+  input: VideoCreateInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<VideoLaunchHandle> {
+  assertPrompt(input.prompt);
+  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
+
+  const body: Record<string, unknown> = {
+    prompt: input.prompt,
+    ...input.params,
+  };
+  if (input.storage) body.storage = input.storage;
+
+  // Submit — includes the workflow resume token header so the service can resume
+  // the paused step when the job completes (no-op outside a workflow context).
+  const submitRes = await ensureOk(
+    await transport.fetch(`${baseUrl}/run/${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...workflowResumeHeaders(transport.resumeToken),
+      },
+      body: JSON.stringify(body),
+    }),
+    "Failed to submit video generation",
+  );
+  const handle = (await submitRes.json()) as QueueHandle;
+  if (!handle.response_url) {
+    throw new Error("Video submit did not return a result URL to poll");
+  }
+
+  const requestId = handle.request_id ?? "unknown";
+  const responseUrl = handle.response_url;
+
+  const wait = async ({
+    timeoutMs = DEFAULT_VIDEO_TIMEOUT_MS,
+    pollMs = DEFAULT_VIDEO_POLL_INTERVAL_MS,
+  }: {
+    timeoutMs?: number;
+    pollMs?: number;
+  } = {}): Promise<VideoGenerationResult> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const res = await transport.fetch(responseUrl, { method: "GET" });
+      if (res.ok) {
+        const raw = (await res.json()) as RawVideoResult;
+        if (raw.video?.url) return mapVideoResult(raw);
+      } else {
+        try {
+          await res.body?.cancel();
+        } catch {
+          // best-effort drain
+        }
+      }
+      await sleep(pollMs);
+    }
+    throw new Error(
+      `Video generation did not complete within ${timeoutMs}ms (request id: ${requestId})`,
+    );
+  };
+
+  return {
+    requestId,
+    dispatch: { correlationId: requestId, resultSignal: VIDEO_RESULT_SIGNAL },
+    wait,
+  };
+}
+
+/** The `video` sub-namespace: `contentGeneration.video.create(...)` and `contentGeneration.video.launch(...)`. */
+export const video = { create: createVideo, launch: launchVideo };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -60,6 +60,13 @@ export { FileStorageHttpError } from "./file-storage/index.js";
 
 export * as contentGeneration from "./content-generation/index.js";
 export { ContentGenerationHttpError } from "./content-generation/index.js";
+// Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
+export { VIDEO_RESULT_SIGNAL } from "./content-generation/index.js";
+// The shape a step resumed from `pauseUntilSignal(videoLaunchHandle, …)` receives
+// as input — annotate the resumed step with it instead of hand-rolling the shape.
+export type { VideoResultPayload } from "./content-generation/index.js";
+// Map a live VideoGenerationResult to the wire shape the resumed step receives.
+export { toVideoResumePayload } from "./content-generation/index.js";
 
 export * as search from "./search/index.js";
 export { SearchHttpError } from "./search/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -593,7 +593,7 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                   contentType: "image/png",
                   width: 512,
                   height: 512,
-                  // mirror the real stitch: a fileId only when storage was requested.
+                  // mirror the real behavior: a fileId only when storage was requested.
                   ...(input.storage ? { fileId: "stub-file" } : {}),
                 },
               ],
@@ -607,7 +607,7 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               video: {
                 url: "https://content.local/stub-video.mp4",
                 contentType: "video/mp4",
-                // mirror the real stitch: a fileId only when storage was requested.
+                // mirror the real behavior: a fileId only when storage was requested.
                 ...(input.storage ? { fileId: "stub-file" } : {}),
               },
             })) as VideoGenerationResult,

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -34,9 +34,14 @@ import type {
   ListResponse,
   FileMetadata,
 } from "../file-storage/index.js";
+import {
+  VIDEO_RESULT_SIGNAL,
+  toVideoResumePayload,
+} from "../content-generation/index.js";
 import type {
   ImageGenerationResult,
   VideoGenerationResult,
+  VideoLaunchHandle,
 } from "../content-generation/index.js";
 import type {
   ScrapeResult,
@@ -607,6 +612,35 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               },
             })) as VideoGenerationResult,
           ),
+        launch: (input) => {
+          const requestId = `stub-video-${++launchSeq}`;
+          const result = r(
+            dispatchedKeys("contentGeneration.video"),
+            [input],
+            () => ({
+              video: {
+                url: "https://content.local/stub-video.mp4",
+                contentType: "video/mp4",
+                ...(input.storage ? { fileId: "stub-file" } : {}),
+              },
+            }),
+          ) as VideoGenerationResult;
+
+          const handle: VideoLaunchHandle = {
+            requestId,
+            dispatch: {
+              correlationId: requestId,
+              resultSignal: VIDEO_RESULT_SIGNAL,
+            },
+            wait: () => Promise.resolve(result),
+          };
+
+          // Register the resume payload so a local `pauseUntilSignal` on this handle
+          // resolves with a VideoResultPayload.
+          return dispatchable(handle, opts.signals, () =>
+            toVideoResumePayload(result),
+          );
+        },
       },
     },
     search: {


### PR DESCRIPTION
## Summary
Adds `contentGeneration.video.launch()` — the **dispatchable** surface for video generation, the async sibling of `video.create`. A workflow step can launch a video job, **pause**, and **auto-resume** when the video is ready (instead of blocking a runner for the whole generation). Mirrors `agent.coding.launch`.

## What's new
- **`contentGeneration.video.launch(input)`** → returns a `VideoLaunchHandle` immediately. Hand it to `pauseUntilSignal(handle, { resumeStep })` to suspend a workflow step until the video is ready, or call `handle.wait()` to block inline (same result as `video.create`).
- **`VideoLaunchHandle`** satisfies `DispatchHandle` (`dispatch.correlationId` / `dispatch.resultSignal`) — the join keys the orchestration engine uses to resume a paused step.
- **`VIDEO_RESULT_SIGNAL`** (`"contentGeneration.video.result"`) — the capability-stable signal constant for a step's static `pause: { signal }` declaration.
- **`VideoResultPayload` + `toVideoResumePayload`** — the plain-JSON payload a resumed step receives (`outputs[].fileId` / `outputs[].storageError`).
- **Stub + orchestration wiring** — `createStubClient()` registers `video.launch` as a dispatchable stub (local workflow testing), and the auto-resume signal list includes the video signal.
- **Prompt guard (hardening)** — `images.create`, `video.create`, and `video.launch` now throw a typed error immediately when `prompt` is null, empty, or not a string, before any request.

## `create` vs `launch`
`video.create` stays the standalone blocking call (submit + await). `video.launch` is the same submit but returns a pausable handle — use it inside workflow steps so the step idles and auto-resumes rather than holding a runner.

## Testing
- [x] 33 new unit tests (148 total in `@sapiom/tools`); 1 new orchestration auto-resume test (6 total). typecheck + lint + build green.
- [x] Covers: launch submits + returns a `DispatchHandle`; the resume token header is sent only inside a workflow context; `wait()` polls to completion; `toVideoResumePayload` mapping; the prompt guard throws before any network call.

## Checklist
- [ ] Code follows project guidelines
- [ ] All tests passing
- [ ] No hardcoded secrets
- [ ] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
