### PR TITLE
fix(orchestration-core): gate coding-pause publish behind human approval (SAP-1038)

### DIFF
--- a/.changeset/coding-pause-two-agent-gate.md
+++ b/.changeset/coding-pause-two-agent-gate.md
@@ -1,0 +1,16 @@
+---
+"@sapiom/orchestration-core": patch
+---
+
+`coding-pause` template now gates the publish to `main` behind the human approval
+(SAP-1038)
+
+The scaffolded `coding-pause` orchestration previously let the coding agent push
+inside its own run before the pause, so the approval sat _downstream_ of the
+irreversible push — "reject" couldn't prevent anything. The template is rewritten
+as the two-agent variant: agent #1 writes the change to a non-canonical
+`proposed/<executionId>` branch, the workflow pauses on a `review.decision`
+signal, and only on approve does agent #2 promote that branch onto `main`. A
+rejected (or unapproved) run leaves `main` untouched; an approved run publishes to
+`main` only after the approve signal. No engine or platform change — it works on
+the local coding substrate today.

--- a/packages/orchestration-core/templates/coding-pause/README.md
+++ b/packages/orchestration-core/templates/coding-pause/README.md
@@ -22,10 +22,11 @@ of the one that touches `main`:
   **non-canonical** `proposed/<executionId>` branch — never `main`.
 - **review** is resumed with agent #1's `CodingResultPayload`; it then suspends on
   the `review.decision` signal (the human approval).
