### PR TITLE
feat: add database capability

### DIFF
--- a/.changeset/tools-database-namespace.md
+++ b/.changeset/tools-database-namespace.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `database` namespace for on-demand Postgres databases:
+
+- `database.create` — provision a database for a chosen `duration`, returned with direct connection credentials (`connection.connectionString`, `host`, `port`, `username`, `password`, `databaseName`).
+- `database.get` — retrieve a database by its id or handle.
+- `database.delete` — delete a database by its id or handle.
+
+Results use normalized camelCase types, and a typed `DatabaseHttpError` (`{ status, body }`) is thrown on non-2xx responses.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -76,6 +76,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `contentGeneration` | Media generation (images + video; audio soon), with optional `storage`                                | [src/content-generation](./src/content-generation/README.md) |
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
 | `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
+| `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -48,6 +48,11 @@
       "import": "./dist/esm/search/index.js",
       "require": "./dist/cjs/search/index.js"
     },
+    "./database": {
+      "types": "./dist/cjs/database/index.d.ts",
+      "import": "./dist/esm/database/index.js",
+      "require": "./dist/cjs/database/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -73,6 +73,8 @@ import type {
   DomainSearchInput,
   DomainSearchResult,
 } from "./search/index.js";
+import * as database from "./database/index.js";
+import type { CreateDatabaseInput, Database } from "./database/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -147,6 +149,15 @@ export interface Sapiom {
       domainSearch(input: DomainSearchInput): Promise<DomainSearchResult>;
     };
   };
+  /** On-demand Postgres databases, returned with direct connection credentials. */
+  readonly database: {
+    /** Provision a database (returns connection credentials). `duration` is required. */
+    create(input: CreateDatabaseInput): Promise<Database>;
+    /** Retrieve a database by its id or handle. */
+    get(idOrHandle: string): Promise<Database>;
+    /** Delete a database by its id or handle. */
+    delete(idOrHandle: string): Promise<void>;
+  };
   /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
@@ -204,6 +215,11 @@ function bind(transport: Transport): Sapiom {
         verifyEmail: (input) => verifyEmail(input, transport),
         domainSearch: (input) => domainSearch(input, transport),
       },
