### PR TITLE
feat(orchestration-core): watchExecution() SSE async-iterator + live waitForExecution (SAP-1342)

### DIFF
--- a/packages/orchestration-core/src/client.ts
+++ b/packages/orchestration-core/src/client.ts
@@ -76,6 +76,62 @@ export class GatewayClient {
   post<T = unknown>(path: string, body?: unknown): Promise<T> {
     return this.request<T>('POST', path, body);
   }
+
+  /**
+   * Open a Server-Sent Events stream and return the raw {@link Response} so the
+   * caller can read `body` as it arrives (see `watchExecution`). Auth is the same
+   * `x-api-key` presented on every request — the engine sits behind the
+   * service-key proxy, so the SDK just presents its key. Handshake failures map
+   * to the same `OrchestrationError` shape as {@link request} (never a bare
+   * fetch rejection or a non-ok Response the caller has to re-inspect).
+   *
+   * The body is NOT consumed here: on success the live stream is handed back
+   * open. `signal` lets the caller abort the connection (iterator teardown);
+   * `lastEventId` is forwarded as the resume cursor (`Last-Event-ID`).
+   */
+  async openStream(
+    path: string,
+    opts: { signal?: AbortSignal; lastEventId?: string } = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      'x-api-key': this.apiKey,
+      accept: 'text/event-stream',
+    };
+    if (opts.lastEventId) {
+      headers['last-event-id'] = opts.lastEventId;
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(`${this.base}${path}`, { method: 'GET', headers, signal: opts.signal });
+    } catch (err) {
+      throw new OrchestrationError({
+        code: 'NETWORK',
+        message: `Could not reach ${this.base}.`,
+        hint: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      const data = text ? safeParse(text) : undefined;
+      throw new OrchestrationError({
+        code: `HTTP_${res.status}`,
+        message: messageFrom(data) ?? `Stream request failed (${res.status} ${res.statusText}).`,
+        hint:
+          res.status === 401 || res.status === 403
+            ? 'Check your API key (`sapiom login` or SAPIOM_API_KEY) and that it has access to this orchestration.'
+            : undefined,
+      });
+    }
+    if (!res.body) {
+      throw new OrchestrationError({
+        code: 'NETWORK',
+        message: `Stream at ${this.base}${path} returned no body.`,
+      });
+    }
+    return res;
+  }
 }
 
 /**

--- a/packages/orchestration-core/src/index.ts
+++ b/packages/orchestration-core/src/index.ts
@@ -78,7 +78,10 @@ export type {
   StepErrorTrace,
   StepErrorFrame,
   StepEvent,
+  SseEvent,
+  SseEventType,
 } from "./types.js";
+export { SSE_EVENT_TYPES } from "./types.js";
 
 // projection decode (tolerant normalization of the REST body) — the reusable
 // entry point consumers use to re-decode a body after an SSE refetch. The
@@ -102,6 +105,10 @@ export type {
   WaitForExecutionResult,
   WaitStopReason,
 } from "./inspect.js";
+
+// watch (networked) — live SSE async-iterator over a run's event channel
+export { watchExecution, parseSseFrame, parseSseEvent } from "./watch.js";
+export type { WatchExecutionOptions } from "./watch.js";
 
 // signal (networked)
 export { signal, parseSignalPayload } from "./signal.js";

--- a/packages/orchestration-core/src/inspect.spec.ts
+++ b/packages/orchestration-core/src/inspect.spec.ts
@@ -4,7 +4,7 @@
  */
 import type { GatewayClient } from "./client.js";
 import { isExecutionTerminal, waitForExecution } from "./inspect.js";
-import type { ExecutionProjection } from "./types.js";
+import type { ExecutionProjection, SseEvent } from "./types.js";
 
 /** A GatewayClient whose `get` returns the queued snapshots (last one repeats). */
 function fakeClient(snapshots: Partial<ExecutionProjection>[]): {
@@ -23,6 +23,22 @@ function fakeClient(snapshots: Partial<ExecutionProjection>[]): {
 }
 
 const noopSleep = () => Promise.resolve();
+
+/** A `watch` that yields the given events then completes. */
+function fakeWatch(events: SseEvent[]): NonNullable<
+  Parameters<typeof waitForExecution>[0]["watch"]
+> {
+  return async function* () {
+    for (const ev of events) yield ev;
+  };
+}
+
+const EV: SseEvent = {
+  type: "step.captured",
+  executionId: "e1",
+  traceRoot: null,
+  nodeId: "s1",
+};
 
 describe("isExecutionTerminal", () => {
   it("treats completed/failed as terminal and running/paused as not", () => {
@@ -95,6 +111,88 @@ describe("waitForExecution", () => {
     expect(res.reason).toBe("needs-signal");
     expect(res.done).toBe(false);
     expect(calls()).toBe(1); // returns immediately, no further polling
+  });
+
+  it("wakes on SSE events and refetches until terminal (live path)", async () => {
+    const { client, calls } = fakeClient([
+      { status: "running" }, // initial read
+      { status: "running" }, // after event 1
+      { status: "completed" }, // after event 2
+    ]);
+
+    const res = await waitForExecution(
+      {
+        executionId: "e1",
+        sleep: noopSleep,
+        now: () => 0,
+        watch: fakeWatch([EV, EV]),
+      },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+    // Initial read + one refetch per event; no poll sleeps were needed.
+    expect(calls()).toBe(3);
+  });
+
+  it("tears down the SSE iterator once the run settles", async () => {
+    const { client } = fakeClient([{ status: "running" }, { status: "completed" }]);
+    let torn = false;
+    // An infinite stream: only the consumer returning early can end it.
+    const watch: NonNullable<Parameters<typeof waitForExecution>[0]["watch"]> =
+      async function* () {
+        try {
+          for (;;) yield EV;
+        } finally {
+          torn = true;
+        }
+      };
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0, watch },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(torn).toBe(true);
+  });
+
+  it("reverts to polling when the SSE watch throws (SSE drop)", async () => {
+    const { client, calls } = fakeClient([
+      { status: "running" }, // initial read
+      { status: "completed" }, // poll-fallback read
+    ]);
+    const watch: NonNullable<Parameters<typeof waitForExecution>[0]["watch"]> =
+      // eslint-disable-next-line require-yield
+      async function* () {
+        throw new Error("SSE connection dropped");
+      };
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0, watch },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+    expect(calls()).toBe(2);
+  });
+
+  it("reverts to polling when the SSE stream ends without settling", async () => {
+    const { client, calls } = fakeClient([
+      { status: "running" }, // initial read
+      { status: "completed" }, // poll-fallback read
+    ]);
+
+    const res = await waitForExecution(
+      { executionId: "e1", sleep: noopSleep, now: () => 0, watch: fakeWatch([]) },
+      client,
+    );
+
+    expect(res.reason).toBe("terminal");
+    expect(res.done).toBe(true);
+    expect(calls()).toBe(2);
   });
 
   it("returns timeout (not done) when the budget elapses before terminal", async () => {

--- a/packages/orchestration-core/src/inspect.ts
+++ b/packages/orchestration-core/src/inspect.ts
@@ -7,7 +7,8 @@
  */
 import { GatewayClient } from "./client.js";
 import { decodeExecutionProjection, decodeExecutionRef } from "./decode.js";
-import type { ExecutionProjection, ExecutionRef } from "./types.js";
+import type { ExecutionProjection, ExecutionRef, SseEvent } from "./types.js";
+import { watchExecution } from "./watch.js";
 
 export interface BuildDetail {
   id?: string;
@@ -67,15 +68,24 @@ export type WaitStopReason = "terminal" | "needs-signal" | "timeout";
 
 export interface WaitForExecutionOptions {
   executionId: string;
-  /** Max wall-clock to poll before returning the latest snapshot. Default 45_000. */
+  /** Max wall-clock to wait before returning the latest snapshot. Default 45_000. */
   maxWaitMs?: number;
-  /** First poll interval; backs off (×1.5, capped at 5s) between reads. Default 1_000. */
+  /** Poll-fallback interval; backs off (×1.5, capped at 5s) between reads. Default 1_000. */
   pollMs?: number;
   /** Paused signals that auto-resume — keep waiting through them rather than returning. */
   autoResumeSignals?: string[];
   /** Injectable for deterministic tests. */
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
+  /**
+   * The live event source. Defaults to {@link watchExecution}; injectable so
+   * tests can drive the SSE path deterministically. When it throws / ends
+   * without the run settling, the wait reverts to the poll loop below.
+   */
+  watch?: (
+    opts: { executionId: string; signal?: AbortSignal },
+    client: GatewayClient,
+  ) => AsyncIterable<SseEvent>;
 }
 
 export interface WaitForExecutionResult {
@@ -90,12 +100,42 @@ const defaultSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Poll an execution until it reaches a terminal status, settles on a pause that
- * needs an external signal, or the wait budget elapses — so callers (and the
- * tool that wraps this) never hand-roll a sleep loop and can't misjudge elapsed
- * time. Reads at least once; returns the latest snapshot and why it stopped.
+ * Whether an execution has settled into a state `waitForExecution` should return
+ * on. `null` means "still in flight — keep waiting". A paused run only settles
+ * when its signal is NOT one the engine auto-resumes.
+ */
+function settledResult(
+  execution: ExecutionProjection,
+  autoResume: string[],
+): { reason: WaitStopReason; done: boolean } | null {
+  if (isExecutionTerminal(execution.status)) {
+    return { reason: "terminal", done: true };
+  }
+  if (execution.status === "paused") {
+    const signal = execution.pausedSignalName ?? null;
+    if (!signal || !autoResume.includes(signal)) {
+      // Won't progress on its own — an external signal is required.
+      return { reason: "needs-signal", done: false };
+    }
+  }
+  return null;
+}
+
+/**
+ * Wait for an execution to reach a terminal status, settle on a pause that needs
+ * an external signal, or exhaust the wait budget — so callers (and the tool that
+ * wraps this) never hand-roll a wait loop and can't misjudge elapsed time. Reads
+ * at least once; returns the latest snapshot and why it stopped.
  *
- * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
+ * Live by default: it wakes on {@link watchExecution} SSE events and refetches
+ * `inspect()` on each, so it reflects live run state instead of polling on a
+ * timer. On ANY SSE failure or drop it reverts to the original poll loop (×1.5
+ * backoff, capped at 5s) for the remaining budget — no functional regression,
+ * matching Module A's fallback invariant. Heartbeats never wake it, so the wait
+ * is bounded by aborting the stream at the deadline.
+ *
+ * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) on gateway errors from
+ * the `inspect()` refetch (SSE handshake errors are swallowed into the fallback).
  */
 export async function waitForExecution(
   opts: WaitForExecutionOptions,
@@ -105,29 +145,58 @@ export async function waitForExecution(
   const autoResume = opts.autoResumeSignals ?? AUTO_RESUME_PAUSE_SIGNALS;
   const sleep = opts.sleep ?? defaultSleep;
   const now = opts.now ?? Date.now;
+  const watch = opts.watch ?? watchExecution;
 
   const deadline = now() + maxWaitMs;
+
+  const read = () => inspect({ executionId: opts.executionId }, client);
+
+  // Read at least once — an already-settled run resolves without waiting.
+  let execution = await read();
+  let settled = settledResult(execution, autoResume);
+  if (settled) return { execution, ...settled };
+  if (now() >= deadline) return { execution, reason: "timeout", done: false };
+
+  // Live path: wake on SSE, refetch, re-evaluate. Bounded by aborting the stream
+  // at the deadline (heartbeats are filtered, so nothing else would wake us). Any
+  // SSE failure/drop falls through to the poll loop below — no regression.
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), Math.max(0, deadline - now()));
+  timer.unref?.();
+  const events = watch({ executionId: opts.executionId, signal: abort.signal }, client)[
+    Symbol.asyncIterator
+  ]();
+  try {
+    for (;;) {
+      const next = await events.next(); // resolves on each SSE event (heartbeats filtered)
+      if (next.done) break; // stream ended — drop to polling for any remaining budget
+      execution = await read();
+      settled = settledResult(execution, autoResume);
+      if (settled) return { execution, ...settled };
+      if (now() >= deadline) return { execution, reason: "timeout", done: false };
+    }
+    if (now() >= deadline) return { execution, reason: "timeout", done: false };
+  } catch {
+    // SSE unavailable / dropped — fall back to polling below.
+  } finally {
+    // Tear the stream down (aborts the underlying fetch) and stop the deadline
+    // timer, whether we settled, timed out, or are falling back to polling.
+    clearTimeout(timer);
+    await events.return?.(undefined);
+  }
+
+  // Poll fallback (the pre-SSE behavior) for the remaining budget.
   let interval = opts.pollMs ?? 1_000;
-
   for (;;) {
-    const execution = await inspect({ executionId: opts.executionId }, client);
-
-    if (isExecutionTerminal(execution.status)) {
-      return { execution, reason: "terminal", done: true };
-    }
-    if (execution.status === "paused") {
-      const signal = execution.pausedSignalName ?? null;
-      if (!signal || !autoResume.includes(signal)) {
-        // Won't progress on its own — an external signal is required.
-        return { execution, reason: "needs-signal", done: false };
-      }
-    }
-
     const remaining = deadline - now();
     if (remaining <= 0) return { execution, reason: "timeout", done: false };
 
     await sleep(Math.min(interval, remaining));
     interval = Math.min(interval * 1.5, 5_000);
+
+    execution = await read();
+    settled = settledResult(execution, autoResume);
+    if (settled) return { execution, ...settled };
   }
 }
 

--- a/packages/orchestration-core/src/types.ts
+++ b/packages/orchestration-core/src/types.ts
@@ -106,6 +106,40 @@ export interface StepError {
 }
 
 /**
+ * The event kinds the live SSE spine delivers (Module A / SAP-1139). Mirrors the
+ * engine's `SSE_EVENT_TYPES` — kept in lock-step so an unknown kind is dropped by
+ * {@link SseEvent} consumers rather than silently trusted.
+ */
+export const SSE_EVENT_TYPES = [
+  "step.started",
+  "step.captured",
+  "cost.updated",
+  "run.paused",
+  "run.resumed",
+  "run.terminal",
+] as const;
+
+export type SseEventType = (typeof SSE_EVENT_TYPES)[number];
+
+/**
+ * One live notification from the run's SSE channel — **IDs only, no payload**.
+ * Mirrors the engine's browser-facing frame (Module A). An `SseEvent` says
+ * "something about this run changed — refetch"; consumers re-read the canonical
+ * {@link ExecutionProjection} via `inspect()`. Carrying no state is deliberate:
+ * SSE can therefore never drift from the REST source of truth.
+ */
+export interface SseEvent {
+  /** What changed. One of {@link SSE_EVENT_TYPES}. */
+  type: SseEventType;
+  /** The execution the change applies to. */
+  executionId: string;
+  /** Root trace id the run belongs to; null until a trace is stamped. */
+  traceRoot: string | null;
+  /** Step or child-run id the change applies to; the executionId for run-level events. */
+  nodeId: string | null;
+}
+
+/**
  * A lightweight reference to an execution in the dispatch tree — used both for
  * a run's `children` and as the `listExecutions()` element.
  *

--- a/packages/orchestration-core/src/watch.spec.ts
+++ b/packages/orchestration-core/src/watch.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * watchExecution — the live SSE async-iterator. Tests drive a fake `fetch`
+ * whose body is a `ReadableStream` of SSE frames, so the real `openStream` +
+ * framing + teardown paths are exercised offline.
+ */
+import { createClient, type GatewayClient } from "./client.js";
+import type { SseEvent } from "./types.js";
+import { parseSseEvent, parseSseFrame, watchExecution } from "./watch.js";
+
+// ── Fake SSE transport ─────────────────────────────────────────────────────────
+
+/** A `ReadableStream` that emits the given string chunks then closes. */
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const queue = [...chunks];
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) controller.close();
+      else controller.enqueue(encoder.encode(next));
+    },
+  });
+}
+
+/** Serialize one event as the engine's wire frame (`id`/`event`/`data`). */
+function frame(id: string, ev: Record<string, unknown>): string {
+  return `id: ${id}\nevent: ${ev.type}\ndata: ${JSON.stringify(ev)}\n\n`;
+}
+
+const HEARTBEAT = "event: heartbeat\ndata: {}\n\n";
+
+/** Mock global.fetch to return an SSE stream; records the init for assertions. */
+function mockSseFetch(
+  chunks: string[],
+  status = 200,
+): { calls: RequestInit[]; spy: jest.SpyInstance } {
+  const ok = status >= 200 && status < 300;
+  const calls: RequestInit[] = [];
+  const spy = jest
+    .spyOn(global, "fetch" as any)
+    .mockImplementation(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit;
+      calls.push(init);
+      return {
+        ok,
+        status,
+        statusText: ok ? "OK" : "Error",
+        body: ok ? streamOf(chunks) : null,
+        text: async () => (ok ? "" : JSON.stringify({ message: "nope" })),
+      } as unknown as Response;
+    });
+  return { calls, spy };
+}
+
+const EV_A = { type: "step.started", executionId: "e1", traceRoot: "t1", nodeId: "s1" };
+const EV_B = { type: "run.terminal", executionId: "e1", traceRoot: "t1", nodeId: "e1" };
+
+async function collect(iter: AsyncIterable<SseEvent>): Promise<SseEvent[]> {
+  const out: SseEvent[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+function client(): GatewayClient {
+  return createClient({ host: "https://example.com", apiKey: "sk_test" });
+}
+
+// ── watchExecution ──────────────────────────────────────────────────────────────
+
+describe("watchExecution", () => {
+  it("yields live events, filtering heartbeats", async () => {
+    mockSseFetch([frame("1", EV_A), HEARTBEAT, frame("2", EV_B)]);
+    const events = await collect(watchExecution({ executionId: "e1" }, client()));
+    expect(events).toEqual([
+      { type: "step.started", executionId: "e1", traceRoot: "t1", nodeId: "s1" },
+      { type: "run.terminal", executionId: "e1", traceRoot: "t1", nodeId: "e1" },
+    ]);
+  });
+
+  it("reassembles a frame split across read chunks", async () => {
+    const whole = frame("1", EV_A);
+    const mid = Math.floor(whole.length / 2);
+    mockSseFetch([whole.slice(0, mid), whole.slice(mid)]);
+    const events = await collect(watchExecution({ executionId: "e1" }, client()));
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("step.started");
+  });
+
+  it("targets the run stream endpoint with the api key and accept header", async () => {
+    const { calls, spy } = mockSseFetch([frame("1", EV_B)]);
+    await collect(watchExecution({ executionId: "e 1/x" }, client()));
+    const [url] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://example.com/v1/workflows/executions/e%201%2Fx/stream");
+    const headers = calls[0].headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("sk_test");
+    expect(headers.accept).toBe("text/event-stream");
+  });
+
+  it("forwards lastEventId as the resume cursor", async () => {
+    const { calls } = mockSseFetch([frame("5", EV_B)]);
+    await collect(watchExecution({ executionId: "e1", lastEventId: "42" }, client()));
+    const headers = calls[0].headers as Record<string, string>;
+    expect(headers["last-event-id"]).toBe("42");
+  });
+
+  it("aborts the underlying fetch when the iterator is torn down early", async () => {
+    // A stream that never closes on its own — only teardown can end it.
+    const encoder = new TextEncoder();
+    let aborted = false;
+    jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (...args: unknown[]) => {
+        const init = args[1] as RequestInit;
+        init.signal?.addEventListener("abort", () => {
+          aborted = true;
+        });
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(frame("1", EV_A)));
+          },
+        });
+        return { ok: true, status: 200, body: stream } as unknown as Response;
+      });
+
+    // Break after the first event — the generator's finally must abort the fetch.
+    for await (const ev of watchExecution({ executionId: "e1" }, client())) {
+      expect(ev.type).toBe("step.started");
+      break;
+    }
+    expect(aborted).toBe(true);
+  });
+
+  it("throws OrchestrationError on a failed handshake", async () => {
+    mockSseFetch([], 404);
+    await expect(
+      collect(watchExecution({ executionId: "missing" }, client())),
+    ).rejects.toMatchObject({ code: "HTTP_404" });
+  });
+});
+
+// ── frame parsing ───────────────────────────────────────────────────────────────
+
+describe("parseSseFrame", () => {
+  it("parses id/event/data into an SseEvent from the data payload", () => {
+    expect(parseSseFrame(frame("9", EV_A).trimEnd())).toEqual({
+      type: "step.started",
+      executionId: "e1",
+      traceRoot: "t1",
+      nodeId: "s1",
+    });
+  });
+
+  it("drops a heartbeat frame", () => {
+    expect(parseSseFrame("event: heartbeat\ndata: {}")).toBeNull();
+  });
+
+  it("drops a comment/retry-only frame", () => {
+    expect(parseSseFrame(": keep-alive\nretry: 3000")).toBeNull();
+  });
+
+  it("joins multi-line data before parsing", () => {
+    const raw = 'data: {"type":"cost.updated",\ndata: "executionId":"e2","traceRoot":null,"nodeId":"n2"}';
+    expect(parseSseFrame(raw)).toEqual({
+      type: "cost.updated",
+      executionId: "e2",
+      traceRoot: null,
+      nodeId: "n2",
+    });
+  });
+});
+
+describe("parseSseEvent", () => {
+  it("narrows a valid payload", () => {
+    expect(parseSseEvent(JSON.stringify(EV_B))?.type).toBe("run.terminal");
+  });
+
+  it("returns null for an unknown type, empty id, or malformed json", () => {
+    expect(parseSseEvent('{"type":"bogus","executionId":"e1"}')).toBeNull();
+    expect(parseSseEvent('{"type":"step.started","executionId":""}')).toBeNull();
+    expect(parseSseEvent("{")).toBeNull();
+    expect(parseSseEvent("{}")).toBeNull();
+  });
+
+  it("defaults optional ids to null", () => {
+    expect(parseSseEvent('{"type":"run.paused","executionId":"e1"}')).toEqual({
+      type: "run.paused",
+      executionId: "e1",
+      traceRoot: null,
+      nodeId: null,
+    });
+  });
+});

