### PR TITLE
feat(domains): add domains capability to @sapiom/tools

### DIFF
--- a/.changeset/domains-capability.md
+++ b/.changeset/domains-capability.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `domains` capability — register domain names and manage their DNS. Check availability and pricing, register (buy) a domain for a year, renew it, list and inspect the domains you own, and start a transfer out; plus a nested `dns` group to create, list, get, update, and delete DNS records on a domain you own. Available as `sapiom.domains.*` on the client, as the ambient `domains` namespace, and from the `@sapiom/tools/domains` subpath. `register` and `renew` charge on success. Failed requests throw `DomainsHttpError`.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, email, orchestrations, and schedules — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, email, domains, orchestrations, and schedules — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -76,9 +76,10 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `contentGeneration` | Media generation (images + video; audio soon), with optional `storage`                                | [src/content-generation](./src/content-generation/README.md) |
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
 | `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
-| `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                              | [src/schedules](./src/schedules/README.md)                   |
+| `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                             | [src/schedules](./src/schedules/README.md)                   |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
-| `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks                | [src/email](./src/email/README.md)                           |
+| `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks               | [src/email](./src/email/README.md)                           |
+| `domains`           | Register domain names and manage their DNS records                                                    | [src/domains](./src/domains/README.md)                       |
 
 ## Composing capabilities
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/esm/email/index.js",
       "require": "./dist/cjs/email/index.js"
     },
+    "./domains": {
+      "types": "./dist/cjs/domains/index.d.ts",
+      "import": "./dist/esm/domains/index.js",
+      "require": "./dist/cjs/domains/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -106,6 +106,18 @@ import type {
   CreateWebhookInput,
   Webhook,
 } from "./email/index.js";
+import * as domains from "./domains/index.js";
+import type {
+  CheckInput,
+  DomainAvailability,
+  DomainNameInput,
+  Domain as OwnedDomain,
+  DomainTransfer,
+  CreateDnsRecordInput,
+  UpdateDnsRecordInput,
+  DnsRecordRef,
+  DnsRecord,
+} from "./domains/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -276,12 +288,43 @@ export interface Sapiom {
     };
   };
   /**
+   * Register domain names and manage their DNS. `register` and `renew` charge on
+   * success; everything else is free. The nested `dns` group manages DNS records
+   * on a domain you own.
+   */
+  readonly domains: {
+    /** Check availability + pricing for up to 50 names (free). */
+    check(input: CheckInput): Promise<DomainAvailability[]>;
+    /** Register (buy) a domain for one year. Charges apply on success. */
+    register(input: DomainNameInput): Promise<OwnedDomain>;
+    /** Renew a domain you own for one more year. Charges apply on success. */
+    renew(input: DomainNameInput): Promise<OwnedDomain>;
+    /** List the domains you own. */
+    list(): Promise<OwnedDomain[]>;
+    /** Get full details for a domain you own. */
+    get(input: DomainNameInput): Promise<OwnedDomain>;
+    /** Start transferring a domain out; returns an auth code for the new registrar. */
+    transferOut(input: DomainNameInput): Promise<DomainTransfer>;
+    /** Create / list / get / update / delete DNS records on a domain you own. */
+    dns: {
+      /** Create a DNS record. */
+      create(input: CreateDnsRecordInput): Promise<DnsRecord>;
+      /** List a domain's DNS records. */
+      list(input: DomainNameInput): Promise<DnsRecord[]>;
+      /** Get a single DNS record. */
+      get(input: DnsRecordRef): Promise<DnsRecord>;
+      /** Update a DNS record (partial — send only the fields to change). */
+      update(input: UpdateDnsRecordInput): Promise<DnsRecord>;
+      /** Delete a DNS record. */
+      delete(input: DnsRecordRef): Promise<void>;
+    };
+  };
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
    */
   withAttribution(attribution: Attribution): Sapiom;
-  // domains, … land here as they're ported.
 }
 
 /** Bind every capability namespace to a transport. `withAttribution` rebinds to a derived one. */
@@ -377,6 +420,21 @@ function bind(transport: Transport): Sapiom {
       webhooks: {
         create: (input) => email.createWebhook(input, transport),
         delete: (id) => email.deleteWebhook(id, transport),
+      },
+    },
+    domains: {
+      check: (input) => domains.check(input, transport),
+      register: (input) => domains.register(input, transport),
+      renew: (input) => domains.renew(input, transport),
+      list: () => domains.list(transport),
+      get: (input) => domains.get(input, transport),
+      transferOut: (input) => domains.transferOut(input, transport),
+      dns: {
+        create: (input) => domains.createDnsRecord(input, transport),
+        list: (input) => domains.listDnsRecords(input, transport),
+        get: (input) => domains.getDnsRecord(input, transport),
+        update: (input) => domains.updateDnsRecord(input, transport),
+        delete: (input) => domains.deleteDnsRecord(input, transport),
       },
     },
     withAttribution: (attribution) =>

--- a/packages/tools/src/domains/README.md
+++ b/packages/tools/src/domains/README.md
@@ -1,0 +1,76 @@
+# domains
+
+Register domain names and manage their DNS. The same domains capability your
+agents call over MCP, callable directly from your code or from within a Sapiom
+workflow step.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// 1. Find an available name and its price (free).
+const results = await sapiom.domains.check({
+  domainNames: ["my-app.dev", "my-app.io", "get-my-app.com"],
+});
+const pick = results.find((r) => r.available);
+
+// 2. Register it for a year (charges apply).
+if (pick) {
+  await sapiom.domains.register({ domainName: pick.domainName });
+
+  // 3. Point it at your server.
+  await sapiom.domains.dns.create({
+    domainName: pick.domainName,
+    type: "A",
+    host: "", // "" = the root domain (@); or "www", "api", …
+    value: "203.0.113.10",
+  });
+}
+```
+
+Ambient import works too: `import { domains } from "@sapiom/tools"`.
+
+## Operations
+
+Top-level (domains):
+
+- `check({ domainNames })` — availability + pricing for up to 50 names (free).
+- `register({ domainName })` — buy a domain for one year (**charges apply**).
+- `renew({ domainName })` — extend a domain you own by one year (**charges apply**).
+- `list()` — the domains you own.
+- `get({ domainName })` — full details for a domain you own (nameservers, lock
+  status, renewal price, transfer eligibility).
+- `transferOut({ domainName })` — start a transfer to another registrar; returns
+  an auth code to give the receiving registrar (**disruptive**).
+
+`dns` (DNS records on a domain you own):
+
+- `dns.create({ domainName, type, host, value, ttl?, priority? })`
+- `dns.list({ domainName })`
+- `dns.get({ domainName, recordId })`
+- `dns.update({ domainName, recordId, type?, host?, value?, ttl?, priority? })`
+- `dns.delete({ domainName, recordId })`
+
+## DNS records
+
+- **`type`** — one of `A`, `AAAA`, `ANAME`, `CNAME`, `MX`, `TXT`, `SRV`, `NS`.
+- **`host`** — use `""` for the root domain (`@`), or a subdomain like `"www"` or
+  `"api"`.
+- **`ttl`** — seconds; minimum `300`, defaults to `300`.
+- **`priority`** — required for `MX`, optional otherwise.
+- **`recordId`** — returned from `dns.create` / `dns.list`; pass it to `dns.get`,
+  `dns.update`, and `dns.delete`.
+
+`dns.update` is a partial update: send only the fields you want to change; the
+rest keep their current values.
+
+## Gotchas
+
+- **`register` and `renew` charge on success and are not reversible.** Check
+  availability and price with `check` first. A rejected request (e.g. a domain you
+  already own, or a malformed name) does not charge.
+- **A newly registered domain is transfer-locked for 60 days** — `transferOut`
+  is rejected until it becomes eligible (see `transferEligibleAt` on `get`).
+- **Prices are decimal strings** (e.g. `"12.99"`), not numbers.
+- **Failed requests throw `DomainsHttpError`** (carries `status` + parsed
+  `body`), exported from `@sapiom/tools`.

