### PR TITLE
feat(tools): single SAPIOM_SERVICES_BASE knob to re-home all capability gateways

### DIFF
--- a/.changeset/services-base-single-knob.md
+++ b/.changeset/services-base-single-knob.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/tools": minor
+---
+
+Add `SAPIOM_SERVICES_BASE` — one env var that re-homes every capability gateway at once.
+
+Each capability resolved its base URL independently (`SAPIOM_<CAP>_URL || "https://<subdomain>.services.sapiom.ai"`). Pointing the whole SDK at a non-prod stack meant setting a separate variable for every capability, and any capability you forgot silently fell back to prod. Now all capabilities resolve through `resolveServiceUrl(subdomain, override)`:
+
+1. an explicit per-capability `SAPIOM_<CAP>_URL` still wins (unchanged, back-compat);
+2. else `SAPIOM_SERVICES_BASE` re-homes every capability by swapping the host suffix and preserving the subdomain (e.g. `SAPIOM_SERVICES_BASE=http://services.localhost:3100` → `http://fal.services.localhost:3100`, `http://git.services.localhost:3100`, …);
+3. else the production default `https://<subdomain>.services.sapiom.ai` (unchanged).
+
+Accepts a full origin or a bare `host[:port]` (assumed https). Production behavior is unchanged when `SAPIOM_SERVICES_BASE` is unset.

--- a/packages/tools/src/_client/service-url.spec.ts
+++ b/packages/tools/src/_client/service-url.spec.ts
@@ -1,0 +1,45 @@
+import { resolveServiceUrl } from "./service-url.js";
+
+describe("resolveServiceUrl", () => {
+  const ORIGINAL = process.env.SAPIOM_SERVICES_BASE;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.SAPIOM_SERVICES_BASE;
+    else process.env.SAPIOM_SERVICES_BASE = ORIGINAL;
+  });
+
+  it("falls back to the production default when nothing is set", () => {
+    delete process.env.SAPIOM_SERVICES_BASE;
+    expect(resolveServiceUrl("fal")).toBe("https://fal.services.sapiom.ai");
+    expect(resolveServiceUrl("git")).toBe("https://git.services.sapiom.ai");
+  });
+
+  it("a per-capability override always wins", () => {
+    process.env.SAPIOM_SERVICES_BASE = "http://services.localhost:3100";
+    expect(resolveServiceUrl("fal", "http://custom:9999")).toBe(
+      "http://custom:9999",
+    );
+  });
+
+  it("SAPIOM_SERVICES_BASE re-homes every capability by injecting its subdomain", () => {
+    process.env.SAPIOM_SERVICES_BASE = "http://services.localhost:3100";
+    expect(resolveServiceUrl("fal")).toBe("http://fal.services.localhost:3100");
+    expect(resolveServiceUrl("file-storage")).toBe(
+      "http://file-storage.services.localhost:3100",
+    );
+    expect(resolveServiceUrl("git")).toBe("http://git.services.localhost:3100");
+  });
+
+  it("accepts a bare host[:port] (assumes https) as well as a full origin", () => {
+    process.env.SAPIOM_SERVICES_BASE = "services.localhost:3100";
+    expect(resolveServiceUrl("agents")).toBe(
+      "https://agents.services.localhost:3100",
+    );
+  });
+
+  it("uses only scheme + host[:port] from the base (ignores any path)", () => {
+    process.env.SAPIOM_SERVICES_BASE = "http://services.localhost:3100/ignored";
+    expect(resolveServiceUrl("blaxel")).toBe(
+      "http://blaxel.services.localhost:3100",
+    );
+  });
+});

