### PR TITLE
fix(tools): align fileStorage with the single file_size field (SAP-1204)

### DIFF
--- a/.changeset/file-storage-file-size.md
+++ b/.changeset/file-storage-file-size.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/tools": minor
+---
+
+**Breaking:** `fileStorage` now uses a single `fileSize` field, matching the service contract.
+
+Previously `upload` 400'd and metadata sizes came back `undefined` because the SDK was on an older field shape.
+
+- `UploadInput.expectedFileSize?: number` → `fileSize: number` (now **required** — the service rejects uploads without it).
+- `FileMetadata.expectedFileSize` / `actualFileSize` → a single `fileSize: string`.
+
+To migrate: pass `fileSize` on `upload(...)`, and read `fileSize` (a string) instead of `expectedFileSize` / `actualFileSize` on returned metadata.

--- a/packages/tools/src/file-storage/README.md
+++ b/packages/tools/src/file-storage/README.md
@@ -12,10 +12,15 @@ const { fileId, uploadUrl, requiredHeaders } = await sapiom.fileStorage.upload({
   contentType: "image/png",
   fileName: "photo.png",
   visibility: "private", // or "public"
+  fileSize: bytes.byteLength, // required — size in bytes
 });
 
 // 2. PUT the bytes to the upload URL yourself.
-await fetch(uploadUrl, { method: "PUT", headers: requiredHeaders, body: bytes });
+await fetch(uploadUrl, {
+  method: "PUT",
+  headers: requiredHeaders,
+  body: bytes,
+});
 
 // 3. Later: a presigned download URL, list, visibility, delete.
 const { downloadUrl } = await sapiom.fileStorage.getDownloadUrl(fileId);