--- a/packages/tools/src/domains/errors.ts
+++ b/packages/tools/src/domains/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error thrown by the domains capability when a request fails (non-2xx
+ * response). Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ */
+export class DomainsHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "DomainsHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link DomainsHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new DomainsHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/domains/index.spec.ts
+++ b/packages/tools/src/domains/index.spec.ts
@@ -716,7 +716,7 @@ describe("domains.updateDnsRecord()", () => {
     expect(bodyOf(calls[0]!)).toEqual({ value: "198.51.100.7" });
   });
 
-  it("treats null optional fields as absent (no null sent upstream)", async () => {
+  it("treats null optional fields as absent (no null in the request body)", async () => {
     const { transport, calls } = makeTransport([
       () => jsonResponse({ ...rawDnsRecord }),
     ]);

--- a/packages/tools/src/domains/index.spec.ts
+++ b/packages/tools/src/domains/index.spec.ts
@@ -1,0 +1,926 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as domains from "./index.js";
+import { DomainsHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly with a real Transport wired to a
+// scripted fetch mock (so URL/method/header/body assertions are exact, and we
+// verify the Transport itself injects the tenant credential).
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+const bodyOf = (c: FetchCall) => JSON.parse(c.init.body as string);
+
+// Sample wire shapes (the service returns camelCase; DNS records carry `id`).
+const rawDomain = {
+  domainName: "my-app.dev",
+  status: "active",
+  expiresAt: "2027-01-01T00:00:00Z",
+  registeredAt: "2026-01-01T00:00:00Z",
+  purchasePrice: "12.99",
+  renewalPrice: "14.99",
+  nameservers: ["ns1.example.com", "ns2.example.com"],
+  locked: true,
+  premium: false,
+  tld: "dev",
+  transferEligibleAt: null,
+};
+
+const rawDnsRecord = {
+  id: "rec-uuid-123",
+  domainName: "my-app.dev",
+  type: "A",
+  host: "",
+  fqdn: "my-app.dev",
+  value: "203.0.113.10",
+  ttl: 3600,
+  priority: undefined,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// check()
+// ---------------------------------------------------------------------------
+
+describe("domains.check()", () => {
+  it("POSTs /v1/domains/check with the names + credential and unwraps results", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          results: [
+            {
+              domainName: "my-app.dev",
+              available: true,
+              purchasePrice: "12.99",
+              renewalPrice: "14.99",
+              premium: false,
+            },
+            { domainName: "taken.com", available: false },
+          ],
+        }),
+    ]);
+
+    const result = await domains.check(
+      { domainNames: ["my-app.dev", "taken.com"] },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual([
+      {
+        domainName: "my-app.dev",
+        available: true,
+        purchasePrice: "12.99",
+        renewalPrice: "14.99",
+        premium: false,
+      },
+      { domainName: "taken.com", available: false },
+    ]);
+    // second result has no wire pricing → those keys are absent, not undefined.
+    expect(result[1]).not.toHaveProperty("purchasePrice");
+    expect(result[1]).not.toHaveProperty("premium");
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/check`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(bodyOf(calls[0]!)).toEqual({
+      domainNames: ["my-app.dev", "taken.com"],
+    });
+  });
+
+  it("throws a clean error (not a TypeError) when domainNames is missing", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+    await expect(
+      domains.check({} as unknown as domains.CheckInput, transport, BASE),
+    ).rejects.toBeInstanceOf(DomainsHttpError);
+    // guard fires before any request is made.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws a clean error when domainNames is empty", async () => {
+    const { transport } = makeTransport([() => jsonResponse({})]);
+    await expect(
+      domains.check({ domainNames: [] }, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response(JSON.stringify({ message: "bad" }), { status: 422 }),
+    ]);
+    await expect(
+      domains.check({ domainNames: ["x.com"] }, transport, BASE),
+    ).rejects.toMatchObject({ status: 422, body: { message: "bad" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// register()
+// ---------------------------------------------------------------------------
+
+describe("domains.register()", () => {
+  it("POSTs /v1/domains with the name and maps the response (201)", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            domainName: "my-app.dev",
+            status: "active",
+            expiresAt: "2027-01-01T00:00:00Z",
+            registeredAt: "2026-01-01T00:00:00Z",
+            purchasePrice: "12.99",
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await domains.register(
+      { domainName: "my-app.dev" },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({
+      domainName: "my-app.dev",
+      status: "active",
+      expiresAt: "2027-01-01T00:00:00Z",
+      registeredAt: "2026-01-01T00:00:00Z",
+      purchasePrice: "12.99",
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({ domainName: "my-app.dev" });
+  });
+
+  it("throws a clean error (not a TypeError) when domainName is nullish", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+    await expect(
+      domains.register(
+        { domainName: undefined } as unknown as domains.DomainNameInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toBeInstanceOf(DomainsHttpError);
+    await expect(
+      domains.register(
+        undefined as unknown as domains.DomainNameInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx (e.g. already registered)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "already registered" }), {
+          status: 409,
+        }),
+    ]);
+    await expect(
+      domains.register({ domainName: "taken.com" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renew()
+// ---------------------------------------------------------------------------
+
+describe("domains.renew()", () => {
+  it("POSTs /v1/domains/:name/renew with an empty body and maps the response", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          domainName: "my-app.dev",
+          expiresAt: "2028-01-01T00:00:00Z",
+          renewalPrice: "14.99",
+        }),
+    ]);
+
+    const result = await domains.renew(
+      { domainName: "my-app.dev" },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({
+      domainName: "my-app.dev",
+      expiresAt: "2028-01-01T00:00:00Z",
+      renewalPrice: "14.99",
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/my-app.dev/renew`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(calls[0]!.init.body).toBe("{}");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("throws DomainsHttpError on non-2xx (e.g. not owned)", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+    await expect(
+      domains.renew({ domainName: "nope.dev" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list()
+// ---------------------------------------------------------------------------
+
+describe("domains.list()", () => {
+  it("GETs /v1/domains and maps each domain", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse([
+          {
+            domainName: "my-app.dev",
+            status: "active",
+            expiresAt: "2027-01-01T00:00:00Z",
+            renewalPrice: "14.99",
+            registeredAt: "2026-01-01T00:00:00Z",
+          },
+        ]),
+    ]);
+
+    const result = await domains.list(transport, BASE);
+
+    expect(result).toEqual([
+      {
+        domainName: "my-app.dev",
+        status: "active",
+        expiresAt: "2027-01-01T00:00:00Z",
+        renewalPrice: "14.99",
+        registeredAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("drops a null renewalPrice from the mapped domain (no null leaks)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse([
+          {
+            domainName: "my-app.dev",
+            status: "active",
+            expiresAt: "2027-01-01T00:00:00Z",
+            renewalPrice: null,
+            registeredAt: "2026-01-01T00:00:00Z",
+          },
+        ]),
+    ]);
+    const [domain] = await domains.list(transport, BASE);
+    expect(domain).not.toHaveProperty("renewalPrice");
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("server error", { status: 500 }),
+    ]);
+    await expect(domains.list(transport, BASE)).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get()
+// ---------------------------------------------------------------------------
+
+describe("domains.get()", () => {
+  it("GETs /v1/domains/:name and maps the full domain (transferEligibleAt null preserved)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(rawDomain)]);
+
+    const result = await domains.get(
+      { domainName: "my-app.dev" },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({
+      domainName: "my-app.dev",
+      status: "active",
+      expiresAt: "2027-01-01T00:00:00Z",
+      registeredAt: "2026-01-01T00:00:00Z",
+      purchasePrice: "12.99",
+      renewalPrice: "14.99",
+      nameservers: ["ns1.example.com", "ns2.example.com"],
+      locked: true,
+      premium: false,
+      tld: "dev",
+      transferEligibleAt: null,
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/my-app.dev`);
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("encodes special characters in the domain name (dots preserved)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(rawDomain)]);
+    await domains.get({ domainName: "sub/weird .dev" }, transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/sub%2Fweird%20.dev`);
+  });
+
+  it("throws a clean error when domainName is nullish", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(rawDomain)]);
+    await expect(
+      domains.get(
+        { domainName: "" } as domains.DomainNameInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("not found", { status: 404 }),
+    ]);
+    await expect(
+      domains.get({ domainName: "nope.dev" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transferOut()
+// ---------------------------------------------------------------------------
+
+describe("domains.transferOut()", () => {
+  it("DELETEs /v1/domains/:name and maps the auth code + instructions", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          domainName: "my-app.dev",
+          authCode: "ABC-123",
+          transferInstructions: "Use this code at the new registrar.",
+        }),
+    ]);
+
+    const result = await domains.transferOut(
+      { domainName: "my-app.dev" },
+      transport,
+      BASE,
+    );
+
+    expect(result).toEqual({
+      domainName: "my-app.dev",
+      authCode: "ABC-123",
+      transferInstructions: "Use this code at the new registrar.",
+    });
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/my-app.dev`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("throws a clean error when domainName is nullish", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+    await expect(
+      domains.transferOut(
+        { domainName: null } as unknown as domains.DomainNameInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx (e.g. transfer-locked)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "locked" }), { status: 409 }),
+    ]);
+    await expect(
+      domains.transferOut({ domainName: "my-app.dev" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dns.create()
+// ---------------------------------------------------------------------------
+
+describe("domains.createDnsRecord()", () => {
+  it("POSTs /v1/domains/:name/records with the record body and maps `id` → recordId", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }, { status: 201 }),
+    ]);
+
+    const result = await domains.createDnsRecord(
+      {
+        domainName: "my-app.dev",
+        type: "A",
+        host: "",
+        value: "203.0.113.10",
+        ttl: 3600,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result).toMatchObject({
+      recordId: "rec-uuid-123",
+      domainName: "my-app.dev",
+      type: "A",
+      host: "",
+      fqdn: "my-app.dev",
+      value: "203.0.113.10",
+      ttl: 3600,
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    // wire `id` never leaks onto the public type.
+    expect(result).not.toHaveProperty("id");
+    // absent priority stays absent, not null/undefined.
+    expect(result).not.toHaveProperty("priority");
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/my-app.dev/records`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({
+      type: "A",
+      host: "",
+      value: "203.0.113.10",
+      ttl: 3600,
+    });
+  });
+
+  it("omits ttl/priority from the body when not provided, and treats null as absent", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }, { status: 201 }),
+    ]);
+
+    await domains.createDnsRecord(
+      {
+        domainName: "my-app.dev",
+        type: "CNAME",
+        host: "www",
+        value: "my-app.dev",
+        ttl: null as unknown as number,
+        priority: null as unknown as number,
+      },
+      transport,
+      BASE,
+    );
+
+    const body = bodyOf(calls[0]!);
+    expect(body).toEqual({ type: "CNAME", host: "www", value: "my-app.dev" });
+    expect(body).not.toHaveProperty("ttl");
+    expect(body).not.toHaveProperty("priority");
+  });
+
+  it("includes priority when provided (e.g. MX record)", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse(
+          {
+            ...rawDnsRecord,
+            type: "MX",
+            value: "mail.example.com",
+            priority: 10,
+          },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await domains.createDnsRecord(
+      {
+        domainName: "my-app.dev",
+        type: "MX",
+        host: "",
+        value: "mail.example.com",
+        priority: 10,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(bodyOf(calls[0]!)).toEqual({
+      type: "MX",
+      host: "",
+      value: "mail.example.com",
+      priority: 10,
+    });
+    expect(result.priority).toBe(10);
+  });
+
+  it("throws a clean error when domainName is nullish", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+    await expect(
+      domains.createDnsRecord(
+        {
+          domainName: "",
+          type: "A",
+          host: "",
+          value: "1.2.3.4",
+        } as domains.CreateDnsRecordInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("bad", { status: 422 }),
+    ]);
+    await expect(
+      domains.createDnsRecord(
+        { domainName: "my-app.dev", type: "A", host: "", value: "x" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dns.list()
+// ---------------------------------------------------------------------------
+
+describe("domains.listDnsRecords()", () => {
+  it("GETs /v1/domains/:name/records and maps each record (id → recordId)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse([{ ...rawDnsRecord, ttl: 300 }]),
+    ]);
+
+    const result = await domains.listDnsRecords(
+      { domainName: "my-app.dev" },
+      transport,
+      BASE,
+    );
+
+    expect(result[0]!.recordId).toBe("rec-uuid-123");
+    expect(result[0]).not.toHaveProperty("id");
+    expect(result[0]!.ttl).toBe(300);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/domains/my-app.dev/records`);
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("nope", { status: 404 }),
+    ]);
+    await expect(
+      domains.listDnsRecords({ domainName: "nope.dev" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dns.get()
+// ---------------------------------------------------------------------------
+
+describe("domains.getDnsRecord()", () => {
+  it("GETs /v1/domains/:name/records/:id and maps the record", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }),
+    ]);
+
+    const result = await domains.getDnsRecord(
+      { domainName: "my-app.dev", recordId: "rec-uuid-123" },
+      transport,
+      BASE,
+    );
+
+    expect(result.recordId).toBe("rec-uuid-123");
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`,
+    );
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("encodes both path params", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }),
+    ]);
+    await domains.getDnsRecord(
+      { domainName: "a b.dev", recordId: "id/with slash" },
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/domains/a%20b.dev/records/id%2Fwith%20slash`,
+    );
+  });
+
+  it("throws a clean error when recordId is nullish (not a TypeError)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }),
+    ]);
+    await expect(
+      domains.getDnsRecord(
+        {
+          domainName: "my-app.dev",
+          recordId: null,
+        } as unknown as domains.DnsRecordRef,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("nope", { status: 404 }),
+    ]);
+    await expect(
+      domains.getDnsRecord(
+        { domainName: "my-app.dev", recordId: "bad" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dns.update()
+// ---------------------------------------------------------------------------
+
+describe("domains.updateDnsRecord()", () => {
+  it("PUTs /v1/domains/:name/records/:id with only the changed fields", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord, value: "198.51.100.7" }),
+    ]);
+
+    const result = await domains.updateDnsRecord(
+      {
+        domainName: "my-app.dev",
+        recordId: "rec-uuid-123",
+        value: "198.51.100.7",
+      },
+      transport,
+      BASE,
+    );
+
+    expect(result.value).toBe("198.51.100.7");
+    expect(result.recordId).toBe("rec-uuid-123");
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`,
+    );
+    expect(calls[0]!.init.method).toBe("PUT");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // partial update — only `value` is sent.
+    expect(bodyOf(calls[0]!)).toEqual({ value: "198.51.100.7" });
+  });
+
+  it("treats null optional fields as absent (no null sent upstream)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }),
+    ]);
+
+    await domains.updateDnsRecord(
+      {
+        domainName: "my-app.dev",
+        recordId: "rec-uuid-123",
+        type: undefined,
+        host: undefined,
+        value: undefined,
+        ttl: null as unknown as number,
+        priority: null as unknown as number,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(bodyOf(calls[0]!)).toEqual({});
+  });
+
+  it("throws a clean error when recordId is nullish", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ ...rawDnsRecord }),
+    ]);
+    await expect(
+      domains.updateDnsRecord(
+        {
+          domainName: "my-app.dev",
+          recordId: "",
+          value: "x",
+        } as domains.UpdateDnsRecordInput,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("bad", { status: 422 }),
+    ]);
+    await expect(
+      domains.updateDnsRecord(
+        { domainName: "my-app.dev", recordId: "rec", value: "x" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 422 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dns.delete()
+// ---------------------------------------------------------------------------
+
+describe("domains.deleteDnsRecord()", () => {
+  it("DELETEs /v1/domains/:name/records/:id and resolves void", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ deleted: true }),
+    ]);
+
+    const result = await domains.deleteDnsRecord(
+      { domainName: "my-app.dev", recordId: "rec-uuid-123" },
+      transport,
+      BASE,
+    );
+
+    expect(result).toBeUndefined();
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`,
+    );
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+  });
+
+  it("throws a clean error when recordId is nullish", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ deleted: true }),
+    ]);
+    await expect(
+      domains.deleteDnsRecord(
+        {
+          domainName: "my-app.dev",
+          recordId: undefined,
+        } as unknown as domains.DnsRecordRef,
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws DomainsHttpError on non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("nope", { status: 404 }),
+    ]);
+    await expect(
+      domains.deleteDnsRecord(
+        { domainName: "my-app.dev", recordId: "bad" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toBeInstanceOf(DomainsHttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client wiring + auth
+// ---------------------------------------------------------------------------
+
+describe("domains — client wiring + credential", () => {
+  it("createClient().domains routes all 11 methods with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      const method = init.method ?? "GET";
+      if (method === "DELETE") {
+        // transferOut returns a transfer body; dns.delete returns { deleted }.
+        return url.includes("/records/")
+          ? jsonResponse({ deleted: true })
+          : jsonResponse({ domainName: "d", authCode: "x" });
+      }
+      if (url.endsWith("/domains/check")) {
+        return jsonResponse({ results: [] });
+      }
+      if (url.endsWith("/records")) {
+        // dns.create (POST) or dns.list (GET)
+        return method === "POST"
+          ? jsonResponse({ ...rawDnsRecord }, { status: 201 })
+          : jsonResponse([]);
+      }
+      if (url.includes("/records/")) {
+        return jsonResponse({ ...rawDnsRecord });
+      }
+      if (url.endsWith("/domains") && method === "GET") {
+        return jsonResponse([]); // list
+      }
+      // register (POST /domains), get (GET /domains/:name), renew (POST .../renew)
+      return jsonResponse({ ...rawDomain }, { status: 201 });
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+    await sapiom.domains.check({ domainNames: ["a.dev"] });
+    await sapiom.domains.register({ domainName: "a.dev" });
+    await sapiom.domains.renew({ domainName: "a.dev" });
+    await sapiom.domains.list();
+    await sapiom.domains.get({ domainName: "a.dev" });
+    await sapiom.domains.transferOut({ domainName: "a.dev" });
+    await sapiom.domains.dns.create({
+      domainName: "a.dev",
+      type: "A",
+      host: "",
+      value: "1.2.3.4",
+    });
+    await sapiom.domains.dns.list({ domainName: "a.dev" });
+    await sapiom.domains.dns.get({ domainName: "a.dev", recordId: "r" });
+    await sapiom.domains.dns.update({
+      domainName: "a.dev",
+      recordId: "r",
+      value: "5.6.7.8",
+    });
+    await sapiom.domains.dns.delete({ domainName: "a.dev", recordId: "r" });
+
+    expect(calls).toHaveLength(11);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("[]")) as typeof globalThis.fetch,
+      });
+      await expect(domains.list(transport, BASE)).rejects.toThrow(
+        /no tenant credential/i,
+      );
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DomainsHttpError
+// ---------------------------------------------------------------------------
+
+describe("DomainsHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new DomainsHttpError("something went wrong", 402, {
+      message: "payment required",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(DomainsHttpError);
+    expect(err.status).toBe(402);
+    expect(err.body).toEqual({ message: "payment required" });
+    expect(err.name).toBe("DomainsHttpError");
+  });
+});

--- a/packages/tools/src/domains/index.ts
+++ b/packages/tools/src/domains/index.ts
@@ -1,0 +1,647 @@
+/**
+ * `domains` capability — register domain names and manage their DNS. Check what's
+ * available and its price, buy a domain for a year, renew it, list and inspect the
+ * domains you own, and start a transfer out. A nested `dns` group creates, reads,
+ * updates, and deletes DNS records on a domain you own.
+ *
+ *   import { domains } from "@sapiom/tools";                 // ambient auth
+ *
+ *   const [candidate] = await domains.check({ domainNames: ["my-app.dev"] });
+ *   if (candidate.available) {
+ *     await domains.register({ domainName: "my-app.dev" });  // charges apply
+ *     await domains.dns.create({
+ *       domainName: "my-app.dev",
+ *       type: "A",
+ *       host: "",                                            // "" = the root domain
+ *       value: "203.0.113.10",
+ *     });
+ *   }
+ *
+ * Or via an explicit client: `createClient({ apiKey }).domains.register(...)`.
+ *
+ * Operations are grouped:
+ *   - top-level — check / register / renew / list / get / transferOut
+ *   - `dns`     — create / list / get / update / delete DNS records
+ *
+ * `register` and `renew` charge on success. Failed requests throw
+ * {@link DomainsHttpError} (carries `status` + parsed `body`).
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, DomainsHttpError } from "./errors.js";
+
+export { DomainsHttpError };
+
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "namecom",
+  process.env.SAPIOM_DOMAINS_URL,
+);
+
+// ===========================================================================
+// Public types (camelCase — the single source of truth for what a caller gets)
+// ===========================================================================
+
+/** A DNS record type. */
+export type DnsRecordType =
+  "A" | "AAAA" | "ANAME" | "CNAME" | "MX" | "TXT" | "SRV" | "NS";
+
+export interface CheckInput {
+  /** Domain names to check (1–50), e.g. `["my-app.dev", "my-app.io"]`. */
+  domainNames: string[];
+}
+
+/** Availability and pricing for a single domain name. */
+export interface DomainAvailability {
+  /** The domain name that was checked. */
+  domainName: string;
+  /** Whether the domain is available to register. */
+  available: boolean;
+  /** First-year price as a decimal string (e.g. "12.99"), when available. */
+  purchasePrice?: string;
+  /** Yearly renewal price as a decimal string, when available. */
+  renewalPrice?: string;
+  /** Whether this is a premium (higher-priced) domain. */
+  premium?: boolean;
+}
+
+export interface DomainNameInput {
+  /** The domain name, e.g. "my-app.dev". */
+  domainName: string;
+}
+
+/** A domain. Which fields are populated depends on the call (see each method). */
+export interface Domain {
+  /** The domain name. */
+  domainName: string;
+  /** Lifecycle status (e.g. "active", "transferring_out"). */
+  status?: string;
+  /** ISO-8601 timestamp when the registration expires. */
+  expiresAt?: string;
+  /** ISO-8601 timestamp when the domain was registered. */
+  registeredAt?: string;
+  /** First-year price paid, as a decimal string. */
+  purchasePrice?: string;
+  /** Yearly renewal price, as a decimal string. */
+  renewalPrice?: string;
+  /** The nameservers set on the domain. */
+  nameservers?: string[];
+  /** Whether the domain is registrar-locked against transfers. */
+  locked?: boolean;
+  /** Whether this is a premium domain. */
+  premium?: boolean;
+  /** The top-level domain (e.g. "dev", "com"). */
+  tld?: string;
+  /** ISO-8601 timestamp from which the domain becomes eligible to transfer out, or `null` if already eligible. */
+  transferEligibleAt?: string | null;
+}
+
+/** The result of starting a transfer out — includes the auth code for the new registrar. */
+export interface DomainTransfer {
+  /** The domain name being transferred. */
+  domainName: string;
+  /** Authorization code to give the receiving registrar to complete the transfer. */
+  authCode?: string;
+  /** Human-readable instructions for completing the transfer. */
+  transferInstructions?: string;
+}
+
+export interface CreateDnsRecordInput {
+  /** The domain to add the record to. */
+  domainName: string;
+  /** Record type. */
+  type: DnsRecordType;
+  /** Host — `""` for the root domain (@), or a subdomain like "www" or "api". */
+  host: string;
+  /** Record value — an IP for A/AAAA, a hostname for CNAME/MX, text for TXT, etc. */
+  value: string;
+  /** Time-to-live in seconds (minimum 300; defaults to 300). */
+  ttl?: number;
+  /** Priority — required for MX, optional for others. */
+  priority?: number;
+}
+
+export interface UpdateDnsRecordInput {
+  /** The domain the record belongs to. */
+  domainName: string;
+  /** The record to update. */
+  recordId: string;
+  /** New record type. */
+  type?: DnsRecordType;
+  /** New host. */
+  host?: string;
+  /** New value. */
+  value?: string;
+  /** New TTL in seconds (minimum 300). */
+  ttl?: number;
+  /** New priority. */
+  priority?: number;
+}
+
+export interface DnsRecordRef {
+  /** The domain the record belongs to. */
+  domainName: string;
+  /** The record identifier. */
+  recordId: string;
+}
+
+/** A DNS record on a domain you own. */
+export interface DnsRecord {
+  /** The record identifier — pass to `dns.get` / `dns.update` / `dns.delete`. */
+  recordId: string;
+  /** The domain the record belongs to. */
+  domainName: string;
+  /** Record type. */
+  type: DnsRecordType;
+  /** Host — `""` for the root domain. */
+  host: string;
+  /** Fully-qualified name of the record (host + domain). */
+  fqdn?: string;
+  /** Record value. */
+  value: string;
+  /** Time-to-live in seconds. */
+  ttl: number;
+  /** Priority, when set (MX/SRV). */
+  priority?: number;
+  /** ISO-8601 timestamp when the record was created. */
+  createdAt?: string;
+}
+
+// ===========================================================================
+// Internal request/response shapes + mappers
+//
+// Each map* helper builds a clean public object field-by-field (never a
+// passthrough spread), so the exported types are the single source of truth for
+// what a caller receives.
+// ===========================================================================
+
+interface RawAvailability {
+  domainName: string;
+  available: boolean;
+  purchasePrice?: string;
+  renewalPrice?: string;
+  premium?: boolean;
+}
+
+interface RawCheckResponse {
+  results: RawAvailability[];
+}
+
+interface RawDomain {
+  domainName: string;
+  status?: string;
+  expiresAt?: string;
+  registeredAt?: string;
+  purchasePrice?: string;
+  renewalPrice?: string | null;
+  nameservers?: string[];
+  locked?: boolean;
+  premium?: boolean;
+  tld?: string;
+  transferEligibleAt?: string | null;
+}
+
+interface RawDomainTransfer {
+  domainName: string;
+  authCode?: string;
+  transferInstructions?: string;
+}
+
+interface RawDnsRecord {
+  id: string;
+  domainName: string;
+  type: DnsRecordType;
+  host: string;
+  fqdn?: string;
+  value: string;
+  ttl: number;
+  priority?: number;
+  createdAt?: string;
+}
+
+function mapAvailability(raw: RawAvailability): DomainAvailability {
+  return {
+    domainName: raw.domainName,
+    available: raw.available,
+    ...(raw.purchasePrice != null && { purchasePrice: raw.purchasePrice }),
+    ...(raw.renewalPrice != null && { renewalPrice: raw.renewalPrice }),
+    ...(raw.premium !== undefined && { premium: raw.premium }),
+  };
+}
+
+function mapDomain(raw: RawDomain): Domain {
+  return {
+    domainName: raw.domainName,
+    ...(raw.status !== undefined && { status: raw.status }),
+    ...(raw.expiresAt !== undefined && { expiresAt: raw.expiresAt }),
+    ...(raw.registeredAt !== undefined && { registeredAt: raw.registeredAt }),
+    ...(raw.purchasePrice != null && { purchasePrice: raw.purchasePrice }),
+    ...(raw.renewalPrice != null && { renewalPrice: raw.renewalPrice }),
+    ...(raw.nameservers !== undefined && { nameservers: raw.nameservers }),
+    ...(raw.locked !== undefined && { locked: raw.locked }),
+    ...(raw.premium !== undefined && { premium: raw.premium }),
+    ...(raw.tld !== undefined && { tld: raw.tld }),
+    ...(raw.transferEligibleAt !== undefined && {
+      transferEligibleAt: raw.transferEligibleAt,
+    }),
+  };
+}
+
+function mapDomainTransfer(raw: RawDomainTransfer): DomainTransfer {
+  return {
+    domainName: raw.domainName,
+    ...(raw.authCode != null && { authCode: raw.authCode }),
+    ...(raw.transferInstructions != null && {
+      transferInstructions: raw.transferInstructions,
+    }),
+  };
+}
+
+function mapDnsRecord(raw: RawDnsRecord): DnsRecord {
+  return {
+    recordId: raw.id,
+    domainName: raw.domainName,
+    type: raw.type,
+    host: raw.host,
+    ...(raw.fqdn != null && { fqdn: raw.fqdn }),
+    value: raw.value,
+    ttl: raw.ttl,
+    ...(raw.priority != null && { priority: raw.priority }),
+    ...(raw.createdAt != null && { createdAt: raw.createdAt }),
+  };
+}
+
+// ===========================================================================
+// Guards & request shaping
+// ===========================================================================
+
+/**
+ * Guard a required string (a domain name / record id) client-side, so a JS caller
+ * passing null / undefined / "" gets a clear error instead of a confusing request
+ * to a malformed path.
+ */
+function assertString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new DomainsHttpError(
+      `${label} is required and must be a non-empty string`,
+      400,
+      undefined,
+    );
+  }
+  return value;
+}
+
+/** Percent-encode a single path segment (a domain name is one segment; dots are preserved). */
+function encodeSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+/** Copy a value onto `body` only when it is neither undefined nor null. */
+function set(body: Record<string, unknown>, key: string, value: unknown): void {
+  if (value !== undefined && value !== null) body[key] = value;
+}
+
+const JSON_HEADERS = { "content-type": "application/json" } as const;
+
+// ===========================================================================
+// Domains — operations
+// ===========================================================================
+
+/**
+ * Check whether one or more domain names are available and get their price. Free.
+ * Use this first, in a workflow step that turns an idea into candidate names,
+ * before deciding what to `register`.
+ *
+ * @param input - `{ domainNames }` — 1 to 50 names to check.
+ * @returns One availability result per name (with pricing when available).
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * const results = await domains.check({ domainNames: ["my-app.dev", "my-app.io"] });
+ * const buyable = results.filter((r) => r.available);
+ */
+export async function check(
+  input: CheckInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DomainAvailability[]> {
+  const domainNames = input?.domainNames;
+  if (!Array.isArray(domainNames) || domainNames.length === 0) {
+    throw new DomainsHttpError(
+      "domainNames is required and must be a non-empty array",
+      400,
+      undefined,
+    );
+  }
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains/check`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ domainNames }),
+    }),
+    "Failed to check domain availability",
+  );
+  const raw = (await res.json()) as RawCheckResponse;
+  return raw.results.map(mapAvailability);
+}
+
+/**
+ * Register (buy) a domain for one year. Charges apply on success and the purchase
+ * is not reversible. Use in a workflow step to acquire a brand's domain before
+ * configuring DNS or email for it; confirm availability and price with `check`
+ * first.
+ *
+ * @param input - `{ domainName }` — the domain to register.
+ * @returns The newly registered domain.
+ * @throws {DomainsHttpError} on a non-2xx response (e.g. already registered, or a price change).
+ *
+ * @example
+ * const domain = await domains.register({ domainName: "my-app.dev" });
+ */
+export async function register(
+  input: DomainNameInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ domainName }),
+    }),
+    `Failed to register domain '${domainName}'`,
+  );
+  return mapDomain((await res.json()) as RawDomain);
+}
+
+/**
+ * Renew a domain you own for one more year. Charges apply on success. Use in a
+ * workflow step that keeps a domain from expiring; read the renewal price from
+ * `get` first if you want to check it.
+ *
+ * @param input - `{ domainName }` — the domain to renew.
+ * @returns The domain with its updated expiry.
+ * @throws {DomainsHttpError} on a non-2xx response (e.g. not owned, or a price change).
+ *
+ * @example
+ * const domain = await domains.renew({ domainName: "my-app.dev" });
+ */
+export async function renew(
+  input: DomainNameInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/renew`,
+      { method: "POST", headers: JSON_HEADERS, body: "{}" },
+    ),
+    `Failed to renew domain '${domainName}'`,
+  );
+  return mapDomain((await res.json()) as RawDomain);
+}
+
+/**
+ * List the domains you own. Free. Use in a workflow step to discover or iterate
+ * over the domains available to configure.
+ *
+ * @returns Your domains, each with status, expiry, and renewal price.
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * const owned = await domains.list();
+ */
+export async function list(
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain[]> {
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains`),
+    "Failed to list domains",
+  );
+  const raw = (await res.json()) as RawDomain[];
+  return raw.map(mapDomain);
+}
+
+/**
+ * Get full details for a domain you own — nameservers, lock status, renewal price,
+ * and transfer eligibility. Free. Use in a workflow step before changing DNS or
+ * starting a transfer, when you need the domain's current state.
+ *
+ * @param input - `{ domainName }` — the domain to look up.
+ * @returns The domain's details.
+ * @throws {DomainsHttpError} on a non-2xx response (e.g. not owned).
+ *
+ * @example
+ * const detail = await domains.get({ domainName: "my-app.dev" });
+ */
+export async function get(
+  input: DomainNameInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Domain> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/domains/${encodeSegment(domainName)}`),
+    `Failed to get domain '${domainName}'`,
+  );
+  return mapDomain((await res.json()) as RawDomain);
+}
+
+/**
+ * Start transferring a domain you own out to another registrar. Returns an auth
+ * code to hand the receiving registrar. Disruptive — this unlocks the domain and
+ * begins the transfer; use in a workflow step only when you intend to move the
+ * domain away.
+ *
+ * @param input - `{ domainName }` — the domain to transfer out.
+ * @returns The auth code and transfer instructions.
+ * @throws {DomainsHttpError} on a non-2xx response (e.g. not owned, or still transfer-locked).
+ *
+ * @example
+ * const { authCode } = await domains.transferOut({ domainName: "my-app.dev" });
+ */
+export async function transferOut(
+  input: DomainNameInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DomainTransfer> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}`,
+      { method: "DELETE" },
+    ),
+    `Failed to transfer out domain '${domainName}'`,
+  );
+  return mapDomainTransfer((await res.json()) as RawDomainTransfer);
+}
+
+// ===========================================================================
+// DNS records — operations
+// ===========================================================================
+
+/**
+ * Create a DNS record on a domain you own. Free. Use in a workflow step to point a
+ * domain at a host (A/AAAA/CNAME), route its email (MX), or add verification text
+ * (TXT). Use `host: ""` for the root domain, or a subdomain like "www".
+ *
+ * @param input - `{ domainName, type, host, value, ttl?, priority? }`.
+ * @returns The created record (with its `recordId`).
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * const record = await domains.dns.create({
+ *   domainName: "my-app.dev",
+ *   type: "A",
+ *   host: "",
+ *   value: "203.0.113.10",
+ * });
+ */
+export async function createDnsRecord(
+  input: CreateDnsRecordInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DnsRecord> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const body: Record<string, unknown> = {
+    type: input.type,
+    host: input.host,
+    value: input.value,
+  };
+  set(body, "ttl", input.ttl);
+  set(body, "priority", input.priority);
+
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/records`,
+      { method: "POST", headers: JSON_HEADERS, body: JSON.stringify(body) },
+    ),
+    `Failed to create DNS record on '${domainName}'`,
+  );
+  return mapDnsRecord((await res.json()) as RawDnsRecord);
+}
+
+/**
+ * List the DNS records on a domain you own. Free. Use in a workflow step to read
+ * the current records (e.g. to find a `recordId` to update or delete).
+ *
+ * @param input - `{ domainName }` — the domain whose records to list.
+ * @returns The domain's DNS records.
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * const records = await domains.dns.list({ domainName: "my-app.dev" });
+ */
+export async function listDnsRecords(
+  input: DomainNameInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DnsRecord[]> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/records`,
+    ),
+    `Failed to list DNS records on '${domainName}'`,
+  );
+  const raw = (await res.json()) as RawDnsRecord[];
+  return raw.map(mapDnsRecord);
+}
+
+/**
+ * Get a single DNS record on a domain you own. Free. Use in a workflow step when
+ * you have a `recordId` and need the record's current values.
+ *
+ * @param input - `{ domainName, recordId }`.
+ * @returns The DNS record.
+ * @throws {DomainsHttpError} on a non-2xx response (e.g. record not found).
+ *
+ * @example
+ * const record = await domains.dns.get({ domainName: "my-app.dev", recordId });
+ */
+export async function getDnsRecord(
+  input: DnsRecordRef,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DnsRecord> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const recordId = assertString(input?.recordId, "recordId");
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/records/${encodeSegment(recordId)}`,
+    ),
+    `Failed to get DNS record '${recordId}'`,
+  );
+  return mapDnsRecord((await res.json()) as RawDnsRecord);
+}
+
+/**
+ * Update a DNS record on a domain you own. Free. Provide only the fields you want
+ * to change. Use in a workflow step to repoint a record (e.g. change an A record's
+ * IP) without recreating it.
+ *
+ * @param input - `{ domainName, recordId, type?, host?, value?, ttl?, priority? }`.
+ * @returns The updated record.
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * const updated = await domains.dns.update({
+ *   domainName: "my-app.dev",
+ *   recordId,
+ *   value: "198.51.100.7",
+ * });
+ */
+export async function updateDnsRecord(
+  input: UpdateDnsRecordInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<DnsRecord> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const recordId = assertString(input?.recordId, "recordId");
+  const body: Record<string, unknown> = {};
+  set(body, "type", input.type);
+  set(body, "host", input.host);
+  set(body, "value", input.value);
+  set(body, "ttl", input.ttl);
+  set(body, "priority", input.priority);
+
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/records/${encodeSegment(recordId)}`,
+      { method: "PUT", headers: JSON_HEADERS, body: JSON.stringify(body) },
+    ),
+    `Failed to update DNS record '${recordId}'`,
+  );
+  return mapDnsRecord((await res.json()) as RawDnsRecord);
+}
+
+/**
+ * Delete a DNS record from a domain you own. Free. Use in a workflow step to
+ * remove a record you no longer need.
+ *
+ * @param input - `{ domainName, recordId }`.
+ * @returns Nothing.
+ * @throws {DomainsHttpError} on a non-2xx response.
+ *
+ * @example
+ * await domains.dns.delete({ domainName: "my-app.dev", recordId });
+ */
+async function deleteDnsRecord(
+  input: DnsRecordRef,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const domainName = assertString(input?.domainName, "domainName");
+  const recordId = assertString(input?.recordId, "recordId");
+  await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/domains/${encodeSegment(domainName)}/records/${encodeSegment(recordId)}`,
+      { method: "DELETE" },
+    ),
+    `Failed to delete DNS record '${recordId}'`,
+  );
+}
+
+export { deleteDnsRecord };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -97,3 +97,6 @@ export { DatabaseHttpError } from "./database/index.js";
 
 export * as email from "./email/index.js";
 export { EmailHttpError } from "./email/index.js";
+
+export * as domains from "./domains/index.js";
+export { DomainsHttpError } from "./domains/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -74,6 +74,12 @@ import type {
   DomainList,
   Webhook,
 } from "../email/index.js";
+import type {
+  DomainAvailability,
+  Domain as OwnedDomain,
+  DomainTransfer,
+  DnsRecord,
+} from "../domains/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -1068,6 +1074,112 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         delete: (id) =>
           Promise.resolve(
             r("email.webhooks.delete", [id], () => undefined) as void,
+          ),
+      },
+    },
+    domains: {
+      check: (input) =>
+        Promise.resolve(
+          r("domains.check", [input], () =>
+            (input.domainNames ?? []).map((domainName) => ({
+              domainName,
+              available: true,
+              purchasePrice: "12.99",
+              renewalPrice: "12.99",
+              premium: false,
+            })),
+          ) as DomainAvailability[],
+        ),
+      register: (input) =>
+        Promise.resolve(
+          r("domains.register", [input], () => ({
+            domainName: input.domainName,
+            status: "active",
+            expiresAt: "2099-01-01T00:00:00Z",
+            registeredAt: "2099-01-01T00:00:00Z",
+            purchasePrice: "12.99",
+          })) as OwnedDomain,
+        ),
+      renew: (input) =>
+        Promise.resolve(
+          r("domains.renew", [input], () => ({
+            domainName: input.domainName,
+            expiresAt: "2099-01-01T00:00:00Z",
+            renewalPrice: "12.99",
+          })) as OwnedDomain,
+        ),
+      list: () =>
+        Promise.resolve(r("domains.list", [], () => []) as OwnedDomain[]),
+      get: (input) =>
+        Promise.resolve(
+          r("domains.get", [input], () => ({
+            domainName: input.domainName,
+            status: "active",
+            expiresAt: "2099-01-01T00:00:00Z",
+            registeredAt: "2099-01-01T00:00:00Z",
+            nameservers: ["ns1.example.com", "ns2.example.com"],
+            locked: true,
+            transferEligibleAt: null,
+          })) as OwnedDomain,
+        ),
+      transferOut: (input) =>
+        Promise.resolve(
+          r("domains.transferOut", [input], () => ({
+            domainName: input.domainName,
+            authCode: "stub-auth-code",
+            transferInstructions:
+              "(stub) provide this auth code to the new registrar.",
+          })) as DomainTransfer,
+        ),
+      dns: {
+        create: (input) =>
+          Promise.resolve(
+            r("domains.dns.create", [input], () => ({
+              recordId: `stub-record-${++launchSeq}`,
+              domainName: input.domainName,
+              type: input.type,
+              host: input.host,
+              fqdn: input.host
+                ? `${input.host}.${input.domainName}`
+                : input.domainName,
+              value: input.value,
+              ttl: input.ttl ?? 300,
+              ...(input.priority !== undefined && { priority: input.priority }),
+              createdAt: "2099-01-01T00:00:00Z",
+            })) as DnsRecord,
+          ),
+        list: (input) =>
+          Promise.resolve(
+            r("domains.dns.list", [input], () => []) as DnsRecord[],
+          ),
+        get: (input) =>
+          Promise.resolve(
+            r("domains.dns.get", [input], () => ({
+              recordId: input.recordId,
+              domainName: input.domainName,
+              type: "A" as const,
+              host: "",
+              fqdn: input.domainName,
+              value: "203.0.113.10",
+              ttl: 300,
+            })) as DnsRecord,
+          ),
+        update: (input) =>
+          Promise.resolve(
+            r("domains.dns.update", [input], () => ({
+              recordId: input.recordId,
+              domainName: input.domainName,
+              type: input.type ?? ("A" as const),
+              host: input.host ?? "",
+              fqdn: input.domainName,
+              value: input.value ?? "203.0.113.10",
+              ttl: input.ttl ?? 300,
+              ...(input.priority !== undefined && { priority: input.priority }),
+            })) as DnsRecord,
+          ),
+        delete: (input) =>
+          Promise.resolve(
+            r("domains.dns.delete", [input], () => undefined) as void,
           ),
       },
     },


### PR DESCRIPTION
Add the `domains` capability to `@sapiom/tools` — register domain names and manage their DNS, callable directly from code the same way agents call it over MCP, or from within a Sapiom workflow step (`ctx.sapiom.domains.*`).

## Operations

Top-level (`sapiom.domains.*`):
- `check({ domainNames })` — availability + pricing for up to 50 names (free)
- `register({ domainName })` — buy a domain for one year (**charges on success**)
- `renew({ domainName })` — extend a domain you own by one year (**charges on success**)
- `list()` — the domains you own
- `get({ domainName })` — full details (nameservers, lock status, renewal price, transfer eligibility)
- `transferOut({ domainName })` — start a transfer to another registrar; returns an auth code

DNS (`sapiom.domains.dns.*`):
- `create` / `list` / `get` / `update` / `delete` DNS records on a domain you own

## What's included

- Typed operations + surface types, with a private wire shape + `map*()` for every response (camelCase surface; never a passthrough).
- `DomainsHttpError` (carries `status` + parsed `body`) thrown on any non-2xx.
- Workflow-authoring-oriented JSDoc on every method (what it does + when to use it in a step).
- Full wiring: client namespace + `bind()`, barrel export, shape-faithful local stub, `./domains` subpath export, package README row, changeset (minor).
- Hermetic unit tests for all 11 operations: request URL/method/headers (incl. the injected credential)/body, response mapping both directions, `DomainsHttpError` on non-2xx, and typed-wrapper edge cases (nullish-required → clean throw, null-optional → absent, path-param encoding, no-credential-configured).

## Verification

- `tsc --noEmit`: clean
- unit tests: 40 new (265 total across the package) passing
- `eslint` on changed files: clean
- `pnpm build`: succeeds; `dist/esm/domains/index.js` + `.d.ts` present, `dist/esm/package.json` is `{"type":"module"}`

Available as `sapiom.domains.*` on the client, as the ambient `domains` namespace, and from the `@sapiom/tools/domains` subpath.