### PR TITLE
feat(examples): eval-gate reference workflow example (SAP-1183)

### DIFF
--- a/examples/eval-gate/README.md
+++ b/examples/eval-gate/README.md
@@ -1,0 +1,126 @@
+# eval-gate
+
+Score an output against **your** rubric, then gate the next step on the score —
+authored as a **deployable Sapiom orchestration**. One artifact (`index.ts`) that
+runs **three different ways with no code changes**.
+
+The eval-gate is **not a capability**. Decomposed, it is a reference template
+built entirely from primitives you already have:
+
+| Piece                  | What it is                                             | Primitive                      |
+| ---------------------- | ------------------------------------------------------ | ------------------------------ |
+| Score an output        | one LLM call with a judge prompt → a number            | the LLM gateway (`judge.ts`)   |
+| Branch on the score    | `score >= threshold ? publish : revise`                | engine control flow            |
+| Build the judge prompt | string templating from **your** rubric + a score parse | `judge.ts` (the only new code) |
+
+We own the harness (a default judge prompt + a score parser) and the pattern.
+**The rubric is yours** — we ship one generic default judge prompt you override,
+never an opinion about what "quality" means.
+
+## The step graph
+
+```
+judge ─▶ gate ─┬─▶ publish   (score >= threshold)
+               └─▶ revise    (score <  threshold)
+```
+
+| Step                 | What it does                                                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `judge` (entry)      | Build the judge prompt from **your** rubric, call the LLM gateway, parse the score from the reply.                                |
+| `gate`               | Pure branch: `score >= threshold` ⇒ `publish`, else `revise`. No capability call — a copy can drive both sides deterministically. |
+| `publish` (terminal) | The output passed; terminate with `{ decision: "publish", score, … }`. **You** decide what "publish" means.                       |
+| `revise` (terminal)  | The output failed; terminate with `{ decision: "revise", score, … }`.                                                             |
+
+Shape: `(input, output, rubric, threshold) → { decision, score }`. Copy this as a
+starter, or call it by slug via `orchestrations.launch` from a parent workflow
+that produced `output` and branch on the returned decision.
+
+> **Why the judge is a raw gateway call (and not `ctx.sapiom.llm.*`):** there is
+> no `llm` capability YET. `judge.ts` reads `LLM_GATEWAY_*` directly (injected
+> like `SAPIOM_API_KEY`). When the `llm` capability lands, `callJudge` swaps for
+> `ctx.sapiom.llm.*` with **no other change** — and because the judge is an
+> ordinary gateway call, the engine's routing/capacity layer sits in front of it
+> for free. No evals-specific execution path is created.
+
+## RUN MODE 1 — offline (free, works today)
+
+`runLocal` plays the engine. The eval-gate makes **no `ctx.sapiom.*` capability
+call** (the judge is a raw gateway call), so there is nothing for `runLocal`'s
+capability stub to intercept — instead the harness **fakes the gateway HTTP** by
+monkeypatching `globalThis.fetch` with a canned judge reply. Same step bodies, no
+network, no credentials.
+
+```bash
+cd examples/eval-gate
+npm install
+npm start
+```
+
+You'll see the per-step trace ending in a `publish` terminal output:
+
+```
+=== OFFLINE MODE — scenario: publish (high score) (faked judge score 0.9, threshold 0.7) ===
+
+workflow "eval-gate" → completed
+
+▶ judge (succeeded)
+    · judge: scored output against rubric {"score":0.9,"threshold":0.7}
+▶ gate (succeeded)
+    · gate: score met threshold → publish {"score":0.9,"threshold":0.7}
+▶ publish (succeeded)
+    · publish: output passed the eval-gate {"score":0.9}
+
+final output: { "decision": "publish", "score": 0.9, "threshold": 0.7, "rationale": "offline stub: canned judge reply" }
+```
+
+**See the other branch** — a faked low score makes `gate` take `revise`:
+
+```bash
+DEMO_SCENARIO=revise npm start
+```
+
+Override the case being judged:
+
+```bash
+npm start -- --rubric "Must cite a source" --output "The sky is blue." --threshold 0.8
+```
+
+## RUN MODE 2 — live (real Sapiom LLM gateway; the judge call is real + metered)
+
+Point the harness at your LLM gateway and run with `--mode live`:
+
+```bash
+LLM_GATEWAY_BASE_URL=https://<your-gateway> \
+LLM_GATEWAY_API_KEY=<your-key> \
+LLM_GATEWAY_MODEL=claude-sonnet-4-6 \
+npm run start:live
+```
+
+- `LLM_GATEWAY_BASE_URL` — the gateway origin; the judge POSTs `…/v1/messages`.
+- `LLM_GATEWAY_API_KEY` — a key the gateway accepts (`Authorization: Bearer …`).
+- `LLM_GATEWAY_MODEL` — optional judge model alias (default: `claude-sonnet-4-6`).
+
+Same step bodies as offline — only the gateway is real instead of faked.
+
+## RUN MODE 3 — Sapiom execution (Blaxel sandbox)
+
+The **same** `index.ts` is the deployed artifact — no code changes between modes.
+The control plane is the `@sapiom/cli`:
+
+```bash
+sapiom orchestrations link eval-gate --create
+sapiom orchestrations deploy
+sapiom orchestrations run \
+  --input '{"input":"Write a tagline for a privacy-first email app.","output":"Inbox peace, finally.","rubric":"Concise, mentions privacy.","threshold":0.7}'
+```
+
+## How it maps onto production
+
+In all three modes the engine/harness swaps _underneath_ the step bodies, never
+the bodies themselves:
+
+- **offline:** `runLocal` is the engine; a faked `fetch` is the gateway.
+- **live:** `runLocal` is the engine; your real LLM gateway serves the judge call.
+- **Sapiom execution:** the real engine bundles `index.ts`, mints a per-run scoped
+  key, and walks the steps in a Blaxel sandbox — the judge call routes through the
+  gateway like any other.