--- a/packages/tools/src/_client/service-url.ts
+++ b/packages/tools/src/_client/service-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Resolve a capability's gateway base URL from a single, uniform source.
+ *
+ * Every capability is hosted at `https://<subdomain>.services.sapiom.ai` in
+ * production — only the subdomain differs (fal, git, agents, file-storage, …).
+ * Resolution order:
+ *
+ *   1. an explicit per-capability override (`SAPIOM_<CAP>_URL`) — wins, so any
+ *      single capability can still be pointed somewhere bespoke;
+ *   2. `SAPIOM_SERVICES_BASE` — ONE knob that re-homes EVERY capability at once
+ *      by swapping the host suffix (the subdomain is preserved). Set it to e.g.
+ *      `http://services.localhost:3100` for a local stack and every capability
+ *      follows — no per-capability env to remember, nothing silently escapes;
+ *   3. the production default `https://<subdomain>.services.sapiom.ai`.
+ *
+ * `SAPIOM_SERVICES_BASE` accepts a full origin (`http://services.localhost:3100`)
+ * or a bare `host[:port]` (`services.localhost:3100`, assumed https). Only its
+ * scheme + host[:port] are used; any path is ignored.
+ */
+export function resolveServiceUrl(
+  subdomain: string,
+  override?: string,
+): string {
+  if (override) return override;
+
+  const base = process.env.SAPIOM_SERVICES_BASE;
+  if (base) {
+    const url = new URL(base.includes("://") ? base : `https://${base}`);
+    return `${url.protocol}//${subdomain}.${url.host}`;
+  }
+
+  return `https://${subdomain}.services.sapiom.ai`;
+}

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -21,12 +21,15 @@
  * wire; this module maps them to the camelCase SDK surface below.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import type { DispatchHandle } from "../dispatch.js";
 import { Sandbox } from "../sandboxes/index.js";
 import type { Repository } from "../repositories/index.js";
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_AGENTS_URL || "https://agents.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "agents",
+  process.env.SAPIOM_AGENTS_URL,
+);
 
 /**
  * Capability-stable signal a coding run fires when it reaches a terminal state
@@ -250,7 +253,9 @@ export interface RunHandle extends DispatchHandle {
  * gateway call back into the engine to resume the paused workflow when the run
  * finishes. Absent outside a workflow → no header, no behavior change.
  */
