### PR TITLE
feat(harness): SPA shell — workflows rail, session bar, canvas pane, action rail

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -62,6 +62,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsx": "^4.19.0",

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -1,0 +1,115 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { WorkflowRegistry } from "./workflow-registry.js";
+
+async function writeMarker(dir: string, definitionId: number | null): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "sapiom.json"), JSON.stringify({ definitionId }));
+}
+
+describe("WorkflowRegistry", () => {
+  let tmpRoot: string;
+  let registryPath: string;
+  let registry: WorkflowRegistry;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-workflow-registry-"));
+    registryPath = path.join(tmpRoot, "state", "workflows.json");
+    registry = new WorkflowRegistry(registryPath);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("starts empty when no registry file exists", async () => {
+    expect(await registry.list()).toEqual([]);
+  });
+
+  it("scans a tree for sapiom.json markers, honoring depth and skip rules", async () => {
+    // Depth 1: has package.json, deployed.
+    await writeMarker(path.join(tmpRoot, "proj-a"), 42);
+    await fs.writeFile(
+      path.join(tmpRoot, "proj-a", "package.json"),
+      JSON.stringify({ name: "@acme/proj-a" }),
+    );
+    // Depth 1: no package.json, undeployed.
+    await writeMarker(path.join(tmpRoot, "proj-b"), null);
+    // Depth 3: right at the boundary — should be found.
+    await writeMarker(path.join(tmpRoot, "a", "b", "c"), 7);
+    // Depth 4: past the boundary — should NOT be found.
+    await writeMarker(path.join(tmpRoot, "d", "e", "f", "g"), 9);
+    // Inside node_modules / .git — should never be scanned.
+    await writeMarker(path.join(tmpRoot, "node_modules", "some-pkg"), 1);
+    await writeMarker(path.join(tmpRoot, ".git", "worktrees", "x"), 1);
+
+    const found = await registry.scan(tmpRoot);
+    const byPath = new Map(found.map((workflow) => [workflow.path, workflow]));
+
+    expect(byPath.get(path.join(tmpRoot, "proj-a"))).toEqual({
+      name: "@acme/proj-a",
+      path: path.join(tmpRoot, "proj-a"),
+      definitionId: 42,
+      source: "scan",
+    });
+    expect(byPath.get(path.join(tmpRoot, "proj-b"))).toEqual({
+      name: "proj-b",
+      path: path.join(tmpRoot, "proj-b"),
+      definitionId: null,
+      source: "scan",
+    });
+    expect(byPath.has(path.join(tmpRoot, "a", "b", "c"))).toBe(true);
+    expect(byPath.has(path.join(tmpRoot, "d", "e", "f", "g"))).toBe(false);
+    expect(
+      found.some((workflow) => workflow.path.includes("node_modules")),
+    ).toBe(false);
+    expect(found.some((workflow) => workflow.path.includes(".git"))).toBe(false);
+  });
+
+  it("persists scan results and reloads them for a fresh registry instance", async () => {
+    await writeMarker(path.join(tmpRoot, "proj-a"), 1);
+    await registry.scan(tmpRoot);
+
+    const reloaded = new WorkflowRegistry(registryPath);
+    const list = await reloaded.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].path).toBe(path.join(tmpRoot, "proj-a"));
+  });
+
+  it("connectPath registers a path even without a sapiom.json marker yet", async () => {
+    const projectDir = path.join(tmpRoot, "not-yet-linked");
+    await fs.mkdir(projectDir, { recursive: true });
+
+    const info = await registry.connectPath(projectDir);
+    expect(info).toEqual({
+      name: "not-yet-linked",
+      path: projectDir,
+      definitionId: null,
+      source: "connect",
+    });
+    expect(await registry.list()).toEqual([info]);
+  });
+
+  it("connectPath picks up an existing marker's definitionId", async () => {
+    const projectDir = path.join(tmpRoot, "linked");
+    await writeMarker(projectDir, 99);
+
+    const info = await registry.connectPath(projectDir);
+    expect(info.definitionId).toBe(99);
+  });
+
+  it("a scan does not overwrite a connect-sourced entry's source", async () => {
+    const projectDir = path.join(tmpRoot, "linked");
+    await writeMarker(projectDir, 1);
+    await registry.connectPath(projectDir);
+
+    await registry.scan(tmpRoot);
+
+    const list = await registry.list();
+    const entry = list.find((workflow) => workflow.path === projectDir);
+    expect(entry?.source).toBe("connect");
+  });
+});

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -1,0 +1,178 @@
+/**
+ * Workflow registry (workstream W2's backend slice).
+ *
+ * Discovers orchestration projects by scanning a directory tree (bounded
+ * depth) for `sapiom.json` marker files, tracks manually-connected paths,
+ * and persists the combined list to HARNESS_PATHS.workflows. Exposes an
+ * Express router implementing the /api/workflows surface from
+ * src/shared/types.ts; the integrator mounts it (and express.json()) on the
+ * shared app.
+ */
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Router, type Router as ExpressRouter } from "express";
+
+import { HARNESS_PATHS, type WorkflowInfo } from "../shared/types.js";
+
+const MAX_SCAN_DEPTH = 3;
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
+
+function expandHome(inputPath: string): string {
+  if (inputPath === "~") return os.homedir();
+  if (inputPath.startsWith("~/")) return path.join(os.homedir(), inputPath.slice(2));
+  return inputPath;
+}
+
+interface SapiomMarker {
+  definitionId?: number | null;
+}
+
+async function readMarker(dir: string): Promise<SapiomMarker | null> {
+  try {
+    const raw = await fs.readFile(path.join(dir, "sapiom.json"), "utf8");
+    return JSON.parse(raw) as SapiomMarker;
+  } catch {
+    return null;
+  }
+}
+
+async function nameFor(dir: string): Promise<string> {
+  try {
+    const raw = await fs.readFile(path.join(dir, "package.json"), "utf8");
+    const pkg = JSON.parse(raw) as { name?: string };
+    if (pkg.name) return pkg.name;
+  } catch {
+    // No package.json (or it doesn't parse) — fall back to the directory name.
+  }
+  return path.basename(dir);
+}
+
+/** Depth-first scan; a directory carrying a marker is registered and not descended into. */
+async function scanDir(dir: string, depth: number, found: WorkflowInfo[]): Promise<void> {
+  if (depth > MAX_SCAN_DEPTH) return;
+
+  const marker = await readMarker(dir);
+  if (marker) {
+    found.push({
+      name: await nameFor(dir),
+      path: dir,
+      definitionId: marker.definitionId ?? null,
+      source: "scan",
+    });
+    return;
+  }
+
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || SKIP_DIR_NAMES.has(entry.name)) continue;
+    await scanDir(path.join(dir, entry.name), depth + 1, found);
+  }
+}
+
+export class WorkflowRegistry {
+  private workflows: WorkflowInfo[] = [];
+  private loaded = false;
+
+  constructor(private readonly registryPath: string = expandHome(HARNESS_PATHS.workflows)) {}
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.registryPath, "utf8");
+      this.workflows = JSON.parse(raw) as WorkflowInfo[];
+    } catch {
+      this.workflows = [];
+    }
+    this.loaded = true;
+  }
+
+  private async persist(): Promise<void> {
+    await fs.mkdir(path.dirname(this.registryPath), { recursive: true });
+    await fs.writeFile(this.registryPath, JSON.stringify(this.workflows, null, 2));
+  }
+
+  async list(): Promise<WorkflowInfo[]> {
+    await this.ensureLoaded();
+    return this.workflows;
+  }
+
+  /** Scans `root` and merges discovered projects into the persisted registry. */
+  async scan(root: string): Promise<WorkflowInfo[]> {
+    await this.ensureLoaded();
+    const absoluteRoot = path.resolve(expandHome(root));
+    const found: WorkflowInfo[] = [];
+    await scanDir(absoluteRoot, 0, found);
+
+    const byPath = new Map(this.workflows.map((workflow) => [workflow.path, workflow]));
+    for (const workflow of found) {
+      const existing = byPath.get(workflow.path);
+      // A manually-connected entry keeps its `source`; a scan only refreshes name/definitionId.
+      byPath.set(workflow.path, existing ? { ...existing, ...workflow, source: existing.source } : workflow);
+    }
+    this.workflows = Array.from(byPath.values());
+    await this.persist();
+    return found;
+  }
+
+  /** Registers an arbitrary path (the "+ Connect" flow); marker is optional at connect time. */
+  async connectPath(inputPath: string): Promise<WorkflowInfo> {
+    await this.ensureLoaded();
+    const absolutePath = path.resolve(expandHome(inputPath));
+    const marker = await readMarker(absolutePath);
+    const info: WorkflowInfo = {
+      name: await nameFor(absolutePath),
+      path: absolutePath,
+      definitionId: marker?.definitionId ?? null,
+      source: "connect",
+    };
+    const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);
+    if (idx >= 0) this.workflows[idx] = info;
+    else this.workflows.push(info);
+    await this.persist();
+    return info;
+  }
+}
+
+export function createWorkflowsRouter(registry: WorkflowRegistry): ExpressRouter {
+  const router = Router();
+
+  router.get("/api/workflows", async (_req, res) => {
+    res.json(await registry.list());
+  });
+
+  router.post("/api/workflows/connect", async (req, res) => {
+    const inputPath = (req.body as { path?: unknown } | undefined)?.path;
+    if (typeof inputPath !== "string" || !inputPath.trim()) {
+      res.status(400).json({ error: "path is required" });
+      return;
+    }
+    try {
+      res.json(await registry.connectPath(inputPath));
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.post("/api/workflows/scan", async (req, res) => {
+    const root = (req.body as { root?: unknown } | undefined)?.root;
+    if (typeof root !== "string" || !root.trim()) {
+      res.status(400).json({ error: "root is required" });
+      return;
+    }
+    try {
+      res.json(await registry.scan(root));
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -4,7 +4,108 @@
  * Layout: workflows rail (left) | session dropdown + terminal (center)
  * | canvas/preview pane (right) | action icon rail (far right).
  */
+import type { JSX } from "react";
+import type { HarnessKind, MacroDef, SessionSummary } from "@shared/types";
+
+import { ActionRail } from "./components/ActionRail";
+import { CanvasPane } from "./components/CanvasPane";
+import { SessionBar } from "./components/SessionBar";
+import { Terminal } from "./components/Terminal";
+import { WorkflowsRail } from "./components/WorkflowsRail";
+import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
-  return <div>Sapiom Harness — W2 builds this.</div>;
+  const harness = useHarnessState();
+
+  if (harness.loading) {
+    return <div className="app-status">Loading Sapiom Harness…</div>;
+  }
+  if (harness.error || !harness.state) {
+    return <div className="app-status app-status-error">Failed to load: {harness.error}</div>;
+  }
+
+  const { state } = harness;
+  const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
+
+  const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
+    await harness.createSession({ cwd, harness: agentHarness });
+  };
+
+  const handleResumeHistory = async (summary: SessionSummary): Promise<void> => {
+    const existing = state.sessions.find((session) => session.agentSessionId === summary.agentSessionId);
+    if (existing) {
+      await harness.resumeSession(existing.id);
+      return;
+    }
+    // Agent-side history the harness never tracked as a session (e.g. transcript-sourced
+    // entries) — there's no registry row to resume, so start fresh in the same place.
+    await harness.createSession({ cwd: summary.cwd, harness: summary.harness });
+  };
+
+  const disabledReasonFor = (macro: MacroDef): string | null => {
+    if (macro.requiresWorkflow) {
+      if (!selectedWorkflow) return "Select a workflow first";
+      if (macro.action.kind === "open-url" && macro.action.url.includes("{{workflow.definitionId}}") &&
+        selectedWorkflow.definitionId == null) {
+        return "Not deployed yet";
+      }
+    }
+    if (macro.action.kind === "inject" && !harness.activeSessionId) return "Start a session first";
+    return null;
+  };
+
+  const handleRunMacro = (macro: MacroDef, subject?: string): void => {
+    if (macro.action.kind === "open-url") {
+      const url = macro.action.url.replace(
+        "{{workflow.definitionId}}",
+        String(selectedWorkflow?.definitionId ?? ""),
+      );
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (!harness.activeSessionId) return;
+    void harness.runMacro(macro.id, {
+      harnessSessionId: harness.activeSessionId,
+      workflowPath: harness.selectedWorkflowPath ?? undefined,
+      subject,
+    });
+  };
+
+  return (
+    <div className="app">
+      <WorkflowsRail
+        workflows={state.workflows}
+        selectedPath={harness.selectedWorkflowPath}
+        onSelect={harness.setSelectedWorkflowPath}
+        onConnect={async (path) => {
+          await harness.connectWorkflow(path);
+        }}
+      />
+
+      <div className="center-pane">
+        <SessionBar
+          sessions={state.sessions}
+          activeSessionId={harness.activeSessionId}
+          onSelectSession={harness.setActiveSessionId}
+          onResumeHistory={(summary) => void handleResumeHistory(summary)}
+          history={harness.history}
+          historyLoading={harness.historyLoading}
+          onOpenDropdown={(cwd) => void harness.loadHistory(cwd)}
+          recentDirs={harness.settings?.recentDirs ?? []}
+          onCreateSession={handleCreateSession}
+        />
+        <div className="terminal-slot">
+          {harness.activeSessionId ? (
+            <Terminal sessionId={harness.activeSessionId} token={harness.bootToken} />
+          ) : (
+            <div className="terminal-empty">No active session — click “+ new” to start one.</div>
+          )}
+        </div>
+      </div>
+
+      <CanvasPane sessionId={harness.activeSessionId} lastMessage={harness.lastMessage} />
+
+      <ActionRail macros={state.macros} disabledReasonFor={disabledReasonFor} onRun={handleRunMacro} />
+    </div>
+  );
 };

--- a/packages/harness/web/src/components/ActionRail.tsx
+++ b/packages/harness/web/src/components/ActionRail.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import type { MacroDef } from "@shared/types";
+
+import { Icon } from "./Icon";
+
+interface ActionRailProps {
+  macros: MacroDef[];
+  disabledReasonFor: (macro: MacroDef) => string | null;
+  onRun: (macro: MacroDef, subject?: string) => void;
+}
+
+function needsSubject(macro: MacroDef): boolean {
+  return macro.action.kind === "inject" && macro.action.text.includes("{{subject}}");
+}
+
+export function ActionRail({ macros, disabledReasonFor, onRun }: ActionRailProps): JSX.Element {
+  const [subjectFor, setSubjectFor] = useState<MacroDef | null>(null);
+  const [subject, setSubject] = useState("");
+
+  const handleClick = (macro: MacroDef): void => {
+    if (needsSubject(macro)) {
+      setSubjectFor(macro);
+      setSubject("");
+      return;
+    }
+    onRun(macro);
+  };
+
+  const submitSubject = (): void => {
+    if (!subjectFor) return;
+    onRun(subjectFor, subject.trim() || undefined);
+    setSubjectFor(null);
+  };
+
+  return (
+    <aside className="rail rail-actions">
+      {macros.map((macro) => {
+        const disabledReason = disabledReasonFor(macro);
+        return (
+          <button
+            key={macro.id}
+            className="action-icon-btn"
+            title={disabledReason ?? macro.label}
+            disabled={Boolean(disabledReason)}
+            onClick={() => handleClick(macro)}
+          >
+            <Icon name={macro.icon} size={18} />
+          </button>
+        );
+      })}
+
+      {subjectFor && (
+        <div className="modal-backdrop" onClick={() => setSubjectFor(null)}>
+          <div className="modal modal-subject" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">{subjectFor.label}</div>
+            <input
+              autoFocus
+              className="modal-input"
+              placeholder="What should the agent visualize?"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitSubject();
+                if (e.key === "Escape") setSubjectFor(null);
+              }}
+            />
+            <div className="modal-actions">
+              <button className="btn-ghost" onClick={() => setSubjectFor(null)}>
+                Cancel
+              </button>
+              <button className="btn-primary" onClick={submitSubject}>
+                Run
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import type { JSX } from "react";
+import type { BusMessage } from "@shared/types";
+
+import { isMockMode } from "../lib/api";
+import { Icon } from "./Icon";
+
+type CanvasMode = "generated" | "preview";
+
+interface CanvasPaneProps {
+  sessionId: string | null;
+  lastMessage: BusMessage | null;
+}
+
+export function CanvasPane({ sessionId, lastMessage }: CanvasPaneProps): JSX.Element {
+  const [mode, setMode] = useState<CanvasMode>("generated");
+  const [previewUrl, setPreviewUrl] = useState("");
+  const [previewInput, setPreviewInput] = useState("");
+  const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [portChip, setPortChip] = useState<{ port: number; url: string } | null>(null);
+
+  // Probe once per session for pre-existing content — the agent may have written
+  // it in an earlier turn, before this pane was around to catch a reload event.
+  useEffect(() => {
+    setHasGeneratedContent(false);
+    setPortChip(null);
+    if (!sessionId || isMockMode()) return;
+    let cancelled = false;
+    fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
+      .then((res) => !cancelled && setHasGeneratedContent(res.ok))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!lastMessage || !sessionId) return;
+    if (lastMessage.type === "canvas.reload" && lastMessage.harnessSessionId === sessionId) {
+      setHasGeneratedContent(true);
+      setReloadKey((key) => key + 1);
+    } else if (lastMessage.type === "port.detected" && lastMessage.harnessSessionId === sessionId) {
+      setPortChip({ port: lastMessage.port, url: lastMessage.url });
+    }
+  }, [lastMessage, sessionId]);
+
+  const openPreviewChip = (): void => {
+    if (!portChip) return;
+    setPreviewUrl(portChip.url);
+    setPreviewInput(portChip.url);
+    setMode("preview");
+  };
+
+  const navigatePreview = (): void => setPreviewUrl(previewInput);
+
+  return (
+    <aside className="canvas-pane">
+      <div className="canvas-header">
+        <div className="canvas-mode-toggle">
+          <button
+            className={"canvas-mode-btn" + (mode === "generated" ? " is-active" : "")}
+            onClick={() => setMode("generated")}
+          >
+            Generated
+          </button>
+          <button
+            className={"canvas-mode-btn" + (mode === "preview" ? " is-active" : "")}
+            onClick={() => setMode("preview")}
+          >
+            Preview
+          </button>
+        </div>
+        {portChip && mode !== "preview" && (
+          <button className="preview-chip" onClick={openPreviewChip}>
+            <Icon name="Radio" size={12} /> Preview :{portChip.port}
+          </button>
+        )}
+      </div>
+
+      {mode === "preview" ? (
+        <div className="canvas-preview">
+          <div className="canvas-urlbar">
+            <input
+              className="canvas-url-input"
+              value={previewInput}
+              placeholder="http://localhost:3000"
+              onChange={(e) => setPreviewInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && navigatePreview()}
+            />
+            <button className="btn-ghost" onClick={navigatePreview}>
+              Go
+            </button>
+          </div>
+          {previewUrl ? (
+            <iframe
+              key={previewUrl}
+              className="canvas-iframe"
+              src={previewUrl}
+              sandbox="allow-scripts allow-forms allow-same-origin"
+            />
+          ) : (
+            <div className="canvas-empty">Enter a localhost URL to preview a running dev server.</div>
+          )}
+        </div>
+      ) : !sessionId ? (
+        <div className="canvas-empty">Start a session to see its canvas here.</div>
+      ) : !hasGeneratedContent ? (
+        <div className="canvas-empty">
+          <p>Nothing rendered yet.</p>
+          <p>
+            Ask your agent to write HTML to <code>.sapiom/canvas/index.html</code> — this pane hot-reloads whenever
+            it changes.
+          </p>
+        </div>
+      ) : (
+        <iframe key={reloadKey} className="canvas-iframe" src={`/canvas/${sessionId}/`} sandbox="allow-scripts" />
+      )}
+    </aside>
+  );
+}

--- a/packages/harness/web/src/components/Icon.tsx
+++ b/packages/harness/web/src/components/Icon.tsx
@@ -1,0 +1,34 @@
+import {
+  ChevronDown,
+  Cloud,
+  ExternalLink,
+  HelpCircle,
+  type LucideIcon,
+  Play,
+  Plus,
+  Radio,
+  Sparkles,
+  Zap,
+} from "lucide-react";
+import type { JSX } from "react";
+
+/**
+ * A curated map, not a barrel import of the whole icon set — keeps the bundle
+ * tree-shakeable. MacroDef.icon is still free-form config; unknown names
+ * fall back to HelpCircle rather than failing to render.
+ */
+const ICONS: Record<string, LucideIcon> = {
+  ChevronDown,
+  Cloud,
+  ExternalLink,
+  Play,
+  Plus,
+  Radio,
+  Sparkles,
+  Zap,
+};
+
+export function Icon({ name, size = 16 }: { name: string; size?: number }): JSX.Element {
+  const Component = ICONS[name] ?? HelpCircle;
+  return <Component size={size} strokeWidth={1.75} aria-hidden="true" />;
+}

--- a/packages/harness/web/src/components/NewSessionModal.tsx
+++ b/packages/harness/web/src/components/NewSessionModal.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import type { HarnessKind } from "@shared/types";
+
+interface NewSessionModalProps {
+  recentDirs: string[];
+  onClose: () => void;
+  onCreate: (cwd: string, harness: HarnessKind) => Promise<void>;
+}
+
+const HARNESS_OPTIONS: { id: HarnessKind; label: string }[] = [
+  { id: "claude-code", label: "Claude Code" },
+  { id: "codex", label: "Codex" },
+];
+
+export function NewSessionModal({ recentDirs, onClose, onCreate }: NewSessionModalProps): JSX.Element {
+  const [cwd, setCwd] = useState(recentDirs[0] ?? "");
+  const [harness, setHarness] = useState<HarnessKind>("claude-code");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (): Promise<void> => {
+    const trimmed = cwd.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onCreate(trimmed, harness);
+      onClose();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">New session</div>
+
+        <label className="modal-label" htmlFor="new-session-cwd">
+          Directory
+        </label>
+        <input
+          id="new-session-cwd"
+          autoFocus
+          className="modal-input"
+          list="recent-dirs"
+          value={cwd}
+          placeholder="/path/to/project"
+          onChange={(e) => setCwd(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && void submit()}
+        />
+        <datalist id="recent-dirs">
+          {recentDirs.map((dir) => (
+            <option key={dir} value={dir} />
+          ))}
+        </datalist>
+        {recentDirs.length > 0 && (
+          <div className="recent-dirs">
+            {recentDirs.map((dir) => (
+              <button key={dir} type="button" className="recent-dir-chip" onClick={() => setCwd(dir)}>
+                {dir}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="modal-label">Harness</div>
+        <div className="harness-picker">
+          {HARNESS_OPTIONS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className={"harness-option" + (harness === option.id ? " is-selected" : "")}
+              onClick={() => setHarness(option.id)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {error && <div className="modal-error">{error}</div>}
+
+        <div className="modal-actions">
+          <button className="btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button className="btn-primary" onClick={() => void submit()} disabled={busy || !cwd.trim()}>
+            {busy ? "Starting…" : "Start session"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import type { HarnessKind, HarnessSession, SessionSummary } from "@shared/types";
+
+import { Icon } from "./Icon";
+import { NewSessionModal } from "./NewSessionModal";
+
+interface SessionBarProps {
+  sessions: HarnessSession[];
+  activeSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onResumeHistory: (summary: SessionSummary) => void;
+  history: SessionSummary[];
+  historyLoading: boolean;
+  onOpenDropdown: (cwd: string) => void;
+  recentDirs: string[];
+  onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
+}
+
+export function SessionBar({
+  sessions,
+  activeSessionId,
+  onSelectSession,
+  onResumeHistory,
+  history,
+  historyLoading,
+  onOpenDropdown,
+  recentDirs,
+  onCreateSession,
+}: SessionBarProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const activeSession = sessions.find((session) => session.id === activeSessionId) ?? null;
+  const runningSessions = sessions.filter((session) => session.status !== "exited");
+
+  const toggle = (): void => {
+    const next = !open;
+    setOpen(next);
+    if (next) {
+      const cwd = activeSession?.cwd ?? recentDirs[0];
+      if (cwd) onOpenDropdown(cwd);
+    }
+  };
+
+  return (
+    <div className="session-bar">
+      <div className="session-dropdown-wrap">
+        <button className="session-dropdown-trigger" onClick={toggle}>
+          <span className="session-dot" data-status={activeSession?.status ?? "none"} />
+          <span className="session-title">{activeSession ? activeSession.title : "No session"}</span>
+          <Icon name="ChevronDown" size={14} />
+        </button>
+
+        {open && (
+          <div className="session-dropdown-menu">
+            <div className="session-dropdown-section">Running</div>
+            {runningSessions.length === 0 && <div className="session-dropdown-empty">No running sessions</div>}
+            {runningSessions.map((session) => (
+              <button
+                key={session.id}
+                className={"session-dropdown-item" + (session.id === activeSessionId ? " is-selected" : "")}
+                onClick={() => {
+                  onSelectSession(session.id);
+                  setOpen(false);
+                }}
+              >
+                <span className="session-dot" data-status={session.status} />
+                <span className="session-item-title">{session.title}</span>
+                <span className="session-item-cwd">{session.cwd}</span>
+              </button>
+            ))}
+
+            <div className="session-dropdown-section">History</div>
+            {historyLoading && <div className="session-dropdown-empty">Loading…</div>}
+            {!historyLoading && history.length === 0 && (
+              <div className="session-dropdown-empty">No past sessions for this directory</div>
+            )}
+            {!historyLoading &&
+              history.map((summary) => (
+                <button
+                  key={summary.agentSessionId}
+                  className="session-dropdown-item"
+                  onClick={() => {
+                    onResumeHistory(summary);
+                    setOpen(false);
+                  }}
+                >
+                  <span className="session-item-title">{summary.title}</span>
+                  <span className="session-item-meta">
+                    {summary.harness} · {new Date(summary.lastActiveAt).toLocaleString()}
+                  </span>
+                </button>
+              ))}
+          </div>
+        )}
+      </div>
+
+      <button className="new-session-btn" onClick={() => setModalOpen(true)}>
+        <Icon name="Plus" size={14} /> new
+      </button>
+
+      {modalOpen && (
+        <NewSessionModal
+          recentDirs={recentDirs}
+          onClose={() => setModalOpen(false)}
+          onCreate={onCreateSession}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/Terminal.tsx
+++ b/packages/harness/web/src/components/Terminal.tsx
@@ -1,0 +1,21 @@
+/**
+ * Placeholder terminal slot. The real xterm.js implementation (WS bridge,
+ * XDA/OSC-52 handling) ships at this exact path from the terminal-core
+ * workstream — this keeps the props signature stable so the SPA shell wires
+ * up cleanly either way.
+ */
+import type { JSX } from "react";
+
+export interface TerminalProps {
+  sessionId: string;
+  token: string;
+}
+
+export function Terminal({ sessionId }: TerminalProps): JSX.Element {
+  return (
+    <div className="terminal-placeholder">
+      <div className="terminal-placeholder-text">terminal loading…</div>
+      <div className="terminal-placeholder-session">session {sessionId}</div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import type { WorkflowInfo } from "@shared/types";
+
+interface WorkflowsRailProps {
+  workflows: WorkflowInfo[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onConnect: (path: string) => Promise<void>;
+}
+
+export function WorkflowsRail({ workflows, selectedPath, onSelect, onConnect }: WorkflowsRailProps): JSX.Element {
+  const [connecting, setConnecting] = useState(false);
+  const [pathInput, setPathInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitConnect = async (): Promise<void> => {
+    const trimmed = pathInput.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onConnect(trimmed);
+      setPathInput("");
+      setConnecting(false);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <aside className="rail rail-workflows">
+      <div className="rail-header">Workflows</div>
+      <div className="rail-list">
+        {workflows.length === 0 && <div className="rail-empty">No workflows yet</div>}
+        {workflows.map((workflow) => (
+          <button
+            key={workflow.path}
+            className={"workflow-item" + (workflow.path === selectedPath ? " is-selected" : "")}
+            onClick={() => onSelect(workflow.path)}
+            title={workflow.path}
+          >
+            <span className="workflow-caret">▸</span>
+            <span className="workflow-name">{workflow.name}</span>
+            {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
+          </button>
+        ))}
+      </div>
+
+      {connecting ? (
+        <div className="connect-form">
+          <input
+            autoFocus
+            className="connect-input"
+            placeholder="/path/to/project"
+            value={pathInput}
+            onChange={(e) => setPathInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submitConnect();
+              if (e.key === "Escape") setConnecting(false);
+            }}
+          />
+          {error && <div className="connect-error">{error}</div>}
+          <div className="connect-actions">
+            <button className="btn-ghost" onClick={() => setConnecting(false)} disabled={busy}>
+              Cancel
+            </button>
+            <button className="btn-primary" onClick={() => void submitConnect()} disabled={busy || !pathInput.trim()}>
+              {busy ? "Connecting…" : "Connect"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button className="connect-trigger" onClick={() => setConnecting(true)}>
+          + Connect
+        </button>
+      )}
+    </aside>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1,0 +1,243 @@
+/**
+ * Typed REST client for the harness server (see the "REST API surface"
+ * section of ../../../src/shared/types.ts). Gated at this layer: with
+ * `VITE_MOCK=1` the whole app runs against in-memory fixtures and never
+ * touches the network — this is what lets W2 build ahead of a running server.
+ */
+import type {
+  AppState,
+  CreateSessionRequest,
+  HarnessSession,
+  HarnessSettings,
+  InjectInputRequest,
+  MacroDef,
+  RunMacroRequest,
+  SessionSummary,
+  WorkflowInfo,
+} from "@shared/types";
+
+import { MOCK_HISTORY, MOCK_MACROS, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_WORKFLOWS } from "./mock-data";
+
+export function isMockMode(): boolean {
+  return import.meta.env.VITE_MOCK === "1";
+}
+
+/** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
+export function getBootToken(): string {
+  const injected = (window as unknown as { __HARNESS__?: { token?: string } }).__HARNESS__;
+  if (injected?.token) return injected.token;
+  return new URLSearchParams(window.location.search).get("token") ?? "";
+}
+
+export interface HarnessApi {
+  getState(): Promise<AppState>;
+  createSession(req: CreateSessionRequest): Promise<HarnessSession>;
+  listSessions(): Promise<HarnessSession[]>;
+  sessionHistory(cwd: string): Promise<SessionSummary[]>;
+  resumeSession(id: string): Promise<HarnessSession>;
+  killSession(id: string): Promise<void>;
+  injectInput(id: string, req: InjectInputRequest): Promise<void>;
+  listWorkflows(): Promise<WorkflowInfo[]>;
+  connectWorkflow(path: string): Promise<WorkflowInfo>;
+  scanWorkflows(root: string): Promise<WorkflowInfo[]>;
+  listMacros(): Promise<MacroDef[]>;
+  runMacro(id: string, req: RunMacroRequest): Promise<void>;
+  getSettings(): Promise<HarnessSettings>;
+  updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings>;
+}
+
+class RealApi implements HarnessApi {
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(path, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Token": getBootToken(),
+        ...init?.headers,
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`${init?.method ?? "GET"} ${path} → ${res.status}${body ? `: ${body}` : ""}`);
+    }
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  getState(): Promise<AppState> {
+    return this.request<AppState>("/api/state");
+  }
+
+  createSession(req: CreateSessionRequest): Promise<HarnessSession> {
+    return this.request<HarnessSession>("/api/sessions", { method: "POST", body: JSON.stringify(req) });
+  }
+
+  listSessions(): Promise<HarnessSession[]> {
+    return this.request<HarnessSession[]>("/api/sessions");
+  }
+
+  sessionHistory(cwd: string): Promise<SessionSummary[]> {
+    return this.request<SessionSummary[]>(`/api/sessions/history?cwd=${encodeURIComponent(cwd)}`);
+  }
+
+  resumeSession(id: string): Promise<HarnessSession> {
+    return this.request<HarnessSession>(`/api/sessions/${encodeURIComponent(id)}/resume`, { method: "POST" });
+  }
+
+  async killSession(id: string): Promise<void> {
+    await this.request<{ ok: true }>(`/api/sessions/${encodeURIComponent(id)}`, { method: "DELETE" });
+  }
+
+  async injectInput(id: string, req: InjectInputRequest): Promise<void> {
+    await this.request<{ ok: true }>(`/api/sessions/${encodeURIComponent(id)}/input`, {
+      method: "POST",
+      body: JSON.stringify(req),
+    });
+  }
+
+  listWorkflows(): Promise<WorkflowInfo[]> {
+    return this.request<WorkflowInfo[]>("/api/workflows");
+  }
+
+  connectWorkflow(path: string): Promise<WorkflowInfo> {
+    return this.request<WorkflowInfo>("/api/workflows/connect", { method: "POST", body: JSON.stringify({ path }) });
+  }
+
+  scanWorkflows(root: string): Promise<WorkflowInfo[]> {
+    return this.request<WorkflowInfo[]>("/api/workflows/scan", { method: "POST", body: JSON.stringify({ root }) });
+  }
+
+  listMacros(): Promise<MacroDef[]> {
+    return this.request<MacroDef[]>("/api/macros");
+  }
+
+  async runMacro(id: string, req: RunMacroRequest): Promise<void> {
+    await this.request<{ ok: true }>(`/api/macros/${encodeURIComponent(id)}/run`, {
+      method: "POST",
+      body: JSON.stringify(req),
+    });
+  }
+
+  getSettings(): Promise<HarnessSettings> {
+    return this.request<HarnessSettings>("/api/settings");
+  }
+
+  updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings> {
+    return this.request<HarnessSettings>("/api/settings", { method: "PATCH", body: JSON.stringify(patch) });
+  }
+}
+
+const delay = (ms = 180): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** In-memory, mutable copies of the fixtures — mutations persist for the tab's lifetime, reset on reload. */
+class MockApi implements HarnessApi {
+  private sessions = MOCK_SESSIONS.map((session) => ({ ...session }));
+  private workflows = MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
+  private settings: HarnessSettings = { ...MOCK_SETTINGS, recentDirs: [...MOCK_SETTINGS.recentDirs] };
+
+  async getState(): Promise<AppState> {
+    await delay();
+    return {
+      version: "0.0.1-mock",
+      authenticated: true,
+      userId: "user_mock",
+      organizationName: "Acme (mock)",
+      telemetryOptIn: this.settings.telemetryOptIn,
+      sessions: this.sessions,
+      workflows: this.workflows,
+      macros: MOCK_MACROS,
+    };
+  }
+
+  async createSession(req: CreateSessionRequest): Promise<HarnessSession> {
+    await delay(300);
+    const session: HarnessSession = {
+      id: `sess-mock-${this.sessions.length + 1}`,
+      agentSessionId: null,
+      harness: req.harness,
+      cwd: req.cwd,
+      title: req.cwd.split("/").filter(Boolean).pop() ?? req.cwd,
+      status: "starting",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
+    this.sessions = [...this.sessions, session];
+    return session;
+  }
+
+  async listSessions(): Promise<HarnessSession[]> {
+    await delay();
+    return this.sessions;
+  }
+
+  async sessionHistory(cwd: string): Promise<SessionSummary[]> {
+    await delay();
+    return MOCK_HISTORY[cwd] ?? [];
+  }
+
+  async resumeSession(id: string): Promise<HarnessSession> {
+    await delay(300);
+    const existing = this.sessions.find((session) => session.agentSessionId === id || session.id === id);
+    if (!existing) throw new Error(`mock: no session to resume for ${id}`);
+    const resumed = { ...existing, status: "running" as const, lastActiveAt: new Date().toISOString() };
+    this.sessions = this.sessions.map((session) => (session.id === resumed.id ? resumed : session));
+    return resumed;
+  }
+
+  async killSession(id: string): Promise<void> {
+    await delay();
+    this.sessions = this.sessions.map((session) =>
+      session.id === id ? { ...session, status: "exited" as const, exitCode: 0 } : session,
+    );
+  }
+
+  async injectInput(_id: string, _req: InjectInputRequest): Promise<void> {
+    await delay();
+  }
+
+  async listWorkflows(): Promise<WorkflowInfo[]> {
+    await delay();
+    return this.workflows;
+  }
+
+  async connectWorkflow(path: string): Promise<WorkflowInfo> {
+    await delay(250);
+    const info: WorkflowInfo = {
+      name: path.split("/").filter(Boolean).pop() ?? path,
+      path,
+      definitionId: null,
+      source: "connect",
+    };
+    this.workflows = [...this.workflows.filter((w) => w.path !== path), info];
+    return info;
+  }
+
+  async scanWorkflows(_root: string): Promise<WorkflowInfo[]> {
+    await delay(250);
+    return this.workflows;
+  }
+
+  async listMacros(): Promise<MacroDef[]> {
+    await delay();
+    return MOCK_MACROS;
+  }
+
+  async runMacro(_id: string, _req: RunMacroRequest): Promise<void> {
+    await delay(200);
+  }
+
+  async getSettings(): Promise<HarnessSettings> {
+    await delay();
+    return this.settings;
+  }
+
+  async updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings> {
+    await delay();
+    this.settings = { ...this.settings, ...patch };
+    return this.settings;
+  }
+}
+
+export function createApi(): HarnessApi {
+  return isMockMode() ? new MockApi() : new RealApi();
+}

--- a/packages/harness/web/src/lib/events.ts
+++ b/packages/harness/web/src/lib/events.ts
@@ -1,0 +1,47 @@
+/**
+ * /ws/events subscription (see the "Event-bus WebSocket" section of
+ * ../../../src/shared/types.ts). No-op in mock mode — there's no server to
+ * connect to, and the mock fixtures are static.
+ */
+import type { BusMessage } from "@shared/types";
+
+import { getBootToken, isMockMode } from "./api";
+
+export type BusListener = (message: BusMessage) => void;
+
+const RECONNECT_DELAY_MS = 2000;
+
+/** Subscribes and returns an unsubscribe function. */
+export function subscribeEvents(onMessage: BusListener): () => void {
+  if (isMockMode()) return () => {};
+
+  const url = new URL("/ws/events", window.location.href);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("token", getBootToken());
+
+  let socket: WebSocket | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const connect = (): void => {
+    socket = new WebSocket(url);
+    socket.addEventListener("message", (event) => {
+      try {
+        onMessage(JSON.parse(event.data as string) as BusMessage);
+      } catch {
+        // Ignore malformed frames rather than tearing down the socket.
+      }
+    });
+    socket.addEventListener("close", () => {
+      if (stopped) return;
+      retryTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+    });
+  };
+  connect();
+
+  return () => {
+    stopped = true;
+    if (retryTimer) clearTimeout(retryTimer);
+    socket?.close();
+  };
+}

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -1,0 +1,117 @@
+/**
+ * Fixture data for `VITE_MOCK=1` — lets the SPA render fully without a
+ * running harness server (see MockApi in ./api).
+ */
+import type { HarnessSession, HarnessSettings, MacroDef, SessionSummary, WorkflowInfo } from "@shared/types";
+
+const now = Date.now();
+const minutesAgo = (n: number): string => new Date(now - n * 60_000).toISOString();
+const daysAgo = (n: number): string => new Date(now - n * 24 * 60 * 60_000).toISOString();
+
+export const MOCK_SESSIONS: HarnessSession[] = [
+  {
+    id: "sess-leasing",
+    agentSessionId: "8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f",
+    harness: "claude-code",
+    cwd: "/Users/demo/acme-app",
+    title: "Build the leasing pipeline",
+    status: "running",
+    createdAt: minutesAgo(42),
+    lastActiveAt: minutesAgo(1),
+  },
+  {
+    id: "sess-rfq",
+    agentSessionId: null,
+    harness: "codex",
+    cwd: "/Users/demo/rfq-workflows",
+    title: "rfq-workflows",
+    status: "exited",
+    createdAt: daysAgo(2),
+    lastActiveAt: daysAgo(1),
+    exitCode: 0,
+  },
+];
+
+export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
+  "/Users/demo/acme-app": [
+    {
+      agentSessionId: "8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f",
+      harness: "claude-code",
+      cwd: "/Users/demo/acme-app",
+      title: "Build the leasing pipeline",
+      lastActiveAt: minutesAgo(1),
+      source: "registry",
+    },
+    {
+      agentSessionId: "2b6d9e10-7711-4c2a-8b0a-9e4f2d1c5a33",
+      harness: "claude-code",
+      cwd: "/Users/demo/acme-app",
+      title: "Wire the screening webhook",
+      lastActiveAt: daysAgo(1),
+      source: "transcript",
+    },
+  ],
+  "/Users/demo/rfq-workflows": [
+    {
+      agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
+      harness: "codex",
+      cwd: "/Users/demo/rfq-workflows",
+      title: "rfq-workflows",
+      lastActiveAt: daysAgo(1),
+      source: "registry",
+    },
+  ],
+};
+
+export const MOCK_WORKFLOWS: WorkflowInfo[] = [
+  { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821, source: "scan" },
+  { name: "rfq", path: "/Users/demo/rfq-workflows", definitionId: null, source: "scan" },
+  { name: "onboarding-flow", path: "/Users/demo/onboarding-flow", definitionId: null, source: "connect" },
+];
+
+export const MOCK_MACROS: MacroDef[] = [
+  {
+    id: "run_local",
+    label: "Run local",
+    icon: "Play",
+    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents run --target local", submit: true },
+    requiresWorkflow: true,
+  },
+  {
+    id: "deploy",
+    label: "Deploy",
+    icon: "Cloud",
+    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents deploy", submit: true },
+    requiresWorkflow: true,
+  },
+  {
+    id: "prod_run",
+    label: "Prod run",
+    icon: "Zap",
+    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents run --target prod", submit: true },
+    requiresWorkflow: true,
+  },
+  {
+    id: "open_prod",
+    label: "Open prod",
+    icon: "ExternalLink",
+    action: { kind: "open-url", url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}" },
+    requiresWorkflow: true,
+  },
+  {
+    id: "visualize",
+    label: "Visualize",
+    icon: "Sparkles",
+    action: {
+      kind: "inject",
+      text: "Write a live HTML visualization of {{subject}} to .sapiom/canvas/index.html and keep it updated as things change.",
+      submit: true,
+    },
+    requiresWorkflow: false,
+  },
+];
+
+export const MOCK_SETTINGS: HarnessSettings = {
+  telemetryOptIn: false,
+  recentDirs: ["/Users/demo/acme-app", "/Users/demo/rfq-workflows", "/Users/demo/onboarding-flow"],
+};

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  AppState,
+  BusMessage,
+  CreateSessionRequest,
+  HarnessSession,
+  HarnessSettings,
+  RunMacroRequest,
+  SessionSummary,
+  WorkflowInfo,
+} from "@shared/types";
+
+import { createApi, getBootToken } from "./api";
+import { subscribeEvents } from "./events";
+
+const api = createApi();
+
+export interface HarnessStateHook {
+  state: AppState | null;
+  loading: boolean;
+  error: string | null;
+  settings: HarnessSettings | null;
+  bootToken: string;
+  selectedWorkflowPath: string | null;
+  setSelectedWorkflowPath: (path: string | null) => void;
+  activeSessionId: string | null;
+  setActiveSessionId: (id: string | null) => void;
+  history: SessionSummary[];
+  historyLoading: boolean;
+  loadHistory: (cwd: string) => Promise<void>;
+  createSession: (req: CreateSessionRequest) => Promise<HarnessSession>;
+  resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
+  connectWorkflow: (path: string) => Promise<WorkflowInfo>;
+  runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
+  lastMessage: BusMessage | null;
+}
+
+/** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
+export function useHarnessState(): HarnessStateHook {
+  const [state, setState] = useState<AppState | null>(null);
+  const [settings, setSettings] = useState<HarnessSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedWorkflowPath, setSelectedWorkflowPath] = useState<string | null>(null);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [history, setHistory] = useState<SessionSummary[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [lastMessage, setLastMessage] = useState<BusMessage | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([api.getState(), api.getSettings()])
+      .then(([appState, harnessSettings]) => {
+        if (cancelled) return;
+        setState(appState);
+        setSettings(harnessSettings);
+        const running = appState.sessions.find((session) => session.status !== "exited");
+        if (running) setActiveSessionId(running.id);
+        if (appState.workflows[0]) setSelectedWorkflowPath(appState.workflows[0].path);
+      })
+      .catch((err: unknown) => !cancelled && setError((err as Error).message))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refreshWorkflows = useCallback(async () => {
+    const workflows = await api.listWorkflows();
+    setState((prev) => (prev ? { ...prev, workflows } : prev));
+  }, []);
+
+  useEffect(() => {
+    return subscribeEvents((message) => {
+      setLastMessage(message);
+      if (message.type === "session.status") {
+        setState((prev) => {
+          if (!prev) return prev;
+          const exists = prev.sessions.some((session) => session.id === message.session.id);
+          const sessions = exists
+            ? prev.sessions.map((session) => (session.id === message.session.id ? message.session : session))
+            : [...prev.sessions, message.session];
+          return { ...prev, sessions };
+        });
+      } else if (message.type === "workflows.changed") {
+        void refreshWorkflows();
+      }
+    });
+  }, [refreshWorkflows]);
+
+  const loadHistory = useCallback(async (cwd: string) => {
+    setHistoryLoading(true);
+    try {
+      setHistory(await api.sessionHistory(cwd));
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  const createSession = useCallback(async (req: CreateSessionRequest): Promise<HarnessSession> => {
+    const session = await api.createSession(req);
+    setState((prev) => (prev ? { ...prev, sessions: [...prev.sessions, session] } : prev));
+    setActiveSessionId(session.id);
+    setSettings((prev) => {
+      const recentDirs = [req.cwd, ...(prev?.recentDirs ?? []).filter((dir) => dir !== req.cwd)].slice(0, 10);
+      void api.updateSettings({ recentDirs });
+      return prev ? { ...prev, recentDirs } : prev;
+    });
+    return session;
+  }, []);
+
+  const resumeSession = useCallback(async (harnessSessionId: string): Promise<HarnessSession> => {
+    const session = await api.resumeSession(harnessSessionId);
+    setState((prev) =>
+      prev ? { ...prev, sessions: prev.sessions.map((s) => (s.id === session.id ? session : s)) } : prev,
+    );
+    setActiveSessionId(session.id);
+    return session;
+  }, []);
+
+  const connectWorkflow = useCallback(async (path: string): Promise<WorkflowInfo> => {
+    const workflow = await api.connectWorkflow(path);
+    setState((prev) =>
+      prev ? { ...prev, workflows: [...prev.workflows.filter((w) => w.path !== workflow.path), workflow] } : prev,
+    );
+    return workflow;
+  }, []);
+
+  const runMacro = useCallback(async (id: string, req: RunMacroRequest): Promise<void> => {
+    await api.runMacro(id, req);
+  }, []);
+
+  return {
+    state,
+    loading,
+    error,
+    settings,
+    bootToken: getBootToken(),
+    selectedWorkflowPath,
+    setSelectedWorkflowPath,
+    activeSessionId,
+    setActiveSessionId,
+    history,
+    historyLoading,
+    loadHistory,
+    createSession,
+    resumeSession,
+    connectWorkflow,
+    runMacro,
+    lastMessage,
+  };
+}

--- a/packages/harness/web/src/main.tsx
+++ b/packages/harness/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.js";
+import "./styles.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1,0 +1,663 @@
+:root {
+  --bg-0: #0a0c11;
+  --bg-1: #12151c;
+  --bg-2: #171b24;
+  --bg-3: #1e232e;
+  --bg-hover: #232936;
+  --border: #262c38;
+  --border-strong: #333c4c;
+  --text: #d7dbe3;
+  --text-dim: #8891a0;
+  --text-faint: #5b6474;
+  --accent: #5b8cff;
+  --accent-dim: #24365e;
+  --green: #3ecf8e;
+  --amber: #e0a13c;
+  --red: #e2555a;
+  --radius: 6px;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg-0);
+  color: var(--text);
+  font: 13px/1.45 var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+input {
+  font: inherit;
+  color: inherit;
+}
+
+.app-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-dim);
+}
+
+.app-status-error {
+  color: var(--red);
+}
+
+/* Layout ------------------------------------------------------------- */
+
+.app {
+  display: grid;
+  grid-template-columns: 220px 1fr minmax(280px, 40%) 48px;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.center-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+/* Rails ---------------------------------------------------------------- */
+
+.rail {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.rail-workflows {
+  padding: 10px 8px;
+}
+
+.rail-header {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 4px 6px 8px;
+}
+
+.rail-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.rail-empty {
+  color: var(--text-faint);
+  padding: 6px;
+  font-size: 12px;
+}
+
+.workflow-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  text-align: left;
+  color: var(--text-dim);
+}
+
+.workflow-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.workflow-item.is-selected {
+  background: var(--accent-dim);
+  color: var(--text);
+}
+
+.workflow-caret {
+  color: var(--text-faint);
+  font-size: 10px;
+}
+
+.workflow-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  flex: 0 0 auto;
+}
+
+.connect-trigger {
+  margin-top: 8px;
+  border: 1px dashed var(--border-strong);
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  text-align: left;
+  font-size: 12px;
+}
+
+.connect-trigger:hover {
+  color: var(--text-dim);
+  border-color: var(--text-faint);
+}
+
+.connect-form {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.connect-input {
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.connect-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.connect-error {
+  color: var(--red);
+  font-size: 11px;
+}
+
+.connect-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.rail-actions {
+  align-items: center;
+  padding: 10px 0;
+  gap: 6px;
+  border-left: 1px solid var(--border);
+}
+
+.action-icon-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: var(--radius);
+  color: var(--text-dim);
+}
+
+.action-icon-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.action-icon-btn:disabled {
+  color: var(--text-faint);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Session bar ------------------------------------------------------------ */
+
+.session-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-1);
+  position: relative;
+}
+
+.session-dropdown-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.session-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text);
+}
+
+.session-dropdown-trigger:hover {
+  border-color: var(--accent);
+}
+
+.session-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 12px;
+}
+
+.session-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--text-faint);
+}
+
+.session-dot[data-status="running"] {
+  background: var(--green);
+}
+
+.session-dot[data-status="starting"] {
+  background: var(--amber);
+}
+
+.session-dot[data-status="exited"] {
+  background: var(--text-faint);
+}
+
+.session-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 20;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.session-dropdown-section {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 6px 6px 4px;
+}
+
+.session-dropdown-empty {
+  color: var(--text-faint);
+  font-size: 12px;
+  padding: 4px 6px 8px;
+}
+
+.session-dropdown-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  text-align: left;
+}
+
+.session-dropdown-item:hover,
+.session-dropdown-item.is-selected {
+  background: var(--bg-hover);
+}
+
+.session-item-title {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.session-item-cwd,
+.session-item-meta {
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+
+.new-session-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  background: var(--accent-dim);
+  color: var(--text);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.new-session-btn:hover {
+  background: var(--accent);
+}
+
+/* Terminal slot ------------------------------------------------------ */
+
+.terminal-slot {
+  flex: 1;
+  min-height: 0;
+  background: var(--bg-0);
+}
+
+.terminal-placeholder,
+.terminal-empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.terminal-placeholder-session {
+  color: var(--text-faint);
+  font-size: 11px;
+}
+
+/* Canvas pane ---------------------------------------------------------- */
+
+.canvas-pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  min-width: 0;
+}
+
+.canvas-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  gap: 8px;
+}
+
+.canvas-mode-toggle {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-2);
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.canvas-mode-btn {
+  padding: 4px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.canvas-mode-btn.is-active {
+  background: var(--bg-3);
+  color: var(--text);
+}
+
+.preview-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px solid var(--green);
+  color: var(--green);
+  background: rgba(62, 207, 142, 0.08);
+  border-radius: 20px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.canvas-preview {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.canvas-urlbar {
+  display: flex;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.canvas-url-input {
+  flex: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 5px 8px;
+  color: var(--text);
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.canvas-url-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.canvas-iframe {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #fff;
+}
+
+.canvas-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  text-align: center;
+  padding: 24px;
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.canvas-empty code {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+/* Shared buttons ------------------------------------------------------- */
+
+.btn-ghost {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--text-dim);
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-faint);
+}
+
+.btn-primary {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: #fff;
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.btn-ghost:disabled,
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Modals ----------------------------------------------------------------- */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 16px;
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+.modal-subject {
+  width: 320px;
+}
+
+.modal-header {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.modal-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 10px 0 4px;
+}
+
+.modal-input {
+  width: 100%;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 7px 9px;
+  color: var(--text);
+  font-size: 12.5px;
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.modal-error {
+  color: var(--red);
+  font-size: 11.5px;
+  margin-top: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.recent-dirs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.recent-dir-chip {
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  color: var(--text-dim);
+  border-radius: 20px;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-dir-chip:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.harness-picker {
+  display: flex;
+  gap: 6px;
+}
+
+.harness-option {
+  flex: 1;
+  padding: 8px;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.harness-option.is-selected {
+  border-color: var(--accent);
+  color: var(--text);
+  background: var(--accent-dim);
+}

--- a/packages/harness/web/src/vite-env.d.ts
+++ b/packages/harness/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,76 @@ importers:
         specifier: ^7.16.0
         version: 7.28.0
 
+  packages/harness:
+    dependencies:
+      '@sapiom/mcp':
+        specifier: workspace:^
+        version: link:../mcp
+      express:
+        specifier: ^4.21.0
+        version: 4.22.2
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+      open:
+        specifier: ^10.1.0
+        version: 10.2.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(@types/node@20.19.43)(tsx@4.23.0))
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-web-links':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@20.19.43)(tsx@4.23.0)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.23.0)
+
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -341,7 +411,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.6(@types/node@20.19.43)
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.23.0)
 
   packages/node-http:
     dependencies:
@@ -599,6 +669,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -676,8 +758,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -688,8 +770,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -700,8 +782,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -712,8 +794,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -724,8 +806,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -736,8 +818,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -748,8 +830,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -760,8 +842,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -772,8 +854,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -784,8 +866,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -796,8 +878,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -808,8 +890,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -820,8 +902,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -832,8 +914,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -844,8 +926,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -856,8 +938,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -868,8 +950,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -880,8 +962,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -892,8 +974,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -904,8 +986,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -916,8 +998,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -928,8 +1010,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -940,8 +1022,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -952,8 +1034,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -964,8 +1046,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -976,8 +1058,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1172,6 +1254,9 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rollup/rollup-android-arm-eabi@4.62.0':
     resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
     cpu: [arm]
@@ -1331,8 +1416,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1340,11 +1431,20 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@4.19.9':
+    resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
   '@types/glob-to-regexp@0.4.4':
     resolution: {integrity: sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1358,6 +1458,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/nock@11.1.0':
     resolution: {integrity: sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==}
     deprecated: This is a stub types definition. nock provides its own type definitions, so you do not need this installed.
@@ -1368,8 +1471,34 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1438,6 +1567,12 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
@@ -1466,6 +1601,23 @@ packages:
 
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-web-links@0.11.0':
+    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1529,6 +1681,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -1585,6 +1740,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -1613,6 +1772,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1700,6 +1863,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -1714,6 +1881,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -1735,6 +1905,17 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1764,6 +1945,18 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1775,6 +1968,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1843,8 +2040,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1944,6 +2141,10 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1994,6 +2195,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -2028,6 +2233,10 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -2154,6 +2363,10 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2201,6 +2414,11 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2216,6 +2434,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -2242,6 +2465,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2491,6 +2718,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@1.23.0:
+    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2508,9 +2740,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -2522,6 +2761,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2543,6 +2786,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2561,6 +2809,9 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2571,6 +2822,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -2583,8 +2838,14 @@ packages:
     resolution: {integrity: sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
@@ -2616,6 +2877,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2684,6 +2949,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -2785,12 +3053,29 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2847,11 +3132,21 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2862,9 +3157,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -3068,6 +3371,11 @@ packages:
       jest-util:
         optional: true
 
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3087,6 +3395,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -3126,6 +3438,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -3139,19 +3455,19 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'
-      less: ^4.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -3237,6 +3553,22 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3434,6 +3766,16 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
@@ -3607,157 +3949,157 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -4076,6 +4418,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/rollup-android-arm-eabi@4.62.0':
     optional: true
 
@@ -4182,20 +4526,45 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.43
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.43
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@4.19.9':
+    dependencies:
+      '@types/node': 20.19.43
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.9
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
 
   '@types/glob-to-regexp@0.4.4': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.19.43
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4212,6 +4581,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/mime@1.3.5': {}
+
   '@types/nock@11.1.0':
     dependencies:
       nock: 14.0.15
@@ -4222,7 +4593,38 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 20.19.43
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.43
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.43
+      '@types/send': 0.17.6
+
   '@types/stack-utils@2.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -4313,6 +4715,18 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@20.19.43)(tsx@4.23.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@20.19.43)(tsx@4.23.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
@@ -4321,13 +4735,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@20.19.43))':
+  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@20.19.43)(tsx@4.23.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@20.19.43)
+      vite: 6.4.3(@types/node@20.19.43)(tsx@4.23.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -4354,6 +4768,21 @@ snapshots:
       '@vitest/pretty-format': 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
 
   accepts@2.0.0:
     dependencies:
@@ -4414,6 +4843,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  array-flatten@1.1.1: {}
 
   array-union@2.1.0: {}
 
@@ -4500,6 +4931,23 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  body-parser@1.20.5:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
@@ -4544,6 +4992,10 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   bytes@3.1.2: {}
 
@@ -4614,6 +5066,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -4621,6 +5077,8 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
@@ -4652,6 +5110,12 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.2.3: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4664,11 +5128,22 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -4726,34 +5201,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  esbuild@0.27.7:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4903,6 +5378,42 @@ snapshots:
       express: 5.2.1
       ip-address: 10.2.0
 
+  express@4.22.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.5
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -4981,6 +5492,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -5021,6 +5544,8 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -5151,6 +5676,10 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -5188,6 +5717,8 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -5197,6 +5728,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-node-process@1.2.0: {}
 
@@ -5213,6 +5748,10 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -5637,6 +6176,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@1.23.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5653,13 +6196,19 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -5678,6 +6227,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   minimatch@3.1.5:
@@ -5692,11 +6243,15 @@ snapshots:
 
   mri@1.2.0: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -5708,7 +6263,13 @@ snapshots:
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
 
+  node-addon-api@7.1.1: {}
+
   node-int64@0.4.0: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.47: {}
 
@@ -5733,6 +6294,13 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -5795,6 +6363,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@8.4.2: {}
 
@@ -5866,6 +6436,13 @@ snapshots:
 
   range-parser@1.2.1: {}
 
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
@@ -5873,7 +6450,16 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -5952,15 +6538,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
   semver@7.8.4: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   send@1.2.1:
     dependencies:
@@ -5975,6 +6585,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6156,6 +6775,12 @@ snapshots:
       esbuild: 0.28.1
       jest-util: 29.7.0
 
+  tsx@4.23.0:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6167,6 +6792,11 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
 
   type-is@2.1.0:
     dependencies:
@@ -6197,6 +6827,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  utils-merge@1.0.1: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -6205,13 +6837,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.43):
+  vite-node@3.2.4(@types/node@20.19.43)(tsx@4.23.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@20.19.43)
+      vite: 6.4.3(@types/node@20.19.43)(tsx@4.23.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6226,9 +6858,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(@types/node@20.19.43):
+  vite@6.4.3(@types/node@20.19.43)(tsx@4.23.0):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
@@ -6237,12 +6869,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
       fsevents: 2.3.3
+      tsx: 4.23.0
 
-  vitest@3.2.6(@types/node@20.19.43):
+  vitest@3.2.6(@types/node@20.19.43)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@20.19.43))
+      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@20.19.43)(tsx@4.23.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -6260,8 +6893,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(@types/node@20.19.43)
-      vite-node: 3.2.4(@types/node@20.19.43)
+      vite: 6.4.3(@types/node@20.19.43)(tsx@4.23.0)
+      vite-node: 3.2.4(@types/node@20.19.43)(tsx@4.23.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43
@@ -6308,6 +6941,12 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@8.21.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

- Four-pane SPA shell: Workflows rail (left) · session dropdown + terminal (center) · Canvas/Preview pane (right) · action icon rail (far right), built against `src/shared/types.ts`.
- Workflows rail: lists `/api/workflows`, highlights the selected one, shows a deployed dot when `definitionId != null`, "+ Connect" posts a path to `/api/workflows/connect`.
- Session bar: dropdown listing running sessions + resumable history (`/api/sessions/history?cwd=`); "+ new" opens a modal (directory input with recents, claude-code/codex picker) that posts to `/api/sessions`.
- Canvas pane: Generated/Preview toggle. Generated mode shows an explanatory empty state until a `canvas.reload` bus event (or an initial HEAD probe) confirms content exists, then iframes `/canvas/<sessionId>/` and hot-reloads on further events. Preview mode is a URL bar + iframe; a `port.detected` event surfaces a "Preview :PORT" chip that switches modes.
- Action rail: renders `/api/macros` as icon buttons (curated lucide-react icon map, not a barrel import — keeps the bundle tree-shakeable), disabled when `requiresWorkflow` and nothing's selected (or, for the deploy-link macro, when nothing's deployed yet). `open-url` macros resolve and open client-side; `inject` macros POST to `/api/macros/:id/run`. The visualize macro (and any future macro whose text references `{{subject}}`) prompts for free text first.
- `VITE_MOCK=1 pnpm --filter @sapiom/harness dev:web` renders the whole UI against in-memory fixtures (2 sessions, 3 workflows incl. one deployed, the 5 default macros) with zero network calls — gated at the API-client layer (`web/src/lib/api.ts`).
- Terminal slot: minimal placeholder at `web/src/components/Terminal.tsx` matching the real component's expected `{sessionId, token}` props — the terminal-core workstream ships the real xterm.js implementation at this exact path.
- Backend: `packages/harness/src/core/workflow-registry.ts` — bounded-depth (3) `sapiom.json` scan (skips `node_modules`/`.git`), name resolution from `package.json` or dirname, persistence to `HARNESS_PATHS.workflows`, `connectPath()`, and an Express router factory (`createWorkflowsRouter`) implementing the three `/api/workflows*` routes. Self-contained; the integrator mounts it (and `express.json()`).

## Contract-change requests (for the team, not applied here)

- `SessionSummary` has no way to point back to an existing `HarnessSession.id` for `source: "registry"` entries returned by `/api/sessions/history`. I resolve this client-side today by matching on `agentSessionId` against the live `/api/sessions` list before calling resume — works, but a `harnessSessionId?: string` field on `SessionSummary` would make it explicit and remove the client-side guess for the `source: "transcript"` case (which currently falls back to starting a fresh session in the same directory rather than a true resume, since there's no harness-tracked session to resume).

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` (server `tsconfig.json`) — clean
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean (added the missing `web/src/vite-env.d.ts` for `import.meta.env`, and switched `JSX.Element` return types to `import type { JSX } from "react"` per the React 19 / `@types/react` 19 namespace change)
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds, 216 KB gzip 67 KB (curated icon import instead of a `lucide-react` barrel import — that alone was 1.1 MB)
- [x] `vitest run` — 6/6 passing for `workflow-registry.test.ts` (depth boundary at 3, `node_modules`/`.git` skip, connect-vs-scan provenance, persistence round-trip)
- [x] `VITE_MOCK=1 vite dev` — booted, `index.html`/`main.tsx`/`App.tsx` all serve 200 with no console/module-resolution errors in the dev server log (no headless browser available in this environment to capture a literal screenshot; the production build above exercises the same module graph, JSX transform, and bundling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)