### PR TITLE
feat(tools): add memory capability for SAP-785

### DIFF
--- a/.changeset/memory-capability.md
+++ b/.changeset/memory-capability.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `memory` capability with `append`, `recall`, `sweep`, `get`, and `forget`. The SDK mirrors the gateway's camelCase contract, including grouped `store` selectors, `ADDED`/`NOOP` append decisions, temporal recall weights, metadata filters, dry-run sweep, and `MemoryHttpError` for non-2xx responses.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -80,6 +80,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 | `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks               | [src/email](./src/email/README.md)                           |
 | `domains`           | Register domain names and manage their DNS records                                                    | [src/domains](./src/domains/README.md)                       |
+| `memory`            | Tenant-scoped long-term memory (append-log; cosine recall, Neon keyword recall)                       | [src/memory](./src/memory/README.md)                         |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -63,6 +63,11 @@
       "import": "./dist/esm/domains/index.js",
       "require": "./dist/cjs/domains/index.js"
     },
+    "./memory": {
+      "types": "./dist/cjs/memory/index.d.ts",
+      "import": "./dist/esm/memory/index.js",
+      "require": "./dist/cjs/memory/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -118,6 +118,17 @@ import type {
   DnsRecordRef,
   DnsRecord,
 } from "./domains/index.js";
+import * as memory from "./memory/index.js";
+import type {
+  AppendInput,
+  AppendResult,
+  RecallInput,
+  RecallResponse,
+  SweepInput,
+  MemorySweepResponse,
+  Memory,
+  MemoryCallOptions,
+} from "./memory/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -320,6 +331,19 @@ export interface Sapiom {
     };
   };
   /**
+   * Tenant-scoped long-term memory. `append` writes (or no-ops on a duplicate),
+   * `recall` searches by cosine vector similarity or Neon keyword strategy, `get`
+   * fetches one by id; prune with Neon `sweep` (LRU/oldest eviction) or `forget`
+   * (hard-delete a single id).
+   */
+  readonly memory: {
+    append(input: AppendInput): Promise<AppendResult>;
+    recall(input: RecallInput): Promise<RecallResponse>;
+    sweep(input?: SweepInput): Promise<MemorySweepResponse>;
+    get(id: string, options?: MemoryCallOptions): Promise<Memory>;
+    forget(id: string, options?: MemoryCallOptions): Promise<void>;
+  };
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
@@ -436,6 +460,13 @@ function bind(transport: Transport): Sapiom {
         update: (input) => domains.updateDnsRecord(input, transport),
         delete: (input) => domains.deleteDnsRecord(input, transport),
       },