--- a/packages/orchestration-core/src/watch.ts
+++ b/packages/orchestration-core/src/watch.ts
@@ -1,0 +1,154 @@
+/**
+ * watchExecution — a live async-iterator over a run's Server-Sent Events channel
+ * (Module A / SAP-1139). Yields `SseEvent`s (IDs only) as the engine reports a
+ * change; consumers refetch the canonical projection via `inspect()`.
+ *
+ * Networked operation: requires a GatewayClient. Mirrors the async-iterator
+ * streaming pattern in `@sapiom/sandbox` `execStream()` (`fetch().body.getReader()`
+ * + `TextDecoder` + `async function*`), adapted to SSE framing (`data:`/`event:`/
+ * `id:` fields, `Last-Event-ID` resume). Teardown (iterator `return`/`break`) runs
+ * the generator's `finally`, which aborts the underlying fetch — no leaked
+ * connections.
+ */
+import type { GatewayClient } from "./client.js";
+import { SSE_EVENT_TYPES, type SseEvent, type SseEventType } from "./types.js";
+
+export interface WatchExecutionOptions {
+  executionId: string;
+  /**
+   * Resume cursor forwarded as `Last-Event-ID` on the handshake — best-effort
+   * resume across an engine advance. The poll fallback in `waitForExecution`
+   * covers any gap, so this is an optimization, not a correctness requirement.
+   */
+  lastEventId?: string;
+  /**
+   * Abort the stream from the outside (in addition to iterator teardown). When
+   * this fires, the underlying fetch is aborted and the iterator completes.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Stream live `SseEvent`s for one execution (the run plus its dispatch subtree)
+ * over `GET /v1/workflows/executions/:id/stream`. Heartbeat frames and malformed
+ * frames are filtered — only well-formed run events are yielded.
+ *
+ * Throws `OrchestrationError` (code `HTTP_*` | `NETWORK`) if the handshake fails.
+ * A mid-stream transport drop surfaces as a thrown error from the iterator (the
+ * caller — e.g. `waitForExecution` — reverts to polling).
+ */
+export async function* watchExecution(
+  opts: WatchExecutionOptions,
+  client: GatewayClient,
+): AsyncGenerator<SseEvent> {
+  // Our own controller so iterator teardown (return/break/throw) always aborts
+  // the fetch, even when the caller passed no signal.
+  const controller = new AbortController();
+  const onExternalAbort = () => controller.abort();
+  if (opts.signal) {
+    if (opts.signal.aborted) controller.abort();
+    else opts.signal.addEventListener("abort", onExternalAbort, { once: true });
+  }
+
+  const path = `/executions/${encodeURIComponent(opts.executionId)}/stream`;
+
+  try {
+    const res = await client.openStream(path, {
+      signal: controller.signal,
+      lastEventId: opts.lastEventId,
+    });
+    // openStream guarantees a non-null body on success.
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        // SSE frames are separated by a blank line. `indexOfFrameBoundary`
+        // handles both the engine's `\n\n` framing and any CRLF intermediary.
+        for (;;) {
+          const boundary = indexOfFrameBoundary(buffer);
+          if (boundary === -1) break;
+          const raw = buffer.slice(0, boundary.at);
+          buffer = buffer.slice(boundary.after);
+          const event = parseSseFrame(raw);
+          if (event) yield event;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  } finally {
+    // Teardown: abort the fetch and detach the external-abort listener so a
+    // long-lived caller signal never accumulates listeners.
+    controller.abort();
+    if (opts.signal) opts.signal.removeEventListener("abort", onExternalAbort);
+  }
+}
+
+/**
+ * Locate the next frame boundary (`\n\n` or `\r\n\r\n`) in the buffer. Returns
+ * where the frame ends (`at`) and where the next frame begins (`after`), or `-1`
+ * when no complete frame is buffered yet.
+ */
+function indexOfFrameBoundary(buffer: string): { at: number; after: number } | -1 {
+  const lf = buffer.indexOf("\n\n");
+  const crlf = buffer.indexOf("\r\n\r\n");
+  if (lf === -1 && crlf === -1) return -1;
+  // Pick whichever boundary comes first; account for its width.
+  if (crlf !== -1 && (lf === -1 || crlf < lf)) return { at: crlf, after: crlf + 4 };
+  return { at: lf, after: lf + 2 };
+}
+
+/**
+ * Parse one SSE frame into an {@link SseEvent}, or `null` when the frame carries
+ * no run event (a heartbeat, a comment, a `retry:` hint, or a payload that does
+ * not narrow to a known event). The `data:` payload already contains the full
+ * IDs-only frame, so it is the authoritative source; the `event:` name is
+ * advisory and heartbeats are dropped by the narrowing in {@link parseSseEvent}.
+ */
+export function parseSseFrame(raw: string): SseEvent | null {
+  const dataLines: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    // Blank lines and comments (`:` prefix, e.g. `: heartbeat`) carry no field.
+    if (!line || line.startsWith(":")) continue;
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? "" : line.slice(colon + 1);
+    // Per the SSE spec a single leading space after the colon is stripped.
+    if (value.startsWith(" ")) value = value.slice(1);
+    if (field === "data") dataLines.push(value);
+  }
+  if (dataLines.length === 0) return null;
+  return parseSseEvent(dataLines.join("\n"));
+}
+
+/**
+ * Narrow a raw SSE `data:` payload to an {@link SseEvent}. A stream is
+ * fire-and-forget, so a malformed, foreign, or heartbeat (`{}`) payload must be
+ * dropped, never trusted — this mirrors the engine's `parseChannelMessage`.
+ */
+export function parseSseEvent(raw: string): SseEvent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const m = parsed as Record<string, unknown>;
+  if (typeof m.type !== "string" || !(SSE_EVENT_TYPES as readonly string[]).includes(m.type)) {
+    return null;
+  }
+  if (typeof m.executionId !== "string" || m.executionId.length === 0) return null;
+  return {
+    type: m.type as SseEventType,
+    executionId: m.executionId,
+    traceRoot: typeof m.traceRoot === "string" ? m.traceRoot : null,
+    nodeId: typeof m.nodeId === "string" ? m.nodeId : null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a live streaming helper so the SDK/CLI reflect **live** run state instead of polling on a timer. Resolves [SAP-1342](https://linear.app/sapiom/issue/SAP-1342).

- **`watchExecution({ executionId }, client) -> AsyncIterable<SseEvent>`** (new `src/watch.ts`) over `GET /v1/workflows/executions/:id/stream` (run + subtree). `SseEvent` is **IDs only** (`{ type, executionId, traceRoot, nodeId }`) — no payload; consumers refetch the `ExecutionProjection` via `inspect()`, so SSE can never drift from the REST source of truth (Module A invariant).
- Mirrors the `@sapiom/sandbox` `execStream()` reader pattern (`fetch().body.getReader()` + `TextDecoder` + `async function*`), adapted to SSE framing (`data:`/`event:`/`id:` fields, `Last-Event-ID` resume). Heartbeat and malformed frames are filtered.
- **Clean teardown:** iterator `return`/`break` runs the generator `finally`, which aborts the underlying `fetch` via an `AbortController` — no leaked connections.
- **`GatewayClient.openStream()`** centralizes the `x-api-key` SSE handshake (engine sits behind the service-key proxy; the SDK just presents its key) and maps failures to the same `OrchestrationError` shape as `request()`.
- **`waitForExecution()` is now SSE-driven:** it wakes on each event and refetches `inspect()`, bounded by aborting the stream at the deadline (heartbeats never wake it). On **any** SSE failure/drop it reverts to the original poll loop (×1.5 backoff, capped 5s) for the remaining budget — **no functional regression**.

## Interface contract

Implements the `watchExecution` / `SseEvent` signatures from the live-observable-execution `interfaces.md`. Consumes the Module A SSE channel (SAP-1139, Done) and `inspect()` (SAP-1341, merged #160). Consumed by CLI `--follow` (SAP-1343) and the tools watch surface (SAP-1344).

## Acceptance criteria

- [x] `watchExecution()` yields live `SseEvent`s from the run stream; iterator teardown aborts the connection.
- [x] `waitForExecution()` reflects live state via SSE and reverts to polling on SSE drop with no regression (all pre-existing wait tests unchanged and green).
- [x] `SseEvent` carries IDs only; live consumers refetch the projection.
- [x] No internal hostnames/customer data in examples (public repo — tests use `example.com`).

## Verification

`pnpm build && pnpm typecheck && pnpm lint && pnpm test` all green in `packages/orchestration-core` — **88 tests pass**, including new coverage for: yielded events, frame reassembly across read chunks, heartbeat filtering, teardown-aborts-fetch, handshake error; and `waitForExecution` live-path, SSE-drop fallback, stream-ended fallback, iterator teardown on settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)