### PR TITLE
feat(tools): add memory capability (SAP-785)

### DIFF
--- a/.changeset/memory-capability.md
+++ b/.changeset/memory-capability.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `memory` capability — tenant-scoped long-term memory over the Sapiom memory gateway (hybrid vector + full-text store). Exposes `append`, `recall`, `get`, and `forget` via `createClient().memory`, the ambient `memory` namespace, or the `@sapiom/tools/memory` subpath. Non-2xx responses throw `MemoryHttpError`. The `@sapiom/tools/stub` client gains a matching `memory` stub so steps that use it can be exercised locally.

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,10 +96,18 @@ On the second request, you should see an `AuthorizationDeniedError` - this means
 | `fetch/` | `@sapiom/fetch` | Native fetch API users |
 | `node-http/` | `@sapiom/node-http` | Raw Node.js HTTP |
 | `langchain-classic/` | `@sapiom/langchain-classic` | LangChain v0.3.x with tool wrappers |
+| `memory-coding-conventions/` | `@sapiom/orchestration` + `@sapiom/tools` | Custom **workflows** + agent **memory** |
 
 > **Note:** The `langchain/` example is for LangChain v1.x. Use `langchain-classic/` if you're on LangChain v0.3.x.
 
 Start with `axios/` or `fetch/` - they're the simplest to understand.
+
+> **`memory-coding-conventions/` is different from the rest.** It's a **workflow**
+> example, not an SDK-adapter one: it runs entirely locally against mocked
+> capabilities (no API key, no demo server, no balance) and demonstrates giving a
+> coding agent durable memory of your house conventions — `recall` prior facts
+> into its prompt, then `append` what it learned. `cd memory-coding-conventions
+> && npm install && npm start`.
 
 ## About the Demo Server
 

--- a/examples/memory-coding-conventions-live/README.md
+++ b/examples/memory-coding-conventions-live/README.md
@@ -1,0 +1,51 @@
+# memory-coding-conventions-live
+
+The **live** sibling of [`../memory-coding-conventions`](../memory-coding-conventions).
+
+| | stub example | this (live) |
+|---|---|---|
+| Engine | `runLocal` (in-process) | real `@sapiom/tools` client |
+| Gateway | `@sapiom/tools/stub` (canned) | real unified-gateway memory provider |
+| Network | none | HTTP to `SAPIOM_MEMORY_URL` |
+| Credentials | none | `SAPIOM_API_KEY` (sent as `x-sapiom-api-key`) |
+| Cost | free | `append` is **x402-paid** ($0.002); `recall` is **not charged today** (metering deferred to an advisory/async follow-up); `get`/`forget` free |
+
+`runLocal` is hardwired to the stub dispatcher, so there is no "live" flag on it —
+hitting a real engine means using the real client directly, which is what this file does.
+
+## Run (against the local sapiom-local stack)
+
+Bring up the full stack first — see
+`workdocs/sap785-memory/DEMO-FULL-STACK.md` in the Sapiom monorepo.
+
+This example resolves the **unpublished local `@sapiom/tools`** (its `./memory`
+capability), so it's a pnpm **workspace member**: install + build from the repo root
+with pnpm (not `npm install` in this folder), then run it pointed at your local
+gateway:
+
+```bash
+# from the repo root — install the workspace + build the local SDK
+pnpm install
+pnpm --filter='./packages/*' build
+
+# run this example against the local memory gateway
+SAPIOM_MEMORY_URL=http://memory.services.localhost:3100 \
+SAPIOM_API_KEY=sk_your_local_key \
+pnpm --filter @sapiom/example-memory-coding-conventions-live start
+```
+
+> **For end users (post-publish):** the dep is `@sapiom/tools` at `latest` and a plain
+> `npm install` in this folder works. The `workspace:*` dep committed here exists only
+> to run against the as-yet-unpublished memory build.
+
+- `SAPIOM_MEMORY_URL` — the memory provider **origin** (no path; the client appends `/v1/memory/…`), e.g. `http://memory.services.localhost:3100`. Matches how every other `@sapiom/tools` capability takes a bare origin.
+- `SAPIOM_API_KEY` — a real Sapiom API key from your **local** backend; the
+  account must be able to pay (the gateway resolves identity + payment by calling
+  back to the backend).
+
+## What it does
+
+`recall` → inject recalled conventions into a prompt → `append` a new convention →
+`append` a near-duplicate (expect `SUPERSEDED`) → `append` a secret (expect
+`REJECTED`) → `get` → `forget` → `forget` again (expect `204` — `forget` is
+idempotent, so deleting the already-gone id succeeds, it is not a `404`).

