### PR TITLE
add support for managing schedules

### DIFF
--- a/.changeset/add-schedules.md
+++ b/.changeset/add-schedules.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/orchestration-core": patch
+"@sapiom/tools": patch
+"@sapiom/cli": patch
+"@sapiom/mcp": patch
+---
+
+Add schedules: run a deployed orchestration on a recurring cron schedule or once at a set time.
+
+- `@sapiom/orchestration-core`: `createSchedule`, `listSchedules`, `getSchedule`, `cancelSchedule`, and `previewCron`.
+- `@sapiom/tools`: a `schedules` namespace (`create`, `list`, `get`, `cancel`).
+- `@sapiom/cli`: `sapiom orchestrations schedule create | list | inspect | cancel | preview`.
+- `@sapiom/mcp`: schedule tools — create, inspect (list/detail + recent fires), cancel, and cron preview.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,5 +16,18 @@ sapiom orchestrations check          # validate locally (bundle, manifest, graph
 sapiom orchestrations deploy         # build and ship
 ```
 
+### Schedules
+
+Run a deployed orchestration on a schedule — recurring (cron) or once at a set time:
+
+```sh
+sapiom orchestrations schedule preview "0 9 * * 1-5"            # check a cron before using it
+sapiom orchestrations schedule create my-app --cron "0 9 * * 1-5" --timezone America/New_York
+sapiom orchestrations schedule create my-app --at 2026-07-01T17:00:00Z   # one-off
+sapiom orchestrations schedule list my-app                     # list an orchestration's schedules
+sapiom orchestrations schedule inspect <scheduleId>            # config, next fire, recent fires
+sapiom orchestrations schedule cancel <scheduleId>
+```
+
 Run `sapiom orchestrations --help` for the full command set. Every command accepts
 `--json` for machine-readable output.

--- a/packages/cli/src/commands/orchestrations/index.ts
+++ b/packages/cli/src/commands/orchestrations/index.ts
@@ -7,6 +7,13 @@ import { runInit } from './init.js';
 import { runLink } from './link.js';
 import { runLogs } from './logs.js';
 import { runRun } from './run.js';
+import {
+  runScheduleCancel,
+  runScheduleCreate,
+  runScheduleInspect,
+  runScheduleList,
+  runSchedulePreview,
+} from './schedule.js';
 import { runSignal } from './signal.js';
 
 /**
@@ -58,4 +65,37 @@ export function registerOrchestrationsCommands(program: Command): void {
     .requiredOption('--correlation-id <id>', 'the signal correlation id')
     .option('--payload <json>', 'signal payload as a JSON string')
     .action(action(runSignal));
+
+  // `sapiom orchestrations schedule …` — cron + one-off schedules for an orchestration (by slug).
+  const schedule = group
+    .command('schedule')
+    .description('Manage schedules (cron + one-off triggers) for an orchestration.');
+
+  withHostFlags(
+    json(schedule.command('create <definition>').description('Create a cron (--cron) or one-off (--at) schedule.')),
+  )
+    .option('--cron <expr>', 'cron expression (recurring schedule)')
+    .option('--timezone <tz>', 'IANA timezone for the cron (default UTC)')
+    .option('--at <iso>', 'one-off fire time (ISO 8601)')
+    .option('--input <json>', 'execution input as a JSON string')
+    .option('--start-at <iso>', 'cron: earliest occurrence (ISO)')
+    .option('--end-at <iso>', 'cron: latest occurrence (ISO)')
+    .action(action(runScheduleCreate));
+
+  withHostFlags(json(schedule.command('list <definition>').description("List an orchestration's schedules.")))
+    .option('--status <status>', 'filter by status (active|paused|completed|disabled)')
+    .action(action(runScheduleList));
+
+  withHostFlags(
+    json(schedule.command('inspect <scheduleId>').description('Show a schedule, its next fire, and recent fires.')),
+  ).action(action(runScheduleInspect));
+
+  withHostFlags(json(schedule.command('cancel <scheduleId>').description('Cancel a schedule.'))).action(
+    action(runScheduleCancel),
+  );
+
+  withHostFlags(json(schedule.command('preview <cron>').description('Preview a cron expression (next occurrences).')))
+    .option('--timezone <tz>', 'IANA timezone (default UTC)')
+    .option('--count <n>', 'number of occurrences to show (default 5)')
+    .action(action(runSchedulePreview));
 }

--- a/packages/cli/src/commands/orchestrations/schedule.ts
+++ b/packages/cli/src/commands/orchestrations/schedule.ts
@@ -1,0 +1,125 @@
+/**
+ * `sapiom orchestrations schedule …` — manage schedules (cron + one-off triggers) for a
+ * server-side orchestration, addressed by its slug. Thin wrappers over @sapiom/orchestration-core.
+ */
+import {
+  cancelSchedule,
+  createSchedule,
+  getSchedule,
+  listSchedules,
+  OrchestrationError,
+  parseJsonInput,
+  previewCron,
+  type ScheduleKind,
+  type ScheduleStatus,
+} from '@sapiom/orchestration-core';
+
+import { type CliTarget, makeClient } from '../../lib/client.js';
+import { readConfig } from '../../lib/config.js';
+import { CliError, ok } from '../../lib/output.js';
+
+interface HostOpts {
+  host?: string;
+  target?: CliTarget;
+}
+
+/** A client scoped to the project's host (if linked) with per-invocation flag overrides. */
+function clientFor(opts: HostOpts) {
+  return makeClient({ projectHost: readConfig(process.cwd())?.host, flagHost: opts.host, flagTarget: opts.target });
+}
+
+function rethrow(err: unknown): never {
+  if (err instanceof OrchestrationError) throw new CliError(err.toStructured());
+  throw err;
+}
+
+export async function runScheduleCreate(
+  definition: string,
+  opts: HostOpts & {
+    cron?: string;
+    timezone?: string;
+    at?: string;
+    input?: string;
+    startAt?: string;
+    endAt?: string;
+  },
+): Promise<void> {
+  try {
+    // `--at` ⇒ one-off; otherwise recurring (the engine validates the kind's required field).
+    const kind: ScheduleKind = opts.at ? 'schedule_once' : 'schedule_cron';
+    const schedule = await createSchedule(
+      {
+        definition,
+        kind,
+        cron: opts.cron,
+        timezone: opts.timezone,
+        at: opts.at,
+        startAt: opts.startAt,
+        endAt: opts.endAt,
+        input: opts.input ? parseJsonInput(opts.input) : undefined,
+      },
+      clientFor(opts),
+    );
+    ok({ schedule }, [
+      `✓ Created schedule ${schedule.id}${schedule.nextFireAt ? ` — next fire ${schedule.nextFireAt}` : ''}`,
+      `  inspect: sapiom orchestrations schedule inspect ${schedule.id}`,
+    ]);
+  } catch (err) {
+    rethrow(err);
+  }
+}
+
+export async function runScheduleList(definition: string, opts: HostOpts & { status?: string }): Promise<void> {
+  try {
+    const rows = await listSchedules(
+      { definition, status: opts.status as ScheduleStatus | undefined },
+      clientFor(opts),
+    );
+    ok({ schedules: rows }, [
+      `${rows.length} schedule(s) for ${definition}`,
+      ...rows.map((r) => `  ${r.id}  ${r.kind}  ${r.status}  ${r.cron ?? ''}  next:${r.nextFireAt ?? '—'}`),
+    ]);
+  } catch (err) {
+    rethrow(err);
+  }
+}
+
+export async function runScheduleInspect(scheduleId: string, opts: HostOpts): Promise<void> {
+  try {
+    const s = await getSchedule(scheduleId, clientFor(opts));
+    ok({ schedule: s }, [
+      `Schedule ${s.id}  (${s.kind}, ${s.status})`,
+      `  next fire: ${s.nextFireAt ?? '—'}`,
+      `  recent fires: ${s.recentFires.length}`,
+    ]);
+  } catch (err) {
+    rethrow(err);
+  }
+}
+
+export async function runScheduleCancel(scheduleId: string, opts: HostOpts): Promise<void> {
+  try {
+    const result = await cancelSchedule(scheduleId, clientFor(opts));
+    ok({ id: result.id, status: result.status }, [`✓ Cancelled schedule ${scheduleId}`]);
+  } catch (err) {
+    rethrow(err);
+  }
+}
+
+export async function runSchedulePreview(
+  cron: string,
+  opts: HostOpts & { timezone?: string; count?: string },
+): Promise<void> {
+  try {
+    const result = await previewCron(
+      { cron, timezone: opts.timezone, count: opts.count ? Number(opts.count) : undefined },
+      clientFor(opts),
+    );
+    ok({ cron: result.cron, timezone: result.timezone, occurrences: result.occurrences }, [
+      `Next ${result.occurrences.length} occurrence(s) of '${cron}' (${result.timezone}):`,
+      ...result.occurrences.map((o) => `  ${o}`),
+    ]);
+  } catch (err) {
+    rethrow(err);
+  }
+}

--- a/packages/mcp/src/tools/orchestrations.schedules.test.ts
+++ b/packages/mcp/src/tools/orchestrations.schedules.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ResolvedEnvironment } from "../credentials.js";
+
+vi.mock("../credentials.js", () => ({
+  readCredentials: vi.fn(),
+}));
+
+// Keep the real module (createClient, OrchestrationError, ...) but stub the networked
+// schedule fns so the tools are tested without touching the backend.
+vi.mock("@sapiom/orchestration-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sapiom/orchestration-core")>();
+  return {
+    ...actual,
+    createSchedule: vi.fn(),
+    listSchedules: vi.fn(),
+    getSchedule: vi.fn(),
+    cancelSchedule: vi.fn(),
+    previewCron: vi.fn(),
+  };
+});
+
+import { register } from "./orchestrations.js";
+import { readCredentials } from "../credentials.js";
+import {
+  cancelSchedule,
+  createSchedule,
+  getSchedule,
+  listSchedules,
+  previewCron,
+} from "@sapiom/orchestration-core";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function createMockServer(): { server: McpServer; handlers: Map<string, ToolHandler> } {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: vi.fn((_name: string, _desc: string, _schema: any, handler: ToolHandler) => {
+      handlers.set(_name, handler);
+    }),
+  } as unknown as McpServer;
+  return { server, handlers };
+}
+
+const env: ResolvedEnvironment = {
+  name: "production",
+  appURL: "https://app.sapiom.ai",
+  apiURL: "https://api.sapiom.ai",
+  services: {},
+  credentials: null,
+};
+
+const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0].text);
+
+describe("orchestration schedule MCP tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readCredentials).mockResolvedValue({
+      apiKey: "sk_test",
+      tenantId: "t-1",
+      organizationName: "Org",
+      apiKeyId: "k-1",
+    } as never);
+  });
+
+  it("registers the 4 schedule tools", () => {
+    const { server, handlers } = createMockServer();
+    register(server, env);
+    for (const name of [
+      "sapiom_dev_orchestrations_schedule",
+      "sapiom_dev_orchestrations_schedule_inspect",
+      "sapiom_dev_orchestrations_schedule_cancel",
+      "sapiom_dev_orchestrations_cron_preview",
+    ]) {
+      expect(handlers.has(name)).toBe(true);
+    }
+  });
+
+  it("schedule create delegates to createSchedule and adds a next-fire hint", async () => {
+    vi.mocked(createSchedule).mockResolvedValue({
+      id: "trig-1",
+      kind: "schedule_cron",
+      status: "active",
+      definitionSlug: "enrich",
+      cron: "0 9 * * *",
+      timezone: "UTC",
+      nextFireAt: "2026-07-01T09:00:00.000Z",
+      createdAt: "x",
+      input: {},
+      startAt: null,
+      endAt: null,
+      policy: null,
+      recentFires: [],
+    } as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_orchestrations_schedule")!({
+      definition: "enrich",
+      kind: "schedule_cron",
+      cron: "0 9 * * *",
+      timezone: "UTC",
+    });
+
+    expect(createSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ definition: "enrich", kind: "schedule_cron", cron: "0 9 * * *" }),
+      expect.anything(),
+    );
+    const out = parse(res);
+    expect(out.schedule.id).toBe("trig-1");
+    expect(out.hint).toContain("next fire at");
+  });
+
+  it("schedule_inspect by id returns detail + a failure hint pointing at the failed run", async () => {
+    vi.mocked(getSchedule).mockResolvedValue({
+      id: "trig-1",
+      kind: "schedule_cron",
+      status: "active",
+      definitionSlug: "enrich",
+      cron: "* * * * *",
+      timezone: "UTC",
+      nextFireAt: "2026-07-01T09:00:00.000Z",
+      createdAt: "x",
+      input: {},
+      startAt: null,
+      endAt: null,
+      policy: null,
+      recentFires: [{ scheduledFor: "x", state: "failed", firedAt: "y", executionId: "exec-9", error: {} }],
+    } as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_orchestrations_schedule_inspect")!({ scheduleId: "trig-1" });
+
+    expect(getSchedule).toHaveBeenCalledWith("trig-1", expect.anything());
+    expect(parse(res).hint).toContain("exec-9");
+  });
+
+  it("schedule_inspect by definition lists schedules", async () => {
+    vi.mocked(listSchedules).mockResolvedValue([{ id: "trig-1" }] as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_orchestrations_schedule_inspect")!({
+      definition: "enrich",
+      status: "active",
+    });
+
+    expect(listSchedules).toHaveBeenCalledWith({ definition: "enrich", status: "active" }, expect.anything());
+    expect(parse(res)).toEqual([{ id: "trig-1" }]);
+  });
+
+  it("schedule_inspect with neither id nor definition is an error", async () => {
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_orchestrations_schedule_inspect")!({});
+
+    expect(res.isError).toBe(true);
+    expect(getSchedule).not.toHaveBeenCalled();
+    expect(listSchedules).not.toHaveBeenCalled();
+  });
+
+  it("schedule_cancel delegates to cancelSchedule", async () => {
+    vi.mocked(cancelSchedule).mockResolvedValue({ id: "trig-1", status: "disabled" } as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    await handlers.get("sapiom_dev_orchestrations_schedule_cancel")!({ scheduleId: "trig-1" });
+
+    expect(cancelSchedule).toHaveBeenCalledWith("trig-1", expect.anything());
+  });
+
+  it("cron_preview delegates to previewCron", async () => {
+    vi.mocked(previewCron).mockResolvedValue({
+      cron: "0 9 * * *",
+      timezone: "UTC",
+      occurrences: ["2026-07-01T09:00:00.000Z"],
+    } as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_orchestrations_cron_preview")!({ cron: "0 9 * * *", count: 1 });
+
+    expect(previewCron).toHaveBeenCalledWith({ cron: "0 9 * * *", timezone: undefined, count: 1 }, expect.anything());
+    expect(parse(res).occurrences).toHaveLength(1);
+  });
+});

--- a/packages/mcp/src/tools/orchestrations.ts
+++ b/packages/mcp/src/tools/orchestrations.ts
@@ -14,17 +14,22 @@ import path from "node:path";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
+  cancelSchedule,
   check,
   createClient,
+  createSchedule,
   deploy,
   GatewayClient,
+  getSchedule,
   inspect,
   inspectBuild,
   isExecutionTerminal,
   link,
   listExecutions,
+  listSchedules,
   OrchestrationError,
   parseStubFile,
+  previewCron,
   requireConfig,
   run,
   runLocalFromDir,
@@ -32,6 +37,8 @@ import {
   signal,
   waitForExecution,
   writeConfig,
+  type ScheduleDetail,
+  type SchedulePolicy,
   type StubFile,
 } from "@sapiom/orchestration-core";
 import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
@@ -145,6 +152,26 @@ const NOT_AUTHED = fail(
     hint: "Use the sapiom_authenticate tool first.",
   }),
 );
+
+/**
+ * Agent-facing one-liner about a schedule's health: surfaces recent fire failures (with the
+ * executionId to inspect) or the next fire time, so the agent knows the next action without
+ * re-deriving it from the raw fire ledger. `recentFires` is newest-first.
+ */
+function scheduleHint(schedule: ScheduleDetail): string | undefined {
+  const failed = schedule.recentFires.filter((f) => f.state === "failed");
+  if (failed.length > 0) {
+    const latest = failed[0];
+    const where = latest.executionId
+      ? ` — inspect execution ${latest.executionId} with sapiom_dev_orchestrations_inspect`
+      : "";
+    return `${failed.length} of the last ${schedule.recentFires.length} fires failed${where}.`;
+  }
+  if (schedule.status === "active" && schedule.nextFireAt) return `Active — next fire at ${schedule.nextFireAt}.`;
+  if (schedule.status === "completed") return "Completed — no further fires.";
+  if (schedule.status === "disabled") return "Cancelled — no further fires.";
+  return undefined;
+}
 
 export function register(server: McpServer, env: ResolvedEnvironment): void {
   // ── Local tools (no network) ──────────────────────────────────────────────
@@ -476,6 +503,138 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         return ok(
           await signal({ executionId, name, correlationId, payload }, client),
         );
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  // ── Schedules (triggers) ──────────────────────────────────────────────────
+
+  server.tool(
+    "sapiom_dev_orchestrations_schedule",
+    "Create a schedule for a deployed orchestration: a recurring cron schedule (kind 'schedule_cron' + cron + timezone) or a one-off delayed run (kind 'schedule_once' + at). Returns the schedule with its next fire time. Tip: validate a cron with sapiom_dev_orchestrations_cron_preview first.",
+    {
+      definition: z
+        .string()
+        .describe("The orchestration's tenant-unique slug (the handle it was deployed under)."),
+      kind: z
+        .enum(["schedule_cron", "schedule_once"])
+        .describe("'schedule_cron' = recurring; 'schedule_once' = a single delayed run."),
+      cron: z
+        .string()
+        .optional()
+        .describe("Cron expression — required for 'schedule_cron'. E.g. '0 9 * * 1-5' = 9am on weekdays."),
+      timezone: z
+        .string()
+        .optional()
+        .describe("IANA timezone the cron runs in (e.g. 'America/New_York'). Defaults to UTC."),
+      at: z
+        .string()
+        .optional()
+        .describe("ISO 8601 fire time — required for 'schedule_once'. E.g. '2026-07-01T17:00:00Z'."),
+      input: z.unknown().optional().describe("Execution input passed to each run (any JSON value)."),
+      startAt: z.string().optional().describe("Cron only: ISO time before which no occurrence fires."),
+      endAt: z.string().optional().describe("Cron only: ISO time after which the schedule completes."),
+      policy: z
+        .unknown()
+        .optional()
+        .describe("Cron only: { catchupPolicy?: 'skip'|'all', overlapPolicy?: 'allow', jitterMs?: number }."),
+    },
+    async ({ definition, kind, cron, timezone, at, input, startAt, endAt, policy }) => {
+      const client = await gatewayClient(env);
+      if (!client) return NOT_AUTHED;
+      try {
+        const schedule = await createSchedule(
+          {
+            definition,
+            kind,
+            cron,
+            timezone,
+            at,
+            input: coerceJson(input),
+            startAt,
+            endAt,
+            policy: coerceJson(policy) as SchedulePolicy | undefined,
+          },
+          client,
+        );
+        const hint = scheduleHint(schedule);
+        return ok({ schedule, ...(hint ? { hint } : {}) });
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  server.tool(
+    "sapiom_dev_orchestrations_schedule_inspect",
+    "Inspect schedules. With scheduleId: returns one schedule's config, next fire time, and recent fire history (each with the run's executionId) — use this to debug a misbehaving schedule, then inspect a failed run's executionId with sapiom_dev_orchestrations_inspect. With definition (slug) and no scheduleId: lists that orchestration's schedules.",
+    {
+      scheduleId: z.string().optional().describe("Inspect one schedule (detail + recent fires + a health hint)."),
+      definition: z
+        .string()
+        .optional()
+        .describe("List schedules for this orchestration slug (used when scheduleId is omitted)."),
+      status: z
+        .enum(["active", "paused", "completed", "disabled"])
+        .optional()
+        .describe("Filter the list by status."),
+    },
+    async ({ scheduleId, definition, status }) => {
+      const client = await gatewayClient(env);
+      if (!client) return NOT_AUTHED;
+      try {
+        if (scheduleId) {
+          const schedule = await getSchedule(scheduleId, client);
+          const hint = scheduleHint(schedule);
+          return ok({ schedule, ...(hint ? { hint } : {}) });
+        }
+        if (definition) {
+          return ok(await listSchedules({ definition, status }, client));
+        }
+        return fail(
+          new OrchestrationError({
+            code: "BAD_INPUT",
+            message: "Provide scheduleId (to inspect one) or definition (to list an orchestration's schedules).",
+          }),
+        );
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  server.tool(
+    "sapiom_dev_orchestrations_schedule_cancel",
+    "Cancel a schedule by id. Stops all future fires (a recurring schedule won't re-arm; a pending one-off won't run). Irreversible — recreate to reschedule.",
+    {
+      scheduleId: z.string().describe("The schedule to cancel."),
+    },
+    async ({ scheduleId }) => {
+      const client = await gatewayClient(env);
+      if (!client) return NOT_AUTHED;
+      try {
+        return ok(await cancelSchedule(scheduleId, client));
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  server.tool(
+    "sapiom_dev_orchestrations_cron_preview",
+    "Validate a cron expression and preview its next occurrences, creating nothing. Use before sapiom_dev_orchestrations_schedule to confirm a cron + timezone fire when you expect (cron syntax is easy to get subtly wrong).",
+    {
+      cron: z.string().describe("Cron expression to validate, e.g. '0 9 * * 1-5'."),
+      timezone: z.string().optional().describe("IANA timezone (default UTC)."),
+      count: z.number().optional().describe("How many upcoming occurrences to return (default 5)."),
+    },
+    async ({ cron, timezone, count }) => {
+      const client = await gatewayClient(env);
+      if (!client) return NOT_AUTHED;
+      try {
+        return ok(await previewCron({ cron, timezone, count }, client));
       } catch (err) {
         return fail(err);
       }

--- a/packages/orchestration-core/src/index.ts
+++ b/packages/orchestration-core/src/index.ts
@@ -92,6 +92,21 @@ export type {
 export { signal, parseSignalPayload } from "./signal.js";
 export type { SignalOptions, SignalResult } from "./signal.js";
 
+// schedules / triggers (networked)
+export { createSchedule, listSchedules, getSchedule, cancelSchedule, previewCron } from "./schedule.js";
+export type {
+  ScheduleKind,
+  ScheduleStatus,
+  SchedulePolicy,
+  CreateScheduleOptions,
+  ListSchedulesOptions,
+  CronPreviewOptions,
+  CronPreview,
+  ScheduleSummary,
+  ScheduleDetail,
+  ScheduleFireRecord,
+} from "./schedule.js";
+
 // git helpers (used by deploy; exported for consumers that need them directly)
 export { assertDeployable, pushHead } from "./git.js";
 

--- a/packages/orchestration-core/src/schedule.spec.ts
+++ b/packages/orchestration-core/src/schedule.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * schedule core fns — assert each builds the right method + path (+ body) against the
+ * `/v1/workflows` base. The GatewayClient is faked to record calls.
+ */
+import type { GatewayClient } from './client.js';
+import { cancelSchedule, createSchedule, getSchedule, listSchedules, previewCron } from './schedule.js';
+
+interface Call {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+function fakeClient(): { client: GatewayClient; calls: Call[] } {
+  const calls: Call[] = [];
+  const client = {
+    get: async (path: string) => {
+      calls.push({ method: 'GET', path });
+      return [];
+    },
+    post: async (path: string, body?: unknown) => {
+      calls.push({ method: 'POST', path, body });
+      return { id: 'trig-1' };
+    },
+    request: async (method: string, path: string, body?: unknown) => {
+      calls.push({ method, path, body });
+      return { id: 'trig-1', status: 'disabled' };
+    },
+  } as unknown as GatewayClient;
+  return { client, calls };
+}
+
+describe('schedule core fns', () => {
+  it('createSchedule POSTs /:slug/triggers with the body (definition stripped)', async () => {
+    const { client, calls } = fakeClient();
+    await createSchedule(
+      { definition: 'enrich-lead', kind: 'schedule_cron', cron: '0 9 * * *', timezone: 'UTC' },
+      client,
+    );
+    expect(calls[0]).toEqual({
+      method: 'POST',
+      path: '/enrich-lead/triggers',
+      body: { kind: 'schedule_cron', cron: '0 9 * * *', timezone: 'UTC' },
+    });
+  });
+
+  it('listSchedules GETs /:slug/triggers with a query string', async () => {
+    const { client, calls } = fakeClient();
+    await listSchedules({ definition: 'enrich-lead', status: 'active', limit: 10 }, client);
+    expect(calls[0]).toEqual({ method: 'GET', path: '/enrich-lead/triggers?status=active&limit=10' });
+  });
+
+  it('listSchedules omits an empty query', async () => {
+    const { client, calls } = fakeClient();
+    await listSchedules({ definition: 'enrich-lead' }, client);
+    expect(calls[0].path).toBe('/enrich-lead/triggers');
+  });
+
+  it('getSchedule GETs /triggers/:id', async () => {
+    const { client, calls } = fakeClient();
+    await getSchedule('trig-1', client);
+    expect(calls[0]).toEqual({ method: 'GET', path: '/triggers/trig-1' });
+  });
+
+  it('cancelSchedule DELETEs /triggers/:id', async () => {
+    const { client, calls } = fakeClient();
+    await cancelSchedule('trig-1', client);
+    expect(calls[0]).toEqual({ method: 'DELETE', path: '/triggers/trig-1', body: undefined });
+  });
+
+  it('previewCron POSTs /triggers/preview-cron', async () => {
+    const { client, calls } = fakeClient();
+    await previewCron({ cron: '0 9 * * *', count: 3 }, client);
+    expect(calls[0]).toEqual({ method: 'POST', path: '/triggers/preview-cron', body: { cron: '0 9 * * *', count: 3 } });
+  });
+});

--- a/packages/orchestration-core/src/schedule.ts
+++ b/packages/orchestration-core/src/schedule.ts
@@ -1,0 +1,121 @@
+/**
+ * schedule — manage scheduled triggers for a server-side orchestration definition.
+ *
+ * Networked operations: each takes a GatewayClient. The backend routes sit under the
+ * `/v1/workflows` base the client already targets: create/list nest under the definition slug
+ * (`/:slug/triggers`); detail/cancel are top-level (`/triggers/:id`); cron preview is stateless
+ * (`/triggers/preview-cron`). "Schedule" is the SDK word for the engine's "trigger".
+ */
+import { GatewayClient } from './client.js';
+
+export type ScheduleKind = 'schedule_cron' | 'schedule_once';
+export type ScheduleStatus = 'active' | 'paused' | 'completed' | 'disabled';
+
+export interface SchedulePolicy {
+  catchupPolicy?: 'skip' | 'all';
+  overlapPolicy?: 'allow' | 'skip';
+  jitterMs?: number;
+}
+
+export interface CreateScheduleOptions {
+  /** Tenant-unique slug of the orchestration to schedule. */
+  definition: string;
+  kind: ScheduleKind;
+  /** Execution input passed to each fire. */
+  input?: unknown;
+  /** Recurring (`schedule_cron`): the cron expression (required for that kind). */
+  cron?: string;
+  /** IANA timezone the cron is evaluated in (defaults to UTC server-side). */
+  timezone?: string;
+  startAt?: string;
+  endAt?: string;
+  policy?: SchedulePolicy;
+  /** One-off (`schedule_once`): the single fire time (ISO 8601; required for that kind). */
+  at?: string;
+}
+
+export interface ScheduleFireRecord {
+  scheduledFor: string;
+  state: string;
+  firedAt: string | null;
+  executionId: string | null;
+  error?: unknown;
+}
+
+export interface ScheduleSummary {
+  id: string;
+  kind: ScheduleKind;
+  status: ScheduleStatus;
+  definitionSlug: string;
+  cron: string | null;
+  timezone: string | null;
+  nextFireAt: string | null;
+  createdAt: string;
+}
+
+export interface ScheduleDetail extends ScheduleSummary {
+  input: unknown;
+  startAt: string | null;
+  endAt: string | null;
+  policy: unknown;
+  /** Recent fire ledger (newest first) — the debug view. */
+  recentFires: ScheduleFireRecord[];
+}
+
+export interface ListSchedulesOptions {
+  definition: string;
+  status?: ScheduleStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CronPreviewOptions {
+  cron: string;
+  timezone?: string;
+  count?: number;
+}
+
+export interface CronPreview {
+  cron: string;
+  timezone: string;
+  occurrences: string[];
+}
+
+/** Create a schedule (cron or one-off) for the orchestration. Returns the schedule detail. */
+export async function createSchedule(opts: CreateScheduleOptions, client: GatewayClient): Promise<ScheduleDetail> {
+  const { definition, ...body } = opts;
+  return client.post<ScheduleDetail>(`/${encodeURIComponent(definition)}/triggers`, body);
+}
+
+/** List an orchestration's schedules (newest first), optionally filtered by status. */
+export async function listSchedules(opts: ListSchedulesOptions, client: GatewayClient): Promise<ScheduleSummary[]> {
+  const { definition, ...filters } = opts;
+  return client.get<ScheduleSummary[]>(`/${encodeURIComponent(definition)}/triggers${toQuery(filters)}`);
+}
+
+/** Get one schedule: config + next fire + recent fire ledger. */
+export async function getSchedule(id: string, client: GatewayClient): Promise<ScheduleDetail> {
+  return client.get<ScheduleDetail>(`/triggers/${encodeURIComponent(id)}`);
+}
+
+/** Cancel a schedule. */
+export async function cancelSchedule(
+  id: string,
+  client: GatewayClient,
+): Promise<{ id: string; status: ScheduleStatus }> {
+  return client.request<{ id: string; status: ScheduleStatus }>('DELETE', `/triggers/${encodeURIComponent(id)}`);
+}
+
+/** Validate a cron expression + timezone and preview the next occurrences (no persistence). */
+export async function previewCron(opts: CronPreviewOptions, client: GatewayClient): Promise<CronPreview> {
+  return client.post<CronPreview>('/triggers/preview-cron', opts);
+}
+
+function toQuery(filters: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== null) params.set(key, String(value));
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, and orchestrations — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, orchestrations, and schedules — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -76,6 +76,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `contentGeneration` | Media generation (images + video; audio soon), with optional `storage`                                | [src/content-generation](./src/content-generation/README.md) |
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
 | `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
