### PR TITLE
fix(domains): expose nested dns namespace on the barrel so domains.dns.* works on direct import

### DIFF
--- a/.changeset/domains-dns-nested-namespace.md
+++ b/.changeset/domains-dns-nested-namespace.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+Expose the nested `dns` namespace on the `domains` capability so `domains.dns.*` (create, list, get, update, delete) works when the `domains` namespace is imported directly, matching the client and the documented `@example`s.

--- a/packages/tools/src/domains/index.spec.ts
+++ b/packages/tools/src/domains/index.spec.ts
@@ -826,6 +826,75 @@ describe("domains.deleteDnsRecord()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// dns.* nested namespace on the barrel (import { domains } from "@sapiom/tools")
+// ---------------------------------------------------------------------------
+
+describe("domains.dns (barrel nested namespace)", () => {
+  it("exposes create/list/get/update/delete as functions", () => {
+    expect(typeof domains.dns.create).toBe("function");
+    expect(typeof domains.dns.list).toBe("function");
+    expect(typeof domains.dns.get).toBe("function");
+    expect(typeof domains.dns.update).toBe("function");
+    expect(typeof domains.dns.delete).toBe("function");
+  });
+
+  it("routes each dns.* call to the right URL + method with the credential", async () => {
+    const { transport, calls } = makeTransport([
+      ({ url, init }) => {
+        const method = init.method ?? "GET";
+        if (method === "DELETE") return jsonResponse({ deleted: true });
+        if (url.endsWith("/records"))
+          return method === "POST"
+            ? jsonResponse({ ...rawDnsRecord }, { status: 201 })
+            : jsonResponse([{ ...rawDnsRecord }]);
+        return jsonResponse({ ...rawDnsRecord });
+      },
+    ]);
+
+    await domains.dns.create(
+      { domainName: "my-app.dev", type: "A", host: "", value: "203.0.113.10" },
+      transport,
+      BASE,
+    );
+    await domains.dns.list({ domainName: "my-app.dev" }, transport, BASE);
+    await domains.dns.get(
+      { domainName: "my-app.dev", recordId: "rec-uuid-123" },
+      transport,
+      BASE,
+    );
+    await domains.dns.update(
+      { domainName: "my-app.dev", recordId: "rec-uuid-123", value: "1.2.3.4" },
+      transport,
+      BASE,
+    );
+    await domains.dns.delete(
+      { domainName: "my-app.dev", recordId: "rec-uuid-123" },
+      transport,
+      BASE,
+    );
+
+    expect(calls.map((c) => [c.init.method ?? "GET", c.url])).toEqual([
+      ["POST", `${BASE}/v1/domains/my-app.dev/records`],
+      ["GET", `${BASE}/v1/domains/my-app.dev/records`],
+      ["GET", `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`],
+      ["PUT", `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`],
+      ["DELETE", `${BASE}/v1/domains/my-app.dev/records/rec-uuid-123`],
+    ]);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("test-key");
+    }
+  });
+
+  it("dns.* are the same functions as the flat exports", () => {
+    expect(domains.dns.create).toBe(domains.createDnsRecord);
+    expect(domains.dns.list).toBe(domains.listDnsRecords);
+    expect(domains.dns.get).toBe(domains.getDnsRecord);
+    expect(domains.dns.update).toBe(domains.updateDnsRecord);
+    expect(domains.dns.delete).toBe(domains.deleteDnsRecord);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Client wiring + auth
 // ---------------------------------------------------------------------------
 

--- a/packages/tools/src/domains/index.ts
+++ b/packages/tools/src/domains/index.ts
@@ -43,7 +43,14 @@ const DEFAULT_BASE_URL = resolveServiceUrl(
 
 /** A DNS record type. */
 export type DnsRecordType =
-  "A" | "AAAA" | "ANAME" | "CNAME" | "MX" | "TXT" | "SRV" | "NS";
+  | "A"
+  | "AAAA"
+  | "ANAME"
+  | "CNAME"
+  | "MX"
+  | "TXT"
+  | "SRV"
+  | "NS";
 
 export interface CheckInput {
   /** Domain names to check (1–50), e.g. `["my-app.dev", "my-app.io"]`. */
@@ -645,3 +652,16 @@ async function deleteDnsRecord(
 }
 
 export { deleteDnsRecord };
+
+/**
+ * The `dns` sub-namespace, so `domains.dns.create(...)` (and `list` / `get` /
+ * `update` / `delete`) reads the same whether imported from the barrel or used on
+ * a client. `delete` maps to {@link deleteDnsRecord} (its own name is reserved).
+ */
+export const dns = {
+  create: createDnsRecord,
+  list: listDnsRecords,
+  get: getDnsRecord,
+  update: updateDnsRecord,
+  delete: deleteDnsRecord,
+};


### PR DESCRIPTION
## What

`domains.dns.create/list/get/update/delete` is documented and works on the client (`createClient().domains.dns.*`), but **not** when the `domains` namespace is imported directly:

```ts
import { domains } from "@sapiom/tools";
await domains.dns.create({ … }); // ❌ TypeError: domains.dns is undefined
```

The barrel (`export * as domains`) re-exported the DNS operations as **flat** functions (`createDnsRecord`, `listDnsRecords`, …), so there was no `dns` object on the directly-imported namespace — and the `@example`s that use `domains.dns.create(...)` were wrong for that import path.

## Fix

Add a `dns` namespace object in `packages/tools/src/domains/index.ts` that aliases the existing flat functions:

```ts
export const dns = {
  create: createDnsRecord,
  list: listDnsRecords,
  get: getDnsRecord,
  update: updateDnsRecord,
  delete: deleteDnsRecord,
};
```

This mirrors the existing `contentGeneration.images` / `contentGeneration.video` pattern, so the directly-imported namespace reads the same as the client and matches the documented examples. The flat functions are **kept** (the client references them), so nothing else changes.

## Tests

Added a suite asserting the barrel nested shape: `domains.dns.*` are functions, route to the correct URL + method with the credential, and are the same references as the flat exports. All existing tests stay green (43 in the domains suite; 321 across the package).

## Changeset

`@sapiom/tools`: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)