### PR TITLE
feat(mcp): fetch authoring instructions from the backend, with static fallback (SAP-1257)

### DIFF
--- a/.changeset/sapiom-mcp-authoring-instructions.md
+++ b/.changeset/sapiom-mcp-authoring-instructions.md
@@ -2,4 +2,4 @@
 "@sapiom/mcp": minor
 ---
 
-Deliver the workflow-authoring primer via the MCP server `instructions` field. Capable clients (e.g. Claude Code) inject it into the agent's context on connect, so any agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically — no skill install or docs hand-off. The primer is concise and points to the full docs (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.
+Deliver the workflow-authoring primer through the MCP server `instructions` field. Capable MCP clients surface it to the model on connect, so an agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically. The primer is concise and points to the full documentation (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.

--- a/.changeset/sapiom-mcp-authoring-instructions.md
+++ b/.changeset/sapiom-mcp-authoring-instructions.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/mcp": minor
+---
+
+Deliver the workflow-authoring primer via the MCP server `instructions` field. Capable clients (e.g. Claude Code) inject it into the agent's context on connect, so any agent that adds `@sapiom/mcp` gets the authoring lifecycle (authenticate → scaffold → check/run_local → deploy/run) and the canonical `@sapiom/orchestration` rules automatically — no skill install or docs hand-off. The primer is concise and points to the full docs (docs.sapiom.ai/workflows) and the scaffold's `AGENTS.md`.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,6 +6,7 @@ import { resolveEnvironment } from "./credentials.js";
 import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerOrchestrations } from "./tools/orchestrations.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
 
 async function main(): Promise<void> {
   // Resolve environment: SAPIOM_ENVIRONMENT env var > file > "production"
@@ -17,11 +18,19 @@ async function main(): Promise<void> {
     );
   }
 
-  const server = new McpServer({
-    // The local dev surface — distinct from the remote Sapiom capabilities MCP.
-    name: "sapiom-dev",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      // The local dev surface — distinct from the remote Sapiom capabilities MCP.
+      name: "sapiom-dev",
+      version: "0.1.0",
+    },
+    {
+      // Auto-delivered to capable clients on connect (the MCP `initialize` handshake),
+      // so any agent that adds this server gets the workflow-authoring primer with no
+      // skill install or docs hand-off. See ./instructions.ts.
+      instructions: AUTHORING_INSTRUCTIONS,
+    },
+  );
 
   // Register all tools
   registerAuthenticate(server, env);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -25,9 +25,9 @@ async function main(): Promise<void> {
       version: "0.1.0",
     },
     {
-      // Auto-delivered to capable clients on connect (the MCP `initialize` handshake),
-      // so any agent that adds this server gets the workflow-authoring primer with no
-      // skill install or docs hand-off. See ./instructions.ts.
+      // Returned in the MCP `initialize` handshake; capable clients surface it to the
+      // model on connect, so an agent that adds this server gets the authoring primer
+      // automatically. See ./instructions.ts.
       instructions: AUTHORING_INSTRUCTIONS,
     },
   );

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,7 +6,7 @@ import { resolveEnvironment } from "./credentials.js";
 import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerOrchestrations } from "./tools/orchestrations.js";
-import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
+import { fetchInstructions } from "./instructions-fetch.js";
 
 async function main(): Promise<void> {
   // Resolve environment: SAPIOM_ENVIRONMENT env var > file > "production"
@@ -18,6 +18,10 @@ async function main(): Promise<void> {
     );
   }
 
+  // Pull the latest authoring instructions from the backend (falls back to the
+  // bundled copy offline / on error), so guidance can change without a release.
+  const instructions = await fetchInstructions(env);
+
   const server = new McpServer(
     {
       // The local dev surface — distinct from the remote Sapiom capabilities MCP.
@@ -27,8 +31,8 @@ async function main(): Promise<void> {
     {
       // Returned in the MCP `initialize` handshake; capable clients surface it to the
       // model on connect, so an agent that adds this server gets the authoring primer
-      // automatically. See ./instructions.ts.
-      instructions: AUTHORING_INSTRUCTIONS,
+      // automatically. Fetched from the backend; bundled fallback in ./instructions.ts.
+      instructions,
     },
   );
 

--- a/packages/mcp/src/instructions-fetch.test.ts
+++ b/packages/mcp/src/instructions-fetch.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { ResolvedEnvironment } from "./credentials.js";
+import { fetchInstructions } from "./instructions-fetch.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
+
+const env: ResolvedEnvironment = {
+  name: "production",
+  appURL: "https://app.sapiom.ai",
+  apiURL: "https://api.sapiom.ai",
+  services: {},
+  credentials: null,
+};
+
+describe("fetchInstructions", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns the fetched body on a 200 response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# Remote instructions"),
+    }) as unknown as typeof globalThis.fetch;
+    await expect(fetchInstructions(env)).resolves.toBe("# Remote instructions");
+  });
+
+  it("requests the instructions endpoint on the resolved apiURL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("ok"),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    await fetchInstructions(env);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.sapiom.ai/v1/mcp/instructions",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it("falls back to the bundled instructions on a non-200", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve("Not found"),
+    }) as unknown as typeof globalThis.fetch;
+    await expect(fetchInstructions(env)).resolves.toBe(AUTHORING_INSTRUCTIONS);
+  });
+
+  it("falls back when the body is empty", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("   "),
+    }) as unknown as typeof globalThis.fetch;
+    await expect(fetchInstructions(env)).resolves.toBe(AUTHORING_INSTRUCTIONS);
+  });
+
+  it("falls back on a network error", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network down")) as unknown as typeof globalThis.fetch;
+    await expect(fetchInstructions(env)).resolves.toBe(AUTHORING_INSTRUCTIONS);
+  });
+
+  it("falls back when the request times out", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_url: string, opts?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const promise = fetchInstructions(env);
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(promise).resolves.toBe(AUTHORING_INSTRUCTIONS);
+  });
+});