-- **decide** is resumed with the human decision. On **reject** (or no explicit
-  approval) it terminates and `main` is left exactly as it was. On **approve** it
-  launches agent #2 to promote `proposed/…` onto `main` — the **only** step that
-  writes the canonical branch, reached only after approval.
+- **decide** is resumed with the human decision. On **reject** (a `review.decision`
+  whose `decision` isn't `approved`) it terminates and `main` is left exactly as it
+  was; with no signal at all the run simply stays paused. On **approve** it launches
+  agent #2 to promote `proposed/…` onto `main` — the **only** step that writes the
+  canonical branch, reached only after approval.
 - **finalize** is resumed with agent #2's result once the promotion is done.
 
 Send the approval from your session with the dev tools' **signal** step (or the

--- a/packages/orchestration-core/templates/coding-pause/README.md
+++ b/packages/orchestration-core/templates/coding-pause/README.md
@@ -1,28 +1,62 @@
-# __PROJECT_NAME__
+# **PROJECT_NAME**
 
-A Sapiom orchestration that runs a **coding agent without blocking the workflow**:
-it launches the agent fire-and-forget, suspends on the run's result signal, and
-resumes once the run finishes — authored as code against
+A Sapiom orchestration that runs a coding agent behind a **human-in-the-loop
+approval that gates the publish to `main`** — authored as code against
 [`@sapiom/orchestration`](https://www.npmjs.com/package/@sapiom/orchestration).
 
 ```
-prepare → kickoff ──pause(agent.coding.result)──▶ finalize
+prepare → propose ──pause(agent.coding.result)──▶ review
+   review ──pause(review.decision)──▶ decide
+       decide ──reject──▶ terminate (main untouched)
+       decide ──approve──pause(agent.coding.result)──▶ finalize
 ```
 
-- **kickoff** calls `agent.coding.launch(...)` (which returns a handle, *not* a
-  result) and returns `pauseUntilSignal(handle, { resumeStep: "finalize" })`. The
-  workflow suspends — a long run holds no worker.
-- **finalize** is resumed by the engine when the run reaches a terminal state.
-  Its `input` **is** the run's result signal payload (typed `CodingResultPayload`).
-  Because that payload crossed the pause/resume boundary, `sandbox` is plain data
-  — re-attach a live handle with `ctx.sapiom.sandboxes.attach(name)` to push.
+**Why two agents.** A single coding run clones, edits, commits and pushes inside
+its own run — before any pause. So a naive "run then pause for approval" gate sits
+_downstream_ of the push: by the time a human sees the work it has already landed
+on `main`, and "reject" would mean reverting code that's already there. This
+template splits the irreversible actions across two runs so the gate is _upstream_
+of the one that touches `main`:
 
-State that must survive the pause goes in `ctx.shared`. To test the **failure**
-branch locally, stub a failed result under the *launching* step in
-`.sapiom-dev/stubs.json` — that value is also the resume payload:
+- **propose** launches agent #1 to write the change and push it to a
+  **non-canonical** `proposed/<executionId>` branch — never `main`.
+- **review** is resumed with agent #1's `CodingResultPayload`; it then suspends on
+  the `review.decision` signal (the human approval).
+- **decide** is resumed with the human decision. On **reject** (or no explicit
+  approval) it terminates and `main` is left exactly as it was. On **approve** it
+  launches agent #2 to promote `proposed/…` onto `main` — the **only** step that
+  writes the canonical branch, reached only after approval.
+- **finalize** is resumed with agent #2's result once the promotion is done.
+
+Send the approval from your session with the dev tools' **signal** step (or the
+engine's signal API): fire `review.decision` with `{ "decision": "approved" }` to
+publish, or `{ "decision": "rejected" }` (or nothing) to leave `main` untouched.
+
+State that must survive a pause goes in `ctx.shared`. A resumed step's `input`
+**is** the signal payload — for a coding run that's a `CodingResultPayload`
+(re-attach any live handle from it), for the human decision it's whatever the
+caller sent.
+
+`run_local` auto-resumes the human-approval pause with an **empty** payload, so a
+local run takes the safe default — the **reject** branch, leaving `main`
+unchanged. That's the intended smoke test: it proves the gate holds. To exercise
+the **failure** branch of a coding run, stub a failed result under the _launching_
+step (`propose` or `decide`) in `.sapiom-dev/stubs.json` — that value is also the
+resume payload:
 
 ```jsonc
-{ "version": 1, "steps": { "kickoff": { "agent.coding.launch": { "status": "failed", "result": { "success": false }, "error": { "stage": "run", "message": "…" } } } } }
+{
+  "version": 1,
+  "steps": {
+    "propose": {
+      "agent.coding.launch": {
+        "status": "failed",
+        "result": { "success": false },
+        "error": { "stage": "run", "message": "…" },
+      },
+    },
+  },
+}
 ```
 
 ## Getting started
@@ -34,8 +68,8 @@ npm install
 Then open `index.ts`. The orchestration is defined with `defineOrchestration({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
 
 ```ts
-const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
-const repo = await ctx.sapiom.repositories.create('my-repo');
+const box = await ctx.sapiom.sandboxes.create({ name: "demo" });
+const repo = await ctx.sapiom.repositories.create("my-repo");
 ```
 
 No credentials to wire — a per-execution tenant credential is injected when your orchestration runs.

--- a/packages/orchestration-core/templates/coding-pause/index.ts
+++ b/packages/orchestration-core/templates/coding-pause/index.ts
@@ -9,33 +9,64 @@ import {
 import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
 
 /**
- * __PROJECT_NAME__ — a non-blocking coding-agent workflow.
+ * __PROJECT_NAME__ — a human-in-the-loop coding-agent workflow that gates the
+ * **publish to `main`** behind an explicit human approval.
  *
- *   prepare → kickoff ──pause(agent.coding.result)──▶ finalize
+ *   prepare → propose ──pause(agent.coding.result)──▶ review
+ *      review ──pause(review.decision)──▶ decide
+ *          decide ──reject──▶ terminate (main untouched)
+ *          decide ──approve──pause(agent.coding.result)──▶ finalize
  *
- * `kickoff` *launches* the coding agent (fire-and-forget) and returns
- * `pauseUntilSignal(handle, …)`, suspending the workflow on the run's result
- * signal — so a long run holds no worker. When the run reaches a terminal state
- * the engine resumes `finalize` with the run result as its input.
+ * Why two agents. The gating action must be the *publish to the canonical branch*,
+ * and it must run **only after** a human approves. A single coding run can't give
+ * us that: the agent clones, edits, commits and pushes inside its own run — before
+ * any pause — so by the time a human sees the work it has already landed, and a
+ * "reject" would be reverting code that's already on `main`. This template splits
+ * the two irreversible actions across two runs so the gate sits *upstream* of the
+ * one that touches `main`:
  *
- * Key idea: the resumed step's `input` IS the signal payload (typed here as
- * `CodingResultPayload`). It crossed a wire boundary, so there are no live
- * handles — re-attach the run's sandbox from `executionEnvironment` with
- * `ctx.sapiom.sandboxes.attach(executionEnvironment.id)`. Anything else the
- * resumed step needs is stashed in `ctx.shared` before pausing.
+ *   - `propose` launches agent #1 to write the change and push it to a
+ *     **non-canonical** `proposed/<executionId>` branch. `main` is never touched.
+ *   - the workflow pauses for a human decision (`review.decision`).
+ *   - on **approve**, `decide` launches agent #2 to promote `proposed/…` onto
+ *     `main`. This is the ONLY step that writes `main`, and it runs only after the
+ *     approve signal.
+ *   - on **reject** (or no explicit approval), the workflow terminates and `main`
+ *     is left exactly as it was.
+ *
+ * Pause/resume mechanics: a resumed step's `input` IS the signal payload. For a
+ * coding run that's a `CodingResultPayload`; for the human decision it's whatever
+ * the caller sent when firing `review.decision`. Payloads cross a wire boundary,
+ * so they carry no live handles — re-attach the repo from `ctx.shared` before
+ * launching the next agent.
  */
 
 const REPO_SLUG = "__PROJECT_NAME__-notes";
 
+/** The signal a human fires to approve or reject the proposed change. */
+const REVIEW_SIGNAL = "review.decision";
+
+/**
+ * Payload a caller sends when firing {@link REVIEW_SIGNAL}. Publishing to `main`
+ * requires `decision === "approved"` — anything else (including an absent
+ * decision) leaves `main` unchanged.
+ */
+interface ReviewDecision {
+  decision?: "approved" | "rejected";
+  note?: string;
+}
+
 interface Shared extends Record<string, unknown> {
   slug: string;
   cloneUrl: string;
+  /** The non-canonical branch agent #1 pushes to and agent #2 promotes from. */
+  branch: string;
 }
 
-/** Find the repo, or create it on the first run. */
+/** Find the repo (or create it on the first run) and pick the proposal branch. */
 const prepare = defineStep({
   name: "prepare",
-  next: ["kickoff"],
+  next: ["propose"],
   async run(_input, ctx) {
     const existing = await ctx.sapiom.repositories.list();
     const repo =
@@ -43,61 +74,136 @@ const prepare = defineStep({
       (await ctx.sapiom.repositories.create(REPO_SLUG));
     ctx.shared.set("slug", repo.slug);
     ctx.shared.set("cloneUrl", repo.cloneUrl);
-    return goto("kickoff", {});
+    // Deterministic + unique per execution, so re-runs don't collide on the repo.
+    ctx.shared.set("branch", `proposed/${ctx.executionId}`);
+    return goto("propose", {});
   },
 });
 
-/** Launch the agent and suspend until it finishes — do NOT await the run. */
-const kickoff = defineStep({
-  name: "kickoff",
+/**
+ * Launch agent #1 to write the change onto the proposal branch — NOT `main` — and
+ * suspend until it finishes. Nothing lands on `main` here.
+ */
+const propose = defineStep({
+  name: "propose",
   next: [],
-  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "finalize" },
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "review" },
   async run(_input, ctx) {
     const repo = ctx.sapiom.repositories.attach(
       ctx.shared.get("slug") as string,
       ctx.shared.get("cloneUrl") as string,
     );
+    const branch = ctx.shared.get("branch") as string;
     const run = await ctx.sapiom.agent.coding.launch({
-      task: "Make a small, self-contained change to this repository and commit it.",
+      task: [
+        "You are in a git checkout of this repository.",
+        `1. Create and switch to a new branch named exactly "${branch}". Do NOT work on "main".`,
+        `2. Make a small, self-contained change and commit it on "${branch}".`,
+        `3. Push the branch to origin: git push -u origin "${branch}".`,
+        'Do NOT push to, merge into, or otherwise modify "main".',
+      ].join("\n"),
       gitRepository: repo, // auto-cloned into the sandbox at /workspace/<slug>
     });
-    ctx.logger.info("agent launched; suspending until it finishes", {
+    ctx.logger.info("proposal agent launched; suspending until it finishes", {
       runId: run.runId,
+      branch,
+    });
+    return pauseUntilSignal(run, { resumeStep: "review" });
+  },
+});
+
+/**
+ * Resumed once agent #1 finishes. The change now lives only on the proposal
+ * branch — `main` is untouched. Pause for a human decision.
+ */
+const review = defineStep({
+  name: "review",
+  next: [],
+  canFail: true,
+  pause: { signal: REVIEW_SIGNAL, resumeStep: "decide" },
+  async run(proposal: CodingResultPayload, ctx) {
+    if (proposal.status !== "completed" || !proposal.result?.success) {
+      return fail(
+        `proposal agent did not succeed: ${proposal.error?.message ?? proposal.status}`,
+      );
+    }
+    ctx.logger.info(
+      "proposal pushed to review branch; awaiting human approval",
+      {
+        branch: ctx.shared.get("branch") as string,
+        runId: proposal.runId,
+      },
+    );
+    // Suspend until a human fires `review.decision`. Publishing to `main` happens
+    // only in `decide`'s approve path below — so a reject (or a stalled review)
+    // never lands anything on the canonical branch.
+    return pauseUntilSignal({ signal: REVIEW_SIGNAL, resumeStep: "decide" });
+  },
+});
+
+/**
+ * Resumed with the human decision. On reject, terminate with `main` untouched. On
+ * approve, launch agent #2 to promote the proposal branch onto `main` — the only
+ * step that writes the canonical branch, reached only after an approve.
+ */
+const decide = defineStep({
+  name: "decide",
+  next: [],
+  terminal: true,
+  canFail: true,
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "finalize" },
+  async run(decision: ReviewDecision, ctx) {
+    const branch = ctx.shared.get("branch") as string;
+    if (decision?.decision !== "approved") {
+      ctx.logger.info("review rejected; leaving main unchanged", {
+        branch,
+        decision: decision?.decision ?? null,
+      });
+      return terminate(
+        { decision: "rejected", published: false, branch },
+        { reason: "rejected" },
+      );
+    }
+    const repo = ctx.sapiom.repositories.attach(
+      ctx.shared.get("slug") as string,
+      ctx.shared.get("cloneUrl") as string,
+    );
+    const run = await ctx.sapiom.agent.coding.launch({
+      task: [
+        "A human approved publishing the proposed change to the canonical branch.",
+        "1. Fetch the latest refs: git fetch origin.",
+        '2. Check out "main" and make sure it matches origin/main.',
+        `3. Merge "origin/${branch}" into "main" (fast-forward when possible).`,
+        "4. Push the result: git push origin main.",
+      ].join("\n"),
+      gitRepository: repo,
+    });
+    ctx.logger.info("review approved; promote agent launched", {
+      runId: run.runId,
+      branch,
     });
     return pauseUntilSignal(run, { resumeStep: "finalize" });
   },
 });
 
-/** Resumed once the run is done. The `input` is the coding result payload. */
+/** Resumed once agent #2 finishes. The change is now on `main`. */
 const finalize = defineStep({
   name: "finalize",
   next: [],
   terminal: true,
   canFail: true,
-  async run(run: CodingResultPayload, ctx) {
-    if (run.status !== "completed" || !run.result?.success) {
+  async run(promotion: CodingResultPayload, ctx) {
+    if (promotion.status !== "completed" || !promotion.result?.success) {
       return fail(
-        `coding agent did not succeed: ${run.error?.message ?? run.status}`,
+        `promote agent did not succeed: ${promotion.error?.message ?? promotion.status}`,
       );
     }
-    // Re-attach live handles from plain values, then publish the agent's work.
-    const repo = ctx.sapiom.repositories.attach(
-      ctx.shared.get("slug") as string,
-      ctx.shared.get("cloneUrl") as string,
-    );
-    const env = run.executionEnvironment;
-    if (!env) {
-      return fail("coding run did not provision an execution environment");
-    }
-    const sandbox = ctx.sapiom.sandboxes.attach(env.id);
-    const push = await repo.pushFromSandbox(sandbox, {
-      message: "chore: automated change",
-    });
     return terminate({
-      runId: run.runId,
-      pushed: push.pushed,
-      sha: push.sha,
-      summary: run.summary,
+      decision: "approved",
+      published: true,
+      branch: ctx.shared.get("branch") as string,
+      runId: promotion.runId,
+      summary: promotion.summary,
     });
   },
 });
@@ -105,5 +211,5 @@ const finalize = defineStep({
 export const orchestration = defineOrchestration<unknown, Shared>({
   name: "__PROJECT_NAME__",
   entry: "prepare",
-  steps: { prepare, kickoff, finalize },
+  steps: { prepare, propose, review, decide, finalize },
 });

--- a/packages/orchestration-core/templates/coding-pause/index.ts
+++ b/packages/orchestration-core/templates/coding-pause/index.ts
@@ -31,8 +31,9 @@ import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
  *   - on **approve**, `decide` launches agent #2 to promote `proposed/…` onto
  *     `main`. This is the ONLY step that writes `main`, and it runs only after the
  *     approve signal.
- *   - on **reject** (or no explicit approval), the workflow terminates and `main`
- *     is left exactly as it was.
+ *   - on **reject** (a `review.decision` that isn't `approved`), the workflow
+ *     terminates and `main` is left exactly as it was; with no signal it stays
+ *     paused. Either way nothing lands on `main`.
  *
  * Pause/resume mechanics: a resumed step's `input` IS the signal payload. For a
  * coding run that's a `CodingResultPayload`; for the human decision it's whatever


### PR DESCRIPTION
## What & why

The scaffolded `coding-pause` template's approval gate didn't actually gate the code push. The coding agent clones, edits, commits **and pushes** inside its own run — *before* the pause — so by the time a human approves, the change is already on `main`, and `reject` prevents nothing. The gate sat downstream of the irreversible action.

Fixes **[SAP-1038](https://linear.app/sapiom/issue/SAP-1038)**.

## Approach — the two-agent variant (Option 1 in the ticket)

Works on the local coding substrate today, **no engine or platform change**. The gate is moved *upstream* of the write to `main` by splitting the irreversible actions across two coding runs:

```
prepare → propose ──pause(agent.coding.result)──▶ review
   review ──pause(review.decision)──▶ decide
       decide ──reject──▶ terminate (main untouched)
       decide ──approve──pause(agent.coding.result)──▶ finalize
```

- **propose** — agent #1 writes the change onto a non-canonical `proposed/<executionId>` branch. `main` is never touched.
- **review** — resumes with agent #1's `CodingResultPayload`, then pauses on the `review.decision` human-approval signal.
- **decide** — resumes with the decision. On **reject** (or no explicit approval) it terminates with `main` unchanged; on **approve** it launches agent #2 to promote `proposed/…` onto `main` — the only step that writes the canonical branch, reached only after the approve signal.
- **finalize** — resumes with agent #2's result.

Fire the approval with `review.decision` = `{ "decision": "approved" }` to publish, or `{ "decision": "rejected" }` (or nothing) to leave `main` untouched.

## Acceptance criteria

- [x] A *rejected* coding-pause run leaves `main` unchanged (promote agent never launches).
- [x] An *approved* run publishes to `main` only after the approve signal (promote runs solely in `decide`'s approve branch).
- [x] Chosen approach documented — template `README.md` here; the Sapiom `workflows-authoring-quickstart.md` §7 caveat is replaced in a companion PR.

## Verification

Templates aren't typechecked by package CI (they ship with placeholder dep versions), so validated against the **built** `@sapiom/orchestration` + `@sapiom/tools`:

- Template `index.ts` typechecks clean (strict).
- `buildManifest` produces a valid manifest (all 5 steps, no blocking graph errors).
- `run_local` completes on the safe **reject** branch — `finalize`/promote never runs.
- Unit-checked the **approve** path: `decide` launches exactly one promote agent (task targets `main`) and pauses toward `finalize`.

Changeset included (`@sapiom/orchestration-core` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)