### PR TITLE
feat(tools): add email capability

### DIFF
--- a/.changeset/email.md
+++ b/.changeset/email.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `email` capability — programmatic transactional email. Create and manage inboxes, send/list/get messages, reply/reply-all/forward, register and verify custom sending domains, list and read conversation threads, and register webhooks for inbound events. Available as `sapiom.email.*` on the client, as the ambient `email` namespace, and from the `@sapiom/tools/email` subpath. Failed requests throw `EmailHttpError`.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, orchestrations, and schedules — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, email, orchestrations, and schedules — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -78,6 +78,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
 | `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                              | [src/schedules](./src/schedules/README.md)                   |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
+| `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks                | [src/email](./src/email/README.md)                           |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/esm/database/index.js",
       "require": "./dist/cjs/database/index.js"
     },
+    "./email": {
+      "types": "./dist/cjs/email/index.d.ts",
+      "import": "./dist/esm/email/index.js",
+      "require": "./dist/cjs/email/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -84,6 +84,28 @@ import type {
 } from "./search/index.js";
 import * as database from "./database/index.js";
 import type { CreateDatabaseInput, Database } from "./database/index.js";
+import * as email from "./email/index.js";
+import type {
+  CreateInboxInput,
+  Inbox,
+  ListInboxesOptions,
+  InboxList,
+  SendMessageInput,
+  SendResult,
+  ListMessagesOptions,
+  MessageList,
+  Message,
+  ReplyInput,
+  ReplyAllInput,
+  ListThreadsOptions,
+  ThreadList,
+  Thread,
+  CreateDomainInput,
+  Domain,
+  DomainList,
+  CreateWebhookInput,
+  Webhook,
+} from "./email/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -183,6 +205,77 @@ export interface Sapiom {
     delete(idOrHandle: string): Promise<void>;
   };
   /**
+   * Programmatic transactional email — inboxes, messages, sending domains,
+   * threads, and inbound-event webhooks. An `inboxId` is the inbox's email address.
+   */
+  readonly email: {
+    /** Create / list / get / delete mailboxes. */
+    inboxes: {
+      /** Create a new inbox (a real, addressable mailbox). */
+      create(input?: CreateInboxInput): Promise<Inbox>;
+      /** List the caller's inboxes. */
+      list(opts?: ListInboxesOptions): Promise<InboxList>;
+      /** Fetch a single inbox by id (its email address). */
+      get(inboxId: string): Promise<Inbox>;
+      /** Delete an inbox by id. */
+      delete(inboxId: string): Promise<void>;
+    };
+    /** Send / list / get / reply / forward messages. */
+    messages: {
+      /** Send a new message from an inbox. */
+      send(inboxId: string, input: SendMessageInput): Promise<SendResult>;
+      /** List messages in an inbox (metadata only — use `get` for the body). */
+      list(inboxId: string, opts?: ListMessagesOptions): Promise<MessageList>;
+      /** Fetch a single full message (including body). */
+      get(inboxId: string, messageId: string): Promise<Message>;
+      /** Reply to a message. */
+      reply(
+        inboxId: string,
+        messageId: string,
+        input?: ReplyInput,
+      ): Promise<SendResult>;
+      /** Reply to everyone on a message. */
+      replyAll(
+        inboxId: string,
+        messageId: string,
+        input?: ReplyAllInput,
+      ): Promise<SendResult>;
+      /** Forward a message to new recipient(s). */
+      forward(
+        inboxId: string,
+        messageId: string,
+        input: SendMessageInput,
+      ): Promise<SendResult>;
+    };
+    /** Register / verify / read custom sending domains. */
+    domains: {
+      /** Register a custom sending domain. Returns the DNS records to publish. */
+      create(input: CreateDomainInput): Promise<Domain>;
+      /** Trigger DNS re-verification; re-fetch with `get` to read the updated status. */
+      verify(domainId: string): Promise<void>;
+      /** Fetch a domain's full status and DNS records by id. */
+      get(domainId: string): Promise<Domain>;
+      /** List registered domains (without per-domain status/records). */
+      list(): Promise<DomainList>;
+      /** Delete a registered domain by id. */
+      delete(domainId: string): Promise<void>;
+    };
+    /** List / get conversation threads. */
+    threads: {
+      /** List conversation threads in an inbox (without their messages). */
+      list(inboxId: string, opts?: ListThreadsOptions): Promise<ThreadList>;
+      /** Fetch a single full thread (including its messages). */
+      get(inboxId: string, threadId: string): Promise<Thread>;
+    };
+    /** Register / delete inbound-event webhooks. */
+    webhooks: {
+      /** Register a webhook for inbound events. The returned `secret` is shown only once. */
+      create(input: CreateWebhookInput): Promise<Webhook>;
+      /** Delete a webhook by id. */
+      delete(id: number): Promise<void>;
+    };
+  };
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
@@ -249,6 +342,42 @@ function bind(transport: Transport): Sapiom {
       create: (input) => database.create(input, transport),
       get: (idOrHandle) => database.get(idOrHandle, transport),
       delete: (idOrHandle) => database.delete(idOrHandle, transport),
+    },
+    email: {
+      inboxes: {
+        create: (input) => email.createInbox(input, transport),
+        list: (opts) => email.listInboxes(opts, transport),
+        get: (inboxId) => email.getInbox(inboxId, transport),
+        delete: (inboxId) => email.deleteInbox(inboxId, transport),
+      },
+      messages: {
+        send: (inboxId, input) => email.sendMessage(inboxId, input, transport),
+        list: (inboxId, opts) => email.listMessages(inboxId, opts, transport),
+        get: (inboxId, messageId) =>
+          email.getMessage(inboxId, messageId, transport),
+        reply: (inboxId, messageId, input) =>
+          email.replyMessage(inboxId, messageId, input, transport),
+        replyAll: (inboxId, messageId, input) =>
+          email.replyAllMessage(inboxId, messageId, input, transport),
+        forward: (inboxId, messageId, input) =>
+          email.forwardMessage(inboxId, messageId, input, transport),
+      },
+      domains: {
+        create: (input) => email.createDomain(input, transport),
+        verify: (domainId) => email.verifyDomain(domainId, transport),
+        get: (domainId) => email.getDomain(domainId, transport),
+        list: () => email.listDomains(transport),
+        delete: (domainId) => email.deleteDomain(domainId, transport),
+      },
+      threads: {
+        list: (inboxId, opts) => email.listThreads(inboxId, opts, transport),
+        get: (inboxId, threadId) =>
+          email.getThread(inboxId, threadId, transport),
+      },
+      webhooks: {
+        create: (input) => email.createWebhook(input, transport),
+        delete: (id) => email.deleteWebhook(id, transport),
+      },
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/email/README.md
+++ b/packages/tools/src/email/README.md
@@ -1,0 +1,96 @@
+# email
+
+Programmatic transactional email. Create real, addressable inboxes, send and
+receive messages, manage custom sending domains, read conversation threads, and
+register webhooks for inbound events. The same email capability your agents call
+over MCP, callable directly from your code.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// Create an inbox, then send from it.
+const inbox = await sapiom.email.inboxes.create({ username: "support" });
+await sapiom.email.messages.send(inbox.inboxId, {
+  to: "customer@example.com",
+  subject: "Welcome",
+  text: "Thanks for signing up!",
+});
+
+// Read what came in, and reply to it.
+const { messages } = await sapiom.email.messages.list(inbox.inboxId);
+const full = await sapiom.email.messages.get(
+  inbox.inboxId,
+  messages[0].messageId,
+);
+await sapiom.email.messages.reply(inbox.inboxId, full.messageId, {
+  text: "Happy to help!",
+});
+```
+
+Ambient import works too: `import { email } from "@sapiom/tools"`.
+
+## Operations
+
+Operations are grouped by resource:
+
+- **`inboxes`** — `create`, `list`, `get`, `delete`
+- **`messages`** — `send`, `list`, `get`, `reply`, `replyAll`, `forward`
+- **`domains`** — `create`, `verify`, `get`, `list`, `delete`
+- **`threads`** — `list`, `get`
+- **`webhooks`** — `create`, `delete`
+
+## Inboxes
+
+An inbox is a real mailbox you own. Its `inboxId` **is its email address** — use it
+directly as the recipient of inbound mail and as the first argument to every message
+and thread call. `create` accepts an optional `username`, `displayName`, and a
+verified custom `domain` (see below); omit them and you get a generated address on
+the default domain.
+
+## Messages
+
+- `send` requires `to` (a single address or an array) and takes `cc` / `bcc` /
+  `replyTo`, `subject`, `text` and/or `html`, `labels`, and custom `headers`.
+- `list` returns **metadata only** — no body. Call `get` for the full message,
+  which additionally includes `text` / `html` and `extractedText` / `extractedHtml`
+  (the "new" content with quoted reply history stripped — what you usually want when
+  processing a reply).
+- `reply`, `replyAll`, and `forward` all return `{ messageId, threadId }`.
+- Custom `headers` may not set address, identity, routing, or MIME headers (e.g.
+  `To`, `From`, `Reply-To`, `Subject`, `Content-Type`) — use the dedicated fields
+  for those; such headers are rejected.
+
+## Domains
+
+To send from your own domain, register it with `domains.create({ domain })`. The
+response includes the DNS `records` you must publish. Once published, call
+`domains.verify(domainId)`, then re-fetch with `domains.get(domainId)` to read the
+updated `status` (`PENDING` → `VERIFIED`). `domains.list` returns domains without
+their `status`/`records`; use `get` for the full detail.
+
+## Threads
+
+A thread groups the messages of a conversation. `threads.list` returns thread
+summaries (without messages); `threads.get` returns the full thread including its
+`messages` array.
+
+## Webhooks
+
+`webhooks.create({ url, eventType })` registers an HTTPS endpoint to receive inbound
+events (e.g. `"message.received"`, or `"*"` for all). The response includes a
+`secret` **returned only once** — store it to verify the signature on delivered
+events.
+
+## Gotchas
+
+- **`inboxId` is the email address.** It contains `@` (and often `.`); pass it
+  as-is — the client handles URL encoding.
+- **`list` is metadata-only.** `messages.list` and `threads.list` omit bodies /
+  messages; fetch the individual resource with `get` to read content.
+- **The webhook `secret` is shown once.** It is present only on the `create`
+  response; capture it then.
+- **Pagination** is cursor-based: pass the previous response's `nextPageToken` back
+  as `pageToken`.
+- **Failed requests throw `EmailHttpError`** (carries `status` + parsed `body`),
+  exported from `@sapiom/tools`.

--- a/packages/tools/src/email/README.md
+++ b/packages/tools/src/email/README.md
@@ -2,8 +2,8 @@
 
 Programmatic transactional email. Create real, addressable inboxes, send and
 receive messages, manage custom sending domains, read conversation threads, and
-register webhooks for inbound events. The same email capability your agents call
-over MCP, callable directly from your code.
+register webhooks for inbound events. Call it directly from your code, or from
+within Sapiom workflow steps.
 
 ```typescript
 import { createClient } from "@sapiom/tools";

--- a/packages/tools/src/email/errors.ts
+++ b/packages/tools/src/email/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error thrown by the `email` capability when a request fails (non-2xx response).
+ * Exposes `status` (HTTP status code) and `body` (parsed JSON body, or raw text
+ * when the body isn't JSON) for programmatic inspection.
+ */
+export class EmailHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "EmailHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw an {@link EmailHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new EmailHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/email/index.spec.ts
+++ b/packages/tools/src/email/index.spec.ts
@@ -1,0 +1,834 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as email from "./index.js";
+import { EmailHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly against a real Transport backed by
+// a scripted fetch mock (so URL/method/header/body assertions are exact, and we
+// verify the Transport itself injects the tenant credential).
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+const bodyOf = (c: FetchCall) => JSON.parse(c.init.body as string);
+
+// Shared response fixtures (the service surface is camelCase both directions).
+const RAW_INBOX = {
+  inboxId: "support@acme.com",
+  email: "support@acme.com",
+  displayName: "Acme Support",
+  clientId: "idem-1",
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-02T00:00:00Z",
+};
+
+const RAW_MESSAGE = {
+  messageId: "m-1",
+  threadId: "t-1",
+  inboxId: "support@acme.com",
+  from: "customer@example.com",
+  to: ["support@acme.com"],
+  cc: ["cc@example.com"],
+  replyTo: ["reply@example.com"],
+  subject: "Help",
+  preview: "hi there",
+  text: "hi there, full body",
+  html: "<p>hi there</p>",
+  extractedText: "hi there",
+  extractedHtml: "<p>hi there</p>",
+  labels: ["inbox"],
+  timestamp: "2026-06-03T00:00:00Z",
+  inReplyTo: "m-0",
+  references: ["m-0"],
+  headers: { "X-Custom": "1" },
+  attachments: [
+    {
+      attachmentId: "a-1",
+      filename: "f.pdf",
+      contentType: "application/pdf",
+      size: 10,
+    },
+  ],
+  size: 100,
+  createdAt: "2026-06-03T00:00:00Z",
+  updatedAt: "2026-06-03T00:00:00Z",
+};
+
+const RAW_THREAD = {
+  threadId: "t-1",
+  inboxId: "support@acme.com",
+  labels: ["inbox"],
+  timestamp: "2026-06-03T00:00:00Z",
+  receivedTimestamp: "2026-06-03T00:00:00Z",
+  sentTimestamp: "2026-06-03T00:01:00Z",
+  subject: "Help",
+  preview: "hi there",
+  senders: ["customer@example.com"],
+  recipients: ["support@acme.com"],
+  lastMessageId: "m-1",
+  messageCount: 1,
+  size: 100,
+  attachments: [
+    {
+      attachmentId: "a-1",
+      filename: "f.pdf",
+      contentType: "application/pdf",
+      size: 10,
+    },
+  ],
+  createdAt: "2026-06-03T00:00:00Z",
+  updatedAt: "2026-06-03T00:00:00Z",
+  messages: [RAW_MESSAGE],
+};
+
+const RAW_DOMAIN = {
+  domainId: "d-1",
+  domain: "mail.acme.com",
+  status: "PENDING",
+  feedbackEnabled: false,
+  records: [
+    { type: "TXT", name: "_x.mail.acme.com", value: "v=1", status: "MISSING" },
+    {
+      type: "MX",
+      name: "mail.acme.com",
+      value: "mx.host",
+      status: "MISSING",
+      priority: 10,
+    },
+  ],
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+};
+
+// ===========================================================================
+// inboxes
+// ===========================================================================
+
+describe("email.inboxes", () => {
+  it("create() POSTs /v1/inboxes with camelCase body + credential and maps the response", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_INBOX, { status: 201 }),
+    ]);
+
+    const result = await email.createInbox(
+      {
+        username: "support",
+        domain: "acme.com",
+        displayName: "Acme Support",
+        clientId: "idem-1",
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({
+      inboxId: "support@acme.com",
+      email: "support@acme.com",
+      displayName: "Acme Support",
+      clientId: "idem-1",
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-02T00:00:00Z",
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/inboxes`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(bodyOf(calls[0]!)).toEqual({
+      username: "support",
+      domain: "acme.com",
+      displayName: "Acme Support",
+      clientId: "idem-1",
+    });
+  });
+
+  it("create() sends an empty body and omits absent optionals when called with no input", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          { ...RAW_INBOX, displayName: undefined, clientId: undefined },
+          { status: 201 },
+        ),
+    ]);
+    const result = await email.createInbox(undefined, transport, BASE);
+    expect(bodyOf(calls[0]!)).toEqual({});
+    expect(result).not.toHaveProperty("displayName");
+    expect(result).not.toHaveProperty("clientId");
+  });
+
+  it("create() treats a null optional as absent (not TypeError, not a null in the body)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_INBOX, { status: 201 }),
+    ]);
+    // JS callers bypass the TS types — a null must be dropped, not forwarded.
+    await email.createInbox(
+      { username: "support", displayName: null as unknown as string },
+      transport,
+      BASE,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({ username: "support" });
+  });
+
+  it("list() GETs /v1/inboxes with pagination params and maps items", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          count: 1,
+          nextPageToken: "next",
+          inboxes: [RAW_INBOX],
+        }),
+    ]);
+
+    const result = await email.listInboxes(
+      { limit: 20, pageToken: "cur" },
+      transport,
+      BASE,
+    );
+
+    expect(result.count).toBe(1);
+    expect(result.nextPageToken).toBe("next");
+    expect(result.inboxes[0]!.inboxId).toBe("support@acme.com");
+    expect(calls[0]!.url).toBe(`${BASE}/v1/inboxes?limit=20&pageToken=cur`);
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("list() omits pagination params when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ count: 0, inboxes: [] }),
+    ]);
+    const result = await email.listInboxes(undefined, transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/inboxes`);
+    expect(result).not.toHaveProperty("nextPageToken");
+  });
+
+  it("get() encodes the inbox address (with @) in the path", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(RAW_INBOX)]);
+    await email.getInbox("support@acme.com", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/inboxes/support%40acme.com`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+  });
+
+  it("delete() DELETEs /v1/inboxes/:id and resolves void", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    const result = await email.deleteInbox("support@acme.com", transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/inboxes/support%40acme.com`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("get() throws a clean EmailHttpError (400) on a nullish id — not a TypeError", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(RAW_INBOX)]);
+    await expect(
+      email.getInbox(undefined as unknown as string, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    // The guard fires before any network call.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("get() throws EmailHttpError with status + body on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "not found" }), { status: 404 }),
+    ]);
+    const err = await email
+      .getInbox("missing@acme.com", transport, BASE)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(EmailHttpError);
+    expect(err.status).toBe(404);
+    expect(err.body).toEqual({ message: "not found" });
+  });
+});
+
+// ===========================================================================
+// messages
+// ===========================================================================
+
+describe("email.messages", () => {
+  it("send() POSTs to /messages with the recipient body and returns the send result", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-9", threadId: "t-9" }, { status: 201 }),
+    ]);
+
+    const result = await email.sendMessage(
+      "support@acme.com",
+      {
+        to: ["a@example.com", "b@example.com"],
+        cc: "c@example.com",
+        subject: "Hi",
+        text: "body",
+        headers: { "X-Trace": "abc" },
+        labels: ["outbound"],
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({ messageId: "m-9", threadId: "t-9" });
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({
+      to: ["a@example.com", "b@example.com"],
+      cc: "c@example.com",
+      subject: "Hi",
+      text: "body",
+      headers: { "X-Trace": "abc" },
+      labels: ["outbound"],
+    });
+  });
+
+  it("send() drops null optionals from the body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-1", threadId: "t-1" }, { status: 201 }),
+    ]);
+    await email.sendMessage(
+      "support@acme.com",
+      {
+        to: "a@example.com",
+        cc: null as unknown as string,
+        subject: undefined,
+      },
+      transport,
+      BASE,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({ to: "a@example.com" });
+  });
+
+  it("list() GETs /messages and maps items to metadata (no body / extracted / replyTo)", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ count: 1, nextPageToken: "n", messages: [RAW_MESSAGE] }),
+    ]);
+
+    const result = await email.listMessages(
+      "support@acme.com",
+      { limit: 5 },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages?limit=5`,
+    );
+    expect(result.count).toBe(1);
+    expect(result.nextPageToken).toBe("n");
+    const item = result.messages[0]!;
+    expect(item.messageId).toBe("m-1");
+    // list items are metadata-only
+    expect(item).not.toHaveProperty("text");
+    expect(item).not.toHaveProperty("html");
+    expect(item).not.toHaveProperty("extractedText");
+    expect(item).not.toHaveProperty("extractedHtml");
+    expect(item).not.toHaveProperty("replyTo");
+    // but keep other metadata incl. attachment metadata
+    expect(item.attachments?.[0]!.attachmentId).toBe("a-1");
+  });
+
+  it("get() returns the full message including body + extracted content", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_MESSAGE),
+    ]);
+    const result = await email.getMessage(
+      "support@acme.com",
+      "m-1",
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages/m-1`,
+    );
+    expect(result.text).toBe("hi there, full body");
+    expect(result.extractedText).toBe("hi there");
+    expect(result.replyTo).toEqual(["reply@example.com"]);
+    expect(result.attachments?.[0]!.filename).toBe("f.pdf");
+  });
+
+  it("reply() POSTs to /messages/:id/reply", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-2", threadId: "t-1" }, { status: 201 }),
+    ]);
+    const result = await email.replyMessage(
+      "support@acme.com",
+      "m-1",
+      { text: "thanks", replyAll: true },
+      transport,
+      BASE,
+    );
+    expect(result).toEqual({ messageId: "m-2", threadId: "t-1" });
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages/m-1/reply`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(bodyOf(calls[0]!)).toEqual({ text: "thanks", replyAll: true });
+  });
+
+  it("reply() sends an empty body when called with no input", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-2", threadId: "t-1" }, { status: 201 }),
+    ]);
+    await email.replyMessage(
+      "support@acme.com",
+      "m-1",
+      undefined,
+      transport,
+      BASE,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({});
+  });
+
+  it("replyAll() POSTs to /messages/:id/reply-all", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-3", threadId: "t-1" }, { status: 201 }),
+    ]);
+    await email.replyAllMessage(
+      "support@acme.com",
+      "m-1",
+      { text: "all" },
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages/m-1/reply-all`,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({ text: "all" });
+  });
+
+  it("forward() POSTs to /messages/:id/forward with a required recipient", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ messageId: "m-4", threadId: "t-2" }, { status: 201 }),
+    ]);
+    await email.forwardMessage(
+      "support@acme.com",
+      "m-1",
+      { to: "fwd@example.com", text: "fyi" },
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/messages/m-1/forward`,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({ to: "fwd@example.com", text: "fyi" });
+  });
+
+  it("get() guards a nullish messageId with a clean 400 before any request", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_MESSAGE),
+    ]);
+    await expect(
+      email.getMessage("support@acme.com", "" as string, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("send() throws EmailHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("rejected", { status: 422 }),
+    ]);
+    await expect(
+      email.sendMessage(
+        "support@acme.com",
+        { to: "a@example.com" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toBeInstanceOf(EmailHttpError);
+  });
+});
+
+// ===========================================================================
+// threads
+// ===========================================================================
+
+describe("email.threads", () => {
+  it("list() GETs /threads and maps items without the messages array", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          count: 1,
+          nextPageToken: "n",
+          threads: [{ ...RAW_THREAD, messages: undefined }],
+        }),
+    ]);
+
+    const result = await email.listThreads(
+      "support@acme.com",
+      { limit: 10 },
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/threads?limit=10`,
+    );
+    expect(result.count).toBe(1);
+    const item = result.threads[0]!;
+    expect(item.threadId).toBe("t-1");
+    expect(item).not.toHaveProperty("messages");
+    expect(item.receivedTimestamp).toBe("2026-06-03T00:00:00Z");
+    expect(item.attachments?.[0]!.attachmentId).toBe("a-1");
+  });
+
+  it("get() returns the full thread including its messages", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_THREAD),
+    ]);
+    const result = await email.getThread(
+      "support@acme.com",
+      "t-1",
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/inboxes/support%40acme.com/threads/t-1`,
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]!.messageId).toBe("m-1");
+  });
+
+  it("get() throws EmailHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("nope", { status: 404 }),
+    ]);
+    await expect(
+      email.getThread("support@acme.com", "t-x", transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ===========================================================================
+// domains
+// ===========================================================================
+
+describe("email.domains", () => {
+  it("create() POSTs /v1/domains and maps records (incl. MX priority)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_DOMAIN, { status: 201 }),
+    ]);
+
+    const result = await email.createDomain(
+      { domain: "mail.acme.com", feedbackEnabled: true },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(bodyOf(calls[0]!)).toEqual({
+      domain: "mail.acme.com",
+      feedbackEnabled: true,
+    });
+    expect(result.status).toBe("PENDING");
+    expect(result.records).toHaveLength(2);
+    expect(result.records[0]).toEqual({
+      type: "TXT",
+      name: "_x.mail.acme.com",
+      value: "v=1",
+      status: "MISSING",
+    });
+    expect(result.records[1]!.priority).toBe(10);
+  });
+
+  it("create() guards a nullish domain with a clean 400", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_DOMAIN, { status: 201 }),
+    ]);
+    await expect(
+      email.createDomain(
+        { domain: undefined as unknown as string },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("verify() POSTs /v1/domains/:id/verify and resolves void", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    const result = await email.verifyDomain("d-1", transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/d-1/verify`);
+    expect(calls[0]!.init.method).toBe("POST");
+  });
+
+  it("get() GETs /v1/domains/:id", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(RAW_DOMAIN),
+    ]);
+    await email.getDomain("d-1", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/d-1`);
+  });
+
+  it("list() GETs /v1/domains and maps summary items (no status/records)", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          count: 1,
+          domains: [
+            {
+              domainId: "d-1",
+              domain: "mail.acme.com",
+              feedbackEnabled: false,
+              createdAt: "2026-06-01T00:00:00Z",
+              updatedAt: "2026-06-01T00:00:00Z",
+            },
+          ],
+        }),
+    ]);
+    const result = await email.listDomains(transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains`);
+    expect(result.count).toBe(1);
+    expect(result.domains[0]!.domainId).toBe("d-1");
+    expect(result.domains[0]).not.toHaveProperty("status");
+    expect(result.domains[0]).not.toHaveProperty("records");
+  });
+
+  it("delete() DELETEs /v1/domains/:id", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await email.deleteDomain("d-1", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/d-1`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+});
+
+// ===========================================================================
+// webhooks
+// ===========================================================================
+
+describe("email.webhooks", () => {
+  it("create() POSTs /v1/webhooks and returns id + secret", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            id: 7,
+            url: "https://hook.acme.com/inbound",
+            eventType: "message.received",
+            secret: "sh-1",
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await email.createWebhook(
+      { url: "https://hook.acme.com/inbound", eventType: "message.received" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/webhooks`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(bodyOf(calls[0]!)).toEqual({
+      url: "https://hook.acme.com/inbound",
+      eventType: "message.received",
+    });
+    expect(result).toEqual({
+      id: 7,
+      url: "https://hook.acme.com/inbound",
+      eventType: "message.received",
+      secret: "sh-1",
+    });
+  });
+
+  it("create() guards a nullish url/eventType with a clean 400", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({}, { status: 201 }),
+    ]);
+    await expect(
+      email.createWebhook(
+        { url: "", eventType: "message.received" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      email.createWebhook(
+        {
+          url: "https://hook.acme.com",
+          eventType: undefined as unknown as string,
+        },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("delete() DELETEs /v1/webhooks/:id (numeric)", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    const result = await email.deleteWebhook(7, transport, BASE);
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/webhooks/7`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("delete() guards a non-number id with a clean 400", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await expect(
+      email.deleteWebhook(undefined as unknown as number, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// Client wiring + auth
+// ===========================================================================
+
+describe("email — client wiring + credential", () => {
+  it("createClient().email routes every operation with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      const method = init.method ?? "GET";
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (url.endsWith("/verify")) return new Response(null, { status: 204 });
+      if (url.endsWith("/messages") && method === "POST")
+        return jsonResponse({ messageId: "m", threadId: "t" }, { status: 201 });
+      if (url.includes("/messages/") && method === "POST")
+        return jsonResponse({ messageId: "m", threadId: "t" }, { status: 201 });
+      if (url.includes("/messages/")) return jsonResponse(RAW_MESSAGE);
+      if (url.endsWith("/messages"))
+        return jsonResponse({ count: 0, messages: [] });
+      if (url.includes("/threads/")) return jsonResponse(RAW_THREAD);
+      if (url.endsWith("/threads"))
+        return jsonResponse({ count: 0, threads: [] });
+      if (url.endsWith("/webhooks"))
+        return jsonResponse(
+          { id: 1, url: "https://h", eventType: "*", secret: "s" },
+          { status: 201 },
+        );
+      if (url.endsWith("/domains"))
+        return method === "POST"
+          ? jsonResponse(RAW_DOMAIN, { status: 201 })
+          : jsonResponse({ count: 0, domains: [] });
+      if (url.includes("/domains/")) return jsonResponse(RAW_DOMAIN);
+      if (url.endsWith("/inboxes"))
+        return method === "POST"
+          ? jsonResponse(RAW_INBOX, { status: 201 })
+          : jsonResponse({ count: 0, inboxes: [] });
+      if (url.includes("/inboxes/")) return jsonResponse(RAW_INBOX);
+      return jsonResponse({});
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+
+    await sapiom.email.inboxes.create({ username: "s" });
+    await sapiom.email.inboxes.list();
+    await sapiom.email.inboxes.get("s@acme.com");
+    await sapiom.email.inboxes.delete("s@acme.com");
+    await sapiom.email.messages.send("s@acme.com", { to: "a@example.com" });
+    await sapiom.email.messages.list("s@acme.com");
+    await sapiom.email.messages.get("s@acme.com", "m-1");
+    await sapiom.email.messages.reply("s@acme.com", "m-1", { text: "x" });
+    await sapiom.email.messages.replyAll("s@acme.com", "m-1", { text: "x" });
+    await sapiom.email.messages.forward("s@acme.com", "m-1", {
+      to: "b@example.com",
+    });
+    await sapiom.email.threads.list("s@acme.com");
+    await sapiom.email.threads.get("s@acme.com", "t-1");
+    await sapiom.email.domains.create({ domain: "mail.acme.com" });
+    await sapiom.email.domains.verify("d-1");
+    await sapiom.email.domains.get("d-1");
+    await sapiom.email.domains.list();
+    await sapiom.email.domains.delete("d-1");
+    await sapiom.email.webhooks.create({ url: "https://h", eventType: "*" });
+    await sapiom.email.webhooks.delete(1);
+
+    expect(calls).toHaveLength(19);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("{}")) as typeof globalThis.fetch,
+      });
+      await expect(
+        email.listInboxes(undefined, transport, BASE),
+      ).rejects.toThrow(/no tenant credential/i);
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ===========================================================================
+// EmailHttpError
+// ===========================================================================
+
+describe("EmailHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new EmailHttpError("boom", 422, { message: "invalid" });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(EmailHttpError);
+    expect(err.status).toBe(422);
+    expect(err.body).toEqual({ message: "invalid" });
+    expect(err.name).toBe("EmailHttpError");
+  });
+});

--- a/packages/tools/src/email/index.spec.ts
+++ b/packages/tools/src/email/index.spec.ts
@@ -259,6 +259,16 @@ describe("email.inboxes", () => {
     expect(calls[0]!.init.method).toBe("DELETE");
   });
 
+  it("delete() throws a clean EmailHttpError (400) on a nullish id before any request", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await expect(
+      email.deleteInbox(undefined as unknown as string, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
   it("get() throws a clean EmailHttpError (400) on a nullish id — not a TypeError", async () => {
     const { transport, calls } = makeTransport([() => jsonResponse(RAW_INBOX)]);
     await expect(
@@ -602,6 +612,19 @@ describe("email.domains", () => {
     expect(calls[0]!.init.method).toBe("POST");
   });
 
+  it("verify() (a void/204 op) throws EmailHttpError with status + body on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "not found" }), { status: 404 }),
+    ]);
+    const err = await email
+      .verifyDomain("d-x", transport, BASE)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(EmailHttpError);
+    expect(err.status).toBe(404);
+    expect(err.body).toEqual({ message: "not found" });
+  });
+
   it("get() GETs /v1/domains/:id", async () => {
     const { transport, calls } = makeTransport([
       () => jsonResponse(RAW_DOMAIN),
@@ -641,6 +664,16 @@ describe("email.domains", () => {
     await email.deleteDomain("d-1", transport, BASE);
     expect(calls[0]!.url).toBe(`${BASE}/v1/domains/d-1`);
     expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("delete() throws a clean EmailHttpError (400) on a nullish id before any request", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await expect(
+      email.deleteDomain(undefined as unknown as string, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/packages/tools/src/email/index.ts
+++ b/packages/tools/src/email/index.ts
@@ -1,0 +1,1168 @@
+/**
+ * `email` capability — programmatic transactional email: create inboxes, send and
+ * receive messages, manage sending domains and threads, and register webhooks for
+ * inbound events. Each inbox is a real, addressable mailbox your code owns.
+ *
+ *   import { email } from "@sapiom/tools";                 // ambient auth
+ *
+ *   const inbox = await email.inboxes.create({ username: "support" });
+ *   await email.messages.send(inbox.inboxId, {
+ *     to: "customer@example.com",
+ *     subject: "Welcome",
+ *     text: "Thanks for signing up!",
+ *   });
+ *
+ * Or via an explicit client: `createClient({ apiKey }).email.inboxes.create(...)`.
+ *
+ * Operations are grouped:
+ *   - `inboxes`  — create / list / get / delete mailboxes
+ *   - `messages` — send / list / get / reply / replyAll / forward
+ *   - `domains`  — register a custom sending domain, verify it, read status
+ *   - `threads`  — list / get conversation threads
+ *   - `webhooks` — register / delete inbound-event webhooks
+ *
+ * An `inboxId` is the inbox's email address; message, thread, and domain ids are
+ * opaque strings returned by their create/list calls. Failed requests throw
+ * {@link EmailHttpError} (carries `status` + parsed `body`).
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, EmailHttpError } from "./errors.js";
+
+export { EmailHttpError };
+
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "agentmail",
+  process.env.SAPIOM_EMAIL_URL,
+);
+
+// ===========================================================================
+// Shared types
+// ===========================================================================
+
+/**
+ * A recipient field — a single email address or a list of them. Used by `to`,
+ * `cc`, `bcc`, and `replyTo`.
+ */
+export type Recipients = string | string[];
+
+/** Verification state of a sending domain. */
+export type DomainStatus =
+  | "NOT_STARTED"
+  | "PENDING"
+  | "VERIFYING"
+  | "VERIFIED"
+  | "INVALID"
+  | "FAILED";
+
+// ===========================================================================
+// Inboxes
+// ===========================================================================
+
+export interface CreateInboxInput {
+  /** Local part of the address (before the `@`). Generated for you if omitted. */
+  username?: string;
+  /** A verified custom sending domain to create the address on. Uses the default domain if omitted. */
+  domain?: string;
+  /** A display name shown to recipients (e.g. "Acme Support"). */
+  displayName?: string;
+  /** Your own idempotency / correlation key for the inbox. */
+  clientId?: string;
+}
+
+export interface Inbox {
+  /** Unique inbox identifier — this is the inbox's email address. */
+  inboxId: string;
+  /** The inbox's email address. */
+  email: string;
+  /** Display name shown to recipients, if set. */
+  displayName?: string;
+  /** Your idempotency / correlation key, if set at creation. */
+  clientId?: string;
+  /** ISO-8601 timestamp when the inbox was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the inbox was last updated. */
+  updatedAt: string;
+}
+
+export interface ListInboxesOptions {
+  /** Maximum number of inboxes to return (1–100). */
+  limit?: number;
+  /** Opaque page cursor from a previous response's `nextPageToken`. */
+  pageToken?: string;
+}
+
+export interface InboxList {
+  /** Number of inboxes on this page. */
+  count: number;
+  /** Cursor for the next page, if more exist. Pass it back as `pageToken`. */
+  nextPageToken?: string;
+  /** Inboxes on the current page. */
+  inboxes: Inbox[];
+}
+
+// ===========================================================================
+// Messages & threads
+// ===========================================================================
+
+export interface Attachment {
+  /** Unique attachment identifier. */
+  attachmentId: string;
+  /** Original file name, if available. */
+  filename?: string;
+  /** MIME content type, if available. */
+  contentType?: string;
+  /** Size in bytes. */
+  size: number;
+}
+
+export interface Message {
+  /** Unique message identifier. */
+  messageId: string;
+  /** Identifier of the thread this message belongs to. */
+  threadId: string;
+  /** Identifier of the inbox this message belongs to. */
+  inboxId: string;
+  /** Sender address. */
+  from: string;
+  /** Recipient addresses. */
+  to: string[];
+  /** Carbon-copy addresses, if any. */
+  cc?: string[];
+  /** Blind carbon-copy addresses, if any. */
+  bcc?: string[];
+  /** Reply-to addresses, if any. */
+  replyTo?: string[];
+  /** Subject line, if any. */
+  subject?: string;
+  /** Short preview of the body. */
+  preview?: string;
+  /** Plain-text body. */
+  text?: string;
+  /** HTML body. */
+  html?: string;
+  /** The plain-text body with quoted reply history removed — the "new" content only. */
+  extractedText?: string;
+  /** The HTML body with quoted reply history removed — the "new" content only. */
+  extractedHtml?: string;
+  /** Labels applied to the message. */
+  labels: string[];
+  /** ISO-8601 timestamp of the message. */
+  timestamp: string;
+  /** The `messageId` this message is a reply to, if any. */
+  inReplyTo?: string;
+  /** Message ids referenced by this message (threading chain), if any. */
+  references?: string[];
+  /** Custom headers on the message, if any. */
+  headers?: Record<string, string>;
+  /** Attachment metadata, if any. */
+  attachments?: Attachment[];
+  /** Total size in bytes. */
+  size: number;
+  /** ISO-8601 timestamp when the record was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the record was last updated. */
+  updatedAt: string;
+}
+
+/**
+ * A message as it appears in a list — metadata only (no `text` / `html` /
+ * `extractedText` / `extractedHtml` / `replyTo`). Fetch the full message with
+ * `messages.get` to read the body.
+ */
+export type MessageListItem = Omit<
+  Message,
+  "text" | "html" | "extractedText" | "extractedHtml" | "replyTo"
+>;
+
+export interface MessageList {
+  /** Number of messages on this page. */
+  count: number;
+  /** Cursor for the next page, if more exist. Pass it back as `pageToken`. */
+  nextPageToken?: string;
+  /** Messages on the current page (metadata only). */
+  messages: MessageListItem[];
+}
+
+export interface ListMessagesOptions {
+  /** Maximum number of messages to return (1–100). */
+  limit?: number;
+  /** Opaque page cursor from a previous response's `nextPageToken`. */
+  pageToken?: string;
+}
+
+/** The result of a send / reply / forward — identifies the created message and its thread. */
+export interface SendResult {
+  /** Identifier of the created message. */
+  messageId: string;
+  /** Identifier of the thread the message belongs to. */
+  threadId: string;
+}
+
+export interface SendMessageInput {
+  /** Recipient(s). Required. */
+  to: Recipients;
+  /** Carbon-copy recipient(s). */
+  cc?: Recipients;
+  /** Blind carbon-copy recipient(s). */
+  bcc?: Recipients;
+  /** Reply-to address(es). */
+  replyTo?: Recipients;
+  /** Subject line. */
+  subject?: string;
+  /** Plain-text body. */
+  text?: string;
+  /** HTML body. */
+  html?: string;
+  /** Custom headers. Routing/identity/MIME headers are rejected — use the dedicated fields instead. */
+  headers?: Record<string, string>;
+  /** Labels to apply to the sent message. */
+  labels?: string[];
+}
+
+export interface ReplyInput {
+  /** Override the recipient(s). Defaults to the original sender if omitted. */
+  to?: Recipients;
+  /** Carbon-copy recipient(s). */
+  cc?: Recipients;
+  /** Blind carbon-copy recipient(s). */
+  bcc?: Recipients;
+  /** Reply-to address(es). */
+  replyTo?: Recipients;
+  /** Reply to everyone on the original message. */
+  replyAll?: boolean;
+  /** Plain-text body. */
+  text?: string;
+  /** HTML body. */
+  html?: string;
+  /** Custom headers. Routing/identity/MIME headers are rejected — use the dedicated fields instead. */
+  headers?: Record<string, string>;
+  /** Labels to apply to the reply. */
+  labels?: string[];
+}
+
+export interface ReplyAllInput {
+  /** Reply-to address(es). */
+  replyTo?: Recipients;
+  /** Plain-text body. */
+  text?: string;
+  /** HTML body. */
+  html?: string;
+  /** Custom headers. Routing/identity/MIME headers are rejected — use the dedicated fields instead. */
+  headers?: Record<string, string>;
+  /** Labels to apply to the reply. */
+  labels?: string[];
+}
+
+export interface Thread {
+  /** Unique thread identifier. */
+  threadId: string;
+  /** Identifier of the inbox this thread belongs to. */
+  inboxId: string;
+  /** Labels applied to the thread. */
+  labels: string[];
+  /** ISO-8601 timestamp of the thread's latest activity. */
+  timestamp: string;
+  /** ISO-8601 timestamp of the last received message, if any. */
+  receivedTimestamp?: string;
+  /** ISO-8601 timestamp of the last sent message, if any. */
+  sentTimestamp?: string;
+  /** Subject line, if any. */
+  subject?: string;
+  /** Short preview of the latest message. */
+  preview?: string;
+  /** Distinct sender addresses in the thread. */
+  senders: string[];
+  /** Distinct recipient addresses in the thread. */
+  recipients: string[];
+  /** Identifier of the most recent message in the thread. */
+  lastMessageId: string;
+  /** Number of messages in the thread. */
+  messageCount: number;
+  /** Total size in bytes. */
+  size: number;
+  /** Attachment metadata across the thread, if any. */
+  attachments?: Attachment[];
+  /** ISO-8601 timestamp when the record was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the record was last updated. */
+  updatedAt: string;
+  /** The messages in the thread, oldest to newest. */
+  messages: Message[];
+}
+
+/** A thread as it appears in a list — without the `messages` array. */
+export type ThreadListItem = Omit<Thread, "messages">;
+
+export interface ThreadList {
+  /** Number of threads on this page. */
+  count: number;
+  /** Cursor for the next page, if more exist. Pass it back as `pageToken`. */
+  nextPageToken?: string;
+  /** Threads on the current page (without their messages). */
+  threads: ThreadListItem[];
+}
+
+export interface ListThreadsOptions {
+  /** Maximum number of threads to return (1–100). */
+  limit?: number;
+  /** Opaque page cursor from a previous response's `nextPageToken`. */
+  pageToken?: string;
+}
+
+// ===========================================================================
+// Domains
+// ===========================================================================
+
+export interface CreateDomainInput {
+  /** Fully-qualified domain to register, e.g. "mail.example.com". Required. */
+  domain: string;
+  /** Enable bounce/complaint feedback for this domain. Defaults to false. */
+  feedbackEnabled?: boolean;
+}
+
+/** A DNS record you must publish to verify a domain. */
+export interface DomainRecord {
+  /** Record type. */
+  type: "TXT" | "CNAME" | "MX";
+  /** Record name (host). */
+  name: string;
+  /** Record value. */
+  value: string;
+  /** Whether the record has been observed as published and valid. */
+  status: "MISSING" | "INVALID" | "VALID";
+  /** Priority — present only for MX records. */
+  priority?: number;
+}
+
+export interface Domain {
+  /** Unique domain identifier. */
+  domainId: string;
+  /** The registered domain. */
+  domain: string;
+  /** Verification status. */
+  status: DomainStatus;
+  /** Whether bounce/complaint feedback is enabled. */
+  feedbackEnabled: boolean;
+  /** DNS records to publish to verify the domain. */
+  records: DomainRecord[];
+  /** ISO-8601 timestamp when the domain was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the domain was last updated (bumps as verification re-checks DNS). */
+  updatedAt: string;
+}
+
+/**
+ * A domain as it appears in a list — without the `status` and `records` fields.
+ * Call `domains.get` for the full status and DNS records.
+ */
+export interface DomainListItem {
+  /** Unique domain identifier. */
+  domainId: string;
+  /** The registered domain. */
+  domain: string;
+  /** Whether bounce/complaint feedback is enabled. */
+  feedbackEnabled: boolean;
+  /** ISO-8601 timestamp when the domain was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp when the domain was last updated. */
+  updatedAt: string;
+}
+
+export interface DomainList {
+  /** Number of domains. */
+  count: number;
+  /** Domains (without status/records). */
+  domains: DomainListItem[];
+}
+
+// ===========================================================================
+// Webhooks
+// ===========================================================================
+
+export interface CreateWebhookInput {
+  /** HTTPS URL to deliver events to. Required. */
+  url: string;
+  /**
+   * The event to subscribe to (e.g. "message.received"), or "*" for all events.
+   * Required.
+   */
+  eventType: string;
+}
+
+export interface Webhook {
+  /** Unique webhook identifier. */
+  id: number;
+  /** The delivery URL. */
+  url: string;
+  /** The subscribed event type ("*" for all). */
+  eventType: string;
+  /**
+   * Signing secret for verifying delivered event signatures. Returned only at
+   * creation time — store it now; it cannot be retrieved later.
+   */
+  secret: string;
+}
+
+// ===========================================================================
+// Internal response shapes + mappers
+//
+// Each map* helper builds a clean public object field-by-field (never a
+// passthrough spread), so the exported types are the single source of truth for
+// what a caller receives.
+// ===========================================================================
+
+interface RawInbox {
+  inboxId: string;
+  email: string;
+  displayName?: string;
+  clientId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawInboxList {
+  count: number;
+  nextPageToken?: string;
+  inboxes: RawInbox[];
+}
+
+interface RawAttachment {
+  attachmentId: string;
+  filename?: string;
+  contentType?: string;
+  size: number;
+}
+
+interface RawMessage {
+  messageId: string;
+  threadId: string;
+  inboxId: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  subject?: string;
+  preview?: string;
+  text?: string;
+  html?: string;
+  extractedText?: string;
+  extractedHtml?: string;
+  labels: string[];
+  timestamp: string;
+  inReplyTo?: string;
+  references?: string[];
+  headers?: Record<string, string>;
+  attachments?: RawAttachment[];
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawMessageList {
+  count: number;
+  nextPageToken?: string;
+  messages: RawMessage[];
+}
+
+interface RawSendResult {
+  messageId: string;
+  threadId: string;
+}
+
+interface RawThread {
+  threadId: string;
+  inboxId: string;
+  labels: string[];
+  timestamp: string;
+  receivedTimestamp?: string;
+  sentTimestamp?: string;
+  subject?: string;
+  preview?: string;
+  senders: string[];
+  recipients: string[];
+  lastMessageId: string;
+  messageCount: number;
+  size: number;
+  attachments?: RawAttachment[];
+  createdAt: string;
+  updatedAt: string;
+  messages: RawMessage[];
+}
+
+interface RawThreadList {
+  count: number;
+  nextPageToken?: string;
+  threads: Omit<RawThread, "messages">[];
+}
+
+interface RawDomainRecord {
+  type: "TXT" | "CNAME" | "MX";
+  name: string;
+  value: string;
+  status: "MISSING" | "INVALID" | "VALID";
+  priority?: number;
+}
+
+interface RawDomain {
+  domainId: string;
+  domain: string;
+  status: DomainStatus;
+  feedbackEnabled: boolean;
+  records: RawDomainRecord[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawDomainListItem {
+  domainId: string;
+  domain: string;
+  feedbackEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawDomainList {
+  count: number;
+  domains: RawDomainListItem[];
+}
+
+interface RawWebhook {
+  id: number;
+  url: string;
+  eventType: string;
+  secret: string;
+}
+
+function mapInbox(raw: RawInbox): Inbox {
+  return {
+    inboxId: raw.inboxId,
+    email: raw.email,
+    ...(raw.displayName !== undefined && { displayName: raw.displayName }),
+    ...(raw.clientId !== undefined && { clientId: raw.clientId }),
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function mapAttachment(raw: RawAttachment): Attachment {
+  return {
+    attachmentId: raw.attachmentId,
+    ...(raw.filename !== undefined && { filename: raw.filename }),
+    ...(raw.contentType !== undefined && { contentType: raw.contentType }),
+    size: raw.size,
+  };
+}
+
+function mapMessage(raw: RawMessage): Message {
+  return {
+    messageId: raw.messageId,
+    threadId: raw.threadId,
+    inboxId: raw.inboxId,
+    from: raw.from,
+    to: raw.to,
+    ...(raw.cc !== undefined && { cc: raw.cc }),
+    ...(raw.bcc !== undefined && { bcc: raw.bcc }),
+    ...(raw.replyTo !== undefined && { replyTo: raw.replyTo }),
+    ...(raw.subject !== undefined && { subject: raw.subject }),
+    ...(raw.preview !== undefined && { preview: raw.preview }),
+    ...(raw.text !== undefined && { text: raw.text }),
+    ...(raw.html !== undefined && { html: raw.html }),
+    ...(raw.extractedText !== undefined && {
+      extractedText: raw.extractedText,
+    }),
+    ...(raw.extractedHtml !== undefined && {
+      extractedHtml: raw.extractedHtml,
+    }),
+    labels: raw.labels,
+    timestamp: raw.timestamp,
+    ...(raw.inReplyTo !== undefined && { inReplyTo: raw.inReplyTo }),
+    ...(raw.references !== undefined && { references: raw.references }),
+    ...(raw.headers !== undefined && { headers: raw.headers }),
+    ...(raw.attachments !== undefined && {
+      attachments: raw.attachments.map(mapAttachment),
+    }),
+    size: raw.size,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function mapMessageListItem(raw: RawMessage): MessageListItem {
+  const { text, html, extractedText, extractedHtml, replyTo, ...rest } =
+    mapMessage(raw);
+  // Reference the destructured body fields so the omit is intentional, not a lint error.
+  void text;
+  void html;
+  void extractedText;
+  void extractedHtml;
+  void replyTo;
+  return rest;
+}
+
+function mapThreadListItem(raw: Omit<RawThread, "messages">): ThreadListItem {
+  return {
+    threadId: raw.threadId,
+    inboxId: raw.inboxId,
+    labels: raw.labels,
+    timestamp: raw.timestamp,
+    ...(raw.receivedTimestamp !== undefined && {
+      receivedTimestamp: raw.receivedTimestamp,
+    }),
+    ...(raw.sentTimestamp !== undefined && {
+      sentTimestamp: raw.sentTimestamp,
+    }),
+    ...(raw.subject !== undefined && { subject: raw.subject }),
+    ...(raw.preview !== undefined && { preview: raw.preview }),
+    senders: raw.senders,
+    recipients: raw.recipients,
+    lastMessageId: raw.lastMessageId,
+    messageCount: raw.messageCount,
+    size: raw.size,
+    ...(raw.attachments !== undefined && {
+      attachments: raw.attachments.map(mapAttachment),
+    }),
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function mapThread(raw: RawThread): Thread {
+  return {
+    ...mapThreadListItem(raw),
+    messages: raw.messages.map(mapMessage),
+  };
+}
+
+function mapDomainRecord(raw: RawDomainRecord): DomainRecord {
+  return {
+    type: raw.type,
+    name: raw.name,
+    value: raw.value,
+    status: raw.status,
+    ...(raw.priority !== undefined && { priority: raw.priority }),
+  };
+}
+
+function mapDomain(raw: RawDomain): Domain {
+  return {
+    domainId: raw.domainId,
+    domain: raw.domain,
+    status: raw.status,
+    feedbackEnabled: raw.feedbackEnabled,
+    records: raw.records.map(mapDomainRecord),
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function mapDomainListItem(raw: RawDomainListItem): DomainListItem {
+  return {
+    domainId: raw.domainId,
+    domain: raw.domain,
+    feedbackEnabled: raw.feedbackEnabled,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function mapWebhook(raw: RawWebhook): Webhook {
+  return {
+    id: raw.id,
+    url: raw.url,
+    eventType: raw.eventType,
+    secret: raw.secret,
+  };
+}
+
+// ===========================================================================
+// Guards & request shaping
+// ===========================================================================
+
+/**
+ * Guard a required id (inbox / message / thread / domain) client-side, so a JS
+ * caller passing null / undefined / "" gets a clear error instead of a confusing
+ * request to a malformed path.
+ */
+function assertId(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new EmailHttpError(
+      `${label} is required and must be a non-empty string`,
+      400,
+      undefined,
+    );
+  }
+  return value;
+}
+
+/**
+ * Percent-encode a path segment while preserving the address form of an inbox id
+ * (which contains `@` and may contain `.`): encode the whole segment. An inbox id
+ * is a single segment, so a plain `encodeURIComponent` is correct.
+ */
+function encodeSegment(id: string): string {
+  return encodeURIComponent(id);
+}
+
+/** Append `limit` / `pageToken` to a URL when present (each a truthy check → null/undefined dropped). */
+function appendPageParams(
+  url: URL,
+  opts?: { limit?: number; pageToken?: string },
+): void {
+  if (opts?.limit != null) url.searchParams.set("limit", String(opts.limit));
+  if (opts?.pageToken != null && opts.pageToken !== "") {
+    url.searchParams.set("pageToken", opts.pageToken);
+  }
+}
+
+/** Copy a value onto `body` only when it is neither undefined nor null. */
+function set(body: Record<string, unknown>, key: string, value: unknown): void {
+  if (value !== undefined && value !== null) body[key] = value;
+}
+
+function sendBody(input: SendMessageInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  set(body, "to", input.to);
+  set(body, "cc", input.cc);
+  set(body, "bcc", input.bcc);
+  set(body, "replyTo", input.replyTo);
+  set(body, "subject", input.subject);
+  set(body, "text", input.text);
+  set(body, "html", input.html);
+  set(body, "headers", input.headers);
+  set(body, "labels", input.labels);
+  return body;
+}
+
+function replyBody(input: ReplyInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  set(body, "to", input.to);
+  set(body, "cc", input.cc);
+  set(body, "bcc", input.bcc);
+  set(body, "replyTo", input.replyTo);
+  set(body, "replyAll", input.replyAll);
+  set(body, "text", input.text);
+  set(body, "html", input.html);
+  set(body, "headers", input.headers);
+  set(body, "labels", input.labels);
+  return body;
+}
+
+function replyAllBody(input: ReplyAllInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  set(body, "replyTo", input.replyTo);
+  set(body, "text", input.text);
+  set(body, "html", input.html);
+  set(body, "headers", input.headers);
+  set(body, "labels", input.labels);
+  return body;
+}
+
+const JSON_HEADERS = { "content-type": "application/json" } as const;
+
+// ===========================================================================
+// Inboxes — operations
+// ===========================================================================
+
+/** Create a new inbox (a real, addressable mailbox). */
+export async function createInbox(
+  input: CreateInboxInput = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Inbox> {
+  const body: Record<string, unknown> = {};
+  set(body, "username", input.username);
+  set(body, "domain", input.domain);
+  set(body, "displayName", input.displayName);
+  set(body, "clientId", input.clientId);
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/inboxes`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    }),
+    "Failed to create inbox",
+  );
+  return mapInbox((await res.json()) as RawInbox);
+}
+
+/** List the caller's inboxes. */
+export async function listInboxes(
+  opts?: ListInboxesOptions,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<InboxList> {
+  const url = new URL(`${baseUrl}/v1/inboxes`);
+  appendPageParams(url, opts);
+  const res = await ensureOk(
+    await transport.fetch(url.toString()),
+    "Failed to list inboxes",
+  );
+  const raw = (await res.json()) as RawInboxList;
+  return {
+    count: raw.count,
+    ...(raw.nextPageToken !== undefined && {
+      nextPageToken: raw.nextPageToken,
+    }),
+    inboxes: raw.inboxes.map(mapInbox),
+  };
+}
+
+/** Fetch a single inbox by id (the inbox's email address). */
+export async function getInbox(
+  inboxId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Inbox> {
+  const id = assertId(inboxId, "inboxId");
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/inboxes/${encodeSegment(id)}`),
+    `Failed to get inbox '${id}'`,
+  );
+  return mapInbox((await res.json()) as RawInbox);
+}
+
+/** Delete an inbox by id. */
+async function deleteInbox(
+  inboxId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const id = assertId(inboxId, "inboxId");
+  await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/inboxes/${encodeSegment(id)}`, {
+      method: "DELETE",
+    }),
+    `Failed to delete inbox '${id}'`,
+  );
+}
+
+export { deleteInbox };
+
+// ===========================================================================
+// Messages — operations
+// ===========================================================================
+
+/** Send a new message from an inbox. */
+export async function sendMessage(
+  inboxId: string,
+  input: SendMessageInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SendResult> {
+  const id = assertId(inboxId, "inboxId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(id)}/messages`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(sendBody(input)),
+      },
+    ),
+    `Failed to send message from inbox '${id}'`,
+  );
+  const raw = (await res.json()) as RawSendResult;
+  return { messageId: raw.messageId, threadId: raw.threadId };
+}
+
+/** List messages in an inbox (metadata only — use `get` for the body). */
+export async function listMessages(
+  inboxId: string,
+  opts?: ListMessagesOptions,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<MessageList> {
+  const id = assertId(inboxId, "inboxId");
+  const url = new URL(`${baseUrl}/v1/inboxes/${encodeSegment(id)}/messages`);
+  appendPageParams(url, opts);
+  const res = await ensureOk(
+    await transport.fetch(url.toString()),
+    `Failed to list messages in inbox '${id}'`,
+  );
+  const raw = (await res.json()) as RawMessageList;
+  return {
+    count: raw.count,
+    ...(raw.nextPageToken !== undefined && {
+      nextPageToken: raw.nextPageToken,
+    }),
+    messages: raw.messages.map(mapMessageListItem),
+  };
+}
+
+/** Fetch a single full message (including body) by id. */
+export async function getMessage(
+  inboxId: string,
+  messageId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Message> {
+  const inbox = assertId(inboxId, "inboxId");
+  const message = assertId(messageId, "messageId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(inbox)}/messages/${encodeSegment(message)}`,
+    ),
+    `Failed to get message '${message}'`,
+  );
+  return mapMessage((await res.json()) as RawMessage);
+}
+
+/** Reply to a message. */
+export async function replyMessage(
+  inboxId: string,
+  messageId: string,
+  input: ReplyInput = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SendResult> {
+  const inbox = assertId(inboxId, "inboxId");
+  const message = assertId(messageId, "messageId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(inbox)}/messages/${encodeSegment(message)}/reply`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(replyBody(input)),
+      },
+    ),
+    `Failed to reply to message '${message}'`,
+  );
+  const raw = (await res.json()) as RawSendResult;
+  return { messageId: raw.messageId, threadId: raw.threadId };
+}
+
+/** Reply to everyone on a message. */
+export async function replyAllMessage(
+  inboxId: string,
+  messageId: string,
+  input: ReplyAllInput = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SendResult> {
+  const inbox = assertId(inboxId, "inboxId");
+  const message = assertId(messageId, "messageId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(inbox)}/messages/${encodeSegment(message)}/reply-all`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(replyAllBody(input)),
+      },
+    ),
+    `Failed to reply-all to message '${message}'`,
+  );
+  const raw = (await res.json()) as RawSendResult;
+  return { messageId: raw.messageId, threadId: raw.threadId };
+}
+
+/** Forward a message to new recipient(s). */
+export async function forwardMessage(
+  inboxId: string,
+  messageId: string,
+  input: SendMessageInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SendResult> {
+  const inbox = assertId(inboxId, "inboxId");
+  const message = assertId(messageId, "messageId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(inbox)}/messages/${encodeSegment(message)}/forward`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(sendBody(input)),
+      },
+    ),
+    `Failed to forward message '${message}'`,
+  );
+  const raw = (await res.json()) as RawSendResult;
+  return { messageId: raw.messageId, threadId: raw.threadId };
+}
+
+// ===========================================================================
+// Threads — operations
+// ===========================================================================
+
+/** List conversation threads in an inbox (without their messages). */
+export async function listThreads(
+  inboxId: string,
+  opts?: ListThreadsOptions,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<ThreadList> {
+  const id = assertId(inboxId, "inboxId");
+  const url = new URL(`${baseUrl}/v1/inboxes/${encodeSegment(id)}/threads`);
+  appendPageParams(url, opts);
+  const res = await ensureOk(
+    await transport.fetch(url.toString()),
+    `Failed to list threads in inbox '${id}'`,
+  );
+  const raw = (await res.json()) as RawThreadList;
+  return {
+    count: raw.count,
+    ...(raw.nextPageToken !== undefined && {
+      nextPageToken: raw.nextPageToken,
+    }),
+    threads: raw.threads.map(mapThreadListItem),
+  };
+}
+
+/** Fetch a single full thread (including its messages) by id. */
+export async function getThread(
+  inboxId: string,
+  threadId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Thread> {
+  const inbox = assertId(inboxId, "inboxId");
+  const thread = assertId(threadId, "threadId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/inboxes/${encodeSegment(inbox)}/threads/${encodeSegment(thread)}`,
+    ),
+    `Failed to get thread '${thread}'`,
+  );
+  return mapThread((await res.json()) as RawThread);
+}
+
+// ===========================================================================
+// Domains — operations
+// ===========================================================================
+
+/** Register a custom sending domain. Returns the DNS records to publish. */
+export async function createDomain(
+  input: CreateDomainInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain> {
+  const domain = assertId(input?.domain, "domain");
+  const body: Record<string, unknown> = { domain };
+  set(body, "feedbackEnabled", input.feedbackEnabled);
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    }),
+    `Failed to create domain '${domain}'`,
+  );
+  return mapDomain((await res.json()) as RawDomain);
+}
+
+/**
+ * Trigger DNS re-verification for a domain. Returns nothing — re-fetch the domain
+ * with `domains.get` to read the updated status and records.
+ */
+export async function verifyDomain(
+  domainId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const id = assertId(domainId, "domainId");
+  await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains/${encodeSegment(id)}/verify`, {
+      method: "POST",
+    }),
+    `Failed to verify domain '${id}'`,
+  );
+}
+
+/** Fetch a domain's full status and DNS records by id. */
+export async function getDomain(
+  domainId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain> {
+  const id = assertId(domainId, "domainId");
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains/${encodeSegment(id)}`),
+    `Failed to get domain '${id}'`,
+  );
+  return mapDomain((await res.json()) as RawDomain);
+}
+
+/** List registered domains (without per-domain status/records). */
+export async function listDomains(
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DomainList> {
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains`),
+    "Failed to list domains",
+  );
+  const raw = (await res.json()) as RawDomainList;
+  return { count: raw.count, domains: raw.domains.map(mapDomainListItem) };
+}
+
+/** Delete a registered domain by id. */
+async function deleteDomain(
+  domainId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const id = assertId(domainId, "domainId");
+  await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains/${encodeSegment(id)}`, {
+      method: "DELETE",
+    }),
+    `Failed to delete domain '${id}'`,
+  );
+}
+
+export { deleteDomain };
+
+// ===========================================================================
+// Webhooks — operations
+// ===========================================================================
+
+/**
+ * Register a webhook for inbound events. The returned `secret` is shown only once —
+ * store it to verify delivered event signatures.
+ */
+export async function createWebhook(
+  input: CreateWebhookInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Webhook> {
+  const url = assertId(input?.url, "url");
+  const eventType = assertId(input?.eventType, "eventType");
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/webhooks`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ url, eventType }),
+    }),
+    "Failed to create webhook",
+  );
+  return mapWebhook((await res.json()) as RawWebhook);
+}
+
+/** Delete a webhook by id. */
+async function deleteWebhook(
+  id: number,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  if (typeof id !== "number" || !Number.isFinite(id)) {
+    throw new EmailHttpError(
+      "webhook id is required and must be a number",
+      400,
+      undefined,
+    );
+  }
+  await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/webhooks/${encodeURIComponent(String(id))}`,
+      { method: "DELETE" },
+    ),
+    `Failed to delete webhook '${id}'`,
+  );
+}
+
+export { deleteWebhook };

