### PR TITLE
[SAP-1365] Agent-authoring skill v2 + scaffold templates ship it + instructions fallback sync

### DIFF
--- a/.changeset/sapiom-agent-authoring-skill.md
+++ b/.changeset/sapiom-agent-authoring-skill.md
@@ -1,0 +1,18 @@
+---
+"@sapiom/agent-core": minor
+"@sapiom/mcp": minor
+---
+
+Ship the `sapiom-agent-authoring` skill with every scaffold, and finish the MCP
+instructions rename.
+
+- New canonical skill (`agent-core/skills/sapiom-agent-authoring/SKILL.md`) with a
+  task-shape trigger ("automate a multi-step / scheduled / deployable task"), the full
+  authoring guide (`defineAgent`, directives, pause/resume, stubs), and a bootstrap
+  step for agents whose client doesn't have the sapiom-dev MCP yet.
+- Both scaffold templates ship it at `.claude/skills/sapiom-agent-authoring/` (auto-loads
+  as a project skill in Claude Code) and `AGENTS.md` points to it, so every scaffolded
+  project self-documents. A sync test keeps template copies identical to the canonical.
+- `@sapiom/mcp`'s bundled instructions fallback rewritten to the agents/models
+  vocabulary (the rename left it on the old text), thinned to lifecycle + canonical
+  rules + pointers — deep guidance lives in the skill/AGENTS.md/docs.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -88,8 +88,9 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
-`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
+are its deprecated pre-launch names (still visible on npm and in older projects; never use or
+install them).
 
 ### `defineAgent` shape
 
@@ -382,8 +383,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
-  find the right one) or the SDK instead of scaffolding.
+  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
+  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -382,8 +382,8 @@ Write each step the way it should run in production — never weaken logic to sh
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
   [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
-  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
+  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: sapiom-agent-authoring
+description: Build, test, and deploy a Sapiom agent — a controlled, multi-step,
+  deployable automation defined in TypeScript. Use when the user wants to
+  automate a multi-step, scheduled, recurring, or deployable task ("build an
+  agent that checks competitor prices every morning", "automate our weekly
+  report", "make a bot that reviews PRs"), or names Sapiom, defineAgent,
+  @sapiom/agent, or the sapiom-dev MCP. Also use to run, inspect, or resume an
+  existing Sapiom agent. Do NOT use for a single one-off capability call
+  (a web search, one scrape, one image) with no automation to keep — use
+  Sapiom's remote MCP or SDK for that.
+---
+
+# Building Sapiom Agents
+
+A Sapiom **agent** is a small TypeScript project you author with your coding agent: a
+`defineAgent({ name, entry, steps })` where each step's `run(input, ctx)` does work — calling
+paid Sapiom capabilities through the typed `ctx.sapiom.*` client — and returns a directive.
+You test it locally for free, then deploy it to run on Sapiom's cloud: on demand, on a
+schedule, or resumed by signals. All from the terminal; no dashboard required.
+
+**Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
+scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
+
+## If the Sapiom dev MCP isn't connected yet
+
+The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
+(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+
+```bash
+claude mcp add sapiom -- npx -y @sapiom/mcp
+```
+
+Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
+[docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+
+## Lifecycle from Zero
+
+### 1. Authenticate (required before deploy/run)
+
+Run `sapiom_authenticate` — it opens a browser login and caches an API key in
+`~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
+API-key principal; deployed agents inherit that authority to call paid capabilities.
+
+### 2. Scaffold
+
+Call `sapiom_dev_agents_scaffold` with a target directory. The scaffold writes:
+
+```
+my-agent/
+├── index.ts            # your agent definition (edit this)
+├── AGENTS.md           # quick in-project reference
+├── CLAUDE.md           # points your coding agent at AGENTS.md
+├── .claude/skills/     # this skill, locally — the deep guide
+├── .sapiom-dev/stubs.json
+├── package.json / tsconfig.json / ...
+```
+
+Install deps: `npm install`. Templates: `"default"` (minimal two-step starter) or
+`"coding-pause"` (launch + pause/resume coding-model pattern).
+
+### 3. Write steps → typecheck → check → run_local → deploy
+
+| Command | What it does |
+|---|---|
+| `npm run typecheck` | Confirms types compile and every `ctx.sapiom.*` call exists |
+| `sapiom_dev_agents_check` | Bundles `index.ts` + validates the step graph (offline, instant) |
+| `sapiom_dev_agents_run_local` | Runs real step code with all capabilities stubbed — free, no spend |
+
+Then ship:
+
+| Command | What it does |
+|---|---|
+| `sapiom_dev_agents_link` | Registers the agent under your tenant |
+| `sapiom_dev_agents_deploy` | Builds and deploys to Sapiom's cloud |
+| `sapiom_dev_agents_run` | Starts a real (billed) execution |
+| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+
+## The Step Model — Hard Rules
+
+### Canonical API
+
+| Import | From |
+|---|---|
+| `defineAgent` | `@sapiom/agent` |
+| `defineStep` | `@sapiom/agent` |
+| `goto / terminate / fail / retry / pauseUntilSignal` | `@sapiom/agent` |
+| `AgentExecutionContext` | `@sapiom/agent` |
+| `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
+
+**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
+`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+
+### `defineAgent` shape
+
+```typescript
+export const agent = defineAgent({
+  name: "my-agent",      // string — used for logging and inspect
+  entry: "start",        // must name a key in steps
+  steps: { start, finish },
+});
+```
+
+Export exactly one `defineAgent(...)` from `index.ts`.
+
+### `defineStep` fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | `string` | yes | Step's id; must match its key in the steps object |
+| `next` | `readonly string[]` | yes | Step names this step may `goto`. Empty array if terminal |
+| `terminal` | `boolean` | no | `true` if this step ends the agent's execution |
+| `canFail` | `boolean` | no | Must be `true` to return `fail()` |
+| `pause` | `{ signal, resumeStep }` | no | Required when returning `pauseUntilSignal(...)` |
+| `inputSchema` | `ZodType` | no | Zod schema validating this step's input |
+| `timeoutMs` | `number` | no | Per-step timeout; no automatic retry cap |
+| `run(input, ctx)` | `async function` | yes | Returns a directive |
+
+Import Zod via the `zod/v4` subpath — `import { z } from "zod/v4"` — to match the SDK's
+schema types. Don't import from bare `"zod"` or add a second zod dependency.
+
+### Directives — what `run` must return
+
+| Directive | Function | Constraint |
+|---|---|---|
+| `goto(target, output?)` | Advance to another step | `target` must be in `next[]` |
+| `terminate(output?, opts?)` | End the execution successfully | Step must have `terminal: true` |
+| `fail(reason?, opts?)` | End the execution as failed | Step must have `canFail: true` |
+| `retry(opts?)` | Re-run this step | Bound with `ctx.attempts` — no automatic cap |
+| `pauseUntilSignal(handle, opts?)` | Suspend until a signal fires | Step must declare `pause: { signal, resumeStep }` |
+
+TypeScript enforces these constraints at compile time — a `terminate` in a non-terminal step,
+or a `fail` without `canFail: true`, is a type error.
+
+### Minimal two-step example
+
+```typescript
+import { defineAgent, defineStep, goto, terminate } from "@sapiom/agent";
+
+const start = defineStep({
+  name: "start",
+  next: ["finish"],
+  async run(input: { name: string }, ctx) {
+    ctx.logger.info("got input", { name: input.name });
+    return goto("finish", { greeting: `Hello, ${input.name}` });
+  },
+});
+
+const finish = defineStep({
+  name: "finish",
+  next: [],
+  terminal: true,
+  async run(input: { greeting: string }, ctx) {
+    return terminate({ result: input.greeting });
+  },
+});
+
+export const agent = defineAgent({
+  name: "greet",
+  entry: "start",
+  steps: { start, finish },
+});
+```
+
+## Cross-Step State with `ctx.shared`
+
+`goto(target, payload)` passes data to the next step's `input`. For data multiple downstream
+steps need, use `ctx.shared` — a typed key/value store that persists across the whole execution.
+
+```typescript
+interface Shared extends Record<string, unknown> {
+  taskId: string;
+}
+
+// In a step:
+ctx.shared.set("taskId", "abc-123");
+
+// In a later step:
+const taskId = ctx.shared.get("taskId"); // typed as string | undefined
+```
+
+`ctx.shared` API: `get(key)`, `set(key, value)`, `has(key)`, `snapshot()`.
+
+**A step's `run(input, ctx)` first argument is its inbound input** — the entry input at the
+entry step, or the previous step's `goto(target, payload)` value at later steps. The entry
+input reaches only the entry step's argument; to use it in later steps, write it into
+`ctx.shared` from the entry step.
+
+## `ctx` Reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `ctx.executionId` | `string` | Unique id for this execution |
+| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
+| `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
+| `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
+| `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
+| `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.organizationId` | `string \| null` | Tenant org |
+| `ctx.tenantId` | `string \| null` | Tenant id |
+
+## Capabilities from Steps
+
+Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
+coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
+databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
+types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the full catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+
+## Failure Handling & Retries
+
+There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
+The common pattern is a bounded loop that escalates:
+
+```typescript
+const reconsider = defineStep({
+  name: "reconsider",
+  next: ["work", "escalate"],
+  async run(_input, ctx: AgentExecutionContext<{ attempt: number }>) {
+    const attempt = ctx.shared.get("attempt") ?? 0;
+    if (attempt >= 3) return goto("escalate", {});
+    ctx.shared.set("attempt", attempt + 1);
+    return goto("work", {});
+  },
+});
+```
+
+For a step's own retries (transient errors):
+
+```typescript
+async run(input, ctx) {
+  try {
+    const result = await ctx.sapiom.sandboxes.create({ name: "demo" });
+    return terminate({ result });
+  } catch (err) {
+    // ctx.attempts is 0-indexed: `+ 1 < N` gives exactly N total attempts.
+    // (`ctx.attempts < N` would run N+1 times — a common off-by-one.)
+    if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+    return fail("too many attempts");  // requires canFail: true
+  }
+}
+```
+
+`timeoutMs` on a step caps how long its `run` may take. There is no engine-level retry cap —
+you own the bound.
+
+## Pause & Resume (Long-Running Dispatched Steps)
+
+A step's `run` completes in one synchronous dispatch. For long-running capabilities (a
+dispatched coding-model run), **launch fire-and-forget and pause** — the engine suspends the
+execution until the result signal fires, then resumes into a designated step whose `input`
+IS the result payload.
+
+```typescript
+import {
+  defineAgent, defineStep, goto, pauseUntilSignal, terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+}
+
+const launch = defineStep({
+  name: "launch",
+  next: ["collect"],
+  // Declare the signal and resume step so the engine knows what to wait for.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "collect" },
+  async run(input: { task: string }, ctx: AgentExecutionContext<Shared>) {
+    const repo = await ctx.sapiom.repositories.create("my-repo");
+    ctx.shared.set("repoSlug", repo.slug);               // stash before pausing
+    const run = await ctx.sapiom.models.coding.launch({ task: input.task, gitRepository: repo });
+    return pauseUntilSignal(run, { resumeStep: "collect" }); // pass the handle, not the signal name
+  },
+});
+
+const collect = defineStep({
+  name: "collect",
+  next: [],
+  terminal: true,
+  // input IS the CodingResultPayload delivered by the resume signal.
+  async run(result: CodingResultPayload, ctx: AgentExecutionContext<Shared>) {
+    if (result.status !== "completed") {
+      return terminate({ status: result.status, error: result.error });
+    }
+    // Re-attach the sandbox — the payload crossed a wire boundary, so there are no live handles.
+    if (result.executionEnvironment?.type === "blaxel_sandbox") {
+      const sandbox = ctx.sapiom.sandboxes.attach(result.executionEnvironment.id);
+      // … push from sandbox, read files, etc.
+    }
+    return terminate({ status: result.status, summary: result.summary });
+  },
+});
+
+export const agent = defineAgent<{ task: string }, Shared>({
+  name: "code-and-collect",
+  entry: "launch",
+  steps: { launch, collect },
+});
+```
+
+Key rules:
+
+- `pause: { signal, resumeStep }` is **required** on the step that returns `pauseUntilSignal`.
+  Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
+- The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
+  Annotate it explicitly — don't hand-roll the shape.
+- The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
+  `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
+- For a **manual human-gate** (no capability handle), use the object form and fire the signal
+  from your approval flow:
+
+```typescript
+return pauseUntilSignal({
+  signal: "my.approval",
+  resumeStep: "finalize",
+  correlationId: ctx.executionId,  // makes the awaited signal unique to this execution
+});
+```
+
+Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual gate
+auto-resumes with `{}` unless stubbed — type the resumed step's input with optional fields
+accordingly.
+
+## Determinism
+
+A step body runs **once** on the happy path. It re-runs only on retry (after a throw or
+`retry()`). Do not rely on a value being recomputed identically across a pause/resume or a
+retry. Capture non-deterministic values (timestamps, random ids) once and carry them forward
+via `goto` input or `ctx.shared`.
+
+## Testing with `run_local` and Stubs
+
+`run_local` works with **no stubs** — capabilities return sensible defaults. Add
+`.sapiom-dev/stubs.json` overrides only when a step branches on a specific result:
+
+```jsonc
+{
+  "version": 1,
+  "steps": {
+    // Stub the coding run under the LAUNCHING step (here `launch`), not the resume step.
+    "launch": {
+      "models.coding.run": { "status": "completed", "summary": "done", "result": null, "error": null, "executionEnvironment": null }
+    },
+    "check": {
+      "repositories.list": [{ "slug": "my-repo", "cloneUrl": "https://..." }]
+    }
+  }
+}
+```
+
+Stub naming rules:
+
+- Namespace calls use the **plural/namespace path**: `repositories.list`, `models.coding.run`.
+- Handle method calls use the **singular**: `repository.pushFromSandbox`, `sandbox.exec`.
+- To stub a coding run's resume payload, override `models.coding.run` (or
+  `models.coding.launch`) in the **launching step** — that value is both the inline result
+  and the payload the paused step resumes with.
+- `run_local` reports `unusedStubs` (key matched nothing — usually a typo or plural/singular
+  slip) and `stubWarnings` (key matched but wrong shape). A green run with either non-empty
+  means the stub silently didn't apply.
+- **Local retry cap:** the `run_local` tool defaults to `maxAttemptsPerStep: 3`. If a step's
+  own retry bound allows ≥3 retries, pass a higher `maxAttemptsPerStep` so the local harness
+  doesn't stop the loop before your `fail()` fires. This cap is local-test only — production
+  has no engine-level retry cap.
+
+Write each step the way it should run in production — never weaken logic to shape a local run.
+
+## Tips
+
+- **Types are the source of truth.** What's on `ctx.sapiom` is defined by `@sapiom/tools`.
+  Use autocomplete and `npm run typecheck` rather than guessing — a wrong capability name is
+  a type error, not a runtime surprise.
+- **`check` before deploy.** It validates the step graph (names, `next` references,
+  `terminal` consistency) — a misconfigured graph is caught here, not at runtime.
+- **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
+- **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
+  `ctx.shared` in the entry step — don't thread it through every `goto` payload.
+- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
+  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
+  find the right one) or the SDK instead of scaffolding.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Cannot find module '@sapiom/agent'` | Deps not installed | `npm install` inside the scaffolded dir |
+| Type error: `fail(...)` not assignable | Step missing `canFail: true` | Add `canFail: true` to `defineStep` |
+| Type error: `terminate(...)` not assignable | Step missing `terminal: true` | Add `terminal: true` to `defineStep` |
+| `goto` target rejected by types | Target not in `next[]` | Add the target name to `next` |
+| `check` fails: step missing from graph | `steps` object key doesn't match `name` field | Match the key in `steps: { start }` to `defineStep({ name: "start" })` |
+| `run_local` reports `unusedStubs` | Stub path typo or namespace/handle mix-up | Namespace path for calls (`repositories.list`), singular for handles (`repository.pushFromSandbox`) |
+| Paused step resumes with empty input | Manual gate; `run_local` auto-resumes with `{}` | Type the resumed step's input with optional fields |
+| `sapiom_authenticate` → credential not found at deploy | Authenticated in a different shell | Re-run `sapiom_authenticate`; credential is per-machine in `~/.sapiom/credentials.json` |
+
+## References
+
+| Resource | What it covers |
+|---|---|
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start) | Scaffold → write → test → deploy walkthrough |
+| [Capabilities](https://docs.sapiom.ai/capabilities) | The full `ctx.sapiom.*` catalog with pricing |
+| `AGENTS.md` in your scaffold | The quick in-project reference |

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -191,13 +191,13 @@ input reaches only the entry step's argument; to use it in later steps, write it
 | Field | Type | Notes |
 |---|---|---|
 | `ctx.executionId` | `string` | Unique id for this execution |
-| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.agentName` | `string` | The agent's `name` |
 | `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
 | `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
 | `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
 | `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
 | `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
-| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — the `Sapiom` interface from `@sapiom/tools`, installed in your `node_modules` (see "Capabilities" below) |
 | `ctx.organizationId` | `string \| null` | Tenant org |
 | `ctx.tenantId` | `string \| null` | Tenant id |
 
@@ -206,9 +206,10 @@ input reaches only the entry step's argument; to use it in later steps, write it
 Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
 coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
 databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
-rejects what doesn't, and the full catalog with pricing lives at
-[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
+— installed in your project's `node_modules`, so its types match the exact version you're on.
+`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
+catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
 ## Failure Handling & Retries
 

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -88,9 +88,7 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
-are its deprecated pre-launch names (still visible on npm and in older projects; never use or
-install them).
+`@sapiom/agent` is the only authoring package.
 
 ### `defineAgent` shape
 