--- a/examples/memory-coding-conventions-live/index.ts
+++ b/examples/memory-coding-conventions-live/index.ts
@@ -1,0 +1,118 @@
+/**
+ * memory-coding-conventions-LIVE
+ * ------------------------------
+ * The LIVE sibling of ../memory-coding-conventions.
+ *
+ * The original example is a teaching artifact: it runs `runLocal` against a STUB
+ * engine + STUB gateway (no network, no credentials). It can NEVER reach a real
+ * memory engine, because `runLocal` is hardwired to @sapiom/tools/stub.
+ *
+ * THIS file does the opposite: it uses the REAL `@sapiom/tools` memory client and
+ * hits a REAL memory engine. Point it at your LOCAL unified-gateway memory provider
+ * (the sapiom-local stack) with two env vars:
+ *
+ *   SAPIOM_MEMORY_URL = http://memory.services.localhost:3100
+ *   SAPIOM_API_KEY    = <a real Sapiom API key from your LOCAL backend>
+ *
+ * NOTE — this costs money / x402: `recall` and `append` are x402-PAID operations.
+ * The account behind SAPIOM_API_KEY must be able to pay (the gateway resolves your
+ * identity + payment context by calling back to the Sapiom backend). `get` and
+ * `forget` are free for identified callers.
+ *
+ * Run:
+ *   cd examples/memory-coding-conventions-live
+ *   npm install
+ *   SAPIOM_MEMORY_URL=http://memory.services.localhost:3100 \
+ *   SAPIOM_API_KEY=sk_... \
+ *   npm start
+ *
+ * This mirrors the same recall -> inject -> append loop as the stub example, but
+ * every call crosses the wire to the gateway, embeds via real OpenRouter, and
+ * reads/writes a real per-tenant pgvector store on Neon.
+ */
+
+import { memory } from "@sapiom/tools";
+
+const SCOPE = "house-conventions";
+
+function assertEnv() {
+  if (!process.env.SAPIOM_MEMORY_URL) {
+    throw new Error("Set SAPIOM_MEMORY_URL (e.g. http://memory.services.localhost:3100)");
+  }
+  if (!process.env.SAPIOM_API_KEY) {
+    throw new Error("Set SAPIOM_API_KEY to a real Sapiom API key from your local backend");
+  }
+}
+
+async function main() {
+  assertEnv();
+  const task = "Write a TypeScript service method that loads a user by id.";
+
+  // 1) RECALL — pull prior conventions for this scope (identity-gated; not charged today)
+  const { results, count } = await memory.recall({ query: task, scope: SCOPE, topK: 5 });
+  console.log(`recall  -> ${count} prior memories for scope="${SCOPE}"`);
+
+  // 2) INJECT — fold recalled conventions into the agent prompt
+  const conventions = results.map((m, i) => `  ${i + 1}. ${m.content}`).join("\n");
+  const enrichedTask = conventions
+    ? `${task}\n\nFollow these house conventions:\n${conventions}`
+    : task;
+  console.log("inject  -> enriched task:\n" + enrichedTask + "\n");
+
+  // (A real coding agent would run here against `enrichedTask`. Omitted: this
+  //  demo isolates the memory loop, not the agent.)
+
+  // 3) APPEND — persist a new convention learned this run (x402-paid)
+  const learned = "Inject DataSource and pass EntityManager through service methods; never use @InjectRepository.";
+  const appended = await memory.append({
+    content: learned,
+    scope: SCOPE,
+    metadata: { source: "memory-coding-conventions-live" },
+  });
+  console.log(
+    `append  -> id=${appended.id} decision=${appended.decision}` +
+      (appended.supersededId ? ` supersededId=${appended.supersededId}` : "") +
+      (appended.similarityScore != null ? ` similarity=${appended.similarityScore}` : ""),
+  );
+
+  // 3b) APPEND a NEAR-DUPLICATE — expect decision=SUPERSEDED (cosine >= 0.80)
+  const nearDup = await memory.append({
+    content: "Always inject the DataSource; do not use @InjectRepository in services.",
+    scope: SCOPE,
+    metadata: { source: "memory-coding-conventions-live", variant: "near-duplicate" },
+  });
+  console.log(`append2 -> decision=${nearDup.decision} supersededId=${nearDup.supersededId ?? "-"}`);
+
+  // 3c) APPEND a SECRET — expect the gateway to REJECT (HTTP 400, decision REJECTED)
+  // Assembled so secret-scanners don't flag this intentional fake key; the gate still sees the full value at runtime.
+  const LEAKED_SECRET = ["sk", "live", "51HxYzAbCdEfGhIjKlMnOpQrStUvWxYz0123456789"].join("_");
+  try {
+    await memory.append({
+      content: `Prod DB password is ${LEAKED_SECRET}`,
+      scope: SCOPE,
+    });
+    console.log("append3 -> UNEXPECTED: secret was accepted (should have been REJECTED)");
+  } catch (err) {
+    console.log(`append3 -> REJECTED as expected: ${(err as Error).message}`);
+  }
+
+  // 4) GET (free for identified callers)
+  const fetched = await memory.get(appended.id);
+  console.log(`get     -> id=${fetched.id} status=${fetched.status}`);
+
+  // 5) FORGET, then FORGET AGAIN — forget is a hard delete but idempotent, so the
+  //    second call of the now-gone id succeeds too (204 No Content, not a 404).
+  await memory.forget(appended.id);
+  console.log(`forget  -> deleted ${appended.id}`);
+  try {
+    await memory.forget(appended.id);
+    console.log("forget2 -> OK as expected: second forget succeeded (idempotent 204)");
+  } catch (err) {
+    console.log(`forget2 -> UNEXPECTED error (idempotent forget should succeed): ${(err as Error).message}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/memory-coding-conventions-live/package.json
+++ b/examples/memory-coding-conventions-live/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-memory-coding-conventions-live",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "LIVE variant: recall -> inject -> append against a REAL Sapiom memory engine (local unified-gateway memory provider)",
+  "scripts": {
+    "start": "npx tsx index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "_localDevNote": "Dep uses `workspace:*` so this example resolves the UNPUBLISHED local @sapiom/tools build (the `./memory` capability). For END USERS, post-publish, this is `@sapiom/tools` at `latest`. See README → 'Run'.",
+  "dependencies": {
+    "@sapiom/tools": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/memory-coding-conventions-live/tsconfig.json
+++ b/examples/memory-coding-conventions-live/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/memory-coding-conventions-workflow/.sapiom-dev/stubs.json
+++ b/examples/memory-coding-conventions-workflow/.sapiom-dev/stubs.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "steps": {
+    "recall": {
+      "memory.recall": {
+        "results": [
+          {
+            "id": "mem_prior_1",
+            "content": "Validate every request body with a zod schema before using it.",
+            "scope": "house-conventions",
+            "vectorScore": 0.6,
+            "textScore": 0.4,
+            "combinedScore": 0.55,
+            "status": "active",
+            "createdAt": "2026-06-01T00:00:00Z",
+            "metadata": {}
+          }
+        ],
+        "query": "stubbed",
+        "topK": 5,
+        "count": 1
+      }
+    },
+    "learn": {
+      "memory.append": {
+        "id": "mem_stub_1",
+        "content": "stubbed convention",
+        "scope": "house-conventions",
+        "status": "active",
+        "decision": "ADDED",
+        "supersededId": null,
+        "similarityScore": null,
+        "createdAt": "2026-06-24T00:00:00Z",
+        "metadata": { "source": "memory-coding-conventions-workflow" }
+      }
+    },
+    "verify": {
+      "memory.get": {
+        "id": "mem_stub_1",
+        "content": "stubbed convention",
+        "scope": "house-conventions",
+        "status": "active",
+        "supersededBy": null,
+        "supersededReason": null,
+        "createdAt": "2026-06-24T00:00:00Z",
+        "updatedAt": "2026-06-24T00:00:00Z",
+        "metadata": { "source": "memory-coding-conventions-workflow" }
+      }
+    }
+  }
+}

--- a/examples/memory-coding-conventions-workflow/README.md
+++ b/examples/memory-coding-conventions-workflow/README.md
@@ -1,0 +1,179 @@
+# memory-coding-conventions-workflow
+
+The **workflow** version of the memory demo. The same recall → apply → learn →
+verify memory loop as its two siblings, but authored as a **deployable Sapiom
+orchestration** — one artifact (`index.ts`) that runs **three different ways with
+no code changes**.
+
+## What this is (and how it differs from the siblings)
+
+| | [`memory-coding-conventions`](../memory-coding-conventions) | [`memory-coding-conventions-live`](../memory-coding-conventions-live) | **this** |
+|---|---|---|---|
+| Shape | orchestration | bare `main()` | orchestration |
+| `index.ts` deployable? | no — `runLocal` is called inside it | n/a (not a workflow) | **yes — side-effect-free** |
+| Runs locally (stub) | yes | no | yes |
+| Runs against the live gateway | no | yes | yes (dev walker) |
+| Runs on the Sapiom engine | no | no | **yes** |
+
+The stub sibling is a teaching artifact whose `runLocal` call lives *inside*
+`index.ts`, so that file can't be deployed. The `-live` sibling is a bare script
+that hits the real gateway but isn't a workflow at all. **This** example keeps the
+deployable artifact (`index.ts`) free of any top-level execution and puts the
+harness in a separate `run-local.ts`, so the *same* `index.ts` is what runs
+locally, what runs against the live gateway, and what the engine bundles and runs
+in a Blaxel sandbox.
+
+## The step graph
+
+```
+recall ─▶ apply ─┬─▶ learn ─▶ verify   (a new convention was recorded)
+                 └─▶ skip            (the convention was already known)
+```
+
+| Step | Capability | What it does |
+|------|-----------|--------------|
+| `recall` (entry) | `memory.recall` | Pull prior house conventions for the repo and **inject** them into the task prompt as a numbered preamble. |
+| `apply` | — (pure) | Derive the convention to record; **branch** on whether the top recalled match already covers the task (combinedScore ≥ 0.8). |
+| `learn` (`canFail`) | `memory.append` | Append the new convention so the **next** run recalls it. |
+| `verify` (terminal) | `memory.get` | Read the memory back to prove it persisted; terminate with the result. |
+| `skip` (terminal) | — | Nothing new to record; terminate early. |
+
+`apply` makes no capability call — it's a real branch, deterministic, so stubs can
+drive **both** sides. `learn` declares `canFail` to document the seam between a
+diagnosed terminal `fail()` and a throw (which the engine retries up to its cap);
+this demo throws nothing and fails nowhere, but the seam is there.
+
+## RUN MODE 1 — stub-local (offline, free, works today)
+
+`runLocal` plays the engine and `@sapiom/tools/stub` plays the gateway. No
+network, no credentials, no Sapiom account. This example resolves the
+**unpublished local SDK build** via pnpm's `workspace:` protocol, so install +
+build from the repo root with **pnpm** (not `npm` in this folder):
+
+```bash
+# from the repo root
+pnpm install                                # links this example to the local packages
+pnpm --filter='./packages/*' build          # build the local SDK (writes each package's dist/)
+pnpm --filter @sapiom/example-memory-coding-conventions-workflow start
+```
+
+You'll see the per-step trace ending in a `terminate` output, with no unused
+stubs and no stub warnings:
+
+```
+=== STUB MODE (offline) — scenario: learn (weak prior) ===
+
+workflow "memory-coding-conventions-workflow" → completed
+
+▶ recall (succeeded)
+    · recalled {"count":1}
+▶ apply (succeeded)
+    · new convention to record {"convention":"…"}
+▶ learn (succeeded)
+    · appended {"id":"mem_stub_1","decision":"ADDED"}
+▶ verify (succeeded)
+    · verified {"id":"mem_stub_1","status":"active"}
+
+final output: { "id": "mem_stub_1", "decision": "ADDED", "status": "active", "scope": "house-conventions" }
+
+✓ no unused stubs, no stub warnings
+```
+
+**See the other branch** — a strong prior makes `apply` take `skip`:
+
+```bash
+DEMO_SCENARIO=skip pnpm --filter @sapiom/example-memory-coding-conventions-workflow start
+```
+
+> The committed [`.sapiom-dev/stubs.json`](./.sapiom-dev/stubs.json) is a hand-kept
+> mirror of the inline default-scenario (weak-prior / learn) stub. It is the file a
+> `runLocalFromDir` harness *would* load — but nothing in this example loads it:
+> `pnpm start` builds the stubs inline via `buildStubs()` and calls `runLocal()`
+> directly. And `sapiom orchestrations check` does **not** read it either — `check`
+> only typechecks, bundles, and validates the graph/manifest; it never runs a step or
+> reads stubs. So treat `stubs.json` as documentation of the canned shapes, not as
+> something exercised here, and keep it in sync with `buildStubs()` by hand if you
+> edit either.
+
+## RUN MODE 2 — live-local (real LOCAL gateway; x402-paid recall/append)
+
+Bring up the full `sapiom-local` stack first — see
+`workdocs/sap785-memory/DEMO-FULL-STACK.md` in the Sapiom monorepo. Then point
+this at your local memory gateway and run with `--mode live`:
+
+```bash
+SAPIOM_API_KEY=sk_your_local_key \
+SAPIOM_MEMORY_URL=http://memory.services.localhost:3100 \
+pnpm --filter @sapiom/example-memory-coding-conventions-workflow start:live
+```
+
+- `SAPIOM_MEMORY_URL` — the memory provider **origin** (no path; the client appends `/v1/memory/…`).
+  `createClient()` takes only an `apiKey`; the memory base URL is read from this
+  env var by `@sapiom/tools`, so live mode **requires** it.
+- `SAPIOM_API_KEY` — a real key from your **local** backend; the account must be
+  able to pay (the gateway resolves identity + payment by calling the backend).
+
+`run-local.ts` contains a small, clearly-labeled **dev walker** that reproduces
+the engine's step-walk (start at `entry`; follow `goto` / `terminate` / `fail` /
+`retry` via the `isContinue` / `isTerminate` / `isFail` / `isRetry` guards) and
+drives the **same** step bodies from `index.ts` against the real gateway. It is
+for local dev only — in production the Sapiom engine runs these identical bodies
+inside a Blaxel sandbox.
+
+> `recall` and `append` are **x402-paid**. `get` is free. If your local stack's
+> OpenRouter key is a placeholder, `append` may return **503 on embeddings** —
+> that is a known external blocker of the local stack, not a bug in this example.
+
+## RUN MODE 3 — Sapiom execution (Blaxel sandbox) against LOCAL dev infra
+
+The **same** `index.ts` is the deployed artifact — no code changes between modes.
+The control plane is the `@sapiom/cli`:
+
+```bash
+# point the CLI at your local backend (http://localhost:3000)
+sapiom config set-target local
+
+# link this workflow to a backend definition, then deploy + run
+sapiom orchestrations link memory-coding-conventions-workflow --create
+sapiom orchestrations deploy
+sapiom orchestrations run \
+  --input '{"repoSlug":"api","task":"Add a POST /users endpoint that creates a user."}' \
+  --target local
+sapiom orchestrations logs <executionId>
+```
+
+### Two hard caveats for LOCAL infra
+
+1. **Capability keys are OFF by default.** The backend's
+   `WORKFLOWS_INJECT_CAPABILITY_KEYS` defaults to **false**, so local capability
+   steps run **tokenless** (they skip or 401). To actually exercise `memory.*`
+   you must run the backend with `WORKFLOWS_INJECT_CAPABILITY_KEYS=true` **and**
+   point the capability hosts at the local unified gateway, otherwise
+   `@sapiom/tools` defaults to the prod `*.services.sapiom.ai` hosts and a
+   locally-minted key 401s:
+
+   ```
+   WORKFLOWS_INJECT_CAPABILITY_KEYS=true
+   SAPIOM_SANDBOX_URL=http://sandbox.services.localhost:3100/...
+   SAPIOM_AGENTS_URL=http://agents.services.localhost:3100/...
+   SAPIOM_MEMORY_URL=http://memory.services.localhost:3100
+   SAPIOM_FILE_STORAGE_URL=http://files.services.localhost:3100/...
+   SAPIOM_GIT_URL=http://git.services.localhost:3100/...
+   ```
+
+2. **`deploy` 404s today.** The backend deploy/link **CREATE** routes
+   (`POST /definitions`, push-credentials, builds) are **not yet merged**, so
+   `sapiom orchestrations deploy` (and `link --create`) return **404** for now.
+   Linking to an **existing** definition works. The artifact is correct and
+   deploy-ready; this is purely a server-side gap, not an issue with this example.
+
+## How it maps onto production
+
+In all three modes the engine/harness swaps *underneath* the step bodies, never
+the bodies themselves:
+
+- **stub-local:** `runLocal` is the engine; `@sapiom/tools/stub` is the gateway.
+- **live-local:** the dev walker is the engine; the real local gateway serves
+  `ctx.sapiom.memory.*`.
+- **Sapiom execution:** the real engine bundles `index.ts`, mints a per-run
+  scoped key, and walks the steps in a Blaxel sandbox with a real `ctx.sapiom`.

--- a/examples/memory-coding-conventions-workflow/index.ts
+++ b/examples/memory-coding-conventions-workflow/index.ts
@@ -1,0 +1,245 @@
+/**
+ * memory-coding-conventions-WORKFLOW
+ * ----------------------------------
+ * The workflow (orchestration) version of the memory demo. Same recall → apply →
+ * learn → verify memory loop as the two siblings, but authored as a DEPLOYABLE
+ * Sapiom orchestration that runs THREE ways without a single code change:
+ *
+ *   1. stub-local  — `runLocal` + canned stubs, offline + free (see run-local.ts).
+ *   2. live-local  — a dev walker drives these same step bodies against the REAL
+ *                    local memory gateway (see run-local.ts `--mode live`).
+ *   3. Sapiom execution — the engine imports THIS file, bundles it, and walks the
+ *                    identical step bodies inside a Blaxel sandbox (see README).
+ *
+ * Contrast with the siblings:
+ *   - ../memory-coding-conventions       — stub-only teaching artifact; its
+ *     `runLocal` call lives INSIDE index.ts (so index.ts is not deployable).
+ *   - ../memory-coding-conventions-live  — a bare `main()` against the live
+ *     gateway; not a workflow at all (no steps, no engine, no deploy path).
+ *
+ * THIS file is the DEPLOYABLE ARTIFACT and is therefore SIDE-EFFECT-FREE: it only
+ * defines steps and exports exactly ONE `defineOrchestration`. There is no
+ * `main()`, no `runLocal` call, no top-level execution — so the engine can import
+ * and bundle it cleanly. The harness that runs it lives in `run-local.ts`.
+ *
+ * Step graph:
+ *
+ *   recall ─▶ apply ─┬─▶ learn ─▶ verify   (a new convention was recorded)
+ *                    └─▶ skip            (the convention was already known)
+ */
+import { defineStep, defineOrchestration, goto, terminate } from "@sapiom/orchestration";
+// The memory capability's types are published under the `memory` namespace export
+// of @sapiom/tools (`export * as memory`), so we reference them as `memory.*`.
+import type { memory } from "@sapiom/tools";
+import { z } from "zod/v4";
+
+type RecallMatch = memory.RecallMatch;
+type AppendResult = memory.AppendResult;
+type Memory = memory.Memory;
+
+/** What the workflow is kicked off with. */
+export interface WorkflowInput {
+  /** The repo the agent works in — also the memory partition for its conventions. */
+  repoSlug: string;
+  /** The feature request, before any house conventions are layered on. */
+  task: string;
+}
+
+/** Run-scoped values stashed in `ctx.shared` so later steps can read them. */
+export interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+}
+
+/** The memory scope this workflow's conventions live under. */
+const SCOPE = "house-conventions";
+
+// ---------------------------------------------------------------------------
+// Step 1 — recall the conventions and inject them into the task (recall→inject)
+// ---------------------------------------------------------------------------
+
+const recall = defineStep({
+  name: "recall",
+  next: ["apply"],
+  inputSchema: z.object({
+    repoSlug: z.string(),
+    task: z.string(),
+  }),
+  async run(input: WorkflowInput, ctx) {
+    // Stash the repo so the audit trail (and any downstream step) can read it.
+    ctx.shared.set("repoSlug", input.repoSlug);
+
+    // RECALL: hybrid (vector + full-text) search over what we learned before.
+    const { results, count } = await ctx.sapiom.memory.recall({
+      query: input.task,
+      scope: SCOPE,
+      topK: 5,
+    });
+    ctx.logger.info("recalled", { count });
+
+    // INJECT: fold the recalled facts into the agent's task prompt as a numbered
+    // "House conventions" preamble. A stateless agent has no memory of its own —
+    // this preamble is the only thing carrying prior knowledge into its context.
+    const preamble =
+      count === 0
+        ? ""
+        : [
+            "",
+            `Follow these house conventions (recalled from prior runs in the ${input.repoSlug} repo):`,
+            ...results.map((m, i) => `  ${i + 1}. ${m.content}`),
+          ].join("\n");
+    const enrichedTask = `${input.task}${preamble}`;
+
+    // `topMatch` is the best prior memory (or null). `apply` branches on it.
+    const topMatch: RecallMatch | null = results[0] ?? null;
+    return goto("apply", { enrichedTask, priorCount: count, topMatch });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — decide the new convention, and branch on whether it's already known
+// ---------------------------------------------------------------------------
+
+interface ApplyInput {
+  enrichedTask: string;
+  priorCount: number;
+  topMatch: RecallMatch | null;
+}
+
+const apply = defineStep({
+  name: "apply",
+  next: ["learn", "skip"],
+  async run(input: ApplyInput, ctx) {
+    // PURE LOGIC — no capability call here, so this step has nothing to stub.
+    // (In a fuller demo a coding agent would run against `input.enrichedTask`
+    //  here; we keep `apply` deterministic so stubs can drive BOTH branches.)
+
+    // Derive a one-line convention from the task, deterministically. This stands
+    // in for "the durable, repo-specific fact this run surfaced" that we want the
+    // NEXT run to recall automatically.
+    const repoSlug = ctx.shared.get("repoSlug") ?? "this";
+    const convention = `When working on "${input.enrichedTask.split("\n")[0]}" in the ${repoSlug} repo, follow the recalled house conventions before writing new code.`;
+
+    // BRANCH — the real decision the whole demo turns on:
+    //   Is this convention ALREADY recorded? The heuristic is intentionally
+    //   simple and well-commented so a stub can flip it either way:
+    //     - we have a prior match (topMatch present, priorCount > 0), AND
+    //     - that prior match's combined score is high enough that we treat it as
+    //       "already covers this task" (>= 0.8 — the same cosine threshold the
+    //       gateway uses to supersede a near-duplicate on append).
+    //   When both hold we SKIP the write (nothing new to learn); otherwise we LEARN.
+    const alreadyKnown =
+      input.topMatch !== null &&
+      input.priorCount > 0 &&
+      input.topMatch.combinedScore >= 0.8;
+
+    if (alreadyKnown) {
+      ctx.logger.info("convention already recorded — skipping the write");
+      return goto("skip", {
+        reason: "convention already recorded",
+        matched: input.topMatch,
+      });
+    }
+
+    ctx.logger.info("new convention to record", { convention });
+    return goto("learn", { convention });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 — append the new learning so the next run starts smarter (append)
+// ---------------------------------------------------------------------------
+
+interface LearnInput {
+  convention: string;
+}
+
+const learn = defineStep({
+  name: "learn",
+  next: ["verify"],
+  // `canFail: true` lets this step return `fail(...)` on a KNOWN-TERMINAL
+  // condition (e.g. the gateway reports the write was rejected). We don't do that
+  // here, but declaring it documents the seam. THROWING is reserved for
+  // UNEXPECTED/transient errors (a network blip) — those hit the engine's
+  // retry-up-to-cap self-heal path. Picking `fail()` vs throw is the difference
+  // between "diagnosed, don't retry" and "might be transient, do retry".
+  canFail: true,
+  async run(input: LearnInput, ctx) {
+    // APPEND: record the durable, repo-specific fact this run surfaced. On the
+    // next run, `recall` returns this and `apply` folds it into the task prompt.
+    const res: AppendResult = await ctx.sapiom.memory.append({
+      content: input.convention,
+      scope: SCOPE,
+      metadata: { source: "memory-coding-conventions-workflow" },
+    });
+    ctx.logger.info("appended", { id: res.id, decision: res.decision });
+
+    return goto("verify", {
+      id: res.id,
+      decision: res.decision,
+      supersededId: res.supersededId,
+      similarityScore: res.similarityScore,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 4 — read the memory back to prove it persisted (terminal)
+// ---------------------------------------------------------------------------
+
+interface VerifyInput {
+  id: string;
+  decision: AppendResult["decision"];
+  supersededId: string | null;
+  similarityScore: number | null;
+}
+
+const verify = defineStep({
+  name: "verify",
+  terminal: true,
+  async run(input: VerifyInput, ctx) {
+    // GET is free for identified callers — read the row back to confirm it stuck.
+    const mem: Memory = await ctx.sapiom.memory.get(input.id);
+    ctx.logger.info("verified", { id: mem.id, status: mem.status });
+
+    return terminate(
+      {
+        id: mem.id,
+        decision: input.decision,
+        status: mem.status,
+        scope: mem.scope,
+      },
+      { reason: "convention persisted" },
+    );
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 4' — the skip branch: nothing new to record (terminal)
+// ---------------------------------------------------------------------------
+
+interface SkipInput {
+  reason: string;
+  matched: RecallMatch | null;
+}
+
+const skip = defineStep({
+  name: "skip",
+  terminal: true,
+  async run(input: SkipInput, ctx) {
+    ctx.logger.info("skipped the write", { reason: input.reason });
+    return terminate({ skipped: true, reason: input.reason });
+  },
+});
+
+/**
+ * The workflow. In production the engine imports THIS `orchestration` export,
+ * bundles it, and walks these step bodies inside a Blaxel sandbox.
+ *
+ * Exactly ONE `defineOrchestration` is exported from this module — the
+ * orchestration-core loader requires precisely one.
+ */
+export const orchestration = defineOrchestration<WorkflowInput, Shared>({
+  name: "memory-coding-conventions-workflow",
+  entry: "recall",
+  steps: { recall, apply, learn, verify, skip },
+});

--- a/examples/memory-coding-conventions-workflow/package.json
+++ b/examples/memory-coding-conventions-workflow/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@sapiom/example-memory-coding-conventions-workflow",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom workflow example: the recall -> apply -> learn -> verify memory loop, authored as a deployable orchestration that runs three ways (stub-local, live-local, Sapiom execution)",
+  "scripts": {
+    "start": "npx tsx run-local.ts",
+    "start:live": "npx tsx run-local.ts --mode live",
+    "check": "npx tsx run-local.ts --mode stub",
+    "typecheck": "tsc --noEmit"
+  },
+  "_localDevNote": "Deps use `workspace:*` so this example resolves the UNPUBLISHED local SDK build (the memory capability on @sapiom/tools + the runLocal/stub harness in @sapiom/orchestration-core + the orchestration authoring surface). For END USERS, post-publish, these are `@sapiom/orchestration`, `@sapiom/orchestration-core`, `@sapiom/tools` at `latest`. See README -> 'Run'.",
+  "dependencies": {
+    "@sapiom/orchestration": "workspace:*",
+    "@sapiom/orchestration-core": "workspace:*",
+    "@sapiom/tools": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/memory-coding-conventions-workflow/run-local.ts
+++ b/examples/memory-coding-conventions-workflow/run-local.ts
@@ -1,0 +1,312 @@
+/**
+ * run-local.ts — the LOCAL RUNNER / harness for the workflow in `index.ts`.
+ *
+ * `index.ts` is the deployable artifact (side-effect-free). This file is the dev
+ * harness that exercises it locally, two ways:
+ *
+ *   pnpm start                       → STUB mode  (default; offline, free, works today)
+ *   pnpm start:live                  → LIVE mode  (real LOCAL memory gateway; x402-paid)
+ *
+ * Flags / env:
+ *   --mode stub|live   (default: stub)
+ *   --task "<text>"    (default: a sensible demo task)
+ *   --repo "<slug>"    (default: "api")
+ *   DEMO_SCENARIO=skip (stub mode only) — uses a stronger prior so the SKIP branch runs.
+ *
+ * The third way the SAME `index.ts` runs — Sapiom execution inside a Blaxel
+ * sandbox — needs no code here; see the README RUN MODE 3.
+ */
+import {
+  buildManifest,
+  isContinue,
+  isTerminate,
+  isFail,
+  isRetry,
+  isPause,
+  InMemoryContextStore,
+  type StepDefinition,
+  type OrchestrationExecutionContext,
+} from "@sapiom/orchestration";
+import { runLocal, type StubFile } from "@sapiom/orchestration-core";
+import { createClient, type Sapiom } from "@sapiom/tools";
+
+import { orchestration, type WorkflowInput, type Shared } from "./index.js";
+
+const SCOPE = "house-conventions";
+
+// ---------------------------------------------------------------------------
+// argv / env
+// ---------------------------------------------------------------------------
+
+interface Args {
+  mode: "stub" | "live";
+  task: string;
+  repo: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  let mode: "stub" | "live" = "stub";
+  let task = "Add a POST /users endpoint that creates a user.";
+  let repo = "api";
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--mode") mode = argv[++i] === "live" ? "live" : "stub";
+    else if (a === "--task") task = argv[++i] ?? task;
+    else if (a === "--repo") repo = argv[++i] ?? repo;
+  }
+  return { mode, task, repo };
+}
+
+// ---------------------------------------------------------------------------
+// STUB MODE — runLocal + canned stubs. Offline, free, works today.
+// ---------------------------------------------------------------------------
+
+/**
+ * The golden rule: only stub what a step BRANCHES ON or what a downstream step
+ * CONSUMES. For this workflow that's three calls:
+ *   - recall.memory.recall — `apply` branches on `topMatch` + `combinedScore`.
+ *   - learn.memory.append  — `verify` consumes the returned `id`.
+ *   - verify.memory.get    — its `status` lands in the terminal output.
+ * `apply` and `skip` make no capability calls, so they have nothing to stub.
+ *
+ * Two scenarios:
+ *   default        — a weak prior (combinedScore < 0.8) → apply takes the LEARN branch.
+ *   DEMO_SCENARIO=skip — a strong prior (combinedScore >= 0.8) → apply takes the SKIP branch.
+ * This shows BOTH sides of the real branch from the same artifact.
+ */
+function buildStubs(takeSkipBranch: boolean): StubFile {
+  // The prior memory `recall` returns. Its `combinedScore` is what `apply`
+  // branches on (>= 0.8 ⇒ "already known" ⇒ skip; otherwise ⇒ learn).
+  const prior = {
+    id: "mem_prior_1",
+    content: "Validate every request body with a zod schema before using it.",
+    scope: SCOPE,
+    vectorScore: takeSkipBranch ? 0.95 : 0.6,
+    textScore: takeSkipBranch ? 0.9 : 0.4,
+    combinedScore: takeSkipBranch ? 0.92 : 0.55,
+    status: "active",
+    createdAt: "2026-06-01T00:00:00Z",
+    metadata: {},
+  };
+
+  return {
+    version: 1,
+    steps: {
+      recall: {
+        "memory.recall": {
+          results: [prior],
+          query: "stubbed",
+          topK: 5,
+          count: 1,
+        },
+      },
+      // Consumed by `verify` (its `id`). Only reached on the LEARN branch.
+      learn: {
+        "memory.append": {
+          id: "mem_stub_1",
+          content: "stubbed convention",
+          scope: SCOPE,
+          status: "active",
+          decision: "ADDED",
+          supersededId: null,
+          similarityScore: null,
+          createdAt: "2026-06-24T00:00:00Z",
+          metadata: { source: "memory-coding-conventions-workflow" },
+        },
+      },
+      // Read back by `verify`. Only reached on the LEARN branch.
+      verify: {
+        "memory.get": {
+          id: "mem_stub_1",
+          content: "stubbed convention",
+          scope: SCOPE,
+          status: "active",
+          supersededBy: null,
+          supersededReason: null,
+          createdAt: "2026-06-24T00:00:00Z",
+          updatedAt: "2026-06-24T00:00:00Z",
+          metadata: { source: "memory-coding-conventions-workflow" },
+        },
+      },
+    },
+  };
+}
+
+async function runStub(args: Args): Promise<void> {
+  // The build phase produces this manifest in production; we build it inline.
+  const manifest = buildManifest(orchestration, {
+    sdkVersion: "0.0.0-example",
+    artifact: { sha256: "example", entryFile: "index.ts" },
+  });
+
+  const takeSkipBranch = process.env.DEMO_SCENARIO === "skip";
+  const stubs = buildStubs(takeSkipBranch);
+
+  console.log(
+    `\n=== STUB MODE (offline) — scenario: ${takeSkipBranch ? "skip (strong prior)" : "learn (weak prior)"} ===`,
+  );
+
+  const result = await runLocal({
+    definition: orchestration,
+    manifest,
+    input: { repoSlug: args.repo, task: args.task } satisfies WorkflowInput,
+    stubs,
+  });
+
+  // ----- print the trace so you can watch recall → apply → {learn → verify | skip} -----
+  console.log(`\nworkflow "${orchestration.name}" → ${result.outcome}\n`);
+  for (const step of result.steps) {
+    console.log(`▶ ${step.step} (${step.status})`);
+    for (const entry of step.logs) {
+      const meta = entry.meta ? ` ${JSON.stringify(entry.meta)}` : "";
+      console.log(`    · ${entry.msg}${meta}`);
+    }
+  }
+  console.log(`\nfinal output: ${JSON.stringify(result.output, null, 2)}`);
+
+  if (result.unusedStubs.length > 0) {
+    console.log(`\n⚠ unused stubs:`, result.unusedStubs);
+  }
+  if (result.stubWarnings.length > 0) {
+    console.log(`\n⚠ stub warnings:`, result.stubWarnings);
+  }
+  if (result.unusedStubs.length === 0 && result.stubWarnings.length === 0) {
+    console.log(`\n✓ no unused stubs, no stub warnings`);
+  }
+}
+
+// ===========================================================================
+// DEV HARNESS — reproduces the engine's step-walk so the workflow runs against
+// the real LOCAL gateway. In production the Sapiom engine runs these identical
+// step bodies inside a Blaxel sandbox; this walker is for local dev only.
+// NOTE: this harness does NOT validate each step's `inputSchema` before run()
+// (the real engine does) — it is a faithful-enough step driver, not full parity.
+// ===========================================================================
+
+function assertLiveEnv(): void {
+  if (!process.env.SAPIOM_API_KEY) {
+    throw new Error("LIVE mode requires SAPIOM_API_KEY (a real Sapiom API key from your local backend).");
+  }
+  if (!process.env.SAPIOM_MEMORY_URL) {
+    throw new Error(
+      "LIVE mode requires SAPIOM_MEMORY_URL (e.g. http://memory.services.localhost:3100). " +
+        "createClient() does not take a base URL — the memory client reads it from this env var.",
+    );
+  }
+}
+
+/**
+ * Build a `ctx` that satisfies `OrchestrationExecutionContext`: a Map-backed
+ * shared store (via the SDK's `InMemoryContextStore`), a console-backed logger,
+ * a derived (non-random) executionId, and a REAL `ctx.sapiom`.
+ */
+function buildLiveCtx(sapiom: Sapiom, input: WorkflowInput): OrchestrationExecutionContext<Shared> {
+  const shared = new InMemoryContextStore<Shared>();
+  const logger = {
+    info: (msg: string, meta?: Record<string, unknown>) =>
+      console.log(`    · ${msg}${meta ? " " + JSON.stringify(meta) : ""}`),
+    warn: (msg: string, meta?: Record<string, unknown>) =>
+      console.warn(`    · [warn] ${msg}${meta ? " " + JSON.stringify(meta) : ""}`),
+    error: (msg: string, meta?: Record<string, unknown>) =>
+      console.error(`    · [error] ${msg}${meta ? " " + JSON.stringify(meta) : ""}`),
+    debug: (msg: string, meta?: Record<string, unknown>) =>
+      console.debug(`    · [debug] ${msg}${meta ? " " + JSON.stringify(meta) : ""}`),
+  };
+  return {
+    executionId: `local-dev-${process.pid}`,
+    workflowName: orchestration.name,
+    organizationId: null,
+    tenantId: null,
+    input,
+    shared,
+    history: [],
+    attempts: 0,
+    logger,
+    sapiom,
+  };
+}
+
+async function runLive(args: Args): Promise<void> {
+  assertLiveEnv();
+  console.log(`\n=== LIVE MODE — against ${process.env.SAPIOM_MEMORY_URL} ===`);
+
+  // REAL client. NOTE: createClient takes only an apiKey; the memory base URL is
+  // resolved by @sapiom/tools from SAPIOM_MEMORY_URL (asserted above).
+  const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+  const input: WorkflowInput = { repoSlug: args.repo, task: args.task };
+  const ctx = buildLiveCtx(sapiom, input);
+
+  // The dev walker: start at the entry step and follow the directives the SAME
+  // step bodies return, exactly as the engine would.
+  const steps = orchestration.steps as Record<string, StepDefinition<Shared>>;
+  let name: string = orchestration.entry;
+  let currentInput: unknown = input;
+  const MAX_ATTEMPTS = 3;
+  const MAX_STEPS = 100;
+
+  for (let i = 0; i < MAX_STEPS; i++) {
+    const step = steps[name];
+    if (!step) throw new Error(`live walker: no step '${name}' in the definition`);
+    console.log(`▶ ${name}`);
+
+    // retry loop with an attempt cap, mirroring the engine's maxAttemptsPerStep.
+    let directive;
+    let attempt = 0;
+    for (;;) {
+      directive = await step.run(currentInput, ctx);
+      if (!isRetry(directive)) break;
+      if (++attempt >= MAX_ATTEMPTS) {
+        throw new Error(`live walker: step '${name}' exceeded ${MAX_ATTEMPTS} retries`);
+      }
+      console.log(`    · retry (${directive.reason ?? "no reason"})`);
+    }
+
+    if (isContinue(directive)) {
+      // Goto: stepName = next step, input = this step's output AND next step's input.
+      name = directive.stepName;
+      currentInput = directive.input;
+      continue;
+    }
+    if (isTerminate(directive)) {
+      // The narrowed wire `TerminateDirective` doesn't carry `output` (it rides on
+      // the branded `terminate()` value the step returned). Read it the same way
+      // the SDK's own dispatcher does — off the runtime object.
+      const output = (directive as { output?: unknown }).output;
+      console.log(`\nworkflow → completed (${directive.reason ?? "no reason"})`);
+      console.log(`final output: ${JSON.stringify(output, null, 2)}`);
+      return;
+    }
+    if (isFail(directive)) {
+      const output = (directive as { output?: unknown }).output;
+      console.log(`\nworkflow → failed: ${directive.reason ?? "no reason"}`);
+      if (output !== undefined) {
+        console.log(`failure output: ${JSON.stringify(output, null, 2)}`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    if (isPause(directive)) {
+      throw new Error("pause not supported in live-local (no pause steps in this demo)");
+    }
+    throw new Error(`live walker: unrecognized directive kind '${(directive as { kind: string }).kind}'`);
+  }
+  throw new Error(`live walker: exceeded ${MAX_STEPS} steps (non-terminating graph?)`);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.mode === "live") {
+    await runLive(args);
+  } else {
+    await runStub(args);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/memory-coding-conventions-workflow/tsconfig.json
+++ b/examples/memory-coding-conventions-workflow/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/memory-coding-conventions/README.md
+++ b/examples/memory-coding-conventions/README.md
@@ -1,0 +1,127 @@
+# memory-coding-conventions
+
+A custom Sapiom **workflow** that gives a coding agent a memory of your team's
+house conventions — so it stops forgetting them on every run.
+
+> Unlike the other examples in this folder (which call paid HTTP APIs through an
+> SDK adapter), this is a **workflow** example. It runs entirely locally against
+> mocked capabilities — no Sapiom account, no network, no credentials — so you
+> can read it top-to-bottom and run it instantly.
+
+## The problem
+
+A coding agent has no memory between runs. Each time you ask it to add an
+endpoint it re-derives your conventions from whatever it can see — and often
+gets them wrong: a default export where you only use named ones, a request body
+used without validation, a commit message that ignores your format. You fix it
+in review, and next run it makes the same mistakes, because last run taught it
+nothing.
+
+## The pattern: recall → inject → append
+
+```
+recall ─▶ code ─▶ learn
+```
+
+| Step | Memory op | What it does |
+|------|-----------|--------------|
+| `recall` | `memory.recall` | Pull the conventions learned on prior runs and **inject** them into the agent's task prompt. |
+| `code` | — | Run the coding agent on the convention-enriched task. |
+| `learn` | `memory.append` | Record a new, hard-won fact so the **next** run recalls it automatically. |
+
+The agent itself stays stateless and replaceable; the *workflow* carries the
+institutional memory. `recall` is where prior knowledge enters the agent's
+context; `append` is where this run's knowledge is saved for the future. Over
+time the recalled set grows and the agent's first draft gets steadily closer to
+house style.
+
+### Where the injection happens
+
+A coding run's only natural-language channel is its `task`. So "inject into the
+agent context" means **composing the recalled facts into the task prompt**:
+
+```ts
+const enrichedTask = [
+  baseTask,
+  "",
+  "Follow these house conventions (recalled from prior runs):",
+  ...results.map((m) => `- ${m.content}`),
+].join("\n");
+
+await ctx.sapiom.agent.coding.run({ task: enrichedTask });
+```
+
+## Run it
+
+This example resolves the **unpublished local SDK build** — the `memory` capability
+on `@sapiom/tools` plus the `runLocal`/stub harness in `@sapiom/orchestration-core`.
+Those packages reference each other through pnpm's `workspace:` protocol, which only a
+pnpm **workspace** install can resolve, so this example is a workspace member and you
+install it **from the repo root with pnpm** (not `npm install` in this folder):
+
+```bash
+# from the repo root
+pnpm install                          # links this example to the local packages
+pnpm --filter='./packages/*' build    # build the local SDK (writes each package's dist/)
+pnpm --filter @sapiom/example-memory-coding-conventions start
+```
+
+> **For end users (post-publish):** the deps are `@sapiom/orchestration`,
+> `@sapiom/orchestration-core`, and `@sapiom/tools` at `latest`, and a plain
+> `npm install && npm start` in this folder works. The `workspace:*` deps committed
+> here exist only to run against the as-yet-unpublished memory build.
+
+You'll see the per-step trace — the conventions that were recalled and injected,
+the agent's result, and the new learning that was appended:
+
+```
+=== workflow "memory-coding-conventions" → completed ===
+
+▶ recall (succeeded)
+    · recalled 3 house convention(s) {"conventions":["Validate every request body…", …]}
+    · injected recalled conventions into the coding task
+▶ code (succeeded)
+    · coding agent finished {"status":"completed","summary":"Added POST /users…"}
+▶ learn (succeeded)
+    · appended a new house-convention learning {"memoryId":"stub-memory","decision":"ADDED"}
+
+final output: { "learningId": "stub-memory", "decision": "ADDED", "summary": "Added POST /users…" }
+```
+
+> Requires a build of the Sapiom SDK that includes the `memory` capability on
+> `@sapiom/tools` (and the local-run harness in `@sapiom/orchestration-core`).
+
+## How the mock works
+
+In production the **engine** drives the workflow and the **gateway** serves each
+`ctx.sapiom.*` call. Here both are mocked:
+
+- **`runLocal({ definition, manifest, input, stubs })`** (`@sapiom/orchestration-core`)
+  plays the engine — it runs your *real* step code, in order, following the
+  `goto` / `terminate` / `fail` directives your steps return.
+- **Stubs** play the gateway. Each step's capability calls resolve from canned
+  responses in the `stubs` object (the in-code form of `.sapiom-dev/stubs.json`),
+  keyed by capability path (`"memory.recall"`, `"agent.coding.run"`, …).
+
+The golden rule for stubs: **only stub what a step branches on.** This example
+stubs `memory.recall` (its results get injected) and `agent.coding.run` (its
+success gates the `learn` step). It deliberately does **not** stub
+`memory.append` — nothing branches on the append result, so it falls back to the
+built-in default. `runLocal` reports any stub key that matched nothing
+(`unusedStubs`) or carried the wrong shape (`stubWarnings`), so typos don't pass
+silently.
+
+The step code is written exactly as it would run in production — the mock swaps
+out the engine and gateway underneath it, never the workflow logic itself.
+
+## Going further
+
+- **Long-running agents:** await-inline `agent.coding.run` keeps this trace
+  readable, but a real coding run can take minutes. Use `launch` +
+  `pauseUntilSignal` so the workflow suspends instead of holding a worker — see
+  the `coding-pause` template (`@sapiom/orchestration-core`).
+- **Scoping memory:** this example partitions conventions per repo via the
+  `scope` field. You might also scope by team, language, or service.
+- **Pruning:** when a convention changes, `memory.append` auto-supersedes a
+  near-duplicate (demoting the old one); to erase one outright, `memory.forget(id)`
+  hard-deletes it.

--- a/examples/memory-coding-conventions/index.ts
+++ b/examples/memory-coding-conventions/index.ts
@@ -1,0 +1,275 @@
+/**
+ * Sapiom workflow example — "the coding agent forgets house conventions."
+ *
+ * A coding agent has no memory between runs: left alone it re-derives (or
+ * violates) your team's house style every single time. This workflow fixes that
+ * with the `memory` capability:
+ *
+ *   recall ─▶ code ─▶ learn
+ *
+ *   1. recall  — pull the house conventions learned on PRIOR runs and INJECT them
+ *                into the agent's task prompt (recall → inject).
+ *   2. code    — run the coding agent with that convention-enriched task.
+ *   3. learn   — APPEND a new, hard-won fact back to memory, so the NEXT run
+ *                recalls it and the agent never "forgets" it again.
+ *
+ * This file is a teaching artifact: it mocks the engine + gateway with
+ * `runLocal` + stub capabilities (no network, no credentials, no Sapiom
+ * account), then prints the per-step trace so you can watch recall → inject →
+ * append happen. See the README for how the mock maps onto production.
+ */
+import {
+  defineOrchestration,
+  defineStep,
+  goto,
+  terminate,
+  fail,
+  buildManifest,
+} from "@sapiom/orchestration";
+import { runLocal, type StubFile } from "@sapiom/orchestration-core";
+
+/** What the workflow is kicked off with. */
+interface WorkflowInput {
+  /** The repo the agent will work in — also the memory partition for its conventions. */
+  repoSlug: string;
+  /** The feature request, before any house conventions are layered on. */
+  baseTask: string;
+}
+
+/** Run-scoped values stashed in `ctx.shared` so later steps can read them. */
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+}
+
+/** The memory scope this repo's conventions live under. */
+const CONVENTIONS_SCOPE = "house-conventions";
+
+// ---------------------------------------------------------------------------
+// Step 1 — recall the conventions and inject them into the task (recall→inject)
+// ---------------------------------------------------------------------------
+
+const recall = defineStep({
+  name: "recall",
+  next: ["code"],
+  async run(input: WorkflowInput, ctx) {
+    ctx.shared.set("repoSlug", input.repoSlug);
+
+    // RECALL: hybrid (vector + full-text) search over what we learned before.
+    const { results } = await ctx.sapiom.memory.recall({
+      query: `coding conventions and house style for the ${input.repoSlug} repo`,
+      scope: CONVENTIONS_SCOPE,
+      topK: 10,
+    });
+    ctx.logger.info(`recalled ${results.length} house convention(s)`, {
+      conventions: results.map((m) => m.content),
+    });
+
+    // INJECT: fold the recalled facts into the agent's task prompt. The agent
+    // has no memory of its own — this is the only thing standing between it and
+    // re-litigating your house style from scratch.
+    const enrichedTask =
+      results.length === 0
+        ? input.baseTask
+        : [
+            input.baseTask,
+            "",
+            `Follow these house conventions (recalled from prior runs in the ${input.repoSlug} repo):`,
+            ...results.map((m) => `- ${m.content}`),
+          ].join("\n");
+
+    ctx.logger.info("injected recalled conventions into the coding task");
+    return goto("code", { task: enrichedTask });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — run the coding agent with the convention-enriched task
+// ---------------------------------------------------------------------------
+
+const code = defineStep({
+  name: "code",
+  next: ["learn"],
+  async run(input: { task: string }, ctx) {
+    // We `run` (await inline) for a readable, top-to-bottom teaching trace. A
+    // production workflow with a long-running agent would instead `launch` +
+    // `pauseUntilSignal` so a long run holds no worker — see the `coding-pause`
+    // template. The memory pattern is identical either way.
+    const run = await ctx.sapiom.agent.coding.run({ task: input.task });
+    ctx.logger.info("coding agent finished", {
+      status: run.status,
+      summary: run.summary,
+    });
+    return goto("learn", {
+      success: run.result?.success ?? false,
+      summary: run.summary,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 — append a new learning so the next run starts smarter (append)
+// ---------------------------------------------------------------------------
+
+const learn = defineStep({
+  name: "learn",
+  next: [],
+  terminal: true,
+  canFail: true,
+  async run(input: { success: boolean; summary: string | null }, ctx) {
+    if (!input.success) {
+      return fail(`coding agent did not succeed: ${input.summary ?? "unknown"}`);
+    }
+    const repoSlug = ctx.shared.get("repoSlug") as string;
+
+    // APPEND: record a durable, repo-specific fact this run surfaced — exactly
+    // the kind of gotcha the agent would otherwise forget by next time. On the
+    // next run, `recall` returns this and `code` injects it automatically.
+    const appended = await ctx.sapiom.memory.append({
+      content:
+        `When adding an HTTP endpoint to the ${repoSlug} repo, also register it in ` +
+        `src/routes/index.ts — the router does not auto-discover handlers.`,
+      scope: CONVENTIONS_SCOPE,
+      metadata: { repo: repoSlug, source: "coding-run" },
+    });
+    ctx.logger.info("appended a new house-convention learning", {
+      memoryId: appended.id,
+      decision: appended.decision,
+    });
+
+    return terminate({
+      learningId: appended.id,
+      decision: appended.decision,
+      summary: input.summary,
+    });
+  },
+});
+
+/** The workflow. In production the engine imports this `orchestration` export. */
+export const orchestration = defineOrchestration<WorkflowInput, Shared>({
+  name: "memory-coding-conventions",
+  entry: "recall",
+  steps: { recall, code, learn },
+});
+
+// ===========================================================================
+// Local run — mocks the engine (`runLocal`) and the gateway (stub capabilities)
+// ===========================================================================
+
+async function main(): Promise<void> {
+  // The build phase produces this manifest in production; we build it inline.
+  const manifest = buildManifest(orchestration, {
+    sdkVersion: "0.0.0-example",
+    artifact: { sha256: "example", entryFile: "index.ts" },
+  });
+
+  // Stub the gateway. The golden rule (same as `.sapiom-dev/stubs.json`): only
+  // stub what a step BRANCHES ON. `recall`'s results get injected, and `code`'s
+  // success gates the `learn` step — so both are stubbed. `memory.append` is
+  // fire-and-record (nothing branches on its result), so it's left to the
+  // built-in default.
+  const stubs: StubFile = {
+    version: 1,
+    steps: {
+      recall: {
+        "memory.recall": {
+          results: [
+            {
+              id: "m1",
+              content:
+                "Validate every request body with a zod schema before using it.",
+              scope: CONVENTIONS_SCOPE,
+              vectorScore: 0.9,
+              textScore: 0.5,
+              combinedScore: 0.82,
+              status: "active",
+              createdAt: "2026-06-01T00:00:00Z",
+              metadata: {},
+            },
+            {
+              id: "m2",
+              content:
+                "Use named exports only — no default exports anywhere in this codebase.",
+              scope: CONVENTIONS_SCOPE,
+              vectorScore: 0.88,
+              textScore: 0.4,
+              combinedScore: 0.79,
+              status: "active",
+              createdAt: "2026-06-02T00:00:00Z",
+              metadata: {},
+            },
+            {
+              id: "m3",
+              content:
+                "Commit messages must follow Conventional Commits (e.g. 'feat: ...').",
+              scope: CONVENTIONS_SCOPE,
+              vectorScore: 0.85,
+              textScore: 0.45,
+              combinedScore: 0.77,
+              status: "active",
+              createdAt: "2026-06-03T00:00:00Z",
+              metadata: {},
+            },
+          ],
+          query: "coding conventions and house style for the api repo",
+          topK: 10,
+          count: 3,
+        },
+      },
+      code: {
+        "agent.coding.run": {
+          runId: "run-stub-1",
+          status: "completed",
+          summary:
+            "Added POST /users with zod validation and a named export; committed as 'feat: add user creation endpoint'.",
+          result: {
+            success: true,
+            turns: 4,
+            modelUsed: "stub-model",
+            durationMs: 1234,
+            toolCallCount: 7,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheCreateTokens: 0,
+              thinkingTokens: 0,
+            },
+          },
+          error: null,
+        },
+      },
+    },
+  };
+
+  const result = await runLocal({
+    definition: orchestration,
+    manifest,
+    input: {
+      repoSlug: "api",
+      baseTask: "Add a POST /users endpoint that creates a user.",
+    } satisfies WorkflowInput,
+    stubs,
+  });
+
+  // ----- print the trace so you can watch recall → inject → append -----
+  console.log(`\n=== workflow "${orchestration.name}" → ${result.outcome} ===\n`);
+  for (const step of result.steps) {
+    console.log(`▶ ${step.step} (${step.status})`);
+    for (const entry of step.logs) {
+      const meta = entry.meta ? ` ${JSON.stringify(entry.meta)}` : "";
+      console.log(`    · ${entry.msg}${meta}`);
+    }
+  }
+  console.log(`\nfinal output: ${JSON.stringify(result.output, null, 2)}`);
+  if (result.unusedStubs.length > 0) {
+    console.log(`\nunused stubs:`, result.unusedStubs);
+  }
+  if (result.stubWarnings.length > 0) {
+    console.log(`\nstub warnings:`, result.stubWarnings);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/memory-coding-conventions/package.json
+++ b/examples/memory-coding-conventions/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sapiom/example-memory-coding-conventions",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom workflow example: recall house conventions into a coding agent's context, then append what it learned",
+  "scripts": {
+    "start": "npx tsx index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "_localDevNote": "Deps use `workspace:*` so this example resolves the UNPUBLISHED local SDK build (the memory capability + runLocal/stub harness). For END USERS, post-publish, these are `@sapiom/orchestration`, `@sapiom/orchestration-core`, `@sapiom/tools` at `latest`. See README → 'Run it'.",
+  "dependencies": {
+    "@sapiom/orchestration": "workspace:*",
+    "@sapiom/orchestration-core": "workspace:*",
+    "@sapiom/tools": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/memory-coding-conventions/tsconfig.json
+++ b/examples/memory-coding-conventions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -77,6 +77,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
 | `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
+| `memory`            | Tenant-scoped long-term memory (hybrid vector + full-text)                                            | [src/memory](./src/memory/README.md)                         |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/esm/database/index.js",
       "require": "./dist/cjs/database/index.js"
     },
+    "./memory": {
+      "types": "./dist/cjs/memory/index.d.ts",
+      "import": "./dist/esm/memory/index.js",
+      "require": "./dist/cjs/memory/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -76,6 +76,14 @@ import type {
 } from "./search/index.js";
 import * as database from "./database/index.js";
 import type { CreateDatabaseInput, Database } from "./database/index.js";
+import * as memory from "./memory/index.js";
+import type {
+  AppendInput,
+  AppendResult,
+  RecallInput,
+  RecallResponse,
+  Memory,
+} from "./memory/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -137,6 +145,12 @@ export interface Sapiom {
        */
       launch(input: VideoCreateInput): Promise<VideoLaunchHandle>;
     };
+  };
+  readonly memory: {
+    append(input: AppendInput): Promise<AppendResult>;
+    recall(input: RecallInput): Promise<RecallResponse>;
+    get(id: string): Promise<Memory>;
+    forget(id: string): Promise<void>;
   };
   /**
    * Search the web, read pages, and look up professional emails. More operations
@@ -229,6 +243,12 @@ function bind(transport: Transport): Sapiom {
       create: (input) => database.create(input, transport),
       get: (idOrHandle) => database.get(idOrHandle, transport),
       delete: (idOrHandle) => database.delete(idOrHandle, transport),
+    },
+    memory: {
+      append: (input) => memory.append(input, transport),
+      recall: (input) => memory.recall(input, transport),
+      get: (id) => memory.get(id, transport),
+      forget: (id) => memory.forget(id, transport),
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -73,3 +73,6 @@ export { SearchHttpError } from "./search/index.js";
 
 export * as database from "./database/index.js";
 export { DatabaseHttpError } from "./database/index.js";
+
+export * as memory from "./memory/index.js";
+export { MemoryHttpError } from "./memory/index.js";

--- a/packages/tools/src/memory/README.md
+++ b/packages/tools/src/memory/README.md
@@ -1,0 +1,100 @@
+# memory
+
+Tenant-scoped long-term memory backed by the Sapiom memory gateway — a hybrid
+vector + full-text store, one per owner. The same memory capability your agents
+call over MCP, callable directly from your code.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// Write a memory. Optionally scope it and attach opaque metadata.
+const { id, decision } = await sapiom.memory.append({
+  content: "User prefers dark mode.",
+  scope: "user", // defaults to "default"
+  metadata: { source: "preference-survey" },
+});
+
+// Search by natural language (hybrid vector + full-text).
+const { results } = await sapiom.memory.recall({
+  query: "ui preferences",
+  scope: "user", // omit to search every scope for your owner
+  topK: 5, // 1–50, default 10
+});
+
+// Fetch one record by id (includes superseded records).
+const record = await sapiom.memory.get(id);
+
+// Forget (hard-delete) a memory — the row is erased (GDPR / right-to-be-forgotten).
+await sapiom.memory.forget(id);
+```
+
+Ambient import works too: `import { memory } from "@sapiom/tools"`.
+
+## Operations
+
+| Method | What it does |
+|---|---|
+| `append(input)` | Embed and store `content`; returns the written (or echoed) record + a `decision`. |
+| `recall(input)` | Hybrid vector + full-text search; returns the top-K active matches. |
+| `get(id)` | Fetch a single record by id (active or superseded). |
+| `forget(id)` | Hard-delete a record (the row is erased — GDPR / right-to-be-forgotten). |
+
+## Supersession & the `decision` (dedup on append)
+
+`append()` embeds the content and checks for a near-duplicate in the same scope,
+then reports — never silently — one of three `decision` values:
+
+| `decision` | When | Result |
+|---|---|---|
+| `"ADDED"` | No near-duplicate existed | A new memory is written; nothing superseded. |
+| `"SUPERSEDED"` | Nearest prior is **cosine ≥ 0.80** similar | A new memory is written and the prior is superseded; `supersededId` points to it (with `similarityScore`). |
+| `"NOOP"` | Byte-identical content (exact match or cosine ≈ 1.0), or an `idempotencyKey` re-submit | The existing memory is echoed (`id` is *its* id) and **nothing is written**. |
+
+Pass an **`idempotencyKey`** (1–255 chars) to make a retry safe: re-submitting with
+the same key within the same owner + scope returns `"NOOP"` with the existing
+memory, so a duplicated call never writes twice.
+
+> A secret caught by the admission gate is **not** a `decision` — it comes back as a
+> `400` (`MemoryHttpError`) whose body carries `decision: "REJECTED"` (see Gotchas).
+
+## Recall semantics
+
+- Each match carries a single canonical `score` ([0–1] relevance); results are
+  ranked by it, highest first, and only **active** memories are returned. A backend
+  that computes component legs (e.g. the hybrid backend's vector / text / combined)
+  also returns an optional `scoreBreakdown` map; an opaque backend omits it.
+- `minSimilarity` (0–1) drops matches below the threshold; `topK` (1–50, default
+  10) caps the count.
+- An empty list is a normal response — it means nothing matched, or no memory
+  store has been provisioned for your owner yet (not an error).
+
+## Scoping & tenancy
+
+Every memory is scoped to your owner key (derived from the credential) and a
+`scope` label (alphanumeric + hyphens/underscores, ≤ 100 chars, defaulting to
+`"default"`). Cross-owner access is impossible — you only ever see your own
+memories.
+
+## Gotchas
+
+- **`append` rejects secrets.** Content and metadata pass through an admission
+  gate; a detected API key / token / password is rejected with a `400`
+  (`MemoryHttpError`, `body.error === "SecretDetected"`, `body.decision === "REJECTED"`).
+  Don't store credentials. `REJECTED` is *not* an `AppendResult.decision` — it only
+  ever rides back on the error body.
+- **`forget` is a hard delete _and_ idempotent.** It erases the row outright
+  (distinct from supersession, which only supersedes), and always succeeds: the
+  gateway returns `204 No Content`. A second forget of an already-deleted id —
+  like an unknown or cross-owner id — is success, not an error (no `404` for a
+  gone-already id, no `409` "already superseded" state for forget).
+- **`metadata` is opaque.** It's stored and returned verbatim but never indexed or
+  searched. Max 10 KB JSON-serialized. `content` is capped at 32,000 chars,
+  `query` at 4,096.
+- **Non-2xx responses throw `MemoryHttpError`** (carries `status` + parsed
+  `body`), exported from `@sapiom/tools`. Neither `append` nor `recall` has a
+  memory-layer fee — you pay only the composed embedding + store sub-costs, billed
+  to your run. Both are identity-gated and `recall` never blocks on billing.
+  `get`/`forget` are free for identified callers.
+- **Base URL** defaults to the production gateway; override with the
+  `SAPIOM_MEMORY_URL` env var (e.g. to target a staging gateway).

--- a/packages/tools/src/memory/errors.ts
+++ b/packages/tools/src/memory/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * Error thrown by the memory capability when the gateway returns a non-2xx
+ * response. Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ *
+ * Useful statuses to branch on: `404` (memory not found / wrong owner on `get`;
+ * note `forget` is idempotent — a `forget` of an already-gone id returns 204,
+ * not 404), `400` (validation, or a secret detected in `append`
+ * content/metadata — the body carries `error: "SecretDetected"` and
+ * `decision: "REJECTED"`), `402` (insufficient balance), `422` (spending rules
+ * blocked the call), `503` (memory store unavailable).
+ */
+export class MemoryHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "MemoryHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link MemoryHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new MemoryHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/memory/index.spec.ts
+++ b/packages/tools/src/memory/index.spec.ts
@@ -1,0 +1,782 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as memory from "./index.js";
+import { MemoryHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly with a real Transport wired to a
+// scripted fetch mock (so URL/method/header/body assertions are exact, and we
+// verify the Transport itself injects the tenant credential).
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+// ---------------------------------------------------------------------------
+// append()
+// ---------------------------------------------------------------------------
+
+describe("memory.append()", () => {
+  it("POSTs /append with JSON body + credential and returns the camelCase payload as-is", async () => {
+    const raw = {
+      id: "m-123",
+      content: "User prefers dark mode.",
+      scope: "user",
+      status: "active",
+      decision: "ADDED",
+      supersededId: null,
+      similarityScore: null,
+      createdAt: "2026-06-22T12:00:00Z",
+      metadata: { source: "survey" },
+    };
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(raw, { status: 201 }),
+    ]);
+
+    const result = await memory.append(
+      {
+        content: "User prefers dark mode.",
+        scope: "user",
+        metadata: { source: "survey" },
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual(raw);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/append`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "User prefers dark mode.",
+      scope: "user",
+      metadata: { source: "survey" },
+    });
+    // experimentalBackend omitted from the body when not supplied → gateway
+    // falls back to its neon-pgvector default.
+    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
+      "experimentalBackend",
+    );
+  });
+
+  it("forwards experimentalBackend in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "ADDED",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2026-06-22T12:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    await memory.append(
+      { content: "c", experimentalBackend: "upstash-vector" },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      experimentalBackend: "upstash-vector",
+    });
+  });
+
+  it("forwards namespace + experimentalEmbedder in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "ADDED",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2026-06-22T12:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    await memory.append(
+      {
+        content: "c",
+        namespace: "tenant-7",
+        experimentalEmbedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      namespace: "tenant-7",
+      experimentalEmbedder: {
+        provider: "openrouter",
+        model: "openai/text-embedding-3-large",
+      },
+    });
+  });
+
+  it("surfaces a SUPERSEDED decision unchanged", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-new",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "SUPERSEDED",
+            supersededId: "m-old",
+            similarityScore: 0.91,
+            createdAt: "2026-06-22T12:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await memory.append({ content: "c" }, transport, BASE);
+    expect(result.decision).toBe("SUPERSEDED");
+    expect(result.supersededId).toBe("m-old");
+    expect(result.similarityScore).toBe(0.91);
+  });
+
+  it("surfaces a NOOP decision echoing the existing memory (nothing written)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-existing",
+            content: "User prefers dark mode.",
+            scope: "user",
+            status: "active",
+            decision: "NOOP",
+            supersededId: null,
+            similarityScore: 1,
+            createdAt: "2026-06-01T00:00:00Z",
+            metadata: { source: "survey" },
+          },
+          // NOOP may come back as 200 or 201; either is a success and parses the same.
+          { status: 200 },
+        ),
+    ]);
+
+    const result = await memory.append(
+      { content: "User prefers dark mode.", scope: "user" },
+      transport,
+      BASE,
+    );
+    expect(result.decision).toBe("NOOP");
+    expect(result.id).toBe("m-existing"); // the existing memory's id, echoed
+    expect(result.supersededId).toBeNull();
+  });
+
+  it("sends idempotencyKey in the body and returns NOOP on a re-submit", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-existing",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "NOOP",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2026-06-01T00:00:00Z",
+            metadata: {},
+          },
+          { status: 200 },
+        ),
+    ]);
+
+    const result = await memory.append(
+      { content: "c", idempotencyKey: "import-42" },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      idempotencyKey: "import-42",
+    });
+    expect(result.decision).toBe("NOOP");
+    expect(result.id).toBe("m-existing");
+  });
+
+  it("omits optional fields from the body when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "ADDED",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2026-06-22T12:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    await memory.append({ content: "c" }, transport, BASE);
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({ content: "c" });
+    expect(body).not.toHaveProperty("scope");
+    expect(body).not.toHaveProperty("metadata");
+    expect(body).not.toHaveProperty("idempotencyKey");
+    expect(body).not.toHaveProperty("namespace");
+    expect(body).not.toHaveProperty("experimentalEmbedder");
+  });
+
+  it("throws MemoryHttpError carrying the REJECTED body on a 400 SecretDetected", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({
+            statusCode: 400,
+            error: "SecretDetected",
+            decision: "REJECTED",
+            message: "Potential secret detected in content or metadata.",
+          }),
+          { status: 400 },
+        ),
+    ]);
+
+    // REJECTED is not a success decision — it rides back on the 400 error body, so
+    // it must surface via MemoryHttpError.body, never as an AppendResult.decision.
+    await expect(
+      memory.append({ content: "sk-live-abc" }, transport, BASE),
+    ).rejects.toMatchObject({
+      status: 400,
+      body: { error: "SecretDetected", decision: "REJECTED" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recall()
+// ---------------------------------------------------------------------------
+
+describe("memory.recall()", () => {
+  const match = {
+    id: "m-1",
+    content: "The project deadline is end of Q3.",
+    scope: "project",
+    // Provider now returns a single canonical [0,1] `score` plus an optional
+    // backend-specific `scoreBreakdown` map (the hybrid backend fills vector/text/
+    // combined; an opaque backend omits it).
+    score: 0.71,
+    scoreBreakdown: { vector: 0.82, text: 0.4, combined: 0.71 },
+    status: "active",
+    createdAt: "2026-06-01T00:00:00Z",
+    metadata: {},
+  };
+
+  it("POSTs /recall with the query and returns results + echoed fields", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          results: [match],
+          query: "deadline",
+          topK: 10,
+          count: 1,
+        }),
+    ]);
+
+    const result = await memory.recall({ query: "deadline" }, transport, BASE);
+
+    expect(result.count).toBe(1);
+    expect(result.topK).toBe(10);
+    expect(result.query).toBe("deadline");
+    expect(result.results[0]).toEqual(match);
+    // The match maps the new score shape 1:1 — canonical `score` + optional
+    // `scoreBreakdown`, no fixed vector/text/combined fields.
+    expect(result.results[0]!.score).toBe(0.71);
+    expect(result.results[0]!.scoreBreakdown).toEqual({
+      vector: 0.82,
+      text: 0.4,
+      combined: 0.71,
+    });
+    expect(result.results[0]).not.toHaveProperty("combinedScore");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/recall`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "deadline",
+    });
+    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
+      "experimentalBackend",
+    );
+  });
+
+  it("surfaces a match with only the canonical score when an opaque backend omits scoreBreakdown", async () => {
+    const opaqueMatch = {
+      id: "m-opaque",
+      content: "Opaque-backend match.",
+      scope: "default",
+      score: 0.66,
+      status: "active",
+      createdAt: "2026-06-01T00:00:00Z",
+      metadata: {},
+    };
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          results: [opaqueMatch],
+          query: "q",
+          topK: 10,
+          count: 1,
+        }),
+    ]);
+
+    const result = await memory.recall({ query: "q" }, transport, BASE);
+    expect(result.results[0]).toEqual(opaqueMatch);
+    expect(result.results[0]!.score).toBe(0.66);
+    expect(result.results[0]!.scoreBreakdown).toBeUndefined();
+  });
+
+  it("includes scope, topK, and minSimilarity in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
+    ]);
+
+    await memory.recall(
+      { query: "q", scope: "project", topK: 5, minSimilarity: 0.5 },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      scope: "project",
+      topK: 5,
+      minSimilarity: 0.5,
+    });
+  });
+
+  it("forwards experimentalBackend in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    await memory.recall(
+      { query: "q", experimentalBackend: "upstash-vector" },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      experimentalBackend: "upstash-vector",
+    });
+  });
+
+  it("forwards namespace + experimentalEmbedder in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    await memory.recall(
+      {
+        query: "q",
+        namespace: "tenant-7",
+        experimentalEmbedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      namespace: "tenant-7",
+      experimentalEmbedder: {
+        provider: "openrouter",
+        model: "openai/text-embedding-3-large",
+      },
+    });
+  });
+
+  it("returns an empty result set without error", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    const result = await memory.recall({ query: "q" }, transport, BASE);
+    expect(result.results).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it("throws MemoryHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("server error", { status: 503 }),
+    ]);
+
+    await expect(
+      memory.recall({ query: "q" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get()
+// ---------------------------------------------------------------------------
+
+describe("memory.get()", () => {
+  const record = {
+    id: "m-1",
+    content: "c",
+    scope: "default",
+    status: "superseded",
+    supersededBy: "m-2",
+    supersededReason: "near-duplicate",
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-02T00:00:00Z",
+    metadata: {},
+  };
+
+  it("GETs /:id and returns the record (including supersession chain)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    const result = await memory.get("m-1", transport, BASE);
+
+    expect(result).toEqual(record);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("appends ?experimentalBackend when the option is provided", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {
+      experimentalBackend: "upstash-vector",
+    });
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/memory/m-1?experimentalBackend=upstash-vector`,
+    );
+  });
+
+  it("omits the experimentalBackend query param when the option is absent", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.url).not.toContain("experimentalBackend");
+  });
+
+  it("appends namespace + experimentalEmbedder query params (embedder via bracket notation)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {
+      namespace: "tenant-7",
+      experimentalEmbedder: {
+        provider: "openrouter",
+        model: "openai/text-embedding-3-large",
+      },
+    });
+    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
+    expect(query.get("namespace")).toBe("tenant-7");
+    expect(query.get("experimentalEmbedder[provider]")).toBe("openrouter");
+    expect(query.get("experimentalEmbedder[model]")).toBe(
+      "openai/text-embedding-3-large",
+    );
+  });
+
+  it("omits namespace + experimentalEmbedder query params when the options are absent", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.url).not.toContain("namespace");
+    expect(calls[0]!.url).not.toContain("experimentalEmbedder");
+  });
+
+  it("encodes special characters in the id", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
+  });
+
+  it("throws MemoryHttpError on 404", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+
+    await expect(memory.get("bad-id", transport, BASE)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forget()
+// ---------------------------------------------------------------------------
+
+describe("memory.forget()", () => {
+  it("DELETEs /:id and resolves void on 204", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    const result = await memory.forget("m-abc", transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("appends ?experimentalBackend when the option is provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {
+      experimentalBackend: "upstash-vector",
+    });
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/memory/m-abc?experimentalBackend=upstash-vector`,
+    );
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("omits the experimentalBackend query param when the option is absent", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.url).not.toContain("experimentalBackend");
+  });
+
+  it("appends namespace + experimentalEmbedder query params (embedder via bracket notation)", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {
+      namespace: "tenant-7",
+      experimentalEmbedder: {
+        provider: "openrouter",
+        model: "openai/text-embedding-3-large",
+      },
+    });
+    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
+    expect(query.get("namespace")).toBe("tenant-7");
+    expect(query.get("experimentalEmbedder[provider]")).toBe("openrouter");
+    expect(query.get("experimentalEmbedder[model]")).toBe(
+      "openai/text-embedding-3-large",
+    );
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("omits namespace + experimentalEmbedder query params when the options are absent", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.url).not.toContain("namespace");
+    expect(calls[0]!.url).not.toContain("experimentalEmbedder");
+  });
+
+  it("encodes special characters in the id", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
+  });
+
+  it("is idempotent: a second forget of an already-gone id resolves (204, no throw)", async () => {
+    // forget is a hard DELETE but idempotent: the gateway always returns
+    // 204 No Content, whether or not the id existed. Deleting an already-gone
+    // (or never-existed) id is success — NOT a 404. Mirror the gateway by
+    // returning 204 on every call.
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await expect(
+      memory.forget("m-abc", transport, BASE),
+    ).resolves.toBeUndefined();
+    // Second forget of the now-gone id still succeeds (idempotent).
+    await expect(
+      memory.forget("m-abc", transport, BASE),
+    ).resolves.toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls.every((c) => c.init.method === "DELETE")).toBe(true);
+  });
+
+  it("still surfaces a real transport error as MemoryHttpError (non-JSON body)", async () => {
+    // Idempotency only covers gone-already ids (→ 204). Genuine failures
+    // (e.g. a 500) must still throw, exercising forget()'s inline error parser.
+    const { transport } = makeTransport([
+      () => new Response("upstream boom", { status: 500 }),
+    ]);
+
+    await expect(
+      memory.forget("bad-id", transport, BASE),
+    ).rejects.toMatchObject({ status: 500 });
+    await expect(
+      memory.forget("bad-id", transport, BASE),
+    ).rejects.toBeInstanceOf(MemoryHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client wiring + auth
+// ---------------------------------------------------------------------------
+
+describe("memory — client wiring + credential", () => {
+  it("createClient().memory routes all four methods with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      const method = init.method ?? "GET";
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (url.endsWith("/recall"))
+        return jsonResponse({ results: [], query: "q", topK: 10, count: 0 });
+      if (url.endsWith("/append"))
+        return jsonResponse(
+          {
+            id: "m",
+            content: "c",
+            scope: "default",
+            status: "active",
+            decision: "ADDED",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2026-06-22T12:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        );
+      // GET /:id
+      return jsonResponse({
+        id: "m",
+        content: "c",
+        scope: "default",
+        status: "active",
+        supersededBy: null,
+        supersededReason: null,
+        createdAt: "2026-06-22T12:00:00Z",
+        updatedAt: "2026-06-22T12:00:00Z",
+        metadata: {},
+      });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+    await sapiom.memory.append({ content: "c" });
+    await sapiom.memory.recall({ query: "q" });
+    await sapiom.memory.get("m");
+    await sapiom.memory.forget("m");
+
+    expect(calls).toHaveLength(4);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("{}")) as typeof globalThis.fetch,
+      });
+      await expect(
+        memory.recall({ query: "q" }, transport, BASE),
+      ).rejects.toThrow(/no tenant credential/i);
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MemoryHttpError
+// ---------------------------------------------------------------------------
+
+describe("MemoryHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new MemoryHttpError("something went wrong", 422, {
+      code: "authorization_denied",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err.status).toBe(422);
+    expect(err.body).toEqual({ code: "authorization_denied" });
+    expect(err.name).toBe("MemoryHttpError");
+  });
+});