+    },
+    memory: {
+      append: (input) => memory.append(input, transport),
+      recall: (input) => memory.recall(input, transport),
+      sweep: (input) => memory.sweep(input, transport),
+      get: (id, options) => memory.get(id, transport, undefined, options),
+      forget: (id, options) => memory.forget(id, transport, undefined, options),
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -100,3 +100,6 @@ export { EmailHttpError } from "./email/index.js";
 
 export * as domains from "./domains/index.js";
 export { DomainsHttpError } from "./domains/index.js";
+
+export * as memory from "./memory/index.js";
+export { MemoryHttpError } from "./memory/index.js";

--- a/packages/tools/src/memory/README.md
+++ b/packages/tools/src/memory/README.md
@@ -1,0 +1,70 @@
+# memory
+
+Tenant-scoped long-term memory over the Sapiom memory gateway.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+const { id, decision } = await sapiom.memory.append({
+  content: "User prefers dark mode.",
+  scope: "user",
+  metadata: { source: "preference-survey" },
+});
+
+const { results } = await sapiom.memory.recall({
+  query: "ui preferences",
+  scope: "user",
+  topK: 5,
+});
+
+const record = await sapiom.memory.get(id);
+await sapiom.memory.forget(id);
+```
+
+Ambient import works too: `import { memory } from "@sapiom/tools"`.
+
+## Operations
+
+| Method                 | Notes                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| `append(input)`        | Writes a memory or returns an existing near-duplicate. Success decisions are `"ADDED"` or `"NOOP"`.   |
+| `recall(input)`        | Searches memories by `query`; supports `strategy`, temporal `weight`, metadata `filter`, and `store`. |
+| `sweep(input?)`        | Neon-only compaction. `dryRun` defaults to `true`; pass `false` to delete selected rows.              |
+| `get(id, options?)`    | Fetches one memory. Pass `options.store` when the write used a non-default store.                     |
+| `forget(id, options?)` | Hard-deletes one memory. Idempotent: already-gone rows still resolve successfully.                    |
+
+## Store Identity
+
+`store` selects the physical store. Reads must pass the same selector used by the matching write.
+
+```typescript
+export interface MemoryStore {
+  backend?: "neon-pgvector" | "upstash-vector";
+  embedder?: {
+    provider: string;
+    model: string;
+  };
+  namespace?: string;
+}
+```
+
+Pass the same `store` to reads/deletes that was used when writing. Omit `store` for the v0 default: Neon pgvector, your default namespace, and OpenRouter `openai/text-embedding-3-small`.
+
+## Contract Notes
+
+- `append` is append-log only. It never mutates or supersedes existing rows.
+- Secret-like content or metadata is rejected before embedding with `MemoryHttpError` status `400` and body fields such as `error: "SecretDetected"` and `decision: "REJECTED"`.
+- `occurredAt` is optional event time. When omitted, the backend stores `null`; temporal recall falls back to `createdAt`.
+- `recall` defaults to `strategy: "cosine"`, `topK: 5`, and `minSimilarity: 0`.
+- `strategy: "keyword"` is Neon-only; requesting it on `upstash-vector` returns `400`.
+- `sweep` is Neon-only; for Upstash-backed stores, call `forget` on specific ids.
+- `upstash-vector` is experimental in v0. Append, cosine recall, get, and forget work; native Upstash embedding, keyword recall, and sweep are not part of this SDK contract yet.
+- The gateway is authoritative for embedder support. v0 currently supports OpenRouter-backed embedding providers/models and returns `400` for unsupported selectors.
+- `filter` is a hard metadata filter. Neon uses JSONB containment; Upstash supports scalar equality filters.
+- After the route gate succeeds, recall degrades child infra, billing, rate-limit, and timeout failures to `{ results: [], count: 0 }`. Bad requests, missing identity, and ownership failures still throw.
+- Every route has the near-zero x402 minimum gate. Embedding and store operations are child costs billed to the run.
+- Non-2xx responses throw `MemoryHttpError` with `status` and parsed `body`.
+
+The base URL follows the shared service resolver: `SAPIOM_MEMORY_URL`, then `SAPIOM_SERVICES_BASE`, then `https://memory.services.sapiom.ai`.

--- a/packages/tools/src/memory/errors.ts
+++ b/packages/tools/src/memory/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * Error thrown by the memory capability when the gateway returns a non-2xx
+ * response. Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ *
+ * Useful statuses to branch on: `400` (validation or `SecretDetected`), `401`
+ * (missing identity), `402` (route gate balance), `403` (ownership failure),
+ * `404` (`get` only), `422` (resource limit), and `507` (store full).
+ */
+export class MemoryHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "MemoryHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link MemoryHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new MemoryHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/memory/index.spec.ts
+++ b/packages/tools/src/memory/index.spec.ts
@@ -1,0 +1,1067 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as memory from "./index.js";
+import { MemoryHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly with a real Transport wired to a
+// scripted fetch mock (so URL/method/header/body assertions are exact, and we
+// verify the Transport itself injects the tenant credential).
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+// ---------------------------------------------------------------------------
+// Public contract constants
+// ---------------------------------------------------------------------------
+
+describe("memory — public contract constants", () => {
+  it("exports the current backend allowlist", () => {
+    expect(memory.MEMORY_BACKENDS).toEqual([
+      "neon-pgvector",
+      "upstash-vector",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Base URL resolution (resolveServiceUrl at module load)
+// ---------------------------------------------------------------------------
+
+describe("memory — base URL resolution", () => {
+  it("defaults to the production memory service origin when nothing overrides it", async () => {
+    // DEFAULT_BASE_URL is captured at module load from process.env; with no
+    // SAPIOM_MEMORY_URL / SAPIOM_SERVICES_BASE set in this test run it must be
+    // the production origin, and the /v1/memory path prefix is appended per-method.
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    // Call WITHOUT the baseUrl arg so the module-level default is exercised.
+    await memory.append({ content: "c" }, transport);
+    expect(calls[0]!.url).toBe(
+      "https://memory.services.sapiom.ai/v1/memory/append",
+    );
+  });
+
+  it("honors an explicit per-call baseUrl override verbatim (path prefix appended)", async () => {
+    // An SAPIOM_MEMORY_URL override wins verbatim, but it is read at module load;
+    // the per-call baseUrl arg is the same bare-origin knob threaded per request,
+    // so we exercise the override shape through it.
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    await memory.append(
+      { content: "c" },
+      transport,
+      "http://memory.services.localhost:3100",
+    );
+    expect(calls[0]!.url).toBe(
+      "http://memory.services.localhost:3100/v1/memory/append",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// append()
+// ---------------------------------------------------------------------------
+
+describe("memory.append()", () => {
+  it("POSTs /append with JSON body + credential and returns the camelCase payload as-is", async () => {
+    const raw = {
+      id: "m-123",
+      content: "User prefers dark mode.",
+      scope: "user",
+      decision: "ADDED",
+      createdAt: "2026-06-22T12:00:00Z",
+      occurredAt: null,
+      metadata: { source: "survey" },
+    };
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(raw, { status: 201 }),
+    ]);
+
+    const result = await memory.append(
+      {
+        content: "User prefers dark mode.",
+        scope: "user",
+        metadata: { source: "survey" },
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual(raw);
+    expect(result.decision).toBe("ADDED");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/append`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "User prefers dark mode.",
+      scope: "user",
+      metadata: { source: "survey" },
+    });
+    // store omitted from the body when not supplied → gateway falls back to its
+    // neon-pgvector default store.
+    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
+      "store",
+    );
+  });
+
+  it("includes occurredAt in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: "2026-05-01T00:00:00Z",
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await memory.append(
+      { content: "c", occurredAt: "2026-05-01T00:00:00Z" },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      occurredAt: "2026-05-01T00:00:00Z",
+    });
+    // occurredAt echoed back on the result.
+    expect(result.occurredAt).toBe("2026-05-01T00:00:00Z");
+  });
+
+  it("forwards the store selector (backend) in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const store: memory.MemoryStore = { backend: "upstash-vector" };
+    await memory.append({ content: "c", store }, transport, BASE);
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      store: { backend: "upstash-vector" },
+    });
+  });
+
+  it("forwards the full store selector (namespace + embedder) verbatim in the body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const store: memory.MemoryStore = {
+      namespace: "tenant-7",
+      embedder: {
+        provider: "openrouter",
+        model: "openai/text-embedding-3-large",
+      },
+    };
+    await memory.append({ content: "c", store }, transport, BASE);
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      content: "c",
+      store: {
+        namespace: "tenant-7",
+        embedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+    });
+  });
+
+  it("surfaces a NOOP decision echoing the existing memory (nothing written)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-existing",
+            content: "User prefers dark mode.",
+            scope: "user",
+            decision: "NOOP",
+            createdAt: "2026-06-01T00:00:00Z",
+            occurredAt: null,
+            metadata: { source: "survey" },
+          },
+          // NOOP may come back as 200 or 201; either is a success and parses the same.
+          { status: 200 },
+        ),
+    ]);
+
+    const result = await memory.append(
+      { content: "User prefers dark mode.", scope: "user" },
+      transport,
+      BASE,
+    );
+    expect(result.decision).toBe("NOOP");
+    expect(result.id).toBe("m-existing"); // the existing memory's id, echoed
+  });
+
+  it("returns NOOP on byte-identical content (no idempotency key sent)", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-existing",
+            content: "c",
+            scope: "default",
+            decision: "NOOP",
+            createdAt: "2026-06-01T00:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 200 },
+        ),
+    ]);
+
+    // NOOP is decided purely on byte-identical content (or a near-exact semantic
+    // duplicate) in the same owner + scope — there is no idempotency key on the wire.
+    const result = await memory.append({ content: "c" }, transport, BASE);
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ content: "c" });
+    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
+      "idempotencyKey",
+    );
+    expect(result.decision).toBe("NOOP");
+    expect(result.id).toBe("m-existing");
+  });
+
+  it("omits optional fields from the body when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: "m-1",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    await memory.append({ content: "c" }, transport, BASE);
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({ content: "c" });
+    expect(body).not.toHaveProperty("scope");
+    expect(body).not.toHaveProperty("metadata");
+    expect(body).not.toHaveProperty("idempotencyKey");
+    expect(body).not.toHaveProperty("occurredAt");
+    expect(body).not.toHaveProperty("store");
+  });
+
+  it("throws MemoryHttpError carrying the REJECTED body on a 400 SecretDetected", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({
+            statusCode: 400,
+            error: "SecretDetected",
+            decision: "REJECTED",
+            message: "Potential secret detected in content or metadata.",
+          }),
+          { status: 400 },
+        ),
+    ]);
+
+    // REJECTED is not a success decision — it rides back on the 400 error body, so
+    // it must surface via MemoryHttpError.body, never as an AppendResult.decision.
+    await expect(
+      memory.append({ content: "sk-live-abc" }, transport, BASE),
+    ).rejects.toMatchObject({
+      status: 400,
+      body: { error: "SecretDetected", decision: "REJECTED" },
+    });
+  });
+
+  it("throws MemoryHttpError on a 507 (store full)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({ statusCode: 507, message: "Memory store full." }),
+          { status: 507 },
+        ),
+    ]);
+
+    await expect(
+      memory.append({ content: "c" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 507 });
+    await expect(
+      memory.append({ content: "c" }, transport, BASE),
+    ).rejects.toBeInstanceOf(MemoryHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recall()
+// ---------------------------------------------------------------------------
+
+describe("memory.recall()", () => {
+  const match = {
+    id: "m-1",
+    content: "The project deadline is end of Q3.",
+    scope: "project",
+    // Provider returns a single canonical [0,1] `score` plus an optional
+    // backend-specific `scoreBreakdown` map (some backends fill component scores;
+    // opaque/dense-only paths omit it).
+    score: 0.71,
+    scoreBreakdown: { vector: 0.82, text: 0.4, combined: 0.71 },
+    createdAt: "2026-06-01T00:00:00Z",
+    occurredAt: "2026-05-15T00:00:00Z",
+    lastAccessedAt: "2026-06-20T00:00:00Z",
+    metadata: {},
+  };
+
+  it("POSTs /recall with the query and returns results + echoed fields", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          results: [match],
+          query: "deadline",
+          topK: 10,
+          count: 1,
+        }),
+    ]);
+
+    const result = await memory.recall({ query: "deadline" }, transport, BASE);
+
+    expect(result.count).toBe(1);
+    expect(result.topK).toBe(10);
+    expect(result.query).toBe("deadline");
+    expect(result.results[0]).toEqual(match);
+    // The match maps the score shape 1:1 — canonical `score` + optional
+    // `scoreBreakdown`, plus occurredAt / lastAccessedAt passthrough.
+    expect(result.results[0]!.score).toBe(0.71);
+    expect(result.results[0]!.scoreBreakdown).toEqual({
+      vector: 0.82,
+      text: 0.4,
+      combined: 0.71,
+    });
+    expect(result.results[0]!.occurredAt).toBe("2026-05-15T00:00:00Z");
+    expect(result.results[0]!.lastAccessedAt).toBe("2026-06-20T00:00:00Z");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/recall`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "deadline",
+    });
+    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
+      "store",
+    );
+  });
+
+  it("surfaces a match with null occurredAt/lastAccessedAt and no scoreBreakdown (opaque backend)", async () => {
+    const opaqueMatch = {
+      id: "m-opaque",
+      content: "Opaque-backend match.",
+      scope: "default",
+      score: 0.66,
+      createdAt: "2026-06-01T00:00:00Z",
+      occurredAt: null,
+      lastAccessedAt: null,
+      metadata: {},
+    };
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          results: [opaqueMatch],
+          query: "q",
+          topK: 10,
+          count: 1,
+        }),
+    ]);
+
+    const result = await memory.recall({ query: "q" }, transport, BASE);
+    expect(result.results[0]).toEqual(opaqueMatch);
+    expect(result.results[0]!.score).toBe(0.66);
+    expect(result.results[0]!.scoreBreakdown).toBeUndefined();
+    expect(result.results[0]!.occurredAt).toBeNull();
+    expect(result.results[0]!.lastAccessedAt).toBeNull();
+  });
+
+  it("includes scope, topK, minSimilarity, and strategy in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
+    ]);
+
+    await memory.recall(
+      {
+        query: "q",
+        scope: "project",
+        topK: 5,
+        minSimilarity: 0.5,
+        strategy: "keyword",
+      },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      scope: "project",
+      topK: 5,
+      minSimilarity: 0.5,
+      strategy: "keyword",
+    });
+  });
+
+  it("includes weight and filter in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
+    ]);
+
+    await memory.recall(
+      {
+        query: "q",
+        weight: {
+          temporal: { center: "2026-06-01T00:00:00Z", halfLifeDays: 14 },
+        },
+        filter: { source: "survey" },
+      },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      weight: {
+        temporal: { center: "2026-06-01T00:00:00Z", halfLifeDays: 14 },
+      },
+      filter: { source: "survey" },
+    });
+  });
+
+  it("forwards the store selector (backend) in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    await memory.recall(
+      { query: "q", store: { backend: "upstash-vector" } },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      store: { backend: "upstash-vector" },
+    });
+  });
+
+  it("forwards the full store selector (namespace + embedder) verbatim in the body", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    await memory.recall(
+      {
+        query: "q",
+        store: {
+          namespace: "tenant-7",
+          embedder: {
+            provider: "openrouter",
+            model: "openai/text-embedding-3-large",
+          },
+        },
+      },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      query: "q",
+      store: {
+        namespace: "tenant-7",
+        embedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+    });
+  });
+
+  it("omits optional fields from the body when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
+    ]);
+
+    await memory.recall({ query: "q" }, transport, BASE);
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({ query: "q" });
+    expect(body).not.toHaveProperty("scope");
+    expect(body).not.toHaveProperty("topK");
+    expect(body).not.toHaveProperty("minSimilarity");
+    expect(body).not.toHaveProperty("strategy");
+    expect(body).not.toHaveProperty("weight");
+    expect(body).not.toHaveProperty("filter");
+    expect(body).not.toHaveProperty("store");
+  });
+
+  it("returns an empty result set without error", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
+    ]);
+
+    const result = await memory.recall({ query: "q" }, transport, BASE);
+    expect(result.results).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it("throws MemoryHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("server error", { status: 503 }),
+    ]);
+
+    await expect(
+      memory.recall({ query: "q" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sweep()
+// ---------------------------------------------------------------------------
+
+describe("memory.sweep()", () => {
+  it("POSTs /sweep with an empty body by default (dryRun omitted, server defaults it true)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ evicted: 0, candidates: [] }),
+    ]);
+
+    const result = await memory.sweep(undefined, transport, BASE);
+
+    expect(result.evicted).toBe(0);
+    expect(result.candidates).toEqual([]);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/sweep`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    // dryRun now defaults to true SERVER-side; the client only sends it when the
+    // caller provides it, so an unspecified sweep sends no dryRun at all.
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({});
+    expect(body).not.toHaveProperty("dryRun");
+  });
+
+  it("includes count, strategy, and the store selector in the body when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ evicted: 2 }),
+    ]);
+
+    await memory.sweep(
+      {
+        count: 2,
+        strategy: "oldest",
+        store: {
+          backend: "upstash-vector",
+          namespace: "tenant-7",
+          embedder: {
+            provider: "openrouter",
+            model: "openai/text-embedding-3-large",
+          },
+        },
+      },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      count: 2,
+      strategy: "oldest",
+      store: {
+        backend: "upstash-vector",
+        namespace: "tenant-7",
+        embedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+    });
+  });
+
+  it("returns the candidates a dryRun would evict (evicted: 0)", async () => {
+    const candidate = {
+      id: "m-old",
+      content: "stale note",
+      scope: "default",
+      createdAt: "2026-01-01T00:00:00Z",
+      lastAccessedAt: null,
+    };
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ evicted: 0, candidates: [candidate] }),
+    ]);
+
+    // dryRun:true is the server default, but when the caller passes it explicitly
+    // the client forwards it in the body.
+    const result = await memory.sweep({ dryRun: true }, transport, BASE);
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ dryRun: true });
+    expect(result.evicted).toBe(0);
+    expect(result.candidates).toEqual([candidate]);
+    expect(result.candidates![0]!.lastAccessedAt).toBeNull();
+  });
+
+  it("sends dryRun:false in the body when the caller opts into a real eviction", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ evicted: 4 }),
+    ]);
+
+    const result = await memory.sweep({ dryRun: false }, transport, BASE);
+    // Only sent because the caller provided it; the client never injects a default.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      dryRun: false,
+    });
+    expect(result.evicted).toBe(4);
+  });
+
+  it("throws MemoryHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("server error", { status: 500 }),
+    ]);
+
+    await expect(memory.sweep({}, transport, BASE)).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get()
+// ---------------------------------------------------------------------------
+
+describe("memory.get()", () => {
+  const record = {
+    id: "m-1",
+    content: "c",
+    scope: "default",
+    createdAt: "2026-06-01T00:00:00Z",
+    occurredAt: "2026-05-15T00:00:00Z",
+    lastAccessedAt: "2026-06-20T00:00:00Z",
+    metadata: {},
+  };
+
+  it("GETs /:id and returns the record", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    const result = await memory.get("m-1", transport, BASE);
+
+    expect(result).toEqual(record);
+    expect(result.occurredAt).toBe("2026-05-15T00:00:00Z");
+    expect(result.lastAccessedAt).toBe("2026-06-20T00:00:00Z");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("returns a record with null occurredAt/lastAccessedAt", async () => {
+    const bare = {
+      id: "m-2",
+      content: "c",
+      scope: "default",
+      createdAt: "2026-06-01T00:00:00Z",
+      occurredAt: null,
+      lastAccessedAt: null,
+      metadata: {},
+    };
+    const { transport } = makeTransport([() => jsonResponse(bare)]);
+
+    const result = await memory.get("m-2", transport, BASE);
+    expect(result).toEqual(bare);
+    expect(result.occurredAt).toBeNull();
+    expect(result.lastAccessedAt).toBeNull();
+  });
+
+  it("appends the flat storeBackend query param when the option is provided", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {
+      store: { backend: "upstash-vector" },
+    });
+    const expected = new URLSearchParams();
+    expected.set("storeBackend", "upstash-vector");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1?${expected.toString()}`);
+  });
+
+  it("omits the store query params when the option is absent", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.url).not.toContain("store");
+  });
+
+  it("appends flat store query params (namespace + embedder)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {
+      store: {
+        namespace: "tenant-7",
+        embedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+    });
+    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
+    expect(query.get("storeNamespace")).toBe("tenant-7");
+    expect(query.get("storeEmbedderProvider")).toBe("openrouter");
+    expect(query.get("storeEmbedderModel")).toBe(
+      "openai/text-embedding-3-large",
+    );
+  });
+
+  it("omits the flat store query params when the store option is absent", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("m-1", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
+    expect(calls[0]!.url).not.toContain("store");
+  });
+
+  it("encodes special characters in the id", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
+
+    await memory.get("id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
+  });
+
+  it("throws MemoryHttpError on 404", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+
+    await expect(memory.get("bad-id", transport, BASE)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forget()
+// ---------------------------------------------------------------------------
+
+describe("memory.forget()", () => {
+  it("DELETEs /:id and resolves void on 204", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    const result = await memory.forget("m-abc", transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("appends the flat storeBackend query param when the option is provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {
+      store: { backend: "upstash-vector" },
+    });
+    const expected = new URLSearchParams();
+    expected.set("storeBackend", "upstash-vector");
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/memory/m-abc?${expected.toString()}`,
+    );
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("omits the store query params when the option is absent", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.url).not.toContain("store");
+  });
+
+  it("appends flat store query params (namespace + embedder)", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {
+      store: {
+        namespace: "tenant-7",
+        embedder: {
+          provider: "openrouter",
+          model: "openai/text-embedding-3-large",
+        },
+      },
+    });
+    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
+    expect(query.get("storeNamespace")).toBe("tenant-7");
+    expect(query.get("storeEmbedderProvider")).toBe("openrouter");
+    expect(query.get("storeEmbedderModel")).toBe(
+      "openai/text-embedding-3-large",
+    );
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("omits the flat store query params when the store option is absent", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("m-abc", transport, BASE, {});
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    expect(calls[0]!.url).not.toContain("store");
+  });
+
+  it("encodes special characters in the id", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await memory.forget("id/with slash", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
+  });
+
+  it("is idempotent: a second forget of an already-gone id resolves (204, no throw)", async () => {
+    // forget is a hard DELETE but idempotent: the gateway always returns
+    // 204 No Content, whether or not the id existed. Deleting an already-gone
+    // (or never-existed / other-owner) id is success — NOT a 404. Mirror the
+    // gateway by returning 204 on every call.
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+      () => new Response(null, { status: 204 }),
+    ]);
+
+    await expect(
+      memory.forget("m-abc", transport, BASE),
+    ).resolves.toBeUndefined();
+    // Second forget of the now-gone id still succeeds (idempotent).
+    await expect(
+      memory.forget("m-abc", transport, BASE),
+    ).resolves.toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls.every((c) => c.init.method === "DELETE")).toBe(true);
+  });
+
+  it("surfaces a real transport error as MemoryHttpError with status + parsed JSON body", async () => {
+    // Idempotency only covers gone-already ids (→ 204). Genuine failures must
+    // still throw, exercising forget()'s inline error parser (not ensureOk).
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "boom", code: "internal" }), {
+          status: 500,
+        }),
+    ]);
+
+    await expect(
+      memory.forget("bad-id", transport, BASE),
+    ).rejects.toMatchObject({
+      status: 500,
+      body: { message: "boom", code: "internal" },
+    });
+  });
+
+  it("surfaces a real transport error as MemoryHttpError (non-JSON body)", async () => {
+    const { transport } = makeTransport([
+      () => new Response("upstream boom", { status: 500 }),
+    ]);
+
+    await expect(
+      memory.forget("bad-id", transport, BASE),
+    ).rejects.toMatchObject({ status: 500, body: "upstream boom" });
+    await expect(
+      memory.forget("bad-id", transport, BASE),
+    ).rejects.toBeInstanceOf(MemoryHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client wiring + auth
+// ---------------------------------------------------------------------------
+
+describe("memory — client wiring + credential", () => {
+  it("createClient().memory routes all five methods with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      const method = init.method ?? "GET";
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (url.endsWith("/recall"))
+        return jsonResponse({ results: [], query: "q", topK: 10, count: 0 });
+      if (url.endsWith("/sweep")) return jsonResponse({ evicted: 0 });
+      if (url.endsWith("/append"))
+        return jsonResponse(
+          {
+            id: "m",
+            content: "c",
+            scope: "default",
+            decision: "ADDED",
+            createdAt: "2026-06-22T12:00:00Z",
+            occurredAt: null,
+            metadata: {},
+          },
+          { status: 201 },
+        );
+      // GET /:id
+      return jsonResponse({
+        id: "m",
+        content: "c",
+        scope: "default",
+        createdAt: "2026-06-22T12:00:00Z",
+        occurredAt: null,
+        lastAccessedAt: null,
+        metadata: {},
+      });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+    await sapiom.memory.append({ content: "c" });
+    await sapiom.memory.recall({ query: "q" });
+    await sapiom.memory.sweep();
+    await sapiom.memory.get("m", { store: { namespace: "tenant-7" } });
+    await sapiom.memory.forget("m", { store: { namespace: "tenant-7" } });
+
+    expect(calls).toHaveLength(5);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+    const expected = new URLSearchParams();
+    expected.set("storeNamespace", "tenant-7");
+    expect(calls[3]!.url).toBe(
+      `https://memory.services.sapiom.ai/v1/memory/m?${expected.toString()}`,
+    );
+    expect(calls[4]!.url).toBe(
+      `https://memory.services.sapiom.ai/v1/memory/m?${expected.toString()}`,
+    );
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("{}")) as typeof globalThis.fetch,
+      });
+      await expect(
+        memory.recall({ query: "q" }, transport, BASE),
+      ).rejects.toThrow(/no tenant credential/i);
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MemoryHttpError
+// ---------------------------------------------------------------------------
+
+describe("MemoryHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new MemoryHttpError("something went wrong", 422, {
+      code: "authorization_denied",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err.status).toBe(422);
+    expect(err.body).toEqual({ code: "authorization_denied" });
+    expect(err.name).toBe("MemoryHttpError");
+  });
+});

