### PR TITLE
feat(tools): repoint scrape/email/images verbs to /v1/capabilities (SAP-1116)

### DIFF
--- a/.changeset/repoint-routed-capabilities.md
+++ b/.changeset/repoint-routed-capabilities.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": minor
+---
+
+Repoint `scrape`, `emailSearch.*` (find/verify/domainSearch), and `contentGeneration.images.create` onto the Capability Router: each now sends `POST /v1/capabilities/<dotted-id>` on the single Core base URL instead of a provider-gateway subdomain.
+
+A new shared `capabilityCall(id, req, opts)` seam (in `_client/`) is the one place the routed-call contract lives — building the `/v1/capabilities/<id>` request, sending the `x-api-key` credential header, resolving the Core base URL **at call time** (no per-capability URL knob, no module-const import freeze), and mapping non-2xx to the capability's typed error. `web.search` is refactored onto it, and the three migrated verbs route through it too.
+
+Public verb names and signatures are unchanged (non-breaking); request/response shapes are mapped to the router's normalized DTOs internally. The deferred async/stateful capabilities (video, sandboxes, agents, …) keep their existing provider-gateway path.

--- a/packages/tools/src/_client/capability-call.spec.ts
+++ b/packages/tools/src/_client/capability-call.spec.ts
@@ -1,0 +1,165 @@
+import { Transport } from "./index.js";
+import { capabilityCall, resolveCoreBaseUrl } from "./capability-call.js";
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  response: (call: FetchCall) => Response,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url = String(input);
+    calls.push({ url, init });
+    return response({ url, init });
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+class FakeError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "FakeError";
+  }
+}
+const makeError = (m: string, s: number, b: unknown): Error =>
+  new FakeError(m, s, b);
+
+// ---------------------------------------------------------------------------
+// resolveCoreBaseUrl — call-time resolution from client config, single knob
+// ---------------------------------------------------------------------------
+
+describe("resolveCoreBaseUrl()", () => {
+  const KEYS = ["SAPIOM_BASE_URL", "SAPIOM_API_URL"] as const;
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("defaults to the production Core base URL", () => {
+    expect(resolveCoreBaseUrl()).toBe("https://api.sapiom.ai");
+  });
+
+  it("prefers SAPIOM_BASE_URL, then SAPIOM_API_URL", () => {
+    process.env.SAPIOM_API_URL = "https://api-url.example";
+    expect(resolveCoreBaseUrl()).toBe("https://api-url.example");
+    process.env.SAPIOM_BASE_URL = "https://base-url.example";
+    expect(resolveCoreBaseUrl()).toBe("https://base-url.example");
+  });
+
+  it("is resolved at call time — a value set after import is honored", () => {
+    expect(resolveCoreBaseUrl()).toBe("https://api.sapiom.ai");
+    process.env.SAPIOM_BASE_URL = "http://localhost:3000";
+    // No module-level freeze: the very next call reflects the new env.
+    expect(resolveCoreBaseUrl()).toBe("http://localhost:3000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capabilityCall — the single routed-call seam
+// ---------------------------------------------------------------------------
+
+describe("capabilityCall()", () => {
+  it("POSTs /v1/capabilities/<id> on the given base URL with x-api-key and a JSON body", async () => {
+    const { transport, calls } = makeTransport(() =>
+      jsonResponse({ ok: true }),
+    );
+
+    const out = await capabilityCall<{ ok: boolean }>(
+      "web.scrape",
+      { url: "https://example.com" },
+      {
+        transport,
+        baseUrl: "https://api.test",
+        makeError,
+        errorPrefix: "Failed to scrape",
+      },
+    );
+
+    expect(out).toEqual({ ok: true });
+    expect(calls[0]!.url).toBe("https://api.test/v1/capabilities/web.scrape");
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("defaults the base URL to the resolved Core base URL when none is given", async () => {
+    const { transport, calls } = makeTransport(() => jsonResponse({}));
+
+    await capabilityCall(
+      "email.verify",
+      { email: "a@b.com" },
+      { transport, makeError, errorPrefix: "x" },
+    );
+
+    expect(calls[0]!.url).toBe(
+      "https://api.sapiom.ai/v1/capabilities/email.verify",
+    );
+  });
+
+  it("throws the capability's typed error with the parsed JSON body on a non-2xx", async () => {
+    const { transport } = makeTransport(
+      () => new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
+    );
+
+    await expect(
+      capabilityCall(
+        "web.scrape",
+        {},
+        { transport, makeError, errorPrefix: "Failed to scrape" },
+      ),
+    ).rejects.toMatchObject({
+      name: "FakeError",
+      status: 500,
+      body: { error: "boom" },
+    });
+  });
+
+  it("falls back to the raw text body when the error response isn't JSON", async () => {
+    const { transport } = makeTransport(
+      () => new Response("upstream exploded", { status: 502 }),
+    );
+
+    await expect(
+      capabilityCall(
+        "web.scrape",
+        {},
+        { transport, makeError, errorPrefix: "Failed to scrape" },
+      ),
+    ).rejects.toMatchObject({ status: 502, body: "upstream exploded" });
+  });
+});

--- a/packages/tools/src/_client/capability-call.ts
+++ b/packages/tools/src/_client/capability-call.ts
@@ -1,0 +1,100 @@
+/**
+ * `capabilityCall` — the single routed-call seam every capability that lives on
+ * the Capability Router goes through (SAP-1116). It is the SDK-side anti-drift
+ * foundation: one place builds `POST /v1/capabilities/<id>`, one place resolves the
+ * Core base URL, one place sends the credential header, one place maps a non-2xx to
+ * a typed error. A NEW routed verb is then ~5 lines (build request DTO → call →
+ * map response DTO) and *cannot* diverge on transport, auth, or error handling.
+ *
+ *   const res = await capabilityCall<ScrapeResponse>("web.scrape", { url }, {
+ *     transport, makeError: (m, s, b) => new SearchHttpError(m, s, b),
+ *     errorPrefix: "Failed to scrape",
+ *   });
+ *
+ * Two patterns coexist by design (SAP-1112): routed caps come here; the deferred
+ * async/stateful caps (SAP-1117) keep their `resolveServiceUrl` → provider-gateway
+ * path. Do not consolidate the two until the async/resource primitives exist.
+ */
+import { Transport, defaultTransport } from "./index.js";
+
+/**
+ * The single Core base URL, resolved at CALL TIME — never frozen in a module-level
+ * const. Freezing the base URL at import is the SAP-1107 prod-escape 401 root cause:
+ * an in-process workflow step that imported a capability before the runtime set the
+ * env kept a stale (often prod) URL forever. Reading it per call means routed caps
+ * always honor the current client/runtime config, so that 401 class is structurally
+ * gone for routed caps even locally.
+ *
+ * Mirrors `@sapiom/core`'s base-URL convention (`SAPIOM_BASE_URL` → `SAPIOM_API_URL`
+ * → the production default). There is no per-capability URL knob: one Core base URL
+ * re-homes every routed verb at once, so nothing silently escapes to a stale host.
+ */
+export function resolveCoreBaseUrl(): string {
+  return (
+    process.env.SAPIOM_BASE_URL ??
+    process.env.SAPIOM_API_URL ??
+    "https://api.sapiom.ai"
+  );
+}
+
+/** Options for {@link capabilityCall}. */
+export interface CapabilityCallOptions {
+  /** Transport carrying the tenant credential. Defaults to the ambient transport. */
+  transport?: Transport;
+  /**
+   * Override the Core base URL. Defaults to {@link resolveCoreBaseUrl} evaluated at
+   * call time — the seam tests pin and the only place a routed verb's host is set.
+   */
+  baseUrl?: string;
+  /**
+   * Build the capability-specific typed error to throw on a non-2xx response. Each
+   * capability namespace passes its own (`SearchHttpError`, `ContentGenerationHttpError`,
+   * …) so the public error surface stays unchanged; the call/parse path is shared.
+   */
+  makeError: (message: string, status: number, body: unknown) => Error;
+  /** Human-readable prefix for the thrown error's message. */
+  errorPrefix: string;
+}
+
+/**
+ * Send a routed capability request: `POST <core>/v1/capabilities/<id>` with the
+ * tenant credential on `x-api-key` (the header the `/v1` controller guard reads —
+ * NOT the gateway-direct `x-sapiom-api-key`, which would silently 401 here), the
+ * request DTO as a JSON body, and the parsed JSON response DTO returned. A non-2xx
+ * throws the capability's typed error (parsed JSON body when possible, else raw text).
+ */
+export async function capabilityCall<Res>(
+  id: string,
+  req: Record<string, unknown>,
+  opts: CapabilityCallOptions,
+): Promise<Res> {
+  const transport = opts.transport ?? defaultTransport();
+  const baseUrl = opts.baseUrl ?? resolveCoreBaseUrl();
+
+  const res = await transport.fetch(
+    `${baseUrl}/v1/capabilities/${id}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(req),
+    },
+    { authHeader: "x-api-key" },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+    throw opts.makeError(
+      `${opts.errorPrefix}: ${res.status} ${text}`,
+      res.status,
+      body,
+    );
+  }
+
+  return (await res.json()) as Res;
+}

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -200,3 +200,9 @@ let _default: Transport | undefined;
 export function defaultTransport(): Transport {
   return (_default ??= new Transport({ attribution: attributionFromEnv() }));
 }
+
+export {
+  capabilityCall,
+  resolveCoreBaseUrl,
+  type CapabilityCallOptions,
+} from "./capability-call.js";

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -65,33 +65,36 @@ const headerOf = (c: FetchCall, k: string) =>
 // ---------------------------------------------------------------------------
 
 describe("contentGeneration.images.create()", () => {
-  it("POSTs the default model with just the prompt + credential and maps the wire result to camelCase", async () => {
+  it("POSTs to /v1/capabilities/content.generation.images with x-api-key and the prompt", async () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          images: [{ url: "https://media/x.png", content_type: "image/png" }],
-          seed: 7,
+          images: [{ url: "https://media/x.png", contentType: "image/png" }],
         }),
     ]);
 
     const out = await createImage({ prompt: "a red bike" }, transport, BASE);
 
-    // wire snake (content_type) → camelCase surface (contentType); top-level extras pass through.
+    // The router returns the normalized camelCase DTO (servedBy stripped at the boundary).
     expect(out).toEqual({
       images: [{ url: "https://media/x.png", contentType: "image/png" }],
-      seed: 7,
     });
-    // model defaults internally — the caller named no provider.
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/flux/schnell`);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.images`,
+    );
     expect(calls[0]!.init.method).toBe("POST");
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    // Routed verbs authenticate via x-api-key (the /v1 guard's header), NOT the
+    // gateway-direct x-sapiom-api-key — wrong header = silent 401.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // model omitted → the router's adapter defaults it; no /run/<model> URL building here.
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "a red bike",
     });
   });
 
-  it("maps numImages → num_images, forwards `params` verbatim, honors an explicit model (slashes preserved)", async () => {
+  it("forwards numImages (camelCase), `params` as a nested field, and an explicit model verbatim", async () => {
     const { transport, calls } = makeTransport([
       () => jsonResponse({ images: [] }),
     ]);
@@ -101,24 +104,25 @@ describe("contentGeneration.images.create()", () => {
         prompt: "x",
         numImages: 3,
         params: { image_size: "square", seed: 42 },
-        model: "/some/other/model/",
+        model: "fal-ai/flux/dev",
       },
       transport,
       BASE,
     );
 
-    expect(calls[0]!.url).toBe(`${BASE}/run/some/other/model`);
+    // model rides in the body (the adapter turns it into the provider path), and
+    // params is nested — not spread — so the adapter forwards it verbatim.
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "x",
-      image_size: "square",
-      seed: 42,
-      num_images: 3,
+      numImages: 3,
+      params: { image_size: "square", seed: 42 },
+      model: "fal-ai/flux/dev",
     });
   });
 
   it("merges the optional `storage` param; the mapped image carries fileId", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ images: [{ url: "u", file_id: "f1" }] }),
+      () => jsonResponse({ images: [{ url: "u", fileId: "f1" }] }),
     ]);
 
     const out = await createImage(
@@ -167,9 +171,9 @@ describe("contentGeneration.images.create()", () => {
       () =>
         jsonResponse({
           images: [
-            { url: "a", file_id: "f-a" },
-            { url: "b", file_id: "f-b" },
-            { url: "c", storage_error: "exceeded max upload size" },
+            { url: "a", fileId: "f-a" },
+            { url: "b", fileId: "f-b" },
+            { url: "c", storageError: "exceeded max upload size" },
           ],
         }),
     ]);
@@ -211,7 +215,9 @@ describe("contentGeneration.images.create()", () => {
     ]);
 
     await images.create({ prompt: "x" }, transport, BASE);
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/flux/schnell`);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.images`,
+    );
   });
 });
 
@@ -220,14 +226,14 @@ describe("contentGeneration.images.create()", () => {
 // ---------------------------------------------------------------------------
 
 describe("createClient().contentGeneration.images.create", () => {
-  it("binds to the client's credential + default generation host, merging storage, mapping the result", async () => {
+  it("binds to the client's credential + the Core base URL, sending x-api-key, mapping the result", async () => {
     const calls: FetchCall[] = [];
     const fetchMock = (async (
       input: Parameters<typeof globalThis.fetch>[0],
       init: RequestInit = {},
     ): Promise<Response> => {
       calls.push({ url: String(input), init });
-      return jsonResponse({ images: [{ url: "u", file_id: "f" }] });
+      return jsonResponse({ images: [{ url: "u", fileId: "f" }] });
     }) as typeof globalThis.fetch;
 
     const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
@@ -238,9 +244,10 @@ describe("createClient().contentGeneration.images.create", () => {
 
     expect(out.images?.[0]?.fileId).toBe("f");
     expect(calls[0]!.url).toBe(
-      "https://fal.services.sapiom.ai/run/fal-ai/flux/schnell",
+      "https://api.sapiom.ai/v1/capabilities/content.generation.images",
     );
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "x",
       storage: { visibility: "private" },

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -19,13 +19,23 @@
  * inline to block until done — same as `video.create` but with the ability to
  * pause a running workflow.
  */
-import { Transport, defaultTransport } from "../_client/index.js";
+import {
+  Transport,
+  capabilityCall,
+  defaultTransport,
+  resolveCoreBaseUrl,
+} from "../_client/index.js";
 import { resolveServiceUrl } from "../_client/service-url.js";
 import { ensureOk, ContentGenerationHttpError } from "./errors.js";
 import type { DispatchHandle } from "../dispatch.js";
 
 export { ContentGenerationHttpError };
 
+/**
+ * Base URL for the still-provider-direct video ops (deferred — async/poll, SAP-1117).
+ * The routed `images.create` verb does NOT use this; it resolves the single Core
+ * base URL at call time via {@link resolveCoreBaseUrl} (SAP-1116).
+ */
 const DEFAULT_BASE_URL = resolveServiceUrl(
   "fal",
   process.env.SAPIOM_CONTENT_GENERATION_URL,
@@ -38,9 +48,6 @@ const DEFAULT_BASE_URL = resolveServiceUrl(
  * value carried in the handle's `dispatch.resultSignal`.
  */
 export const VIDEO_RESULT_SIGNAL = "contentGeneration.video.result";
-
-/** Default image model when the caller doesn't pick one — a fast, low-cost model. */
-const DEFAULT_IMAGE_MODEL = "fal-ai/flux/schnell";
 
 // ----- Types -----
 
@@ -102,15 +109,20 @@ export interface ImageGenerationResult {
   [key: string]: unknown;
 }
 
-// ----- Internal request/response shapes -----
+// ----- Internal response shapes (the router's normalized image DTO) -----
+//
+// The router returns the camelCase normalized shape (the fal adapter maps fal's
+// snake_case wire fields away), with `servedBy` stripped at the public boundary —
+// so this mirrors the public `GeneratedImage` and the mapper is a defensive pass,
+// not a snake→camel translation.
 
 interface RawImage {
   url: string;
-  content_type?: string;
+  contentType?: string;
   width?: number;
   height?: number;
-  file_id?: string;
-  storage_error?: string;
+  fileId?: string;
+  storageError?: string;
 }
 
 interface RawImageResult {
@@ -121,11 +133,11 @@ interface RawImageResult {
 function mapImage(raw: RawImage): GeneratedImage {
   return {
     url: raw.url,
-    ...(raw.content_type !== undefined && { contentType: raw.content_type }),
+    ...(raw.contentType !== undefined && { contentType: raw.contentType }),
     ...(raw.width !== undefined && { width: raw.width }),
     ...(raw.height !== undefined && { height: raw.height }),
-    ...(raw.file_id !== undefined && { fileId: raw.file_id }),
-    ...(raw.storage_error !== undefined && { storageError: raw.storage_error }),
+    ...(raw.fileId !== undefined && { fileId: raw.fileId }),
+    ...(raw.storageError !== undefined && { storageError: raw.storageError }),
   };
 }
 
@@ -176,33 +188,42 @@ function workflowResumeHeaders(
  * Generate one or more images from a prompt. Pass `storage` to persist each output
  * (the returned images then carry `fileId`). Failed requests throw
  * {@link ContentGenerationHttpError}.
+ *
+ * Routed (SAP-1116): goes through the shared {@link capabilityCall} seam to
+ * `POST /v1/capabilities/content.generation.images` on the single Core base URL.
+ * `model` is now a request-body field the router's adapter turns into the provider
+ * path (and defaults when omitted) — the SDK no longer builds the `/run/<model>`
+ * URL itself.
  */
 export async function createImage(
   input: ImageCreateInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<ImageGenerationResult> {
   assertPrompt(input.prompt);
-  const path = modelToPath(input.model || DEFAULT_IMAGE_MODEL);
 
-  const body: Record<string, unknown> = {
-    prompt: input.prompt,
-    ...input.params,
-  };
-  if (input.numImages !== undefined) body.num_images = input.numImages;
-  // Truthy check (not `!== undefined`) so a caller passing `storage: null` is
-  // treated as "no storage" rather than sending a null field.
+  // Map to the router's camelCase `ImageCreateRequest`. `params` rides as a nested
+  // field (not spread) so the adapter forwards it verbatim. `!= null` keeps a JS
+  // caller's explicit null off the wire; `storage` uses a truthy check so
+  // `storage: null` is "no storage" rather than a null field.
+  const body: Record<string, unknown> = { prompt: input.prompt };
+  if (input.model != null) body.model = input.model;
+  if (input.numImages !== undefined) body.numImages = input.numImages;
   if (input.storage) body.storage = input.storage;
+  if (input.params != null) body.params = input.params;
 
-  const res = await ensureOk(
-    await transport.fetch(`${baseUrl}/run/${path}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
-    "Failed to generate image",
+  const raw = await capabilityCall<RawImageResult>(
+    "content.generation.images",
+    body,
+    {
+      transport,
+      baseUrl,
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to generate image",
+    },
   );
-  return mapResult((await res.json()) as RawImageResult);
+  return mapResult(raw);
 }
 
 /**

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -13,6 +13,10 @@ import {
 // Helpers — the capability fn is tested directly with a real Transport wired to
 // a scripted fetch mock, so URL/method/header/body assertions are exact and we
 // verify the Transport injects the tenant credential.
+//
+// Every verb here is routed (SAP-1116): `POST /v1/capabilities/<id>` on the Core
+// base URL, authenticated via `x-api-key` (NOT the gateway-direct x-sapiom-api-key
+// — wrong header = silent 401), with the router's normalized DTO as the response.
 // ---------------------------------------------------------------------------
 
 interface FetchCall {
@@ -58,34 +62,33 @@ function makeTransport(
 const BASE = "https://api.test";
 const headerOf = (c: FetchCall, k: string) =>
   (c.init.headers as Record<string, string>)[k];
+const bodyOf = (c: FetchCall) => JSON.parse(c.init.body as string);
 
 // ---------------------------------------------------------------------------
-// search.scrape()
+// search.scrape() → web.scrape
 // ---------------------------------------------------------------------------
 
 describe("search.scrape()", () => {
-  it("POSTs just the url + credential (default formats omitted) and maps the wire result", async () => {
+  it("POSTs to /v1/capabilities/web.scrape with x-api-key and maps the normalized result", async () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          success: true,
-          data: {
-            markdown: "# Hello\n\nworld",
-            metadata: {
-              title: "Hello",
-              description: "a page",
-              language: "en",
-              sourceURL: "https://example.com",
-              statusCode: 200,
-              error: null,
-            },
+          url: "https://example.com",
+          markdown: "# Hello\n\nworld",
+          metadata: {
+            title: "Hello",
+            description: "a page",
+            language: "en",
+            sourceURL: "https://example.com",
+            statusCode: 200,
+            error: null,
           },
         }),
     ]);
 
     const out = await scrape({ url: "https://example.com" }, transport, BASE);
 
-    // metadata.sourceURL → sourceUrl; the {success} wrapper is dropped; url echoes input.
+    // metadata.sourceURL → sourceUrl; the result carries only the public fields.
     expect(out).toEqual({
       url: "https://example.com",
       markdown: "# Hello\n\nworld",
@@ -97,22 +100,19 @@ describe("search.scrape()", () => {
         statusCode: 200,
       },
     });
-    expect(calls[0]!.url).toBe(`${BASE}/v2/scrape`);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/web.scrape`);
     expect(calls[0]!.init.method).toBe("POST");
-    // scrape sends the default credential header, NOT x-api-key (guards against
-    // regression from the per-destination auth-header change).
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    // Routed: x-api-key, not the gateway-direct x-sapiom-api-key.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
     // formats is omitted entirely when the caller didn't pass it.
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      url: "https://example.com",
-    });
+    expect(bodyOf(calls[0]!)).toEqual({ url: "https://example.com" });
   });
 
   it("forwards formats, onlyMainContent, and waitFor when provided", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ success: true, data: { metadata: {} } }),
+      () => jsonResponse({ url: "https://example.com", metadata: {} }),
     ]);
 
     await scrape(
@@ -126,7 +126,7 @@ describe("search.scrape()", () => {
       BASE,
     );
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       url: "https://example.com",
       formats: ["markdown", "html", "links"],
       onlyMainContent: true,
@@ -136,7 +136,7 @@ describe("search.scrape()", () => {
 
   it("forwards onlyMainContent: false (a meaningful value, not dropped)", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ success: true, data: { metadata: {} } }),
+      () => jsonResponse({ url: "https://example.com", metadata: {} }),
     ]);
 
     await scrape(
@@ -145,7 +145,7 @@ describe("search.scrape()", () => {
       BASE,
     );
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       url: "https://example.com",
       onlyMainContent: false,
     });
@@ -153,7 +153,7 @@ describe("search.scrape()", () => {
 
   it("treats null optionals (JS caller bypassing types) as absent in the body", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ success: true, data: { metadata: {} } }),
+      () => jsonResponse({ url: "https://example.com", metadata: {} }),
     ]);
 
     await scrape(
@@ -167,24 +167,20 @@ describe("search.scrape()", () => {
       BASE,
     );
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      url: "https://example.com",
-    });
+    expect(bodyOf(calls[0]!)).toEqual({ url: "https://example.com" });
   });
 
-  it("maps every requested format and the page links", async () => {
+  it("maps every returned format and the page links (defensive — when the router surfaces them)", async () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          success: true,
-          data: {
-            markdown: "md",
-            html: "<p>h</p>",
-            rawHtml: "<html>raw</html>",
-            screenshot: "https://shots/x.png",
-            links: ["https://a", "https://b"],
-            metadata: { title: "T", sourceURL: "https://example.com" },
-          },
+          url: "https://example.com",
+          markdown: "md",
+          html: "<p>h</p>",
+          rawHtml: "<html>raw</html>",
+          screenshot: "https://shots/x.png",
+          links: ["https://a", "https://b"],
+          metadata: { title: "T", sourceURL: "https://example.com" },
         }),
     ]);
 
@@ -207,14 +203,12 @@ describe("search.scrape()", () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          success: true,
-          data: {
-            markdown: "x",
-            metadata: {
-              title: ["First Title", "Second Title"],
-              description: ["First desc", "Second desc"],
-              sourceURL: "https://example.com",
-            },
+          url: "https://example.com",
+          markdown: "x",
+          metadata: {
+            title: ["First Title", "Second Title"],
+            description: ["First desc", "Second desc"],
+            sourceURL: "https://example.com",
           },
         }),
     ]);
@@ -225,20 +219,17 @@ describe("search.scrape()", () => {
     expect(out.metadata.description).toBe("First desc");
   });
 
-  it("drops the success wrapper and extra fields; omits absent metadata fields", async () => {
+  it("builds the result from known fields only; extra top-level fields never surface", async () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          success: true,
-          data: {
-            markdown: "x",
-            // extra fields that must not surface on the result
-            branding: { foo: "bar" },
-            changeTracking: null,
-            warning: null,
-            actions: null,
-            metadata: { sourceURL: "https://example.com", statusCode: 200 },
-          },
+          url: "https://example.com",
+          markdown: "x",
+          // extra/internal fields that must not surface on the result
+          servedBy: "firecrawl",
+          branding: { foo: "bar" },
+          warning: null,
+          metadata: { sourceURL: "https://example.com", statusCode: 200 },
         }),
     ]);
 
@@ -249,55 +240,47 @@ describe("search.scrape()", () => {
       markdown: "x",
       metadata: { sourceUrl: "https://example.com", statusCode: 200 },
     });
-    // no leaked extras and no `success` key on the result.
-    expect(out).not.toHaveProperty("success");
+    expect(out).not.toHaveProperty("servedBy");
     expect(out).not.toHaveProperty("branding");
-    expect(out).not.toHaveProperty("changeTracking");
     // title/description were absent on the wire → absent on the surface.
     expect(out.metadata).not.toHaveProperty("title");
     expect(out.metadata).not.toHaveProperty("description");
   });
 
-  it("returns an empty metadata object when the wire omits data/metadata entirely", async () => {
+  it("returns an empty metadata object when the wire omits metadata entirely", async () => {
     const { transport } = makeTransport([
-      () => jsonResponse({ success: true }),
+      () => jsonResponse({ url: "https://example.com" }),
     ]);
 
     const out = await scrape({ url: "https://example.com" }, transport, BASE);
 
-    expect(out).toEqual({
-      url: "https://example.com",
-      metadata: {},
-    });
+    expect(out).toEqual({ url: "https://example.com", metadata: {} });
   });
 
-  it("treats null fields (unrequested formats / empty metadata) as absent, not null", async () => {
+  it("falls back to the input url and treats null fields as absent, not null", async () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          success: true,
-          data: {
-            markdown: "# Hello",
-            // unrequested formats arrive explicitly null
-            html: null,
-            rawHtml: null,
-            screenshot: null,
-            links: null,
-            metadata: {
-              title: "Hello",
-              description: null,
-              language: null,
-              sourceURL: "https://example.com",
-              statusCode: 200,
-              error: null,
-            },
+          markdown: "# Hello",
+          // unrequested formats arrive explicitly null
+          html: null,
+          rawHtml: null,
+          screenshot: null,
+          links: null,
+          metadata: {
+            title: "Hello",
+            description: null,
+            language: null,
+            sourceURL: "https://example.com",
+            statusCode: 200,
+            error: null,
           },
         }),
     ]);
 
     const out = await scrape({ url: "https://example.com" }, transport, BASE);
 
-    // null formats are omitted, not surfaced as `field: null`.
+    // null formats are omitted, not surfaced as `field: null`; url falls back to input.
     expect(out).toEqual({
       url: "https://example.com",
       markdown: "# Hello",
@@ -316,7 +299,7 @@ describe("search.scrape()", () => {
   it("throws SearchHttpError (with status + body) on a non-2xx", async () => {
     const { transport } = makeTransport([
       () =>
-        new Response(JSON.stringify({ success: false, error: "Bad Request" }), {
+        new Response(JSON.stringify({ message: "Bad Request" }), {
           status: 400,
         }),
     ]);
@@ -326,7 +309,7 @@ describe("search.scrape()", () => {
     ).rejects.toMatchObject({
       name: "SearchHttpError",
       status: 400,
-      body: { error: "Bad Request" },
+      body: { message: "Bad Request" },
     });
     await expect(
       scrape({ url: "https://example.com" }, transport, BASE),
@@ -339,7 +322,7 @@ describe("search.scrape()", () => {
 // ---------------------------------------------------------------------------
 
 describe("createClient().search.scrape", () => {
-  it("binds to the client's credential + default host, mapping the result", async () => {
+  it("binds to the client's credential + the Core base URL, sending x-api-key", async () => {
     const calls: FetchCall[] = [];
     const fetchMock = (async (
       input: Parameters<typeof globalThis.fetch>[0],
@@ -347,11 +330,9 @@ describe("createClient().search.scrape", () => {
     ): Promise<Response> => {
       calls.push({ url: String(input), init });
       return jsonResponse({
-        success: true,
-        data: {
-          markdown: "ok",
-          metadata: { sourceURL: "https://example.com" },
-        },
+        url: "https://example.com",
+        markdown: "ok",
+        metadata: { sourceURL: "https://example.com" },
       });
     }) as typeof globalThis.fetch;
 
@@ -361,17 +342,16 @@ describe("createClient().search.scrape", () => {
     expect(out.markdown).toBe("ok");
     expect(out.metadata.sourceUrl).toBe("https://example.com");
     expect(calls[0]!.url).toBe(
-      "https://firecrawl.services.sapiom.ai/v2/scrape",
+      "https://api.sapiom.ai/v1/capabilities/web.scrape",
     );
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      url: "https://example.com",
-    });
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    expect(bodyOf(calls[0]!)).toEqual({ url: "https://example.com" });
   });
 });
 
 // ---------------------------------------------------------------------------
-// search.webSearch()
+// search.webSearch() → web.search
 // ---------------------------------------------------------------------------
 
 describe("search.webSearch()", () => {
@@ -408,7 +388,7 @@ describe("search.webSearch()", () => {
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
     // intent defaults to "answer"; depth omitted when not provided.
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       query: "llm agents",
       intent: "answer",
     });
@@ -425,7 +405,7 @@ describe("search.webSearch()", () => {
       BASE,
     );
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       query: "q",
       depth: "deep",
       intent: "links",
@@ -439,7 +419,7 @@ describe("search.webSearch()", () => {
 
     await webSearch({ query: "q", depth: "standard" }, transport, BASE);
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       query: "q",
       depth: "standard",
       intent: "answer",
@@ -457,10 +437,7 @@ describe("search.webSearch()", () => {
       BASE,
     );
 
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "q",
-      intent: "answer",
-    });
+    expect(bodyOf(calls[0]!)).toEqual({ query: "q", intent: "answer" });
   });
 
   it("omits answer when the wire has none (intent:'links') and defaults missing results to []", async () => {
@@ -565,50 +542,27 @@ describe("createClient().search.webSearch", () => {
     );
     expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "q",
-      intent: "answer",
-    });
+    expect(bodyOf(calls[0]!)).toEqual({ query: "q", intent: "answer" });
   });
 });
 
 // ---------------------------------------------------------------------------
-// Helpers for the email-search GET ops
-// ---------------------------------------------------------------------------
-
-/** Parse a request URL's path and query params for assertions. */
-function parseUrl(url: string): {
-  path: string;
-  params: Record<string, string>;
-} {
-  const u = new URL(url);
-  const params: Record<string, string> = {};
-  u.searchParams.forEach((value, key) => {
-    params[key] = value;
-  });
-  return { path: `${u.origin}${u.pathname}`, params };
-}
-
-// ---------------------------------------------------------------------------
-// search.emailSearch.findEmail()
+// search.emailSearch.findEmail() → email.find
 // ---------------------------------------------------------------------------
 
 describe("search.emailSearch.findEmail()", () => {
-  it("GETs the email-finder with query params (snake_case) and the default credential, mapping snake→camel", async () => {
+  it("POSTs to /v1/capabilities/email.find with the camelCase body and x-api-key, mapping the normalized result", async () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          data: {
-            email: "ada@example.com",
-            score: 97,
-            first_name: "Ada",
-            last_name: "Lovelace",
-            position: "Engineer",
-            company: "Example",
-            linkedin_url: "https://linkedin.com/in/ada",
-            verification: { status: "valid", date: "2026-01-01" },
-          },
-          meta: { params: {} },
+          email: "ada@example.com",
+          score: 97,
+          firstName: "Ada",
+          lastName: "Lovelace",
+          position: "Engineer",
+          company: "Example",
+          linkedinUrl: "https://linkedin.com/in/ada",
+          verification: { status: "valid", date: "2026-01-01" },
         }),
     ]);
 
@@ -618,7 +572,6 @@ describe("search.emailSearch.findEmail()", () => {
       BASE,
     );
 
-    // linkedin_url → linkedinUrl; first_name → firstName; etc.
     expect(out).toEqual({
       email: "ada@example.com",
       score: 97,
@@ -630,23 +583,21 @@ describe("search.emailSearch.findEmail()", () => {
       verification: { status: "valid", date: "2026-01-01" },
     });
 
-    const { path, params } = parseUrl(calls[0]!.url);
-    expect(path).toBe(`${BASE}/v2/email-finder`);
-    expect(calls[0]!.init.method).toBe("GET");
-    expect(params).toEqual({
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/email.find`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // only the provided fields ride the body (camelCase router DTO).
+    expect(bodyOf(calls[0]!)).toEqual({
       domain: "example.com",
-      first_name: "Ada",
-      last_name: "Lovelace",
+      firstName: "Ada",
+      lastName: "Lovelace",
     });
-    // email-search hosts authenticate via the default x-sapiom-api-key, NOT
-    // x-api-key (which is the backend-hub-only path used by webSearch).
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
   });
 
   it("accepts company + fullName as a valid combination", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ data: { email: "ada@example.com" } }),
+      () => jsonResponse({ email: "ada@example.com" }),
     ]);
 
     await findEmail(
@@ -655,16 +606,15 @@ describe("search.emailSearch.findEmail()", () => {
       BASE,
     );
 
-    const { params } = parseUrl(calls[0]!.url);
-    expect(params).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       company: "Example Inc",
-      full_name: "Ada Lovelace",
+      fullName: "Ada Lovelace",
     });
   });
 
   it("returns email: null (not a thrown error) when the lookup finds nothing", async () => {
     const { transport } = makeTransport([
-      () => jsonResponse({ data: { email: null, score: 0 } }),
+      () => jsonResponse({ email: null, score: 0 }),
     ]);
 
     const out = await findEmail(
@@ -681,15 +631,13 @@ describe("search.emailSearch.findEmail()", () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          data: {
-            email: "ada@example.com",
-            score: 80,
-            first_name: "Ada",
-            last_name: null,
-            position: null,
-            company: null,
-            linkedin_url: null,
-          },
+          email: "ada@example.com",
+          score: 80,
+          firstName: "Ada",
+          lastName: null,
+          position: null,
+          company: null,
+          linkedinUrl: null,
         }),
     ]);
 
@@ -732,9 +680,7 @@ describe("search.emailSearch.findEmail()", () => {
 
     for (const [label, input] of invalid) {
       it(`throws SearchHttpError and does not fetch: ${label}`, async () => {
-        const { transport, calls } = makeTransport([
-          () => jsonResponse({ data: {} }),
-        ]);
+        const { transport, calls } = makeTransport([() => jsonResponse({})]);
 
         await expect(findEmail(input, transport, BASE)).rejects.toBeInstanceOf(
           SearchHttpError,
@@ -751,7 +697,7 @@ describe("search.emailSearch.findEmail()", () => {
   it("throws SearchHttpError (status + body) on a non-2xx", async () => {
     const { transport } = makeTransport([
       () =>
-        new Response(JSON.stringify({ errors: [{ details: "Bad domain" }] }), {
+        new Response(JSON.stringify({ message: "Bad domain" }), {
           status: 400,
         }),
     ]);
@@ -765,30 +711,28 @@ describe("search.emailSearch.findEmail()", () => {
     ).rejects.toMatchObject({
       name: "SearchHttpError",
       status: 400,
-      body: { errors: [{ details: "Bad domain" }] },
+      body: { message: "Bad domain" },
     });
   });
 });
 
 // ---------------------------------------------------------------------------
-// search.emailSearch.verifyEmail()
+// search.emailSearch.verifyEmail() → email.verify
 // ---------------------------------------------------------------------------
 
 describe("search.emailSearch.verifyEmail()", () => {
-  it("GETs the email-verifier with the email param and maps snake→camel", async () => {
+  it("POSTs to /v1/capabilities/email.verify with the email and maps the normalized result", async () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          data: {
-            email: "ada@example.com",
-            status: "valid",
-            result: "deliverable",
-            score: 95,
-            smtp_check: true,
-            accept_all: false,
-            disposable: false,
-            webmail: false,
-          },
+          email: "ada@example.com",
+          status: "valid",
+          result: "deliverable",
+          score: 95,
+          smtpCheck: true,
+          acceptAll: false,
+          disposable: false,
+          webmail: false,
         }),
     ]);
 
@@ -809,25 +753,22 @@ describe("search.emailSearch.verifyEmail()", () => {
       webmail: false,
     });
 
-    const { path, params } = parseUrl(calls[0]!.url);
-    expect(path).toBe(`${BASE}/v2/email-verifier`);
-    expect(calls[0]!.init.method).toBe("GET");
-    expect(params).toEqual({ email: "ada@example.com" });
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/email.verify`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(bodyOf(calls[0]!)).toEqual({ email: "ada@example.com" });
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
   });
 
   it("preserves boolean false flags (not dropped as falsy)", async () => {
     const { transport } = makeTransport([
       () =>
         jsonResponse({
-          data: {
-            email: "ada@example.com",
-            smtp_check: false,
-            accept_all: false,
-            disposable: false,
-            webmail: false,
-          },
+          email: "ada@example.com",
+          smtpCheck: false,
+          acceptAll: false,
+          disposable: false,
+          webmail: false,
         }),
     ]);
 
@@ -845,7 +786,7 @@ describe("search.emailSearch.verifyEmail()", () => {
 
   it("falls back to the input email when the wire omits it", async () => {
     const { transport } = makeTransport([
-      () => jsonResponse({ data: { status: "valid" } }),
+      () => jsonResponse({ status: "valid" }),
     ]);
 
     const out = await verifyEmail(
@@ -858,9 +799,7 @@ describe("search.emailSearch.verifyEmail()", () => {
   });
 
   it("throws SearchHttpError before fetching when email is empty (JS caller)", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ data: {} }),
-    ]);
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
 
     await expect(
       verifyEmail({ email: "" as string }, transport, BASE),
@@ -884,32 +823,30 @@ describe("search.emailSearch.verifyEmail()", () => {
 });
 
 // ---------------------------------------------------------------------------
-// search.emailSearch.domainSearch()
+// search.emailSearch.domainSearch() → email.domain.search
 // ---------------------------------------------------------------------------
 
 describe("search.emailSearch.domainSearch()", () => {
-  it("GETs the domain-search, joins array filters to CSV, and maps value→email", async () => {
+  it("POSTs to /v1/capabilities/email.domain.search, keeps array filters as arrays, and maps the result", async () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          data: {
-            domain: "example.com",
-            organization: "Example Inc",
-            pattern: "{first}.{last}",
-            accept_all: false,
-            emails: [
-              {
-                value: "ada@example.com",
-                type: "personal",
-                confidence: 99,
-                first_name: "Ada",
-                last_name: "Lovelace",
-                position: "CTO",
-                department: "engineering",
-                seniority: "executive",
-              },
-            ],
-          },
+          domain: "example.com",
+          organization: "Example Inc",
+          pattern: "{first}.{last}",
+          acceptAll: false,
+          emails: [
+            {
+              email: "ada@example.com",
+              type: "personal",
+              confidence: 99,
+              firstName: "Ada",
+              lastName: "Lovelace",
+              position: "CTO",
+              department: "engineering",
+              seniority: "executive",
+            },
+          ],
         }),
     ]);
 
@@ -925,7 +862,6 @@ describe("search.emailSearch.domainSearch()", () => {
       BASE,
     );
 
-    // Hunter's `value` → our `email`; snake → camel on each row.
     expect(out).toEqual({
       domain: "example.com",
       organization: "Example Inc",
@@ -945,24 +881,23 @@ describe("search.emailSearch.domainSearch()", () => {
       ],
     });
 
-    const { path, params } = parseUrl(calls[0]!.url);
-    expect(path).toBe(`${BASE}/v2/domain-search`);
-    expect(calls[0]!.init.method).toBe("GET");
-    // arrays serialize as comma-separated values on the wire.
-    expect(params).toEqual({
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/email.domain.search`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // arrays stay arrays in the router DTO (the adapter CSV-joins for Hunter).
+    expect(bodyOf(calls[0]!)).toEqual({
       domain: "example.com",
-      limit: "5",
+      limit: 5,
       type: "personal",
-      seniority: "senior,executive",
-      department: "engineering,sales",
+      seniority: ["senior", "executive"],
+      department: ["engineering", "sales"],
     });
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
   });
 
   it("omits array filters entirely when empty, and optional scalars when absent", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ data: { domain: "example.com", emails: [] } }),
+      () => jsonResponse({ domain: "example.com", emails: [] }),
     ]);
 
     await domainSearch(
@@ -971,17 +906,13 @@ describe("search.emailSearch.domainSearch()", () => {
       BASE,
     );
 
-    const { params } = parseUrl(calls[0]!.url);
-    // empty arrays produce no query param at all.
-    expect(params).toEqual({ domain: "example.com" });
-    expect(params).not.toHaveProperty("seniority");
-    expect(params).not.toHaveProperty("department");
-    expect(params).not.toHaveProperty("limit");
+    // empty arrays produce no body field at all.
+    expect(bodyOf(calls[0]!)).toEqual({ domain: "example.com" });
   });
 
   it("defaults missing emails to [] and omits absent top-level fields", async () => {
     const { transport } = makeTransport([
-      () => jsonResponse({ data: { domain: "example.com" } }),
+      () => jsonResponse({ domain: "example.com" }),
     ]);
 
     const out = await domainSearch({ domain: "example.com" }, transport, BASE);
@@ -992,9 +923,7 @@ describe("search.emailSearch.domainSearch()", () => {
   });
 
   it("throws SearchHttpError before fetching when domain is empty (JS caller)", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ data: {} }),
-    ]);
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
 
     await expect(
       domainSearch({ domain: "" } as { domain: string }, transport, BASE),
@@ -1025,14 +954,14 @@ describe("search.emailSearch.domainSearch()", () => {
 // ---------------------------------------------------------------------------
 
 describe("createClient().search.emailSearch", () => {
-  it("binds findEmail to the client's credential + default host", async () => {
+  it("binds findEmail to the client's credential + the Core base URL, sending x-api-key", async () => {
     const calls: FetchCall[] = [];
     const fetchMock = (async (
       input: Parameters<typeof globalThis.fetch>[0],
       init: RequestInit = {},
     ): Promise<Response> => {
       calls.push({ url: String(input), init });
-      return jsonResponse({ data: { email: "ada@example.com", score: 90 } });
+      return jsonResponse({ email: "ada@example.com", score: 90 });
     }) as typeof globalThis.fetch;
 
     const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
@@ -1042,32 +971,34 @@ describe("createClient().search.emailSearch", () => {
     });
 
     expect(out.email).toBe("ada@example.com");
-    const { path } = parseUrl(calls[0]!.url);
-    expect(path).toBe("https://hunter.services.sapiom.ai/v2/email-finder");
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(calls[0]!.url).toBe(
+      "https://api.sapiom.ai/v1/capabilities/email.find",
+    );
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
   });
 
-  it("binds verifyEmail and domainSearch to the default host", async () => {
+  it("binds verifyEmail and domainSearch to the Core base URL", async () => {
     const calls: FetchCall[] = [];
     const fetchMock = (async (
       input: Parameters<typeof globalThis.fetch>[0],
       init: RequestInit = {},
     ): Promise<Response> => {
       calls.push({ url: String(input), init });
-      return jsonResponse({ data: { domain: "example.com", emails: [] } });
+      return jsonResponse({ domain: "example.com", emails: [] });
     }) as typeof globalThis.fetch;
 
     const sapiom = createClient({ apiKey: "client-key", fetch: fetchMock });
     await sapiom.search.emailSearch.verifyEmail({ email: "ada@example.com" });
     await sapiom.search.emailSearch.domainSearch({ domain: "example.com" });
 
-    expect(parseUrl(calls[0]!.url).path).toBe(
-      "https://hunter.services.sapiom.ai/v2/email-verifier",
+    expect(calls[0]!.url).toBe(
+      "https://api.sapiom.ai/v1/capabilities/email.verify",
     );
-    expect(parseUrl(calls[1]!.url).path).toBe(
-      "https://hunter.services.sapiom.ai/v2/domain-search",
+    expect(calls[1]!.url).toBe(
+      "https://api.sapiom.ai/v1/capabilities/email.domain.search",
     );
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
-    expect(headerOf(calls[1]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[1]!, "x-api-key")).toBe("client-key");
   });
 });

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -18,24 +18,26 @@
  *
  * Or via an explicit client: `createClient({ apiKey }).search.webSearch(...)`.
  *
- * Failed requests throw {@link SearchHttpError} (carries `status` + parsed `body`).
+ * Every operation here is **routed**: it goes through the shared
+ * {@link capabilityCall} seam to `POST /v1/capabilities/<id>` on the single Core
+ * base URL (SAP-1116). The dotted capability id (`web.scrape`, `web.search`,
+ * `email.find` / `email.verify` / `email.domain.search`) appears only on the wire —
+ * the public verb names and shapes below are unchanged. Failed requests throw
+ * {@link SearchHttpError} (carries `status` + parsed `body`).
  */
-import { Transport, defaultTransport } from "../_client/index.js";
-import { resolveServiceUrl } from "../_client/service-url.js";
-import { SearchHttpError, ensureOk } from "./errors.js";
+import {
+  Transport,
+  capabilityCall,
+  defaultTransport,
+  resolveCoreBaseUrl,
+} from "../_client/index.js";
+import { SearchHttpError } from "./errors.js";
 
 export { SearchHttpError };
 
-const DEFAULT_BASE_URL = resolveServiceUrl(
-  "firecrawl",
-  process.env.SAPIOM_SCRAPE_URL,
-);
-
-const DEFAULT_WEB_SEARCH_BASE_URL =
-  process.env.SAPIOM_SEARCH_URL || "https://api.sapiom.ai";
-
-const DEFAULT_EMAIL_SEARCH_BASE_URL =
-  process.env.SAPIOM_EMAIL_SEARCH_URL || "https://hunter.services.sapiom.ai";
+/** Build the capability-specific error the routed call throws on a non-2xx. */
+const searchError = (message: string, status: number, body: unknown): Error =>
+  new SearchHttpError(message, status, body);
 
 // ----- Types -----
 
@@ -88,7 +90,7 @@ export interface ScrapeResult {
   metadata: ScrapeMetadata;
 }
 
-// ----- Internal request/response shapes -----
+// ----- Internal response shapes (the router's normalized scrape DTO) -----
 
 interface RawMetadata {
   // May arrive as an array on some pages; normalized to a single string.
@@ -100,19 +102,22 @@ interface RawMetadata {
   [key: string]: unknown;
 }
 
-interface RawScrapeData {
+/**
+ * The router's normalized `web.scrape` response. The `{ success, data }` Firecrawl
+ * envelope is gone — the router's adapter unwraps it and returns the flat shape
+ * below (with `servedBy` stripped at the public boundary). `metadata` is the raw
+ * provider metadata, so {@link mapMetadata} still normalizes its key shapes.
+ */
+interface RawScrapeResponse {
+  url?: string;
   markdown?: string;
   html?: string;
   rawHtml?: string;
   screenshot?: string;
+  // The router doesn't surface page links today; mapped defensively if it ever does.
   links?: string[];
   metadata?: RawMetadata;
   [key: string]: unknown;
-}
-
-interface RawScrapeResponse {
-  success?: boolean;
-  data?: RawScrapeData;
 }
 
 /** Collapse a field that may be a single value or an array down to one value. */
@@ -136,17 +141,16 @@ function mapMetadata(raw: RawMetadata | undefined): ScrapeMetadata {
 }
 
 function mapScrape(url: string, raw: RawScrapeResponse): ScrapeResult {
-  const data = raw.data ?? {};
   // Unrequested formats come back null; treat null as absent (`!=`) so each
   // format field is present only when it was actually returned.
   return {
-    url,
-    ...(data.markdown != null && { markdown: data.markdown }),
-    ...(data.html != null && { html: data.html }),
-    ...(data.rawHtml != null && { rawHtml: data.rawHtml }),
-    ...(data.screenshot != null && { screenshot: data.screenshot }),
-    ...(data.links != null && { links: data.links }),
-    metadata: mapMetadata(data.metadata),
+    url: raw.url ?? url,
+    ...(raw.markdown != null && { markdown: raw.markdown }),
+    ...(raw.html != null && { html: raw.html }),
+    ...(raw.rawHtml != null && { rawHtml: raw.rawHtml }),
+    ...(raw.screenshot != null && { screenshot: raw.screenshot }),
+    ...(raw.links != null && { links: raw.links }),
+    metadata: mapMetadata(raw.metadata),
   };
 }
 
@@ -162,7 +166,7 @@ function mapScrape(url: string, raw: RawScrapeResponse): ScrapeResult {
 export async function scrape(
   input: ScrapeInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<ScrapeResult> {
   // `!= null` so an optional explicitly passed as null (a JS caller bypassing the
   // types) is treated as absent rather than forwarded as a null field.
@@ -172,15 +176,13 @@ export async function scrape(
     body.onlyMainContent = input.onlyMainContent;
   if (input.waitFor != null) body.waitFor = input.waitFor;
 
-  const res = await ensureOk(
-    await transport.fetch(`${baseUrl}/v2/scrape`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
-    "Failed to scrape",
-  );
-  return mapScrape(input.url, (await res.json()) as RawScrapeResponse);
+  const raw = await capabilityCall<RawScrapeResponse>("web.scrape", body, {
+    transport,
+    baseUrl,
+    makeError: searchError,
+    errorPrefix: "Failed to scrape",
+  });
+  return mapScrape(input.url, raw);
 }
 
 // ----- search.webSearch -----
@@ -264,7 +266,7 @@ function mapWebSearch(
 export async function webSearch(
   input: WebSearchInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_WEB_SEARCH_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<WebSearchResponse> {
   // `!= null` so an optional explicitly passed as null (a JS caller bypassing the
   // types) is treated as absent rather than forwarded as a null field.
@@ -274,61 +276,23 @@ export async function webSearch(
   };
   if (input.depth != null) body.depth = input.depth;
 
-  const res = await ensureOk(
-    await transport.fetch(
-      `${baseUrl}/v1/capabilities/web.search`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-      },
-      { authHeader: "x-api-key" },
-    ),
-    "Failed to search the web",
-  );
-  return mapWebSearch(input.query, (await res.json()) as RawWebSearchResponse);
+  const raw = await capabilityCall<RawWebSearchResponse>("web.search", body, {
+    transport,
+    baseUrl,
+    makeError: searchError,
+    errorPrefix: "Failed to search the web",
+  });
+  return mapWebSearch(input.query, raw);
 }
 
 // ----- search.emailSearch -----
 //
 // Three operations for working with professional email addresses: find an email
 // for a known person, verify an address is deliverable, and discover the emails
-// published at a company domain.
-
-// ----- Shared request/response helpers -----
-
-/**
- * Build a query string from a set of params. Skips any value that is null or
- * undefined (so a JS caller passing an optional as `null` doesn't put `null` on
- * the wire), and stringifies everything else.
- */
-function toQuery(params: Record<string, unknown>): string {
-  const search = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value != null) search.set(key, String(value));
-  }
-  const qs = search.toString();
-  return qs ? `?${qs}` : "";
-}
-
-/** Responses arrive wrapped in a `{ data }` envelope; the payload is `data`. */
-interface RawEnvelope<T> {
-  data?: T;
-  [key: string]: unknown;
-}
-
-async function getEnvelope<T>(
-  transport: Transport,
-  url: string,
-  errorPrefix: string,
-): Promise<T | undefined> {
-  const res = await ensureOk(
-    await transport.fetch(url, { method: "GET" }),
-    errorPrefix,
-  );
-  const body = (await res.json()) as RawEnvelope<T>;
-  return body.data;
-}
+// published at a company domain. Each routes to its own dotted capability id
+// (`email.find` / `email.verify` / `email.domain.search`); the router's normalized
+// response is already the SDK's camelCase result shape, so the mappers below are a
+// defensive null-normalizing pass, not a snake→camel translation.
 
 // ----- emailSearch.findEmail -----
 
@@ -367,11 +331,11 @@ export interface FindEmailResult {
 interface RawFindEmail {
   email?: string | null;
   score?: number;
-  first_name?: string | null;
-  last_name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
   position?: string | null;
   company?: string | null;
-  linkedin_url?: string | null;
+  linkedinUrl?: string | null;
   verification?: { status?: string; date?: string };
   [key: string]: unknown;
 }
@@ -383,11 +347,11 @@ function mapFindEmail(raw: RawFindEmail | undefined): FindEmailResult {
   return {
     email: d.email != null ? d.email : null,
     ...(d.score != null && { score: d.score }),
-    ...(d.first_name != null && { firstName: d.first_name }),
-    ...(d.last_name != null && { lastName: d.last_name }),
+    ...(d.firstName != null && { firstName: d.firstName }),
+    ...(d.lastName != null && { lastName: d.lastName }),
     ...(d.position != null && { position: d.position }),
     ...(d.company != null && { company: d.company }),
-    ...(d.linkedin_url != null && { linkedinUrl: d.linkedin_url }),
+    ...(d.linkedinUrl != null && { linkedinUrl: d.linkedinUrl }),
     ...(d.verification != null && { verification: d.verification }),
   };
 }
@@ -406,11 +370,13 @@ function mapFindEmail(raw: RawFindEmail | undefined): FindEmailResult {
 export async function findEmail(
   input: FindEmailInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_EMAIL_SEARCH_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<FindEmailResult> {
   // Guard the required combination client-side so an under-specified lookup fails
   // fast and clearly, never as a confusing network round-trip. `!= null` plus a
-  // truthiness check rejects null/undefined/empty-string for JS callers.
+  // truthiness check rejects null/undefined/empty-string for JS callers. (The
+  // router validates the same combination, but the client guard keeps the
+  // no-network-on-invalid contract the SDK has always offered.)
   const hasOrg = Boolean(input.domain) || Boolean(input.company);
   const hasPerson =
     Boolean(input.fullName) ||
@@ -423,19 +389,22 @@ export async function findEmail(
     );
   }
 
-  const query = toQuery({
-    domain: input.domain,
-    company: input.company,
-    first_name: input.firstName,
-    last_name: input.lastName,
-    full_name: input.fullName,
-  });
-  const data = await getEnvelope<RawFindEmail>(
+  // Forward only the provided fields (camelCase router DTO). `!= null` keeps a
+  // JS-caller's explicit null off the wire.
+  const body: Record<string, unknown> = {};
+  if (input.domain != null) body.domain = input.domain;
+  if (input.company != null) body.company = input.company;
+  if (input.firstName != null) body.firstName = input.firstName;
+  if (input.lastName != null) body.lastName = input.lastName;
+  if (input.fullName != null) body.fullName = input.fullName;
+
+  const raw = await capabilityCall<RawFindEmail>("email.find", body, {
     transport,
-    `${baseUrl}/v2/email-finder${query}`,
-    "Failed to find email",
-  );
-  return mapFindEmail(data);
+    baseUrl,
+    makeError: searchError,
+    errorPrefix: "Failed to find email",
+  });
+  return mapFindEmail(raw);
 }
 
 // ----- emailSearch.verifyEmail -----
@@ -469,8 +438,8 @@ interface RawVerifyEmail {
   status?: string;
   result?: string;
   score?: number;
-  smtp_check?: boolean;
-  accept_all?: boolean;
+  smtpCheck?: boolean;
+  acceptAll?: boolean;
   disposable?: boolean;
   webmail?: boolean;
   [key: string]: unknown;
@@ -486,8 +455,8 @@ function mapVerifyEmail(
     ...(d.status != null && { status: d.status }),
     ...(d.result != null && { result: d.result }),
     ...(d.score != null && { score: d.score }),
-    ...(d.smtp_check != null && { smtpCheck: d.smtp_check }),
-    ...(d.accept_all != null && { acceptAll: d.accept_all }),
+    ...(d.smtpCheck != null && { smtpCheck: d.smtpCheck }),
+    ...(d.acceptAll != null && { acceptAll: d.acceptAll }),
     ...(d.disposable != null && { disposable: d.disposable }),
     ...(d.webmail != null && { webmail: d.webmail }),
   };
@@ -503,18 +472,22 @@ function mapVerifyEmail(
 export async function verifyEmail(
   input: VerifyEmailInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_EMAIL_SEARCH_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<VerifyEmailResult> {
   if (!input.email) {
     throw new SearchHttpError("verifyEmail requires an email", 400, undefined);
   }
-  const query = toQuery({ email: input.email });
-  const data = await getEnvelope<RawVerifyEmail>(
-    transport,
-    `${baseUrl}/v2/email-verifier${query}`,
-    "Failed to verify email",
+  const raw = await capabilityCall<RawVerifyEmail>(
+    "email.verify",
+    { email: input.email },
+    {
+      transport,
+      baseUrl,
+      makeError: searchError,
+      errorPrefix: "Failed to verify email",
+    },
   );
-  return mapVerifyEmail(input.email, data);
+  return mapVerifyEmail(input.email, raw);
 }
 
 // ----- emailSearch.domainSearch -----
@@ -565,11 +538,11 @@ export interface DomainSearchResult {
 }
 
 interface RawDomainEmail {
-  value?: string;
+  email?: string;
   type?: string;
   confidence?: number;
-  first_name?: string | null;
-  last_name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
   position?: string | null;
   department?: string | null;
   seniority?: string | null;
@@ -580,18 +553,18 @@ interface RawDomainSearch {
   domain?: string;
   organization?: string;
   pattern?: string;
-  accept_all?: boolean;
+  acceptAll?: boolean;
   emails?: RawDomainEmail[];
   [key: string]: unknown;
 }
 
 function mapDomainEmail(raw: RawDomainEmail): DomainEmail {
   return {
-    email: raw.value ?? "",
+    email: raw.email ?? "",
     ...(raw.type != null && { type: raw.type }),
     ...(raw.confidence != null && { confidence: raw.confidence }),
-    ...(raw.first_name != null && { firstName: raw.first_name }),
-    ...(raw.last_name != null && { lastName: raw.last_name }),
+    ...(raw.firstName != null && { firstName: raw.firstName }),
+    ...(raw.lastName != null && { lastName: raw.lastName }),
     ...(raw.position != null && { position: raw.position }),
     ...(raw.department != null && { department: raw.department }),
     ...(raw.seniority != null && { seniority: raw.seniority }),
@@ -608,7 +581,7 @@ function mapDomainSearch(
     domain: d.domain ?? domain,
     ...(d.organization != null && { organization: d.organization }),
     ...(d.pattern != null && { pattern: d.pattern }),
-    ...(d.accept_all != null && { acceptAll: d.accept_all }),
+    ...(d.acceptAll != null && { acceptAll: d.acceptAll }),
     emails,
   };
 }
@@ -623,30 +596,30 @@ function mapDomainSearch(
 export async function domainSearch(
   input: DomainSearchInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_EMAIL_SEARCH_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<DomainSearchResult> {
   if (!input.domain) {
     throw new SearchHttpError("domainSearch requires a domain", 400, undefined);
   }
-  // Array filters travel as comma-separated values; an empty array becomes
-  // nothing on the wire (filtered by `toQuery`).
-  const query = toQuery({
-    domain: input.domain,
-    limit: input.limit,
-    type: input.type,
-    seniority:
-      input.seniority != null && input.seniority.length > 0
-        ? input.seniority.join(",")
-        : undefined,
-    department:
-      input.department != null && input.department.length > 0
-        ? input.department.join(",")
-        : undefined,
-  });
-  const data = await getEnvelope<RawDomainSearch>(
-    transport,
-    `${baseUrl}/v2/domain-search${query}`,
-    "Failed to search domain",
+  // Forward only the provided fields. Array filters travel as arrays in the router
+  // DTO; an empty array is omitted entirely (no filter), and absent scalars are left off.
+  const body: Record<string, unknown> = { domain: input.domain };
+  if (input.limit != null) body.limit = input.limit;
+  if (input.type != null) body.type = input.type;
+  if (input.seniority != null && input.seniority.length > 0)
+    body.seniority = input.seniority;
+  if (input.department != null && input.department.length > 0)
+    body.department = input.department;
+
+  const raw = await capabilityCall<RawDomainSearch>(
+    "email.domain.search",
+    body,
+    {
+      transport,
+      baseUrl,
+      makeError: searchError,
+      errorPrefix: "Failed to search domain",
+    },
   );
-  return mapDomainSearch(input.domain, data);
+  return mapDomainSearch(input.domain, raw);
 }


### PR DESCRIPTION
## What

Repoints the migrated capability verbs in `@sapiom/tools` from provider-gateway subdomains onto the **Capability Router** at the single **Core base URL**, mirroring `search.webSearch`:

| Verb (public, unchanged) | Now sends |
|---|---|
| `search.scrape` | `POST /v1/capabilities/web.scrape` |
| `search.emailSearch.findEmail` | `POST /v1/capabilities/email.find` |
| `search.emailSearch.verifyEmail` | `POST /v1/capabilities/email.verify` |
| `search.emailSearch.domainSearch` | `POST /v1/capabilities/email.domain.search` |
| `contentGeneration.images.create` | `POST /v1/capabilities/content.generation.images` |

## Shared helper (anti-drift foundation)

New `capabilityCall(id, req, opts)` in `packages/tools/src/_client/` is the single seam every routed verb goes through — one place builds `POST /v1/capabilities/<id>`, sends the credential header, resolves the Core base URL, and maps a non-2xx to the capability's typed error. `web.search` is refactored onto it; a future routed verb is ~5 lines and **cannot** diverge on transport/auth/error handling. Foundation that SAP-1135 (self-registering scaffold) builds on.

## Call contract (the subtle bugs, handled)

1. **Auth header = `x-api-key`** (the `/v1` controller guard's header), not the gateway-direct `x-sapiom-api-key`. Wrong header = silent 401. The helper standardizes it.
2. **Core base URL resolved at call time** (`resolveCoreBaseUrl()` → `SAPIOM_BASE_URL` → `SAPIOM_API_URL` → `https://api.sapiom.ai`), never a module-level const. This structurally removes the SAP-1107 import-freeze 401 class for routed caps. No per-cap URL knob (`SAPIOM_SCRAPE_URL` / `SAPIOM_SEARCH_URL` / `SAPIOM_EMAIL_SEARCH_URL` removed).
3. **Public API unchanged** — verb names/signatures identical; request/response shapes map to the router's normalized DTOs internally. The router DTOs are already the SDK's camelCase result shapes (`servedBy` stripped at the boundary), so the email/image mappers became defensive null-normalizing passes rather than snake→camel translations.

## Two patterns coexist by design

Routed caps → `capabilityCall()` → Core. The deferred async/stateful caps (video, sandboxes, agents, …) keep their `resolveServiceUrl` → provider-gateway path. Not consolidated (per SAP-1117).

## Notes

- `web.scrape`'s normalized DTO doesn't carry page `links` today; the SDK keeps the `links` type surface (non-breaking) and maps it defensively if the router ever returns it.
- Engine pin bump to drop `SAPIOM_<CAP>_URL` is tracked in **SAP-1118**.

## Testing

- `pnpm --filter @sapiom/tools typecheck` ✅
- `pnpm --filter @sapiom/tools lint` ✅
- `pnpm --filter @sapiom/tools build` ✅
- `pnpm --filter @sapiom/tools test` ✅ — **191 passed**, incl. a new `_client/capability-call.spec.ts` and rewritten search/content-generation specs asserting the routed URL, `x-api-key`, and normalized-DTO mapping.
- Changeset added (`@sapiom/tools` minor).

Blocked-by C1–C3 (SAP-1113/1114/1115) are **deployed**, so `/v1/capabilities/<id>` resolves.

Closes SAP-1116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)