### PR TITLE
improve authoring, add new tools

### DIFF
--- a/.changeset/authoring-bundle-for-deploy.md
+++ b/.changeset/authoring-bundle-for-deploy.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/orchestration-core": patch
+---
+
+Improve the initial git + deploy experience for workflow authoring. Adds `bundleForDeploy` — a local, no-network bundler that inlines local/shared source and externalizes npm dependencies — and smooths first-time git init / deploy so a fresh workflow project deploys cleanly.
+
+```ts
+import { bundleForDeploy } from "@sapiom/orchestration-core";
+
+const bundle = await bundleForDeploy(/* … */);
+```

--- a/.changeset/general-agent-tool.md
+++ b/.changeset/general-agent-tool.md
@@ -1,0 +1,19 @@
+---
+"@sapiom/tools": patch
+---
+
+Add the general `agent` capability — an instant, in-server agent (prompt → text), optionally calling tools on remote MCP servers. No sandbox.
+
+```ts
+import { agent } from "@sapiom/tools";
+
+// run inline:
+const res = await agent.run({ prompt: "Summarize this transcript: …" });
+console.log(res.output);
+
+// or dispatch from a workflow step and resume when it finishes:
+const handle = await agent.launch({ prompt: "…", mcps: [{ /* … */ }] });
+return pauseUntilSignal(handle, { resumeStep: "use-result" });
+```
+
+`run` resolves to an `AgentRunResult` (`output` carries the final text); `launch` returns a handle usable with `pauseUntilSignal`. Also exports `AGENT_RUN_RESULT_SIGNAL` for the static `pause` declaration on a step. This sits alongside the existing `agent.coding` capability.

--- a/.changeset/sandboxes-get-list.md
+++ b/.changeset/sandboxes-get-list.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/tools": patch
+---
+
+Add `sandboxes.get` and `sandboxes.list` — read-only access to a sandbox's metadata and current status.
+
+```ts
+import { sandboxes } from "@sapiom/tools";
+
+const info = await sandboxes.get("build-01"); // { status, url, tier, expiresAt, … }
+const all = await sandboxes.list();
+```
+
+Both return plain `SandboxInfo` metadata (status, URL, tier, TTL), not a live handle — use `attach(name)` to operate on a sandbox. Handy for checking readiness, or whether a sandbox already exists before creating one. `get` throws if the named sandbox does not exist.