--- a/packages/tools/src/memory/index.ts
+++ b/packages/tools/src/memory/index.ts
@@ -1,0 +1,424 @@
+/**
+ * `memory` capability — tenant-scoped long-term memory on the Sapiom memory
+ * gateway (hybrid semantic + full-text memory store, one per owner).
+ *
+ *   import { memory } from "@sapiom/tools";                 // ambient auth
+ *   const { id } = await memory.append({ content: "User prefers dark mode.", scope: "user" });
+ *   const { results } = await memory.recall({ query: "ui preferences", topK: 5 });
+ *   const record = await memory.get(id);
+ *   await memory.forget(id);
+ *
+ * Or via an explicit client: `createClient({ apiKey }).memory.append(...)`.
+ *
+ * Thin client: the gateway already speaks camelCase JSON, so request inputs and
+ * response objects map 1:1 to the wire — there is no snake_case translation layer
+ * here (unlike the file-storage capability, whose gateway is snake_case). The only
+ * work this module does is assembling the request body (omitting unset optionals)
+ * and surfacing non-2xx responses as {@link MemoryHttpError}.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { ensureOk, MemoryHttpError } from "./errors.js";
+
+export { MemoryHttpError };
+
+/**
+ * Memory service ORIGIN — override via SAPIOM_MEMORY_URL. Like every other
+ * @sapiom/tools capability (sandbox/agents/git/file-storage), this is the bare
+ * origin; the `/v1/memory` path prefix is appended per-method below. So a local
+ * override is just the gateway origin, e.g. `http://memory.services.localhost:3100`.
+ */
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_MEMORY_URL || "https://memory.services.sapiom.ai";
+
+// ----- SDK-facing types (identical to the wire; camelCase end to end) -----
+
+/**
+ * EXPERIMENTAL storage backend for a memory call. This folds into the store
+ * identity: a memory written under one backend is a SEPARATE store, only visible
+ * when read with the same backend (store-fixed per backend, like the embedder
+ * lock). Intended for A/B testing alternate backends; omit it for the default,
+ * production `"neon-pgvector"`.
+ */
+export type ExperimentalBackend = "neon-pgvector" | "upstash-vector";
+
+/**
+ * EXPERIMENTAL embedder override for a memory call. Choosing a non-default embedder
+ * folds into the store identity — a different embedder is a SEPARATE store (a
+ * re-embed), so write and read must use the same embedder. Example:
+ * `{ provider: "openrouter", model: "openai/text-embedding-3-large" }`. Omit for
+ * the standard OpenRouter embedder.
+ */
+export interface ExperimentalEmbedder {
+  /** Embedding provider, e.g. `"openrouter"`. */
+  provider: string;
+  /** Embedding model, e.g. `"openai/text-embedding-3-large"`. */
+  model: string;
+}
+
+export interface AppendInput {
+  /**
+   * Text to store as a memory (1–32,000 chars). Must not contain secrets — the
+   * gateway runs an admission gate and rejects API keys / tokens / passwords with
+   * a 400.
+   */
+  content: string;
+  /**
+   * Scope label grouping related memories (e.g. "session", "user", "project").
+   * Alphanumeric plus hyphens/underscores, 1–100 chars. Defaults to "default".
+   */
+  scope?: string;
+  /**
+   * Arbitrary JSON stored alongside the memory and returned on read. Opaque to
+   * search (not indexed). Max 10 KB when JSON-serialized.
+   */
+  metadata?: Record<string, unknown>;
+  /**
+   * Idempotency key (1–255 chars; alphanumeric plus `. _ : -`). Re-submitting an
+   * append with the same key within the same owner + scope returns the existing
+   * memory unchanged with `decision: "NOOP"` — nothing new is written.
+   */
+  idempotencyKey?: string;
+  /**
+   * EXPERIMENTAL: select the storage backend for this write. Folds into the store
+   * identity — a memory written under one backend is a SEPARATE store, only visible
+   * when read (recall/get/forget) with the SAME backend (store-fixed per backend).
+   * Omit for the default, production `"neon-pgvector"`.
+   */
+  experimentalBackend?: ExperimentalBackend;
+  /**
+   * EXPERIMENTAL: choose the embedding model (e.g. provider `"openrouter"`, model
+   * `"openai/text-embedding-3-large"`). Folds into the store identity (different
+   * embedder = a separate store). the default standard OpenRouter embedder.
+   */
+  experimentalEmbedder?: ExperimentalEmbedder;
+  /**
+   * Optional physical-isolation selector: a different namespace resolves a SEPARATE
+   * physical store (its own database/index). Lets you isolate your own tenants'
+   * memory. Folds into the store identity — write and read must use the same
+   * namespace. Default = your default store. 1–100 chars, `[a-zA-Z0-9_-]`.
+   */
+  namespace?: string;
+}
+
+export interface AppendResult {
+  /**
+   * UUID of the memory. For `decision: "ADDED"` / `"SUPERSEDED"` this is the newly
+   * created record; for `decision: "NOOP"` it is the existing memory that was
+   * echoed (nothing was written).
+   */
+  id: string;
+  /** The stored content, echoed back. */
+  content: string;
+  /** The resolved scope label ("default" when you omitted it). */
+  scope: string;
+  /** Always "active" for the returned memory. */
+  status: "active";
+  /**
+   * What the gateway did, made legible (never a silent write):
+   * - `"ADDED"`      — a new memory was written; nothing was superseded.
+   * - `"SUPERSEDED"` — a new memory was written and the nearest prior
+   *   (cosine ≥ 0.80) was superseded; `supersededId` points to it.
+   * - `"NOOP"`       — byte-identical content (exact match or cosine ≈ 1.0) or an
+   *   `idempotencyKey` re-submit; the existing memory is echoed and nothing is
+   *   written.
+   *
+   * A secret caught by the admission gate is *not* a decision here — it surfaces as
+   * a 400 {@link MemoryHttpError} whose body carries `decision: "REJECTED"`.
+   */
+  decision: "ADDED" | "SUPERSEDED" | "NOOP";
+  /** UUID of the prior memory superseded by this write — non-null only when `decision` is `"SUPERSEDED"`, else `null`. */
+  supersededId: string | null;
+  /** Cosine similarity to the nearest prior memory (0–1), or `null` when no neighbor existed. */
+  similarityScore: number | null;
+  /** ISO-8601 timestamp when the memory was created. */
+  createdAt: string;
+  /** The stored metadata (`{}` when none was provided). */
+  metadata: Record<string, unknown>;
+}
+
+export interface RecallInput {
+  /** Natural-language search text (1–4,096 chars). Embedded and compared against stored memories. */
+  query: string;
+  /** Restrict the search to this scope label. Omit to search every scope for your owner. */
+  scope?: string;
+  /** Maximum number of results to return (1–50). Defaults to 10. */
+  topK?: number;
+  /** Minimum combined score [0–1]; matches below it are dropped. Defaults to 0. */
+  minSimilarity?: number;
+  /**
+   * EXPERIMENTAL: select the storage backend to search. Folds into the store
+   * identity — recall only sees memories appended under the SAME backend
+   * (store-fixed per backend). Omit for the default, production `"neon-pgvector"`.
+   */
+  experimentalBackend?: ExperimentalBackend;
+  /**
+   * EXPERIMENTAL: choose the embedding model (e.g. provider `"openrouter"`, model
+   * `"openai/text-embedding-3-large"`). Folds into the store identity — recall only
+   * sees memories appended under the SAME embedder. the default standard OpenRouter
+   * embedder.
+   */
+  experimentalEmbedder?: ExperimentalEmbedder;
+  /**
+   * Optional physical-isolation selector: a different namespace reads a SEPARATE
+   * physical store (its own database/index). Must match the namespace the memory was
+   * written under. Default = your default store.
+   */
+  namespace?: string;
+}
+
+export interface RecallMatch {
+  /** UUID of the memory. */
+  id: string;
+  /** The stored content. */
+  content: string;
+  /** The scope label. */
+  scope: string;
+  /**
+   * Canonical [0–1] relevance the matches are ranked and thresholded on (highest
+   * first). Provider-neutral: an opaque backend reports only this single score.
+   */
+  score: number;
+  /**
+   * Optional backend-specific score legs. The hybrid backend fills this with its
+   * `{ vector, text, combined }` components; an opaque backend omits it entirely.
+   * An open map — don't assume a fixed set of keys.
+   */
+  scoreBreakdown?: Record<string, number>;
+  /** Lifecycle status — always `"active"` (superseded memories are excluded from recall). */
+  status: "active";
+  /** ISO-8601 timestamp when the memory was created. */
+  createdAt: string;
+  /** The stored metadata. */
+  metadata: Record<string, unknown>;
+}
+
+export interface RecallResponse {
+  /** Matches ranked by `score` (highest first). Empty when nothing matched or no store exists yet. */
+  results: RecallMatch[];
+  /** The query, echoed back. */
+  query: string;
+  /** The effective top-K used (after clamping to the 1–50 range). */
+  topK: number;
+  /** Number of results returned (≤ `topK`). */
+  count: number;
+}
+
+export interface Memory {
+  /** UUID of the memory. */
+  id: string;
+  /** The stored content. */
+  content: string;
+  /** The scope label. */
+  scope: string;
+  /** Lifecycle status: `"active"` or `"superseded"`. */
+  status: "active" | "superseded";
+  /** UUID of the newer memory that superseded this one, or `null`. */
+  supersededBy: string | null;
+  /** Reason this memory was superseded, or `null`. */
+  supersededReason: string | null;
+  /** ISO-8601 timestamp when the memory was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the memory was last updated (e.g. superseded). */
+  updatedAt: string;
+  /** The stored metadata. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Per-call options for the bodyless reads {@link get} and {@link forget}. The
+ * append/recall counterpart rides on {@link AppendInput}/{@link RecallInput}; the
+ * bodyless routes take these as query params instead — including the embedder, which
+ * is flattened to bracket notation (`experimentalEmbedder[provider]`,
+ * `experimentalEmbedder[model]`) to match the gateway's query DTO.
+ */
+export interface MemoryCallOptions {
+  /**
+   * EXPERIMENTAL: select the storage backend to read from. Must match the backend
+   * the memory was appended under — the id folds into the store identity, so a
+   * get/forget under a different backend won't find it. Sent as a query param;
+   * omit for the default, production `"neon-pgvector"`.
+   */
+  experimentalBackend?: ExperimentalBackend;
+  /**
+   * EXPERIMENTAL: choose the embedding model. Must match the embedder the memory was
+   * appended under (it folds into the store identity). Sent as bracket-notation query
+   * params; omit for the standard OpenRouter embedder.
+   */
+  experimentalEmbedder?: ExperimentalEmbedder;
+  /**
+   * Optional physical-isolation selector. Must match the namespace the memory was
+   * written under (it selects a SEPARATE physical store). Sent as a query param;
+   * omit for your default store.
+   */
+  namespace?: string;
+}
+
+// ----- capability operations -----
+
+/**
+ * Append a memory. The gateway embeds the content and runs a supersede check: if a
+ * near-duplicate (cosine ≥ 0.80) already exists in the same scope, this memory
+ * supersedes it — the prior is marked `superseded` (`decision: "SUPERSEDED"`,
+ * `supersededId` set).
+ * Byte-identical content — or a re-submit carrying the same `idempotencyKey` — is a
+ * no-op that echoes the existing memory (`decision: "NOOP"`); any other write
+ * returns `decision: "ADDED"`. Content/metadata pass through a secret-detection
+ * gate — a detected secret is rejected with a 400 ({@link MemoryHttpError}, body
+ * `decision: "REJECTED"`).
+ */
+export async function append(
+  input: AppendInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<AppendResult> {
+  const body: Record<string, unknown> = { content: input.content };
+  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.metadata !== undefined) body.metadata = input.metadata;
+  if (input.idempotencyKey !== undefined) {
+    body.idempotencyKey = input.idempotencyKey;
+  }
+  if (input.experimentalBackend !== undefined) {
+    body.experimentalBackend = input.experimentalBackend;
+  }
+  if (input.experimentalEmbedder !== undefined) {
+    body.experimentalEmbedder = input.experimentalEmbedder;
+  }
+  if (input.namespace !== undefined) {
+    body.namespace = input.namespace;
+  }
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/memory/append`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to append memory",
+  );
+  return (await res.json()) as AppendResult;
+}
+
+/**
+ * Recall memories by natural-language query (hybrid vector + full-text search).
+ * Returns the top-K active matches ranked by combined score; an empty list when
+ * nothing matches or no memory store has been provisioned yet (not an error).
+ */
+export async function recall(
+  input: RecallInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<RecallResponse> {
+  const body: Record<string, unknown> = { query: input.query };
+  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.topK !== undefined) body.topK = input.topK;
+  if (input.minSimilarity !== undefined) body.minSimilarity = input.minSimilarity;
+  if (input.experimentalBackend !== undefined) {
+    body.experimentalBackend = input.experimentalBackend;
+  }
+  if (input.experimentalEmbedder !== undefined) {
+    body.experimentalEmbedder = input.experimentalEmbedder;
+  }
+  if (input.namespace !== undefined) {
+    body.namespace = input.namespace;
+  }
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/memory/recall`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to recall memories",
+  );
+  return (await res.json()) as RecallResponse;
+}
+
+/**
+ * Build the `/v1/memory/:id` URL for the bodyless get/forget routes, appending the
+ * store-identity selectors the caller supplied as query params (an omitted selector
+ * falls through to the gateway default). The embedder object is flattened to bracket
+ * notation (`experimentalEmbedder[provider]=...&experimentalEmbedder[model]=...`) to
+ * match the gateway's query DTO.
+ */
+function memoryItemUrl(
+  baseUrl: string,
+  id: string,
+  options?: MemoryCallOptions,
+): string {
+  const path = `${baseUrl}/v1/memory/${encodeURIComponent(id)}`;
+  const params = new URLSearchParams();
+  if (options?.experimentalBackend !== undefined) {
+    params.set("experimentalBackend", options.experimentalBackend);
+  }
+  if (options?.namespace !== undefined) {
+    params.set("namespace", options.namespace);
+  }
+  if (options?.experimentalEmbedder !== undefined) {
+    params.set(
+      "experimentalEmbedder[provider]",
+      options.experimentalEmbedder.provider,
+    );
+    params.set(
+      "experimentalEmbedder[model]",
+      options.experimentalEmbedder.model,
+    );
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+/**
+ * Fetch a single memory by id, including superseded records (so you can
+ * follow a supersession chain via `supersededBy`). Throws {@link MemoryHttpError}
+ * with `status: 404` when the memory doesn't exist or belongs to another owner.
+ */
+export async function get(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+  options?: MemoryCallOptions,
+): Promise<Memory> {
+  const res = await ensureOk(
+    await transport.fetch(memoryItemUrl(baseUrl, id, options)),
+    `Failed to get memory '${id}'`,
+  );
+  return (await res.json()) as Memory;
+}
+
+/**
+ * Forget (hard-delete) a memory by id — a true `DELETE` of the row (GDPR /
+ * right-to-be-forgotten). The content is erased: its audit rows cascade away and
+ * any `supersededBy` pointers to it are cleared. This is distinct from
+ * supersession, which only *supersedes* a prior memory (recoverable via {@link get});
+ * `forget` is destructive.
+ *
+ * Idempotent: forget always resolves (the gateway returns `204 No Content`).
+ * Deleting an already-gone id — or one that never existed — is success, not an
+ * error; there is no 404 for a missing id and no "already superseded" 409 state
+ * for forget. (Real transport/auth failures still surface as {@link MemoryHttpError}.)
+ */
+export async function forget(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+  options?: MemoryCallOptions,
+): Promise<void> {
+  const res = await transport.fetch(memoryItemUrl(baseUrl, id, options), {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    throw new MemoryHttpError(
+      `Failed to forget memory '${id}': ${res.status} ${text}`,
+      res.status,
+      parsed,
+    );
+  }
+  // 204 No Content — nothing to parse.
+}

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -51,6 +51,11 @@ import type {
   DomainSearchResult,
 } from "../search/index.js";
 import type { Database } from "../database/index.js";
+import type {
+  AppendResult,
+  RecallResponse,
+  Memory,
+} from "../memory/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -780,6 +785,47 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         Promise.resolve(
           r("database.delete", [idOrHandle], () => undefined) as void,
         ),
+    },
+    memory: {
+      append: (input) =>
+        Promise.resolve(
+          r("memory.append", [input], () => ({
+            id: "stub-memory",
+            content: input.content,
+            scope: input.scope ?? "default",
+            status: "active",
+            decision: "ADDED",
+            supersededId: null,
+            similarityScore: null,
+            createdAt: "2099-01-01T00:00:00Z",
+            metadata: input.metadata ?? {},
+          })) as AppendResult,
+        ),
+      recall: (input) =>
+        Promise.resolve(
+          r("memory.recall", [input], () => ({
+            results: [],
+            query: input.query,
+            topK: input.topK ?? 10,
+            count: 0,
+          })) as RecallResponse,
+        ),
+      get: (id) =>
+        Promise.resolve(
+          r("memory.get", [id], () => ({
+            id,
+            content: "(stub) memory content",
+            scope: "default",
+            status: "active",
+            supersededBy: null,
+            supersededReason: null,
+            createdAt: "2099-01-01T00:00:00Z",
+            updatedAt: "2099-01-01T00:00:00Z",
+            metadata: {},
+          })) as Memory,
+        ),
+      forget: (id) =>
+        Promise.resolve(r("memory.forget", [id], () => undefined) as void),
     },
     withAttribution: () => client,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,69 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  examples/memory-coding-conventions:
+    dependencies:
+      '@sapiom/orchestration':
+        specifier: workspace:*
+        version: link:../../packages/orchestration
+      '@sapiom/orchestration-core':
+        specifier: workspace:*
+        version: link:../../packages/orchestration-core
+      '@sapiom/tools':
+        specifier: workspace:*
+        version: link:../../packages/tools
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      tsx:
+        specifier: ^4.7.0
+        version: 4.22.4
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
+  examples/memory-coding-conventions-live:
+    dependencies:
+      '@sapiom/tools':
+        specifier: workspace:*
+        version: link:../../packages/tools
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      tsx:
+        specifier: ^4.7.0
+        version: 4.22.4
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
+  examples/memory-coding-conventions-workflow:
+    dependencies:
+      '@sapiom/orchestration':
+        specifier: workspace:*
+        version: link:../../packages/orchestration
+      '@sapiom/orchestration-core':
+        specifier: workspace:*
+        version: link:../../packages/orchestration-core
+      '@sapiom/tools':
+        specifier: workspace:*
+        version: link:../../packages/tools
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      tsx:
+        specifier: ^4.7.0
+        version: 4.22.4
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
   packages/axios:
     dependencies:
       '@sapiom/core':
@@ -242,7 +305,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.6(@types/node@20.19.43)
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
 
   packages/node-http:
     dependencies:
@@ -3089,6 +3152,11 @@ packages:
       jest-util:
         optional: true
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4342,13 +4410,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@20.19.43))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@20.19.43)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@20.19.43)
+      vite: 7.3.5(@types/node@20.19.43)(tsx@4.22.4)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -6177,6 +6245,12 @@ snapshots:
       esbuild: 0.28.1
       jest-util: 29.7.0
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6226,13 +6300,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.43):
+  vite-node@3.2.4(@types/node@20.19.43)(tsx@4.22.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@20.19.43)
+      vite: 7.3.5(@types/node@20.19.43)(tsx@4.22.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6247,7 +6321,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@20.19.43):
+  vite@7.3.5(@types/node@20.19.43)(tsx@4.22.4):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6258,12 +6332,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
       fsevents: 2.3.3