--- a/packages/mcp/src/instructions-fetch.ts
+++ b/packages/mcp/src/instructions-fetch.ts
@@ -1,0 +1,32 @@
+import type { ResolvedEnvironment } from "./credentials.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
+
+/** How long to wait for the instructions endpoint before falling back. */
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetch the authoring instructions from the Sapiom backend
+ * (`GET {apiURL}/v1/mcp/instructions`, public / no auth), so the guidance a
+ * coding agent receives on connect can change without republishing this package.
+ *
+ * Falls back to the bundled {@link AUTHORING_INSTRUCTIONS} on any failure — a
+ * non-200, an empty body, a network error, or a timeout. Never throws: the MCP
+ * server must always start with usable instructions, online or off.
+ */
+export async function fetchInstructions(env: ResolvedEnvironment): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${env.apiURL}/v1/mcp/instructions`, {
+      headers: { Accept: "text/markdown, text/plain" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return AUTHORING_INSTRUCTIONS;
+    const body = (await response.text()).trim();
+    return body.length > 0 ? body : AUTHORING_INSTRUCTIONS;
+  } catch {
+    return AUTHORING_INSTRUCTIONS;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AUTHORING_INSTRUCTIONS } from "./instructions.js";
+
+describe("server instructions", () => {
+  it("are delivered to a client over the initialize handshake", async () => {
+    const server = new McpServer(
+      { name: "sapiom-dev", version: "0.1.0" },
+      { instructions: AUTHORING_INSTRUCTIONS },
+    );
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    // This is the channel a capable client injects into the agent's context.
+    expect(client.getInstructions()).toBe(AUTHORING_INSTRUCTIONS);
+  });
+
+  it("primer covers the lifecycle, canonical rules, and points to the docs", () => {
+    // Lifecycle tools an agent must drive
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_authenticate");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_orchestrations_scaffold");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_orchestrations_run_local");
+    // Canonical naming (and the stale name it must steer away from)
+    expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/orchestration");
+    expect(AUTHORING_INSTRUCTIONS).toContain("defineOrchestration");
+    // the stale names appear only inside the explicit "NEVER use" warning
+    expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
+    // Single-source pointer to the full docs + the scaffold guide
+    expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
+    expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
+  });
+});

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -36,5 +36,8 @@ describe("server instructions", () => {
     // Pointer to the full docs + the scaffold guide
     expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
+    // The two-MCP frame: agents learn the remote MCP exists for direct tool calls
+    expect(AUTHORING_INSTRUCTIONS).toContain("remote MCP");
+    expect(AUTHORING_INSTRUCTIONS).toContain("api.sapiom.ai/v1/mcp");
   });
 });

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -33,7 +33,7 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("defineOrchestration");
     // the stale names appear only inside the explicit "NEVER use" warning
     expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
-    // Single-source pointer to the full docs + the scaffold guide
+    // Pointer to the full docs + the scaffold guide
     expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
   });

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -18,7 +18,7 @@ This server is the **authoring MCP** — it builds, tests, and deploys **workflo
 \`sapiom_dev_orchestrations_*\` tools below). For a **one-off capability call** without authoring a
 workflow, use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
 (\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
-capability as a direct \`sapiom_*\` tool — or call the gateway from code with the SDK
+capability as a direct \`sapiom_*\` tool (e.g. \`sapiom_search\`; run \`tool_discover\` to find the right one) — or call the gateway from code with the SDK
 (\`@sapiom/fetch\`). Rule of thumb: author a workflow for anything multi-step, scheduled, or
 deployable; use the remote MCP or the SDK for a single action.
 

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -31,8 +31,9 @@ step's \`run(input, ctx)\` does work and returns a directive. All from the termi
   \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\` target
   must be listed in \`next[]\`. TypeScript enforces all of these.
 - Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
-- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent.coding, fileStorage,
-  contentGeneration.images) — a typed subset of the gateway catalog; use autocomplete/typecheck.
+- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent(+coding), orchestrations,
+  fileStorage, contentGeneration.{images,video}, search, database) — a typed subset of the gateway
+  catalog; use autocomplete/typecheck.
 
 Full reference: https://docs.sapiom.ai/workflows (authoring · capabilities · reference · examples)
 and the \`AGENTS.md\` inside your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -1,12 +1,11 @@
 /**
- * MCP server `instructions` — returned in the `initialize` handshake. Capable clients
- * (e.g. Claude Code) inject this into the agent's context on connect, so any coding agent
- * that adds this MCP gets the workflow-authoring primer automatically — no skill to install,
- * no docs to hand over.
+ * The MCP server `instructions` string, returned during the `initialize` handshake.
+ * Capable MCP clients surface it to the model on connect, so an agent that adds this
+ * server gets a workflow-authoring primer without any extra setup.
  *
- * Keep this CONCISE: it is always in context while the server is connected. It POINTS to the
- * single-source full docs (https://docs.sapiom.ai/workflows) and the `AGENTS.md` the scaffold
- * writes into every project, rather than restating them — so it rarely needs to change.
+ * Kept intentionally short — it stays in the model's context for the whole session, and
+ * points to the full documentation and the `AGENTS.md` generated into each scaffolded
+ * project rather than restating them.
  */
 export const AUTHORING_INSTRUCTIONS = `# Sapiom Workflow Authoring
 

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -13,6 +13,15 @@ These tools let a coding agent build, test, and deploy a Sapiom workflow — a
 \`defineOrchestration({ name, entry, steps })\` (from \`@sapiom/orchestration\`) where each
 step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
 
+## Two ways to use Sapiom
+This server is the **authoring MCP** — it builds, tests, and deploys **workflows** (the
+\`sapiom_dev_orchestrations_*\` tools below). For a **one-off capability call** without authoring a
+workflow, use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
+(\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
+capability as a direct \`sapiom_*\` tool — or call the gateway from code with the SDK
+(\`@sapiom/fetch\`). Rule of thumb: author a workflow for anything multi-step, scheduled, or
+deployable; use the remote MCP or the SDK for a single action.
+
 ## Lifecycle (in order)
 1. \`sapiom_authenticate\` — browser login; caches an API key (makes you an API-key principal,
    required for deploy/run). Confirm with \`sapiom_status\`.

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -7,15 +7,17 @@
  * points to the full documentation and the `AGENTS.md` generated into each scaffolded
  * project rather than restating them.
  */
-export const AUTHORING_INSTRUCTIONS = `# Sapiom Workflow Authoring
+export const AUTHORING_INSTRUCTIONS = `# Sapiom dev MCP (sapiom-dev)
 
-These tools let a coding agent build, test, and deploy a Sapiom workflow — a
-\`defineOrchestration({ name, entry, steps })\` (from \`@sapiom/orchestration\`) where each
-step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
+\`sapiom-dev\` is Sapiom's local developer MCP — the terminal surface for setting up and managing
+your Sapiom projects. Today it drives **workflow authoring** (more dev/management tools will land
+here over time): these tools build, test, and deploy a Sapiom workflow — a
+\`defineOrchestration({ name, entry, steps })\` (from \`@sapiom/orchestration\`) where each step's
+\`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
 
 ## Two ways to use Sapiom
-This server is the **authoring MCP** — it builds, tests, and deploys **workflows** (the
-\`sapiom_dev_orchestrations_*\` tools below). For a **one-off capability call** without authoring a
+This server (\`sapiom-dev\`) is where you **author workflows** — the
+\`sapiom_dev_orchestrations_*\` tools build, test, and deploy them. For a **one-off capability call** without authoring a
 workflow, use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
 (\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
 capability as a direct \`sapiom_*\` tool (e.g. \`sapiom_search\`; run \`tool_discover\` to find the right one) — or call the gateway from code with the SDK
@@ -44,5 +46,5 @@ deployable; use the remote MCP or the SDK for a single action.
   fileStorage, contentGeneration.{images,video}, search, database) — a typed subset of the gateway
   catalog; use autocomplete/typecheck.
 
-Full reference: https://docs.sapiom.ai/workflows (authoring · capabilities · reference · examples)
+Full reference: https://docs.sapiom.ai/workflows/quick-start (authoring · capabilities · reference · examples)
 and the \`AGENTS.md\` inside your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -1,0 +1,39 @@
+/**
+ * MCP server `instructions` — returned in the `initialize` handshake. Capable clients
+ * (e.g. Claude Code) inject this into the agent's context on connect, so any coding agent
+ * that adds this MCP gets the workflow-authoring primer automatically — no skill to install,
+ * no docs to hand over.
+ *
+ * Keep this CONCISE: it is always in context while the server is connected. It POINTS to the
+ * single-source full docs (https://docs.sapiom.ai/workflows) and the `AGENTS.md` the scaffold
+ * writes into every project, rather than restating them — so it rarely needs to change.
+ */
+export const AUTHORING_INSTRUCTIONS = `# Sapiom Workflow Authoring
+
+These tools let a coding agent build, test, and deploy a Sapiom workflow — a
+\`defineOrchestration({ name, entry, steps })\` (from \`@sapiom/orchestration\`) where each
+step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
+
+## Lifecycle (in order)
+1. \`sapiom_authenticate\` — browser login; caches an API key (makes you an API-key principal,
+   required for deploy/run). Confirm with \`sapiom_status\`.
+2. \`sapiom_dev_orchestrations_scaffold\` — writes a project. READ its \`AGENTS.md\` first; it is
+   the full authoring guide, shipped inside every scaffold. Then \`npm install\`.
+3. Test for free: \`npm run typecheck\` → \`sapiom_dev_orchestrations_check\` (validates the step
+   graph, offline) → \`sapiom_dev_orchestrations_run_local\` (capabilities are stubbed; zero spend).
+4. Ship: \`sapiom_dev_orchestrations_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.
+
+## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
+- Import \`defineOrchestration\`, \`defineStep\`, and the directives
+  (\`goto\` / \`terminate\` / \`fail\` / \`retry\` / \`pauseUntilSignal\`) from \`@sapiom/orchestration\`.
+  NEVER \`defineWorkflow\` or \`@sapiom/workflow-sdk\` (they do not exist). Import Zod from \`zod/v4\`.
+- \`defineStep({ name, next, terminal?, canFail?, pause?, inputSchema?, run })\`:
+  \`terminate()\` requires \`terminal: true\`; \`fail()\` requires \`canFail: true\`;
+  \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\` target
+  must be listed in \`next[]\`. TypeScript enforces all of these.
+- Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
+- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent.coding, fileStorage,
+  contentGeneration.images) — a typed subset of the gateway catalog; use autocomplete/typecheck.
+
+Full reference: https://docs.sapiom.ai/workflows (authoring · capabilities · reference · examples)
+and the \`AGENTS.md\` inside your scaffolded project.`;


