### PR TITLE
support dispatching to a scheduled workflow run

### DIFF
--- a/.changeset/orchestrations-delayed-dispatch.md
+++ b/.changeset/orchestrations-delayed-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+`orchestrations.launch({ at })`: from inside a step, schedule a child orchestration to run at a future time and pause on the returned handle — the step resumes with the child's result once the scheduled run finishes (delayed dispatch). Immediate `launch`/`run` are unchanged.

--- a/packages/orchestration-core/src/schedule.ts
+++ b/packages/orchestration-core/src/schedule.ts
@@ -30,8 +30,8 @@ export interface CreateScheduleOptions {
   startAt?: string;
   endAt?: string;
   policy?: SchedulePolicy;
-  /** One-off (`schedule_once`): the single fire time (ISO 8601; required for that kind). */
-  at?: string;
+  /** One-off (`schedule_once`): the single fire time. Accepts a `Date` or an ISO 8601 string. */
+  at?: string | Date;
 }
 
 export interface ScheduleFireRecord {

--- a/packages/tools/src/orchestrations/README.md
+++ b/packages/tools/src/orchestrations/README.md
@@ -48,3 +48,5 @@ const useResult = defineStep({
 - **Addressed by slug.** `definition` is the deployed orchestration's slug — its stable handle. `input` is passed to its entry step.
 
 - **`idempotencyKey` deduplicates.** Repeating a launch with the same key returns the existing run instead of starting a new one.
+
+- **Delayed dispatch (`at`).** `launch({ definition, input, at })` schedules the child to run at a future time (`at` is a `Date` or ISO 8601 string) instead of now, and returns a **pause-only** handle: hand it to `pauseUntilSignal` and the step resumes with the child's result once the scheduled run finishes. `status`/`wait` aren't available on a delayed handle (there's no run until then), so use `launch` + `pauseUntilSignal`, not `run`. For a plain fire-and-forget one-off (no resume), use the `schedules` capability instead.

--- a/packages/tools/src/orchestrations/index.ts
+++ b/packages/tools/src/orchestrations/index.ts
@@ -47,6 +47,15 @@ export interface OrchestrationRunSpec {
   input?: Record<string, unknown>;
   /** Optional idempotency key — a repeat with the same key returns the existing run. */
   idempotencyKey?: string;
+  /**
+   * Delayed dispatch (from inside a step): schedule the child to run at this time instead of now,
+   * and pause on the returned handle — the step resumes with the child's result once it fires and
+   * finishes. The handle is pause-only (`status`/`wait` throw), since the child doesn't exist until
+   * the scheduled time. Accepts a `Date` or an ISO 8601 string (a `Date` is sent as UTC ISO).
+   *
+   * For a plain fire-and-forget one-off (no pause/resume), use `schedules.create` instead.
+   */
+  at?: string | Date;
 }
 
 /** A live, awaited run (the standalone `run()`/`wait()` result). */
@@ -168,11 +177,43 @@ interface ExecutionDoc {
   error?: unknown;
 }
 
+/**
+ * Delayed dispatch: create a one-off schedule (carrying the parent resume token) instead of a run
+ * now. The child fires at `spec.at`; when it finishes it resumes the step paused on this handle.
+ * The correlation is derived from the created schedule's id (`trigger-<id>`) — the same value the
+ * engine stamps on the eventually-fired child, so the resume lands. Pause-only: there is no child
+ * to poll until the scheduled time, so `status`/`wait` throw.
+ */
+async function launchScheduled(spec: OrchestrationRunSpec, transport: Transport, baseUrl: string): Promise<RunHandle> {
+  const res = await transport.request<{ id: string }>(
+    `${baseUrl}/v1/workflows/${encodeURIComponent(spec.definition)}/triggers`,
+    {
+      method: "POST",
+      body: JSON.stringify({ kind: "schedule_once", at: spec.at, input: spec.input ?? {} }),
+      headers: workflowResumeHeaders(),
+    },
+  );
+  const notAvailable = (): never => {
+    throw new Error(
+      "status()/wait() are not available for a scheduled (delayed) dispatch — the child runs at the scheduled time. Use launch + pauseUntilSignal (not run).",
+    );
+  };
+  return {
+    executionId: "", // no child execution exists until the schedule fires
+    dispatch: { correlationId: `trigger-${res.id}`, resultSignal: ORCHESTRATIONS_RESULT_SIGNAL },
+    status: notAvailable,
+    wait: notAvailable,
+  };
+}
+
 export async function launch(
   spec: OrchestrationRunSpec,
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<RunHandle> {
+  if (spec.at) {
+    return launchScheduled(spec, transport, baseUrl);
+  }
   const res = await transport.request<StartResponse>(
     `${baseUrl}/v1/workflows/${encodeURIComponent(spec.definition)}/executions`,
     {

--- a/packages/tools/src/orchestrations/schedule-launch.spec.ts
+++ b/packages/tools/src/orchestrations/schedule-launch.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * orchestrations.launch({ at }) — delayed (scheduled) dispatch.
+ *
+ * A step scheduling a child for LATER: launch creates a one-off schedule (not a run now), forwards
+ * the parent resume token as a header, and returns a pause-only DispatchHandle whose correlation is
+ * derived from the created schedule's id (`trigger-<id>`) — the value the eventually-fired child
+ * resumes the step on. status()/wait() throw (no child exists until the scheduled time).
+ */
+import { createClient } from "../index.js";
+import { ORCHESTRATIONS_RESULT_SIGNAL } from "./index.js";
+
+function fakeFetch(capture: { url?: string; init?: RequestInit }): typeof globalThis.fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    capture.url = url;
+    capture.init = init;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "trig-9" }),
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("orchestrations.launch — delayed (scheduled) dispatch", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("schedules a one-off (not a run now) and returns a pause-only handle correlated to the schedule", async () => {
+    const cap: { url?: string; init?: RequestInit } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(cap) });
+
+    const handle = await sapiom.orchestrations.launch({
+      definition: "B",
+      at: "2026-07-01T00:00:00.000Z",
+      input: { a: 1 },
+    });
+
+    // Hits the schedule (trigger) create route, not the execution route.
+    expect(cap.url).toMatch(/\/v1\/workflows\/B\/triggers$/);
+    expect(cap.init?.method).toBe("POST");
+    expect(JSON.parse(cap.init?.body as string)).toEqual({
+      kind: "schedule_once",
+      at: "2026-07-01T00:00:00.000Z",
+      input: { a: 1 },
+    });
+    // Pause-only handle: correlation derived from the created schedule id.
+    expect(handle.dispatch).toEqual({
+      correlationId: "trigger-trig-9",
+      resultSignal: ORCHESTRATIONS_RESULT_SIGNAL,
+    });
+    expect(() => handle.wait()).toThrow(/scheduled/i);
+    expect(() => handle.status()).toThrow(/scheduled/i);
+  });
+
+  it("accepts a Date for `at` and sends it as a UTC ISO string", async () => {
+    const cap: { url?: string; init?: RequestInit } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(cap) });
+
+    await sapiom.orchestrations.launch({ definition: "B", at: new Date("2026-07-01T00:00:00.000Z") });
+
+    expect(JSON.parse(cap.init?.body as string).at).toBe("2026-07-01T00:00:00.000Z");
+  });
+
+  it("forwards the parent resume token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-abc";
+    const cap: { url?: string; init?: RequestInit } = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(cap) });
+
+    await sapiom.orchestrations.launch({ definition: "B", at: "2026-07-01T00:00:00.000Z" });
+
+    expect((cap.init?.headers as Record<string, string>)["x-sapiom-workflow-token"]).toBe("tok-abc");
+  });
+});