--- a/packages/tools/src/email/index.ts
+++ b/packages/tools/src/email/index.ts
@@ -369,6 +369,8 @@ export interface DomainListItem {
   updatedAt: string;
 }
 
+// Domain lists are returned in full — not paginated — so there is no page cursor
+// (unlike inbox / message / thread lists).
 export interface DomainList {
   /** Number of domains. */
   count: number;

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -56,7 +56,10 @@ export type {
   AgentRunResultPayload,
   AgentMcp,
 } from "./agent/index.js";
-export { agentRunResultSchema, AgentRunResultSchemaError } from "./agent/index.js";
+export {
+  agentRunResultSchema,
+  AgentRunResultSchemaError,
+} from "./agent/index.js";
 
 export * as orchestrations from "./orchestrations/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
@@ -91,3 +94,6 @@ export { SearchHttpError } from "./search/index.js";
 
 export * as database from "./database/index.js";
 export { DatabaseHttpError } from "./database/index.js";
+
+export * as email from "./email/index.js";
+export { EmailHttpError } from "./email/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -62,6 +62,18 @@ import type {
   DomainSearchResult,
 } from "../search/index.js";
 import type { Database } from "../database/index.js";
+import type {
+  Inbox,
+  InboxList,
+  SendResult,
+  MessageList,
+  Message,
+  ThreadList,
+  Thread,
+  Domain,
+  DomainList,
+  Webhook,
+} from "../email/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -885,6 +897,179 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         Promise.resolve(
           r("database.delete", [idOrHandle], () => undefined) as void,
         ),