--- a/packages/tools/src/memory/index.ts
+++ b/packages/tools/src/memory/index.ts
@@ -1,0 +1,484 @@
+/**
+ * Tenant-scoped long-term memory on the Sapiom memory gateway.
+ *
+ *   import { memory } from "@sapiom/tools";                 // ambient auth
+ *   const { id } = await memory.append({ content: "User prefers dark mode.", scope: "user" });
+ *   const { results } = await memory.recall({ query: "ui preferences", topK: 5 });
+ *   const record = await memory.get(id);
+ *   await memory.forget(id);
+ *
+ * Or via an explicit client: `createClient({ apiKey }).memory.append(...)`.
+ *
+ * The gateway speaks camelCase JSON, so this client keeps request and response
+ * objects 1:1 with the wire contract.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, MemoryHttpError } from "./errors.js";
+
+export { MemoryHttpError };
+
+/**
+ * Memory service ORIGIN. Resolves like every other @sapiom/tools capability: an
+ * explicit `SAPIOM_MEMORY_URL` override wins, else the `SAPIOM_SERVICES_BASE` knob
+ * re-homes it (subdomain preserved), else the production
+ * `https://memory.services.sapiom.ai`. This is the bare origin; the `/v1/memory`
+ * path prefix is appended per-method below (a local override is just the gateway
+ * origin, e.g. `http://memory.services.localhost:3100`).
+ */
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "memory",
+  process.env.SAPIOM_MEMORY_URL,
+);
+
+// ----- SDK-facing types (identical to the wire; camelCase end to end) -----
+
+/** Storage backend selector. Omit for the v0 default `"neon-pgvector"`. */
+export const MEMORY_BACKENDS = ["neon-pgvector", "upstash-vector"] as const;
+export type MemoryBackend = (typeof MEMORY_BACKENDS)[number];
+
+/** Embedding model selector. Omit for the default OpenRouter text-embedding-3-small embedder. */
+export interface MemoryEmbedder {
+  /**
+   * Embedding provider. The gateway is authoritative for provider support and
+   * returns 400 for unknown providers; v0 currently supports `"openrouter"`.
+   */
+  provider: string;
+  /**
+   * Embedding model. A model is part of the store identity, so a write and all
+   * later reads must use the same model. The gateway is authoritative for model
+   * support and returns 400 for unknown models.
+   */
+  model: string;
+}
+
+/**
+ * Optional store selector. Omit for the default Neon store.
+ *
+ * A memory is only visible from the store it was written to. If you set any of
+ * these fields on append, pass the same `store` to recall/get/forget/sweep.
+ */
+export interface MemoryStore {
+  /**
+   * Storage backend. Default: `"neon-pgvector"`. `"upstash-vector"` is experimental
+   * and does not support keyword recall or sweep.
+   */
+  backend?: MemoryBackend;
+  /**
+   * Embedding model. Default: OpenRouter `"openai/text-embedding-3-small"`.
+   */
+  embedder?: MemoryEmbedder;
+  /**
+   * Physical isolation namespace. Use to separate projects/tenants under one
+   * owner. 1-100 chars, `[a-zA-Z0-9_-]`.
+   */
+  namespace?: string;
+}
+
+export interface AppendInput {
+  /**
+   * Text to store as a memory (1–32,000 chars). Must not contain secrets — the
+   * gateway runs an admission gate and rejects API keys / tokens / passwords with
+   * a 400 (`error: "SecretDetected"`, `decision: "REJECTED"`) before anything is
+   * embedded or stored.
+   */
+  content: string;
+  /**
+   * Scope label grouping related memories (e.g. "session", "user", "project").
+   * Alphanumeric plus hyphens/underscores, 1–100 chars. Defaults to "default".
+   */
+  scope?: string;
+  /**
+   * Arbitrary JSON stored alongside the memory and returned on read. Opaque to
+   * ranking (not embedded), but usable as a hard `filter` on recall. Max 10 KB when
+   * JSON-serialized.
+   */
+  metadata?: Record<string, unknown>;
+  /**
+   * Event-time this memory is *about* (ISO-8601), distinct from `createdAt` (the
+   * server ingestion time). Drives temporal recall weighting. When omitted, the
+   * gateway stores `null` and temporal recall falls back to `createdAt`.
+   */
+  occurredAt?: string;
+  /** Optional store selector. Omit for the default store. See {@link MemoryStore}. */
+  store?: MemoryStore;
+}
+
+export interface AppendResult {
+  /**
+   * UUID of the memory. For `decision: "ADDED"` this is the newly created record;
+   * for `decision: "NOOP"` it is the existing memory that was echoed (nothing was
+   * written).
+   */
+  id: string;
+  /** The stored content, echoed back. */
+  content: string;
+  /** The resolved scope label ("default" when you omitted it). */
+  scope: string;
+  /**
+   * What the gateway did, made legible (never a silent write):
+   * - `"ADDED"` — a new memory was written to the append-log.
+   * - `"NOOP"`  — byte-identical content or a near-exact semantic duplicate in the
+   *   same owner + scope; the existing memory is echoed and nothing is written.
+   *
+   * A secret caught by the admission gate is *not* a decision here — it surfaces as
+   * a 400 {@link MemoryHttpError} whose body carries `decision: "REJECTED"`.
+   */
+  decision: "ADDED" | "NOOP";
+  /** ISO-8601 timestamp when the memory was created (server ingestion time). */
+  createdAt: string;
+  /**
+   * ISO-8601 event-time this memory is *about*, or `null` when none was supplied on
+   * append (the gateway does not backfill it with `createdAt`).
+   */
+  occurredAt: string | null;
+  /** The stored metadata (`{}` when none was provided). */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Retrieval strategy for {@link recall}:
+ * - `"cosine"`  — dense vector similarity (default; supported on every backend).
+ * - `"keyword"` — full-text / BM25 ranking. Neon-only; requesting it on a backend
+ *   that doesn't support it is a 400 {@link MemoryHttpError} (never degraded).
+ */
+export type RetrievalStrategy = "cosine" | "keyword";
+
+/** Time-decay weighting for {@link RecallInput.weight}. Optional; omit for pure relevance. */
+export interface TemporalWeight {
+  /**
+   * ISO-8601 anchor the decay is measured from. Defaults to "now" at recall time.
+   * (A Unix-epoch integer is not accepted — pass an ISO-8601 string.)
+   */
+  center?: string;
+  /**
+   * Half-life in days (1–365, default 30): a memory whose `occurredAt` is this far
+   * from `center` keeps half its relevance. Smaller = sharper recency preference.
+   */
+  halfLifeDays?: number;
+}
+
+/** Optional scoring weights for {@link recall}. Extensible; only `temporal` is supported today. */
+export interface RecallWeight {
+  /** Multiplicative time-decay applied to each match's base similarity. */
+  temporal?: TemporalWeight;
+}
+
+export interface RecallInput {
+  /** Natural-language search text (1–4,096 chars). Embedded and compared against stored memories. */
+  query: string;
+  /** Restrict the search to this scope label. Omit to search every scope for your owner. */
+  scope?: string;
+  /** Maximum number of results to return (1–50). Defaults to 5. */
+  topK?: number;
+  /** Minimum score [0–1]; matches below it are dropped. Defaults to 0. */
+  minSimilarity?: number;
+  /**
+   * Retrieval strategy — `"cosine"` (default) or `"keyword"` (Neon-only). See
+   * {@link RetrievalStrategy}.
+   */
+  strategy?: RetrievalStrategy;
+  /**
+   * Optional scoring weights. Today only `weight.temporal` is honored — it applies
+   * a time-decay against each memory's `occurredAt`. Omit for pure relevance.
+   */
+  weight?: RecallWeight;
+  /**
+   * Hard metadata filter. Neon uses JSONB containment; Upstash supports scalar
+   * equality filters. Applied before ranking; max 4 KB serialized.
+   */
+  filter?: Record<string, unknown>;
+  /** Optional store selector. Pass the same store used at write time. See {@link MemoryStore}. */
+  store?: MemoryStore;
+}
+
+export interface RecallMatch {
+  /** UUID of the memory. */
+  id: string;
+  /** The stored content. */
+  content: string;
+  /** The scope label. */
+  scope: string;
+  /**
+   * Canonical [0–1] relevance the matches are ranked and thresholded on (highest
+   * first). Provider-neutral: an opaque backend reports only this single score.
+   */
+  score: number;
+  /**
+   * Optional backend-specific score legs. A backend may fill this with its own
+   * components; most dense-only paths omit it entirely. This is an open map —
+   * don't assume a fixed set of keys.
+   */
+  scoreBreakdown?: Record<string, number>;
+  /** ISO-8601 timestamp when the memory was created. */
+  createdAt: string;
+  /** ISO-8601 event-time this memory is *about*, or `null` when none was supplied. */
+  occurredAt: string | null;
+  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
+  lastAccessedAt: string | null;
+  /** The stored metadata. */
+  metadata: Record<string, unknown>;
+}
+
+export interface RecallResponse {
+  /** Matches ranked by `score` (highest first). Empty when nothing matched or no store exists yet. */
+  results: RecallMatch[];
+  /** The query, echoed back. */
+  query: string;
+  /** The effective top-K used by the gateway. */
+  topK: number;
+  /** Number of results returned (≤ `topK`). */
+  count: number;
+}
+
+export interface Memory {
+  /** UUID of the memory. */
+  id: string;
+  /** The stored content. */
+  content: string;
+  /** The scope label. */
+  scope: string;
+  /** ISO-8601 timestamp when the memory was created (server ingestion time). */
+  createdAt: string;
+  /** ISO-8601 event-time this memory is *about*, or `null` when none was supplied. */
+  occurredAt: string | null;
+  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
+  lastAccessedAt: string | null;
+  /** The stored metadata. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Eviction order for {@link sweep}:
+ * - `"lru"`    — least-recently-accessed first (`lastAccessedAt` ascending). Default.
+ * - `"oldest"` — oldest-inserted first (`createdAt` ascending).
+ */
+export type SweepStrategy = "lru" | "oldest";
+
+export interface SweepInput {
+  /**
+   * Maximum number of memories to preview/delete (1–10,000). Omit to use the
+   * gateway's default sweep batch (100 rows).
+   */
+  count?: number;
+  /** Eviction order — `"lru"` (default) or `"oldest"`. See {@link SweepStrategy}. */
+  strategy?: SweepStrategy;
+  /**
+   * Preview vs delete. **Defaults to `true`** (a safe preview): the gateway returns
+   * the `candidates` it would evict without deleting anything (`evicted: 0`). Pass
+   * `false` to actually evict.
+   */
+  dryRun?: boolean;
+  /** Optional store selector. Sweep is Neon-only. See {@link MemoryStore}. */
+  store?: MemoryStore;
+}
+
+/** A memory that a `sweep` would evict. */
+export interface MemorySweepCandidate {
+  /** UUID of the memory. */
+  id: string;
+  /** The stored content. */
+  content: string;
+  /** The scope label. */
+  scope: string;
+  /** ISO-8601 timestamp when the memory was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
+  lastAccessedAt: string | null;
+}
+
+export interface MemorySweepResponse {
+  /** Number of memories evicted (`0` on a `dryRun`). */
+  evicted: number;
+  /**
+   * The memories that *would* be evicted — present on a `dryRun` (the default).
+   * Review them, then {@link forget} specific ids or re-run `sweep` with
+   * `dryRun: false`.
+   */
+  candidates?: MemorySweepCandidate[];
+}
+
+/** Per-call options for {@link get} and {@link forget}. */
+export interface MemoryCallOptions {
+  /** Optional store selector. Pass the same store used at write time. See {@link MemoryStore}. */
+  store?: MemoryStore;
+}
+
+// ----- capability operations -----
+
+/**
+ * Append a memory to the store (an append-log — no prior memory is mutated). The
+ * gateway runs a secret-detection gate first (a detected secret is rejected with a
+ * 400 {@link MemoryHttpError}, body `decision: "REJECTED"`), then embeds the
+ * content and writes it, returning `decision: "ADDED"`.
+ *
+ * Byte-identical content, or a near-exact semantic duplicate, in the same owner +
+ * scope is a no-op that echoes the existing memory unchanged (`decision: "NOOP"`);
+ * nothing new is written.
+ *
+ * On a full Neon store the gateway returns `507` ({@link MemoryHttpError}); call
+ * {@link sweep} (or {@link forget}) to free space, then retry. On Upstash, first
+ * provisioning can return `422` when the account/index limit is reached.
+ */
+export async function append(
+  input: AppendInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<AppendResult> {
+  const body: Record<string, unknown> = { content: input.content };
+  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.metadata !== undefined) body.metadata = input.metadata;
+  if (input.occurredAt !== undefined) body.occurredAt = input.occurredAt;
+  if (input.store !== undefined) body.store = input.store;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/memory/append`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to append memory",
+  );
+  return (await res.json()) as AppendResult;
+}
+
+/**
+ * Recall memories by natural-language query. Returns the top-K matches ranked by
+ * score; an empty list when nothing matches or no memory store has been provisioned
+ * yet (not an error).
+ *
+ * After the route gate succeeds, infra, child billing, rate-limit, and timeout
+ * failures degrade to an empty result set. Bad requests, missing identity, and
+ * ownership failures (`400`/`401`/`403`) surface as {@link MemoryHttpError}.
+ */
+export async function recall(
+  input: RecallInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<RecallResponse> {
+  const body: Record<string, unknown> = { query: input.query };
+  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.topK !== undefined) body.topK = input.topK;
+  if (input.minSimilarity !== undefined)
+    body.minSimilarity = input.minSimilarity;
+  if (input.strategy !== undefined) body.strategy = input.strategy;
+  if (input.weight !== undefined) body.weight = input.weight;
+  if (input.filter !== undefined) body.filter = input.filter;
+  if (input.store !== undefined) body.store = input.store;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/memory/recall`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to recall memories",
+  );
+  return (await res.json()) as RecallResponse;
+}
+
+/**
+ * Sweep (evict) memories to reclaim space — consumer-triggered, never automatic.
+ * Call it after a `507` on {@link append}, or proactively to compact the store.
+ * Eviction is Neon-only today; a store with nothing to sweep returns `{ evicted: 0 }`.
+ *
+ * `dryRun` **defaults to `true`**: the gateway returns the `candidates` it would
+ * evict without deleting anything — review them, then {@link forget} specific ids
+ * or re-run with `dryRun: false` to actually evict.
+ */
+export async function sweep(
+  input: SweepInput = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<MemorySweepResponse> {
+  const body: Record<string, unknown> = {};
+  if (input.count !== undefined) body.count = input.count;
+  if (input.strategy !== undefined) body.strategy = input.strategy;
+  if (input.dryRun !== undefined) body.dryRun = input.dryRun;
+  if (input.store !== undefined) body.store = input.store;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/memory/sweep`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to sweep memories",
+  );
+  return (await res.json()) as MemorySweepResponse;
+}
+
+/**
+ * Build the `/v1/memory/:id` URL for get/forget, including any store selector.
+ */
+function memoryItemUrl(
+  baseUrl: string,
+  id: string,
+  options?: MemoryCallOptions,
+): string {
+  const path = `${baseUrl}/v1/memory/${encodeURIComponent(id)}`;
+  const params = new URLSearchParams();
+  const store = options?.store;
+  if (store) {
+    if (store.backend !== undefined) {
+      params.set("storeBackend", store.backend);
+    }
+    if (store.namespace !== undefined) {
+      params.set("storeNamespace", store.namespace);
+    }
+    if (store.embedder !== undefined) {
+      params.set("storeEmbedderProvider", store.embedder.provider);
+      params.set("storeEmbedderModel", store.embedder.model);
+    }
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+/**
+ * Fetch a single memory by id. Throws {@link MemoryHttpError} with `status: 404`
+ * when the memory doesn't exist or belongs to another owner (existence is not
+ * leaked across owners).
+ */
+export async function get(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+  options?: MemoryCallOptions,
+): Promise<Memory> {
+  const res = await ensureOk(
+    await transport.fetch(memoryItemUrl(baseUrl, id, options)),
+    `Failed to get memory '${id}'`,
+  );
+  return (await res.json()) as Memory;
+}
+
+/**
+ * Forget (hard-delete) a memory by id. Idempotent: a missing or already-deleted
+ * id is treated as success by the gateway.
+ */
+export async function forget(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+  options?: MemoryCallOptions,
+): Promise<void> {
+  const res = await transport.fetch(memoryItemUrl(baseUrl, id, options), {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    throw new MemoryHttpError(
+      `Failed to forget memory '${id}': ${res.status} ${text}`,
+      res.status,
+      parsed,
+    );
+  }
+  // 204 No Content — nothing to parse.
+}

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -14,9 +14,11 @@ import {
   repositories,
   agent,
   search,
+  memory,
   Sandbox,
   Repository,
   SearchHttpError,
+  MemoryHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -47,6 +49,13 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.database.get).toBe("function");
     expect(typeof sapiom.database.delete).toBe("function");
 
+    expect(typeof sapiom.memory).toBe("object");
+    expect(typeof sapiom.memory.append).toBe("function");
+    expect(typeof sapiom.memory.recall).toBe("function");
+    expect(typeof sapiom.memory.sweep).toBe("function");
+    expect(typeof sapiom.memory.get).toBe("function");
+    expect(typeof sapiom.memory.forget).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -62,7 +71,9 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof repositories).toBe("object");
     expect(typeof agent).toBe("object");
     expect(typeof search).toBe("object");
+    expect(typeof memory).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
+    expect(typeof MemoryHttpError).toBe("function");
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -80,6 +80,13 @@ import type {
   DomainTransfer,
   DnsRecord,
 } from "../domains/index.js";
+import type {
+  AppendResult,
+  RecallResponse,
+  MemorySweepResponse,
+  Memory,
+  MemoryCallOptions,
+} from "../memory/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -1182,6 +1189,53 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             r("domains.dns.delete", [input], () => undefined) as void,
           ),
       },
+    },
+    memory: {
+      append: (input) =>
+        Promise.resolve(
+          r("memory.append", [input], () => ({
+            id: "stub-memory",
+            content: input.content,
+            scope: input.scope ?? "default",
+            decision: "ADDED",
+            createdAt: "2099-01-01T00:00:00Z",
+            occurredAt: input.occurredAt ?? null,
+            metadata: input.metadata ?? {},
+          })) as AppendResult,
+        ),
+      recall: (input) =>
+        Promise.resolve(
+          r("memory.recall", [input], () => ({
+            results: [],
+            query: input.query,
+            topK: input.topK ?? 5,
+            count: 0,
+          })) as RecallResponse,
+        ),
+      sweep: (input) =>
+        Promise.resolve(
+          r("memory.sweep", [input], () =>
+            input?.dryRun === false
+              ? { evicted: 0 }
+              : { evicted: 0, candidates: [] },
+          ) as MemorySweepResponse,
+        ),
+      get: (id: string, options?: MemoryCallOptions) =>
+        Promise.resolve(
+          r("memory.get", [id, options], () => ({
+            id,
+            content: "(stub) memory content",
+            scope: "default",
+            createdAt: "2099-01-01T00:00:00Z",
+            occurredAt: null,
+            lastAccessedAt: null,
+            metadata: {},
+          })) as Memory,
+        ),
+      forget: (id: string, options?: MemoryCallOptions) =>
+        Promise.resolve(
+          r("memory.forget", [id, options], () => undefined) as void,
+        ),
     },
     withAttribution: () => client,
   };


### PR DESCRIPTION
## Summary
Adds the `@sapiom/tools` SDK counterpart for the SAP-785 memory capability. The SDK exposes the same five verbs as the gateway: `append`, `recall`, `sweep`, `get`, and `forget`.

## Changes
- Add `@sapiom/tools/memory` with typed request/response shapes and `MemoryHttpError`.
- Wire `createClient().memory`, the ambient `memory` namespace, barrel exports, package subpath export, and the stub client.
- Preserve the gateway wire contract: camelCase bodies, grouped `store` selectors in append/recall/sweep bodies, and flat store query params for `get`/`forget`.
- Type and document the current v0 store contract once at `MemoryStore`: Neon pgvector default, Upstash Vector experimental, keyword/sweep Neon-only, and gateway-authoritative embedder selectors.
- Add memory unit tests, public surface smoke coverage, README docs, and changeset.

## Context / Caveats
- This SDK PR depends on the gateway/backend memory PR landing first.
- Upstash is exposed as an experimental backend selector, not as the default.
- Native Upstash embeddings are not part of this SDK contract yet. The SDK does not duplicate the gateway's embedder provider/model registry; `store.embedder.provider` and `store.embedder.model` are typed as `string`, and the gateway is authoritative for support.
- The final diff is memory SDK surface only; it does not change the shared `_client` transport behavior.

## Testing
- `pnpm --filter @sapiom/tools typecheck`
- `pnpm --filter @sapiom/tools exec jest --runInBand`
  - 15 suites passed, 271 tests passed
- `pnpm --filter @sapiom/tools lint`
- `pnpm --filter @sapiom/tools build`
- `git diff --check origin/main...HEAD`

## Related
Refs: SAP-785