--- a/packages/agent-core/src/__tests__/skill-sync.test.ts
+++ b/packages/agent-core/src/__tests__/skill-sync.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Drift guard: the `sapiom-agent-authoring` skill has one canonical source
+ * (skills/sapiom-agent-authoring/SKILL.md) and is shipped verbatim inside every
+ * scaffold template's `.claude/skills/` directory. If a template copy diverges
+ * from the canonical, scaffolded projects teach different rules than the
+ * published guide — this test makes that impossible to merge silently.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const PKG_ROOT = path.resolve(__dirname, "..", "..");
+const CANONICAL = path.join(
+  PKG_ROOT,
+  "skills",
+  "sapiom-agent-authoring",
+  "SKILL.md",
+);
+const TEMPLATES_DIR = path.join(PKG_ROOT, "templates");
+
+describe("sapiom-agent-authoring skill sync", () => {
+  const canonical = readFileSync(CANONICAL, "utf8");
+
+  it("has a canonical source with the task-shape trigger frontmatter", () => {
+    expect(canonical.startsWith("---\nname: sapiom-agent-authoring")).toBe(true);
+    expect(canonical).toContain("description:");
+  });
+
+  const templates = readdirSync(TEMPLATES_DIR);
+
+  it("there is at least one template to guard", () => {
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  for (const template of templates) {
+    it(`template "${template}" ships an identical copy of the skill`, () => {
+      const copy = path.join(
+        TEMPLATES_DIR,
+        template,
+        ".claude",
+        "skills",
+        "sapiom-agent-authoring",
+        "SKILL.md",
+      );
+      expect(readFileSync(copy, "utf8")).toBe(canonical);
+    });
+  }
+});
+
+// The Claude Code plugin (repo root, plugins/sapiom — SAP-1366) carries its own
+// copy of the skill. Guarded: the plugin may not exist yet on this branch.
+describe("plugin skill copy (when present)", () => {
+  const pluginCopy = path.resolve(
+    PKG_ROOT,
+    "..",
+    "..",
+    "plugins",
+    "sapiom",
+    "skills",
+    "sapiom-agent-authoring",
+    "SKILL.md",
+  );
+
+  it("matches the canonical if the plugin ships it", () => {
+    if (!existsSync(pluginCopy)) return; // plugin PR not merged yet
+    const canonical = readFileSync(CANONICAL, "utf8");
+    expect(readFileSync(pluginCopy, "utf8")).toBe(canonical);
+  });
+});

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -88,8 +88,9 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
-`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
+are its deprecated pre-launch names (still visible on npm and in older projects; never use or
+install them).
 
 ### `defineAgent` shape
 
@@ -382,8 +383,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
-  find the right one) or the SDK instead of scaffolding.
+  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
+  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -382,8 +382,8 @@ Write each step the way it should run in production — never weaken logic to sh
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
   [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
-  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
+  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: sapiom-agent-authoring
+description: Build, test, and deploy a Sapiom agent — a controlled, multi-step,
+  deployable automation defined in TypeScript. Use when the user wants to
+  automate a multi-step, scheduled, recurring, or deployable task ("build an
+  agent that checks competitor prices every morning", "automate our weekly
+  report", "make a bot that reviews PRs"), or names Sapiom, defineAgent,
+  @sapiom/agent, or the sapiom-dev MCP. Also use to run, inspect, or resume an
+  existing Sapiom agent. Do NOT use for a single one-off capability call
+  (a web search, one scrape, one image) with no automation to keep — use
+  Sapiom's remote MCP or SDK for that.
+---
+
+# Building Sapiom Agents
+
+A Sapiom **agent** is a small TypeScript project you author with your coding agent: a
+`defineAgent({ name, entry, steps })` where each step's `run(input, ctx)` does work — calling
+paid Sapiom capabilities through the typed `ctx.sapiom.*` client — and returns a directive.
+You test it locally for free, then deploy it to run on Sapiom's cloud: on demand, on a
+schedule, or resumed by signals. All from the terminal; no dashboard required.
+
+**Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
+scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
+
+## If the Sapiom dev MCP isn't connected yet
+
+The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
+(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+
+```bash
+claude mcp add sapiom -- npx -y @sapiom/mcp
+```
+
+Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
+[docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+
+## Lifecycle from Zero
+
+### 1. Authenticate (required before deploy/run)
+
+Run `sapiom_authenticate` — it opens a browser login and caches an API key in
+`~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
+API-key principal; deployed agents inherit that authority to call paid capabilities.
+
+### 2. Scaffold
+
+Call `sapiom_dev_agents_scaffold` with a target directory. The scaffold writes:
+
+```
+my-agent/
+├── index.ts            # your agent definition (edit this)
+├── AGENTS.md           # quick in-project reference
+├── CLAUDE.md           # points your coding agent at AGENTS.md
+├── .claude/skills/     # this skill, locally — the deep guide
+├── .sapiom-dev/stubs.json
+├── package.json / tsconfig.json / ...
+```
+
+Install deps: `npm install`. Templates: `"default"` (minimal two-step starter) or
+`"coding-pause"` (launch + pause/resume coding-model pattern).
+
+### 3. Write steps → typecheck → check → run_local → deploy
+
+| Command | What it does |
+|---|---|
+| `npm run typecheck` | Confirms types compile and every `ctx.sapiom.*` call exists |
+| `sapiom_dev_agents_check` | Bundles `index.ts` + validates the step graph (offline, instant) |
+| `sapiom_dev_agents_run_local` | Runs real step code with all capabilities stubbed — free, no spend |
+
+Then ship:
+
+| Command | What it does |
+|---|---|
+| `sapiom_dev_agents_link` | Registers the agent under your tenant |
+| `sapiom_dev_agents_deploy` | Builds and deploys to Sapiom's cloud |
+| `sapiom_dev_agents_run` | Starts a real (billed) execution |
+| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+
+## The Step Model — Hard Rules
+
+### Canonical API
+
+| Import | From |
+|---|---|
+| `defineAgent` | `@sapiom/agent` |
+| `defineStep` | `@sapiom/agent` |
+| `goto / terminate / fail / retry / pauseUntilSignal` | `@sapiom/agent` |
+| `AgentExecutionContext` | `@sapiom/agent` |
+| `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
+
+**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
+`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+
+### `defineAgent` shape
+
+```typescript
+export const agent = defineAgent({
+  name: "my-agent",      // string — used for logging and inspect
+  entry: "start",        // must name a key in steps
+  steps: { start, finish },
+});
+```
+
+Export exactly one `defineAgent(...)` from `index.ts`.
+
+### `defineStep` fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | `string` | yes | Step's id; must match its key in the steps object |
+| `next` | `readonly string[]` | yes | Step names this step may `goto`. Empty array if terminal |
+| `terminal` | `boolean` | no | `true` if this step ends the agent's execution |
+| `canFail` | `boolean` | no | Must be `true` to return `fail()` |
+| `pause` | `{ signal, resumeStep }` | no | Required when returning `pauseUntilSignal(...)` |
+| `inputSchema` | `ZodType` | no | Zod schema validating this step's input |
+| `timeoutMs` | `number` | no | Per-step timeout; no automatic retry cap |
+| `run(input, ctx)` | `async function` | yes | Returns a directive |
+
+Import Zod via the `zod/v4` subpath — `import { z } from "zod/v4"` — to match the SDK's
+schema types. Don't import from bare `"zod"` or add a second zod dependency.
+
+### Directives — what `run` must return
+
+| Directive | Function | Constraint |
+|---|---|---|
+| `goto(target, output?)` | Advance to another step | `target` must be in `next[]` |
+| `terminate(output?, opts?)` | End the execution successfully | Step must have `terminal: true` |
+| `fail(reason?, opts?)` | End the execution as failed | Step must have `canFail: true` |
+| `retry(opts?)` | Re-run this step | Bound with `ctx.attempts` — no automatic cap |
+| `pauseUntilSignal(handle, opts?)` | Suspend until a signal fires | Step must declare `pause: { signal, resumeStep }` |
+
+TypeScript enforces these constraints at compile time — a `terminate` in a non-terminal step,
+or a `fail` without `canFail: true`, is a type error.
+
+### Minimal two-step example
+
+```typescript
+import { defineAgent, defineStep, goto, terminate } from "@sapiom/agent";
+
+const start = defineStep({
+  name: "start",
+  next: ["finish"],
+  async run(input: { name: string }, ctx) {
+    ctx.logger.info("got input", { name: input.name });
+    return goto("finish", { greeting: `Hello, ${input.name}` });
+  },
+});
+
+const finish = defineStep({
+  name: "finish",
+  next: [],
+  terminal: true,
+  async run(input: { greeting: string }, ctx) {
+    return terminate({ result: input.greeting });
+  },
+});
+
+export const agent = defineAgent({
+  name: "greet",
+  entry: "start",
+  steps: { start, finish },
+});
+```
+
+## Cross-Step State with `ctx.shared`
+
+`goto(target, payload)` passes data to the next step's `input`. For data multiple downstream
+steps need, use `ctx.shared` — a typed key/value store that persists across the whole execution.
+
+```typescript
+interface Shared extends Record<string, unknown> {
+  taskId: string;
+}
+
+// In a step:
+ctx.shared.set("taskId", "abc-123");
+
+// In a later step:
+const taskId = ctx.shared.get("taskId"); // typed as string | undefined
+```
+
+`ctx.shared` API: `get(key)`, `set(key, value)`, `has(key)`, `snapshot()`.
+
+**A step's `run(input, ctx)` first argument is its inbound input** — the entry input at the
+entry step, or the previous step's `goto(target, payload)` value at later steps. The entry
+input reaches only the entry step's argument; to use it in later steps, write it into
+`ctx.shared` from the entry step.
+
+## `ctx` Reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `ctx.executionId` | `string` | Unique id for this execution |
+| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
+| `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
+| `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
+| `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
+| `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.organizationId` | `string \| null` | Tenant org |
+| `ctx.tenantId` | `string \| null` | Tenant id |
+
+## Capabilities from Steps
+
+Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
+coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
+databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
+types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the full catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+
+## Failure Handling & Retries
+
+There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
+The common pattern is a bounded loop that escalates:
+
+```typescript
+const reconsider = defineStep({
+  name: "reconsider",
+  next: ["work", "escalate"],
+  async run(_input, ctx: AgentExecutionContext<{ attempt: number }>) {
+    const attempt = ctx.shared.get("attempt") ?? 0;
+    if (attempt >= 3) return goto("escalate", {});
+    ctx.shared.set("attempt", attempt + 1);
+    return goto("work", {});
+  },
+});
+```
+
+For a step's own retries (transient errors):
+
+```typescript
+async run(input, ctx) {
+  try {
+    const result = await ctx.sapiom.sandboxes.create({ name: "demo" });
+    return terminate({ result });
+  } catch (err) {
+    // ctx.attempts is 0-indexed: `+ 1 < N` gives exactly N total attempts.
+    // (`ctx.attempts < N` would run N+1 times — a common off-by-one.)
+    if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+    return fail("too many attempts");  // requires canFail: true
+  }
+}
+```
+
+`timeoutMs` on a step caps how long its `run` may take. There is no engine-level retry cap —
+you own the bound.
+
+## Pause & Resume (Long-Running Dispatched Steps)
+
+A step's `run` completes in one synchronous dispatch. For long-running capabilities (a
+dispatched coding-model run), **launch fire-and-forget and pause** — the engine suspends the
+execution until the result signal fires, then resumes into a designated step whose `input`
+IS the result payload.
+
+```typescript
+import {
+  defineAgent, defineStep, goto, pauseUntilSignal, terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+}
+
+const launch = defineStep({
+  name: "launch",
+  next: ["collect"],
+  // Declare the signal and resume step so the engine knows what to wait for.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "collect" },
+  async run(input: { task: string }, ctx: AgentExecutionContext<Shared>) {
+    const repo = await ctx.sapiom.repositories.create("my-repo");
+    ctx.shared.set("repoSlug", repo.slug);               // stash before pausing
+    const run = await ctx.sapiom.models.coding.launch({ task: input.task, gitRepository: repo });
+    return pauseUntilSignal(run, { resumeStep: "collect" }); // pass the handle, not the signal name
+  },
+});
+
+const collect = defineStep({
+  name: "collect",
+  next: [],
+  terminal: true,
+  // input IS the CodingResultPayload delivered by the resume signal.
+  async run(result: CodingResultPayload, ctx: AgentExecutionContext<Shared>) {
+    if (result.status !== "completed") {
+      return terminate({ status: result.status, error: result.error });
+    }
+    // Re-attach the sandbox — the payload crossed a wire boundary, so there are no live handles.
+    if (result.executionEnvironment?.type === "blaxel_sandbox") {
+      const sandbox = ctx.sapiom.sandboxes.attach(result.executionEnvironment.id);
+      // … push from sandbox, read files, etc.
+    }
+    return terminate({ status: result.status, summary: result.summary });
+  },
+});
+
+export const agent = defineAgent<{ task: string }, Shared>({
+  name: "code-and-collect",
+  entry: "launch",
+  steps: { launch, collect },
+});
+```
+
+Key rules:
+
+- `pause: { signal, resumeStep }` is **required** on the step that returns `pauseUntilSignal`.
+  Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
+- The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
+  Annotate it explicitly — don't hand-roll the shape.
+- The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
+  `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
+- For a **manual human-gate** (no capability handle), use the object form and fire the signal
+  from your approval flow:
+
+```typescript
+return pauseUntilSignal({
+  signal: "my.approval",
+  resumeStep: "finalize",
+  correlationId: ctx.executionId,  // makes the awaited signal unique to this execution
+});
+```
+
+Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual gate
+auto-resumes with `{}` unless stubbed — type the resumed step's input with optional fields
+accordingly.
+
+## Determinism
+
+A step body runs **once** on the happy path. It re-runs only on retry (after a throw or
+`retry()`). Do not rely on a value being recomputed identically across a pause/resume or a
+retry. Capture non-deterministic values (timestamps, random ids) once and carry them forward
+via `goto` input or `ctx.shared`.
+
+## Testing with `run_local` and Stubs
+
+`run_local` works with **no stubs** — capabilities return sensible defaults. Add
+`.sapiom-dev/stubs.json` overrides only when a step branches on a specific result:
+
+```jsonc
+{
+  "version": 1,
+  "steps": {
+    // Stub the coding run under the LAUNCHING step (here `launch`), not the resume step.
+    "launch": {
+      "models.coding.run": { "status": "completed", "summary": "done", "result": null, "error": null, "executionEnvironment": null }
+    },
+    "check": {
+      "repositories.list": [{ "slug": "my-repo", "cloneUrl": "https://..." }]
+    }
+  }
+}
+```
+
+Stub naming rules:
+
+- Namespace calls use the **plural/namespace path**: `repositories.list`, `models.coding.run`.
+- Handle method calls use the **singular**: `repository.pushFromSandbox`, `sandbox.exec`.
+- To stub a coding run's resume payload, override `models.coding.run` (or
+  `models.coding.launch`) in the **launching step** — that value is both the inline result
+  and the payload the paused step resumes with.
+- `run_local` reports `unusedStubs` (key matched nothing — usually a typo or plural/singular
+  slip) and `stubWarnings` (key matched but wrong shape). A green run with either non-empty
+  means the stub silently didn't apply.
+- **Local retry cap:** the `run_local` tool defaults to `maxAttemptsPerStep: 3`. If a step's
+  own retry bound allows ≥3 retries, pass a higher `maxAttemptsPerStep` so the local harness
+  doesn't stop the loop before your `fail()` fires. This cap is local-test only — production
+  has no engine-level retry cap.
+
+Write each step the way it should run in production — never weaken logic to shape a local run.
+
+## Tips
+
+- **Types are the source of truth.** What's on `ctx.sapiom` is defined by `@sapiom/tools`.
+  Use autocomplete and `npm run typecheck` rather than guessing — a wrong capability name is
+  a type error, not a runtime surprise.
+- **`check` before deploy.** It validates the step graph (names, `next` references,
+  `terminal` consistency) — a misconfigured graph is caught here, not at runtime.
+- **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
+- **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
+  `ctx.shared` in the entry step — don't thread it through every `goto` payload.
+- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
+  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
+  find the right one) or the SDK instead of scaffolding.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Cannot find module '@sapiom/agent'` | Deps not installed | `npm install` inside the scaffolded dir |
+| Type error: `fail(...)` not assignable | Step missing `canFail: true` | Add `canFail: true` to `defineStep` |
+| Type error: `terminate(...)` not assignable | Step missing `terminal: true` | Add `terminal: true` to `defineStep` |
+| `goto` target rejected by types | Target not in `next[]` | Add the target name to `next` |
+| `check` fails: step missing from graph | `steps` object key doesn't match `name` field | Match the key in `steps: { start }` to `defineStep({ name: "start" })` |
+| `run_local` reports `unusedStubs` | Stub path typo or namespace/handle mix-up | Namespace path for calls (`repositories.list`), singular for handles (`repository.pushFromSandbox`) |
+| Paused step resumes with empty input | Manual gate; `run_local` auto-resumes with `{}` | Type the resumed step's input with optional fields |
+| `sapiom_authenticate` → credential not found at deploy | Authenticated in a different shell | Re-run `sapiom_authenticate`; credential is per-machine in `~/.sapiom/credentials.json` |
+
+## References
+
+| Resource | What it covers |
+|---|---|
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start) | Scaffold → write → test → deploy walkthrough |
+| [Capabilities](https://docs.sapiom.ai/capabilities) | The full `ctx.sapiom.*` catalog with pricing |
+| `AGENTS.md` in your scaffold | The quick in-project reference |

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -191,13 +191,13 @@ input reaches only the entry step's argument; to use it in later steps, write it
 | Field | Type | Notes |
 |---|---|---|
 | `ctx.executionId` | `string` | Unique id for this execution |
-| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.agentName` | `string` | The agent's `name` |
 | `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
 | `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
 | `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
 | `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
 | `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
-| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — the `Sapiom` interface from `@sapiom/tools`, installed in your `node_modules` (see "Capabilities" below) |
 | `ctx.organizationId` | `string \| null` | Tenant org |
 | `ctx.tenantId` | `string \| null` | Tenant id |
 
@@ -206,9 +206,10 @@ input reaches only the entry step's argument; to use it in later steps, write it
 Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
 coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
 databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
-rejects what doesn't, and the full catalog with pricing lives at
-[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
+— installed in your project's `node_modules`, so its types match the exact version you're on.
+`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
+catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
 ## Failure Handling & Retries
 

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -88,9 +88,7 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
-are its deprecated pre-launch names (still visible on npm and in older projects; never use or
-install them).
+`@sapiom/agent` is the only authoring package.
 
 ### `defineAgent` shape
 

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -1,6 +1,8 @@
-# Working in this orchestration
+# Working in this agent project
 