+    },
+    email: {
+      inboxes: {
+        create: (input) =>
+          Promise.resolve(
+            r("email.inboxes.create", [input], () => {
+              const username = input?.username ?? "inbox";
+              const domain = input?.domain ?? "example.com";
+              return {
+                inboxId: `${username}@${domain}`,
+                email: `${username}@${domain}`,
+                ...(input?.displayName && { displayName: input.displayName }),
+                ...(input?.clientId && { clientId: input.clientId }),
+                createdAt: "2099-01-01T00:00:00Z",
+                updatedAt: "2099-01-01T00:00:00Z",
+              };
+            }) as Inbox,
+          ),
+        list: (opts) =>
+          Promise.resolve(
+            r("email.inboxes.list", [opts], () => ({
+              count: 0,
+              inboxes: [],
+            })) as InboxList,
+          ),
+        get: (inboxId) =>
+          Promise.resolve(
+            r("email.inboxes.get", [inboxId], () => ({
+              inboxId,
+              email: inboxId,
+              createdAt: "2099-01-01T00:00:00Z",
+              updatedAt: "2099-01-01T00:00:00Z",
+            })) as Inbox,
+          ),
+        delete: (inboxId) =>
+          Promise.resolve(
+            r("email.inboxes.delete", [inboxId], () => undefined) as void,
+          ),
+      },
+      messages: {
+        send: (inboxId, input) =>
+          Promise.resolve(
+            r("email.messages.send", [inboxId, input], () => ({
+              messageId: `stub-msg-${++launchSeq}`,
+              threadId: `stub-thread-${launchSeq}`,
+            })) as SendResult,
+          ),
+        list: (inboxId, opts) =>
+          Promise.resolve(
+            r("email.messages.list", [inboxId, opts], () => ({
+              count: 0,
+              messages: [],
+            })) as MessageList,
+          ),
+        get: (inboxId, messageId) =>
+          Promise.resolve(
+            r("email.messages.get", [inboxId, messageId], () => ({
+              messageId,
+              threadId: "stub-thread",
+              inboxId,
+              from: "sender@example.com",
+              to: [inboxId],
+              labels: [],
+              timestamp: "2099-01-01T00:00:00Z",
+              size: 0,
+              createdAt: "2099-01-01T00:00:00Z",
+              updatedAt: "2099-01-01T00:00:00Z",
+            })) as Message,
+          ),
+        reply: (inboxId, messageId, input) =>
+          Promise.resolve(
+            r("email.messages.reply", [inboxId, messageId, input], () => ({
+              messageId: `stub-msg-${++launchSeq}`,
+              threadId: `stub-thread-${launchSeq}`,
+            })) as SendResult,
+          ),
+        replyAll: (inboxId, messageId, input) =>
+          Promise.resolve(
+            r("email.messages.replyAll", [inboxId, messageId, input], () => ({
+              messageId: `stub-msg-${++launchSeq}`,
+              threadId: `stub-thread-${launchSeq}`,
+            })) as SendResult,
+          ),
+        forward: (inboxId, messageId, input) =>
+          Promise.resolve(
+            r("email.messages.forward", [inboxId, messageId, input], () => ({
+              messageId: `stub-msg-${++launchSeq}`,
+              threadId: `stub-thread-${launchSeq}`,
+            })) as SendResult,
+          ),
+      },
+      domains: {
+        create: (input) =>
+          Promise.resolve(
+            r("email.domains.create", [input], () => ({
+              domainId: "stub-domain",
+              domain: input.domain,
+              status: "PENDING" as const,
+              feedbackEnabled: input.feedbackEnabled ?? false,
+              records: [],
+              createdAt: "2099-01-01T00:00:00Z",
+              updatedAt: "2099-01-01T00:00:00Z",
+            })) as Domain,
+          ),
+        verify: (domainId) =>
+          Promise.resolve(
+            r("email.domains.verify", [domainId], () => undefined) as void,
+          ),
+        get: (domainId) =>
+          Promise.resolve(
+            r("email.domains.get", [domainId], () => ({
+              domainId,
+              domain: "example.com",
+              status: "VERIFIED" as const,
+              feedbackEnabled: false,
+              records: [],
+              createdAt: "2099-01-01T00:00:00Z",
+              updatedAt: "2099-01-01T00:00:00Z",
+            })) as Domain,
+          ),
+        list: () =>
+          Promise.resolve(
+            r("email.domains.list", [], () => ({
+              count: 0,
+              domains: [],
+            })) as DomainList,
+          ),
+        delete: (domainId) =>
+          Promise.resolve(
+            r("email.domains.delete", [domainId], () => undefined) as void,
+          ),
+      },
+      threads: {
+        list: (inboxId, opts) =>
+          Promise.resolve(
+            r("email.threads.list", [inboxId, opts], () => ({
+              count: 0,
+              threads: [],
+            })) as ThreadList,
+          ),
+        get: (inboxId, threadId) =>
+          Promise.resolve(
+            r("email.threads.get", [inboxId, threadId], () => ({
+              threadId,
+              inboxId,
+              labels: [],
+              timestamp: "2099-01-01T00:00:00Z",
+              senders: [],
+              recipients: [],
+              lastMessageId: "stub-msg",
+              messageCount: 0,
+              size: 0,
+              createdAt: "2099-01-01T00:00:00Z",
+              updatedAt: "2099-01-01T00:00:00Z",
+              messages: [],
+            })) as Thread,
+          ),
+      },
+      webhooks: {
+        create: (input) =>
+          Promise.resolve(
+            r("email.webhooks.create", [input], () => ({
+              id: ++launchSeq,
+              url: input.url,
+              eventType: input.eventType,
+              secret: "stub-webhook-secret",
+            })) as Webhook,
+          ),
+        delete: (id) =>
+          Promise.resolve(
+            r("email.webhooks.delete", [id], () => undefined) as void,
+          ),
+      },
     },
     withAttribution: () => client,
   };


