### PR TITLE
feat(tools): llm.submit deferred-start verb + llm.redeem (gateway sub…

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -33,6 +33,11 @@
       "import": "./dist/esm/agent/index.js",
       "require": "./dist/cjs/agent/index.js"
     },
+    "./llm": {
+      "types": "./dist/cjs/llm/index.d.ts",
+      "import": "./dist/esm/llm/index.js",
+      "require": "./dist/cjs/llm/index.js"
+    },
     "./file-storage": {
       "types": "./dist/cjs/file-storage/index.d.ts",
       "import": "./dist/esm/file-storage/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -37,6 +37,12 @@ import type {
   AgentRunResult,
   AgentRunHandle,
 } from "./agent/index.js";
+import { submit as llmSubmit, redeem as llmRedeem } from "./llm/index.js";
+import type {
+  LlmSubmitSpec,
+  LlmRouteHandle,
+  LlmGrantLink,
+} from "./llm/index.js";
 import {
   run as orchestrationsRun,
   launch as orchestrationsLaunch,
@@ -164,6 +170,21 @@ export interface Sapiom {
     run(spec: OrchestrationRunSpec): Promise<OrchestrationRunResult>;
     /** Launch a deployed orchestration; pass the handle to `pauseUntilSignal` to suspend on it. */
     launch(spec: OrchestrationRunSpec): Promise<OrchestrationRunHandle>;
+  };
+  /**
+   * Deferred-start routed LLM calls — the gateway's capacity-aware submit-job
+   * seam. `submit` asks for one LLM call and returns a pausable handle; the
+   * gateway grants a single-use link when a model has room (escalating toward
+   * run-now as the deadline nears); `redeem` spends the link.
+   */
+  readonly llm: {
+    /** Submit a routed call; pass the handle to `pauseUntilSignal` to suspend on it. */
+    submit(spec: LlmSubmitSpec): Promise<LlmRouteHandle>;
+    /** Spend a granted link: POST the (re-sent) request to /v1/messages with it. */
+    redeem<T = Record<string, unknown>>(
+      link: LlmGrantLink,
+      request: Record<string, unknown>,
+    ): Promise<T>;
   };
   readonly fileStorage: {
     upload(input: UploadInput): Promise<UploadResponse>;
@@ -378,6 +399,10 @@ function bind(transport: Transport): Sapiom {
     orchestrations: {
       run: (spec) => orchestrationsRun(spec, transport),
       launch: (spec) => orchestrationsLaunch(spec, transport),
+    },
+    llm: {
+      submit: (spec) => llmSubmit(spec, transport),
+      redeem: (link, request) => llmRedeem(link, request),
     },
     fileStorage: {
       upload: (input) => fileStorage.upload(input, transport),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -61,6 +61,27 @@ export {
   AgentRunResultSchemaError,
 } from "./agent/index.js";
 
+// llm — deferred-start routed LLM calls (the gateway's capacity-aware submit-job
+// seam): `llm.submit` returns a pausable handle, `llm.redeem` spends the granted
+// single-use link.
+export * as llm from "./llm/index.js";
+// Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
+export { LLM_ROUTE_RESULT_SIGNAL } from "./llm/index.js";
+// The shape a step resumed from `pauseUntilSignal(llmHandle, …)` receives as
+// input — annotate the resumed step with it instead of hand-rolling the shape.
+export type {
+  LlmSubmitSpec,
+  LlmRouteHandle,
+  LlmGrantLink,
+  LlmRouteStatus,
+  LlmRouteResultPayload,
+} from "./llm/index.js";
+// Validate an LlmRouteResultPayload at the resume boundary.
+export {
+  llmRouteResultSchema,
+  LlmRouteResultSchemaError,
+} from "./llm/index.js";
+
 export * as orchestrations from "./orchestrations/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
 export { ORCHESTRATIONS_RESULT_SIGNAL } from "./orchestrations/index.js";

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -1,0 +1,327 @@
+/**
+ * `llm` capability — deferred-start routed LLM calls (the LLM gateway's submit-job
+ * seam, `POST /v2/route/async`).
+ *
+ * Unlike `agent.run` (a full in-server loop), this routes ONE LLM call through the
+ * gateway's capacity-aware admission: `submit` asks for the call and returns a
+ * handle immediately; the gateway holds the job ordered by deadline and — when a
+ * model has room, or the deadline is close enough to escalate toward run-now —
+ * mints a single-use link and reports back. The request body itself is NEVER
+ * stored by the gateway: the caller re-sends it at redemption (`redeem`).
+ *
+ *   const handle = await ctx.sapiom.llm.submit({
+ *     request: { messages: [{ role: "user", content: "…" }], max_tokens: 512 },
+ *     model: "smart",
+ *     deadlineMinutes: 30,
+ *   });
+ *   return pauseUntilSignal(handle, { resumeStep: "use-answer" });
+ *
+ *   // …and in the resumed step (input: LlmRouteResultPayload):
+ *   const reply = await ctx.sapiom.llm.redeem(input.link!, savedRequestBody);
+ *
+ * Inside a workflow the engine's resume token (ambient on the transport) rides the
+ * `x-sapiom-workflow-token` header; the gateway echoes it in its webhook so the
+ * engine's forwarder can resume the paused step. Standalone callers can instead
+ * poll `handle.wait()` — same admission, no pause.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import type { DispatchHandle } from "../dispatch.js";
+
+const DEFAULT_BASE_URL = resolveServiceUrl("llm", process.env.SAPIOM_LLM_URL);
+
+/**
+ * Capability-stable signal a routed job fires when it reaches a terminal state
+ * (granted OR failed — it carries the result either way, the resumed step
+ * branches). A workflow step paused on a submit handle resumes on this; it is the
+ * value carried in the handle's `dispatch.resultSignal`.
+ */
+export const LLM_ROUTE_RESULT_SIGNAL = "llm.route.result";
+
+/** Job lifecycle, mirrored from the gateway's async status endpoint. */
+export type LlmRouteStatus =
+  | "queued"
+  | "granted"
+  | "consumed"
+  | "failed"
+  | "expired"
+  | "lost"
+  | "not_found";
+const TERMINAL = new Set<LlmRouteStatus>([
+  "granted",
+  "consumed",
+  "failed",
+  "expired",
+  "lost",
+]);
+
+export interface LlmSubmitSpec {
+  /**
+   * The verbatim LLM request (Anthropic messages shape). Used only to estimate
+   * routing weight at submit — the gateway does NOT store it; keep it (e.g. in
+   * `ctx.shared`) and re-send it to `redeem` when the grant arrives.
+   */
+  request: Record<string, unknown>;
+  /** Model pin, or `"smart"` for smart routing. Gateway default when omitted. */
+  model?: string;
+  /**
+   * How long the caller will wait, in minutes. Omitted or <= 0 → run-now (top
+   * priority, immediate escalation). The gateway orders jobs earliest-deadline-
+   * first and escalates toward run-now as the deadline nears.
+   */
+  deadlineMinutes?: number;
+  /** Explicit complexity/capacity weight override (gateway clamps to its bounds). */
+  complexity?: number;
+  /**
+   * Where the gateway reports the grant (or failure). Inside a workflow leave it
+   * unset — the engine injects `SAPIOM_LLM_WEBHOOK_URL` (its resume forwarder).
+   * Standalone callers must pass one, or rely purely on `handle.wait()` polling
+   * via a URL of their own.
+   */
+  webhookUrl?: string;
+  /** HMAC secret: the gateway signs the webhook body as `X-Sapiom-Signature`. */
+  webhookSecret?: string;
+}
+
+/**
+ * The single-use link a granted job carries: call `POST {anthropicBaseUrl}/v1/messages`
+ * with `apiKey` (or hand both to `redeem`). Spent on first use; expires at
+ * `expiresAtMs` if never redeemed.
+ */
+export interface LlmGrantLink {
+  anthropicBaseUrl: string;
+  apiKey: string;
+  /** USER-FACING model label (e.g. `"smart"`, `"m2.7"`) — the provider is never disclosed. */
+  model: string;
+  expiresAtMs: number;
+  usage: string;
+}
+
+/**
+ * The routed job's terminal result as it arrives at a step **resumed** from
+ * `pauseUntilSignal(handle, { resumeStep })` — the signal payload delivered as
+ * that step's `input`. `link` is present iff `status === "granted"`; on
+ * `"failed"`, `error` says why (e.g. `deadline_exhausted`, `grant_mint_failed`,
+ * `expired`, `lost`). Annotate the resumed step's input with this.
+ */
+export interface LlmRouteResultPayload {
+  executionId: string;
+  status: "granted" | "failed";
+  link: LlmGrantLink | null;
+  error: string | null;
+}
+
+/** Thrown by {@link llmRouteResultSchema}.parse on a malformed resume payload. */
+export class LlmRouteResultSchemaError extends Error {}
+
+/** Runtime validator for {@link LlmRouteResultPayload}. */
+export const llmRouteResultSchema = {
+  parse(value: unknown): LlmRouteResultPayload {
+    const fail = (msg: string): never => {
+      throw new LlmRouteResultSchemaError(
+        `invalid llm route result payload: ${msg}`,
+      );
+    };
+    if (!value || typeof value !== "object") fail("not an object");
+    const v = value as Record<string, unknown>;
+    if (typeof v.executionId !== "string")
+      fail("executionId must be a string");
+    if (v.status !== "granted" && v.status !== "failed")
+      fail('status must be "granted" or "failed"');
+    if (v.error !== null && typeof v.error !== "string")
+      fail("error must be a string or null");
+    if (!("link" in v)) fail("link is required (use null on failure)");
+    if (v.link !== null) {
+      const l = v.link as Record<string, unknown>;
+      if (!l || typeof l !== "object") fail("link must be an object or null");
+      if (typeof l.anthropicBaseUrl !== "string")
+        fail("link.anthropicBaseUrl must be a string");
+      if (typeof l.apiKey !== "string") fail("link.apiKey must be a string");
+      if (typeof l.model !== "string") fail("link.model must be a string");
+      if (typeof l.expiresAtMs !== "number")
+        fail("link.expiresAtMs must be a number");
+    }
+    return value as LlmRouteResultPayload;
+  },
+};
+
+/**
+ * A submitted-but-not-awaited routed job. Satisfies {@link DispatchHandle}, so it
+ * can be handed straight to `pauseUntilSignal(handle, { resumeStep })` to suspend
+ * a workflow step until the gateway grants (or fails) it — or `wait()`-ed inline
+ * for standalone use (polls the gateway's status endpoint).
+ */
+export interface LlmRouteHandle extends DispatchHandle {
+  executionId: string;
+  /** Fetch the current lifecycle status without blocking. */
+  status(): Promise<LlmRouteStatus>;
+  /** Poll to a terminal state and resolve the result payload. */
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<LlmRouteResultPayload>;
+}
+
+/** Same header the engine resume token rides on coding/agent launches. */
+function workflowResumeHeaders(
+  token: string | undefined,
+): Record<string, string> {
+  return token ? { "x-sapiom-workflow-token": token } : {};
+}
+
+// --- wire shapes (snake_case, as served by the gateway) ---
+
+interface SubmitDoc {
+  execution_id: string;
+  status: string;
+  poll?: string;
+}
+
+interface WireLink {
+  anthropic_base_url: string;
+  api_key: string;
+  model: string;
+  expires_at_ms: number;
+  usage?: string;
+}
+
+interface StatusDoc {
+  execution_id: string;
+  status: LlmRouteStatus;
+  link?: WireLink | null;
+  error?: string | null;
+}
+
+function mapLink(l: WireLink | null | undefined): LlmGrantLink | null {
+  if (!l) return null;
+  return {
+    anthropicBaseUrl: l.anthropic_base_url,
+    apiKey: l.api_key,
+    model: l.model,
+    expiresAtMs: l.expires_at_ms,
+    usage: l.usage ?? "single_request",
+  };
+}
+
+function toPayload(executionId: string, d: StatusDoc): LlmRouteResultPayload {
+  // consumed = granted-and-already-redeemed; the link is spent, so surface it as a
+  // failure rather than handing back a dead credential. expired/lost carry their
+  // wire status as the error.
+  if (d.status === "granted") {
+    return {
+      executionId,
+      status: "granted",
+      link: mapLink(d.link),
+      error: null,
+    };
+  }
+  return {
+    executionId,
+    status: "failed",
+    link: null,
+    error: d.error ?? d.status,
+  };
+}
+
+function submitHeaders(spec: LlmSubmitSpec, resumeToken: string | undefined) {
+  const webhookUrl = spec.webhookUrl ?? process.env.SAPIOM_LLM_WEBHOOK_URL;
+  if (!webhookUrl) {
+    throw new Error(
+      "llm.submit: no webhook URL. Inside a workflow the engine injects " +
+        "SAPIOM_LLM_WEBHOOK_URL; standalone callers must pass { webhookUrl }.",
+    );
+  }
+  const h: Record<string, string> = {
+    "x-sapiom-webhook-url": webhookUrl,
+    ...workflowResumeHeaders(resumeToken),
+  };
+  if (spec.webhookSecret) h["x-sapiom-webhook-secret"] = spec.webhookSecret;
+  if (spec.model) h["x-sapiom-model"] = spec.model;
+  if (spec.deadlineMinutes !== undefined)
+    h["x-sapiom-deadline"] = String(spec.deadlineMinutes);
+  if (spec.complexity !== undefined)
+    h["x-sapiom-complexity"] = String(spec.complexity);
+  return h;
+}
+
+export async function submit(
+  spec: LlmSubmitSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<LlmRouteHandle> {
+  // 202 + {execution_id, status: "queued", poll}. The LLM gateway authenticates the
+  // tenant virtual key Anthropic-style (x-api-key), not via x-sapiom-api-key.
+  const doc = await transport.request<SubmitDoc>(
+    `${baseUrl}/v2/route/async`,
+    {
+      method: "POST",
+      body: JSON.stringify(spec.request),
+      headers: submitHeaders(spec, transport.resumeToken),
+    },
+    { authHeader: "x-api-key" },
+  );
+  const executionId = doc.execution_id;
+
+  const fetchDoc = () =>
+    transport.request<StatusDoc>(
+      `${baseUrl}/v2/route/async/${encodeURIComponent(executionId)}`,
+      {},
+      { authHeader: "x-api-key" },
+    );
+
+  return {
+    executionId,
+    // Framework plumbing for `pauseUntilSignal` — see DispatchHandle. correlationId
+    // is the gateway execution id (echoed back with the webhook's callback_token).
+    dispatch: {
+      correlationId: executionId,
+      resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+    },
+    async status() {
+      return (await fetchDoc()).status;
+    },
+    async wait({ timeoutMs = 30 * 60_000, pollMs = 2_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (TERMINAL.has(d.status)) return toPayload(executionId, d);
+        if (Date.now() > deadline) {
+          throw new Error(
+            `llm route ${executionId} timed out after ${timeoutMs}ms (last status: ${d.status})`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+/**
+ * Spend a granted link: `POST {link.anthropicBaseUrl}/v1/messages` with the
+ * single-use grant as the credential and the caller's (re-sent) request body.
+ * The gateway hard-pins the model the grant was bound to, so `request.model` may
+ * be anything — the routed deployment wins. Returns the parsed LLM response.
+ *
+ * The grant IS the credential (not the tenant key), so this takes a plain fetch
+ * rather than the authenticated transport.
+ */
+export async function redeem<T = Record<string, unknown>>(
+  link: LlmGrantLink,
+  request: Record<string, unknown>,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+): Promise<T> {
+  const url = `${link.anthropicBaseUrl.replace(/\/$/, "")}/v1/messages`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "x-api-key": link.apiKey,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ ...request, model: link.model }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST ${url} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as T;
+}

--- a/packages/tools/src/llm/submit.spec.ts
+++ b/packages/tools/src/llm/submit.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * llm.submit() — dispatch-handle shape, routing headers, resume-token forwarding,
+ * wait() polling, and redeem().
+ *
+ * Injects a fake fetch (no real network) to assert the handle satisfies
+ * DispatchHandle, the routing controls ride as x-sapiom-* headers (the body stays
+ * a verbatim LLM request), and the engine-injected resume token is forwarded as a
+ * header only when present — so standalone use is unaffected.
+ */
+import { createClient } from "../index.js";
+import {
+  LLM_ROUTE_RESULT_SIGNAL,
+  llmRouteResultSchema,
+  LlmRouteResultSchemaError,
+  redeem,
+  type LlmGrantLink,
+} from "./index.js";
+
+const WIRE_LINK = {
+  anthropic_base_url: "https://llm.services.sapiom.ai",
+  api_key: "sapiom-grant-xyz",
+  model: "smart",
+  expires_at_ms: 1_726_574_400_000,
+  usage: "single_request",
+};
+
+interface Captured {
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/** 202 on POST (submit), then the given status docs on successive GETs (poll). */
+function fakeGatewayFetch(
+  capture: Captured,
+  statusDocs: Array<Record<string, unknown>> = [],
+): typeof globalThis.fetch {
+  const polls = [...statusDocs];
+  return (async (url: string, init: RequestInit = {}) => {
+    if ((init.method ?? "GET") === "POST") {
+      capture.url = url;
+      capture.headers = init.headers as Record<string, string>;
+      capture.body = init.body as string;
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({
+          execution_id: "exec-1",
+          status: "queued",
+          poll: "/v2/route/async/exec-1",
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    }
+    const doc = polls.length > 1 ? polls.shift() : polls[0];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => doc,
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const SPEC = {
+  request: { messages: [{ role: "user", content: "hi" }], max_tokens: 64 },
+  model: "smart",
+  deadlineMinutes: 30,
+  complexity: 2,
+  webhookUrl: "https://engine.example/llm-callback",
+};
+
+describe("llm.submit — dispatch handle", () => {
+  it("returns a handle that satisfies DispatchHandle", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    expect(handle.executionId).toBe("exec-1");
+    expect(handle.dispatch).toEqual({
+      correlationId: "exec-1",
+      resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+    });
+  });
+
+  it("LLM_ROUTE_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(LLM_ROUTE_RESULT_SIGNAL).toBe("llm.route.result");
+  });
+});
+
+describe("llm.submit — routing headers + body", () => {
+  it("sends routing controls as x-sapiom-* headers and the request verbatim as the body", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.url).toContain("/v2/route/async");
+    expect(cap.headers?.["x-sapiom-webhook-url"]).toBe(SPEC.webhookUrl);
+    expect(cap.headers?.["x-sapiom-model"]).toBe("smart");
+    expect(cap.headers?.["x-sapiom-deadline"]).toBe("30");
+    expect(cap.headers?.["x-sapiom-complexity"]).toBe("2");
+    // tenant credential rides Anthropic-style for the LLM gateway
+    expect(cap.headers?.["x-api-key"]).toBe("k");
+    expect(JSON.parse(cap.body ?? "{}")).toEqual(SPEC.request);
+  });
+
+  it("throws without a webhook URL (no spec field, no env)", async () => {
+    delete process.env.SAPIOM_LLM_WEBHOOK_URL;
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch({}) });
+    await expect(
+      sapiom.llm.submit({ request: SPEC.request }),
+    ).rejects.toThrow(/webhook URL/);
+  });
+
+  it("falls back to SAPIOM_LLM_WEBHOOK_URL from the env", async () => {
+    process.env.SAPIOM_LLM_WEBHOOK_URL = "https://engine.example/from-env";
+    try {
+      const cap: Captured = {};
+      const sapiom = createClient({
+        apiKey: "k",
+        fetch: fakeGatewayFetch(cap),
+      });
+      await sapiom.llm.submit({ request: SPEC.request });
+      expect(cap.headers?.["x-sapiom-webhook-url"]).toBe(
+        "https://engine.example/from-env",
+      );
+    } finally {
+      delete process.env.SAPIOM_LLM_WEBHOOK_URL;
+    }
+  });
+});
+
+describe("llm.submit — workflow resume token", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("forwards the env token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-abc";
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.headers?.["x-sapiom-workflow-token"]).toBe("tok-abc");
+    expect(cap.body).not.toContain("tok-abc"); // header, never the body
+  });
+
+  it("sends no token header when none is present (standalone)", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
+  });
+});
+
+describe("llm.submit — wait() polling", () => {
+  it("polls to granted and maps the link to camelCase", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}, [
+        { execution_id: "exec-1", status: "queued" },
+        { execution_id: "exec-1", status: "granted", link: WIRE_LINK },
+      ]),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    const result = await handle.wait({ pollMs: 1 });
+    expect(result).toEqual({
+      executionId: "exec-1",
+      status: "granted",
+      link: {
+        anthropicBaseUrl: "https://llm.services.sapiom.ai",
+        apiKey: "sapiom-grant-xyz",
+        model: "smart",
+        expiresAtMs: 1_726_574_400_000,
+        usage: "single_request",
+      },
+      error: null,
+    });
+  });
+
+  it("maps failure terminals (deadline_exhausted / expired / lost) to failed + error", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}, [
+        { execution_id: "exec-1", status: "failed", error: "deadline_exhausted" },
+      ]),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    const result = await handle.wait({ pollMs: 1 });
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("deadline_exhausted");
+    expect(result.link).toBeNull();
+  });
+});
+
+describe("llm.redeem", () => {
+  const LINK: LlmGrantLink = {
+    anthropicBaseUrl: "https://llm.services.sapiom.ai",
+    apiKey: "sapiom-grant-xyz",
+    model: "smart",
+    expiresAtMs: 1,
+    usage: "single_request",
+  };
+
+  it("POSTs /v1/messages with the grant as x-api-key and pins the granted model", async () => {
+    const cap: Captured = {};
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      cap.url = url;
+      cap.headers = init.headers as Record<string, string>;
+      cap.body = init.body as string;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ content: [{ type: "text", text: "hello" }] }),
+        text: async () => "",
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+
+    const out = await redeem(LINK, { messages: [], model: "ignored" }, fetchImpl);
+    expect(cap.url).toBe("https://llm.services.sapiom.ai/v1/messages");
+    expect(cap.headers?.["x-api-key"]).toBe("sapiom-grant-xyz");
+    expect(JSON.parse(cap.body ?? "{}").model).toBe("smart"); // grant's label wins
+    expect(out).toEqual({ content: [{ type: "text", text: "hello" }] });
+  });
+});
+
+describe("llmRouteResultSchema", () => {
+  it("accepts a granted payload", () => {
+    const payload = {
+      executionId: "exec-1",
+      status: "granted",
+      link: {
+        anthropicBaseUrl: "https://llm.services.sapiom.ai",
+        apiKey: "sapiom-grant-xyz",
+        model: "smart",
+        expiresAtMs: 1,
+        usage: "single_request",
+      },
+      error: null,
+    };
+    expect(llmRouteResultSchema.parse(payload)).toBe(payload);
+  });
+
+  it("accepts a failed payload with a null link", () => {
+    const payload = {
+      executionId: "exec-1",
+      status: "failed",
+      link: null,
+      error: "deadline_exhausted",
+    };
+    expect(llmRouteResultSchema.parse(payload)).toBe(payload);
+  });
+
+  it("rejects a malformed payload", () => {
+    expect(() => llmRouteResultSchema.parse({ status: "granted" })).toThrow(
+      LlmRouteResultSchemaError,
+    );
+    expect(() =>
+      llmRouteResultSchema.parse({
+        executionId: "e",
+        status: "granted",
+        error: null,
+      }),
+    ).toThrow(/link is required/);
+  });
+});

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -30,6 +30,12 @@ import type {
   RunHandle,
   RunStatus,
 } from "../agent/index.js";