+    },
+    database: {
+      create: (input) => database.create(input, transport),
+      get: (idOrHandle) => database.get(idOrHandle, transport),
+      delete: (idOrHandle) => database.delete(idOrHandle, transport),
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/database/README.md
+++ b/packages/tools/src/database/README.md
@@ -1,0 +1,62 @@
+# database
+
+On-demand Postgres databases. The same database capability your agents call over
+MCP, callable directly from your code. You get back direct connection credentials,
+so you can connect with any standard Postgres client or driver.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// 1. Provision a database. `duration` is required.
+const db = await sapiom.database.create({
+  duration: "1h", // "15m" | "1h" | "4h" | "24h" | "7d"
+  handle: "analytics", // optional, stable key to look it up later
+});
+
+// 2. Connect with any Postgres client using the credentials.
+db.connection?.connectionString; // a ready-to-use Postgres URI
+db.connection?.host;
+db.connection?.port;
+db.connection?.username;
+db.connection?.password;
+db.connection?.databaseName;
+
+// 3. Retrieve it later by id or handle, then delete it.
+const again = await sapiom.database.get(db.id); // or get("analytics")
+await sapiom.database.delete(db.id); // or delete("analytics")
+```
+
+Ambient import works too: `import { database } from "@sapiom/tools"`.
+
+## This is a provisioning surface, not a query layer
+
+`database` hands you connection credentials; it does not run SQL for you. You
+connect with the Postgres client of your choice (`pg`, `postgres`, an ORM, `psql`,
+…) using `connection.connectionString` and run your own queries.
+
+## Lifecycle
+
+- A database is created with a `duration` and is **automatically removed** when it
+  expires — there is no long-lived state to clean up by hand. `expiresAt` tells you
+  when that happens.
+- Right after `create`, `status` is `"active"` and `connection` carries credentials.
+- `get` on a database that is still provisioning may return `connection: null` until
+  it is ready.
+
+## Looking up a database
+
+`get` and `delete` accept either the database `id` or the `handle` you set at
+creation. A `handle` is a stable, human-friendly key (`3–63` chars,
+`^[a-z0-9][a-z0-9-]*[a-z0-9]$`) that is unique within your tenant — handy for
+passing a database between steps or agents without carrying the id around.
+
+## Gotchas
+
+- **`duration` is required.** Omitting it is rejected before any request is made.
+- **`connection` can be `null`** while a database is still provisioning — guard it
+  (`db.connection?.connectionString`) before connecting.
+- **`connectionString` is always present** on a non-null `connection`, even if the
+  individual component fields couldn't be parsed.
+- **Failed requests throw `DatabaseHttpError`** (carries `status` + parsed `body`),
+  exported from `@sapiom/tools`.

--- a/packages/tools/src/database/errors.ts
+++ b/packages/tools/src/database/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error thrown by the `database` capability when a request fails (non-2xx
+ * response). Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ */
+export class DatabaseHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "DatabaseHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link DatabaseHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new DatabaseHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/database/index.spec.ts
+++ b/packages/tools/src/database/index.spec.ts
@@ -1,0 +1,388 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as database from "./index.js";
+import { DatabaseHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly with a real Transport plus a
+// scripted fetch mock (so URL/method/header/body assertions are exact, and we
+// verify the Transport itself injects the tenant credential).
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+const CONNECTION_URI =
+  "postgresql://db_user:s3cr3t@db.example.com:5433/appdb?sslmode=require";
+
+const rawDatabase = (overrides: Record<string, unknown> = {}) => ({
+  id: "db_abc123",
+  handle: "analytics",
+  name: "Analytics",
+  description: "events",
+  status: "active",
+  region: "us-east-1",
+  pgVersion: 17,
+  duration: "1h",
+  connectionUri: CONNECTION_URI,
+  expiresAt: "2026-06-25T13:00:00Z",
+  createdAt: "2026-06-25T12:00:00Z",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// create()
+// ---------------------------------------------------------------------------
+
+describe("database.create()", () => {
+  it("POSTs /v1/databases with JSON body + credential and parses the connection URI", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(rawDatabase(), { status: 201 }),
+    ]);
+
+    const db = await database.create(
+      {
+        duration: "1h",
+        handle: "analytics",
+        name: "Analytics",
+        description: "events",
+        region: "us-east-1",
+        pgVersion: 17,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/databases`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      duration: "1h",
+      handle: "analytics",
+      name: "Analytics",
+      description: "events",
+      region: "us-east-1",
+      pgVersion: 17,
+    });
+
+    // Top-level fields copied 1:1; the connection URI is parsed into components.
+    expect(db).toEqual({
+      id: "db_abc123",
+      handle: "analytics",
+      name: "Analytics",
+      description: "events",
+      status: "active",
+      region: "us-east-1",
+      pgVersion: 17,
+      duration: "1h",
+      connection: {
+        connectionString: CONNECTION_URI,
+        host: "db.example.com",
+        port: 5433,
+        username: "db_user",
+        password: "s3cr3t",
+        databaseName: "appdb",
+        sslmode: "require",
+      },
+      expiresAt: "2026-06-25T13:00:00Z",
+      createdAt: "2026-06-25T12:00:00Z",
+    });
+  });
+
+  it("omits undefined optional fields from the body", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(rawDatabase({ handle: null }), { status: 201 }),
+    ]);
+
+    await database.create({ duration: "15m" }, transport, BASE);
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({ duration: "15m" });
+    expect(body).not.toHaveProperty("handle");
+    expect(body).not.toHaveProperty("name");
+    expect(body).not.toHaveProperty("region");
+    expect(body).not.toHaveProperty("pgVersion");
+  });
+
+  it("defaults a missing port to 5432", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          rawDatabase({
+            connectionUri: "postgresql://u:p@host.example.com/appdb",
+          }),
+          { status: 201 },
+        ),
+    ]);
+
+    const db = await database.create({ duration: "1h" }, transport, BASE);
+    expect(db.connection?.port).toBe(5432);
+    expect(db.connection?.sslmode).toBeUndefined();
+  });
+
+  it("decodes URL-encoded credentials in the connection URI", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          rawDatabase({
+            connectionUri:
+              "postgresql://us%40r:p%40ss%2Fword@host.example.com:5432/appdb",
+          }),
+          { status: 201 },
+        ),
+    ]);
+
+    const db = await database.create({ duration: "1h" }, transport, BASE);
+    expect(db.connection?.username).toBe("us@r");
+    expect(db.connection?.password).toBe("p@ss/word");
+  });
+
+  it("maps a null connectionUri to connection: null (still provisioning)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          rawDatabase({ status: "provisioning", connectionUri: null }),
+          {
+            status: 201,
+          },
+        ),
+    ]);
+
+    const db = await database.create({ duration: "1h" }, transport, BASE);
+    expect(db.status).toBe("provisioning");
+    expect(db.connection).toBeNull();
+  });
+
+  it("preserves connectionString even when the URI is malformed", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(rawDatabase({ connectionUri: "not-a-valid-uri" }), {
+          status: 201,
+        }),
+    ]);
+
+    const db = await database.create({ duration: "1h" }, transport, BASE);
+    expect(db.connection?.connectionString).toBe("not-a-valid-uri");
+    expect(db.connection?.host).toBeUndefined();
+  });
+
+  it("throws a clean error (before any fetch) when duration is missing", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      database.create(
+        { duration: undefined as unknown as "1h" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "DatabaseHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws DatabaseHttpError (with status + body) on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "duplicate handle" }), {
+          status: 409,
+        }),
+    ]);
+
+    await expect(
+      database.create({ duration: "1h", handle: "taken" }, transport, BASE),
+    ).rejects.toMatchObject({
+      name: "DatabaseHttpError",
+      status: 409,
+      body: { message: "duplicate handle" },
+    });
+    await expect(
+      database.create({ duration: "1h" }, transport, BASE),
+    ).rejects.toBeInstanceOf(DatabaseHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get()
+// ---------------------------------------------------------------------------
+
+describe("database.get()", () => {
+  it("GETs /v1/databases/:idOrHandle and maps the response", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(rawDatabase()),
+    ]);
+
+    const db = await database.get("db_abc123", transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/databases/db_abc123`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(db.id).toBe("db_abc123");
+    expect(db.connection?.host).toBe("db.example.com");
+  });
+
+  it("URL-encodes the idOrHandle path segment", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(rawDatabase()),
+    ]);
+
+    await database.get("weird id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/databases/weird%20id%2Fwith%20slash`,
+    );
+  });
+
+  it("throws DatabaseHttpError on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+
+    await expect(
+      database.get("missing", transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete()
+// ---------------------------------------------------------------------------
+
+describe("database.delete()", () => {
+  it("DELETEs /v1/databases/:idOrHandle and resolves void on 204", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    const result = await database.delete("db_abc123", transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/databases/db_abc123`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("URL-encodes the idOrHandle path segment", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await database.delete("weird id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/databases/weird%20id%2Fwith%20slash`,
+    );
+  });
+
+  it("throws DatabaseHttpError on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+
+    await expect(
+      database.delete("missing", transport, BASE),
+    ).rejects.toBeInstanceOf(DatabaseHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client wiring + auth
+// ---------------------------------------------------------------------------
+
+describe("database — client wiring + credential", () => {
+  it("createClient().database routes create/get/delete with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      const method = init.method ?? "GET";
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      return jsonResponse(rawDatabase(), {
+        status: method === "POST" ? 201 : 200,
+      });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+    await sapiom.database.create({ duration: "1h" });
+    await sapiom.database.get("db_abc123");
+    await sapiom.database.delete("db_abc123");
+
+    expect(calls).toHaveLength(3);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+    expect(calls[0]!.url).toBe("https://neon.services.sapiom.ai/v1/databases");
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("{}")) as typeof globalThis.fetch,
+      });
+      await expect(database.get("db_abc123", transport, BASE)).rejects.toThrow(
+        /no tenant credential/i,
+      );
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DatabaseHttpError
+// ---------------------------------------------------------------------------
+
+describe("DatabaseHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new DatabaseHttpError("something went wrong", 422, {
+      message: "invalid",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(DatabaseHttpError);
+    expect(err.status).toBe(422);
+    expect(err.body).toEqual({ message: "invalid" });
+    expect(err.name).toBe("DatabaseHttpError");
+  });
+});

--- a/packages/tools/src/database/index.spec.ts
+++ b/packages/tools/src/database/index.spec.ts
@@ -195,7 +195,7 @@ describe("database.create()", () => {
     expect(db.connection).toBeNull();
   });
 
-  it("preserves connectionString even when the URI is malformed", async () => {
+  it("preserves connectionString (canonical) and leaves components undefined when the URI is malformed", async () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse(rawDatabase({ connectionUri: "not-a-valid-uri" }), {
@@ -203,9 +203,17 @@ describe("database.create()", () => {
         }),
     ]);
 
+    // Does not throw out of the mapper; connectionString is always preserved and
+    // the best-effort component fields are simply absent.
     const db = await database.create({ duration: "1h" }, transport, BASE);
+    expect(db.connection).toEqual({ connectionString: "not-a-valid-uri" });
     expect(db.connection?.connectionString).toBe("not-a-valid-uri");
     expect(db.connection?.host).toBeUndefined();
+    expect(db.connection?.port).toBeUndefined();
+    expect(db.connection?.username).toBeUndefined();
+    expect(db.connection?.password).toBeUndefined();
+    expect(db.connection?.databaseName).toBeUndefined();
+    expect(db.connection?.sslmode).toBeUndefined();
   });
 
   it("throws a clean error (before any fetch) when duration is missing", async () => {

--- a/packages/tools/src/database/index.ts
+++ b/packages/tools/src/database/index.ts
@@ -1,0 +1,244 @@
+/**
+ * `database` capability — provision an on-demand Postgres database, retrieve it,
+ * and delete it. You get back direct connection credentials, so you can connect
+ * with any standard Postgres client or driver.
+ *
+ *   import { database } from "@sapiom/tools";              // ambient auth
+ *   const db = await database.create({ duration: "1h", handle: "analytics" });
+ *   db.connection?.connectionString;                      // a ready-to-use Postgres URI
+ *
+ *   const again = await database.get(db.id);              // or get("analytics") by handle
+ *   await database.delete(db.id);                         // or delete("analytics")
+ *
+ * Or via an explicit client: `createClient({ apiKey }).database.create(...)`.
+ *
+ * This is a provisioning surface, not a query layer: it hands you connection
+ * credentials and you run your own SQL with the client of your choice.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { ensureOk, DatabaseHttpError } from "./errors.js";
+
+export { DatabaseHttpError };
+
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_DATABASE_URL || "https://neon.services.sapiom.ai";
+
+// ----- Types -----
+
+/** How long the database lives before it is automatically removed. */
+export type DatabaseDuration = "15m" | "1h" | "4h" | "24h" | "7d";
+
+/** Lifecycle state of a database. */
+export type DatabaseStatus =
+  | "provisioning"
+  | "active"
+  | "expired"
+  | "deleting"
+  | "deleted";
+
+export interface CreateDatabaseInput {
+  /** How long the database lives before it is automatically removed (required). */
+  duration: DatabaseDuration;
+  /**
+   * Optional stable, human-friendly key you can use to look the database up later
+   * (`get(handle)` / `delete(handle)`). 3–63 chars, `^[a-z0-9][a-z0-9-]*[a-z0-9]$`.
+   * Unique within your tenant.
+   */
+  handle?: string;
+  /** Optional display name. */
+  name?: string;
+  /** Optional description (up to 500 chars). */
+  description?: string;
+  /** Optional region to provision in. Defaults to a US region. */
+  region?: string;
+  /** Optional Postgres major version. Defaults to the latest supported. */
+  pgVersion?: 15 | 16 | 17;
+}
+
+export interface DatabaseConnection {
+  /** The full Postgres connection URI — pass this to any Postgres client. */
+  connectionString: string;
+  /** Database host. */
+  host: string;
+  /** Database port. */
+  port: number;
+  /** Database user. */
+  username: string;
+  /** Database password. */
+  password: string;
+  /** Name of the database to connect to. */
+  databaseName: string;
+  /** SSL mode from the connection URI, when present (e.g. "require"). */
+  sslmode?: string;
+}
+
+export interface Database {
+  /** Unique database identifier. */
+  id: string;
+  /** The handle you set at creation, or `null` if none was given. */
+  handle: string | null;
+  /** Display name, or `null`. */
+  name: string | null;
+  /** Description, or `null`. */
+  description: string | null;
+  /** Lifecycle state. */
+  status: DatabaseStatus;
+  /** Region the database is provisioned in. */
+  region: string;
+  /** Postgres major version. */
+  pgVersion: number;
+  /** The lifetime the database was created with. */
+  duration: DatabaseDuration | string;
+  /** Connection credentials — `null` while the database is still being provisioned. */
+  connection: DatabaseConnection | null;
+  /** ISO-8601 timestamp when the database expires, or `null`. */
+  expiresAt: string | null;
+  /** ISO-8601 timestamp when the database was created. */
+  createdAt: string;
+}
+
+// ----- Internal request/response shapes -----
+
+interface RawCreateDatabaseRequest {
+  duration: string;
+  handle?: string;
+  name?: string;
+  description?: string;
+  region?: string;
+  pgVersion?: number;
+}
+
+interface RawDatabaseResponse {
+  id: string;
+  handle: string | null;
+  name: string | null;
+  description: string | null;
+  status: string;
+  region: string;
+  pgVersion: number;
+  duration: string;
+  connectionUri: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+/**
+ * Break a Postgres connection URI into its parts. `connectionString` is always
+ * preserved (it is the value you pass to a client); the parsed components are a
+ * convenience. If the URI can't be parsed, only `connectionString` is returned.
+ */
+function parseConnectionUri(uri: string): DatabaseConnection {
+  try {
+    const u = new URL(uri);
+    return {
+      connectionString: uri,
+      host: u.hostname,
+      port: u.port ? Number(u.port) : 5432,
+      username: decodeURIComponent(u.username),
+      password: decodeURIComponent(u.password),
+      databaseName: u.pathname.replace(/^\//, ""),
+      sslmode: u.searchParams.get("sslmode") ?? undefined,
+    };
+  } catch {
+    return { connectionString: uri } as DatabaseConnection;
+  }
+}
+
+function mapDatabase(raw: RawDatabaseResponse): Database {
+  return {
+    id: raw.id,
+    handle: raw.handle,
+    name: raw.name,
+    description: raw.description,
+    status: raw.status as DatabaseStatus,
+    region: raw.region,
+    pgVersion: raw.pgVersion,
+    duration: raw.duration,
+    connection:
+      raw.connectionUri == null ? null : parseConnectionUri(raw.connectionUri),
+    expiresAt: raw.expiresAt,
+    createdAt: raw.createdAt,
+  };
+}
+
+// ----- Capability operations -----
+
+/**
+ * Provision a new Postgres database. `duration` is required. Returns the database
+ * with connection credentials in `connection`. Failed requests throw
+ * {@link DatabaseHttpError}.
+ */
+export async function create(
+  input: CreateDatabaseInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Database> {
+  if (!input.duration) {
+    throw new DatabaseHttpError("duration is required", 400, {
+      message: "duration is required",
+    });
+  }
+
+  const body: RawCreateDatabaseRequest = { duration: input.duration };
+  if (input.handle !== undefined) body.handle = input.handle;
+  if (input.name !== undefined) body.name = input.name;
+  if (input.description !== undefined) body.description = input.description;
+  if (input.region !== undefined) body.region = input.region;
+  if (input.pgVersion !== undefined) body.pgVersion = input.pgVersion;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/databases`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to create database",
+  );
+  return mapDatabase((await res.json()) as RawDatabaseResponse);
+}
+
+/** Retrieve a database by its id or handle. */
+export async function get(
+  idOrHandle: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Database> {
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/databases/${encodeURIComponent(idOrHandle)}`,
+    ),
+    `Failed to get database '${idOrHandle}'`,
+  );
+  return mapDatabase((await res.json()) as RawDatabaseResponse);
+}
+
+/**
+ * Delete a database by its id or handle. Exported as `delete`:
+ * `import { database } from "@sapiom/tools"; await database.delete(id)`.
+ */
+async function deleteDatabase(
+  idOrHandle: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const res = await transport.fetch(
+    `${baseUrl}/v1/databases/${encodeURIComponent(idOrHandle)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    throw new DatabaseHttpError(
+      `Failed to delete database '${idOrHandle}': ${res.status} ${text}`,
+      res.status,
+      parsed,
+    );
+  }
+}
+
+export { deleteDatabase as delete };

--- a/packages/tools/src/database/index.ts
+++ b/packages/tools/src/database/index.ts
@@ -56,18 +56,22 @@ export interface CreateDatabaseInput {
 }
 
 export interface DatabaseConnection {
-  /** The full Postgres connection URI — pass this to any Postgres client. */
+  /**
+   * The full Postgres connection URI — pass this to any Postgres client. This is
+   * the canonical value and is always present; the component fields below are
+   * parsed from it on a best-effort basis and may be absent if it can't be parsed.
+   */
   connectionString: string;
   /** Database host. */
-  host: string;
+  host?: string;
   /** Database port. */
-  port: number;
+  port?: number;
   /** Database user. */
-  username: string;
+  username?: string;
   /** Database password. */
-  password: string;
+  password?: string;
   /** Name of the database to connect to. */
-  databaseName: string;
+  databaseName?: string;
   /** SSL mode from the connection URI, when present (e.g. "require"). */
   sslmode?: string;
 }
@@ -140,7 +144,7 @@ function parseConnectionUri(uri: string): DatabaseConnection {
       sslmode: u.searchParams.get("sslmode") ?? undefined,
     };
   } catch {
-    return { connectionString: uri } as DatabaseConnection;
+    return { connectionString: uri };
   }
 }
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -63,3 +63,6 @@ export { ContentGenerationHttpError } from "./content-generation/index.js";
 
 export * as search from "./search/index.js";
 export { SearchHttpError } from "./search/index.js";
+
+export * as database from "./database/index.js";
+export { DatabaseHttpError } from "./database/index.js";

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -42,6 +42,11 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.search).toBe("object");
     expect(typeof sapiom.search.scrape).toBe("function");
 
+    expect(typeof sapiom.database).toBe("object");
+    expect(typeof sapiom.database.create).toBe("function");
+    expect(typeof sapiom.database.get).toBe("function");
+    expect(typeof sapiom.database.delete).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -45,6 +45,7 @@ import type {
   VerifyEmailResult,
   DomainSearchResult,
 } from "../search/index.js";
+import type { Database } from "../database/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -689,6 +690,62 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             })) as DomainSearchResult,
           ),
       },
+    },
+    database: {
+      create: (input) =>
+        Promise.resolve(
+          r("database.create", [input], () => {
+            const handle = input.handle ?? null;
+            const name = `stub-${handle ?? "db"}`;
+            return {
+              id: "stub-db",
+              handle,
+              name: input.name ?? null,
+              description: input.description ?? null,
+              status: "active",
+              region: input.region ?? "us-east-1",
+              pgVersion: input.pgVersion ?? 17,
+              duration: input.duration,
+              connection: {
+                connectionString: `postgresql://stub_user:stub_pass@localhost:5432/${name}`,
+                host: "localhost",
+                port: 5432,
+                username: "stub_user",
+                password: "stub_pass",
+                databaseName: name,
+              },
+              expiresAt: "2099-01-01T00:00:00Z",
+              createdAt: "2099-01-01T00:00:00Z",
+            };
+          }) as Database,
+        ),
+      get: (idOrHandle) =>
+        Promise.resolve(
+          r("database.get", [idOrHandle], () => ({
+            id: "stub-db",
+            handle: idOrHandle,
+            name: `stub-${idOrHandle}`,
+            description: null,
+            status: "active",
+            region: "us-east-1",
+            pgVersion: 17,
+            duration: "1h",
+            connection: {
+              connectionString: `postgresql://stub_user:stub_pass@localhost:5432/stub-${idOrHandle}`,
+              host: "localhost",
+              port: 5432,
+              username: "stub_user",
+              password: "stub_pass",
+              databaseName: `stub-${idOrHandle}`,
+            },
+            expiresAt: "2099-01-01T00:00:00Z",
+            createdAt: "2099-01-01T00:00:00Z",
+          })) as Database,
+        ),
+      delete: (idOrHandle) =>
+        Promise.resolve(
+          r("database.delete", [idOrHandle], () => undefined) as void,
+        ),
     },
     withAttribution: () => client,
   };


### PR DESCRIPTION
## Summary

Adds a `database` namespace to `@sapiom/tools` for on-demand Postgres databases — the same database capability your agents call over MCP, now callable directly from your code. You get back direct connection credentials, so you can connect with any standard Postgres client or driver.

## API

```typescript
import { createClient } from "@sapiom/tools";
const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });

// Provision a database (duration is required).
const db = await sapiom.database.create({
  duration: "1h", // "15m" | "1h" | "4h" | "24h" | "7d"
  handle: "analytics", // optional, stable key to look it up later
});

// Connect with any Postgres client.
db.connection?.connectionString; // ready-to-use Postgres URI
db.connection?.host;
db.connection?.port;
db.connection?.username;
db.connection?.password;
db.connection?.databaseName;

// Retrieve later by id or handle, then delete.
const again = await sapiom.database.get(db.id); // or get("analytics")
await sapiom.database.delete(db.id); // or delete("analytics")
```

Ambient import works too: `import { database } from "@sapiom/tools"`.

## What's included

- **`database.create`** — provision a database for a chosen `duration`; returns rich metadata plus a nested `connection` object parsed from the connection URI (`connectionString`, `host`, `port`, `username`, `password`, `databaseName`, `sslmode?`). `connection` is `null` while a database is still provisioning.
- **`database.get`** — retrieve a database by its id or handle.
- **`database.delete`** — delete a database by its id or handle.
- Normalized camelCase types and a typed `DatabaseHttpError` (`{ status, body }`) thrown on non-2xx responses.
- A shape-faithful stub (`@sapiom/tools/stub`) so workflows run locally with zero setup, and the `./database` subpath export.
- Unit tests covering request/response, connection-URI parsing (including `null` and malformed-URI fallback), path encoding, the required-`duration` guard, error mapping, and client wiring.

## Notes

- `database` is a provisioning surface, not a query layer: it hands you connection credentials and you run your own SQL with the client of your choice.
- This is a `minor` bump (a new capability); changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)