@@ -36,8 +41,8 @@ returns `requiredHeaders` you **must** include on the `PUT` (notably `Content-Ty
 ## Lifecycle
 
 After you `PUT` the bytes, the file's `status` moves from `pending_upload` →
-`uploaded` (usually within seconds) and `actualFileSize` is recorded. Until then,
-`getDownloadUrl()` on a still-pending file is rejected.
+`uploaded` (usually within seconds) and `fileSize` is updated to the measured size.
+Until then, `getDownloadUrl()` on a still-pending file is rejected.
 
 ## Visibility
 
@@ -49,9 +54,9 @@ files; another tenant cannot read your private files.
 
 ## Gotchas
 
-- **Sizes are strings.** `expectedFileSize` / `actualFileSize` on returned metadata
-  are `string | null` to avoid JS `Number` precision loss on large files.
-  (`expectedFileSize` on the `upload()` *input* is a regular `number`.)
+- **`fileSize` is a string on metadata.** `fileSize` on returned metadata is a
+  `string` to avoid JS `Number` precision loss on large files. (`fileSize` on the
+  `upload()` _input_ is a regular `number`, and is **required**.)
 - **`delete` is idempotent** — deleting an already-deleted file resolves without
   error.
 - **Failed requests throw `FileStorageHttpError`** (carries `status` + parsed

--- a/packages/tools/src/file-storage/index.spec.ts
+++ b/packages/tools/src/file-storage/index.spec.ts
@@ -77,7 +77,7 @@ describe("fileStorage.upload()", () => {
         contentType: "image/png",
         fileName: "photo.png",
         visibility: "public",
-        expectedFileSize: 1024,
+        fileSize: 1024,
       },
       transport,
       BASE,
@@ -98,7 +98,7 @@ describe("fileStorage.upload()", () => {
       content_type: "image/png",
       file_name: "photo.png",
       visibility: "public",
-      expected_file_size: 1024,
+      file_size: 1024,
     });
   });
 
@@ -117,15 +117,14 @@ describe("fileStorage.upload()", () => {
     ]);
 
     await fileStorage.upload(
-      { contentType: "application/pdf" },
+      { contentType: "application/pdf", fileSize: 512 },
       transport,
       BASE,
     );
     const body = JSON.parse(calls[0]!.init.body as string);
-    expect(body).toEqual({ content_type: "application/pdf" });
+    expect(body).toEqual({ content_type: "application/pdf", file_size: 512 });
     expect(body).not.toHaveProperty("file_name");
     expect(body).not.toHaveProperty("visibility");
-    expect(body).not.toHaveProperty("expected_file_size");
   });
 
   it("throws FileStorageHttpError on non-2xx", async () => {
@@ -137,7 +136,11 @@ describe("fileStorage.upload()", () => {
     ]);
 
     await expect(
-      fileStorage.upload({ contentType: "image/png" }, transport, BASE),
+      fileStorage.upload(
+        { contentType: "image/png", fileSize: 1 },
+        transport,
+        BASE,
+      ),
     ).rejects.toBeInstanceOf(FileStorageHttpError);
   });
 });
@@ -202,9 +205,8 @@ describe("fileStorage.list()", () => {
     content_type: "application/pdf",
     visibility: "private",
     status: "uploaded",
-    // gateway serializes int64 sizes as strings (verified live: e.g. "37")
-    expected_file_size: "2048",
-    actual_file_size: "2000",
+    // gateway serializes the int64 size as a string (verified live: e.g. "37")
+    file_size: "2048",
     created_at: "2026-06-01T00:00:00Z",
     uploaded_at: "2026-06-01T00:01:00Z",
     deleted_at: null,
@@ -232,8 +234,7 @@ describe("fileStorage.list()", () => {
       contentType: "application/pdf",
       visibility: "private",
       status: "uploaded",
-      expectedFileSize: "2048",
-      actualFileSize: "2000",
+      fileSize: "2048",
       downloadRequestCount: 3,
     });
     expect(calls[0]!.url).toBe(`${BASE}/files`);
@@ -326,6 +327,7 @@ describe("fileStorage.setVisibility()", () => {
     content_type: "application/pdf",
     visibility: "public",
     status: "uploaded",
+    file_size: "4096",
     created_at: "2026-06-01T00:00:00Z",
     download_request_count: 0,
   };
@@ -387,6 +389,7 @@ describe("fileStorage — client wiring + credential", () => {
           content_type: "text/plain",
           visibility: "private",
           status: "uploaded",
+          file_size: "0",
           created_at: "2026-06-01T00:00:00Z",
           download_request_count: 0,
         });
@@ -404,7 +407,7 @@ describe("fileStorage — client wiring + credential", () => {
     }) as typeof globalThis.fetch;
 
     const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
-    await sapiom.fileStorage.upload({ contentType: "text/plain" });
+    await sapiom.fileStorage.upload({ contentType: "text/plain", fileSize: 8 });
     await sapiom.fileStorage.getDownloadUrl("f");
     await sapiom.fileStorage.list();
     await sapiom.fileStorage.delete("f");

--- a/packages/tools/src/file-storage/index.ts
+++ b/packages/tools/src/file-storage/index.ts
@@ -15,8 +15,9 @@
  *
  * Or via an explicit client: `createClient({ apiKey }).fileStorage.upload(...)`.
  *
- * Byte-size fields (`expectedFileSize` / `actualFileSize` on returned metadata) are
- * returned as `string | null` to stay precise for large files.
+ * The `fileSize` on returned metadata is a `string` (bigint serialized as a string
+ * to stay precise for large files); the `fileSize` on the `upload()` input is a
+ * regular `number`.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
 import { resolveServiceUrl } from "../_client/service-url.js";
@@ -42,8 +43,8 @@ export interface UploadInput {
    * - "public"  — download URL is unauthenticated.
    */
   visibility?: "private" | "public";
-  /** Expected file size in bytes. */
-  expectedFileSize?: number;
+  /** File size in bytes. Required — the service rejects uploads without it. */
+  fileSize: number;
 }
 
 export interface UploadResponse {
@@ -75,10 +76,12 @@ export interface FileMetadata {
   visibility: "private" | "public";
   /** Upload lifecycle status (e.g. "pending_upload", "uploaded", "deleted"). */
   status: string;
-  /** Expected (client-declared) size in bytes — a string, `null` when not declared. */
-  expectedFileSize?: string | null;
-  /** Actual size in bytes after upload (string; `null` until the upload is verified). */
-  actualFileSize?: string | null;
+  /**
+   * File size in bytes, as a string (serialized as a string to stay precise for
+   * large files). Reflects the size you declared at upload time, updated to the
+   * measured size once the upload completes.
+   */
+  fileSize: string;
   /** ISO-8601 timestamp when the record was created. */
   createdAt: string;
   /** ISO-8601 timestamp when the bytes were uploaded. */
@@ -127,9 +130,8 @@ interface RawFileMetadata {
   content_type: string;
   visibility: "private" | "public";
   status: string;
-  // Byte counts are strings (precise for large files); null when unset.
-  expected_file_size?: string | null;
-  actual_file_size?: string | null;
+  // Byte count is serialized as a string to stay precise for large files.
+  file_size: string;
   created_at: string;
   uploaded_at?: string;
   deleted_at?: string;
@@ -150,12 +152,7 @@ function mapFileMetadata(raw: RawFileMetadata): FileMetadata {
     contentType: raw.content_type,
     visibility: raw.visibility,
     status: raw.status,
-    ...(raw.expected_file_size !== undefined && {
-      expectedFileSize: raw.expected_file_size,
-    }),
-    ...(raw.actual_file_size !== undefined && {
-      actualFileSize: raw.actual_file_size,
-    }),
+    fileSize: raw.file_size,
     createdAt: raw.created_at,
     ...(raw.uploaded_at !== undefined && { uploadedAt: raw.uploaded_at }),
     ...(raw.deleted_at !== undefined && { deletedAt: raw.deleted_at }),
@@ -174,12 +171,13 @@ export async function upload(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<UploadResponse> {
-  const body: Record<string, unknown> = { content_type: input.contentType };
+  const body: Record<string, unknown> = {
+    content_type: input.contentType,
+    // The service requires `file_size` on upload.
+    file_size: input.fileSize,
+  };
   if (input.fileName !== undefined) body.file_name = input.fileName;
   if (input.visibility !== undefined) body.visibility = input.visibility;
-  if (input.expectedFileSize !== undefined) {
-    body.expected_file_size = input.expectedFileSize;
-  }
 
   const res = await ensureOk(
     await transport.fetch(`${baseUrl}/upload`, {


### PR DESCRIPTION
## Problem

The file-storage service expects a single `file_size` field, but `@sapiom/tools` `fileStorage` was on an older field shape:

- `fileStorage.upload(...)` returned a **400** (`file_size should not be null or undefined`).
- `fileStorage.list()` / metadata returned `expectedFileSize` / `actualFileSize` as `undefined`.

## Fix

- `upload` sends `file_size`; metadata reads `file_size`.
- Public API (**breaking**):
  - `UploadInput.expectedFileSize?: number` → **`fileSize: number`** (now required — the service rejects uploads without it).
  - `FileMetadata.expectedFileSize` / `actualFileSize` → a single **`fileSize: string`**.
- Updated `index.spec.ts`, `README.md`, and the doc comment.
- Added a `minor` changeset (breaking change, pre-1.0).

## Migration for consumers

Pass `fileSize` on `upload(...)`; read `fileSize` (a string) instead of `expectedFileSize` / `actualFileSize` on returned metadata.

## Test plan

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` (`@sapiom/tools`) — 174/174 pass
- `pnpm build` — succeeds

Closes SAP-1204.