-function workflowResumeHeaders(token: string | undefined): Record<string, string> {
+function workflowResumeHeaders(
+  token: string | undefined,
+): Record<string, string> {
   return token ? { "x-sapiom-workflow-token": token } : {};
 }
 

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -20,13 +20,16 @@
  * pause a running workflow.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import { ensureOk, ContentGenerationHttpError } from "./errors.js";
 import type { DispatchHandle } from "../dispatch.js";
 
 export { ContentGenerationHttpError };
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_CONTENT_GENERATION_URL || "https://fal.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "fal",
+  process.env.SAPIOM_CONTENT_GENERATION_URL,
+);
 
 /**
  * Capability-stable signal a video launch fires when the video reaches a terminal

--- a/packages/tools/src/file-storage/index.ts
+++ b/packages/tools/src/file-storage/index.ts
@@ -19,13 +19,15 @@
  * returned as `string | null` to stay precise for large files.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import { ensureOk, FileStorageHttpError } from "./errors.js";
 
 export { FileStorageHttpError };
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_FILE_STORAGE_URL ||
-  "https://file-storage.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "file-storage",
+  process.env.SAPIOM_FILE_STORAGE_URL,
+);
 
 // ----- SDK-facing types -----
 

--- a/packages/tools/src/orchestrations/index.ts
+++ b/packages/tools/src/orchestrations/index.ts
@@ -15,10 +15,13 @@
  * a pausable handle). An orchestration is addressed by its **slug** (its stable handle).
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import type { DispatchHandle } from "../dispatch.js";
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_WORKFLOWS_URL || "https://workflows.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "workflows",
+  process.env.SAPIOM_WORKFLOWS_URL,
+);
 
 /**
  * Signal a run fires when it reaches a terminal state (completed OR failed — the
@@ -96,7 +99,9 @@ export class OrchestrationResultSchemaError extends Error {}
  * `output` itself is the child orchestration's contract, not validated here.
  */
 export const orchestrationResultSchema = {
-  parse<TOutput = unknown>(value: unknown): OrchestrationRunResultPayload<TOutput> {
+  parse<TOutput = unknown>(
+    value: unknown,
+  ): OrchestrationRunResultPayload<TOutput> {
     const fail = (msg: string): never => {
       throw new OrchestrationResultSchemaError(
         `invalid orchestration result payload: ${msg}`,
@@ -131,7 +136,10 @@ export interface RunHandle extends DispatchHandle {
   /** Fetch the current status without blocking. */
   status(): Promise<ExecutionStatus>;
   /** Poll to a terminal state and resolve the run result. */
-  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<OrchestrationRunResult>;
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<OrchestrationRunResult>;
 }
 
 /**
@@ -169,7 +177,10 @@ export async function launch(
     `${baseUrl}/v1/workflows/${encodeURIComponent(spec.definition)}/executions`,
     {
       method: "POST",
-      body: JSON.stringify({ input: spec.input ?? {}, idempotencyKey: spec.idempotencyKey }),
+      body: JSON.stringify({
+        input: spec.input ?? {},
+        idempotencyKey: spec.idempotencyKey,
+      }),
       headers: workflowResumeHeaders(),
     },
   );
@@ -184,7 +195,10 @@ export async function launch(
     executionId,
     // Framework plumbing for `pauseUntilSignal` — see DispatchHandle. correlationId
     // is this run's id (the resume's correlation key).
-    dispatch: { correlationId: executionId, resultSignal: ORCHESTRATIONS_RESULT_SIGNAL },
+    dispatch: {
+      correlationId: executionId,
+      resultSignal: ORCHESTRATIONS_RESULT_SIGNAL,
+    },
     async status() {
       return (await fetchDoc()).status;
     },
@@ -194,7 +208,12 @@ export async function launch(
       while (true) {
         const d = await fetchDoc();
         if (TERMINAL.has(d.status)) {
-          return { executionId, status: d.status, output: d.output ?? null, error: d.error ?? null };
+          return {
+            executionId,
+            status: d.status,
+            output: d.output ?? null,
+            error: d.error ?? null,
+          };
         }
         if (Date.now() > deadline) {
           throw new Error(

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -8,10 +8,10 @@
  *   await repo.pushFromSandbox(box, { message: "build: page" });
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import type { Sandbox } from "../sandboxes/index.js";
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_GIT_URL || "https://git.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl("git", process.env.SAPIOM_GIT_URL);
 
 /** `GET`/`list` shape from the git gateway. */
 interface RepoSummary {

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -13,6 +13,7 @@
  *   await box.destroy();
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import {
   DEFAULT_CONCURRENCY,
   DEFAULT_MAX_RETRIES,
@@ -60,8 +61,10 @@ export type {
 } from "./types.js";
 
 /** Platform sandbox service. Host routing is an internal detail — override via `baseUrl` or SAPIOM_SANDBOX_URL. */
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_SANDBOX_URL || "https://blaxel.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "blaxel",
+  process.env.SAPIOM_SANDBOX_URL,
+);
 const DEFAULT_POLL_INTERVAL = 1000;
 const DEFAULT_EXEC_TIMEOUT = 60_000;
 

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -21,12 +21,15 @@
  * Failed requests throw {@link SearchHttpError} (carries `status` + parsed `body`).
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
 import { SearchHttpError, ensureOk } from "./errors.js";
 
 export { SearchHttpError };
 
-const DEFAULT_BASE_URL =
-  process.env.SAPIOM_SCRAPE_URL || "https://firecrawl.services.sapiom.ai";
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "firecrawl",
+  process.env.SAPIOM_SCRAPE_URL,
+);
 
 const DEFAULT_WEB_SEARCH_BASE_URL =
   process.env.SAPIOM_SEARCH_URL || "https://api.sapiom.ai";


### PR DESCRIPTION
## Summary
Each `@sapiom/tools` capability resolved its gateway base URL independently, each with its own prod default. Pointing the SDK at a non-prod stack therefore meant setting one env var per capability — and any you forgot silently fell back to the prod host. This adds a single knob.

## Changes
- New `resolveServiceUrl(subdomain, override)` (`packages/tools/src/_client/service-url.ts`) with resolution order:
  1. explicit per-capability `SAPIOM_<CAP>_URL` (still wins),
  2. `SAPIOM_SERVICES_BASE` — one knob that re-homes **every** capability, preserving each capability's subdomain,
  3. the unchanged prod default `https://<subdomain>.services.sapiom.ai`.
- All 7 capability modules (agent, content-generation, file-storage, orchestrations, repositories, sandboxes, search) route through it.
- `SAPIOM_SERVICES_BASE` accepts a full origin (`http://services.localhost:3100`) or a bare `host[:port]`.

## Note
`DEFAULT_BASE_URL` is still resolved at module load, so this does not remove the import-order escape for in-process callers — it is a usability win (one knob instead of N) and the foundation for a later lazy/per-call resolution.

## Testing
- [x] `@sapiom/tools` build clean (cjs + esm)
- [x] `@sapiom/tools` tests pass (174/174, incl. new `service-url.spec.ts`)

## Related
- Closes: SAP-1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)