### PR TITLE
feat(tools): surface downloadUrl on content-generation outputs (SAP-1241)

### DIFF
--- a/.changeset/tools-content-generation-download-url.md
+++ b/.changeset/tools-content-generation-download-url.md
@@ -2,11 +2,11 @@
 "@sapiom/tools": minor
 ---
 
-`contentGeneration` image + video outputs now include a ready-to-use `downloadUrl` alongside the durable `fileId` when `storage` is requested.
+`contentGeneration` image + video outputs now include a ready-to-use `downloadUrl` (and its `downloadUrlExpiresAt`) alongside the durable `fileId` when `storage` is requested.
 
-- `GeneratedImage` and `GeneratedVideo` gain an optional `downloadUrl` — a short-lived, ready-to-use signed URL for the persisted output, surfaced inline on the result so you don't need a follow-up `fileStorage.getDownloadUrl(fileId)` call just to fetch it. It expires; `fileId` remains the durable reference (re-mint a fresh URL any time via `fileStorage.getDownloadUrl(fileId)`).
-- `VideoResultPayload.outputs[]` (delivered to a step resumed from `pauseUntilSignal`) carries `downloadUrl` too, and `toVideoResumePayload` maps it through.
+- `GeneratedImage` and `GeneratedVideo` gain an optional `downloadUrl` — a short-lived, ready-to-use signed URL for the persisted output, surfaced inline on the result so you don't need a follow-up `fileStorage.getDownloadUrl(fileId)` call just to fetch it — plus `downloadUrlExpiresAt` (ISO) so the field is self-describing. It expires; `fileId` remains the durable reference (re-mint a fresh URL any time via `fileStorage.getDownloadUrl(fileId)`).
+- `VideoResultPayload.outputs[]` (delivered to a step resumed from `pauseUntilSignal`) carries `downloadUrl` + `downloadUrlExpiresAt` too, and `toVideoResumePayload` maps them through.
 - The provider-hosted `url` is now documented as the raw, possibly short-lived / unauthenticated URL — prefer `downloadUrl` (ready to use) or `fileId` (durable) when you requested `storage`.
-- `createStubClient()` mirrors the new field: stubbed image / video outputs include a `downloadUrl` when `storage` is passed.
+- `createStubClient()` mirrors the new fields: stubbed image / video outputs include a `downloadUrl` + `downloadUrlExpiresAt` when `storage` is passed.
 
-Backward compatible: `downloadUrl` is optional and additive; the existing `fileId` / `url` / `storageError` fields are unchanged.
+Backward compatible: the new fields are optional and additive; the existing `fileId` / `url` / `storageError` fields are unchanged.

--- a/.changeset/tools-content-generation-download-url.md
+++ b/.changeset/tools-content-generation-download-url.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/tools": minor
+---
+
+`contentGeneration` image + video outputs now include a ready-to-use `downloadUrl` alongside the durable `fileId` when `storage` is requested.
+
+- `GeneratedImage` and `GeneratedVideo` gain an optional `downloadUrl` — a short-lived, ready-to-use signed URL for the persisted output, surfaced inline on the result so you don't need a follow-up `fileStorage.getDownloadUrl(fileId)` call just to fetch it. It expires; `fileId` remains the durable reference (re-mint a fresh URL any time via `fileStorage.getDownloadUrl(fileId)`).
+- `VideoResultPayload.outputs[]` (delivered to a step resumed from `pauseUntilSignal`) carries `downloadUrl` too, and `toVideoResumePayload` maps it through.
+- The provider-hosted `url` is now documented as the raw, possibly short-lived / unauthenticated URL — prefer `downloadUrl` (ready to use) or `fileId` (durable) when you requested `storage`.
+- `createStubClient()` mirrors the new field: stubbed image / video outputs include a `downloadUrl` when `storage` is passed.
+
+Backward compatible: `downloadUrl` is optional and additive; the existing `fileId` / `url` / `storageError` fields are unchanged.

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -2,7 +2,7 @@
 
 Generate media — images and video today (audio to come) — with an optional
 `storage` param that persists each output to Sapiom file storage, so you get a