### PR DESCRIPTION
## Summary

Adds a new **`email`** capability to `@sapiom/tools` — programmatic transactional email, callable directly from your code, or from within Sapiom workflow steps.

Create real, addressable inboxes, send and receive messages, manage custom sending domains, read conversation threads, and register webhooks for inbound events.

## Operations

Grouped by resource:

- **`inboxes`** — `create`, `list`, `get`, `delete`
- **`messages`** — `send`, `list`, `get`, `reply`, `replyAll`, `forward`
- **`domains`** — `create`, `verify`, `get`, `list`, `delete`
- **`threads`** — `list`, `get`
- **`webhooks`** — `create`, `delete`

## Usage

```typescript
import { createClient } from "@sapiom/tools";
const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });

const inbox = await sapiom.email.inboxes.create({ username: "support" });
await sapiom.email.messages.send(inbox.inboxId, {
  to: "customer@example.com",
  subject: "Welcome",
  text: "Thanks for signing up!",
});

const { messages } = await sapiom.email.messages.list(inbox.inboxId);
const full = await sapiom.email.messages.get(inbox.inboxId, messages[0].messageId);
await sapiom.email.messages.reply(inbox.inboxId, full.messageId, { text: "Happy to help!" });
```

Available as `sapiom.email.*` on the client, as the ambient `email` namespace, and from the `@sapiom/tools/email` subpath. An `inboxId` is the inbox's email address; the client handles URL encoding. Failed requests throw `EmailHttpError` (carries `status` + parsed `body`).

## Notes

- `messages.list` / `threads.list` return metadata only; fetch the full message/thread with `get` to read content.
- The webhook `secret` is returned only on `create` — store it to verify delivered event signatures.
- Pagination is cursor-based (`nextPageToken` → `pageToken`); domain lists are returned in full and are not paginated.

## Testing

- Unit tests cover every operation: exact URL / method / headers / body, response mapping, error handling (`EmailHttpError` with `status` + `body`), and JS-caller edge cases (nullish required fields fail cleanly on every id/create path incl. the delete paths; `null` optionals are treated as absent; a void/204 op's non-2xx error path; missing-credential path).
- `38` email tests; full package suite green (`225` tests), typecheck / lint / build clean.
- Includes a shape-faithful local stub so workflows using this capability run locally with zero setup.

A capability README (`src/email/README.md`) and a changeset (minor bump) are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