-This project defines exactly one Sapiom orchestration in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+This project defines exactly one Sapiom agent in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+
+The full authoring guide ships inside this project at `.claude/skills/sapiom-agent-authoring/SKILL.md` — read it for the step model, directives, failure patterns, pause/resume, and stub rules.
 
 ## Authoring
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -88,8 +88,9 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
-`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
+are its deprecated pre-launch names (still visible on npm and in older projects; never use or
+install them).
 
 ### `defineAgent` shape
 
@@ -382,8 +383,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
-  find the right one) or the SDK instead of scaffolding.
+  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
+  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -382,8 +382,8 @@ Write each step the way it should run in production — never weaken logic to sh
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
 - **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
   [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the SDK
-  ([`@sapiom/fetch`](https://www.npmjs.com/package/@sapiom/fetch)) instead of scaffolding.
+  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
+  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
 
 ## Troubleshooting
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: sapiom-agent-authoring
+description: Build, test, and deploy a Sapiom agent — a controlled, multi-step,
+  deployable automation defined in TypeScript. Use when the user wants to
+  automate a multi-step, scheduled, recurring, or deployable task ("build an
+  agent that checks competitor prices every morning", "automate our weekly
+  report", "make a bot that reviews PRs"), or names Sapiom, defineAgent,
+  @sapiom/agent, or the sapiom-dev MCP. Also use to run, inspect, or resume an
+  existing Sapiom agent. Do NOT use for a single one-off capability call
+  (a web search, one scrape, one image) with no automation to keep — use
+  Sapiom's remote MCP or SDK for that.
+---
+
+# Building Sapiom Agents
+
+A Sapiom **agent** is a small TypeScript project you author with your coding agent: a
+`defineAgent({ name, entry, steps })` where each step's `run(input, ctx)` does work — calling
+paid Sapiom capabilities through the typed `ctx.sapiom.*` client — and returns a directive.
+You test it locally for free, then deploy it to run on Sapiom's cloud: on demand, on a
+schedule, or resumed by signals. All from the terminal; no dashboard required.
+
+**Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
+scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
+
+## If the Sapiom dev MCP isn't connected yet
+
+The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
+(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+
+```bash
+claude mcp add sapiom -- npx -y @sapiom/mcp
+```
+
+Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
+[docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+
+## Lifecycle from Zero
+
+### 1. Authenticate (required before deploy/run)
+
+Run `sapiom_authenticate` — it opens a browser login and caches an API key in
+`~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
+API-key principal; deployed agents inherit that authority to call paid capabilities.
+
+### 2. Scaffold
+
+Call `sapiom_dev_agents_scaffold` with a target directory. The scaffold writes:
+
+```
+my-agent/
+├── index.ts            # your agent definition (edit this)
+├── AGENTS.md           # quick in-project reference
+├── CLAUDE.md           # points your coding agent at AGENTS.md
+├── .claude/skills/     # this skill, locally — the deep guide
+├── .sapiom-dev/stubs.json
+├── package.json / tsconfig.json / ...
+```
+
+Install deps: `npm install`. Templates: `"default"` (minimal two-step starter) or
+`"coding-pause"` (launch + pause/resume coding-model pattern).
+
+### 3. Write steps → typecheck → check → run_local → deploy
+
+| Command | What it does |
+|---|---|
+| `npm run typecheck` | Confirms types compile and every `ctx.sapiom.*` call exists |
+| `sapiom_dev_agents_check` | Bundles `index.ts` + validates the step graph (offline, instant) |
+| `sapiom_dev_agents_run_local` | Runs real step code with all capabilities stubbed — free, no spend |
+
+Then ship:
+
+| Command | What it does |
+|---|---|
+| `sapiom_dev_agents_link` | Registers the agent under your tenant |
+| `sapiom_dev_agents_deploy` | Builds and deploys to Sapiom's cloud |
+| `sapiom_dev_agents_run` | Starts a real (billed) execution |
+| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+
+## The Step Model — Hard Rules
+
+### Canonical API
+
+| Import | From |
+|---|---|
+| `defineAgent` | `@sapiom/agent` |
+| `defineStep` | `@sapiom/agent` |
+| `goto / terminate / fail / retry / pauseUntilSignal` | `@sapiom/agent` |
+| `AgentExecutionContext` | `@sapiom/agent` |
+| `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
+
+**NEVER use `defineWorkflow`, `defineOrchestration`, `@sapiom/workflow-sdk`, or
+`@sapiom/orchestration`** — those are stale names. The correct package is `@sapiom/agent`.
+
+### `defineAgent` shape
+
+```typescript
+export const agent = defineAgent({
+  name: "my-agent",      // string — used for logging and inspect
+  entry: "start",        // must name a key in steps
+  steps: { start, finish },
+});
+```
+
+Export exactly one `defineAgent(...)` from `index.ts`.
+
+### `defineStep` fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | `string` | yes | Step's id; must match its key in the steps object |
+| `next` | `readonly string[]` | yes | Step names this step may `goto`. Empty array if terminal |
+| `terminal` | `boolean` | no | `true` if this step ends the agent's execution |
+| `canFail` | `boolean` | no | Must be `true` to return `fail()` |
+| `pause` | `{ signal, resumeStep }` | no | Required when returning `pauseUntilSignal(...)` |
+| `inputSchema` | `ZodType` | no | Zod schema validating this step's input |
+| `timeoutMs` | `number` | no | Per-step timeout; no automatic retry cap |
+| `run(input, ctx)` | `async function` | yes | Returns a directive |
+
+Import Zod via the `zod/v4` subpath — `import { z } from "zod/v4"` — to match the SDK's
+schema types. Don't import from bare `"zod"` or add a second zod dependency.
+
+### Directives — what `run` must return
+
+| Directive | Function | Constraint |
+|---|---|---|
+| `goto(target, output?)` | Advance to another step | `target` must be in `next[]` |
+| `terminate(output?, opts?)` | End the execution successfully | Step must have `terminal: true` |
+| `fail(reason?, opts?)` | End the execution as failed | Step must have `canFail: true` |
+| `retry(opts?)` | Re-run this step | Bound with `ctx.attempts` — no automatic cap |
+| `pauseUntilSignal(handle, opts?)` | Suspend until a signal fires | Step must declare `pause: { signal, resumeStep }` |
+
+TypeScript enforces these constraints at compile time — a `terminate` in a non-terminal step,
+or a `fail` without `canFail: true`, is a type error.
+
+### Minimal two-step example
+
+```typescript
+import { defineAgent, defineStep, goto, terminate } from "@sapiom/agent";
+
+const start = defineStep({
+  name: "start",
+  next: ["finish"],
+  async run(input: { name: string }, ctx) {
+    ctx.logger.info("got input", { name: input.name });
+    return goto("finish", { greeting: `Hello, ${input.name}` });
+  },
+});
+
+const finish = defineStep({
+  name: "finish",
+  next: [],
+  terminal: true,
+  async run(input: { greeting: string }, ctx) {
+    return terminate({ result: input.greeting });
+  },
+});
+
+export const agent = defineAgent({
+  name: "greet",
+  entry: "start",
+  steps: { start, finish },
+});
+```
+
+## Cross-Step State with `ctx.shared`
+
+`goto(target, payload)` passes data to the next step's `input`. For data multiple downstream
+steps need, use `ctx.shared` — a typed key/value store that persists across the whole execution.
+
+```typescript
+interface Shared extends Record<string, unknown> {
+  taskId: string;
+}
+
+// In a step:
+ctx.shared.set("taskId", "abc-123");
+
+// In a later step:
+const taskId = ctx.shared.get("taskId"); // typed as string | undefined
+```
+
+`ctx.shared` API: `get(key)`, `set(key, value)`, `has(key)`, `snapshot()`.
+
+**A step's `run(input, ctx)` first argument is its inbound input** — the entry input at the
+entry step, or the previous step's `goto(target, payload)` value at later steps. The entry
+input reaches only the entry step's argument; to use it in later steps, write it into
+`ctx.shared` from the entry step.
+
+## `ctx` Reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `ctx.executionId` | `string` | Unique id for this execution |
+| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
+| `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
+| `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
+| `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
+| `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.organizationId` | `string \| null` | Tenant org |
+| `ctx.tenantId` | `string \| null` | Tenant id |
+
+## Capabilities from Steps
+
+Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
+coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
+databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
+types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the full catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+
+## Failure Handling & Retries
+
+There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
+The common pattern is a bounded loop that escalates:
+
+```typescript
+const reconsider = defineStep({
+  name: "reconsider",
+  next: ["work", "escalate"],
+  async run(_input, ctx: AgentExecutionContext<{ attempt: number }>) {
+    const attempt = ctx.shared.get("attempt") ?? 0;
+    if (attempt >= 3) return goto("escalate", {});
+    ctx.shared.set("attempt", attempt + 1);
+    return goto("work", {});
+  },
+});
+```
+
+For a step's own retries (transient errors):
+
+```typescript
+async run(input, ctx) {
+  try {
+    const result = await ctx.sapiom.sandboxes.create({ name: "demo" });
+    return terminate({ result });
+  } catch (err) {
+    // ctx.attempts is 0-indexed: `+ 1 < N` gives exactly N total attempts.
+    // (`ctx.attempts < N` would run N+1 times — a common off-by-one.)
+    if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+    return fail("too many attempts");  // requires canFail: true
+  }
+}
+```
+
+`timeoutMs` on a step caps how long its `run` may take. There is no engine-level retry cap —
+you own the bound.
+
+## Pause & Resume (Long-Running Dispatched Steps)
+
+A step's `run` completes in one synchronous dispatch. For long-running capabilities (a
+dispatched coding-model run), **launch fire-and-forget and pause** — the engine suspends the
+execution until the result signal fires, then resumes into a designated step whose `input`
+IS the result payload.
+
+```typescript
+import {
+  defineAgent, defineStep, goto, pauseUntilSignal, terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+}
+
+const launch = defineStep({
+  name: "launch",
+  next: ["collect"],
+  // Declare the signal and resume step so the engine knows what to wait for.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "collect" },
+  async run(input: { task: string }, ctx: AgentExecutionContext<Shared>) {
+    const repo = await ctx.sapiom.repositories.create("my-repo");
+    ctx.shared.set("repoSlug", repo.slug);               // stash before pausing
+    const run = await ctx.sapiom.models.coding.launch({ task: input.task, gitRepository: repo });
+    return pauseUntilSignal(run, { resumeStep: "collect" }); // pass the handle, not the signal name
+  },
+});
+
+const collect = defineStep({
+  name: "collect",
+  next: [],
+  terminal: true,
+  // input IS the CodingResultPayload delivered by the resume signal.
+  async run(result: CodingResultPayload, ctx: AgentExecutionContext<Shared>) {
+    if (result.status !== "completed") {
+      return terminate({ status: result.status, error: result.error });
+    }
+    // Re-attach the sandbox — the payload crossed a wire boundary, so there are no live handles.
+    if (result.executionEnvironment?.type === "blaxel_sandbox") {
+      const sandbox = ctx.sapiom.sandboxes.attach(result.executionEnvironment.id);
+      // … push from sandbox, read files, etc.
+    }
+    return terminate({ status: result.status, summary: result.summary });
+  },
+});
+
+export const agent = defineAgent<{ task: string }, Shared>({
+  name: "code-and-collect",
+  entry: "launch",
+  steps: { launch, collect },
+});
+```
+
+Key rules:
+
+- `pause: { signal, resumeStep }` is **required** on the step that returns `pauseUntilSignal`.
+  Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
+- The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
+  Annotate it explicitly — don't hand-roll the shape.
+- The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
+  `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
+- For a **manual human-gate** (no capability handle), use the object form and fire the signal
+  from your approval flow:
+
+```typescript
+return pauseUntilSignal({
+  signal: "my.approval",
+  resumeStep: "finalize",
+  correlationId: ctx.executionId,  // makes the awaited signal unique to this execution
+});
+```
+
+Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual gate
+auto-resumes with `{}` unless stubbed — type the resumed step's input with optional fields
+accordingly.
+
+## Determinism
+
+A step body runs **once** on the happy path. It re-runs only on retry (after a throw or
+`retry()`). Do not rely on a value being recomputed identically across a pause/resume or a
+retry. Capture non-deterministic values (timestamps, random ids) once and carry them forward
+via `goto` input or `ctx.shared`.
+
+## Testing with `run_local` and Stubs
+
+`run_local` works with **no stubs** — capabilities return sensible defaults. Add
+`.sapiom-dev/stubs.json` overrides only when a step branches on a specific result:
+
+```jsonc
+{
+  "version": 1,
+  "steps": {
+    // Stub the coding run under the LAUNCHING step (here `launch`), not the resume step.
+    "launch": {
+      "models.coding.run": { "status": "completed", "summary": "done", "result": null, "error": null, "executionEnvironment": null }
+    },
+    "check": {
+      "repositories.list": [{ "slug": "my-repo", "cloneUrl": "https://..." }]
+    }
+  }
+}
+```
+
+Stub naming rules:
+
+- Namespace calls use the **plural/namespace path**: `repositories.list`, `models.coding.run`.
+- Handle method calls use the **singular**: `repository.pushFromSandbox`, `sandbox.exec`.
+- To stub a coding run's resume payload, override `models.coding.run` (or
+  `models.coding.launch`) in the **launching step** — that value is both the inline result
+  and the payload the paused step resumes with.
+- `run_local` reports `unusedStubs` (key matched nothing — usually a typo or plural/singular
+  slip) and `stubWarnings` (key matched but wrong shape). A green run with either non-empty
+  means the stub silently didn't apply.
+- **Local retry cap:** the `run_local` tool defaults to `maxAttemptsPerStep: 3`. If a step's
+  own retry bound allows ≥3 retries, pass a higher `maxAttemptsPerStep` so the local harness
+  doesn't stop the loop before your `fail()` fires. This cap is local-test only — production
+  has no engine-level retry cap.
+
+Write each step the way it should run in production — never weaken logic to shape a local run.
+
+## Tips
+
+- **Types are the source of truth.** What's on `ctx.sapiom` is defined by `@sapiom/tools`.
+  Use autocomplete and `npm run typecheck` rather than guessing — a wrong capability name is
+  a type error, not a runtime surprise.
+- **`check` before deploy.** It validates the step graph (names, `next` references,
+  `terminal` consistency) — a misconfigured graph is caught here, not at runtime.
+- **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
+- **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
+  `ctx.shared` in the entry step — don't thread it through every `goto` payload.
+- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
+  remote MCP (`https://api.sapiom.ai/v1/mcp`, direct `sapiom_*` tools, `tool_discover` to
+  find the right one) or the SDK instead of scaffolding.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Cannot find module '@sapiom/agent'` | Deps not installed | `npm install` inside the scaffolded dir |
+| Type error: `fail(...)` not assignable | Step missing `canFail: true` | Add `canFail: true` to `defineStep` |
+| Type error: `terminate(...)` not assignable | Step missing `terminal: true` | Add `terminal: true` to `defineStep` |
+| `goto` target rejected by types | Target not in `next[]` | Add the target name to `next` |
+| `check` fails: step missing from graph | `steps` object key doesn't match `name` field | Match the key in `steps: { start }` to `defineStep({ name: "start" })` |
+| `run_local` reports `unusedStubs` | Stub path typo or namespace/handle mix-up | Namespace path for calls (`repositories.list`), singular for handles (`repository.pushFromSandbox`) |
+| Paused step resumes with empty input | Manual gate; `run_local` auto-resumes with `{}` | Type the resumed step's input with optional fields |
+| `sapiom_authenticate` → credential not found at deploy | Authenticated in a different shell | Re-run `sapiom_authenticate`; credential is per-machine in `~/.sapiom/credentials.json` |
+
+## References
+
+| Resource | What it covers |
+|---|---|
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start) | Scaffold → write → test → deploy walkthrough |
+| [Capabilities](https://docs.sapiom.ai/capabilities) | The full `ctx.sapiom.*` catalog with pricing |
+| `AGENTS.md` in your scaffold | The quick in-project reference |

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -191,13 +191,13 @@ input reaches only the entry step's argument; to use it in later steps, write it
 | Field | Type | Notes |
 |---|---|---|
 | `ctx.executionId` | `string` | Unique id for this execution |
-| `ctx.workflowName` | `string` | The agent's `name` (field name predates the rename) |
+| `ctx.agentName` | `string` | The agent's `name` |
 | `ctx.input` | `unknown` | The execution's entry input — same value the entry step's `run` arg receives. Use `ctx.shared` to carry it forward; don't rely on `ctx.input` downstream. |
 | `ctx.shared` | `TypedContextStore<TShared>` | Cross-step key/value store |
 | `ctx.history` | `readonly StepExecutionRecord[]` | Previous steps' records |
 | `ctx.attempts` | `number` | How many times this step has run (0-indexed) |
 | `ctx.logger` | `StepLogger` | `info / warn / error / debug(msg, meta?)` |
-| `ctx.sapiom` | `Sapiom` | The typed capability client — see "Capabilities" below |
+| `ctx.sapiom` | `Sapiom` | The typed capability client — the `Sapiom` interface from `@sapiom/tools`, installed in your `node_modules` (see "Capabilities" below) |
 | `ctx.organizationId` | `string \| null` | Tenant org |
 | `ctx.tenantId` | `string \| null` | Tenant id |
 
@@ -206,9 +206,10 @@ input reaches only the entry step's argument; to use it in later steps, write it
 Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
 coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
 databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
-rejects what doesn't, and the full catalog with pricing lives at
-[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
+— installed in your project's `node_modules`, so its types match the exact version you're on.
+`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
+catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
 ## Failure Handling & Retries
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -88,9 +88,7 @@ Then ship:
 | `AgentExecutionContext` | `@sapiom/agent` |
 | `CODING_RESULT_SIGNAL / CodingResultPayload` | `@sapiom/tools` |
 
