### PR TITLE
feat(harness): canvas watcher/router, macro engine, port detector

### DIFF
--- a/packages/harness/.eslintrc.cjs
+++ b/packages/harness/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+  },
+  ignorePatterns: ['.eslintrc.cjs', 'vitest.config.ts', 'dist', 'node_modules', 'web'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/harness/src/core/canvas-watcher.test.ts
+++ b/packages/harness/src/core/canvas-watcher.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { watchCanvas, snapshotCanvasDir, type CanvasWatcherHandle } from "./canvas-watcher.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+let cwd: string;
+let handle: CanvasWatcherHandle | null;
+
+describe("watchCanvas", () => {
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "harness-canvas-watch-"));
+    handle = null;
+  });
+
+  afterEach(async () => {
+    handle?.close();
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  it("fires onReload when a file is created under a not-yet-existing canvas dir", async () => {
+    let calls = 0;
+    handle = watchCanvas(cwd, () => calls++);
+
+    await fs.mkdir(path.join(cwd, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(cwd, ".sapiom", "canvas", "index.html"), "<html></html>");
+
+    await sleep(500);
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("fires onReload again when an existing canvas file changes", async () => {
+    await fs.mkdir(path.join(cwd, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(cwd, ".sapiom", "canvas", "index.html"), "<html>v1</html>");
+
+    let calls = 0;
+    handle = watchCanvas(cwd, () => calls++);
+    await sleep(100);
+
+    await fs.writeFile(path.join(cwd, ".sapiom", "canvas", "index.html"), "<html>v2</html>");
+    await sleep(500);
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("debounces rapid successive writes into fewer reloads than writes", async () => {
+    await fs.mkdir(path.join(cwd, ".sapiom", "canvas"), { recursive: true });
+    let calls = 0;
+    handle = watchCanvas(cwd, () => calls++);
+    await sleep(100);
+
+    for (let i = 0; i < 5; i++) {
+      await fs.writeFile(path.join(cwd, ".sapiom", "canvas", "index.html"), `<html>${i}</html>`);
+    }
+    await sleep(500);
+
+    expect(calls).toBeGreaterThan(0);
+    expect(calls).toBeLessThan(5);
+  });
+
+  it("does not fire for changes outside the canvas dir", async () => {
+    let calls = 0;
+    handle = watchCanvas(cwd, () => calls++);
+    await sleep(100);
+
+    await fs.writeFile(path.join(cwd, "README.md"), "unrelated change");
+    await sleep(400);
+
+    expect(calls).toBe(0);
+  });
+
+  it("close() stops further reloads", async () => {
+    let calls = 0;
+    handle = watchCanvas(cwd, () => calls++);
+    handle.close();
+
+    await fs.mkdir(path.join(cwd, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(cwd, ".sapiom", "canvas", "index.html"), "<html></html>");
+    await sleep(400);
+
+    expect(calls).toBe(0);
+  });
+});
+
+describe("snapshotCanvasDir", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-snapshot-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns an empty string when the directory doesn't exist", () => {
+    expect(snapshotCanvasDir(path.join(dir, "missing"))).toBe("");
+  });
+
+  it("changes when a file is added", async () => {
+    const before = snapshotCanvasDir(dir);
+    await fs.writeFile(path.join(dir, "index.html"), "hi");
+    const after = snapshotCanvasDir(dir);
+    expect(after).not.toBe(before);
+    expect(after.length).toBeGreaterThan(0);
+  });
+
+  it("changes when a file's content (and mtime/size) changes", async () => {
+    await fs.writeFile(path.join(dir, "index.html"), "hi");
+    const before = snapshotCanvasDir(dir);
+    await sleep(10);
+    await fs.writeFile(path.join(dir, "index.html"), "a longer body");
+    const after = snapshotCanvasDir(dir);
+    expect(after).not.toBe(before);
+  });
+
+  it("is stable across calls when nothing changed", async () => {
+    await fs.writeFile(path.join(dir, "index.html"), "hi");
+    expect(snapshotCanvasDir(dir)).toBe(snapshotCanvasDir(dir));
+  });
+});

--- a/packages/harness/src/core/canvas-watcher.ts
+++ b/packages/harness/src/core/canvas-watcher.ts
@@ -1,0 +1,92 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CANVAS_DIR } from "../shared/types.js";
+
+const DEBOUNCE_MS = 150;
+const POLL_INTERVAL_MS = 500;
+
+export interface CanvasWatcherHandle {
+  close(): void;
+}
+
+/**
+ * Cheap change fingerprint for a directory tree: sorted `path:mtime:size`
+ * entries. Used by the polling fallback (and directly testable on its own)
+ * — not a content hash, just enough to notice something moved.
+ */
+export function snapshotCanvasDir(canvasDir: string): string {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(canvasDir, { recursive: true }) as string[];
+  } catch {
+    return "";
+  }
+
+  const parts = entries.map((entry) => {
+    try {
+      const stat = fs.statSync(path.join(canvasDir, entry));
+      return `${entry}:${stat.mtimeMs}:${stat.size}`;
+    } catch {
+      return `${entry}:gone`;
+    }
+  });
+  return parts.sort().join("|");
+}
+
+/**
+ * Watches a session's canvas directory (`<cwd>/.sapiom/canvas`, see
+ * CANVAS_DIR) and invokes `onReload` (debounced) whenever its contents
+ * change. The agent may not have created the directory yet when the session
+ * starts, so this watches the whole project root recursively and filters for
+ * changes under the canvas dir — that way there's no separate "wait for it
+ * to appear" phase.
+ */
+export function watchCanvas(cwd: string, onReload: () => void): CanvasWatcherHandle {
+  const canvasDir = path.join(cwd, CANVAS_DIR);
+  const canvasPrefix = CANVAS_DIR + path.sep;
+
+  let watcher: fs.FSWatcher | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+  let lastSnapshot = "";
+
+  const debouncedReload = (): void => {
+    if (closed) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(onReload, DEBOUNCE_MS);
+  };
+
+  const isCanvasPath = (filename: string | null): boolean => {
+    // A `null` filename means the platform couldn't report which path
+    // changed — reload to be safe rather than miss an update.
+    if (!filename) return true;
+    return filename === CANVAS_DIR || filename.startsWith(canvasPrefix);
+  };
+
+  try {
+    watcher = fs.watch(cwd, { recursive: true }, (_event, filename) => {
+      if (isCanvasPath(filename)) debouncedReload();
+    });
+  } catch {
+    // `recursive` watch isn't available on this platform (notably Linux) —
+    // fall back to polling a directory-tree fingerprint.
+    lastSnapshot = snapshotCanvasDir(canvasDir);
+    pollTimer = setInterval(() => {
+      const snapshot = snapshotCanvasDir(canvasDir);
+      if (snapshot !== lastSnapshot) {
+        lastSnapshot = snapshot;
+        debouncedReload();
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  return {
+    close(): void {
+      closed = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (pollTimer) clearInterval(pollTimer);
+      watcher?.close();
+    },
+  };
+}

--- a/packages/harness/src/core/macro-runner.test.ts
+++ b/packages/harness/src/core/macro-runner.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { resolveMacro, MacroValidationError, type MacroContext } from "./macro-runner.js";
+import type { MacroDef, WorkflowInfo } from "../shared/types.js";
+
+const workflow: WorkflowInfo = {
+  name: "leasing",
+  path: "/Users/demo/acme-app/leasing",
+  definitionId: 4821,
+  source: "scan",
+};
+
+const baseCtx: MacroContext = {
+  workflow,
+  sessionCwd: "/Users/demo/acme-app",
+  canvasPath: "/Users/demo/acme-app/.sapiom/canvas/index.html",
+  subject: "the leasing funnel",
+};
+
+describe("resolveMacro", () => {
+  it("substitutes all documented placeholders in an inject macro", () => {
+    const macro: MacroDef = {
+      id: "kitchen-sink",
+      label: "Kitchen sink",
+      icon: "Sparkles",
+      action: {
+        kind: "inject",
+        text: "{{workflow.path}} {{workflow.name}} {{workflow.definitionId}} {{session.cwd}} {{canvas.path}} {{subject}}",
+      },
+    };
+
+    const resolved = resolveMacro(macro, baseCtx);
+    expect(resolved).toEqual({
+      kind: "inject",
+      text: "/Users/demo/acme-app/leasing leasing 4821 /Users/demo/acme-app /Users/demo/acme-app/.sapiom/canvas/index.html the leasing funnel",
+      submit: true,
+    });
+  });
+
+  it("defaults submit to true when the macro omits it, and honors submit:false", () => {
+    const macro: MacroDef = {
+      id: "no-submit",
+      label: "No submit",
+      icon: "Play",
+      action: { kind: "inject", text: "hi", submit: false },
+    };
+    expect(resolveMacro(macro, baseCtx)).toEqual({ kind: "inject", text: "hi", submit: false });
+  });
+
+  it("substitutes placeholders in an open-url macro", () => {
+    const macro: MacroDef = {
+      id: "open",
+      label: "Open",
+      icon: "ExternalLink",
+      action: { kind: "open-url", url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}" },
+    };
+    expect(resolveMacro(macro, baseCtx)).toEqual({
+      kind: "open-url",
+      url: "https://app.sapiom.ai/agents/4821",
+    });
+  });
+
+  it("substitutes missing workflow fields with empty strings when no workflow is selected", () => {
+    const macro: MacroDef = {
+      id: "visualize",
+      label: "Visualize",
+      icon: "Sparkles",
+      action: { kind: "inject", text: "path=[{{workflow.path}}] id=[{{workflow.definitionId}}]" },
+    };
+    const resolved = resolveMacro(macro, { ...baseCtx, workflow: null });
+    expect(resolved).toEqual({ kind: "inject", text: "path=[] id=[]", submit: true });
+  });
+
+  it("throws MacroValidationError when requiresWorkflow and no workflow is selected", () => {
+    const macro: MacroDef = {
+      id: "deploy",
+      label: "Deploy",
+      icon: "Cloud",
+      requiresWorkflow: true,
+      action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents deploy" },
+    };
+    expect(() => resolveMacro(macro, { ...baseCtx, workflow: null })).toThrow(MacroValidationError);
+  });
+
+  it("does not require a workflow when requiresWorkflow is falsy, even with a null workflow", () => {
+    const macro: MacroDef = {
+      id: "visualize",
+      label: "Visualize",
+      icon: "Sparkles",
+      action: { kind: "inject", text: "visualize {{subject}}" },
+    };
+    expect(resolveMacro(macro, { ...baseCtx, workflow: null })).toEqual({
+      kind: "inject",
+      text: "visualize the leasing funnel",
+      submit: true,
+    });
+  });
+});

--- a/packages/harness/src/core/macro-runner.ts
+++ b/packages/harness/src/core/macro-runner.ts
@@ -1,0 +1,72 @@
+/**
+ * Macro resolution (workstream W5's backend slice): substitutes the
+ * `{{...}}` placeholders documented on MacroDef (shared/types.ts) into a
+ * macro's action, given the run-time context (selected workflow, session,
+ * canvas path, free-text subject). Pure and side-effect free — the caller
+ * (src/server/macros.ts) executes the resolved action.
+ */
+import type { MacroDef, WorkflowInfo } from "../shared/types.js";
+
+export interface MacroContext {
+  workflow: WorkflowInfo | null;
+  sessionCwd: string;
+  /** Absolute path to the session's canvas index file ({{canvas.path}}). */
+  canvasPath: string;
+  /** Free-text subject for the Visualize macro ({{subject}}). */
+  subject?: string;
+}
+
+export type ResolvedMacroAction =
+  | { kind: "inject"; text: string; submit: boolean }
+  | { kind: "open-url"; url: string };
+
+export class MacroValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MacroValidationError";
+  }
+}
+
+// Target lib is ES2020 (see the root tsconfig) — no String.prototype.replaceAll.
+function replaceAllLiteral(input: string, search: string, replacement: string): string {
+  return input.split(search).join(replacement);
+}
+
+function substitute(template: string, ctx: MacroContext): string {
+  const replacements: Record<string, string> = {
+    "{{workflow.path}}": ctx.workflow?.path ?? "",
+    "{{workflow.name}}": ctx.workflow?.name ?? "",
+    "{{workflow.definitionId}}":
+      ctx.workflow?.definitionId != null ? String(ctx.workflow.definitionId) : "",
+    "{{session.cwd}}": ctx.sessionCwd,
+    "{{canvas.path}}": ctx.canvasPath,
+    "{{subject}}": ctx.subject ?? "",
+  };
+
+  let result = template;
+  for (const [placeholder, value] of Object.entries(replacements)) {
+    result = replaceAllLiteral(result, placeholder, value);
+  }
+  return result;
+}
+
+/**
+ * Resolves a macro's action for execution against `ctx`.
+ * Throws `MacroValidationError` when `macro.requiresWorkflow` and `ctx.workflow`
+ * is null — the caller (the REST handler) turns that into a 400.
+ */
+export function resolveMacro(macro: MacroDef, ctx: MacroContext): ResolvedMacroAction {
+  if (macro.requiresWorkflow && !ctx.workflow) {
+    throw new MacroValidationError(`Macro '${macro.id}' requires a selected workflow.`);
+  }
+
+  if (macro.action.kind === "open-url") {
+    return { kind: "open-url", url: substitute(macro.action.url, ctx) };
+  }
+
+  return {
+    kind: "inject",
+    text: substitute(macro.action.text, ctx),
+    submit: macro.action.submit ?? true,
+  };
+}

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -2,18 +2,18 @@ import { describe, it, expect } from "vitest";
 import { DEFAULT_MACROS } from "./macros.js";
 
 describe("DEFAULT_MACROS", () => {
-  it("defines exactly the 5 action-rail macros", () => {
+  it("defines exactly the 5 action-rail macros, matching the SPA's MOCK_MACROS ids", () => {
     expect(DEFAULT_MACROS.map((m) => m.id)).toEqual([
-      "run-local",
+      "run_local",
       "deploy",
-      "prod-run",
-      "open-prod",
+      "prod_run",
+      "open_prod",
       "visualize",
     ]);
   });
 
-  it("run-local, deploy, and prod-run require a selected workflow and template {{workflow.path}}", () => {
-    for (const id of ["run-local", "deploy", "prod-run"]) {
+  it("run_local, deploy, and prod_run require a selected workflow and template {{workflow.path}}", () => {
+    for (const id of ["run_local", "deploy", "prod_run"]) {
       const macro = DEFAULT_MACROS.find((m) => m.id === id)!;
       expect(macro.requiresWorkflow).toBe(true);
       expect(macro.action.kind).toBe("inject");
@@ -23,18 +23,21 @@ describe("DEFAULT_MACROS", () => {
     }
   });
 
-  it("open-prod opens the app URL and needs no workflow", () => {
-    const macro = DEFAULT_MACROS.find((m) => m.id === "open-prod")!;
-    expect(macro.requiresWorkflow).toBeFalsy();
-    expect(macro.action).toEqual({ kind: "open-url", url: "https://app.sapiom.ai" });
+  it("open_prod deep-links to the workflow and requires one to be selected", () => {
+    const macro = DEFAULT_MACROS.find((m) => m.id === "open_prod")!;
+    expect(macro.requiresWorkflow).toBe(true);
+    expect(macro.action).toEqual({
+      kind: "open-url",
+      url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}",
+    });
   });
 
-  it("visualize templates {{subject}} and {{canvas.path}}", () => {
+  it("visualize templates {{subject}} and needs no workflow", () => {
     const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
+    expect(macro.requiresWorkflow).toBeFalsy();
     expect(macro.action.kind).toBe("inject");
     if (macro.action.kind === "inject") {
       expect(macro.action.text).toContain("{{subject}}");
-      expect(macro.action.text).toContain("{{canvas.path}}");
     }
   });
 

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -1,20 +1,22 @@
 /**
  * Default action-rail macros. Pure data — no execution wiring. The server
  * resolves `{{...}}` placeholders (see MacroDef in shared/types.ts) and
- * either injects the text into the session pty or opens the URL.
+ * either injects the text into the session pty or opens the URL. Matches the
+ * SPA's MOCK_MACROS fixture (web/src/lib/mock-data.ts) so mock and real mode
+ * present the same action rail.
  */
 import type { MacroDef } from "../shared/types.js";
 
 export const DEFAULT_MACROS: MacroDef[] = [
   {
-    id: "run-local",
+    id: "run_local",
     label: "Run local",
     icon: "Play",
     requiresWorkflow: true,
     action: {
       kind: "inject",
       submit: true,
-      text: "Run the agent at {{workflow.path}} locally against stub capabilities (the sapiom_dev_agents_run_local tool) and show me the per-step trace, including any unusedStubs or stubWarnings.",
+      text: "cd {{workflow.path}} && sapiom agents run --target local",
     },
   },
   {
@@ -25,37 +27,39 @@ export const DEFAULT_MACROS: MacroDef[] = [
     action: {
       kind: "inject",
       submit: true,
-      text: "Deploy the agent at {{workflow.path}} (link it if needed, then deploy) and report the build result.",
+      text: "cd {{workflow.path}} && sapiom agents deploy",
     },
   },
   {
-    id: "prod-run",
+    id: "prod_run",
     label: "Prod run",
     icon: "Zap",
     requiresWorkflow: true,
     action: {
       kind: "inject",
       submit: true,
-      text: "Start a real cloud execution of the deployed agent at {{workflow.path}} and give me the executionId so I can track it.",
+      text: "cd {{workflow.path}} && sapiom agents run --target prod",
     },
   },
   {
-    id: "open-prod",
+    id: "open_prod",
     label: "Open prod",
     icon: "ExternalLink",
+    requiresWorkflow: true,
     action: {
       kind: "open-url",
-      url: "https://app.sapiom.ai",
+      url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}",
     },
   },
   {
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
+    requiresWorkflow: false,
     action: {
       kind: "inject",
       submit: true,
-      text: "Render {{subject}} as a self-contained static HTML page at {{canvas.path}} (inline any CSS/JS/data it needs) — I'll view it live in the canvas pane.",
+      text: "Write a live HTML visualization of {{subject}} to .sapiom/canvas/index.html and keep it updated as things change.",
     },
   },
 ];

--- a/packages/harness/src/core/port-detector.test.ts
+++ b/packages/harness/src/core/port-detector.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { detectPort, detectPortInPayload } from "./port-detector.js";
+
+describe("detectPort", () => {
+  it("finds a localhost:<port> reference", () => {
+    expect(detectPort("Server running at http://localhost:3000")).toEqual({
+      port: 3000,
+      url: "http://localhost:3000",
+    });
+  });
+
+  it("finds a port embedded in a longer log line", () => {
+    expect(detectPort("$ npm run dev\n> Local:   http://localhost:5173/\n")).toEqual({
+      port: 5173,
+      url: "http://localhost:5173",
+    });
+  });
+
+  it("returns null when there's no localhost reference", () => {
+    expect(detectPort("Compiled successfully.")).toBeNull();
+  });
+
+  it("returns null for a malformed port (too many digits)", () => {
+    expect(detectPort("localhost:123456")).toBeNull();
+  });
+
+  it("returns null for a single-digit port (below the 2-5 digit window)", () => {
+    expect(detectPort("localhost:8")).toBeNull();
+  });
+});
+
+describe("detectPortInPayload", () => {
+  it("finds a port in the command field", () => {
+    expect(detectPortInPayload({ command: "vite --port 4321 & open http://localhost:4321" })).toEqual({
+      port: 4321,
+      url: "http://localhost:4321",
+    });
+  });
+
+  it("finds a port in the output field when command has none", () => {
+    expect(
+      detectPortInPayload({
+        command: "npm run dev",
+        output: "ready - started server on http://localhost:3001",
+      }),
+    ).toEqual({ port: 3001, url: "http://localhost:3001" });
+  });
+
+  it("returns null when no candidate field has a port", () => {
+    expect(detectPortInPayload({ command: "ls -la", output: "total 0" })).toBeNull();
+  });
+
+  it("ignores non-string candidate fields", () => {
+    expect(detectPortInPayload({ command: 12345, output: null })).toBeNull();
+  });
+
+  it("returns null for an empty payload", () => {
+    expect(detectPortInPayload({})).toBeNull();
+  });
+});

--- a/packages/harness/src/core/port-detector.ts
+++ b/packages/harness/src/core/port-detector.ts
@@ -1,0 +1,48 @@
+/**
+ * Dev-server port detection (workstream W5's backend slice).
+ *
+ * The Preview pane's "Preview :PORT" chip (CanvasPane.tsx) lights up from a
+ * `port.detected` bus message. The signal for that message is a
+ * `localhost:<port>` reference showing up in a `tool.call` analytics event's
+ * command/output — this module is the pure detector; the analytics ingest
+ * pipeline (workstream W3) calls it per tool.call event and, on a hit,
+ * broadcasts `{ type: "port.detected", harnessSessionId, port, url }` on
+ * /ws/events.
+ */
+
+const PORT_REFERENCE = /\blocalhost:(\d{2,5})\b/;
+
+/** Fields commonly carrying a Bash tool call's command/output in the
+ *  schemaless AnalyticsEvent.payload. */
+const CANDIDATE_FIELDS = ["command", "output", "stdout", "stderr", "result", "text"];
+
+export interface DetectedPort {
+  port: number;
+  url: string;
+}
+
+/** Scans free-form text for a `localhost:<port>` reference. */
+export function detectPort(text: string): DetectedPort | null {
+  const match = PORT_REFERENCE.exec(text);
+  if (!match) return null;
+
+  const port = Number(match[1]);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+
+  return { port, url: `http://localhost:${port}` };
+}
+
+/**
+ * Scans a `tool.call` event's schemaless payload for a `localhost:<port>`
+ * reference across the fields it's typically carried in. Returns the first
+ * match found, checking fields in `CANDIDATE_FIELDS` order.
+ */
+export function detectPortInPayload(payload: Record<string, unknown>): DetectedPort | null {
+  for (const field of CANDIDATE_FIELDS) {
+    const value = payload[field];
+    if (typeof value !== "string") continue;
+    const found = detectPort(value);
+    if (found) return found;
+  }
+  return null;
+}

--- a/packages/harness/src/server/canvas.test.ts
+++ b/packages/harness/src/server/canvas.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import type { Server } from "node:http";
+import { createCanvasRouter, type CanvasSession } from "./canvas.js";
+
+let projectDir: string;
+let server: Server;
+let baseUrl: string;
+let port: number;
+const sessions = new Map<string, CanvasSession>();
+
+async function start(): Promise<void> {
+  const app = express();
+  app.use(createCanvasRouter((id) => sessions.get(id)));
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  port = typeof address === "object" && address ? address.port : 0;
+  baseUrl = `http://127.0.0.1:${port}`;
+}
+
+async function stop(): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/**
+ * `fetch()` normalizes percent-encoded dot segments (e.g. `%2e%2e`) client-side
+ * before the request is ever sent — it never reaches the server as-is. To
+ * actually exercise the server's own traversal guard, send the raw request
+ * line ourselves.
+ */
+function rawGet(rawPath: string): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path: rawPath, method: "GET" }, (res) => {
+      res.resume();
+      res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("canvas router", () => {
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-canvas-"));
+    sessions.clear();
+    sessions.set("sess-1", { cwd: projectDir });
+    await start();
+  });
+
+  afterEach(async () => {
+    await stop();
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("404s when no canvas has been written yet", async () => {
+    const res = await fetch(`${baseUrl}/canvas/sess-1/`, { method: "HEAD" });
+    expect(res.status).toBe(404);
+  });
+
+  it("serves index.html at the session's canvas root", async () => {
+    await fs.mkdir(path.join(projectDir, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, ".sapiom", "canvas", "index.html"),
+      "<html><body>hi</body></html>",
+    );
+
+    const head = await fetch(`${baseUrl}/canvas/sess-1/`, { method: "HEAD" });
+    expect(head.status).toBe(200);
+
+    const get = await fetch(`${baseUrl}/canvas/sess-1/`);
+    expect(get.status).toBe(200);
+    expect(get.headers.get("content-type")).toContain("text/html");
+    expect(await get.text()).toBe("<html><body>hi</body></html>");
+  });
+
+  it("serves nested assets under the canvas dir", async () => {
+    await fs.mkdir(path.join(projectDir, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "<html></html>");
+    await fs.writeFile(path.join(projectDir, ".sapiom", "canvas", "chart.js"), "console.log(1);");
+
+    const res = await fetch(`${baseUrl}/canvas/sess-1/chart.js`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/javascript");
+    expect(await res.text()).toBe("console.log(1);");
+  });
+
+  it("404s for an unknown session", async () => {
+    const res = await fetch(`${baseUrl}/canvas/no-such-session/`);
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks a literal '..' traversal attempt with 400, not by escaping the canvas root", async () => {
+    await fs.mkdir(path.join(projectDir, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(projectDir, "secret.txt"), "nope");
+
+    const res = await rawGet("/canvas/sess-1/../../secret.txt");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a percent-encoded traversal attempt with 400, not by escaping the canvas root", async () => {
+    await fs.mkdir(path.join(projectDir, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(projectDir, "secret.txt"), "nope");
+
+    const res = await rawGet("/canvas/sess-1/%2e%2e/%2e%2e/secret.txt");
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/harness/src/server/canvas.ts
+++ b/packages/harness/src/server/canvas.ts
@@ -1,0 +1,88 @@
+/**
+ * Canvas serving (workstream W5's backend slice).
+ *
+ * Serves whatever a session's agent wrote to `<cwd>/.sapiom/canvas/` (see
+ * CANVAS_DIR) at `GET /canvas/:harnessSessionId/*`. The SPA's CanvasPane
+ * embeds this in a sandboxed iframe and probes it with a HEAD request
+ * (`fetch('/canvas/<id>/', { method: 'HEAD' })`), so this stays
+ * intentionally simple and unauthenticated — the server binds 127.0.0.1
+ * only, and an iframe `src` / HEAD probe can't carry the boot token anyway.
+ * The integrator mounts this alongside the SessionManager.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Router, type Router as ExpressRouter, type Request, type Response } from "express";
+import { CANVAS_DIR, CANVAS_INDEX } from "../shared/types.js";
+
+const INDEX_FILENAME = path.basename(CANVAS_INDEX);
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+function contentTypeFor(filePath: string): string {
+  return MIME_TYPES[path.extname(filePath).toLowerCase()] ?? "application/octet-stream";
+}
+
+export interface CanvasSession {
+  cwd: string;
+}
+
+/** Looks up a session by harnessSessionId; undefined when unknown (the real
+ *  implementation is the SessionManager, once workstream W1 lands). */
+export type CanvasSessionLookup = (harnessSessionId: string) => CanvasSession | undefined;
+
+function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Response, relative: string): void {
+  const session = getSession(req.params.harnessSessionId);
+  if (!session) {
+    res.status(404).end();
+    return;
+  }
+
+  const canvasRoot = path.resolve(session.cwd, CANVAS_DIR);
+  const filePath = path.resolve(canvasRoot, relative);
+
+  // Path traversal guard: the resolved file must stay under canvasRoot.
+  if (filePath !== canvasRoot && !filePath.startsWith(canvasRoot + path.sep)) {
+    res.status(400).end();
+    return;
+  }
+
+  fs.stat(filePath, (err, stat) => {
+    if (err || !stat.isFile()) {
+      res.status(404).end();
+      return;
+    }
+    res.setHeader("Content-Type", contentTypeFor(filePath));
+    res.setHeader("Cache-Control", "no-store");
+    fs.createReadStream(filePath).pipe(res);
+  });
+}
+
+export function createCanvasRouter(getSession: CanvasSessionLookup): ExpressRouter {
+  const router = Router();
+
+  router.get("/canvas/:harnessSessionId/*", (req, res) => {
+    // Express's route-param typing doesn't model the unnamed `*` wildcard —
+    // it's there at runtime as params[0], just not in the inferred type.
+    const wildcard = (req.params as unknown as Record<string, string>)[0];
+    serveCanvas(getSession, req, res, wildcard || INDEX_FILENAME);
+  });
+
+  router.get(["/canvas/:harnessSessionId", "/canvas/:harnessSessionId/"], (req, res) => {
+    serveCanvas(getSession, req, res, INDEX_FILENAME);
+  });
+
+  return router;
+}

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import { createMacrosRouter, type MacrosRouterDeps } from "./macros.js";
+import { DEFAULT_MACROS } from "../core/macros.js";
+import type { WorkflowInfo } from "../shared/types.js";
+
+let server: Server;
+let baseUrl: string;
+
+const workflow: WorkflowInfo = {
+  name: "leasing",
+  path: "/Users/demo/acme-app/leasing",
+  definitionId: 4821,
+  source: "scan",
+};
+
+function makeDeps(overrides: Partial<MacrosRouterDeps> = {}): MacrosRouterDeps {
+  return {
+    listMacros: () => DEFAULT_MACROS,
+    findWorkflow: (p) => (p === workflow.path ? workflow : null),
+    getSessionCwd: (id) => (id === "sess-1" ? "/Users/demo/acme-app" : null),
+    injectInput: vi.fn().mockResolvedValue(undefined),
+    openUrl: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+async function start(deps: MacrosRouterDeps): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use(createMacrosRouter(deps));
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  baseUrl = `http://127.0.0.1:${port}`;
+}
+
+async function stop(): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("macros router", () => {
+  afterEach(async () => {
+    await stop();
+  });
+
+  it("GET /api/macros returns the configured macro list", async () => {
+    await start(makeDeps());
+    const res = await fetch(`${baseUrl}/api/macros`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(DEFAULT_MACROS);
+  });
+
+  it("POST /api/macros/:id/run injects the resolved text for an inject macro", async () => {
+    const deps = makeDeps();
+    await start(deps);
+
+    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deps.injectInput).toHaveBeenCalledWith(
+      "sess-1",
+      "cd /Users/demo/acme-app/leasing && sapiom agents deploy",
+      true,
+    );
+    expect(deps.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("opens the resolved URL for an open-url macro", async () => {
+    const deps = makeDeps();
+    await start(deps);
+
+    const res = await fetch(`${baseUrl}/api/macros/open_prod/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deps.openUrl).toHaveBeenCalledWith("https://app.sapiom.ai/agents/4821");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("400s a workflow-required macro run without a workflowPath", async () => {
+    await start(makeDeps());
+    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("requires a selected workflow");
+  });
+
+  it("404s an unknown macro id", async () => {
+    await start(makeDeps());
+    const res = await fetch(`${baseUrl}/api/macros/does-not-exist/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("400s a run request missing harnessSessionId", async () => {
+    await start(makeDeps());
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subject: "the leasing funnel" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s a run request for an unknown session", async () => {
+    await start(makeDeps());
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "no-such-session", subject: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("runs a workflow-optional macro (visualize) without a workflowPath", async () => {
+    const deps = makeDeps();
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", subject: "the leasing funnel" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deps.injectInput).toHaveBeenCalledWith(
+      "sess-1",
+      "Write a live HTML visualization of the leasing funnel to .sapiom/canvas/index.html and keep it updated as things change.",
+      true,
+    );
+  });
+});

--- a/packages/harness/src/server/macros.ts
+++ b/packages/harness/src/server/macros.ts
@@ -1,0 +1,80 @@
+/**
+ * Macro execution endpoint (workstream W5's backend slice): `GET /api/macros`
+ * and `POST /api/macros/:id/run` from src/shared/types.ts. The SPA's action
+ * rail already resolves and opens "open-url" macros client-side — it can't
+ * carry the boot token through `window.open` anyway — so in practice this
+ * only ever executes "inject" macros, but it handles both kinds per the
+ * documented contract. The integrator mounts this (with express.json())
+ * alongside the SessionManager and WorkflowRegistry.
+ */
+import * as path from "node:path";
+import { Router, type Router as ExpressRouter } from "express";
+import { CANVAS_INDEX, type MacroDef, type RunMacroRequest, type WorkflowInfo } from "../shared/types.js";
+import { MacroValidationError, resolveMacro } from "../core/macro-runner.js";
+
+export interface MacrosRouterDeps {
+  listMacros(): MacroDef[];
+  /** Look up a registered workflow by its path; null when not found. */
+  findWorkflow(workflowPath: string): WorkflowInfo | null;
+  /** The session's project directory, or null when the session is unknown. */
+  getSessionCwd(harnessSessionId: string): string | null;
+  /** Injects resolved text into the session's pty (the SessionManager). */
+  injectInput(harnessSessionId: string, text: string, submit: boolean): Promise<void>;
+  /** Opens a URL in the user's default browser (the `open` package). */
+  openUrl(url: string): Promise<void>;
+}
+
+export function createMacrosRouter(deps: MacrosRouterDeps): ExpressRouter {
+  const router = Router();
+
+  router.get("/api/macros", (_req, res) => {
+    res.json(deps.listMacros());
+  });
+
+  router.post("/api/macros/:id/run", async (req, res) => {
+    const macro = deps.listMacros().find((m) => m.id === req.params.id);
+    if (!macro) {
+      res.status(404).json({ error: `Unknown macro '${req.params.id}'` });
+      return;
+    }
+
+    const body = (req.body ?? {}) as Partial<RunMacroRequest>;
+    if (typeof body.harnessSessionId !== "string" || !body.harnessSessionId) {
+      res.status(400).json({ error: "harnessSessionId is required" });
+      return;
+    }
+
+    const cwd = deps.getSessionCwd(body.harnessSessionId);
+    if (!cwd) {
+      res.status(404).json({ error: `Unknown session '${body.harnessSessionId}'` });
+      return;
+    }
+
+    const workflow = typeof body.workflowPath === "string" ? deps.findWorkflow(body.workflowPath) : null;
+
+    try {
+      const resolved = resolveMacro(macro, {
+        workflow,
+        sessionCwd: cwd,
+        canvasPath: path.join(cwd, CANVAS_INDEX),
+        subject: body.subject,
+      });
+
+      if (resolved.kind === "open-url") {
+        await deps.openUrl(resolved.url);
+      } else {
+        await deps.injectInput(body.harnessSessionId, resolved.text, resolved.submit);
+      }
+
+      res.json({ ok: true });
+    } catch (err) {
+      if (err instanceof MacroValidationError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Backend half of W5 (canvas + macros + preview), split off to start before W1's SessionManager/terminal core lands, since these pieces are dependency-injected against a session lookup rather than the real thing:

- **`src/core/canvas-watcher.ts`** — `watchCanvas(cwd, onReload)` watches `<cwd>/.sapiom/canvas` (the canvas convention) recursively via `fs.watch`, debounced (150ms). Falls back to polling a directory-tree fingerprint (`snapshotCanvasDir`, also exported/tested standalone) on platforms where recursive `fs.watch` isn't supported (notably Linux). No "wait for the directory to appear" phase needed — the whole project root is watched and filtered.
- **`src/server/canvas.ts`** — `createCanvasRouter(getSession)`, an Express router for `GET /canvas/:harnessSessionId/*`. Matches the already-merged `CanvasPane.tsx` contract exactly: no auth token (an iframe `src` / `HEAD` probe can't carry one — the server binds `127.0.0.1` only), serves `index.html` at the root, supports nested assets, and guards against path traversal.
- **`src/core/macro-runner.ts`** — `resolveMacro(macro, ctx)`, pure `{{...}}` placeholder substitution (all 6 documented on `MacroDef`) plus `requiresWorkflow` validation (throws `MacroValidationError`, which the router turns into a 400).
- **`src/server/macros.ts`** — `createMacrosRouter(deps)` for `GET /api/macros` + `POST /api/macros/:id/run`, dependency-injected against session/workflow lookups and inject/openUrl effects (the real SessionManager wiring lands with W1).
- **`src/core/macros.ts`** — `DEFAULT_MACROS` realigned to the SPA's already-merged `MOCK_MACROS` fixture (`web/src/lib/mock-data.ts`): ids (`run_local`/`prod_run`/`open_prod`), literal `sapiom agents run/deploy` shell-command inject text, and the deep-linking `open_prod` URL — so mock mode and real mode present an identical action rail.
- **`src/core/port-detector.ts`** — pure `localhost:<port>` detection (`detectPort`, `detectPortInPayload`) for the ingest pipeline to call per `tool.call` event and broadcast `port.detected` on `/ws/events` (powers the Preview pane's port chip).
- **`.eslintrc.cjs`** — the harness package had no lint config since the W0 scaffold (`pnpm lint` failed for everyone); added, matching `@sapiom/mcp`'s.

## Integration notes (for W1 / final integration)

- `createCanvasRouter` / `createMacrosRouter` follow the same DI-router-factory pattern as the already-merged `WorkflowRegistry`/`createWorkflowsRouter` — mount them next to it once `SessionManager` exists, wiring `getSession`/`getSessionCwd`/`injectInput` to the real pty registry.
- `watchCanvas` returns a handle with `close()`; the integrator starts one per session (on session create) and calls `close()` on session exit, broadcasting `canvas.reload` on `/ws/events` from its `onReload` callback.
- `detectPortInPayload` is a pure function, not wired to `/ingest` — the analytics pipeline should call it per `tool.call` event and broadcast `port.detected` on a hit.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` — clean
- [x] `pnpm --filter @sapiom/harness build` (tsc + vite, now includes the SPA's `lucide-react` dep) — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean (new `.eslintrc.cjs`)
- [x] `pnpm --filter @sapiom/harness test` — 69/69 passing across 13 files, including:
  - canvas watcher: creation-before-canvas-dir-exists, in-place file changes, debouncing, no cross-talk from unrelated file changes, `close()` teardown, and a standalone `snapshotCanvasDir` fingerprint suite
  - canvas router: 404 with no canvas yet, serving index + nested assets, unknown-session 404, and both a literal `..` and a percent-encoded (`%2e%2e`) traversal attempt sent via a raw `http.request` (fetch's own URL normalization silently strips both before the request is even sent, so a real HTTP client can't exercise the guard — verified this by hand against a plain echo server first)
  - macro engine: all 6 placeholders, `submit` default/override, `open-url` substitution, missing-workflow validation error, workflow-optional macros
  - macros router: list, inject execution, open-url execution, 400s (missing workflow, missing session id), 404s (unknown macro, unknown session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)