--- a/packages/tools/src/schedules/README.md
+++ b/packages/tools/src/schedules/README.md
@@ -32,7 +32,7 @@ await schedules.cancel(one.id);
 
 ## Things to know
 
-- **Two kinds.** `schedule_cron` takes a `cron` expression (+ optional `timezone`); `schedule_once` takes an `at` time (ISO 8601). A cron schedule fires on every matching tick until cancelled; a one-off fires exactly once.
+- **Two kinds.** `schedule_cron` takes a `cron` expression (+ optional `timezone`); `schedule_once` takes an `at` time (a `Date` or ISO 8601 string). A cron schedule fires on every matching tick until cancelled; a one-off fires exactly once.
 - **Timezone-aware cron.** `timezone` is an IANA name (e.g. `"America/New_York"`); the cron is evaluated in that zone, so daylight-saving shifts are handled for you. Defaults to UTC.
 - **Best-effort timing.** A schedule fires at or shortly after its scheduled time — fine for "around 9am", not for hard real-time deadlines.
 - **`get` shows health.** `get(id)` returns the next scheduled fire (`nextFireAt`) and a recent fire history — each with the `executionId` of the run it started — so you can confirm a schedule is firing or debug one that isn't.

--- a/packages/tools/src/schedules/index.ts
+++ b/packages/tools/src/schedules/index.ts
@@ -36,8 +36,8 @@ export interface CreateScheduleSpec {
   startAt?: string;
   endAt?: string;
   policy?: SchedulePolicy;
-  /** One-off (`schedule_once`): the single fire time (ISO 8601). */
-  at?: string;
+  /** One-off (`schedule_once`): the single fire time. Accepts a `Date` or an ISO 8601 string. */
+  at?: string | Date;
 }
 
 export interface ScheduleFireRecord {


### PR DESCRIPTION
This pull request introduces support for delayed (scheduled) orchestration dispatches via the new `at` parameter to `orchestrations.launch`. This allows a step to schedule a child orchestration to run at a future time, returning a pause-only handle that resumes when the child completes. The change includes updates to documentation, type definitions, and adds comprehensive tests for the new behavior. Immediate launches and existing scheduling remain unchanged.

**New Feature: Delayed Orchestration Dispatch**

* Added support for delayed (scheduled) dispatch in `orchestrations.launch` via the `at` parameter, which accepts a `Date` or ISO 8601 string. When used, it schedules a one-off child orchestration to run at the specified future time and returns a pause-only handle; the step resumes with the child's result after completion. Immediate launch/run behavior is unchanged. (`packages/tools/src/orchestrations/index.ts`, `.changeset/orchestrations-delayed-dispatch.md`, [[1]](diffhunk://#diff-78baa67d8a28ab8207860d18c146375a2449970086e179257c14801548fdf151R1-R5) [[2]](diffhunk://#diff-dfe9adac55a95458df96f15efe4581ce10147378edc92c38b417be910706081dR50-R58) [[3]](diffhunk://#diff-dfe9adac55a95458df96f15efe4581ce10147378edc92c38b417be910706081dR180-R216)
* Updated documentation to explain the new delayed dispatch feature, its usage, and limitations (pause-only handle, no status/wait until the scheduled time). (`packages/tools/src/orchestrations/README.md`, [packages/tools/src/orchestrations/README.mdR51-R52](diffhunk://#diff-773a7ccc84c04c7d896f59e5e7f755f62a0f474352fe7a1bc9d1063a23765957R51-R52))

**Type and Interface Updates**

* Updated the `at` parameter in orchestration and schedule interfaces to accept both `Date` and ISO 8601 string values, improving flexibility for scheduling. (`packages/orchestration-core/src/schedule.ts`, [[1]](diffhunk://#diff-86d53e5b93c29aafa6dd62dc2b5b943210bc94e3099e185fe166e281ee32b3feL33-R34); `packages/tools/src/schedules/index.ts`, [[2]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L39-R40)

**Testing**

* Added comprehensive tests to verify delayed dispatch: ensures correct API calls, correct handle behavior (pause-only), proper handling of `Date`/string for `at`, and forwarding of parent resume tokens. (`packages/tools/src/orchestrations/schedule-launch.spec.ts`, [packages/tools/src/orchestrations/schedule-launch.spec.tsR1-R76](diffhunk://#diff-c7f22e7996a510581cac314ddf38d41361aa1a5a7d56be24034df4aa90386e89R1-R76))

**Documentation Improvements**

* Clarified in schedules documentation that `schedule_once` accepts a `Date` or ISO 8601 string for the `at` parameter, not just ISO strings. (`packages/tools/src/schedules/README.md`, [packages/tools/src/schedules/README.mdL35-R35](diffhunk://#diff-351ca6266f49100e7ef873501a2d7b920eb49e2fa79cd6bda5a48f3059f0bf70L35-R35))