+import { LLM_ROUTE_RESULT_SIGNAL } from "../llm/index.js";
+import type {
+  LlmGrantLink,
+  LlmRouteHandle,
+  LlmRouteResultPayload,
+} from "../llm/index.js";
 import { ORCHESTRATIONS_RESULT_SIGNAL } from "../orchestrations/index.js";
 import type {
   OrchestrationRunResult,
@@ -670,6 +676,51 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           finishedAt: "2099-01-01T00:00:00.000Z",
         }));
       },
+    },
+    llm: {
+      submit: (spec) => {
+        const executionId = `stub-exec-${++launchSeq}`;
+        const stubLink: LlmGrantLink = {
+          anthropicBaseUrl: "https://llm.local",
+          apiKey: "sapiom-grant-stub",
+          model: spec.model ?? "smart",
+          expiresAtMs: 4102444800000,
+          usage: "single_request",
+        };
+        const payload = r("llm.submit", [spec], () => ({
+          executionId,
+          status: "granted" as const,
+          link: stubLink,
+          error: null,
+        })) as LlmRouteResultPayload;
+        const handle: LlmRouteHandle = {
+          executionId,
+          dispatch: {
+            correlationId: executionId,
+            resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+          },
+          status: () =>
+            Promise.resolve(payload.status === "granted" ? "granted" : "failed"),
+          wait: () => Promise.resolve(payload),
+        };
+        // Register the resume payload so a local `pauseUntilSignal` on this handle
+        // resolves with an LlmRouteResultPayload.
+        return dispatchable(handle, opts.signals);
+      },
+      redeem: <T = Record<string, unknown>>(
+        link: LlmGrantLink,
+        request: Record<string, unknown>,
+      ) =>
+        Promise.resolve(
+          r("llm.redeem", [link, request], () => ({
+            id: "stub-msg",
+            type: "message",
+            role: "assistant",
+            model: link.model,
+            content: [{ type: "text", text: "(stub) llm reply" }],
+            stop_reason: "end_turn",
+          })) as T,
+        ),
     },
     fileStorage: {
       upload: (input) =>


### PR DESCRIPTION
…mit-job seam)

New `llm` capability wiring workflows into the LLM gateway's capacity-aware async admission (POST /v2/route/async, SAP-1200/1198 per-call deferred start):

- llm.submit(spec) POSTs the verbatim LLM request with routing controls as x-sapiom-* headers (webhook-url, deadline, model, complexity) and returns an LlmRouteHandle satisfying DispatchHandle — hand it to pauseUntilSignal to suspend the step until the gateway grants (room ready, or escalated toward run-now as the deadline nears) or fails the job. The engine resume token rides x-sapiom-workflow-token (same header as coding/agent launches); the gateway echoes it in its webhook so the resume forwarder can wake the paused step.
- llm.redeem(link, request) spends the granted single-use link against /v1/messages (the gateway stores no body — the caller re-sends it).
- handle.wait() polls GET /v2/route/async/{id} for standalone (no-pause) use.
- LLM_ROUTE_RESULT_SIGNAL + LlmRouteResultPayload + llmRouteResultSchema for the resumed step's input; stub client gets a shape-faithful llm namespace so run_local works offline; ./llm subpath export.

13 new spec tests; package suite 334/334 green; typecheck + lint clean.