### PR TITLE
feat(examples): template.json manifest schema + backfill both examples (SAP-1371)

### DIFF
--- a/examples/hello-workflow/AGENTS.md
+++ b/examples/hello-workflow/AGENTS.md
@@ -1,0 +1,24 @@
+# Working in this orchestration
+
+This project defines exactly one Sapiom orchestration in `index.ts` — **Hello Workflow** — authored against `@sapiom/orchestration`. It's the minimal definition: one terminal `greet` step, no capabilities. `greet` validates an optional `name` input and returns `{ greeting: "Hello, <name>!" }`. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (this template doesn't use any yet).
+
+## Authoring
+
+- An orchestration is `defineOrchestration({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineOrchestration(...)` export.
+- **Capabilities come from the types.** When you reach for one, what's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- To grow this into something real, add a step and declare the transition in the current step's `next` (an undeclared transition is a compile error). The Web Research Digest template is the next step up — one metered capability, an obvious output.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code end-to-end and returns a per-step trace. This template has no capabilities, so `run_local` and a real `run` behave identically.
+- **deploy**, then **run** — ship it, then run it for real.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_orchestrations_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/hello-workflow/template.json
+++ b/examples/hello-workflow/template.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "The minimal single-step Sapiom orchestration — a smoke test for the `build → deploy → run` path. One terminal `greet` step, no capabilities.\n\nUse it to confirm your MCP install and deploy pipeline work end to end before reaching for a metered capability. `greet` validates an optional `name` input and returns `{ greeting: \"Hello, <name>!\" }`, defaulting to `world` when none is given.",
+  "useCases": [
+    "Confirm your MCP install and deploy path work before building something real.",
+    "Start from the smallest valid definition and grow it one step at a time."
+  ],
+  "notes": "No capabilities, so `run_local` and a real `run` behave identically and cost nothing. Once this deploys and runs cleanly, fork a capability-backed template (e.g. Web Research Digest) for the real thing. See `AGENTS.md` for the authoring loop.",
+  "examples": [
+    {
+      "title": "Greet a name",
+      "input": { "name": "Ada" },
+      "output": { "greeting": "Hello, Ada!" }
+    },
+    {
+      "title": "Default greeting",
+      "input": {},
+      "output": { "greeting": "Hello, world!" }
+    }
+  ]
+}

--- a/examples/template.schema.json
+++ b/examples/template.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://sapiom.ai/schemas/examples-template.json",
+  "title": "Sapiom template manifest",
+  "description": "Rich per-template detail, co-located beside each example as `template.json`. The registry (`registry.json`) stays the thin gallery list (id/name/description/tags/sourcePath/capabilities/steps); this manifest is the detail layer the Sapiom backend merges into the template + fork detail view. Everything is optional except `manifestVersion` — a bare `{ \"manifestVersion\": 1 }` is valid.",
+  "type": "object",
+  "required": ["manifestVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional editor hint pointing at this schema for autocomplete + validation."
+    },
+    "manifestVersion": {
+      "const": 1,
+      "description": "Manifest schema version. Only `1` is defined today."
+    },
+    "author": {
+      "type": "object",
+      "description": "Who authored the template.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "description": "Author display name." },
+        "url": { "type": "string", "description": "Optional link to the author (site, profile, or repo)." }
+      }
+    },
+    "longDescription": {
+      "type": "string",
+      "description": "Markdown prose describing what the template is and how it behaves. Shown on the detail view."
+    },
+    "useCases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Short phrases describing concrete things you'd use this template for."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Markdown notes — how to use it, what else it ships with, gotchas."
+    },
+    "examples": {
+      "type": "array",
+      "description": "Sample runs: an input, and optionally the output it produces.",
+      "items": {
+        "type": "object",
+        "required": ["input"],
+        "additionalProperties": false,
+        "properties": {
+          "title": { "type": "string", "description": "Optional label for this example." },
+          "input": { "type": "object", "description": "The run input payload." },
+          "output": { "type": "object", "description": "Optional output the run returns." }
+        }
+      }
+    }
+  }
+}