--- a/packages/orchestration-core/src/bundle.spec.ts
+++ b/packages/orchestration-core/src/bundle.spec.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { bundleForDeploy } from './bundle.js';
+
+describe('bundleForDeploy', () => {
+  let proj: string;
+
+  beforeEach(() => {
+    proj = mkdtempSync(path.join(tmpdir(), 'byo-bundle-'));
+    // A shared local util reached by a relative import — must be INLINED.
+    mkdirSync(path.join(proj, 'shared'), { recursive: true });
+    writeFileSync(path.join(proj, 'shared', 'util.ts'), 'export const greeting = "shared-hi";\n');
+    // A fake installed npm dep — must stay EXTERNAL and have its version resolved.
+    mkdirSync(path.join(proj, 'node_modules', 'left-pad'), { recursive: true });
+    writeFileSync(
+      path.join(proj, 'node_modules', 'left-pad', 'package.json'),
+      JSON.stringify({ name: 'left-pad', version: '1.3.0' }),
+    );
+    writeFileSync(
+      path.join(proj, 'index.ts'),
+      [
+        'import { greeting } from "./shared/util.js";',
+        'import leftPad from "left-pad";',
+        'export const out = greeting + String(leftPad);',
+      ].join('\n') + '\n',
+    );
+  });
+
+  afterEach(() => rmSync(proj, { recursive: true, force: true }));
+
+  it('inlines relative/shared imports and externalizes npm deps with resolved versions', async () => {
+    const { code, dependencies } = await bundleForDeploy(proj);
+
+    // The shared util is inlined — its content is present and the relative import is gone.
+    expect(code).toContain('shared-hi');
+    expect(code).not.toMatch(/from\s+["']\.\/shared\/util/);
+
+    // The npm dep is kept external (the server install provides it)…
+    expect(code).toMatch(/from\s+["']left-pad["']/);
+    // …and pinned to the version installed in the author's tree.
+    expect(dependencies).toEqual({ 'left-pad': '1.3.0' });
+  });
+
+  it('does not list Node built-ins as dependencies', async () => {
+    writeFileSync(
+      path.join(proj, 'index.ts'),
+      ['import { readFileSync } from "node:fs";', 'export const out = typeof readFileSync;'].join('\n') + '\n',
+    );
+    const { dependencies } = await bundleForDeploy(proj);
+    expect(dependencies).toEqual({});
+  });
+});

--- a/packages/orchestration-core/src/bundle.ts
+++ b/packages/orchestration-core/src/bundle.ts
@@ -1,0 +1,138 @@
+/**
+ * bundle-for-deploy — collapse an orchestration's LOCAL/relative code into a
+ * single self-contained `index.ts`, while leaving npm packages external.
+ *
+ * This is what lets a definition import shared local utils (relative imports,
+ * not published packages) and still deploy: esbuild inlines everything reachable
+ * by relative path — including shared files outside the definition's own folder,
+ * e.g. `import { fmt } from "../../shared/format.js"` in a monorepo — so the
+ * pushed source no longer references anything above the repo root.
+ *
+ * npm packages are deliberately kept EXTERNAL (`packages: 'external'`) and
+ * surfaced as a synthesized dependency list (pinned to the author's installed
+ * versions). The server install resolves them at build time — so third-party
+ * deps and the `@sapiom/*` SDK are still installed server-side (bring-your-own-
+ * deps), not frozen into the bundle.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { isBuiltin } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import * as esbuild from 'esbuild';
+
+import { OrchestrationError } from './errors.js';
+
+export interface DeployBundle {
+  /** The bundled `index.ts` source (relative code inlined, npm imports external). */
+  code: string;
+  /** npm dependencies the bundle imports, pinned to the author's installed versions. */
+  dependencies: Record<string, string>;
+}
+
+/**
+ * Bundle `<sourceDir>/index.ts`, inlining relative imports and externalizing npm
+ * packages, then resolve each external package to the version installed in the
+ * author's tree. Throws `OrchestrationError` (`NO_ENTRY` | `BUNDLE_FAILED`).
+ */
+export async function bundleForDeploy(sourceDir: string): Promise<DeployBundle> {
+  const entryFile = path.join(sourceDir, 'index.ts');
+  if (!existsSync(entryFile)) {
+    throw new OrchestrationError({
+      code: 'NO_ENTRY',
+      message: `No index.ts found in ${sourceDir}.`,
+      hint: 'Run this from an orchestration project, or pass its directory.',
+    });
+  }
+
+  const tmp = mkdtempSync(path.join(tmpdir(), 'sapiom-deploy-bundle-'));
+  const outfile = path.join(tmp, 'index.js');
+  try {
+    let result: esbuild.BuildResult;
+    try {
+      result = await esbuild.build({
+        entryPoints: [entryFile],
+        outfile,
+        bundle: true,
+        platform: 'node',
+        target: 'node20',
+        format: 'esm',
+        // Inline relative/local code; keep every npm package import external so the
+        // server install (not this bundle) provides them.
+        packages: 'external',
+        metafile: true,
+        logLevel: 'silent',
+      });
+    } catch (err) {
+      throw new OrchestrationError({
+        code: 'BUNDLE_FAILED',
+        message: 'Failed to bundle the orchestration for deploy.',
+        hint: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const code = readFileSync(outfile, 'utf8');
+    const externals = collectExternalPackages(result.metafile!, outfile);
+    const dependencies = resolveInstalledVersions(sourceDir, externals);
+    return { code, dependencies };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The npm package names left external in the bundle (Node built-ins excluded).
+ * A subpath import (`zod/v4`, `@scope/pkg/sub`) is reduced to its package name.
+ */
+function collectExternalPackages(metafile: esbuild.Metafile, outfile: string): string[] {
+  const key = Object.keys(metafile.outputs).find((k) => path.resolve(k) === path.resolve(outfile));
+  const imports = key ? metafile.outputs[key].imports : [];
+  const names = new Set<string>();
+  for (const imp of imports) {
+    if (!imp.external) continue;
+    const name = packageNameOf(imp.path);
+    if (name && !isBuiltin(name)) names.add(name);
+  }
+  return [...names].sort();
+}
+
+/** `zod/v4` → `zod`; `@sapiom/orchestration/x` → `@sapiom/orchestration`. */
+function packageNameOf(importPath: string): string | null {
+  if (importPath.startsWith('node:')) return null;
+  const parts = importPath.split('/');
+  if (importPath.startsWith('@')) return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+  return parts[0] || null;
+}
+
+/**
+ * Resolve each package to the version installed in the author's tree (walking up
+ * from `sourceDir` like Node resolution), pinned exactly so the server build
+ * installs precisely what the author developed against. A package with no
+ * installed copy is recorded as `latest` (the server install will resolve it).
+ */
+function resolveInstalledVersions(sourceDir: string, packages: string[]): Record<string, string> {
+  const deps: Record<string, string> = {};
+  for (const pkg of packages) {
+    deps[pkg] = readInstalledVersion(sourceDir, pkg) ?? 'latest';
+  }
+  return deps;
+}
+
+function readInstalledVersion(fromDir: string, pkg: string): string | null {
+  let dir = path.resolve(fromDir);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const pkgJson = path.join(dir, 'node_modules', ...pkg.split('/'), 'package.json');
+    if (existsSync(pkgJson)) {
+      try {
+        const version = (JSON.parse(readFileSync(pkgJson, 'utf8')) as { version?: string }).version;
+        if (version) return version;
+      } catch {
+        // unreadable — fall through to keep walking up
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/packages/orchestration-core/src/deploy.ts
+++ b/packages/orchestration-core/src/deploy.ts
@@ -5,9 +5,14 @@
  * Networked operation: requires a GatewayClient. All inputs passed explicitly;
  * no process.cwd() reads — the caller supplies the project directory and client.
  */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { bundleForDeploy } from './bundle.js';
 import { GatewayClient } from './client.js';
 import { OrchestrationError } from './errors.js';
-import { assertDeployable, pushHead } from './git.js';
+import { assertDeployable, pushSynthesizedTree } from './git.js';
 
 interface BuildRun {
   id?: string;
@@ -50,11 +55,30 @@ export async function deploy(opts: DeployOptions, client: GatewayClient): Promis
 
   assertDeployable(projectDir);
 
+  // Bundle the definition's LOCAL code (inlining relative/shared imports) into a
+  // self-contained `index.ts`, with npm packages left external + surfaced as a
+  // generated package.json (pinned to the author's installed versions). We push
+  // THIS synthesized tree — not the author's raw commit — so shared local utils
+  // (relative imports that escape the repo root) are already inlined, while the
+  // server build still installs the npm deps (bring-your-own-deps).
+  const { code, dependencies } = await bundleForDeploy(projectDir);
+
   const { pushUrl } = await client.post<{ pushUrl: string }>(
     `/definitions/${definitionId}/push-credentials`,
     {},
   );
-  pushHead(projectDir, pushUrl, branch);
+
+  const treeDir = mkdtempSync(path.join(tmpdir(), 'sapiom-deploy-'));
+  try {
+    writeFileSync(path.join(treeDir, 'index.ts'), code);
+    writeFileSync(
+      path.join(treeDir, 'package.json'),
+      JSON.stringify({ name: 'orchestration-definition', private: true, type: 'module', dependencies }, null, 2) + '\n',
+    );
+    pushSynthesizedTree(treeDir, pushUrl, branch);
+  } finally {
+    rmSync(treeDir, { recursive: true, force: true });
+  }
 
   const triggered = await client.post<BuildRun>(`/definitions/${definitionId}/builds`, {});
   const buildRunId = triggered.buildRunId ?? triggered.id;

--- a/packages/orchestration-core/src/git.ts
+++ b/packages/orchestration-core/src/git.ts
@@ -49,3 +49,17 @@ export function pushHead(dir: string, pushUrl: string, branch: string): void {
   // of truth for their definition; the remote is only a build source.
   git(['push', '--force', pushUrl, `HEAD:${branch}`], dir);
 }
+
+/**
+ * Initialize a throwaway git repo over a synthesized deploy tree and force-push
+ * it to the definition repo. `deploy` uses this to ship a self-contained build
+ * source (the bundled definition + a generated package.json) rather than the
+ * author's raw commit — so relative imports that escape the author's repo root
+ * (shared local utils) are already inlined and the remote build can resolve them.
+ */
+export function pushSynthesizedTree(treeDir: string, pushUrl: string, branch: string): void {
+  git(['init', '-q', '-b', branch], treeDir);
+  git(['add', '-A'], treeDir);
+  git(['-c', 'user.email=deploy@sapiom.ai', '-c', 'user.name=Sapiom Deploy', 'commit', '-q', '-m', 'deploy'], treeDir);
+  git(['push', '--force', pushUrl, `HEAD:${branch}`], treeDir);
+}

--- a/packages/orchestration-core/src/index.ts
+++ b/packages/orchestration-core/src/index.ts
@@ -50,6 +50,10 @@ export type {
 export { check } from "./check.js";
 export type { CheckOptions, CheckResult } from "./check.js";
 
+// bundle-for-deploy (local, no network) — inline local/shared code, externalize npm deps
+export { bundleForDeploy } from "./bundle.js";
+export type { DeployBundle } from "./bundle.js";
+
 // link (networked)
 export { link } from "./link.js";
 export type { LinkOptions, LinkResult, DefinitionSummary } from "./link.js";

--- a/packages/tools/src/agent/index.ts
+++ b/packages/tools/src/agent/index.ts
@@ -318,7 +318,7 @@ function buildBody(spec: CodingRunSpec): Record<string, unknown> {
   };
 }
 
-export async function launch(
+export async function codingLaunch(
   spec: CodingRunSpec,
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
@@ -375,14 +375,233 @@ export async function launch(
   };
 }
 
-export async function run(
+export async function codingRun(
   spec: CodingRunSpec,
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<CodingRunResult> {
-  const handle = await launch(spec, transport, baseUrl);
+  const handle = await codingLaunch(spec, transport, baseUrl);
   return handle.wait();
 }
 
 /** Ambient-bound `agent.coding` namespace. */
-export const coding = { run, launch };
+export const coding = { run: codingRun, launch: codingLaunch };
+
+// ============================================================================
+// Default agent (instant, in-server loop) — `agent.run` / `agent.launch`
+//
+// The fast, no-sandbox sibling of `agent.coding`: hand it a prompt (and optional
+// remote MCP tools), the loop runs in Sapiom's server and returns text. No
+// filesystem, no sandbox handle. Multi-model under the hood; you just call
+// `agent.run`. Same dispatch contract as coding, so `launch()` works with
+// `pauseUntilSignal(handle, { resumeStep })`.
+// ============================================================================
+
+/**
+ * Capability-stable signal an instant agent run fires when it reaches a terminal
+ * state (completed OR failed — it carries the result either way). A workflow step
+ * paused on an agent-run handle resumes on this; it's the handle's
+ * `dispatch.resultSignal`.
+ */
+export const AGENT_RUN_RESULT_SIGNAL = "agent.run.result";
+
+/** Run lifecycle, mirrored from the gateway's `AgentRunStatus` (no `queued`). */
+export type AgentRunStatus = "pending" | "running" | "completed" | "failed";
+const AGENT_TERMINAL = new Set<AgentRunStatus>(["completed", "failed"]);
+
+/** A remote MCP server (Streamable HTTP) the agent may call tools on. */
+export interface AgentMcp {
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface AgentRunSpec {
+  /** The prompt for the agent. */
+  prompt: string;
+  /** System prompt steering the agent. */
+  system?: string;
+  /** Override the model / routing alias. */
+  model?: string;
+  /** Max output tokens per turn. */
+  maxTokens?: number;
+  /** Remote MCP servers the agent may call tools on (network round-trip per call). */
+  mcps?: AgentMcp[];
+}
+
+export interface AgentRunOutcome {
+  success: boolean;
+  stopReason: string;
+  turns: number;
+  modelUsed: string | null;
+  durationMs: number;
+  costUsd: number;
+  usage: CodingRunUsage;
+}
+
+export interface AgentRunError {
+  message: string;
+}
+
+export interface AgentRunResult {
+  runId: string;
+  status: AgentRunStatus;
+  /** The agent's final text output (null while non-terminal). */
+  output: string | null;
+  result: AgentRunOutcome | null;
+  error: AgentRunError | null;
+}
+
+/**
+ * A launched-but-not-awaited instant run. Satisfies {@link DispatchHandle}, so it
+ * can be handed to `pauseUntilSignal(handle, { resumeStep })` — or `wait()`-ed
+ * inline. Unlike coding there is no `sandbox` (the loop runs in-server).
+ */
+export interface AgentRunHandle extends DispatchHandle {
+  runId: string;
+  status(): Promise<AgentRunStatus>;
+  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<AgentRunResult>;
+}
+
+/**
+ * The instant run's terminal result as it arrives at a step resumed from
+ * `pauseUntilSignal(runHandle, { resumeStep })` — the signal payload delivered as
+ * that step's `input`. No live handles cross the wire, so it equals
+ * {@link AgentRunResult}. Annotate a resumed step's input with this.
+ */
+export type AgentRunResultPayload = AgentRunResult;
+
+/** Thrown by {@link agentRunResultSchema}.parse on a malformed resume payload. */
+export class AgentRunResultSchemaError extends Error {}
+
+/** Runtime validator for {@link AgentRunResultPayload}. */
+export const agentRunResultSchema = {
+  parse(value: unknown): AgentRunResultPayload {
+    const fail = (msg: string): never => {
+      throw new AgentRunResultSchemaError(`invalid agent run result payload: ${msg}`);
+    };
+    if (!value || typeof value !== "object") fail("not an object");
+    const v = value as Record<string, unknown>;
+    if (typeof v.runId !== "string") fail("runId must be a string");
+    if (!(["pending", "running", "completed", "failed"] as AgentRunStatus[]).includes(v.status as AgentRunStatus))
+      fail("status must be a valid AgentRunStatus");
+    if (v.output !== null && typeof v.output !== "string") fail("output must be a string or null");
+    if (v.result !== null && (typeof v.result !== "object" || !v.result)) fail("result must be an object or null");
+    if (v.error !== null && (typeof v.error !== "object" || !v.error)) fail("error must be an object or null");
+    return value as AgentRunResultPayload;
+  },
+};
+
+// --- wire shapes (snake_case, as served by the gateway serializer) ---
+
+interface AgentWireResult {
+  success: boolean;
+  stop_reason: string;
+  turns: number;
+  model_used: string | null;
+  duration_ms: number;
+  cost_usd: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_tokens?: number;
+    cache_create_tokens?: number;
+    thinking_tokens?: number;
+  };
+}
+
+interface AgentRunDoc {
+  data: {
+    id: string;
+    attributes: {
+      status: AgentRunStatus;
+      output?: string | null;
+      result?: AgentWireResult | null;
+      error?: { message: string } | null;
+    };
+  };
+}
+
+function mapAgentResult(r: AgentWireResult | null | undefined): AgentRunOutcome | null {
+  if (!r) return null;
+  return {
+    success: r.success,
+    stopReason: r.stop_reason,
+    turns: r.turns,
+    modelUsed: r.model_used ?? null,
+    durationMs: r.duration_ms,
+    costUsd: r.cost_usd,
+    usage: {
+      inputTokens: r.usage?.input_tokens ?? 0,
+      outputTokens: r.usage?.output_tokens ?? 0,
+      cacheReadTokens: r.usage?.cache_read_tokens ?? 0,
+      cacheCreateTokens: r.usage?.cache_create_tokens ?? 0,
+      thinkingTokens: r.usage?.thinking_tokens ?? 0,
+    },
+  };
+}
+
+function buildAgentBody(spec: AgentRunSpec): Record<string, unknown> {
+  return {
+    prompt: spec.prompt,
+    system: spec.system,
+    model: spec.model,
+    max_tokens: spec.maxTokens,
+    mcps: spec.mcps,
+  };
+}
+
+export async function launch(
+  spec: AgentRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<AgentRunHandle> {
+  const doc = await transport.request<AgentRunDoc>(`${baseUrl}/v1/agent/runs`, {
+    method: "POST",
+    body: JSON.stringify(buildAgentBody(spec)),
+    headers: workflowResumeHeaders(transport.resumeToken),
+  });
+  const runId = doc.data.id;
+
+  const fetchDoc = () =>
+    transport.request<AgentRunDoc>(`${baseUrl}/v1/agent/runs/${encodeURIComponent(runId)}`);
+  const toResult = (d: AgentRunDoc): AgentRunResult => ({
+    runId,
+    status: d.data.attributes.status,
+    output: d.data.attributes.output ?? null,
+    result: mapAgentResult(d.data.attributes.result),
+    error: d.data.attributes.error ?? null,
+  });
+
+  return {
+    runId,
+    // Framework plumbing for `pauseUntilSignal` — correlationId is the run id (the
+    // join key x402 echoes back when it forwards completion).
+    dispatch: { correlationId: runId, resultSignal: AGENT_RUN_RESULT_SIGNAL },
+    async status() {
+      return (await fetchDoc()).data.attributes.status;
+    },
+    async wait({ timeoutMs = 10 * 60_000, pollMs = 2_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (AGENT_TERMINAL.has(d.data.attributes.status)) return toResult(d);
+        if (Date.now() > deadline) {
+          throw new Error(
+            `agent run ${runId} timed out after ${timeoutMs}ms (last status: ${d.data.attributes.status})`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+export async function run(
+  spec: AgentRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<AgentRunResult> {
+  const handle = await launch(spec, transport, baseUrl);
+  return handle.wait();
+}

--- a/packages/tools/src/agent/run-launch.spec.ts
+++ b/packages/tools/src/agent/run-launch.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * agent.run / agent.launch (default, instant in-server agent) — dispatch-handle
+ * shape, terminal-result mapping, and workflow resume-token forwarding. Injects a
+ * fake fetch (no real network).
+ */
+import { createClient } from "../index.js";
+import { AGENT_RUN_RESULT_SIGNAL } from "./index.js";
+
+function fakeFetch(opts: {
+  capture?: { headers?: Record<string, string>; url?: string };
+  terminal?: boolean;
+}): typeof globalThis.fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    if (opts.capture) {
+      opts.capture.headers = init.headers as Record<string, string>;
+      opts.capture.url = url;
+    }
+    const isPost = (init.method ?? "GET") === "POST";
+    const attributes = isPost
+      ? { status: "pending" }
+      : {
+          status: "completed",
+          output: "OK",
+          result: {
+            success: true,
+            stop_reason: "end_turn",
+            turns: 1,
+            model_used: "claude-sonnet-4-6",
+            duration_ms: 1200,
+            cost_usd: 0.001,
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+          error: null,
+        };
+    return {
+      ok: true,
+      status: isPost ? 202 : 200,
+      json: async () => ({ data: { id: "run-abc", attributes } }),
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("agent.launch — dispatch handle", () => {
+  it("returns a handle that satisfies DispatchHandle", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({}) });
+    const handle = await sapiom.agent.launch({ prompt: "say OK" });
+    expect(handle.runId).toBe("run-abc");
+    expect(handle.dispatch).toEqual({
+      correlationId: "run-abc",
+      resultSignal: AGENT_RUN_RESULT_SIGNAL,
+    });
+  });
+
+  it("AGENT_RUN_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(AGENT_RUN_RESULT_SIGNAL).toBe("agent.run.result");
+  });
+
+  it("posts to /v1/agent/runs", async () => {
+    const capture: { url?: string } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({ capture }) });
+    await sapiom.agent.launch({ prompt: "say OK" });
+    expect(capture.url).toContain("/v1/agent/runs");
+  });
+});
+
+describe("agent.run — terminal result mapping", () => {
+  it("maps the wire result (snake_case) to the SDK shape", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({}) });
+    const result = await sapiom.agent.run({ prompt: "say OK" });
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("OK");
+    expect(result.result?.stopReason).toBe("end_turn");
+    expect(result.result?.costUsd).toBe(0.001);
+    expect(result.result?.usage.inputTokens).toBe(10);
+  });
+});
+
+describe("agent.launch — workflow resume token", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("forwards the env token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-xyz";
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({ capture }) });
+    await sapiom.agent.launch({ prompt: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBe("tok-xyz");
+  });
+
+  it("omits the header outside a workflow (no env token)", async () => {
+    const capture: { headers?: Record<string, string> } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({ capture }) });
+    await sapiom.agent.launch({ prompt: "t" });
+    expect(capture.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
+  });
+});

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -23,11 +23,19 @@ import {
 import { Sandbox } from "./sandboxes/index.js";
 import type { SandboxCreateOptions, SandboxInfo } from "./sandboxes/index.js";
 import { Repository } from "./repositories/index.js";
-import { run as codingRun, launch as codingLaunch } from "./agent/index.js";
+import {
+  codingRun,
+  codingLaunch,
+  run as agentRun,
+  launch as agentLaunch,
+} from "./agent/index.js";
 import type {
   CodingRunSpec,
   CodingRunResult,
   RunHandle,
+  AgentRunSpec,
+  AgentRunResult,
+  AgentRunHandle,
 } from "./agent/index.js";
 import {
   run as orchestrationsRun,
@@ -97,6 +105,10 @@ export interface Sapiom {
     attach(slug: string, cloneUrl: string): Repository;
   };
   readonly agent: {
+    /** Instant in-server agent: prompt (+ optional remote MCP tools) → text. No sandbox. */
+    run(spec: AgentRunSpec): Promise<AgentRunResult>;
+    /** Launch an instant run; pass the handle to `pauseUntilSignal` to suspend on it. */
+    launch(spec: AgentRunSpec): Promise<AgentRunHandle>;
     coding: {
       run(spec: CodingRunSpec): Promise<CodingRunResult>;
       launch(spec: CodingRunSpec): Promise<RunHandle>;
@@ -196,6 +208,8 @@ function bind(transport: Transport): Sapiom {
       attach: (slug, cloneUrl) => Repository.attach(slug, cloneUrl, transport),
     },
     agent: {
+      run: (spec) => agentRun(spec, transport),
+      launch: (spec) => agentLaunch(spec, transport),
       coding: {
         run: (spec) => codingRun(spec, transport),
         launch: (spec) => codingLaunch(spec, transport),

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -21,7 +21,7 @@ import {
   type Attribution,
 } from "./_client/index.js";
 import { Sandbox } from "./sandboxes/index.js";
-import type { SandboxCreateOptions } from "./sandboxes/index.js";
+import type { SandboxCreateOptions, SandboxInfo } from "./sandboxes/index.js";
 import { Repository } from "./repositories/index.js";
 import { run as codingRun, launch as codingLaunch } from "./agent/index.js";
 import type {
@@ -84,6 +84,10 @@ export interface Sapiom {
       name: string,
       opts?: { workspaceRoot?: string; baseUrl?: string },
     ): Sandbox;
+    /** Fetch a sandbox's metadata + status by name (read-only; `attach` to operate). */
+    get(name: string, opts?: { baseUrl?: string }): Promise<SandboxInfo>;
+    /** List the caller's sandboxes as read-only metadata. */
+    list(opts?: { baseUrl?: string }): Promise<SandboxInfo[]>;
   };
   readonly repositories: {
     create(slug: string): Promise<Repository>;
@@ -181,6 +185,8 @@ function bind(transport: Transport): Sapiom {
     sandboxes: {
       create: (opts) => Sandbox.create(opts, transport),
       attach: (name, opts) => Sandbox.attach(name, opts, transport),
+      get: (name, opts) => Sandbox.get(name, opts, transport),
+      list: (opts) => Sandbox.list(opts, transport),
     },
     repositories: {
       create: (slug) => Repository.create(slug, transport),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -42,6 +42,21 @@ export {
   toResumePayload,
   EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
 } from "./agent/index.js";
+// Default (instant, in-server) agent — `agent.run` / `agent.launch`. Signal const
+// for a step's static `pause: { signal }` decl; the result payload shape + schema
+// for a step resumed from `pauseUntilSignal(agentHandle, …)`.
+export { AGENT_RUN_RESULT_SIGNAL } from "./agent/index.js";
+export type {
+  AgentRunSpec,
+  AgentRunResult,
+  AgentRunOutcome,
+  AgentRunError,
+  AgentRunStatus,
+  AgentRunHandle,
+  AgentRunResultPayload,
+  AgentMcp,
+} from "./agent/index.js";
+export { agentRunResultSchema, AgentRunResultSchemaError } from "./agent/index.js";
 
 export * as orchestrations from "./orchestrations/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.

--- a/packages/tools/src/sandboxes/README.md
+++ b/packages/tools/src/sandboxes/README.md
@@ -17,6 +17,8 @@ await box.destroy();
 
 - **`name` is how you find a sandbox again.** Use `attach(name)` to reconnect to an already-running sandbox — for example from another process, or one returned by a coding agent run — without provisioning a new one. `create` provisions a fresh sandbox; `attach` adopts an existing one.
 
+- **`get` and `list` are read-only.** `get(name)` returns a sandbox's metadata and current `status` (e.g. `"running"`, `"stopped"`); `list()` returns all your sandboxes. They return plain info, not a handle — `attach(name)` when you want to operate. Handy for checking readiness or whether a sandbox already exists before creating one.
+
 - **Credentials are not injected automatically.** The sandbox environment is empty by default. Pass anything your workload needs explicitly via `envs` when you create the sandbox.
 
 - **`exec` waits for the command to finish.** It returns once the command exits, with `{ exitCode, stdout, stderr }` — including non-zero exits (a failed command resolves with its real `exitCode`; it does not throw). For commands that run longer than a single request, use `execStream` for live output, or start the process and poll it with `getProcess` / `waitForProcess`.
@@ -27,6 +29,6 @@ await box.destroy();
 
 ## Reference
 
-`create` · `attach` · `exec` · `execStream` · `readFile` · `writeFile` · `uploadFile` · `getProcess` · `waitForProcess` · `destroy`
+`create` · `attach` · `get` · `list` · `exec` · `execStream` · `readFile` · `writeFile` · `uploadFile` · `getProcess` · `waitForProcess` · `destroy`
 
 See the exported types for full signatures and options.

--- a/packages/tools/src/sandboxes/index.spec.ts
+++ b/packages/tools/src/sandboxes/index.spec.ts
@@ -163,3 +163,67 @@ describe("Sandbox.uploadFile — multipart lifecycle", () => {
     expect(calls).toContain("abort");
   });
 });
+
+describe("Sandbox.get / Sandbox.list — read-only metadata", () => {
+  function transportRouting(
+    route: (url: string, init: RequestInit) => FakeResponse,
+  ): Transport {
+    const fetchFn = (async (url: string, init: RequestInit = {}) =>
+      route(
+        url,
+        init,
+      ) as unknown as Response) as unknown as typeof globalThis.fetch;
+    return new Transport({ apiKey: "k", fetch: fetchFn });
+  }
+
+  const info = {
+    name: "box-1",
+    source: "user",
+    status: "running",
+    tier: "s",
+    url: "https://box-1.preview",
+    workspaceRoot: "/workspace",
+    expiresAt: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+
+  it("get() fetches a single sandbox's metadata by name", async () => {
+    let seen = "";
+    const t = transportRouting((url) => {
+      seen = url;
+      return ok(info);
+    });
+    const result = await Sandbox.get("box-1", { baseUrl: "https://sbx" }, t);
+    expect(seen).toBe("https://sbx/v1/sandboxes/box-1");
+    expect(result).toEqual(info);
+  });
+
+  it("get() URL-encodes the name", async () => {
+    let seen = "";
+    const t = transportRouting((url) => {
+      seen = url;
+      return ok(info);
+    });
+    await Sandbox.get("a/b", { baseUrl: "https://sbx" }, t);
+    expect(seen).toBe("https://sbx/v1/sandboxes/a%2Fb");
+  });
+
+  it("get() throws when the sandbox does not exist", async () => {
+    const t = transportRouting(() => err(404, "not found"));
+    await expect(
+      Sandbox.get("missing", { baseUrl: "https://sbx" }, t),
+    ).rejects.toThrow();
+  });
+
+  it("list() unwraps and returns the sandboxes array", async () => {
+    let seen = "";
+    const t = transportRouting((url) => {
+      seen = url;
+      return ok({ sandboxes: [info, { ...info, name: "box-2" }] });
+    });
+    const result = await Sandbox.list({ baseUrl: "https://sbx" }, t);
+    expect(seen).toBe("https://sbx/v1/sandboxes");
+    expect(result.map((s) => s.name)).toEqual(["box-1", "box-2"]);
+  });
+});

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -37,6 +37,7 @@ import type {
   ProcessCreateResponse,
   ProcessStatus,
   SandboxCreateOptions,
+  SandboxInfo,
   StreamingExecResult,
   UploadFileOptions,
 } from "./types.js";
@@ -54,6 +55,7 @@ export type {
   PortSpec,
   ProcessStatus,
   SandboxCreateOptions,
+  SandboxInfo,
   SandboxTier,
   StreamingExecResult,
   UploadFileOptions,
@@ -194,6 +196,34 @@ export class Sandbox {
       transport,
       opts.baseUrl ?? DEFAULT_BASE_URL,
     );
+  }
+
+  /**
+   * Fetch a sandbox's metadata + current status by name. Read-only — returns a
+   * {@link SandboxInfo}, not a live handle; use {@link attach} to operate on it.
+   * Throws if the sandbox does not exist.
+   */
+  static get(
+    name: string,
+    opts: { baseUrl?: string } = {},
+    transport: Transport = defaultTransport(),
+  ): Promise<SandboxInfo> {
+    const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+    return transport.request<SandboxInfo>(
+      `${baseUrl}/v1/sandboxes/${encodeURIComponent(name)}`,
+    );
+  }
+
+  /** List the caller's sandboxes as read-only {@link SandboxInfo} metadata. */
+  static async list(
+    opts: { baseUrl?: string } = {},
+    transport: Transport = defaultTransport(),
+  ): Promise<SandboxInfo[]> {
+    const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+    const data = await transport.request<{ sandboxes: SandboxInfo[] }>(
+      `${baseUrl}/v1/sandboxes`,
+    );
+    return data.sandboxes;
   }
 
   private fileUrl(path: string): string {
@@ -631,4 +661,17 @@ export function attach(
   opts?: { workspaceRoot?: string; baseUrl?: string },
 ): Sandbox {
   return Sandbox.attach(name, opts);
+}
+
+/** Fetch a sandbox's metadata + status by name (ambient transport). */
+export function get(
+  name: string,
+  opts?: { baseUrl?: string },
+): Promise<SandboxInfo> {
+  return Sandbox.get(name, opts);
+}
+
+/** List the caller's sandboxes as read-only metadata (ambient transport). */
+export function list(opts?: { baseUrl?: string }): Promise<SandboxInfo[]> {
+  return Sandbox.list(opts);
 }

--- a/packages/tools/src/sandboxes/types.ts
+++ b/packages/tools/src/sandboxes/types.ts
@@ -177,6 +177,35 @@ export interface UploadFileOptions {
   ) => void;
 }
 
+/**
+ * Read-model view of a sandbox returned by `get` / `list` — its metadata and
+ * current status, not a live handle. Use `attach(name)` to operate on it.
+ */
+export interface SandboxInfo {
+  /** Sandbox name — the identifier `attach(name)` takes. */
+  readonly name: string;
+  /** What created the sandbox. */
+  readonly source: string;
+  /** Lifecycle status — e.g. `"deploying"`, `"running"`, `"stopped"`, `"failed"`. */
+  readonly status: string;
+  /** Memory tier the sandbox was allocated with. */
+  readonly tier: string;
+  /** Public base URL when one is exposed, otherwise `null`. */
+  readonly url: string | null;
+  /** Container image, when reported. */
+  readonly image?: string;
+  /** Last error message, when the sandbox is in a failed state. */
+  readonly error?: string;
+  /** Absolute workspace root path inside the sandbox. */
+  readonly workspaceRoot: string;
+  /** ISO-8601 expiry (TTL) timestamp, or `null` when it does not expire. */
+  readonly expiresAt: string | null;
+  /** ISO-8601 creation timestamp. */
+  readonly createdAt: string;
+  /** ISO-8601 last-update timestamp. */
+  readonly updatedAt: string;
+}
+
 // --- internal wire shapes (not part of the public surface) ---
 
 /** @internal Raw create response. */

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -28,6 +28,7 @@ import type {
 import type { Sapiom } from "../client.js";
 import { Repository } from "../repositories/index.js";
 import { Sandbox } from "../sandboxes/index.js";
+import type { SandboxInfo } from "../sandboxes/index.js";
 import type {
   UploadResponse,
   DownloadUrlResponse,
@@ -223,6 +224,21 @@ function asSandbox(data: unknown, overrides: StubOverrides): Sandbox {
     { name: d.name ?? "stub-sandbox", workspaceRoot: d.workspaceRoot },
     overrides,
   );
+}
+
+/** Default read-model for the `sandboxes.get` / `sandboxes.list` stubs. */
+function stubSandboxInfo(name: string): SandboxInfo {
+  return {
+    name,
+    source: "stub",
+    status: "running",
+    tier: "s",
+    url: null,
+    workspaceRoot: "/workspace",
+    expiresAt: null,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
 }
 
 /** Coerce a `repositories.list` override (or default) into Repository handles,
@@ -439,6 +455,18 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         asSandbox(
           r("sandboxes.attach", [name, attachOpts], () => ({ name })),
           overrides,
+        ),
+      get: (name, getOpts) =>
+        Promise.resolve(
+          r("sandboxes.get", [name, getOpts], () =>
+            stubSandboxInfo(name),
+          ) as SandboxInfo,
+        ),
+      list: (listOpts) =>
+        Promise.resolve(
+          r("sandboxes.list", [listOpts], () => [
+            stubSandboxInfo("stub-sandbox"),
+          ]) as SandboxInfo[],
         ),
     },
     repositories: {

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -18,8 +18,18 @@
  * replaces that capability's default; a function `(…args) => value` computes it
  * from the call arguments.
  */
-import { CODING_RESULT_SIGNAL, toResumePayload } from "../agent/index.js";
-import type { CodingRunResult, RunHandle, RunStatus } from "../agent/index.js";
+import {
+  AGENT_RUN_RESULT_SIGNAL,
+  CODING_RESULT_SIGNAL,
+  toResumePayload,
+} from "../agent/index.js";
+import type {
+  AgentRunHandle,
+  AgentRunResult,
+  CodingRunResult,
+  RunHandle,
+  RunStatus,
+} from "../agent/index.js";
 import { ORCHESTRATIONS_RESULT_SIGNAL } from "../orchestrations/index.js";
 import type {
   OrchestrationRunResult,
@@ -412,6 +422,50 @@ function stubRunHandle(
   ) as RunHandle;
 }
 
+function stubAgentResult(): AgentRunResult {
+  return {
+    runId: "stub-run",
+    status: "completed",
+    output: "(stub) agent run completed locally",
+    result: {
+      success: true,
+      stopReason: "end_turn",
+      turns: 1,
+      modelUsed: "stub-model",
+      durationMs: 0,
+      costUsd: 0,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        thinkingTokens: 0,
+      },
+    },
+    error: null,
+  };
+}
+
+function stubAgentRunHandle(
+  overrides: StubOverrides,
+  correlationId: string,
+  result: AgentRunResult,
+): AgentRunHandle {
+  const handle = {
+    runId: correlationId,
+    dispatch: { correlationId, resultSignal: AGENT_RUN_RESULT_SIGNAL },
+    status: () => Promise.resolve(result.status),
+    wait: () => Promise.resolve(result),
+  };
+  return makeHandle(
+    "runHandle",
+    RUN_HANDLE_METHODS,
+    handle as unknown as Record<string, unknown>,
+    overrides,
+    {},
+  ) as AgentRunHandle;
+}
+
 /**
  * Create a stub `Sapiom` client. Runs every capability against built-in defaults;
  * pass `overrides` to control the results a step branches on.
@@ -439,6 +493,14 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
     ) as CodingRunResult;
     return { ...res, sandbox: asSandbox(res.sandbox, overrides) };
   };
+
+  // Default (instant) agent result — no sandbox to re-wrap, so it's the resolved
+  // value as-is. `keys` lets `launch()` accept `agent.launch` and `agent.run`.
+  const resolveAgentResult = (
+    spec: unknown,
+    keys: string | string[],
+  ): AgentRunResult =>
+    r(keys, [spec], () => stubAgentResult()) as AgentRunResult;
 
   const client: Sapiom = {
     sandboxes: {
@@ -506,6 +568,21 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         ),
     },
     agent: {
+      run: (spec) => Promise.resolve(resolveAgentResult(spec, "agent.run")),
+      launch: (spec) => {
+        const correlationId = `stub-run-${++launchSeq}`;
+        // `launch()` honors `agent.launch` first, then the shared `agent.run`.
+        const result = {
+          ...resolveAgentResult(spec, dispatchedKeys("agent")),
+          runId: correlationId,
+        };
+        // The resume payload IS the result (no live handles to strip).
+        return dispatchable(
+          stubAgentRunHandle(overrides, correlationId, result),
+          opts.signals,
+          () => result,
+        );
+      },
       coding: {
         run: (spec) =>
           Promise.resolve(resolveCodingResult(spec, "agent.coding.run")),


### PR DESCRIPTION
This pull request introduces two major features: a new deploy-time bundling system for orchestration definitions, and the addition of support for instant, in-server agent runs in the tools SDK. The deploy process now bundles local/relative code into a self-contained `index.ts`, externalizes npm dependencies (with versions pinned to the author's install), and pushes this synthesized tree to the server. Separately, the agent SDK now exposes `agent.run` and `agent.launch` for instant agent runs (without a sandbox), with full type definitions, result mapping, and workflow integration. Both features are covered by new or updated tests.

**Deploy-time bundling and deployment changes:**

- **Added `bundleForDeploy` to inline local code and externalize npm deps:**  
  The new `bundleForDeploy` function in `bundle.ts` uses esbuild to inline all local/relative code (including shared utilities outside the project root) and leaves npm packages external, generating a dependency list pinned to the installed versions.
- **Deploy now pushes a synthesized tree, not the raw commit:**  
  The deploy logic in `deploy.ts` was updated to use the bundle output, write a generated `index.ts` and `package.json` to a temp directory, and push this synthesized tree using the new `pushSynthesizedTree` function. [[1]](diffhunk://#diff-e077feb3baa622fdb1e3525fb708e44ed5e58fe6dcd7ccc863e101f7c67b2f33R8-R15) [[2]](diffhunk://#diff-e077feb3baa622fdb1e3525fb708e44ed5e58fe6dcd7ccc863e101f7c67b2f33R58-R81) [[3]](diffhunk://#diff-aab9af9f8f43effb1b8df24f293249ba79777b431b974e5a72f64bb2e0f8d3ccR52-R65)
- **Exported bundling API for local use:**  
  The new bundling API (`bundleForDeploy` and `DeployBundle`) is exported from the package entrypoint.
- **Comprehensive tests for bundling behavior:**  
  Added tests to ensure local code is inlined, npm dependencies are externalized and version-pinned, and Node built-ins are not listed as dependencies.

**Agent SDK: instant in-server agent runs (`agent.run` / `agent.launch`):**

- **Introduced `agent.run` and `agent.launch` for instant agent runs:**  
  The SDK now exposes `agent.run` and `agent.launch` (with full type definitions and result mapping) for instant, in-server agent runs that do not require a sandbox. This includes all necessary types, result schemas, and workflow integration. [[1]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L317-R317) [[2]](diffhunk://#diff-f39e3bbb627a6de54fab56e1a66d348ee66a255c600e05187bd89a42ec1e7426L374-R603)
- **Added tests for agent run/launch handle and result mapping:**  
  New tests verify the dispatch handle shape, result mapping, and workflow resume token forwarding for `agent.run` and `agent.launch`.