### PR TITLE
test(harness): mock-mode Playwright UI smoke

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -40,6 +40,7 @@
     "start": "node dist/cli/bin.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ui": "playwright test --config web/e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
     "prepublishOnly": "pnpm build"
@@ -53,6 +54,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.30",
     "@types/react": "^19.0.0",

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// web/e2e/*.spec.ts are Playwright tests (see web/e2e/playwright.config.ts,
+// run via `pnpm test:ui`) — a different runner and API, and opt-in rather
+// than part of the default `test` script. Vitest's default glob would
+// otherwise try (and fail) to execute them here too.
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/harness/web/e2e/.gitignore
+++ b/packages/harness/web/e2e/.gitignore
@@ -1,0 +1,3 @@
+screenshots/
+playwright-report/
+test-results/

--- a/packages/harness/web/e2e/playwright.config.ts
+++ b/packages/harness/web/e2e/playwright.config.ts
@@ -1,0 +1,45 @@
+/**
+ * Config for `pnpm --filter @sapiom/harness test:ui`.
+ *
+ * One-time setup (browsers aren't installed by `pnpm install`):
+ *   npx playwright install chromium
+ *
+ * Runs against the Vite dev server in mock mode (VITE_MOCK=1) — no harness
+ * server, backend, or real agent process needed. Opt-in only: this is not
+ * part of the `test` script.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "..", "..");
+
+const PORT = 5299;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: here,
+  testMatch: "*.spec.ts",
+  // Keep artifacts (traces, the HTML report) next to the tests, not in the package
+  // root — web/e2e/.gitignore covers this directory.
+  outputDir: path.join(here, "test-results"),
+  reporter: [["list"], ["html", { outputFolder: path.join(here, "playwright-report"), open: "never" }]],
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `npx vite --config web/vite.config.ts --port ${PORT} --strictPort`,
+    cwd: packageRoot,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+    env: { VITE_MOCK: "1" },
+  },
+});

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Mock-mode UI smoke test — runs against `vite dev` with VITE_MOCK=1 (see
+ * playwright.config.ts), no harness server required. Fixtures live in
+ * ../src/lib/mock-data.ts: 3 workflows (one deployed), 2 sessions (both
+ * start exited — a fresh launch has no running terminal yet), 5 macros.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+test("renders all four panes", async ({ page }) => {
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await expect(page.locator(".center-pane")).toBeVisible();
+  await expect(page.locator(".session-bar")).toBeVisible();
+  await expect(page.locator(".canvas-pane")).toBeVisible();
+  await expect(page.locator(".rail-actions")).toBeVisible();
+
+  await page.screenshot({ path: "web/e2e/screenshots/app-shell.png", fullPage: true });
+});
+
+test("workflows rail lists the fixtures and selecting one drives macro gating", async ({ page }) => {
+  await expect(page.locator(".workflow-item")).toHaveCount(3);
+
+  // "leasing" is deployed (has a definitionId) — selecting it enables the deploy-link macro.
+  const openProd = page.getByTestId("macro-open_prod");
+  await page.getByTestId("workflow-leasing").click();
+  await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-selected/);
+  await expect(openProd).toBeEnabled();
+
+  // "rfq" has no definitionId — selecting it should disable the deploy-link macro again,
+  // with a reason distinct from "no workflow selected".
+  await page.getByTestId("workflow-rfq").click();
+  await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-selected/);
+  await expect(openProd).toBeDisabled();
+  await expect(openProd).toHaveAttribute("data-tooltip", "Not deployed yet");
+});
+
+test("inject macros are disabled with a reason before any session is active", async ({ page }) => {
+  // No session is active on load (fixtures start exited) — a workflow is auto-selected,
+  // so the reason should be about the session, not the workflow.
+  const runLocal = page.getByTestId("macro-run_local");
+  await expect(runLocal).toBeDisabled();
+  await expect(runLocal).toHaveAttribute("data-tooltip", "Start a session first");
+
+  // The deploy-link macro doesn't touch a pty, so it isn't gated on a session.
+  await expect(page.getByTestId("macro-open_prod")).toBeEnabled();
+
+  await runLocal.hover();
+  await page.screenshot({ path: "web/e2e/screenshots/action-rail-tooltip.png" });
+});
+
+test("new-session modal opens and validates the directory field", async ({ page }) => {
+  await page.getByTestId("new-session-btn").click();
+  await expect(page.getByText("New session")).toBeVisible();
+
+  const startButton = page.getByRole("button", { name: "Start session" });
+  const cwdInput = page.locator("#new-session-cwd");
+
+  await cwdInput.fill("");
+  await expect(startButton).toBeDisabled();
+
+  await cwdInput.fill("/tmp/example-project");
+  await expect(startButton).toBeEnabled();
+
+  await page.screenshot({ path: "web/e2e/screenshots/new-session-modal.png" });
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByText("New session")).toBeHidden();
+});
+
+test("canvas pane shows its empty state when there's no active session", async ({ page }) => {
+  await expect(page.locator(".canvas-empty")).toContainText("Start a session to see its canvas here");
+});
+
+test("visualize macro prompts for a subject before running", async ({ page }) => {
+  // Resume a history entry so the session-gated macro is enabled.
+  await page.getByTestId("session-dropdown-trigger").click();
+  await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
+  await expect(page.getByTestId("macro-visualize")).toBeEnabled();
+
+  await page.getByTestId("macro-visualize").click();
+  await expect(page.getByText("Visualize")).toBeVisible();
+  const subjectInput = page.getByPlaceholder("What should the agent visualize?");
+  await expect(subjectInput).toBeVisible();
+
+  await subjectInput.fill("the leasing pipeline");
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(subjectInput).toBeHidden();
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -5,7 +5,7 @@
  * | canvas/preview pane (right) | action icon rail (far right).
  */
 import type { JSX } from "react";