-durable `fileId` back inline.
+durable `fileId` — plus a ready-to-use `downloadUrl` — back inline.
 
 ```typescript
 import { createClient } from "@sapiom/tools";
@@ -13,8 +13,9 @@ const out = await sapiom.contentGeneration.images.create({
   storage: { visibility: "private" }, // optional — persist outputs to file storage
 });
 
-out.images[0].url; // hosted URL of the generated image
-out.images[0].fileId; // present when `storage` was passed — use with `fileStorage`
+out.images[0].fileId; // durable reference (present when `storage` was passed)
+out.images[0].downloadUrl; // ready-to-use, short-lived signed URL for the stored file
+out.images[0].url; // provider-hosted URL (may be short-lived / unauthenticated)
 ```
 
 Ambient import works too: `import { contentGeneration } from "@sapiom/tools"`.
@@ -23,7 +24,7 @@ Ambient import works too: `import { contentGeneration } from "@sapiom/tools"`.
 
 Pass `storage` and each generated output is persisted to your tenant's file
 storage as it returns — no extra round-trip. Each item in `images` is then
-annotated with its own `fileId`:
+annotated inline with its own durable `fileId` and a ready-to-use `downloadUrl`:
 
 ```typescript
 const out = await sapiom.contentGeneration.images.create({
@@ -32,8 +33,10 @@ const out = await sapiom.contentGeneration.images.create({
   storage: { visibility: "public" },
 });
 for (const img of out.images ?? []) {
-  if (img.fileId) {
-    const { downloadUrl } = await sapiom.fileStorage.getDownloadUrl(img.fileId);
+  if (img.downloadUrl) {
+    // Ready to use immediately — but short-lived. `fileId` is the durable handle:
+    // re-mint a fresh URL any time with `sapiom.fileStorage.getDownloadUrl(img.fileId)`.
+    await fetch(img.downloadUrl);
   }
 }
 ```
@@ -53,14 +56,15 @@ const out = await sapiom.contentGeneration.video.create({
   storage: { visibility: "private" }, // optional — persist the output
 });
 
-out.video?.url; // hosted URL of the generated video
-out.video?.fileId; // present when `storage` was passed — use with `fileStorage`
+out.video?.fileId; // durable reference (present when `storage` was passed)
+out.video?.downloadUrl; // ready-to-use, short-lived signed URL for the stored file
+out.video?.url; // provider-hosted URL (may be short-lived / unauthenticated)
 ```
 
 Video input takes `prompt`, plus optional `storage`, `model`, and `params` (as with
 images), and two async controls: `pollIntervalMs` (poll cadence, default 5s) and
 `timeoutMs` (give up and throw if it isn't ready in time, default 5 min). The
-returned `video` is `{ url, contentType?, fileId?, storageError? }`.
+returned `video` is `{ url, contentType?, fileId?, downloadUrl?, storageError? }`.
 
 ## Dispatchable video: `video.launch`
 
@@ -79,7 +83,7 @@ const handle = await sapiom.contentGeneration.video.launch({
   storage: { visibility: "private" }, // optional — persist the output
 });
 const out = await handle.wait(); // polls until ready
-out.video?.fileId;
+out.video?.fileId; // + out.video?.downloadUrl for a ready-to-use URL
 
 // Option B — suspend a workflow step until the video is ready, then resume:
 // (Inside a Sapiom workflow step; the orchestration engine handles the rest.)
@@ -87,7 +91,7 @@ const handle = await sapiom.contentGeneration.video.launch({
   prompt: "a calm ocean wave at sunset",
 });
 return pauseUntilSignal(handle, { resumeStep: finalize });
-// `finalize` receives a VideoResultPayload: { outputs: [{ fileId?, storageError? }] }
+// `finalize` receives a VideoResultPayload: { outputs: [{ fileId?, downloadUrl?, storageError? }] }
 ```
 
 `handle.wait()` accepts the same `timeoutMs` and `pollMs` overrides as