-`@sapiom/agent` is the only authoring package — `defineOrchestration` / `@sapiom/orchestration`
-are its deprecated pre-launch names (still visible on npm and in older projects; never use or
-install them).
+`@sapiom/agent` is the only authoring package.
 
 ### `defineAgent` shape
 

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -1,6 +1,8 @@
-# Working in this orchestration
+# Working in this agent project
 
-This project defines exactly one Sapiom orchestration in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+This project defines exactly one Sapiom agent in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+
+The full authoring guide ships inside this project at `.claude/skills/sapiom-agent-authoring/SKILL.md` — read it for the step model, directives, failure patterns, pause/resume, and stub rules.
 
 ## Authoring
 

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -27,18 +27,20 @@ describe("server instructions", () => {
     // Lifecycle tools an agent must drive
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_authenticate");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_scaffold");
-    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_clone");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_run_local");
-    // Canonical naming (and the stale name it must steer away from)
+    // Canonical naming (and the stale names it must steer away from)
     expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/agent");
     expect(AUTHORING_INSTRUCTIONS).toContain("defineAgent");
     // the stale names appear only inside the explicit "NEVER use" warning
     expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
-    // Pointer to the full docs + the scaffold guide
-    expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/workflows");
+    expect(AUTHORING_INSTRUCTIONS).toContain("`@sapiom/orchestration` (stale names)");
+    // Pointer to the full docs + the scaffold-shipped guidance (AGENTS.md + skill)
+    expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/agents");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom-agent-authoring");
     // The two-MCP frame: agents learn the remote MCP exists for direct tool calls
     expect(AUTHORING_INSTRUCTIONS).toContain("remote MCP");
     expect(AUTHORING_INSTRUCTIONS).toContain("api.sapiom.ai/v1/mcp");