### PR DESCRIPTION
## Summary

`@sapiom/mcp` served its `instructions` (the authoring primer surfaced to a coding agent on connect) hardcoded in the published package, so changing the guidance meant an npm release. This makes the server **fetch its instructions from `GET /v1/mcp/instructions`** (the public endpoint added in SAP-1256) on startup, with the bundled copy as an offline fallback.

**Supersedes #119** (SAP-1040): the static-instructions work from #119 and the new fetch layer ship together here — please close #119 in favor of this PR.

## Changes

- **`instructions-fetch.ts`** (new) — `fetchInstructions(env)`: `GET ${env.apiURL}/v1/mcp/instructions` with a 5s `AbortController` timeout. Returns the body on 200; falls back to the bundled `AUTHORING_INSTRUCTIONS` on non-200 / empty / network error / timeout. **Never throws.**
- **`index.ts`** — `const instructions = await fetchInstructions(env)` before constructing `McpServer`.
- **`instructions.ts`** — `AUTHORING_INSTRUCTIONS` gains the **"Two ways to use Sapiom"** frame (authoring MCP for workflows · remote MCP `sapiom_*` for direct calls · SDK), single-sourced with the backend seed (`DEFAULT_MCP_INSTRUCTIONS` in SAP-1256). Still the offline fallback.
- **Tests** — `instructions-fetch.test.ts` (200 / endpoint URL / non-200 / empty / network error / fake-timer timeout) + a two-MCP assertion added to `instructions.test.ts`.

## Design notes

- **Fail-open** — the server must always start with usable instructions. Every failure mode resolves to the bundled copy; startup adds at most 5s if the endpoint hangs.
- **`env.apiURL`** resolves to `https://api.sapiom.ai` (production) / `https://api.sapiom.dev` (staging) via `resolveEnvironment` — the fetch follows the same environment as every other call.
- **Node ≥18** — native `fetch` + `AbortController`, no new deps.

## Testing

- [x] `pnpm --filter @sapiom/mcp test` — 61/61 (incl. 6 new fetch cases)
- [x] `pnpm --filter @sapiom/mcp build` (tsc) — clean

## Related

- Closes: SAP-1257 · Supersedes #119 (SAP-1040)
- Parent: SAP-849 (Phase 3) · pairs with SAP-1256 (the backend endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