@@ -119,7 +123,8 @@ The shape delivered to a step resumed from `pauseUntilSignal`:
 ```typescript
 interface VideoResultPayload {
   outputs: Array<{
-    fileId?: string; // present when storage was requested and succeeded
+    fileId?: string; // durable ref — present when storage was requested and succeeded
+    downloadUrl?: string; // ready-to-use short-lived URL (may have expired by resume)
     storageError?: string; // present when storage was requested but failed
   }>;
 }
@@ -139,8 +144,8 @@ to this shape when wiring local tests.
   `seed`, `guidance_scale`).
 
 Each returned image is `{ url, contentType?, width?, height?, fileId?,
-storageError? }`; any additional model-specific fields (e.g. `seed`) are returned
-on the result as-is.
+downloadUrl?, storageError? }`; any additional model-specific fields (e.g. `seed`)
+are returned on the result as-is.
 
 ## Gotchas
 

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -64,7 +64,7 @@ out.video?.url; // provider-hosted URL (may be short-lived / unauthenticated)
 Video input takes `prompt`, plus optional `storage`, `model`, and `params` (as with
 images), and two async controls: `pollIntervalMs` (poll cadence, default 5s) and
 `timeoutMs` (give up and throw if it isn't ready in time, default 5 min). The
-returned `video` is `{ url, contentType?, fileId?, downloadUrl?, storageError? }`.
+returned `video` is `{ url, contentType?, fileId?, downloadUrl?, downloadUrlExpiresAt?, storageError? }`.
 
 ## Dispatchable video: `video.launch`
 
@@ -125,6 +125,7 @@ interface VideoResultPayload {
   outputs: Array<{
     fileId?: string; // durable ref — present when storage was requested and succeeded
     downloadUrl?: string; // ready-to-use short-lived URL (may have expired by resume)
+    downloadUrlExpiresAt?: string; // ISO expiry of downloadUrl, when present
     storageError?: string; // present when storage was requested but failed
   }>;
 }
@@ -144,8 +145,8 @@ to this shape when wiring local tests.
   `seed`, `guidance_scale`).
 
 Each returned image is `{ url, contentType?, width?, height?, fileId?,
-downloadUrl?, storageError? }`; any additional model-specific fields (e.g. `seed`)
-are returned on the result as-is.
+downloadUrl?, downloadUrlExpiresAt?, storageError? }`; any additional
+model-specific fields (e.g. `seed`) are returned on the result as-is.
 
 ## Gotchas
 

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -124,7 +124,14 @@ describe("contentGeneration.images.create()", () => {
     const { transport, calls } = makeTransport([
       () =>
         jsonResponse({
-          images: [{ url: "u", fileId: "f1", downloadUrl: "https://dl/f1" }],
+          images: [
+            {
+              url: "u",
+              fileId: "f1",
+              downloadUrl: "https://dl/f1",
+              downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
+            },
+          ],
         }),
     ]);
 
@@ -139,8 +146,9 @@ describe("contentGeneration.images.create()", () => {
       storage: { visibility: "public" },
     });
     expect(out.images?.[0]?.fileId).toBe("f1");
-    // Core already normalized download_url → downloadUrl; the SDK passes the camelCase field through.
+    // Core already normalized download_url/_expires_at → downloadUrl/downloadUrlExpiresAt; SDK passes them through.
     expect(out.images?.[0]?.downloadUrl).toBe("https://dl/f1");
+    expect(out.images?.[0]?.downloadUrlExpiresAt).toBe("2026-03-03T00:00:00Z");
   });
 
   it("omits `storage` when not provided", async () => {
@@ -333,6 +341,7 @@ describe("contentGeneration.video.create()", () => {
                 content_type: "video/mp4",
                 file_id: "vid-file-1",
                 download_url: "https://dl/vid-1",
+                download_url_expires_at: "2026-03-03T00:00:00Z",
               },
             })
           : null,
@@ -349,6 +358,7 @@ describe("contentGeneration.video.create()", () => {
       contentType: "video/mp4",
       fileId: "vid-file-1",
       downloadUrl: "https://dl/vid-1",
+      downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
     });
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "x",
@@ -802,12 +812,19 @@ describe("toVideoResumePayload()", () => {
     });
   });
 
-  it("carries the convenience downloadUrl alongside fileId", () => {
+  it("carries the convenience downloadUrl + its expiry alongside fileId", () => {
     const payload = toVideoResumePayload({
-      video: { url: "u", fileId: "f-3", downloadUrl: "https://dl/f-3" },
+      video: {
+        url: "u",
+        fileId: "f-3",
+        downloadUrl: "https://dl/f-3",
+        downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
+      },
     });
     expect(payload).toEqual({
-      outputs: [{ fileId: "f-3", downloadUrl: "https://dl/f-3" }],
+      outputs: [
+        { fileId: "f-3", downloadUrl: "https://dl/f-3", downloadUrlExpiresAt: "2026-03-03T00:00:00Z" },
+      ],
     });
   });
 });

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -120,9 +120,12 @@ describe("contentGeneration.images.create()", () => {
     });
   });
 
-  it("merges the optional `storage` param; the mapped image carries fileId", async () => {
+  it("merges the optional `storage` param; the mapped image carries fileId + downloadUrl", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ images: [{ url: "u", fileId: "f1" }] }),
+      () =>
+        jsonResponse({
+          images: [{ url: "u", fileId: "f1", downloadUrl: "https://dl/f1" }],
+        }),
     ]);
 
     const out = await createImage(
@@ -136,6 +139,8 @@ describe("contentGeneration.images.create()", () => {
       storage: { visibility: "public" },
     });
     expect(out.images?.[0]?.fileId).toBe("f1");
+    // Core already normalized download_url → downloadUrl; the SDK passes the camelCase field through.
+    expect(out.images?.[0]?.downloadUrl).toBe("https://dl/f1");
   });
 
   it("omits `storage` when not provided", async () => {
@@ -311,7 +316,7 @@ describe("contentGeneration.video.create()", () => {
     ).toHaveLength(2);
   });
 
-  it("sends storage on submit and surfaces fileId on the polled result", async () => {
+  it("sends storage on submit and surfaces fileId + downloadUrl on the polled result", async () => {
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
@@ -327,6 +332,7 @@ describe("contentGeneration.video.create()", () => {
                 url: "https://media/v2.mp4",
                 content_type: "video/mp4",
                 file_id: "vid-file-1",
+                download_url: "https://dl/vid-1",
               },
             })
           : null,
@@ -342,6 +348,7 @@ describe("contentGeneration.video.create()", () => {
       url: "https://media/v2.mp4",
       contentType: "video/mp4",
       fileId: "vid-file-1",
+      downloadUrl: "https://dl/vid-1",
     });
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "x",
@@ -792,6 +799,15 @@ describe("toVideoResumePayload()", () => {
     });
     expect(payload).toEqual({
       outputs: [{ fileId: "f-2", storageError: "partial" }],
+    });
+  });
+
+  it("carries the convenience downloadUrl alongside fileId", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "u", fileId: "f-3", downloadUrl: "https://dl/f-3" },
+    });
+    expect(payload).toEqual({
+      outputs: [{ fileId: "f-3", downloadUrl: "https://dl/f-3" }],
     });
   });
 });

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -84,17 +84,26 @@ export interface ImageCreateInput {
 }
 
 export interface GeneratedImage {
-  /** Hosted URL of the generated image. */
+  /**
+   * Provider-hosted URL of the generated image. May be short-lived and unauthenticated;
+   * when you requested `storage`, prefer `downloadUrl` (ready to use) or `fileId` (durable).
+   */
   url: string;
   /** MIME type, when reported. */
   contentType?: string;
   width?: number;
   height?: number;
   /**
-   * Present when `storage` was requested and this output was persisted — pass to
-   * `fileStorage.getDownloadUrl(fileId)` to retrieve it.
+   * Present when `storage` was requested and this output was persisted. The durable
+   * reference — re-fetch a fresh download URL any time via `fileStorage.getDownloadUrl(fileId)`.
    */
   fileId?: string;
+  /**
+   * Present when `storage` was requested and this output was persisted: a ready-to-use,
+   * short-lived signed download URL for the stored file. Convenience only — it expires, so
+   * for anything durable keep `fileId` and re-fetch via `fileStorage.getDownloadUrl(fileId)`.
+   */
+  downloadUrl?: string;
   /**
    * Present when `storage` was requested but persisting THIS output failed
    * (best-effort: other images in the same response may still carry `fileId`).
@@ -122,6 +131,7 @@ interface RawImage {
   width?: number;
   height?: number;
   fileId?: string;
+  downloadUrl?: string;
   storageError?: string;
 }
 
@@ -137,6 +147,7 @@ function mapImage(raw: RawImage): GeneratedImage {
     ...(raw.width !== undefined && { width: raw.width }),
     ...(raw.height !== undefined && { height: raw.height }),
     ...(raw.fileId !== undefined && { fileId: raw.fileId }),
+    ...(raw.downloadUrl !== undefined && { downloadUrl: raw.downloadUrl }),
     ...(raw.storageError !== undefined && { storageError: raw.storageError }),
   };
 }
@@ -263,15 +274,24 @@ export interface VideoCreateInput {
 }
 
 export interface GeneratedVideo {
-  /** Hosted URL of the generated video. */
+  /**
+   * Provider-hosted URL of the generated video. May be short-lived and unauthenticated;
+   * when you requested `storage`, prefer `downloadUrl` (ready to use) or `fileId` (durable).
+   */
   url: string;
   /** MIME type, when reported. */
   contentType?: string;
   /**
-   * Present when `storage` was requested and the output was persisted — pass to
-   * `fileStorage.getDownloadUrl(fileId)` to retrieve it.
+   * Present when `storage` was requested and the output was persisted. The durable
+   * reference — re-fetch a fresh download URL any time via `fileStorage.getDownloadUrl(fileId)`.
    */
   fileId?: string;
+  /**
+   * Present when `storage` was requested and the output was persisted: a ready-to-use,
+   * short-lived signed download URL for the stored file. Convenience only — it expires, so
+   * for anything durable keep `fileId` and re-fetch via `fileStorage.getDownloadUrl(fileId)`.
+   */
+  downloadUrl?: string;
   /** Present when `storage` was requested but persisting the output failed. */
   storageError?: string;
 }
@@ -289,6 +309,7 @@ interface RawMedia {
   url: string;
   content_type?: string;
   file_id?: string;
+  download_url?: string;
   storage_error?: string;
 }
 
@@ -309,6 +330,7 @@ function mapVideo(raw: RawMedia): GeneratedVideo {
     url: raw.url,
     ...(raw.content_type !== undefined && { contentType: raw.content_type }),
     ...(raw.file_id !== undefined && { fileId: raw.file_id }),
+    ...(raw.download_url !== undefined && { downloadUrl: raw.download_url }),
     ...(raw.storage_error !== undefined && { storageError: raw.storage_error }),
   };
 }
@@ -415,8 +437,14 @@ export interface VideoLaunchHandle extends DispatchHandle {
  */
 export interface VideoResultPayload {
   outputs: Array<{
-    /** Present when the output was persisted to file storage. */
+    /** Present when the output was persisted to file storage — the durable reference. */
     fileId?: string;
+    /**
+     * A ready-to-use, short-lived signed download URL for the persisted output, when
+     * available. Convenience only — it may have expired by the time a resumed step runs;
+     * re-fetch from `fileId` via `fileStorage.getDownloadUrl(fileId)` for a fresh one.
+     */
+    downloadUrl?: string;
     /** Present when storage was requested but persisting this output failed. */
     storageError?: string;
   }>;
@@ -435,6 +463,9 @@ export function toVideoResumePayload(
       {
         ...(result.video.fileId !== undefined && {
           fileId: result.video.fileId,
+        }),
+        ...(result.video.downloadUrl !== undefined && {
+          downloadUrl: result.video.downloadUrl,
         }),
         ...(result.video.storageError !== undefined && {
           storageError: result.video.storageError,

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -104,6 +104,8 @@ export interface GeneratedImage {
    * for anything durable keep `fileId` and re-fetch via `fileStorage.getDownloadUrl(fileId)`.
    */
   downloadUrl?: string;
+  /** ISO timestamp when `downloadUrl` expires (~15 min out). Absent whenever `downloadUrl` is. */
+  downloadUrlExpiresAt?: string;
   /**
    * Present when `storage` was requested but persisting THIS output failed
    * (best-effort: other images in the same response may still carry `fileId`).
@@ -132,6 +134,7 @@ interface RawImage {
   height?: number;
   fileId?: string;
   downloadUrl?: string;
+  downloadUrlExpiresAt?: string;
   storageError?: string;
 }
 
@@ -148,6 +151,9 @@ function mapImage(raw: RawImage): GeneratedImage {
     ...(raw.height !== undefined && { height: raw.height }),
     ...(raw.fileId !== undefined && { fileId: raw.fileId }),
     ...(raw.downloadUrl !== undefined && { downloadUrl: raw.downloadUrl }),
+    ...(raw.downloadUrlExpiresAt !== undefined && {
+      downloadUrlExpiresAt: raw.downloadUrlExpiresAt,
+    }),
     ...(raw.storageError !== undefined && { storageError: raw.storageError }),
   };
 }
@@ -292,6 +298,8 @@ export interface GeneratedVideo {
    * for anything durable keep `fileId` and re-fetch via `fileStorage.getDownloadUrl(fileId)`.
    */
   downloadUrl?: string;
+  /** ISO timestamp when `downloadUrl` expires (~15 min out). Absent whenever `downloadUrl` is. */
+  downloadUrlExpiresAt?: string;
   /** Present when `storage` was requested but persisting the output failed. */
   storageError?: string;
 }
@@ -310,6 +318,7 @@ interface RawMedia {
   content_type?: string;
   file_id?: string;
   download_url?: string;
+  download_url_expires_at?: string;
   storage_error?: string;
 }
 
@@ -331,6 +340,7 @@ function mapVideo(raw: RawMedia): GeneratedVideo {
     ...(raw.content_type !== undefined && { contentType: raw.content_type }),
     ...(raw.file_id !== undefined && { fileId: raw.file_id }),
     ...(raw.download_url !== undefined && { downloadUrl: raw.download_url }),
+    ...(raw.download_url_expires_at !== undefined && { downloadUrlExpiresAt: raw.download_url_expires_at }),
     ...(raw.storage_error !== undefined && { storageError: raw.storage_error }),
   };
 }
@@ -445,6 +455,8 @@ export interface VideoResultPayload {
      * re-fetch from `fileId` via `fileStorage.getDownloadUrl(fileId)` for a fresh one.
      */
     downloadUrl?: string;
+    /** ISO expiry of `downloadUrl`, when present — may already be past by the time a step resumes. */
+    downloadUrlExpiresAt?: string;
     /** Present when storage was requested but persisting this output failed. */
     storageError?: string;
   }>;
@@ -466,6 +478,9 @@ export function toVideoResumePayload(
         }),
         ...(result.video.downloadUrl !== undefined && {
           downloadUrl: result.video.downloadUrl,
+        }),
+        ...(result.video.downloadUrlExpiresAt !== undefined && {
+          downloadUrlExpiresAt: result.video.downloadUrlExpiresAt,
         }),
         ...(result.video.storageError !== undefined && {
           storageError: result.video.storageError,

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -726,7 +726,11 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                   height: 512,
                   // mirror the real behavior: a fileId only when storage was requested.
                   ...(input.storage
-                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    ? {
+                        fileId: "stub-file",
+                        downloadUrl: "https://content.local/stub-download",
+                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                      }
                     : {}),
                 },
               ],
@@ -742,7 +746,11 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 contentType: "video/mp4",
                 // mirror the real behavior: a fileId only when storage was requested.
                 ...(input.storage
-                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    ? {
+                        fileId: "stub-file",
+                        downloadUrl: "https://content.local/stub-download",
+                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                      }
                     : {}),
               },
             })) as VideoGenerationResult,
@@ -757,7 +765,11 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 url: "https://content.local/stub-video.mp4",
                 contentType: "video/mp4",
                 ...(input.storage
-                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    ? {
+                        fileId: "stub-file",
+                        downloadUrl: "https://content.local/stub-download",
+                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                      }
                     : {}),
               },
             }),

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -725,7 +725,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                   width: 512,
                   height: 512,
                   // mirror the real behavior: a fileId only when storage was requested.
-                  ...(input.storage ? { fileId: "stub-file" } : {}),
+                  ...(input.storage
+                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    : {}),
                 },
               ],
             })) as ImageGenerationResult,
@@ -739,7 +741,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 url: "https://content.local/stub-video.mp4",
                 contentType: "video/mp4",
                 // mirror the real behavior: a fileId only when storage was requested.
-                ...(input.storage ? { fileId: "stub-file" } : {}),
+                ...(input.storage
+                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    : {}),
               },
             })) as VideoGenerationResult,
           ),
@@ -752,7 +756,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               video: {
                 url: "https://content.local/stub-video.mp4",
                 contentType: "video/mp4",
-                ...(input.storage ? { fileId: "stub-file" } : {}),
+                ...(input.storage
+                    ? { fileId: "stub-file", downloadUrl: "https://content.local/stub-download" }
+                    : {}),
               },
             }),
           ) as VideoGenerationResult;


### PR DESCRIPTION
## What & why (SAP-1241 — generate-and-store return contract, SDK side)

When you `create` an image/video with `storage`, the result already carries a durable `fileId`. This adds a **`downloadUrl`** right alongside it — a ready-to-use, short-lived signed URL — so callers don't need a follow-up `fileStorage.getDownloadUrl(fileId)` just to fetch the output. The raw provider `url` is demoted in the docs to "may be short-lived / unauthenticated."

Pairs with the gateway PR that now emits `download_url` on the storage stitch.

## Changes (all additive)

- `GeneratedImage` / `GeneratedVideo` gain optional `downloadUrl`, mapped from the gateway's snake_case `download_url` in `mapImage` / `mapVideo`.
- `VideoResultPayload.outputs[]` (delivered to a step resumed from `pauseUntilSignal`) carries `downloadUrl`; `toVideoResumePayload` maps it through.
- `createStubClient()` mirrors the field — stubbed image/video outputs include a `downloadUrl` when `storage` is passed, so local workflow tests see the real shape.
- README + doc comments updated: `downloadUrl` (ready to use, expires) vs `fileId` (durable), with `url` demoted.
- `minor` changeset.

## Testing
- `content-generation` spec extended: image map, video poll, and `toVideoResumePayload` all assert the camelCase `downloadUrl` surfaces from snake_case `download_url`.
- Full `@sapiom/tools` suite green (12 suites / 185); `typecheck` + `lint` clean.

## Backward compatibility
`downloadUrl` is optional and additive; `fileId` / `url` / `storageError` are unchanged. The URL expires — `fileId` remains the durable reference (`getDownloadUrl(fileId)` re-mints a fresh one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)