### PR TITLE
feat(examples): template gallery registry (SAP-1263)

### DIFF
--- a/examples/hello-workflow/.gitignore
+++ b/examples/hello-workflow/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/hello-workflow/README.md
+++ b/examples/hello-workflow/README.md
@@ -1,0 +1,39 @@
+# Hello Workflow
+
+The minimal single-step Sapiom orchestration — a smoke test for the
+`build → deploy → run` path. One terminal step, no capabilities.
+
+Use it to confirm your MCP install and deploy pipeline work end to end before
+reaching for a metered capability.
+
+## What it does
+
+`greet` validates an optional `name` input and returns `{ greeting: "Hello, <name>!" }`.
+When no name is given it greets `world`.
+
+```
+greet  (terminal)
+```
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_orchestrations_check` → `sapiom_dev_orchestrations_run_local` →
+   `sapiom_dev_orchestrations_link` → `sapiom_dev_orchestrations_deploy` →
+   `sapiom_dev_orchestrations_run`.
+
+## Files
+
+- `index.ts` — the orchestration (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/hello-workflow/index.ts
+++ b/examples/hello-workflow/index.ts
@@ -1,0 +1,36 @@
+import {
+  defineOrchestration,
+  defineStep,
+  terminate,
+} from "@sapiom/orchestration";
+
+/**
+ * Hello Workflow — the minimal single-step Sapiom orchestration.
+ *
+ * The smallest valid definition: one terminal step, no capabilities. Use it to
+ * confirm your MCP install and the build → deploy → run path work end to end
+ * before reaching for a metered capability.
+ *
+ * Each step declares its allowed transitions (`next` / `terminal`); the return
+ * type is derived from them, so an undeclared transition is a compile error.
+ */
+const greet = defineStep({
+  name: "greet",
+  next: [],
+  terminal: true,
+  async run(input: { name?: string }, ctx) {
+    // Validate the input, defaulting to a friendly greeting when none is given.
+    const name =
+      typeof input?.name === "string" && input.name.trim().length > 0
+        ? input.name.trim()
+        : "world";
+    ctx.logger.info("greeting", { name });
+    return terminate({ greeting: `Hello, ${name}!` });
+  },
+});
+
+export const orchestration = defineOrchestration({
+  name: "hello-workflow",
+  entry: "greet",
+  steps: { greet },
+});

--- a/examples/hello-workflow/package-lock.json
+++ b/examples/hello-workflow/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@sapiom/example-hello-workflow",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sapiom/example-hello-workflow",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sapiom/orchestration": "0.4.8",
+        "@sapiom/tools": "0.14.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "typescript": "^5.4.2"
+      }
+    },
+    "node_modules/@sapiom/orchestration": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@sapiom/orchestration/-/orchestration-0.4.8.tgz",
+      "integrity": "sha512-aVOlRHGetx0PjH4yGqGtXysvGPjLCglAxtka2wfRFttWaYxI1qqEwqggyAMdAUf88V4NF0isuOWSiUb919cPEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/tools": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.0.0"
+      }
+    },
+    "node_modules/@sapiom/tools": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/tools/-/tools-0.14.1.tgz",
+      "integrity": "sha512-BTrqI/WmlPTY/J+UU/R1IZFfaBC/jqGVuIvbfjCNE7QGa8j1zz8MnRrAwV3+vwsrvjvSZhXQK2dNJyVUD+ZhFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/hello-workflow/package.json
+++ b/examples/hello-workflow/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-hello-workflow",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom workflow template: the minimal single-step orchestration — a smoke test for the build → deploy → run path.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/orchestration": "0.4.8",
+    "@sapiom/tools": "0.14.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/hello-workflow/tsconfig.json
+++ b/examples/hello-workflow/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "./registry.schema.json",
+  "version": 1,
+  "templates": [
+    {
+      "id": "web-research-digest",
+      "name": "Web Research Digest",
+      "description": "Search the web for a topic and return a concise, sourced digest.",
+      "tags": ["research", "search"],
+      "sourcePath": "examples/web-research-digest",
+      "capabilities": ["web.search"],
+      "whatItDoes": "Takes a topic, runs a web search through the Sapiom search capability, then condenses the top results into a short digest with source links. A legible \"it did a thing\" flagship — one metered capability, an obvious output.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Query the web for the topic.",
+          "capability": "web.search",
+          "next": ["summarize"]
+        },
+        {
+          "name": "summarize",
+          "description": "Condense the results into a sourced digest.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "hello-workflow",
+      "name": "Hello Workflow",
+      "description": "The minimal single-step workflow — a smoke test for the build → deploy → run path.",
+      "tags": ["starter", "minimal"],
+      "sourcePath": "examples/hello-workflow",
+      "capabilities": [],
+      "whatItDoes": "Validates an input name and returns a greeting. The smallest valid definition — use it to confirm your MCP install and deploy path work end to end before reaching for a capability.",
+      "steps": [
+        {
+          "name": "greet",
+          "description": "Validate the input and return a greeting.",
+          "terminal": true
+        }
+      ]
+    }
+  ]
+}

--- a/examples/registry.schema.json
+++ b/examples/registry.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://sapiom.ai/schemas/examples-registry.json",
+  "title": "Sapiom template gallery registry",
+  "description": "Thin gallery index for the onboarding template gallery (SAP-1263). The single edit point: add a template here and it appears in the UI gallery. The Sapiom backend reads this file at a pinned ref, validates it, computes estimated cost from `capabilities`, and expands `steps` into a definition graph for the inspect view.",
+  "type": "object",
+  "required": ["version", "templates"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "type": "integer", "description": "Registry schema version." },
+    "templates": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/template" }
+    }
+  },
+  "definitions": {
+    "template": {
+      "type": "object",
+      "required": ["id", "name", "description", "sourcePath"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "description": "Stable gallery id + the example directory name." },
+        "name": { "type": "string", "minLength": 1, "description": "Display name shown on the card." },
+        "description": { "type": "string", "description": "One-line card description." },
+        "tags": { "type": "array", "items": { "type": "string" }, "description": "Freeform browse tags." },
+        "sourcePath": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path of the example inside this repo (e.g. `examples/<id>`), consumed by the fork + MCP clone handoff."
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Declared catalog capability ids (dotted, e.g. `web.search`). Drives the estimated per-run cost without a built definition."
+        },
+        "whatItDoes": { "type": "string", "description": "Prose shown on the inspect view." },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/step" },
+          "description": "Declared graph, rendered on the inspect view. Array order is execution order; the first step is the entry."
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "description": "Step name (graph node label)." },
+        "description": { "type": "string", "description": "What the step does." },
+        "capability": {
+          "type": ["string", "null"],
+          "description": "Catalog capability id this step calls, or null/omitted for an in-process step."
+        },
+        "next": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Names of steps this step continues to."
+        },
+        "terminal": { "type": "boolean", "description": "True when this step is a sink (ends the run)." }
+      }
+    }
+  }
+}

--- a/examples/web-research-digest/.gitignore
+++ b/examples/web-research-digest/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/web-research-digest/README.md
+++ b/examples/web-research-digest/README.md
@@ -1,0 +1,43 @@
+# Web Research Digest
+
+Search the web for a topic and return a concise, sourced digest. The onboarding
+flagship: one metered capability (`web.search`) and an obvious output.
+
+## What it does
+
+```
+search  ──▶  summarize  (terminal)
+(web.search)   (in-process)
+```
+
+1. **search** — takes a `topic`, calls the Sapiom search capability
+   (`ctx.sapiom.search.webSearch`), and forwards the synthesized answer + results.
+2. **summarize** — formats the answer and its source links into a markdown digest
+   in-process (no LLM), returning `{ topic, digest, sources }`.
+
+Input: `{ "topic": "what is an LLM agent?" }`.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the `search` step
+   inherits that authority to call the metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_orchestrations_check` → `sapiom_dev_orchestrations_run_local`
+   (capabilities stubbed, free) → `sapiom_dev_orchestrations_link` →
+   `sapiom_dev_orchestrations_deploy` → `sapiom_dev_orchestrations_run`
+   (a real, billed web search).
+
+## Files
+
+- `index.ts` — the orchestration (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/web-research-digest/index.ts
+++ b/examples/web-research-digest/index.ts
@@ -1,0 +1,83 @@
+import {
+  defineOrchestration,
+  defineStep,
+  goto,
+  terminate,
+  type OrchestrationExecutionContext,
+} from "@sapiom/orchestration";
+import type { Sapiom } from "@sapiom/tools";
+
+/** The web-search response shape, derived from the capability client. */
+type WebSearchResponse = Awaited<ReturnType<Sapiom["search"]["webSearch"]>>;
+
+/**
+ * Web Research Digest — search the web for a topic and return a concise, sourced
+ * digest.
+ *
+ * A legible "it did a thing" flagship: one metered capability (`web.search`) via
+ * `ctx.sapiom.search.webSearch`, then an in-process `summarize` step that formats
+ * the synthesized answer and its sources into a markdown digest — no LLM call.
+ */
+interface Shared extends Record<string, unknown> {
+  topic: string;
+}
+
+const search = defineStep({
+  name: "search",
+  next: ["summarize"],
+  async run(
+    input: { topic: string },
+    ctx: OrchestrationExecutionContext<Shared>,
+  ) {
+    const topic = input.topic?.trim();
+    if (!topic) {
+      // Nothing to search — hand an empty response to the digest step.
+      const empty: WebSearchResponse = { query: "", results: [] };
+      return goto("summarize", empty);
+    }
+    ctx.shared.set("topic", topic);
+    ctx.logger.info("searching the web", { topic });
+    // Metered + traced; the Sapiom search capability is pre-auth'd on ctx.sapiom.
+    const response = await ctx.sapiom.search.webSearch({
+      query: topic,
+      intent: "answer",
+    });
+    ctx.logger.info("search returned", { results: response.results.length });
+    return goto("summarize", response);
+  },
+});
+
+const summarize = defineStep({
+  name: "summarize",
+  next: [],
+  terminal: true,
+  async run(
+    response: WebSearchResponse,
+    ctx: OrchestrationExecutionContext<Shared>,
+  ) {
+    const topic = ctx.shared.get("topic") ?? response.query;
+    const sources = response.results.map((r) => ({
+      title: r.title,
+      url: r.url,
+    }));
+    const answer = response.answer ?? "No synthesized answer was returned.";
+    const digest = [
+      `# Research digest: ${topic}`,
+      "",
+      answer,
+      "",
+      "## Sources",
+      ...(sources.length > 0
+        ? sources.map((s, i) => `${i + 1}. [${s.title}](${s.url})`)
+        : ["_No sources found._"]),
+    ].join("\n");
+    ctx.logger.info("digest ready", { topic, sourceCount: sources.length });
+    return terminate({ topic, digest, sources });
+  },
+});
+
+export const orchestration = defineOrchestration<{ topic: string }, Shared>({
+  name: "web-research-digest",
+  entry: "search",
+  steps: { search, summarize },
+});

--- a/examples/web-research-digest/package-lock.json
+++ b/examples/web-research-digest/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@sapiom/example-web-research-digest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sapiom/example-web-research-digest",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sapiom/orchestration": "0.4.8",
+        "@sapiom/tools": "0.14.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "typescript": "^5.4.2"
+      }
+    },
+    "node_modules/@sapiom/orchestration": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@sapiom/orchestration/-/orchestration-0.4.8.tgz",
+      "integrity": "sha512-aVOlRHGetx0PjH4yGqGtXysvGPjLCglAxtka2wfRFttWaYxI1qqEwqggyAMdAUf88V4NF0isuOWSiUb919cPEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/tools": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.0.0"
+      }
+    },
+    "node_modules/@sapiom/tools": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/tools/-/tools-0.14.1.tgz",
+      "integrity": "sha512-BTrqI/WmlPTY/J+UU/R1IZFfaBC/jqGVuIvbfjCNE7QGa8j1zz8MnRrAwV3+vwsrvjvSZhXQK2dNJyVUD+ZhFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/web-research-digest/package.json
+++ b/examples/web-research-digest/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-web-research-digest",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom workflow template: search the web for a topic and return a concise, sourced digest — one metered capability (web.search).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/orchestration": "0.4.8",
+    "@sapiom/tools": "0.14.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/web-research-digest/tsconfig.json
+++ b/examples/web-research-digest/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `examples/registry.json` — the thin gallery index for the Sapiom onboarding **template gallery** (SAP-1263). This is the **single source of truth / single edit point** for templates: add an entry here and it appears in the Sapiom UI gallery (browse + read-only inspect).

The Sapiom backend reads this file at a **pinned ref** over raw.githubusercontent, validates it, computes an estimated per-run cost from each entry's declared `capabilities[]`, and expands `steps` into a definition graph for the inspect view — no built definition required.

## What's here

- `examples/registry.json` — two entries to start:
  - **web-research-digest** — the flagship, uses the deploy-ready + metered `web.search` capability (a legible "it did a thing").
  - **hello-workflow** — the minimal single-step smoke test for the build → deploy → run path.
- `examples/registry.schema.json` — a JSON Schema for editor autocomplete/validation when hand-editing the registry.

## Entry shape

`id`, `name`, `description`, `tags`, `sourcePath`, `capabilities[]` (the thin index), plus optional `whatItDoes` prose and a declared `steps` graph for the inspect view.

## Notes

- `sourcePath` points at the example directory each template will live in; the example project contents are populated by the fork/clone workstream (they are not read by the read-only browse+inspect surface).
- Consumed by the Sapiom backend `GET /v1/workflows/templates[/:id]` endpoint (companion Sapiom PR).