--- a/examples/eval-gate/index.ts
+++ b/examples/eval-gate/index.ts
@@ -1,0 +1,216 @@
+/**
+ * eval-gate
+ * ---------
+ * Score an output against a rubric, gate the next step on the score — authored as
+ * a DEPLOYABLE Sapiom orchestration. The eval-gate is NOT a capability. It is a
+ * reference template built entirely from primitives you already have: a single
+ * LLM call through the gateway (the judge, see `judge.ts`), the engine's branch
+ * control flow (the gate), and two terminal outcomes (publish / revise). We own
+ * the harness and the pattern; the RUBRIC is yours — we ship one generic default
+ * judge prompt you override, never an opinion about what "quality" means.
+ *
+ * Load-bearing seam: the judge is an ordinary gateway LLM call, so it rides the
+ * same step→gateway path as everything else and inherits the engine's routing /
+ * capacity / load-balancing for free.
+ *
+ *   judge ─▶ gate ─┬─▶ publish   (score >= threshold)
+ *                  └─▶ revise    (score <  threshold)
+ *
+ * This file is the DEPLOYABLE ARTIFACT and is therefore SIDE-EFFECT-FREE: it only
+ * defines steps and exports exactly ONE `defineOrchestration`. There is no
+ * `main()`, no `runLocal` call, no top-level execution — so the engine can import
+ * and bundle it cleanly. The harness that runs it locally lives in `run-local.ts`.
+ * `judge.ts` exports plain functions (not orchestrations), so importing it here is
+ * safe — the loader still finds exactly one definition.
+ *
+ * Shape: (input, output, rubric, threshold) → { decision, score }. Copy this as a
+ * starter, or call it by slug via `orchestrations.launch` from a parent workflow
+ * that produced `output` and branch on the returned decision.
+ */
+import {
+  defineOrchestration,
+  defineStep,
+  goto,
+  terminate,
+  type OrchestrationExecutionContext,
+} from "@sapiom/orchestration";
+import { z } from "zod/v4";
+
+import { buildJudgePrompt, callJudge, parseScore } from "./judge.js";
+
+/** Run-scoped values stashed in `ctx.shared` so later steps can read them. */
+export interface EvalShared extends Record<string, unknown> {
+  /** The pass bar, stashed by `judge` so `gate` can branch on it. */
+  threshold: number;
+}
+
+const judgeInputSchema = z
+  .object({
+    input: z
+      .unknown()
+      .describe(
+        "The case the output was produced from (task, prompt, question…).",
+      ),
+    output: z.unknown().describe("The produced output to grade."),
+    rubric: z
+      .string()
+      .min(1)
+      .describe(
+        "YOUR criteria. The judge scores the output against this — we ship no scorer taxonomy.",
+      ),
+    threshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.7)
+      .describe(
+        "Pass bar in [0,1]. score >= threshold ⇒ publish, else revise.",
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Judge-model alias the LLM gateway knows (default: a configured cheap judge).",
+      ),
+  })
+  .meta({
+    examples: [
+      {
+        input:
+          "Write a one-line product tagline for a privacy-first email app.",
+        output: "Inbox peace, finally — email that never reads your mail.",
+        rubric:
+          "Concise (<= 12 words), mentions privacy, no jargon, reads naturally.",
+        threshold: 0.7,
+      },
+    ],
+  });
+
+/** What the workflow is kicked off with. */
+export type EvalGateInput = z.infer<typeof judgeInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Step 1 — judge: build the prompt from YOUR rubric, call the gateway, parse score
+// ---------------------------------------------------------------------------
+
+const judge = defineStep({
+  name: "judge",
+  next: ["gate"],
+  timeoutMs: 60_000,
+  inputSchema: judgeInputSchema,
+  async run(
+    input: EvalGateInput,
+    ctx: OrchestrationExecutionContext<EvalShared>,
+  ) {
+    ctx.shared.set("threshold", input.threshold);
+    const prompt = buildJudgePrompt({
+      input: input.input,
+      output: input.output,
+      rubric: input.rubric,
+    });
+    const { score, rationale } = parseScore(
+      await callJudge(prompt, input.model),
+    );
+    ctx.logger.info("judge: scored output against rubric", {
+      score,
+      threshold: input.threshold,
+    });
+    return goto("gate", { score, rationale });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — gate: the branch the whole template turns on (pure logic, no call)
+// ---------------------------------------------------------------------------
+
+interface GateInput {
+  score: number;
+  rationale: string;
+}
+
+interface GateOutcome {
+  score: number;
+  threshold: number;
+  rationale: string;
+}
+
+const gate = defineStep({
+  name: "gate",
+  next: ["publish", "revise"],
+  async run(input: GateInput, ctx: OrchestrationExecutionContext<EvalShared>) {
+    const threshold = ctx.shared.get("threshold") ?? 0.7;
+    const passed = input.score >= threshold;
+    ctx.logger.info(
+      `gate: score ${passed ? "met" : "below"} threshold → ${passed ? "publish" : "revise"}`,
+      {
+        score: input.score,
+        threshold,
+      },
+    );
+    const outcome: GateOutcome = {
+      score: input.score,
+      threshold,
+      rationale: input.rationale,
+    };
+    return passed ? goto("publish", outcome) : goto("revise", outcome);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 — terminal outcomes. The caller decides what publish/revise MEAN.
+// ---------------------------------------------------------------------------
+
+const publish = defineStep({
+  name: "publish",
+  terminal: true,
+  async run(
+    input: GateOutcome,
+    ctx: OrchestrationExecutionContext<EvalShared>,
+  ) {
+    ctx.logger.info("publish: output passed the eval-gate", {
+      score: input.score,
+    });
+    return terminate(
+      {
+        decision: "publish",
+        score: input.score,
+        threshold: input.threshold,
+        rationale: input.rationale,
+      },
+      { reason: "score met threshold" },
+    );
+  },
+});
+
+const revise = defineStep({
+  name: "revise",
+  terminal: true,
+  async run(
+    input: GateOutcome,
+    ctx: OrchestrationExecutionContext<EvalShared>,
+  ) {
+    ctx.logger.info("revise: output failed the eval-gate", {
+      score: input.score,
+    });
+    return terminate(
+      {
+        decision: "revise",
+        score: input.score,
+        threshold: input.threshold,
+        rationale: input.rationale,
+      },
+      { reason: "score below threshold" },
+    );
+  },
+});
+
+/**
+ * The workflow. The engine imports THIS `evalGate` export, bundles it, and walks
+ * these step bodies inside a Blaxel sandbox. Exactly ONE `defineOrchestration` is
+ * exported from this module — the orchestration-core loader requires precisely one.
+ */
+export const evalGate = defineOrchestration<EvalGateInput, EvalShared>({
+  name: "eval-gate",
+  entry: "judge",
+  steps: { judge, gate, publish, revise },
+});

--- a/examples/eval-gate/judge.ts
+++ b/examples/eval-gate/judge.ts
@@ -1,0 +1,137 @@
+/**
+ * judge.ts — the eval-gate's only genuinely new code.
+ *
+ * Three small pieces: a default judge prompt, a gateway call, and a text score
+ * parser. The RUBRIC is the caller's — we own the harness, not an opinion about
+ * what "quality" means. This file is factored out (not inlined in the steps) so
+ * the async/eventually eval variant reuses the EXACT same judge with no change;
+ * only its execution mode differs.
+ *
+ * The judge is reached via the Sapiom LLM gateway read from `LLM_GATEWAY_*`
+ * because `@sapiom/tools` has no `llm` capability YET. When it lands, `callJudge`
+ * swaps for `ctx.sapiom.llm.*` with no behavior change — and because the judge is
+ * an ordinary gateway call, the engine's routing/capacity layer sits in front of
+ * it for free. No evals-specific execution path is created.
+ */
+
+export interface JudgeResult {
+  /** Score in [0,1]: 1.0 fully satisfies the rubric, 0.0 not at all. */
+  score: number;
+  /** Best-effort one-line model explanation (empty when the reply carried none). */
+  rationale: string;
+}
+
+/**
+ * Build the single default judge prompt from the caller's rubric. This is the
+ * unopinionated default — override the RUBRIC, not this scaffolding. We ask for a
+ * JSON object so the parse is robust, but `parseScore` tolerates a bare number
+ * too (no structured-output support on the gateway yet).
+ */
+export function buildJudgePrompt(args: {
+  input: unknown;
+  output: unknown;
+  rubric: string;
+}): string {
+  const { input, output, rubric } = args;
+  const render = (v: unknown): string =>
+    typeof v === "string" ? v : JSON.stringify(v, null, 2);
+  return [
+    "You are an impartial evaluator. Score the OUTPUT from 0.0 to 1.0 on how well it",
+    "satisfies the CRITERIA — 1.0 = fully satisfies, 0.0 = does not satisfy at all.",
+    'Respond with ONLY a JSON object: {"score": <number 0..1>, "rationale": "<one sentence>"}.',
+    "",
+    "CRITERIA (the rubric — supplied by the caller):",
+    rubric,
+    "",
+    "INPUT (what the output was produced from):",
+    render(input),
+    "",
+    "OUTPUT (the thing you are grading):",
+    render(output),
+  ].join("\n");
+}
+
+/** Clamp to [0,1], tolerating a model that answered on a 0–100 scale. */
+function clamp01(n: number): number {
+  const v = n > 1 && n <= 100 ? n / 100 : n;
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * Parse a [0,1] score (and best-effort rationale) out of the model's text reply.
+ * Prefers the JSON object the prompt asked for; falls back to the first bare
+ * number in the text. Throws when no number can be found at all — a malformed
+ * reply is treated as transient, so the engine retries the step up to its cap.
+ */
+export function parseScore(reply: string): JudgeResult {
+  const json = reply.match(/\{[\s\S]*\}/);
+  if (json) {
+    try {
+      const obj = JSON.parse(json[0]) as {
+        score?: unknown;
+        rationale?: unknown;
+      };
+      const n = Number(obj.score);
+      if (Number.isFinite(n)) {
+        return {
+          score: clamp01(n),
+          rationale: typeof obj.rationale === "string" ? obj.rationale : "",
+        };
+      }
+    } catch {
+      // Not valid JSON — fall through to the bare-number path.
+    }
+  }
+  const m = reply.match(/-?\d+(?:\.\d+)?/);
+  if (!m) {
+    throw new Error(
+      `eval-gate judge: could not parse a score from reply: ${reply.slice(0, 200)}`,
+    );
+  }
+  return { score: clamp01(Number(m[0])), rationale: "" };
+}
+
+/**
+ * Issue the judge call through the Sapiom LLM gateway (read from `LLM_GATEWAY_*`).
+ * This is the load-bearing seam: the judge is an ordinary gateway LLM call, so it
+ * rides the same step→gateway path as everything else.
+ */
+export async function callJudge(
+  prompt: string,
+  model?: string,
+): Promise<string> {
+  const base = process.env.LLM_GATEWAY_BASE_URL;
+  const key = process.env.LLM_GATEWAY_API_KEY;
+  const judgeModel =
+    model ?? process.env.LLM_GATEWAY_MODEL ?? "claude-sonnet-4-6";
+  if (!base || !key) {
+    throw new Error(
+      "eval-gate requires LLM_GATEWAY_BASE_URL + LLM_GATEWAY_API_KEY (the Sapiom LLM gateway).",
+    );
+  }
+  const res = await fetch(`${base.replace(/\/$/, "")}/v1/messages`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${key}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: judgeModel,
+      max_tokens: 256,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `LLM gateway ${res.status}: ${(await res.text()).slice(0, 300)}`,
+    );
+  }
+  const data = (await res.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+  return (data.content ?? [])
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("")
+    .trim();
+}

--- a/examples/eval-gate/package-lock.json
+++ b/examples/eval-gate/package-lock.json
@@ -1,0 +1,672 @@
+{
+  "name": "@sapiom/example-eval-gate",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sapiom/example-eval-gate",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sapiom/orchestration": "^0.4.2",
+        "@sapiom/orchestration-core": "^0.3.6",
+        "@sapiom/tools": "^0.8.1",
+        "zod": "3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sapiom/orchestration": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@sapiom/orchestration/-/orchestration-0.4.2.tgz",
+      "integrity": "sha512-nDNr5Mk4laaaEXqjaXAE0yxawdZRLBXozkRI2jPpEvwxfqF64e6jb3Et7Mx+wd+9nlbuvmKM4hT5H9XtairhBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/tools": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.0.0"
+      }
+    },
+    "node_modules/@sapiom/orchestration-core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@sapiom/orchestration-core/-/orchestration-core-0.3.6.tgz",
+      "integrity": "sha512-5+kGM0rzmAlPF1bmpXflyDNLX07FPN6u3z6ar88yj4L6a2rtY7ptnOynX+gEJTY4IL101P5E6+9+/U6hcvtCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/orchestration": "^0.4.2",
+        "@sapiom/orchestration-runtime": "^0.2.2",
+        "@sapiom/tools": "^0.8.0",
+        "esbuild": "^0.28.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sapiom/orchestration-core/node_modules/@sapiom/orchestration-runtime": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@sapiom/orchestration-runtime/-/orchestration-runtime-0.2.2.tgz",
+      "integrity": "sha512-0RkWAdwYHu1MXOO2wgf2a3pgOWJP+z3rUinLu9mu9wdVhE2G4KSKFJuwcpYrnr9JDoFqPEjwuzIEoqAOGlGYJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/orchestration": "^0.4.0",
+        "ajv": "^8.12.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.1.0"
+      }
+    },
+    "node_modules/@sapiom/orchestration-core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@sapiom/tools": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/tools/-/tools-0.8.1.tgz",
+      "integrity": "sha512-7Ictk320n78Tb6i9NK2VA7ls+Z6aRVDWwezOHXYAwSKCua3euBSMqUcqJ+YLBODHXGuOhB1B6VbEalrbZUCF1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/eval-gate/package.json
+++ b/examples/eval-gate/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sapiom/example-eval-gate",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom workflow example: the eval-gate — score an output against YOUR rubric with one LLM-gateway judge call, then branch publish/revise on a threshold. A deployable orchestration that runs offline (faked judge), live (real gateway), and on the Sapiom engine.",
+  "scripts": {
+    "start": "npx tsx run-local.ts",
+    "start:live": "npx tsx run-local.ts --mode live",
+    "check": "npx tsx run-local.ts --mode offline",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sapiom/orchestration": "^0.4.2",
+    "@sapiom/orchestration-core": "^0.3.6",
+    "@sapiom/tools": "^0.8.1",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/eval-gate/run-local.ts
+++ b/examples/eval-gate/run-local.ts
@@ -1,0 +1,182 @@
+/**
+ * run-local.ts — the LOCAL RUNNER / harness for the eval-gate in `index.ts`.
+ *
+ * `index.ts` is the deployable artifact (side-effect-free). This file is the dev
+ * harness that exercises it locally, two ways:
+ *
+ *   pnpm start            → OFFLINE mode (default; fakes the gateway HTTP, free)
+ *   pnpm start:live       → LIVE mode    (real Sapiom LLM gateway via LLM_GATEWAY_*)
+ *
+ * Flags / env:
+ *   --mode offline|live   (default: offline)
+ *   --rubric "<text>"     (the criteria the judge scores against)
+ *   --output "<text>"     (the produced output to grade)
+ *   --threshold <0..1>    (pass bar; default 0.7)
+ *   DEMO_SCENARIO=revise  (offline only) — fake a LOW score so the REVISE branch runs.
+ *
+ * Why OFFLINE fakes the gateway HTTP instead of using a capability stub: the judge
+ * is a raw gateway call — there is no `ctx.sapiom.llm` capability YET, so there is
+ * nothing for `runLocal`'s capability stub to intercept. We monkeypatch
+ * `globalThis.fetch` to return a canned judge reply, then let `runLocal` (the
+ * engine simulator) walk the same step bodies. When the `llm` capability lands,
+ * this becomes an ordinary `runLocal` + capability stub, like the memory example.
+ *
+ * The third way the SAME `index.ts` runs — Sapiom execution inside a Blaxel
+ * sandbox — needs no code here; see the README RUN MODE 3.
+ */
+import { buildManifest } from "@sapiom/orchestration";
+import { runLocal, type StubFile } from "@sapiom/orchestration-core";
+
+import { evalGate, type EvalGateInput } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// argv / env
+// ---------------------------------------------------------------------------
+
+interface Args {
+  mode: "offline" | "live";
+  rubric: string;
+  output: string;
+  input: string;
+  threshold: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  let mode: "offline" | "live" = "offline";
+  let rubric =
+    "Concise (<= 12 words), mentions privacy, no jargon, reads naturally.";
+  let output = "Inbox peace, finally — email that never reads your mail.";
+  let input = "Write a one-line product tagline for a privacy-first email app.";
+  let threshold = 0.7;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--mode") mode = argv[++i] === "live" ? "live" : "offline";
+    else if (a === "--rubric") rubric = argv[++i] ?? rubric;
+    else if (a === "--output") output = argv[++i] ?? output;
+    else if (a === "--input") input = argv[++i] ?? input;
+    else if (a === "--threshold") threshold = Number(argv[++i] ?? threshold);
+  }
+  return { mode, rubric, output, input, threshold };
+}
+
+// ---------------------------------------------------------------------------
+// The single run path — both modes drive the SAME step bodies via runLocal.
+// ---------------------------------------------------------------------------
+
+async function runOnce(args: Args): Promise<void> {
+  // The build phase produces this manifest in production; we build it inline.
+  const manifest = buildManifest(evalGate, {
+    sdkVersion: "0.0.0-example",
+    artifact: { sha256: "example", entryFile: "index.ts" },
+  });
+
+  // The eval-gate makes NO `ctx.sapiom.*` capability call (the judge is a raw
+  // gateway call), so there is nothing to stub — an empty stub file is correct.
+  const stubs: StubFile = { version: 1, steps: {} };
+
+  const input: EvalGateInput = {
+    input: args.input,
+    output: args.output,
+    rubric: args.rubric,
+    threshold: args.threshold,
+  };
+
+  const result = await runLocal({
+    definition: evalGate,
+    manifest,
+    input,
+    stubs,
+  });
+
+  console.log(`\nworkflow "${evalGate.name}" → ${result.outcome}\n`);
+  for (const step of result.steps) {
+    console.log(`▶ ${step.step} (${step.status})`);
+    for (const entry of step.logs) {
+      const meta = entry.meta ? ` ${JSON.stringify(entry.meta)}` : "";
+      console.log(`    · ${entry.msg}${meta}`);
+    }
+  }
+  console.log(`\nfinal output: ${JSON.stringify(result.output, null, 2)}`);
+}
+
+// ---------------------------------------------------------------------------
+// OFFLINE — fake the gateway HTTP so the run is offline + free.
+// ---------------------------------------------------------------------------
+
+/** Replace `globalThis.fetch` with a canned `/v1/messages` judge reply. */
+function installFetchMock(score: number): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    const text = JSON.stringify({
+      score,
+      rationale: "offline stub: canned judge reply",
+    });
+    const body = { content: [{ type: "text", text }] };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+async function runOffline(args: Args): Promise<void> {
+  // `callJudge` guards on these; dummy values are fine since fetch is mocked.
+  process.env.LLM_GATEWAY_BASE_URL ??= "http://stub.local";
+  process.env.LLM_GATEWAY_API_KEY ??= "stub-key";
+
+  const takeReviseBranch = process.env.DEMO_SCENARIO === "revise";
+  const score = takeReviseBranch ? 0.4 : 0.9;
+  console.log(
+    `\n=== OFFLINE MODE — scenario: ${takeReviseBranch ? "revise (low score)" : "publish (high score)"} ` +
+      `(faked judge score ${score}, threshold ${args.threshold}) ===`,
+  );
+
+  const restore = installFetchMock(score);
+  try {
+    await runOnce(args);
+  } finally {
+    restore();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LIVE — real Sapiom LLM gateway (the judge call is real + metered).
+// ---------------------------------------------------------------------------
+
+function assertLiveEnv(): void {
+  if (!process.env.LLM_GATEWAY_BASE_URL || !process.env.LLM_GATEWAY_API_KEY) {
+    throw new Error(
+      "LIVE mode requires LLM_GATEWAY_BASE_URL + LLM_GATEWAY_API_KEY (the Sapiom LLM gateway). " +
+        "Optionally set LLM_GATEWAY_MODEL (default: claude-sonnet-4-6).",
+    );
+  }
+}
+
+async function runLive(args: Args): Promise<void> {
+  assertLiveEnv();
+  console.log(
+    `\n=== LIVE MODE — judging against ${process.env.LLM_GATEWAY_BASE_URL} (threshold ${args.threshold}) ===`,
+  );
+  await runOnce(args);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.mode === "live") {
+    await runLive(args);
+  } else {
+    await runOffline(args);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/eval-gate/tsconfig.json
+++ b/examples/eval-gate/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds `examples/eval-gate/` — a public, copyable **eval-gate** workflow example. Score an output against **your** rubric, then gate the next step on the score:

```
judge ─▶ gate ─┬─▶ publish   (score >= threshold)
               └─▶ revise    (score <  threshold)
```

The eval-gate is **not a capability**. It composes a single LLM-gateway judge call (`judge.ts`), the engine's branch control flow, and two terminal outcomes. The rubric is the user's; we own only the harness (a default judge prompt + a score parser). `judge.ts` is factored out so the async eval variant reuses it unchanged.

Authored as a **deployable orchestration** (side-effect-free `index.ts`, harness in `run-local.ts`), runnable three ways with no code change:

- **offline** (`npm start`) — `runLocal` + a faked gateway HTTP. The eval-gate makes no `ctx.sapiom.*` call (the judge is a raw gateway call — no `llm` capability yet), so there's nothing for `runLocal`'s capability stub to intercept; the harness monkeypatches `globalThis.fetch` with a canned judge reply. When the `llm` capability lands this becomes an ordinary capability stub, like the memory example.
- **live** (`npm run start:live`) — real Sapiom LLM gateway via `LLM_GATEWAY_*`.
- **Sapiom engine** — same `index.ts`, deployed via the CLI.

## Verification

- `npm run typecheck` (tsc) clean against the published SDK (`@sapiom/orchestration` 0.4.2, `@sapiom/orchestration-core` 0.3.6).
- Offline run, both branches: `judge→gate→{publish|revise}` walk correctly through `runLocal` (publish at score 0.9 / revise at 0.4 vs threshold 0.7).
- `prettier --check` (repo config, printWidth 80) passes.

## Notes

- Standalone example (published deps + `npx tsx`), matching the `axios`/`fetch` examples; lockfile committed like `examples/fetch`.
- Mirror of the Sapiom catalog demo in `sapiom/Sapiom` (`apps/workflows-engine/demos/eval-gate`).

Linear: SAP-1183 · foundation for SAP-1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)