--- a/examples/web-research-digest/AGENTS.md
+++ b/examples/web-research-digest/AGENTS.md
@@ -1,0 +1,26 @@
+# Working in this orchestration
+
+This project defines exactly one Sapiom orchestration in `index.ts` — **Web Research Digest** — authored against `@sapiom/orchestration`. It has two steps: `search` (calls the `web.search` capability) → `summarize` (formats the result into a markdown digest, in-process). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here, `ctx.sapiom.search.webSearch(...)`).
+
+## Authoring
+
+- An orchestration is `defineOrchestration({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineOrchestration(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- The digest is built in-process from the search result — there's no LLM call. Extend it by adding a step after `summarize` (e.g. store the digest, or fan out one search per subtopic) and declaring the transition in `next`.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `web.search` returns a built-in default and the workflow runs end-to-end offline for free. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed web search.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_orchestrations_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/web-research-digest/template.json
+++ b/examples/web-research-digest/template.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Search the web for a topic and return a concise, sourced digest — the onboarding flagship for one metered capability with an obvious output.\n\nThe `search` step calls the Sapiom `web.search` capability (`ctx.sapiom.search.webSearch`), which returns a synthesized answer plus ranked results. The `summarize` step then formats that answer and its source links into a markdown digest **in-process** — no LLM call — and returns `{ topic, digest, sources }`.\n\nOne metered call, a legible \"it did a thing\" result. A good first template to fork when you want to see a real capability run end to end.",
+  "useCases": [
+    "Get a quick, sourced briefing on an unfamiliar topic before a meeting.",
+    "Turn a research question into a shareable markdown digest with citations.",
+    "Learn how to wire a single metered capability into a workflow you can extend."
+  ],
+  "notes": "`run_local` stubs the `web.search` capability, so you can trace the full graph offline for free before deploying. A real `deploy` + `run` performs a billed web search.\n\nTo extend it, add a step after `summarize` — e.g. store the digest with `ctx.sapiom.memory.*`, or fan out one search per subtopic. `AGENTS.md` in this directory has the authoring loop.",
+  "examples": [
+    {
+      "title": "Research an unfamiliar term",
+      "input": { "topic": "what is an LLM agent?" },
+      "output": {
+        "topic": "what is an LLM agent?",
+        "digest": "# Research digest: what is an LLM agent?\n\nAn LLM agent is a system that uses a large language model to decide and take actions...\n\n## Sources\n1. [What are LLM agents?](https://example.com/llm-agents)\n2. [Agents overview](https://example.com/agents-overview)",
+        "sources": [
+          {
+            "title": "What are LLM agents?",
+            "url": "https://example.com/llm-agents"
+          },
+          {
+            "title": "Agents overview",
+            "url": "https://example.com/agents-overview"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Foundation for the [rich workflow template manifests epic](https://linear.app/sapiom/issue/SAP-1370) (SAP-1370). Adds the co-located per-template **manifest contract** to `examples/` — a JSON schema plus a real `template.json` + `AGENTS.md` in each existing example — so T2 (backend serve, SAP-1372) and T3/T4 (FE render) build against a real shape, established by **both** schema and reference content.

`registry.json` (merged in #157) stays the thin gallery **list** (id/name/description/tags/sourcePath/capabilities/steps). This PR adds the **rich detail** layer beside each example; no rich fields are duplicated into the registry.

## Changes

- **`examples/template.schema.json`** — draft-07 schema for the manifest. All fields optional except `manifestVersion` (`const: 1`); `additionalProperties: false` so phase-2 fields stay reserved. Fields: `author {name, url?}`, `longDescription` (md), `useCases[]`, `notes` (md), `examples[] {title?, input, output?}`. Uses the same compact one-line-property style as its sibling `registry.schema.json`.
- **`examples/web-research-digest/template.json`** — flagship manifest (author Sapiom, long description, 3 use cases, notes, one worked example with `{ topic }` input + digest output).
- **`examples/hello-workflow/template.json`** — minimal-but-complete manifest.
- **`examples/{web-research-digest,hello-workflow}/AGENTS.md`** — short "build/extend this with Claude" guides that travel with the fork, mirroring the scaffold `AGENTS.md` pattern.

## Validation

Both `template.json` files validate against the schema (ajv, draft-07); the schema is confirmed strict (rejects unknown fields and `manifestVersion != 1`). Each carries a `$schema` ref for editor autocomplete. No repo-side harness exists for `examples/` (the backend validates), and they're outside the pnpm workspace, so the package build/typecheck/test suite is unaffected.

## Acceptance criteria

- [x] Both examples carry a schema-valid `template.json` + an `AGENTS.md`.
- [x] `registry.json` unchanged (list fields stay there; no duplication of rich fields).
- [x] Public repo — anonymized (public product URLs + `example.com` placeholders only).

Closes SAP-1371

🤖 Generated with [Claude Code](https://claude.com/claude-code)