+      tsx: 4.22.4
 
-  vitest@3.2.6(@types/node@20.19.43):
+  vitest@3.2.6(@types/node@20.19.43)(tsx@4.22.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@20.19.43))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@20.19.43)(tsx@4.22.4))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -6281,8 +6356,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@20.19.43)
-      vite-node: 3.2.4(@types/node@20.19.43)
+      vite: 7.3.5(@types/node@20.19.43)(tsx@4.22.4)
+      vite-node: 3.2.4(@types/node@20.19.43)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,12 @@ packages:
   # so -r build/test/publish skip them — until their @langchain/* deps are realigned.
   - '!packages/langchain'
   - '!packages/langchain-classic'
+  # The three SAP-785 memory examples are workspace members ON PURPOSE: they depend on
+  # the unpublished memory capability (@sapiom/tools `./memory`) + the runLocal/stub
+  # harness (@sapiom/orchestration-core), and the local SDK packages reference each
+  # other via the `workspace:` protocol — which only a pnpm workspace install can
+  # resolve. Listed individually (NOT `examples/*`) so the other examples keep using
+  # their published `latest` deps and install standalone, untouched.
+  - 'examples/memory-coding-conventions'
+  - 'examples/memory-coding-conventions-live'
+  - 'examples/memory-coding-conventions-workflow'


### PR DESCRIPTION
## What & why

Lands the **memory capability** (SAP-785) onto `main`. The work was completed on the now-retired `relaunch-hackathon-lfg` branch and never merged back; this cherry-picks it onto `main` as a standalone, reviewable PR (was previously bundled in the #131 merge-bubble, now closed in favor of per-feature PRs).

`@sapiom/tools` gains a `memory` namespace — tenant-scoped long-term memory (hybrid vector + full-text): `append` / `recall` / `get` / `forget`, with stub support and coding-conventions examples.

## Conflict resolution note

`main` has since gained the `database` capability (#126) + the `SAPIOM_SERVICES_BASE` knob, which touch the same barrel/stub/client files. Resolution was purely **additive** — `database` and `memory` coexist; no behavior changed on either side.

## Verification (on current main)

`pnpm --filter @sapiom/tools typecheck && build && test` — all green, **207 tests pass** (incl. `memory/index.spec.ts`).

Linear: SAP-785

🤖 Generated with [Claude Code](https://claude.com/claude-code)