+    expect(AUTHORING_INSTRUCTIONS).toContain("tool_discover");
   });
 });

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -32,9 +32,9 @@ describe("server instructions", () => {
     // Canonical naming (and the stale names it must steer away from)
     expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/agent");
     expect(AUTHORING_INSTRUCTIONS).toContain("defineAgent");
-    // the stale names appear only inside the explicit "NEVER use" warning
-    expect(AUTHORING_INSTRUCTIONS).toContain("NEVER `defineWorkflow`");
-    expect(AUTHORING_INSTRUCTIONS).toContain("`@sapiom/orchestration` (stale names)");
+    // the old package names are gone entirely — new users never see them
+    expect(AUTHORING_INSTRUCTIONS).not.toContain("defineOrchestration");
+    expect(AUTHORING_INSTRUCTIONS).not.toContain("@sapiom/orchestration");
     // Pointer to the full docs + the scaffold-shipped guidance (AGENTS.md + skill)
     expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/agents");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -27,6 +27,7 @@ describe("server instructions", () => {
     // Lifecycle tools an agent must drive
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_authenticate");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_scaffold");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_clone");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_run_local");
     // Canonical naming (and the stale names it must steer away from)
     expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/agent");

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -29,7 +29,7 @@ capability call** without an agent (a search, a scrape, one image), or from **ho
 that cannot run npx** (ChatGPT), use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
 (\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
 capability as a direct \`sapiom_*\` tool (run \`tool_discover\` to find the right one) plus cloud
-agent tools (\`sapiom_agent_*\`: create → deploy with a \`files\` map → execute → inspect/signal).
+workflow tools (\`sapiom_workflow_*\`: create → deploy with a \`files\` map → run → inspect/signal).
 Rule of thumb: author an agent for anything multi-step, scheduled, or deployable; use the
 remote MCP or the SDK for a single action.
 

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -1,52 +1,61 @@
 /**
  * The MCP server `instructions` string, returned during the `initialize` handshake.
  * Capable MCP clients surface it to the model on connect, so an agent that adds this
- * server gets a workflow-authoring primer without any extra setup.
+ * server gets an agent-authoring primer without any extra setup.
  *
- * Kept intentionally short — it stays in the model's context for the whole session, and
- * points to the full documentation and the `AGENTS.md` generated into each scaffolded
- * project rather than restating them.
+ * This is the OFFLINE FALLBACK: at startup the server fetches the live copy from
+ * `GET {apiURL}/v1/mcp/instructions` (see instructions-fetch.ts) and serves that;
+ * this constant is served only when the fetch fails. KEEP IT IDENTICAL to the
+ * backend's `DEFAULT_MCP_INSTRUCTIONS` (Sapiom repo,
+ * backend/src/mcp/mcp-instructions.constants.ts) — the two are one canonical text.
+ *
+ * Kept intentionally short — it stays in the model's context for the whole session.
+ * Deep authoring guidance lives in the scaffold-shipped `sapiom-agent-authoring`
+ * skill and `AGENTS.md`, and the full reference on docs.sapiom.ai; this primer
+ * points there rather than restating them.
  */
 export const AUTHORING_INSTRUCTIONS = `# Sapiom dev MCP (sapiom-dev)
 
-\`sapiom-dev\` is Sapiom's local developer MCP — the terminal surface for setting up and managing
-your Sapiom projects. Today it drives **workflow authoring** (more dev/management tools will land
-here over time): these tools build, test, and deploy a Sapiom workflow — a
-\`defineAgent({ name, entry, steps })\` (from \`@sapiom/agent\`) where each step's
-\`run(input, ctx)\` does work and returns a directive. All from the terminal; no dashboard.
+\`sapiom-dev\` is Sapiom's local developer MCP — the terminal surface for building and managing
+your Sapiom projects. Today it drives **agent authoring** (more dev/management tools will land
+here over time): build, test, and deploy a Sapiom agent — a \`defineAgent({ name, entry, steps })\`
+(from \`@sapiom/agent\`) where each step's \`run(input, ctx)\` does work and returns a directive.
+All from the terminal; no dashboard required.
 
 ## Two ways to use Sapiom
-This server (\`sapiom-dev\`) is where you **author workflows** — the
-\`sapiom_dev_agents_*\` tools build, test, and deploy them. For a **one-off capability call** without authoring a
-workflow, use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
+This server (\`sapiom-dev\`) is where you **author agents** — the \`sapiom_dev_agents_*\` tools
+scaffold, typecheck, run with stubs, and deploy from a local checkout. For a **one-off
+capability call** without an agent (a search, a scrape, one image), or from **hosted clients
+that cannot run npx** (ChatGPT), use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
 (\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
-capability as a direct \`sapiom_*\` tool (e.g. \`sapiom_search\`; run \`tool_discover\` to find the right one) — or call the gateway from code with the SDK
-(\`@sapiom/fetch\`). Rule of thumb: author a workflow for anything multi-step, scheduled, or
-deployable; use the remote MCP or the SDK for a single action.
+capability as a direct \`sapiom_*\` tool (run \`tool_discover\` to find the right one) plus cloud
+agent tools (\`sapiom_agent_*\`: create → deploy with a \`files\` map → execute → inspect/signal).
+Rule of thumb: author an agent for anything multi-step, scheduled, or deployable; use the
+remote MCP or the SDK for a single action.
 
 ## Lifecycle (in order)
 1. \`sapiom_authenticate\` — browser login; caches an API key (makes you an API-key principal,
    required for deploy/run). Confirm with \`sapiom_status\`.
-2. Start a project — either \`sapiom_dev_agents_scaffold\` (a fresh starter) or
-   \`sapiom_dev_agents_clone\` (materialize a gallery template / an existing fork — the
-   "use this template" handoff; forks + git-clones the repo and writes \`sapiom.json\`). READ the
-   project's \`AGENTS.md\` first; it is the full authoring guide. Then \`npm install\`.
-3. Test for free: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (validates the step
-   graph, offline) → \`sapiom_dev_agents_run_local\` (capabilities are stubbed; zero spend).
+2. \`sapiom_dev_agents_scaffold\` — writes the project, including the full authoring guide:
+   read \`AGENTS.md\` first, and the \`sapiom-agent-authoring\` skill in \`.claude/skills/\`
+   (auto-loads in Claude Code). Then \`npm install\`.
+3. Test for free: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (validates the step graph,
+   offline) → \`sapiom_dev_agents_run_local\` (capabilities are stubbed; zero spend).
 4. Ship: \`sapiom_dev_agents_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.
 
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives
   (\`goto\` / \`terminate\` / \`fail\` / \`retry\` / \`pauseUntilSignal\`) from \`@sapiom/agent\`.
-  NEVER \`defineWorkflow\` or \`@sapiom/workflow-sdk\` (they do not exist). Import Zod from \`zod/v4\`.
-- \`defineStep({ name, next, terminal?, canFail?, pause?, inputSchema?, run })\`:
-  \`terminate()\` requires \`terminal: true\`; \`fail()\` requires \`canFail: true\`;
-  \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\` target
-  must be listed in \`next[]\`. TypeScript enforces all of these.
+  NEVER \`defineWorkflow\`, \`defineOrchestration\`, or \`@sapiom/orchestration\` (stale names).
+  Import Zod from \`zod/v4\`.
+- \`terminate()\` requires \`terminal: true\`; \`fail()\` requires \`canFail: true\`;
+  \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\`
+  target must be listed in \`next[]\`. TypeScript enforces all of these.
 - Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
-- Capabilities run via \`ctx.sapiom.*\` (sandboxes, repositories, agent(+coding), agents,
-  fileStorage, contentGeneration.{images,video}, search, database) — a typed subset of the gateway
-  catalog; use autocomplete/typecheck.
+- Capabilities run via the typed \`ctx.sapiom.*\` client (sandboxes, repositories,
+  models.coding, fileStorage, search, database, and more) — don't memorize the catalog;
+  use autocomplete/typecheck.
 
-Full reference: https://docs.sapiom.ai/workflows/quick-start (authoring · capabilities · reference · examples)
-and the \`AGENTS.md\` inside your scaffolded project.`;
+Full reference: https://docs.sapiom.ai/agents/quick-start (authoring · capabilities ·
+reference · examples), plus the \`AGENTS.md\` and \`sapiom-agent-authoring\` skill inside
+your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -48,7 +48,6 @@ remote MCP or the SDK for a single action.
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives
   (\`goto\` / \`terminate\` / \`fail\` / \`retry\` / \`pauseUntilSignal\`) from \`@sapiom/agent\`.
-  NEVER \`defineWorkflow\`, \`defineOrchestration\`, or \`@sapiom/orchestration\` (stale names).
   Import Zod from \`zod/v4\`.
 - \`terminate()\` requires \`terminal: true\`; \`fail()\` requires \`canFail: true\`;
   \`pauseUntilSignal(handle, …)\` requires \`pause: { signal, resumeStep }\`; every \`goto\`

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -36,9 +36,11 @@ remote MCP or the SDK for a single action.
 ## Lifecycle (in order)
 1. \`sapiom_authenticate\` — browser login; caches an API key (makes you an API-key principal,
    required for deploy/run). Confirm with \`sapiom_status\`.
-2. \`sapiom_dev_agents_scaffold\` — writes the project, including the full authoring guide:
-   read \`AGENTS.md\` first, and the \`sapiom-agent-authoring\` skill in \`.claude/skills/\`
-   (auto-loads in Claude Code). Then \`npm install\`.
+2. Start a project — \`sapiom_dev_agents_scaffold\` (a fresh starter) or \`sapiom_dev_agents_clone\`
+   (materialize a gallery template or an existing fork — the "use this template" handoff).
+   READ the project's \`AGENTS.md\` first, plus the \`sapiom-agent-authoring\` skill in
+   \`.claude/skills/\` where present (scaffolded projects include it; auto-loads in Claude Code).
+   Then \`npm install\`.
 3. Test for free: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (validates the step graph,
    offline) → \`sapiom_dev_agents_run_local\` (capabilities are stubbed; zero spend).
 4. Ship: \`sapiom_dev_agents_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.


### PR DESCRIPTION
## ⚠️ Held draft — merge only in the agents/models rename train

Written against the **locked naming map** (`defineAgent`, `@sapiom/agent`, `sapiom_dev_agents_*`, `ctx.sapiom.models.coding`, executions). This branch is intentionally inconsistent with pre-rename `main`; it rebases onto the rename branch and merges in the same release window.

## What

1. **Canonical skill** `packages/orchestration-core/skills/sapiom-agent-authoring/SKILL.md` — task-shape trigger ("automate a multi-step / scheduled / deployable task…"), full authoring guide in the new vocabulary, MCP bootstrap step, capability *pointer* instead of a catalog enumeration (`ctx.sapiom.*` grew 8→11 namespaces in 10 days — enumerations rot).
2. **Both scaffold templates ship it** at `.claude/skills/sapiom-agent-authoring/` (auto-loads as a Claude Code project skill) + one `AGENTS.md` pointer line each. npm-pack dot-dir inclusion verified empirically; zero scaffold-code change (plain `cpSync`).
3. **`@sapiom/mcp` instructions fallback** rewritten to the canonical v2 text (identical to the backend constant PR for SAP-1367) — sapiom-dev identity, two-MCP frame with `tool_discover`, thinned to lifecycle + canonical rules + pointers.
4. **Drift guard**: `skill-sync.test.ts` asserts template copies === canonical.

## Rebase checks (verify against the rename branch at merge time)

- [ ] Export name/generics: `export const agent = defineAgent<...>` matches the renamed manifest loader
- [ ] Context type name `AgentExecutionContext` + `ctx.agentName` field
- [ ] Dev-tool suffixes (`_run_local`, `_run`, `_inspect`) as David ships them
- [ ] Remote cloud-tool names/verbs in the instructions' two-MCP paragraph (execute vs run — SAP-1363 ask #3)
- [ ] `CODING_RESULT_SIGNAL` / `CodingResultPayload` import home after the `agent`→`models` namespace move in @sapiom/tools
- [ ] Docs URLs `/agents/*` live (SAP-1368 ships redirects)

## Verification

- `pnpm --filter @sapiom/mcp test` → **68/68** (9 files, incl. updated instructions assertions)
- `pnpm --filter @sapiom/orchestration-core test` → all pass incl. new `skill-sync.test.ts`
- `pnpm --filter "@sapiom/orchestration-core..." build` → Done (note: bare `--filter @sapiom/orchestration-core build` fails on unbuilt workspace siblings — pre-existing build-order quirk, reproduced on clean main)
- npm pack dry-run: `.claude/skills/**` survives packing under `files:["templates"]`

Ticket: SAP-1365 (research + design decisions on the ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)