-import type { HarnessKind, MacroDef, SessionSummary } from "@shared/types";
+import type { HarnessKind, MacroDef } from "@shared/types";
 
 import { ActionRail } from "./components/ActionRail";
 import { CanvasPane } from "./components/CanvasPane";
@@ -29,17 +29,6 @@ export const App = (): JSX.Element => {
 
   const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
-  };
-
-  const handleResumeHistory = async (summary: SessionSummary): Promise<void> => {
-    const existing = state.sessions.find((session) => session.agentSessionId === summary.agentSessionId);
-    if (existing) {
-      await harness.resumeSession(existing.id);
-      return;
-    }
-    // Agent-side history the harness never tracked as a session (e.g. transcript-sourced
-    // entries) — there's no registry row to resume, so start fresh in the same place.
-    await harness.createSession({ cwd: summary.cwd, harness: summary.harness });
   };
 
   const disabledReasonFor = (macro: MacroDef): string | null => {
@@ -87,7 +76,7 @@ export const App = (): JSX.Element => {
           sessions={state.sessions}
           activeSessionId={harness.activeSessionId}
           onSelectSession={harness.setActiveSessionId}
-          onResumeHistory={(summary) => void handleResumeHistory(summary)}
+          onResumeHistory={(summary) => void harness.resumeFromHistory(summary)}
           history={harness.history}
           historyLoading={harness.historyLoading}
           onOpenDropdown={(cwd) => void harness.loadHistory(cwd)}

--- a/packages/harness/web/src/components/ActionRail.tsx
+++ b/packages/harness/web/src/components/ActionRail.tsx
@@ -41,7 +41,9 @@ export function ActionRail({ macros, disabledReasonFor, onRun }: ActionRailProps
           <button
             key={macro.id}
             className="action-icon-btn"
-            title={disabledReason ?? macro.label}
+            aria-label={macro.label}
+            data-testid={`macro-${macro.id}`}
+            data-tooltip={disabledReason ?? macro.label}
             disabled={Boolean(disabledReason)}
             onClick={() => handleClick(macro)}
           >

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -46,7 +46,7 @@ export function SessionBar({
   return (
     <div className="session-bar">
       <div className="session-dropdown-wrap">
-        <button className="session-dropdown-trigger" onClick={toggle}>
+        <button className="session-dropdown-trigger" data-testid="session-dropdown-trigger" onClick={toggle}>
           <span className="session-dot" data-status={activeSession?.status ?? "none"} />
           <span className="session-title">{activeSession ? activeSession.title : "No session"}</span>
           <Icon name="ChevronDown" size={14} />
@@ -81,6 +81,7 @@ export function SessionBar({
                 <button
                   key={summary.agentSessionId}
                   className="session-dropdown-item"
+                  data-testid={`history-${summary.agentSessionId}`}
                   onClick={() => {
                     onResumeHistory(summary);
                     setOpen(false);
@@ -96,7 +97,7 @@ export function SessionBar({
         )}
       </div>
 
-      <button className="new-session-btn" onClick={() => setModalOpen(true)}>
+      <button className="new-session-btn" data-testid="new-session-btn" onClick={() => setModalOpen(true)}>
         <Icon name="Plus" size={14} /> new
       </button>
 

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -40,6 +40,7 @@ export function WorkflowsRail({ workflows, selectedPath, onSelect, onConnect }: 
           <button
             key={workflow.path}
             className={"workflow-item" + (workflow.path === selectedPath ? " is-selected" : "")}
+            data-testid={`workflow-${workflow.name}`}
             onClick={() => onSelect(workflow.path)}
             title={workflow.path}
           >

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -15,13 +15,18 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     harness: "claude-code",
     cwd: "/Users/demo/acme-app",
     title: "Build the leasing pipeline",
-    status: "running",
+    // Exited, like sess-rfq below — a fresh harness launch starts with no running
+    // terminal; both fixtures are here to resume (session bar history) rather than
+    // to already be the active session. This also keeps the "no session" macro/canvas
+    // empty-states directly visible on load instead of requiring extra setup.
+    status: "exited",
     createdAt: minutesAgo(42),
     lastActiveAt: minutesAgo(1),
+    exitCode: 0,
   },
   {
     id: "sess-rfq",
-    agentSessionId: null,
+    agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
     harness: "codex",
     cwd: "/Users/demo/rfq-workflows",
     title: "rfq-workflows",
@@ -35,6 +40,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
 export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
   "/Users/demo/acme-app": [
     {
+      harnessSessionId: "sess-leasing",
       agentSessionId: "8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f",
       harness: "claude-code",
       cwd: "/Users/demo/acme-app",
@@ -53,6 +59,7 @@ export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
   ],
   "/Users/demo/rfq-workflows": [
     {
+      harnessSessionId: "sess-rfq",
       agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
       harness: "codex",
       cwd: "/Users/demo/rfq-workflows",

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -30,6 +30,7 @@ export interface HarnessStateHook {
   loadHistory: (cwd: string) => Promise<void>;
   createSession: (req: CreateSessionRequest) => Promise<HarnessSession>;
   resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
+  resumeFromHistory: (summary: SessionSummary) => Promise<HarnessSession>;
   connectWorkflow: (path: string) => Promise<WorkflowInfo>;
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
   lastMessage: BusMessage | null;
@@ -118,6 +119,24 @@ export function useHarnessState(): HarnessStateHook {
     return session;
   }, []);
 
+  /**
+   * Resumes a history entry. Prefers the registry's own harnessSessionId back-reference;
+   * falls back to matching agentSessionId against live sessions for older/partial data,
+   * and — for transcript-sourced entries the harness never tracked at all — starts a
+   * fresh session in the same directory rather than blocking on a resume path that
+   * doesn't exist for them.
+   */
+  const resumeFromHistory = useCallback(
+    async (summary: SessionSummary): Promise<HarnessSession> => {
+      const harnessSessionId =
+        summary.harnessSessionId ??
+        state?.sessions.find((session) => session.agentSessionId === summary.agentSessionId)?.id;
+      if (harnessSessionId) return resumeSession(harnessSessionId);
+      return createSession({ cwd: summary.cwd, harness: summary.harness });
+    },
+    [state, resumeSession, createSession],
+  );
+
   const connectWorkflow = useCallback(async (path: string): Promise<WorkflowInfo> => {
     const workflow = await api.connectWorkflow(path);
     setState((prev) =>
@@ -145,6 +164,7 @@ export function useHarnessState(): HarnessStateHook {
     loadHistory,
     createSession,
     resumeSession,
+    resumeFromHistory,
     connectWorkflow,
     runMacro,
     lastMessage,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -85,7 +85,6 @@ input {
   flex-direction: column;
   background: var(--bg-1);
   min-width: 0;
-  overflow: hidden;
 }
 
 .rail-workflows {
@@ -213,6 +212,7 @@ input {
 }
 
 .action-icon-btn {
+  position: relative;
   width: 32px;
   height: 32px;
   display: flex;
@@ -234,6 +234,33 @@ input {
   color: var(--text-faint);
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+/* Custom tooltip (not the native `title` bubble) — shows the macro label, or the
+   disabled reason when it has one, to the left of the rail. */
+.action-icon-btn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 30;
+}
+
+.action-icon-btn:hover::after,
+.action-icon-btn:focus-visible::after {
+  opacity: 1;
 }
 
 /* Session bar ------------------------------------------------------------ */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
         specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.1
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -1253,6 +1256,11 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2254,6 +2262,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2993,6 +3006,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4418,6 +4441,10 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.0':
@@ -5563,6 +5590,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6389,6 +6419,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## Summary

- Opt-in `pnpm --filter @sapiom/harness test:ui` (Playwright) smoke-tests the SPA shell against `vite dev` with `VITE_MOCK=1` — no harness server, backend, or agent process required. Not wired into the plain `test` script; browsers aren't installed automatically either (see below).
- Six specs in `web/e2e/smoke.spec.ts`: all four panes render; the workflows rail lists the 3 fixtures and selecting one drives macro gating (deploy-link macro disables with "Not deployed yet" for a non-deployed workflow); inject macros are disabled with a "Start a session first" reason before any session is active; the new-session modal opens and validates the directory field; the canvas pane shows its empty state; the visualize macro prompts for a subject before running.
- Small behavior/code changes that came out of writing the tests:
  - `SessionBar`/`use-harness-state` now use `SessionSummary.harnessSessionId` (landed on `feat/harness` since PR #171) to resume registry-sourced history directly, instead of matching `agentSessionId` against the live session list. Centralized as `resumeFromHistory()` on the hook; `App.tsx`'s inline version is gone.
  - Mock fixtures: both sessions now start `exited` rather than one `running` — a fresh harness launch has no session yet, and this makes the "no session" macro/canvas empty-states directly visible on load instead of needing extra setup to reach them.
  - Replaced the action rail's native `title` tooltip with a small CSS one (`data-tooltip` + `::after`) — native `title` bubbles don't render in headless screenshots, so the requested "macro rail with tooltip" screenshot would've been empty. Found and fixed a real bug in the process: `.rail`'s `overflow: hidden` (meant for the workflow list's own scroll region) was silently clipping the new tooltip since `ActionRail` shares that base class — removed it (the workflows list scrolls fine via its own `.rail-list` overflow rule).
  - Added a `vitest.config.ts` scoping `vitest run` to `src/**/*.test.ts` — without it, vitest's default glob picked up the Playwright spec and failed trying to run it with the wrong test API.
  - Added `data-testid`s (workflow items, session dropdown trigger/history rows, new-session button, macro buttons) and `aria-label` on macro buttons (stable name independent of the dynamic tooltip text) — test hooks, not behavior changes.

## How to invoke

```bash
pnpm --filter @sapiom/harness exec playwright install chromium   # one-time browser install
pnpm --filter @sapiom/harness test:ui
```

## Screenshots

Saved under `web/e2e/screenshots/` (gitignored, regenerated each run):
- `app-shell.png` — full shell, default state (no session, "leasing" workflow auto-selected)
- `new-session-modal.png` — directory input with recents, harness picker
- `action-rail-tooltip.png` — action rail hover state (full-page capture is small at 1280×720; a tight crop while iterating showed the tooltip clearly legible, e.g. "Start a session first")

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` — 6/6 passing
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds, 216 KB / gzip 67 KB (unchanged)
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 8 files / 30 tests passing, confirmed the Playwright spec is excluded (this is what `vitest.config.ts` fixes — without it this command fails)

## Anything else the smoke surfaced

- The `.rail` overflow-clipping bug above — a real, if minor, CSS bug this smoke test caught before it shipped.
- `typecheck` (server-side, `tsc --noEmit` with no `-p`) currently fails on `src/cli/auth.ts` unable to resolve `@sapiom/mcp/auth` — that's `@sapiom/mcp`'s own dist not being built in a fresh worktree checkout (needs its upstream deps — `@sapiom/core`, `@sapiom/fetch`, `@sapiom/agent-core` — built first), unrelated to this branch (that file isn't touched here) and outside this PR's asked-for verification scope (typecheck **web**, not server). Flagging in case it's blocking the integration branch's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)