### PR TITLE
fix(orchestration-core): scaffold honors npm_config_registry when resolving versions

### DIFF
--- a/.changeset/scaffold-honor-npm-registry.md
+++ b/.changeset/scaffold-honor-npm-registry.md
@@ -1,0 +1,16 @@
+---
+"@sapiom/orchestration-core": minor
+"@sapiom/create-orchestration": minor
+---
+
+Scaffold honors `npm_config_registry` / `@scope:registry` when resolving the
+`@sapiom/*` versions to pin
+
+Version resolution previously hardcoded the public npm registry, so a scaffold
+always pinned public-npm `latest` even when the environment pointed at a
+different registry. It now resolves `latest` from the same registry a plain
+`npm install` would (a scoped `@<scope>:registry` wins over the global
+`npm_config_registry`, which wins over the public default). When that registry
+is non-default, the scaffolded project also gets a matching `.npmrc` so its
+pinned versions are installable. This makes a local registry dev loop work
+end-to-end with no manual pin edits; default scaffolds are unchanged.

--- a/packages/create-orchestration/src/versions.ts
+++ b/packages/create-orchestration/src/versions.ts
@@ -45,7 +45,7 @@ function registryFor(pkg: string): string {
 async function latestVersion(pkg: string): Promise<string | null> {
   try {
     const res = await fetch(
-      `${registryFor(pkg)}/${pkg.replace("/", "%2F")}/latest`,
+      `${registryFor(pkg)}/${pkg.replace(/\//g, "%2F")}/latest`,
       {
         signal: AbortSignal.timeout(5000),
       },

--- a/packages/create-orchestration/src/versions.ts
+++ b/packages/create-orchestration/src/versions.ts
@@ -9,16 +9,16 @@
  * Pins are stamped EXACT (no caret) so a project's local typecheck matches what
  * the build injects — see the SDK version drift-check in the build pipeline.
  */
-const REGISTRY = 'https://registry.npmjs.org';
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
 /** Used when the registry is unreachable. Bump alongside notable SDK releases. */
 const FALLBACK = {
-  orchestration: '0.1.1',
-  tools: '0.1.1',
+  orchestration: "0.1.1",
+  tools: "0.1.1",
 };
 
 /** The zod major the authoring SDK is built against. */
-const ZOD_VERSION = '4.1.12';
+const ZOD_VERSION = "4.1.12";
 
 export interface ResolvedVersions {
   orchestration: string;
@@ -26,14 +26,33 @@ export interface ResolvedVersions {
   zod: string;
 }
 
+/**
+ * The npm registry to resolve `latest` from, honoring the same config a plain
+ * `npm install` would: a scoped `@<scope>:registry` wins over the global
+ * `npm_config_registry`, which wins over the public default. This lets the local
+ * SDK dev loop (a Verdaccio on :4873) scaffold onto a locally-published patch.
+ */
+function registryFor(pkg: string): string {
+  const scope = pkg.startsWith("@") ? pkg.slice(0, pkg.indexOf("/")) : null;
+  const scoped = scope
+    ? process.env[`npm_config_${scope}:registry`]
+    : undefined;
+  const registry =
+    scoped || process.env.npm_config_registry || DEFAULT_REGISTRY;
+  return registry.replace(/\/+$/, "");
+}
+
 async function latestVersion(pkg: string): Promise<string | null> {
   try {
-    const res = await fetch(`${REGISTRY}/${pkg.replace('/', '%2F')}/latest`, {
-      signal: AbortSignal.timeout(5000),
-    });
+    const res = await fetch(
+      `${registryFor(pkg)}/${pkg.replace("/", "%2F")}/latest`,
+      {
+        signal: AbortSignal.timeout(5000),
+      },
+    );
     if (!res.ok) return null;
     const json = (await res.json()) as { version?: string };
-    return typeof json.version === 'string' ? json.version : null;
+    return typeof json.version === "string" ? json.version : null;
   } catch {
     return null;
   }
@@ -41,8 +60,8 @@ async function latestVersion(pkg: string): Promise<string | null> {
 
 export async function resolveVersions(): Promise<ResolvedVersions> {
   const [orchestration, tools] = await Promise.all([
-    latestVersion('@sapiom/orchestration'),
-    latestVersion('@sapiom/tools'),
+    latestVersion("@sapiom/orchestration"),
+    latestVersion("@sapiom/tools"),
   ]);
   return {
     orchestration: orchestration ?? FALLBACK.orchestration,

--- a/packages/orchestration-core/src/__tests__/scaffold.test.ts
+++ b/packages/orchestration-core/src/__tests__/scaffold.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { OrchestrationError } from "../errors";
-import { scaffold } from "../scaffold";
+import { registryFor, scaffold } from "../scaffold";
 
 // Point template resolution at the bundled templates dir (two levels up from
 // src/), bypassing the dist/ path that TEMPLATES_DIR normally expects.
@@ -139,6 +139,87 @@ describe("scaffold", () => {
       });
       expect(existsSync(path.join(targetDir, ".gitignore"))).toBe(true);
       expect(existsSync(path.join(targetDir, "_gitignore"))).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("registryFor", () => {
+  const saved = {
+    registry: process.env.npm_config_registry,
+    scoped: process.env["npm_config_@sapiom:registry"],
+  };
+  afterEach(() => {
+    if (saved.registry === undefined) delete process.env.npm_config_registry;
+    else process.env.npm_config_registry = saved.registry;
+    if (saved.scoped === undefined)
+      delete process.env["npm_config_@sapiom:registry"];
+    else process.env["npm_config_@sapiom:registry"] = saved.scoped;
+  });
+
+  it("defaults to public npm when no override is set", () => {
+    delete process.env.npm_config_registry;
+    delete process.env["npm_config_@sapiom:registry"];
+    expect(registryFor("@sapiom/tools")).toBe("https://registry.npmjs.org");
+  });
+
+  it("honors the global npm_config_registry and strips a trailing slash", () => {
+    delete process.env["npm_config_@sapiom:registry"];
+    process.env.npm_config_registry = "http://localhost:4873/";
+    expect(registryFor("@sapiom/tools")).toBe("http://localhost:4873");
+  });
+
+  it("prefers a scoped @scope:registry over the global one", () => {
+    process.env.npm_config_registry = "http://localhost:4873";
+    process.env["npm_config_@sapiom:registry"] = "http://localhost:9999";
+    expect(registryFor("@sapiom/tools")).toBe("http://localhost:9999");
+    // A different scope ignores the @sapiom-scoped override.
+    expect(registryFor("@other/pkg")).toBe("http://localhost:4873");
+  });
+});
+
+describe("scaffold .npmrc (local registry)", () => {
+  const savedFetch = global.fetch;
+  const savedRegistry = process.env.npm_config_registry;
+  afterEach(() => {
+    global.fetch = savedFetch;
+    if (savedRegistry === undefined) delete process.env.npm_config_registry;
+    else process.env.npm_config_registry = savedRegistry;
+  });
+
+  it("writes an @sapiom:registry .npmrc when versions resolve from a non-default registry", async () => {
+    process.env.npm_config_registry = "http://localhost:4873";
+    global.fetch = (async () => ({
+      ok: true,
+      json: async () => ({ version: "9.9.9" }),
+    })) as unknown as typeof fetch;
+    const base = makeTmp();
+    const targetDir = path.join(base, "local-reg");
+    try {
+      await scaffold({ targetDir }); // no explicit versions → resolveVersions runs
+      const npmrc = readFileSync(path.join(targetDir, ".npmrc"), "utf8");
+      expect(npmrc).toContain("@sapiom:registry=http://localhost:4873");
+      const pkg = JSON.parse(
+        readFileSync(path.join(targetDir, "package.json"), "utf8"),
+      );
+      expect(pkg.dependencies["@sapiom/tools"]).toBe("9.9.9");
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT write an .npmrc when resolving from the default registry", async () => {
+    delete process.env.npm_config_registry;
+    global.fetch = (async () => ({
+      ok: true,
+      json: async () => ({ version: "9.9.9" }),
+    })) as unknown as typeof fetch;
+    const base = makeTmp();
+    const targetDir = path.join(base, "default-reg");
+    try {
+      await scaffold({ targetDir });
+      expect(existsSync(path.join(targetDir, ".npmrc"))).toBe(false);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/packages/orchestration-core/src/scaffold.ts
+++ b/packages/orchestration-core/src/scaffold.ts
@@ -72,7 +72,7 @@ const DOTFILE_NAMES = new Set(["_gitignore", "_npmrc"]);
 
 // ── Version resolution ────────────────────────────────────────────────────────
 
-const REGISTRY = "https://registry.npmjs.org";
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
 /** Offline fallbacks — bump alongside notable releases. */
 const VERSION_FALLBACK = {
@@ -89,11 +89,32 @@ export interface ResolvedVersions {
   zod: string;
 }
 
+/**
+ * The npm registry to resolve `latest` from, honoring the same config a plain
+ * `npm install` would: a scoped `@<scope>:registry` wins over the global
+ * `npm_config_registry`, which wins over the public default. Without this the
+ * scaffold always pinned public-npm latest — so the local SDK dev loop (a
+ * Verdaccio on :4873) could never scaffold a project onto a locally-published
+ * patch, even with `npm_config_registry` set. See the workflows authoring guide §4.
+ */
+export function registryFor(pkg: string): string {
+  const scope = pkg.startsWith("@") ? pkg.slice(0, pkg.indexOf("/")) : null;
+  const scoped = scope
+    ? process.env[`npm_config_${scope}:registry`]
+    : undefined;
+  const registry =
+    scoped || process.env.npm_config_registry || DEFAULT_REGISTRY;
+  return registry.replace(/\/+$/, "");
+}
+
 async function latestNpmVersion(pkg: string): Promise<string | null> {
   try {
-    const res = await fetch(`${REGISTRY}/${encodeURIComponent(pkg)}/latest`, {
-      signal: AbortSignal.timeout(5000),
-    });
+    const res = await fetch(
+      `${registryFor(pkg)}/${encodeURIComponent(pkg)}/latest`,
+      {
+        signal: AbortSignal.timeout(5000),
+      },
+    );
     if (!res.ok) return null;
     const json = (await res.json()) as { version?: string };
     return typeof json.version === "string" ? json.version : null;
@@ -287,6 +308,22 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
     __TOOLS_VERSION__: versions.tools,
     __ZOD_VERSION__: versions.zod,
   });
+
+  // When versions were resolved from a non-default registry (a local Verdaccio
+  // dev loop), the pinned @sapiom/* versions exist ONLY there — so point the
+  // project's installs at the same registry, else `npm install` 404s against
+  // public npm. Skipped for the default registry so a real customer's project
+  // stays clean. Only meaningful when scaffold itself resolved the versions;
+  // an explicit `opts.versions` caller manages its own registry.
+  if (!opts.versions) {
+    const sapiomRegistry = registryFor("@sapiom/tools");
+    if (sapiomRegistry !== DEFAULT_REGISTRY) {
+      writeFileSync(
+        path.join(targetDir, ".npmrc"),
+        `@sapiom:registry=${sapiomRegistry}\n`,
+      );
+    }
+  }
 
   // Seed the committed stub file for the local-run loop. Created here (not
   // shipped in the template) so it doesn't depend on how the registry treats


### PR DESCRIPTION
## What & why

The scaffold's version resolver (`resolveVersions` → `latestNpmVersion`) **hardcoded** `https://registry.npmjs.org`, so a scaffolded project always pinned public-npm `latest` — even when the environment pointed at another registry. This made the local SDK dev loop (a Verdaccio registry) impossible to scaffold against: the scaffold would pin a version that doesn't exist locally, or silently pin the public one and never see a locally-published patch. (The authoring guide already *claimed* the scaffold uses the local registry — the code contradicted it.)

## Changes

- **`orchestration-core/src/scaffold.ts`** — new `registryFor(pkg)` resolves `latest` from the same registry a plain `npm install` would: a scoped `@<scope>:registry` wins over the global `npm_config_registry`, which wins over the public default (trailing slash trimmed). `latestNpmVersion` uses it.
- **`scaffold()`** — when versions were resolved from a **non-default** registry, write a matching `.npmrc` (`@sapiom:registry=<registry>`) into the new project so its pins are installable with a plain `npm install`. Skipped for the default registry, and skipped when the caller passes explicit `versions` (it manages its own registry) — so real-customer scaffolds are byte-for-byte unchanged.
- **`create-orchestration/src/versions.ts`** — same `registryFor` fix for the standalone `npm create` path.
- **tests** — `registryFor` precedence (default / global / scoped-wins / other-scope) and `.npmrc` written-iff-non-default (fetch mocked, no network).

## Verification

- `pnpm --filter @sapiom/orchestration-core test` — 51 pass (5 new).
- End-to-end against a local Verdaccio: scaffold pins `@sapiom/tools` from the local registry **and** writes the `.npmrc`; a plain `npm install` in the scaffolded project (no registry env) then installs that local version. Default-registry scaffold writes no `.npmrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)