+| `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                              | [src/schedules](./src/schedules/README.md)                   |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 
 ## Composing capabilities

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -61,6 +61,9 @@ export { agentRunResultSchema, AgentRunResultSchemaError } from "./agent/index.j
 export * as orchestrations from "./orchestrations/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
 export { ORCHESTRATIONS_RESULT_SIGNAL } from "./orchestrations/index.js";
+
+// schedules — create/manage cron + one-off triggers for a deployed orchestration.
+export * as schedules from "./schedules/index.js";
 // The shape a step resumed from `pauseUntilSignal(orchestrationHandle, …)` receives
 // as input — annotate the resumed step with it instead of hand-rolling the shape.
 export type { OrchestrationRunResultPayload } from "./orchestrations/index.js";

--- a/packages/tools/src/schedules/README.md
+++ b/packages/tools/src/schedules/README.md
@@ -1,0 +1,40 @@
+# schedules
+
+Create and manage schedules for a deployed orchestration: a recurring **cron** schedule, or a **one-off** delayed run. A schedule is attached to an orchestration by its **slug**, and each time it fires it starts a run of that orchestration with the input you set.
+
+```ts
+import { schedules } from "@sapiom/tools";
+
+// Recurring: run "enrich-lead" at 9am New York time, Monday–Friday.
+const daily = await schedules.create({
+  definition: "enrich-lead",
+  kind: "schedule_cron",
+  cron: "0 9 * * 1-5",
+  timezone: "America/New_York",
+  input: { source: "crm" },
+});
+
+// One-off: run once, two hours from now.
+await schedules.create({
+  definition: "send-receipt",
+  kind: "schedule_once",
+  at: new Date(Date.now() + 2 * 60 * 60_000).toISOString(),
+  input: { orderId },
+});
+```
+
+```ts
+// List an orchestration's schedules, inspect one, or cancel it.
+const all = await schedules.list("enrich-lead");
+const one = await schedules.get(all[0].id); // includes nextFireAt + recent fires
+await schedules.cancel(one.id);
+```
+
+## Things to know
+
+- **Two kinds.** `schedule_cron` takes a `cron` expression (+ optional `timezone`); `schedule_once` takes an `at` time (ISO 8601). A cron schedule fires on every matching tick until cancelled; a one-off fires exactly once.
+- **Timezone-aware cron.** `timezone` is an IANA name (e.g. `"America/New_York"`); the cron is evaluated in that zone, so daylight-saving shifts are handled for you. Defaults to UTC.
+- **Best-effort timing.** A schedule fires at or shortly after its scheduled time — fine for "around 9am", not for hard real-time deadlines.
+- **`get` shows health.** `get(id)` returns the next scheduled fire (`nextFireAt`) and a recent fire history — each with the `executionId` of the run it started — so you can confirm a schedule is firing or debug one that isn't.
+- **Cancel is final.** A cancelled schedule stops firing (a recurring one won't re-arm); recreate to reschedule.
+- **Optional bounds (cron).** `startAt` / `endAt` confine when a cron schedule is active.

--- a/packages/tools/src/schedules/index.ts
+++ b/packages/tools/src/schedules/index.ts
@@ -1,0 +1,131 @@
+/**
+ * `schedules` capability — create and manage schedules (cron + one-off triggers) for a deployed
+ * orchestration, addressed by its slug.
+ *
+ *   import { schedules } from "@sapiom/tools";
+ *   await schedules.create({ definition: "enrich-lead", kind: "schedule_cron", cron: "0 9 * * 1-5" });
+ *
+ * "Schedule" is the SDK word for the engine's "trigger". Routes sit under `/v1/workflows`:
+ * create/list nest under the definition slug; detail/cancel are top-level under `/triggers`.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "workflows",
+  process.env.SAPIOM_WORKFLOWS_URL,
+);
+
+export type ScheduleKind = "schedule_cron" | "schedule_once";
+export type ScheduleStatus = "active" | "paused" | "completed" | "disabled";
+
+export interface SchedulePolicy {
+  catchupPolicy?: "skip" | "all";
+  overlapPolicy?: "allow" | "skip";
+  jitterMs?: number;
+}
+
+export interface CreateScheduleSpec {
+  /** The orchestration's tenant-unique slug. */
+  definition: string;
+  kind: ScheduleKind;
+  input?: unknown;
+  /** Recurring (`schedule_cron`): cron expression + optional timezone/bounds/policy. */
+  cron?: string;
+  timezone?: string;
+  startAt?: string;
+  endAt?: string;
+  policy?: SchedulePolicy;
+  /** One-off (`schedule_once`): the single fire time (ISO 8601). */
+  at?: string;
+}
+
+export interface ScheduleFireRecord {
+  scheduledFor: string;
+  state: string;
+  firedAt: string | null;
+  executionId: string | null;
+  error?: unknown;
+}
+
+export interface ScheduleSummary {
+  id: string;
+  kind: ScheduleKind;
+  status: ScheduleStatus;
+  definitionSlug: string;
+  cron: string | null;
+  timezone: string | null;
+  nextFireAt: string | null;
+  createdAt: string;
+}
+
+export interface ScheduleDetail extends ScheduleSummary {
+  input: unknown;
+  startAt: string | null;
+  endAt: string | null;
+  policy: unknown;
+  recentFires: ScheduleFireRecord[];
+}
+
+export interface ListSchedulesOptions {
+  status?: ScheduleStatus;
+  limit?: number;
+  offset?: number;
+}
+
+/** Create a schedule (cron or one-off) for the orchestration. */
+export async function create(
+  spec: CreateScheduleSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<ScheduleDetail> {
+  const { definition, ...body } = spec;
+  return transport.request<ScheduleDetail>(
+    `${baseUrl}/v1/workflows/${encodeURIComponent(definition)}/triggers`,
+    { method: "POST", body: JSON.stringify(body) },
+  );
+}
+
+/** List an orchestration's schedules. */
+export async function list(
+  definition: string,
+  opts: ListSchedulesOptions = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<ScheduleSummary[]> {
+  return transport.request<ScheduleSummary[]>(
+    `${baseUrl}/v1/workflows/${encodeURIComponent(definition)}/triggers${toQuery(opts)}`,
+  );
+}
+
+/** Get one schedule: config + next fire + recent fire ledger. */
+export async function get(
+  scheduleId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<ScheduleDetail> {
+  return transport.request<ScheduleDetail>(
+    `${baseUrl}/v1/workflows/triggers/${encodeURIComponent(scheduleId)}`,
+  );
+}
+
+/** Cancel a schedule. */
+export async function cancel(
+  scheduleId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<{ id: string; status: ScheduleStatus }> {
+  return transport.request<{ id: string; status: ScheduleStatus }>(
+    `${baseUrl}/v1/workflows/triggers/${encodeURIComponent(scheduleId)}`,
+    { method: "DELETE" },
+  );
+}
+
+function toQuery(opts: ListSchedulesOptions): string {
+  const params = new URLSearchParams();
+  if (opts.status !== undefined) params.set("status", opts.status);
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.offset !== undefined) params.set("offset", String(opts.offset));
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for orchestration schedules (cron and one-off triggers) across the CLI, orchestration core, and MCP tool layers. The changes add new commands and APIs to create, list, inspect, cancel, and preview orchestration schedules, along with full test coverage and agent-facing documentation.

**Key changes include:**

### CLI: Orchestration Schedule Commands

* Added new CLI commands under `sapiom orchestrations schedule` to create, list, inspect, cancel, and preview schedules, with options for cron expressions, timezones, one-off triggers, and input payloads (`index.ts`, `schedule.ts`). [[1]](diffhunk://#diff-6c9c6a3180b805acd3cfef501d8a4b24b76cb7b4436ded8cfd7832709f09b303R10-R16) [[2]](diffhunk://#diff-6c9c6a3180b805acd3cfef501d8a4b24b76cb7b4436ded8cfd7832709f09b303R68-R100) [[3]](diffhunk://#diff-2266a55e54f8c287b923c9b28870e10c1eb3bf8b4cc3ec9b2ef1af60c8301c8aR1-R125)

### Orchestration Core: Schedule API

* Exposed new schedule-related functions (`createSchedule`, `listSchedules`, `getSchedule`, `cancelSchedule`, `previewCron`) and their associated types in the orchestration core package, enabling programmatic management of orchestration schedules (`index.ts`).
* Added unit tests for all schedule core functions to verify correct HTTP methods, paths, and payloads (`schedule.spec.ts`).

### MCP Tools: Schedule Integration

* Integrated schedule management tools into the MCP server, providing agent-facing tools for creating, inspecting, canceling, and previewing schedules, with clear documentation and error handling (`orchestrations.ts`). [[1]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR17-R41) [[2]](diffhunk://#diff-7ab852d398f7c91fb6970aa1204734b6133b91536534742c3d8d1d266df2f2bfR511-R642)
* Added a helper to generate agent-facing schedule health hints based on recent fire history and status (`orchestrations.ts`).
* Added comprehensive tests for the MCP schedule tools, including mocking orchestration core APIs and verifying tool registration and behavior (`orchestrations.schedules.test.ts`).