### PR TITLE
feat(analytics-core): zero-dep usage analytics emitter (identity, consent, batching)

### DIFF
--- a/.changeset/analytics-core-walking-skeleton.md
+++ b/.changeset/analytics-core-walking-skeleton.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/analytics-core": minor
+---
+
+Introduce `@sapiom/analytics-core` — a zero-dependency usage analytics emitter shared by Sapiom SDK packages.
+
+- `createAnalytics(config)` returns `{ track, flush, shutdown, enabled, anonymousId, sessionId }`; `track()` is a synchronous enqueue that never throws, and `flush()`/`shutdown()` never reject.
+- Consent precedence: programmatic `disabled: true` → `SAPIOM_TELEMETRY_DISABLED=1` → `DO_NOT_TRACK=1` → injected consent provider → default on. When disabled, nothing is written or sent.
+- Anonymous machine identity persisted at `~/.sapiom/analytics.json` (mode 0600, created lazily, corrupt files silently regenerated), plus a one-time first-run notice on stderr.
+- Batched delivery: flush every 3s, at 20 events, or best-effort on process exit; at most one retry per batch (jittered), then silent drop; per-field ~16KB cap flagged via `data._truncated`.

--- a/packages/analytics-core/.eslintrc.js
+++ b/packages/analytics-core/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/analytics-core/LICENSE
+++ b/packages/analytics-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -1,0 +1,67 @@
+# @sapiom/analytics-core
+
+Zero-dependency usage analytics emitter shared by Sapiom SDK packages.
+
+Sapiom packages use it to send anonymous usage events (which commands and
+capabilities are used, SDK name/version, coarse runtime info) to
+`https://api.sapiom.ai/v1/analytics/collector` so we can understand real-world
+usage and improve the SDK. It is designed to be invisible to the host
+application:
+
+- **Never throws, never blocks.** `track()` is a synchronous enqueue; every
+  failure inside analytics is silently swallowed.
+- **Batched and bounded.** Events flush every 3 seconds, at 20 events, or
+  best-effort on process exit. A failed batch is retried at most once, then
+  dropped. Oversized fields are truncated (flagged with `data._truncated`).
+- **Zero runtime dependencies.** Node built-ins only.
+
+## Consent and opting out
+
+Analytics is on by default. The first-ever tracked event on a machine prints a
+one-line notice to stderr so it is never silent.
+
+Opt out in any of these ways (highest precedence first):
+
+1. Programmatically: `createAnalytics({ ..., disabled: true })`
+2. `SAPIOM_TELEMETRY_DISABLED=1` in the environment
+3. `DO_NOT_TRACK=1` in the environment (the ecosystem-wide convention)
+
+When opted out, nothing is sent, nothing is written to disk, and zero network
+calls are made.
+
+## What is stored locally
+
+A single file, `~/.sapiom/analytics.json` (permissions `0600`), holding a
+random anonymous machine id and the first-run-notice marker. It contains no
+personal information. Delete it at any time to reset the identity.
+
+## Usage
+
+```typescript
+import { createAnalytics } from "@sapiom/analytics-core";
+
+const analytics = createAnalytics({
+  source: "cli",
+  sdkName: "@sapiom/cli",
+  sdkVersion: "1.0.0",
+});
+
+analytics.track("cli_command", { command: "dev" });
+
+await analytics.flush(); // best-effort send, never rejects
+await analytics.shutdown(); // flush + stop timers, never rejects
+```
+
+`track(eventType, data?, overrides?)` accepts an arbitrary event type, a JSON
+payload, and optional per-event envelope overrides (for example
+`{ user_id: "usr_123" }` when a signed-in identity is known).
+
+## Status
+
+This package is the shared emitter used by other `@sapiom/*` packages; its
+API may still evolve. A fuller description of the event schema and data
+handling will ship alongside the packages that adopt it.
+
+## License
+
+MIT

--- a/packages/analytics-core/jest.config.js
+++ b/packages/analytics-core/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  testEnvironment: 'node',
+  passWithNoTests: true,
+  roots: ['<rootDir>/src'],
+  // Only *.test.ts / *.spec.ts are test suites; __tests__/ also holds shared helpers.
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.ts',
+    '!src/**/*.spec.ts',
+    '!src/**/__tests__/**',
+    '!src/index.ts',
+  ],
+};

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@sapiom/analytics-core",
+  "version": "0.0.0",
+  "description": "Zero-dependency usage analytics emitter shared by Sapiom SDK packages — consent-aware, batched, and guaranteed to never throw or block the host application.",
+  "license": "MIT",
+  "author": "Sapiom",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/analytics-core"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "npm run build:cjs && npm run build:esm && npm run build:esm-pkg",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build:esm-pkg": "echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc --watch --project tsconfig.cjs.json",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepublishOnly": "pnpm build"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/analytics-core/src/__tests__/batching.test.ts
+++ b/packages/analytics-core/src/__tests__/batching.test.ts
@@ -1,0 +1,143 @@
+import { createAnalytics } from "../analytics.js";
+import { FLUSH_INTERVAL_MS, MAX_BATCH_SIZE } from "../batch-queue.js";
+import type { AnalyticsConfig } from "../types.js";
+import {
+  cleanAnalyticsEnv,
+  createCapturingFetch,
+  instanceTracker,
+  useTempHome,
+  type TempHome,
+} from "./helpers.js";
+
+describe("batching", () => {
+  let home: TempHome;
+  let restoreEnv: () => void;
+  const tracker = instanceTracker();
+
+  const baseConfig = (
+    overrides: Partial<AnalyticsConfig> = {},
+  ): AnalyticsConfig => ({
+    source: "mcp",
+    sdkName: "@sapiom/test",
+    sdkVersion: "0.0.0",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    restoreEnv = cleanAnalyticsEnv();
+    home = useTempHome();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await tracker.shutdownAll();
+    home.restore();
+    restoreEnv();
+  });
+
+  it(`flushes immediately at ${MAX_BATCH_SIZE} events`, async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    for (let i = 0; i < MAX_BATCH_SIZE; i++) {
+      analytics.track("event", { i });
+    }
+    await analytics.flush();
+
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.batch()).toHaveLength(MAX_BATCH_SIZE);
+  });
+
+  it("splits overflow into the next batch", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    for (let i = 0; i < MAX_BATCH_SIZE + 5; i++) {
+      analytics.track("event", { i });
+    }
+    await analytics.flush();
+
+    expect(capture.calls).toHaveLength(2);
+    expect(capture.batch(0)).toHaveLength(MAX_BATCH_SIZE);
+    expect(capture.batch(1)).toHaveLength(5);
+  });
+
+  it(`flushes on the ${FLUSH_INTERVAL_MS}ms timer`, async () => {
+    jest.useFakeTimers();
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event_a");
+    analytics.track("event_b");
+    expect(capture.calls).toHaveLength(0);
+
+    await jest.advanceTimersByTimeAsync(FLUSH_INTERVAL_MS - 1);
+    expect(capture.calls).toHaveLength(0);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.batch()).toHaveLength(2);
+  });
+
+  it("does not call the collector when nothing was tracked", async () => {
+    jest.useFakeTimers();
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    await jest.advanceTimersByTimeAsync(FLUSH_INTERVAL_MS * 3);
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(0);
+  });
+
+  it("flushes best-effort on beforeExit", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    expect(capture.calls).toHaveLength(0);
+
+    process.emit("beforeExit", 0);
+    await analytics.flush(); // settle the in-flight send
+
+    expect(capture.calls).toHaveLength(1);
+  });
+
+  it("stops flushing on beforeExit after shutdown (listener removed)", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    const listenersBefore = process.listenerCount("beforeExit");
+    analytics.track("event");
+    await analytics.shutdown();
+    expect(process.listenerCount("beforeExit")).toBe(listenersBefore - 1);
+
+    analytics.track("late_event"); // no-op after shutdown
+    process.emit("beforeExit", 0);
+    await analytics.flush();
+
+    expect(capture.calls).toHaveLength(1); // only the pre-shutdown flush
+  });
+
+  it("flush on an empty queue resolves; shutdown is idempotent", async () => {
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({ fetchImpl: createCapturingFetch().fetchImpl }),
+      ),
+    );
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    await expect(analytics.shutdown()).resolves.toBeUndefined();
+    await expect(analytics.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/packages/analytics-core/src/__tests__/consent.test.ts
+++ b/packages/analytics-core/src/__tests__/consent.test.ts
@@ -1,0 +1,172 @@
+import * as fs from "fs";
+
+import { createAnalytics } from "../analytics.js";
+import type { AnalyticsConfig } from "../types.js";
+import {
+  cleanAnalyticsEnv,
+  createCapturingFetch,
+  instanceTracker,
+  useTempHome,
+  type TempHome,
+} from "./helpers.js";
+
+describe("consent resolution", () => {
+  let home: TempHome;
+  let restoreEnv: () => void;
+  const tracker = instanceTracker();
+
+  const baseConfig = (
+    overrides: Partial<AnalyticsConfig> = {},
+  ): AnalyticsConfig => ({
+    source: "cli",
+    sdkName: "@sapiom/test",
+    sdkVersion: "0.0.0",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    restoreEnv = cleanAnalyticsEnv();
+    home = useTempHome();
+  });
+
+  afterEach(async () => {
+    await tracker.shutdownAll();
+    home.restore();
+    restoreEnv();
+  });
+
+  describe.each([
+    ["SAPIOM_TELEMETRY_DISABLED", "1"],
+    ["SAPIOM_TELEMETRY_DISABLED", "true"],
+    ["SAPIOM_TELEMETRY_DISABLED", "TRUE"],
+    ["DO_NOT_TRACK", "1"],
+    ["DO_NOT_TRACK", "true"],
+  ])("%s=%s", (envVar, value) => {
+    it("disables analytics: zero fetch calls, no identity file", async () => {
+      process.env[envVar] = value;
+      const capture = createCapturingFetch();
+      const analytics = tracker.register(
+        createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+      );
+
+      expect(analytics.enabled).toBe(false);
+      expect(analytics.anonymousId).toBeNull();
+
+      analytics.track("some_event", { a: 1 });
+      await analytics.flush();
+      await analytics.shutdown();
+
+      expect(capture.calls).toHaveLength(0);
+      expect(fs.existsSync(home.identityPath)).toBe(false);
+    });
+  });
+
+  it("does not treat other env values as opt-out", async () => {
+    process.env.SAPIOM_TELEMETRY_DISABLED = "0";
+    process.env.DO_NOT_TRACK = "no";
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    expect(analytics.enabled).toBe(true);
+    analytics.track("some_event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(1);
+  });
+
+  it("disabled: true wins over everything", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({
+          disabled: true,
+          consentProvider: () => true,
+          fetchImpl: capture.fetchImpl,
+        }),
+      ),
+    );
+
+    expect(analytics.enabled).toBe(false);
+    analytics.track("some_event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(0);
+    expect(fs.existsSync(home.identityPath)).toBe(false);
+  });
+
+  it("env opt-out wins over a consent provider that grants", () => {
+    process.env.SAPIOM_TELEMETRY_DISABLED = "1";
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ consentProvider: () => true })),
+    );
+    expect(analytics.enabled).toBe(false);
+  });
+
+  it("consent provider returning false disables", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({
+          consentProvider: () => false,
+          fetchImpl: capture.fetchImpl,
+        }),
+      ),
+    );
+
+    expect(analytics.enabled).toBe(false);
+    analytics.track("some_event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(0);
+  });
+
+  it("consent provider returning true enables", () => {
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({
+          consentProvider: () => true,
+          fetchImpl: createCapturingFetch().fetchImpl,
+        }),
+      ),
+    );
+    expect(analytics.enabled).toBe(true);
+  });
+
+  it.each([
+    ["undefined", () => undefined],
+    [
+      "throwing",
+      () => {
+        throw new Error("boom");
+      },
+    ],
+  ])(
+    "consent provider with no opinion (%s) falls through to default ON",
+    (_label, provider) => {
+      const analytics = tracker.register(
+        createAnalytics(
+          baseConfig({
+            consentProvider: provider as () => boolean | undefined,
+            fetchImpl: createCapturingFetch().fetchImpl,
+          }),
+        ),
+      );
+      expect(analytics.enabled).toBe(true);
+    },
+  );
+
+  it("defaults to enabled with a clean environment", () => {
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({ fetchImpl: createCapturingFetch().fetchImpl }),
+      ),
+    );
+    expect(analytics.enabled).toBe(true);
+  });
+
+  it("disabled instance flush/shutdown resolve and never reject", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    await expect(analytics.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/packages/analytics-core/src/__tests__/envelope.test.ts
+++ b/packages/analytics-core/src/__tests__/envelope.test.ts
@@ -1,0 +1,190 @@
+import { createAnalytics } from "../analytics.js";
+import { MAX_FIELD_LENGTH } from "../data.js";
+import type { AnalyticsConfig } from "../types.js";
+import {
+  cleanAnalyticsEnv,
+  createCapturingFetch,
+  instanceTracker,
+  useTempHome,
+  UUID_V4_REGEX,
+  type TempHome,
+} from "./helpers.js";
+
+describe("event envelope", () => {
+  let home: TempHome;
+  let restoreEnv: () => void;
+  const tracker = instanceTracker();
+
+  const baseConfig = (
+    overrides: Partial<AnalyticsConfig> = {},
+  ): AnalyticsConfig => ({
+    source: "tools",
+    sdkName: "@sapiom/tools",
+    sdkVersion: "1.2.3",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    restoreEnv = cleanAnalyticsEnv();
+    home = useTempHome();
+  });
+
+  afterEach(async () => {
+    await tracker.shutdownAll();
+    home.restore();
+    restoreEnv();
+  });
+
+  it("emits the full envelope shape", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("capability_call", { capability: "search" });
+    await analytics.flush();
+
+    const [event] = capture.batch();
+    expect(event.event_id).toMatch(UUID_V4_REGEX);
+    expect(event.anonymous_id).toBe(analytics.anonymousId);
+    expect(event.session_id).toBe(analytics.sessionId);
+    expect(new Date(event.event_timestamp).toString()).not.toBe("Invalid Date");
+    expect(event.source).toBe("tools");
+    expect(event.event_type).toBe("capability_call");
+    expect(event.sdk_name).toBe("@sapiom/tools");
+    expect(event.sdk_version).toBe("1.2.3");
+    expect(event.schema_version).toBe("1");
+    expect(event.data).toEqual({ capability: "search" });
+    expect("user_id" in event).toBe(false);
+  });
+
+  it("includes user_id only when provided", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({ userId: "usr_123", fetchImpl: capture.fetchImpl }),
+      ),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.batch()[0].user_id).toBe("usr_123");
+  });
+
+  it("applies per-event envelope overrides and ignores unknown keys", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track(
+      "event",
+      { a: 1 },
+      {
+        user_id: "usr_override",
+        session_id: "11111111-1111-4111-8111-111111111111",
+        environment: "test",
+        // Unknown top-level keys must not leak into the envelope.
+        ...({ org_id: "org_nope", data: { b: 2 } } as object),
+      },
+    );
+    await analytics.flush();
+
+    const [event] = capture.batch();
+    expect(event.user_id).toBe("usr_override");
+    expect(event.session_id).toBe("11111111-1111-4111-8111-111111111111");
+    expect(event.environment).toBe("test");
+    expect("org_id" in event).toBe(false);
+    expect(event.data).toEqual({ a: 1 }); // data is not overridable
+  });
+
+  it("wraps non-object data as { value }", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track(
+      "event",
+      "plain string" as unknown as Record<string, unknown>,
+    );
+    analytics.track("event", [1, 2, 3] as unknown as Record<string, unknown>);
+    analytics.track("event"); // no data at all
+    await analytics.flush();
+
+    const events = capture.batch();
+    expect(events[0].data).toEqual({ value: "plain string" });
+    expect(events[1].data).toEqual({ value: [1, 2, 3] });
+    expect(events[2].data).toEqual({});
+  });
+
+  it("never throws on unserializable data (circular, BigInt)", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() =>
+      analytics.track("event", { circular, big: BigInt(7), fine: "ok" }),
+    ).not.toThrow();
+    await analytics.flush();
+
+    const [event] = capture.batch();
+    expect(event.data.circular).toBe("[unserializable]");
+    expect(event.data.big).toBe("[unserializable]");
+    expect(event.data.fine).toBe("ok");
+    expect(event.data._truncated).toBe(true);
+  });
+
+  it("truncates oversized fields and flags data._truncated", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    const huge = "x".repeat(MAX_FIELD_LENGTH + 5_000);
+    analytics.track("event", { huge, small: "ok" });
+    analytics.track("event", { small: "ok" });
+    await analytics.flush();
+
+    const events = capture.batch();
+    expect((events[0].data.huge as string).length).toBe(MAX_FIELD_LENGTH);
+    expect(events[0].data.small).toBe("ok");
+    expect(events[0].data._truncated).toBe(true);
+    expect("_truncated" in events[1].data).toBe(false);
+  });
+
+  it("caps oversized non-string fields via their serialized form", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    const bigObject = { nested: "y".repeat(MAX_FIELD_LENGTH + 1_000) };
+    analytics.track("event", { bigObject });
+    await analytics.flush();
+
+    const [event] = capture.batch();
+    expect(typeof event.data.bigObject).toBe("string");
+    expect((event.data.bigObject as string).length).toBe(MAX_FIELD_LENGTH);
+    expect(event.data._truncated).toBe(true);
+  });
+
+  it("tolerates a hostile debug hook and a mostly-empty config", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics({
+        fetchImpl: capture.fetchImpl,
+        debug: () => {
+          throw new Error("hostile hook");
+        },
+      } as unknown as AnalyticsConfig),
+    );
+
+    expect(() => analytics.track("event")).not.toThrow();
+    await expect(analytics.flush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/analytics-core/src/__tests__/fault-injection.test.ts
+++ b/packages/analytics-core/src/__tests__/fault-injection.test.ts
@@ -1,0 +1,198 @@
+import { createAnalytics } from "../analytics.js";
+import { DEFAULT_ENDPOINT } from "../http-sender.js";
+import type { AnalyticsConfig } from "../types.js";
+import {
+  cleanAnalyticsEnv,
+  createCapturingFetch,
+  getClosedPort,
+  instanceTracker,
+  useTempHome,
+  type TempHome,
+} from "./helpers.js";
+
+describe("fault injection", () => {
+  let home: TempHome;
+  let restoreEnv: () => void;
+  const tracker = instanceTracker();
+
+  const baseConfig = (
+    overrides: Partial<AnalyticsConfig> = {},
+  ): AnalyticsConfig => ({
+    source: "cli",
+    sdkName: "@sapiom/test",
+    sdkVersion: "0.0.0",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    restoreEnv = cleanAnalyticsEnv();
+    home = useTempHome();
+  });
+
+  afterEach(async () => {
+    await tracker.shutdownAll();
+    home.restore();
+    restoreEnv();
+  });
+
+  it("collector down (rejecting fetch): no throw, exactly one retry, then silent drop", async () => {
+    const capture = createCapturingFetch({ reject: true });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    expect(() => analytics.track("event")).not.toThrow();
+    await expect(analytics.flush()).resolves.toBeUndefined();
+
+    expect(capture.calls).toHaveLength(2); // initial attempt + 1 retry
+
+    // The batch was dropped — nothing further is ever sent for it.
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    expect(capture.calls).toHaveLength(2);
+  });
+
+  it("collector down (real ECONNREFUSED on a closed port, env endpoint override): never rejects", async () => {
+    const port = await getClosedPort();
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = `http://127.0.0.1:${port}/collector`;
+
+    // Real global fetch, real connection failure.
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    expect(analytics.enabled).toBe(true);
+
+    expect(() => analytics.track("event", { n: 1 })).not.toThrow();
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    await expect(analytics.shutdown()).resolves.toBeUndefined();
+  });
+
+  it("HTTP 500: no throw, at most one retry, then silent drop", async () => {
+    const capture = createCapturingFetch({ status: 500 });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    expect(capture.calls).toHaveLength(2);
+
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    expect(capture.calls).toHaveLength(2); // dropped, not re-sent
+  });
+
+  it("HTTP 500 then 202: the single retry succeeds", async () => {
+    const capture = createCapturingFetch({ status: [500, 202] });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(2);
+  });
+
+  it("HTTP 400 is dropped without a retry", async () => {
+    const capture = createCapturingFetch({ status: 400 });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(1);
+  });
+
+  it("HTTP 429 gets the single permitted retry", async () => {
+    const capture = createCapturingFetch({ status: [429, 202] });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls).toHaveLength(2);
+  });
+
+  it("slow collector never blocks the hot path", async () => {
+    const capture = createCapturingFetch({ delayMs: 250 });
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    const start = Date.now();
+    for (let i = 0; i < 50; i++) {
+      analytics.track("event", { i });
+    }
+    const elapsed = Date.now() - start;
+    // 50 synchronous enqueues (including three batch-triggered sends)
+    // must return immediately, not wait on the 250ms collector.
+    expect(elapsed).toBeLessThan(100);
+
+    await expect(analytics.flush()).resolves.toBeUndefined();
+    expect(capture.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses the default public endpoint when nothing overrides it", async () => {
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls[0].url).toBe(DEFAULT_ENDPOINT);
+  });
+
+  it("config endpoint beats the environment override", async () => {
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = "http://127.0.0.1:9/env";
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(
+        baseConfig({
+          endpoint: "http://127.0.0.1:9/config",
+          fetchImpl: capture.fetchImpl,
+        }),
+      ),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls[0].url).toBe("http://127.0.0.1:9/config");
+  });
+
+  it("environment override beats the default", async () => {
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = "http://127.0.0.1:9/env";
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    analytics.track("event");
+    await analytics.flush();
+    expect(capture.calls[0].url).toBe("http://127.0.0.1:9/env");
+  });
+
+  it("sends x-sapiom-api-key only when an apiKey is configured", async () => {
+    const withKey = createCapturingFetch();
+    const keyed = tracker.register(
+      createAnalytics(
+        baseConfig({ apiKey: "sk-test-123", fetchImpl: withKey.fetchImpl }),
+      ),
+    );
+    keyed.track("event");
+    await keyed.flush();
+    expect(withKey.calls[0].init.headers["x-sapiom-api-key"]).toBe(
+      "sk-test-123",
+    );
+    expect(withKey.calls[0].init.headers["content-type"]).toBe(
+      "application/json",
+    );
+    expect(withKey.calls[0].init.method).toBe("POST");
+
+    const withoutKey = createCapturingFetch();
+    const anonymous = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: withoutKey.fetchImpl })),
+    );
+    anonymous.track("event");
+    await anonymous.flush();
+    expect("x-sapiom-api-key" in withoutKey.calls[0].init.headers).toBe(false);
+  });
+});

--- a/packages/analytics-core/src/__tests__/helpers.ts
+++ b/packages/analytics-core/src/__tests__/helpers.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared test helpers. This file is intentionally not matched by
+ * `testMatch` (only *.test.ts / *.spec.ts are test suites).
+ */
+import * as fs from "fs";
+import * as net from "net";
+import * as os from "os";
+import * as path from "path";
+
+import type {
+  Envelope,
+  FetchLike,
+  FetchRequestInit,
+  SapiomAnalytics,
+} from "../types.js";
+
+export const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface TempHome {
+  dir: string;
+  identityPath: string;
+  restore(): void;
+}
+
+/**
+ * Redirect the identity store to a fresh temp home dir (simulates a separate
+ * machine/process). The store resolves its location from `HOME`/`USERPROFILE`,
+ * which works under jest where `process.env` mutations never reach the
+ * native environ that `os.homedir()` reads.
+ */
+export function useTempHome(): TempHome {
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sapiom-analytics-"));
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+
+  // Tripwire: fail loudly if a test ever escapes the sandbox and touches the
+  // real ~/.sapiom/analytics.json instead of the temp one.
+  const realIdentityPath = path.join(os.homedir(), ".sapiom", "analytics.json");
+  const realIdentityBefore = readFileOrNull(realIdentityPath);
+
+  return {
+    dir,
+    identityPath: path.join(dir, ".sapiom", "analytics.json"),
+    restore() {
+      restoreEnvVar("HOME", previousHome);
+      restoreEnvVar("USERPROFILE", previousUserProfile);
+      fs.rmSync(dir, { recursive: true, force: true });
+      if (readFileOrNull(realIdentityPath) !== realIdentityBefore) {
+        throw new Error(
+          `test escaped the temp HOME sandbox and modified ${realIdentityPath}`,
+        );
+      }
+    },
+  };
+}
+
+function readFileOrNull(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/** Clear consent/endpoint env vars for the duration of a test; returns a restore fn. */
+export function cleanAnalyticsEnv(): () => void {
+  const keys = [
+    "SAPIOM_TELEMETRY_DISABLED",
+    "DO_NOT_TRACK",
+    "SAPIOM_ANALYTICS_ENDPOINT",
+  ];
+  const saved: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return () => {
+    for (const key of keys) restoreEnvVar(key, saved[key]);
+  };
+}
+
+function restoreEnvVar(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+export interface CapturedCall {
+  url: string;
+  init: FetchRequestInit;
+}
+
+export interface CapturingFetch {
+  calls: CapturedCall[];
+  fetchImpl: FetchLike;
+  /** Events of the nth captured batch. */
+  batch(index?: number): Envelope[];
+}
+
+export interface CapturingFetchOptions {
+  /** Single status for all calls, or a sequence (last one repeats). */
+  status?: number | number[];
+  /** Resolve after this many ms (slow collector). */
+  delayMs?: number;
+  /** Reject every call (network failure / collector down). */
+  reject?: boolean;
+}
+
+export function createCapturingFetch(
+  options: CapturingFetchOptions = {},
+): CapturingFetch {
+  const calls: CapturedCall[] = [];
+  const statusSequence = Array.isArray(options.status)
+    ? [...options.status]
+    : undefined;
+
+  const fetchImpl: FetchLike = async (url, init) => {
+    calls.push({ url: String(url), init });
+    if (options.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+    }
+    if (options.reject) {
+      throw Object.assign(new Error("connect ECONNREFUSED 127.0.0.1"), {
+        code: "ECONNREFUSED",
+      });
+    }
+    const status = statusSequence
+      ? statusSequence.length > 1
+        ? (statusSequence.shift() as number)
+        : statusSequence[0]
+      : ((options.status as number | undefined) ?? 202);
+    return { ok: status >= 200 && status < 300, status };
+  };
+
+  return {
+    calls,
+    fetchImpl,
+    batch(index = 0) {
+      const call = calls[index];
+      if (!call) throw new Error(`no captured fetch call at index ${index}`);
+      return JSON.parse(call.init.body).events as Envelope[];
+    },
+  };
+}
+
+/** Find a local port with nothing listening on it (for real ECONNREFUSED). */
+export function getClosedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as net.AddressInfo;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+/** Track created instances so afterEach can shut them all down. */
+export function instanceTracker(): {
+  register: <T extends SapiomAnalytics>(instance: T) => T;
+  shutdownAll: () => Promise<void>;
+} {
+  const instances: SapiomAnalytics[] = [];
+  return {
+    register(instance) {
+      instances.push(instance);
+      return instance;
+    },
+    async shutdownAll() {
+      await Promise.all(instances.splice(0).map((i) => i.shutdown()));
+    },
+  };
+}

--- a/packages/analytics-core/src/__tests__/identity.test.ts
+++ b/packages/analytics-core/src/__tests__/identity.test.ts
@@ -1,0 +1,153 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { createAnalytics, FIRST_RUN_NOTICE } from "../analytics.js";
+import type { AnalyticsConfig } from "../types.js";
+import {
+  cleanAnalyticsEnv,
+  createCapturingFetch,
+  instanceTracker,
+  useTempHome,
+  UUID_V4_REGEX,
+  type TempHome,
+} from "./helpers.js";
+
+describe("identity store + first-run notice", () => {
+  let home: TempHome;
+  let restoreEnv: () => void;
+  let stderrSpy: jest.SpyInstance;
+  const tracker = instanceTracker();
+
+  const baseConfig = (
+    overrides: Partial<AnalyticsConfig> = {},
+  ): AnalyticsConfig => ({
+    source: "tools",
+    sdkName: "@sapiom/test",
+    sdkVersion: "0.0.0",
+    fetchImpl: createCapturingFetch().fetchImpl,
+    ...overrides,
+  });
+
+  const noticeCount = (): number =>
+    stderrSpy.mock.calls.filter((call) =>
+      String(call[0]).includes(FIRST_RUN_NOTICE),
+    ).length;
+
+  beforeEach(() => {
+    restoreEnv = cleanAnalyticsEnv();
+    home = useTempHome();
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(async () => {
+    stderrSpy.mockRestore();
+    await tracker.shutdownAll();
+    home.restore();
+    restoreEnv();
+  });
+
+  it("creates ~/.sapiom/analytics.json lazily with mode 0600 and a uuid4", () => {
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    expect(fs.existsSync(home.identityPath)).toBe(false); // lazy: not yet
+
+    analytics.track("first_event");
+
+    expect(fs.existsSync(home.identityPath)).toBe(true);
+    expect(fs.statSync(home.identityPath).mode & 0o777).toBe(0o600);
+
+    const record = JSON.parse(fs.readFileSync(home.identityPath, "utf8"));
+    expect(record.anonymous_id).toMatch(UUID_V4_REGEX);
+    expect(analytics.anonymousId).toBe(record.anonymous_id);
+  });
+
+  it("reuses the persisted anonymous id across instances", () => {
+    const first = tracker.register(createAnalytics(baseConfig()));
+    first.track("event");
+    const firstId = first.anonymousId;
+    expect(firstId).toMatch(UUID_V4_REGEX);
+
+    const second = tracker.register(createAnalytics(baseConfig()));
+    second.track("event");
+    expect(second.anonymousId).toBe(firstId);
+  });
+
+  it("silently regenerates a corrupt identity file", () => {
+    fs.mkdirSync(path.dirname(home.identityPath), { recursive: true });
+    fs.writeFileSync(home.identityPath, "not json at all {{{");
+
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    analytics.track("event");
+
+    expect(analytics.anonymousId).toMatch(UUID_V4_REGEX);
+    const record = JSON.parse(fs.readFileSync(home.identityPath, "utf8"));
+    expect(record.anonymous_id).toBe(analytics.anonymousId);
+  });
+
+  it("regenerates when the file is valid JSON but the wrong shape", () => {
+    fs.mkdirSync(path.dirname(home.identityPath), { recursive: true });
+    fs.writeFileSync(home.identityPath, JSON.stringify({ hello: "world" }));
+
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    analytics.track("event");
+    expect(analytics.anonymousId).toMatch(UUID_V4_REGEX);
+  });
+
+  it("prints the first-run notice exactly once across separate instances", () => {
+    const first = tracker.register(createAnalytics(baseConfig()));
+    first.track("event_one");
+    first.track("event_two");
+    expect(noticeCount()).toBe(1);
+
+    const record = JSON.parse(fs.readFileSync(home.identityPath, "utf8"));
+    expect(typeof record.first_run_notice_at).toBe("string");
+    expect(new Date(record.first_run_notice_at).toString()).not.toBe(
+      "Invalid Date",
+    );
+
+    // A second instance with the same HOME simulates a later process:
+    // the persisted marker suppresses the notice.
+    const second = tracker.register(createAnalytics(baseConfig()));
+    second.track("event_three");
+    expect(noticeCount()).toBe(1);
+  });
+
+  it("prints no notice and writes no file when disabled", async () => {
+    process.env.SAPIOM_TELEMETRY_DISABLED = "1";
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    analytics.track("event");
+    await analytics.flush();
+
+    expect(noticeCount()).toBe(0);
+    expect(fs.existsSync(home.identityPath)).toBe(false);
+  });
+
+  it("keeps emitting (anonymous_id null, no notice) when HOME is unwritable", async () => {
+    // Point HOME below a regular file so mkdir must fail.
+    const blocker = path.join(home.dir, "blocker");
+    fs.writeFileSync(blocker, "i am a file");
+    process.env.HOME = path.join(blocker, "nested");
+    process.env.USERPROFILE = process.env.HOME;
+
+    const capture = createCapturingFetch();
+    const analytics = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+
+    expect(() => analytics.track("event")).not.toThrow();
+    await analytics.flush();
+
+    expect(noticeCount()).toBe(0);
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.batch()[0].anonymous_id).toBeNull();
+    expect(analytics.anonymousId).toBeNull();
+  });
+
+  it("shares one session id per process and exposes it as uuid4", () => {
+    const first = tracker.register(createAnalytics(baseConfig()));
+    const second = tracker.register(createAnalytics(baseConfig()));
+    expect(first.sessionId).toMatch(UUID_V4_REGEX);
+    expect(second.sessionId).toBe(first.sessionId);
+  });
+});

--- a/packages/analytics-core/src/analytics.ts
+++ b/packages/analytics-core/src/analytics.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from "crypto";
+
+import { BatchQueue } from "./batch-queue.js";
+import { resolveConsent } from "./consent.js";
+import { buildEnvelope } from "./envelope.js";
+import { HttpSender, resolveEndpoint } from "./http-sender.js";
+import { IdentityStore } from "./identity.js";
+import type {
+  AnalyticsConfig,
+  DebugHook,
+  EnvelopeFields,
+  SapiomAnalytics,
+} from "./types.js";
+
+/** Printed to stderr once per machine, on the first-ever tracked event. */
+export const FIRST_RUN_NOTICE =
+  "Sapiom collects anonymous usage analytics to improve the SDK. " +
+  "Opt out: SAPIOM_TELEMETRY_DISABLED=1 (https://docs.sapiom.ai/telemetry)";
+
+let processSessionId: string | null = null;
+
+/** One session id per process, shared by every analytics instance. */
+function getProcessSessionId(): string {
+  if (processSessionId === null) processSessionId = randomUUID();
+  return processSessionId;
+}
+
+/**
+ * Create an analytics emitter.
+ *
+ * Guarantees, regardless of configuration or environment:
+ * - `createAnalytics` and `track` never throw
+ * - `flush`/`shutdown` never reject
+ * - nothing is written or sent unless consent resolves to enabled
+ */
+export function createAnalytics(config: AnalyticsConfig): SapiomAnalytics {
+  try {
+    return buildAnalytics(config);
+  } catch (error) {
+    try {
+      config?.debug?.("analytics initialization failed; disabled", error);
+    } catch {
+      // Never throw.
+    }
+    return createDisabledInstance(safeSessionId());
+  }
+}
+
+function buildAnalytics(config: AnalyticsConfig): SapiomAnalytics {
+  const debug: DebugHook = (message, detail) => {
+    try {
+      config.debug?.(message, detail);
+    } catch {
+      // The debug hook itself must never take the host down.
+    }
+  };
+
+  const sessionId = getProcessSessionId();
+  if (!resolveConsent(config)) return createDisabledInstance(sessionId);
+
+  const identityStore = new IdentityStore(debug);
+  const sender = new HttpSender({
+    endpoint: resolveEndpoint(config.endpoint),
+    apiKey: config.apiKey,
+    fetchImpl: config.fetchImpl,
+    debug,
+  });
+  const queue = new BatchQueue(sender, debug);
+
+  let noticeAttempted = false;
+  let stopped = false;
+
+  return {
+    track(
+      eventType: string,
+      data?: Record<string, unknown>,
+      overrides?: Partial<EnvelopeFields>,
+    ): void {
+      try {
+        if (stopped) return;
+        const identity = identityStore.load();
+
+        // First-ever tracked event across all packages on this machine
+        // prints a one-line notice (marker lives in the identity file).
+        if (!noticeAttempted) {
+          noticeAttempted = true;
+          if (identityStore.markFirstRunNoticeShown()) {
+            try {
+              process.stderr.write(FIRST_RUN_NOTICE + "\n");
+            } catch {
+              // Best effort.
+            }
+          }
+        }
+
+        queue.enqueue(
+          buildEnvelope({
+            config,
+            anonymousId: identity ? identity.anonymous_id : null,
+            sessionId,
+            eventType,
+            data,
+            overrides,
+          }),
+        );
+      } catch (error) {
+        debug("track failed", error);
+      }
+    },
+
+    async flush(): Promise<void> {
+      try {
+        await queue.flush();
+      } catch (error) {
+        debug("flush failed", error);
+      }
+    },
+
+    async shutdown(): Promise<void> {
+      try {
+        stopped = true;
+        await queue.shutdown();
+      } catch (error) {
+        debug("shutdown failed", error);
+      }
+    },
+
+    enabled: true,
+
+    get anonymousId(): string | null {
+      try {
+        return identityStore.load()?.anonymous_id ?? null;
+      } catch {
+        return null;
+      }
+    },
+
+    sessionId,
+  };
+}
+
+function createDisabledInstance(sessionId: string): SapiomAnalytics {
+  return {
+    track(): void {
+      // Consent denied: drop at the entry, before anything is touched.
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+    shutdown(): Promise<void> {
+      return Promise.resolve();
+    },
+    enabled: false,
+    anonymousId: null,
+    sessionId,
+  };
+}
+
+function safeSessionId(): string {
+  try {
+    return getProcessSessionId();
+  } catch {
+    return "00000000-0000-4000-8000-000000000000";
+  }
+}

--- a/packages/analytics-core/src/batch-queue.ts
+++ b/packages/analytics-core/src/batch-queue.ts
@@ -1,0 +1,152 @@
+import type { SendOutcome } from "./http-sender.js";
+import type { DebugHook, Envelope } from "./types.js";
+
+/** Flush cadence when the batch-size trigger is not hit first. */
+export const FLUSH_INTERVAL_MS = 3_000;
+/** Batch-size trigger: an immediate flush once this many events are buffered. */
+export const MAX_BATCH_SIZE = 20;
+
+const RETRY_BASE_DELAY_MS = 200;
+const RETRY_JITTER_MS = 250;
+
+export interface BatchSender {
+  send(events: Envelope[]): Promise<SendOutcome>;
+}
+
+export interface BatchQueueOptions {
+  flushIntervalMs?: number;
+  maxBatchSize?: number;
+  retryBaseDelayMs?: number;
+  retryJitterMs?: number;
+}
+
+/**
+ * In-memory batching with three flush triggers: every {@link FLUSH_INTERVAL_MS},
+ * at {@link MAX_BATCH_SIZE} events, or best-effort on process exit
+ * (`beforeExit`). Each batch gets at most one retry (small jittered delay),
+ * then is silently dropped. All timers are `unref()`ed so the queue never
+ * holds the process open.
+ */
+export class BatchQueue {
+  private readonly flushIntervalMs: number;
+  private readonly maxBatchSize: number;
+  private readonly retryBaseDelayMs: number;
+  private readonly retryJitterMs: number;
+
+  private buffer: Envelope[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly inFlight = new Set<Promise<void>>();
+  private exitListener: (() => void) | null = null;
+  private stopped = false;
+
+  constructor(
+    private readonly sender: BatchSender,
+    private readonly debug: DebugHook,
+    options: BatchQueueOptions = {},
+  ) {
+    this.flushIntervalMs = options.flushIntervalMs ?? FLUSH_INTERVAL_MS;
+    this.maxBatchSize = options.maxBatchSize ?? MAX_BATCH_SIZE;
+    this.retryBaseDelayMs = options.retryBaseDelayMs ?? RETRY_BASE_DELAY_MS;
+    this.retryJitterMs = options.retryJitterMs ?? RETRY_JITTER_MS;
+
+    this.exitListener = () => {
+      void this.flushNow();
+    };
+    try {
+      process.on("beforeExit", this.exitListener);
+    } catch (error) {
+      this.debug("failed to register exit flush", error);
+      this.exitListener = null;
+    }
+  }
+
+  /** Synchronous, never throws (given a sender whose `send` never throws synchronously). */
+  enqueue(event: Envelope): void {
+    if (this.stopped) return;
+    this.buffer.push(event);
+    if (this.buffer.length >= this.maxBatchSize) {
+      void this.flushNow();
+      return;
+    }
+    if (!this.flushTimer) {
+      this.flushTimer = setTimeout(() => {
+        void this.flushNow();
+      }, this.flushIntervalMs);
+      this.flushTimer.unref?.();
+    }
+  }
+
+  /** Flush the buffer and wait for every in-flight batch. Never rejects. */
+  async flush(): Promise<void> {
+    try {
+      await Promise.all([this.flushNow(), ...this.inFlight]);
+    } catch (error) {
+      this.debug("flush failed", error);
+    }
+  }
+
+  /** Flush, then stop accepting events and detach timers/exit hooks. Never rejects. */
+  async shutdown(): Promise<void> {
+    try {
+      this.stopped = true;
+      if (this.exitListener) {
+        try {
+          process.removeListener("beforeExit", this.exitListener);
+        } catch {
+          // Best effort.
+        }
+        this.exitListener = null;
+      }
+      await this.flush();
+      if (this.flushTimer) {
+        clearTimeout(this.flushTimer);
+        this.flushTimer = null;
+      }
+    } catch (error) {
+      this.debug("shutdown failed", error);
+    }
+  }
+
+  private flushNow(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.buffer.length === 0) return Promise.resolve();
+
+    const batch = this.buffer;
+    this.buffer = [];
+    const pending: Promise<void> = this.sendWithRetry(batch)
+      .catch((error) => {
+        this.debug("batch delivery failed", error);
+      })
+      .finally(() => {
+        this.inFlight.delete(pending);
+      });
+    this.inFlight.add(pending);
+    return pending;
+  }
+
+  /** One attempt + at most one retry; anything after that is a silent drop. */
+  private async sendWithRetry(batch: Envelope[]): Promise<void> {
+    if ((await this.trySend(batch)) !== "retry") return;
+    await sleep(this.retryBaseDelayMs + Math.random() * this.retryJitterMs);
+    await this.trySend(batch);
+  }
+
+  private async trySend(batch: Envelope[]): Promise<SendOutcome> {
+    try {
+      return await this.sender.send(batch);
+    } catch (error) {
+      this.debug("send attempt failed", error);
+      return "retry";
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}

--- a/packages/analytics-core/src/consent.ts
+++ b/packages/analytics-core/src/consent.ts
@@ -1,0 +1,38 @@
+import type { AnalyticsConfig } from "./types.js";
+
+/**
+ * Resolve consent once, at instance creation. Precedence (highest wins):
+ *
+ * 1. programmatic `disabled: true`
+ * 2. `SAPIOM_TELEMETRY_DISABLED=1` (or `true`)
+ * 3. `DO_NOT_TRACK=1` (or `true`)
+ * 4. injected `consentProvider` (`true`/`false` decides, `undefined` falls through)
+ * 5. default: enabled
+ */
+export function resolveConsent(config: AnalyticsConfig): boolean {
+  try {
+    if (config.disabled === true) return false;
+    if (isEnvFlagSet(process.env.SAPIOM_TELEMETRY_DISABLED)) return false;
+    if (isEnvFlagSet(process.env.DO_NOT_TRACK)) return false;
+    if (typeof config.consentProvider === "function") {
+      try {
+        const decision = config.consentProvider();
+        if (decision === true) return true;
+        if (decision === false) return false;
+      } catch {
+        // A broken consent provider has no opinion.
+      }
+    }
+    return true;
+  } catch {
+    // If consent cannot be resolved, stay off: never emit without a
+    // positive resolution.
+    return false;
+  }
+}
+
+function isEnvFlagSet(value: string | undefined): boolean {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}

--- a/packages/analytics-core/src/data.ts
+++ b/packages/analytics-core/src/data.ts
@@ -1,0 +1,59 @@
+/**
+ * Event `data` sanitation: guarantee the payload is a JSON-serializable
+ * object and cap each top-level field at ~16 KB.
+ */
+
+/** Per-field cap (~16 KB), measured on the serialized value. */
+export const MAX_FIELD_LENGTH = 16 * 1024;
+
+/**
+ * Normalize arbitrary caller input into a safe `data` object.
+ *
+ * - `null`/`undefined` → `{}`
+ * - non-objects (and arrays) → `{ value: <input> }`
+ * - oversized fields are truncated and `data._truncated: true` is set
+ * - unserializable fields (circular, BigInt, …) are replaced, never thrown on
+ */
+export function sanitizeData(input: unknown): Record<string, unknown> {
+  try {
+    if (input === null || input === undefined) return {};
+    const source: Record<string, unknown> =
+      typeof input === "object" && !Array.isArray(input)
+        ? (input as Record<string, unknown>)
+        : { value: input };
+
+    const data: Record<string, unknown> = {};
+    let truncated = false;
+    for (const [key, value] of Object.entries(source)) {
+      const capped = capValue(value);
+      data[key] = capped.value;
+      if (capped.truncated) truncated = true;
+    }
+    if (truncated) data._truncated = true;
+    return data;
+  } catch {
+    return {};
+  }
+}
+
+function capValue(value: unknown): { value: unknown; truncated: boolean } {
+  if (typeof value === "string") {
+    return value.length > MAX_FIELD_LENGTH
+      ? { value: value.slice(0, MAX_FIELD_LENGTH), truncated: true }
+      : { value, truncated: false };
+  }
+
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    // Circular references, BigInt, … — drop the value, keep the event.
+    return { value: "[unserializable]", truncated: true };
+  }
+  // undefined / function / symbol serialize to nothing; JSON will omit them.
+  if (serialized === undefined) return { value: undefined, truncated: false };
+  if (serialized.length > MAX_FIELD_LENGTH) {
+    return { value: serialized.slice(0, MAX_FIELD_LENGTH), truncated: true };
+  }
+  return { value, truncated: false };
+}

--- a/packages/analytics-core/src/envelope.ts
+++ b/packages/analytics-core/src/envelope.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "crypto";
+
+import { sanitizeData } from "./data.js";
+import type { AnalyticsConfig, Envelope, EnvelopeFields } from "./types.js";
+
+/** Wire schema version. Envelope changes are additive-only within a version. */
+export const SCHEMA_VERSION = "1";
+
+/** Envelope keys that per-event overrides may replace. Unknown keys are ignored. */
+const OVERRIDABLE_KEYS: ReadonlySet<string> = new Set([
+  "event_id",
+  "anonymous_id",
+  "session_id",
+  "event_timestamp",
+  "source",
+  "event_type",
+  "user_id",
+  "sdk_name",
+  "sdk_version",
+  "schema_version",
+  "environment",
+]);
+
+export interface BuildEnvelopeArgs {
+  config: AnalyticsConfig;
+  anonymousId: string | null;
+  sessionId: string;
+  eventType: string;
+  data?: Record<string, unknown>;
+  overrides?: Partial<EnvelopeFields>;
+}
+
+export function buildEnvelope(args: BuildEnvelopeArgs): Envelope {
+  const { config, anonymousId, sessionId, eventType, data, overrides } = args;
+
+  const envelope: Envelope = {
+    event_id: randomUUID(),
+    anonymous_id: anonymousId,
+    session_id: sessionId,
+    event_timestamp: new Date().toISOString(),
+    source: config.source,
+    event_type: typeof eventType === "string" ? eventType : String(eventType),
+    sdk_name: config.sdkName,
+    sdk_version: config.sdkVersion,
+    schema_version: SCHEMA_VERSION,
+    data: sanitizeData(data),
+  };
+
+  // user_id is only ever present when a real identity was provided.
+  if (typeof config.userId === "string" && config.userId.length > 0) {
+    envelope.user_id = config.userId;
+  }
+
+  if (overrides && typeof overrides === "object") {
+    const target = envelope as unknown as Record<string, unknown>;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === undefined || !OVERRIDABLE_KEYS.has(key)) continue;
+      target[key] = value;
+    }
+  }
+
+  return envelope;
+}

--- a/packages/analytics-core/src/http-sender.ts
+++ b/packages/analytics-core/src/http-sender.ts
@@ -1,0 +1,105 @@
+import type { DebugHook, Envelope, FetchLike } from "./types.js";
+
+/** Public collector endpoint. */
+export const DEFAULT_ENDPOINT = "https://api.sapiom.ai/v1/analytics/collector";
+
+/** Environment override of the endpoint (used by tests). */
+const ENDPOINT_ENV_VAR = "SAPIOM_ANALYTICS_ENDPOINT";
+
+/** Bound every request so a hung collector can never wedge a flush. */
+const REQUEST_TIMEOUT_MS = 5_000;
+
+/**
+ * What the queue should do with a batch:
+ * - `ok`    — delivered
+ * - `retry` — transient failure (network error, 429, 5xx); one retry allowed
+ * - `drop`  — permanent failure (4xx, unserializable); retrying cannot help
+ */
+export type SendOutcome = "ok" | "retry" | "drop";
+
+/** Endpoint resolution: explicit config → environment override → default. */
+export function resolveEndpoint(configEndpoint?: string): string {
+  if (typeof configEndpoint === "string" && configEndpoint.length > 0) {
+    return configEndpoint;
+  }
+  const fromEnv = process.env[ENDPOINT_ENV_VAR];
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  return DEFAULT_ENDPOINT;
+}
+
+export interface HttpSenderOptions {
+  endpoint: string;
+  apiKey?: string;
+  fetchImpl?: FetchLike;
+  debug: DebugHook;
+  timeoutMs?: number;
+}
+
+/**
+ * POSTs `{ events: [...] }` to the collector with native `fetch`.
+ * Never rejects — every failure maps to a {@link SendOutcome}.
+ */
+export class HttpSender {
+  constructor(private readonly options: HttpSenderOptions) {}
+
+  async send(events: Envelope[]): Promise<SendOutcome> {
+    try {
+      const fetchImpl = this.resolveFetch();
+      if (!fetchImpl) return "drop";
+
+      let body: string;
+      try {
+        body = JSON.stringify({ events });
+      } catch (error) {
+        this.options.debug("batch not serializable; dropped", error);
+        return "drop";
+      }
+
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+      };
+      if (this.options.apiKey) {
+        headers["x-sapiom-api-key"] = this.options.apiKey;
+      }
+
+      const response = await fetchImpl(this.options.endpoint, {
+        method: "POST",
+        headers,
+        body,
+        signal: createTimeoutSignal(
+          this.options.timeoutMs ?? REQUEST_TIMEOUT_MS,
+        ),
+      });
+      if (response.ok) return "ok";
+      if (response.status === 429 || response.status >= 500) return "retry";
+      // Anything else (400 not-JSON, 413 too large, …): retrying cannot help.
+      return "drop";
+    } catch (error) {
+      this.options.debug("collector request failed", error);
+      return "retry";
+    }
+  }
+
+  private resolveFetch(): FetchLike | null {
+    if (this.options.fetchImpl) return this.options.fetchImpl;
+    const globalFetch = (globalThis as { fetch?: FetchLike }).fetch;
+    return typeof globalFetch === "function" ? globalFetch : null;
+  }
+}
+
+/** `AbortSignal.timeout` where available; its timer never holds the process open. */
+function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  try {
+    const signalCtor = (
+      globalThis as {
+        AbortSignal?: { timeout?: (ms: number) => AbortSignal };
+      }
+    ).AbortSignal;
+    if (signalCtor && typeof signalCtor.timeout === "function") {
+      return signalCtor.timeout(timeoutMs);
+    }
+  } catch {
+    // Optional capability.
+  }
+  return undefined;
+}

--- a/packages/analytics-core/src/identity.ts
+++ b/packages/analytics-core/src/identity.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import type { DebugHook } from "./types.js";
+
+export interface IdentityRecord {
+  anonymous_id: string;
+  first_run_notice_at: string | null;
+}
+
+/**
+ * Persistent anonymous identity at `~/.sapiom/analytics.json` (mode 0600).
+ *
+ * - Created lazily, on first use — never at import time, never when disabled.
+ * - A corrupt or unreadable file is silently regenerated.
+ * - When the file cannot be read or written at all (e.g. unwritable HOME),
+ *   every method degrades to `null`/`false` and the caller carries on with
+ *   an anonymous_id of `null`.
+ */
+export class IdentityStore {
+  private cached: IdentityRecord | null = null;
+  private unavailable = false;
+
+  constructor(private readonly debug: DebugHook) {}
+
+  /** Load the identity record, creating it if needed. `null` when persistence is impossible. */
+  load(): IdentityRecord | null {
+    if (this.cached) return this.cached;
+    if (this.unavailable) return null;
+    try {
+      const filePath = this.identityFilePath();
+      let record = this.readRecord(filePath);
+      if (!record) {
+        record = { anonymous_id: randomUUID(), first_run_notice_at: null };
+        this.writeRecord(filePath, record);
+      }
+      this.cached = record;
+      return record;
+    } catch (error) {
+      this.debug("identity store unavailable", error);
+      this.unavailable = true;
+      return null;
+    }
+  }
+
+  /**
+   * Stamp `first_run_notice_at` if it has never been stamped.
+   * Returns `true` only for the call that performed the transition — i.e.
+   * the caller that should print the first-run notice.
+   */
+  markFirstRunNoticeShown(): boolean {
+    try {
+      const record = this.load();
+      if (!record || record.first_run_notice_at) return false;
+      record.first_run_notice_at = new Date().toISOString();
+      this.writeRecord(this.identityFilePath(), record);
+      return true;
+    } catch (error) {
+      this.debug("failed to persist first-run notice marker", error);
+      return false;
+    }
+  }
+
+  private identityFilePath(): string {
+    return path.join(resolveHomeDir(), ".sapiom", "analytics.json");
+  }
+
+  /** Read + validate. Any corruption yields `null` so the caller regenerates. */
+  private readRecord(filePath: string): IdentityRecord | null {
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        typeof (parsed as IdentityRecord).anonymous_id === "string" &&
+        (parsed as IdentityRecord).anonymous_id.length > 0
+      ) {
+        const noticeAt = (parsed as IdentityRecord).first_run_notice_at;
+        return {
+          anonymous_id: (parsed as IdentityRecord).anonymous_id,
+          first_run_notice_at: typeof noticeAt === "string" ? noticeAt : null,
+        };
+      }
+      return null;
+    } catch {
+      // Missing or corrupt — regenerate.
+      return null;
+    }
+  }
+
+  private writeRecord(filePath: string, record: IdentityRecord): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, JSON.stringify(record, null, 2) + "\n", {
+      mode: 0o600,
+    });
+    try {
+      // `mode` only applies on creation; keep pre-existing files private too.
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Best effort.
+    }
+  }
+}
+
+/**
+ * Prefer the HOME/USERPROFILE environment variables over `os.homedir()`:
+ * identical in normal operation (`os.homedir()` consults them anyway), but
+ * it keeps the location overridable in sandboxed environments where
+ * `process.env` mutations never reach the native environ.
+ */
+function resolveHomeDir(): string {
+  const fromEnv = process.env.HOME || process.env.USERPROFILE;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  return os.homedir();
+}

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * `@sapiom/analytics-core` — zero-dependency usage analytics emitter shared
+ * by Sapiom SDK packages.
+ *
+ *   import { createAnalytics } from "@sapiom/analytics-core";
+ *
+ *   const analytics = createAnalytics({
+ *     source: "cli",
+ *     sdkName: "@sapiom/cli",
+ *     sdkVersion: "1.0.0",
+ *   });
+ *   analytics.track("cli_command", { command: "dev" });
+ *   await analytics.shutdown();
+ *
+ * Opt out with `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or
+ * `disabled: true`. Analytics never throws and never blocks the host.
+ */
+export { createAnalytics, FIRST_RUN_NOTICE } from "./analytics.js";
+export { FLUSH_INTERVAL_MS, MAX_BATCH_SIZE } from "./batch-queue.js";
+export { MAX_FIELD_LENGTH } from "./data.js";
+export { SCHEMA_VERSION } from "./envelope.js";
+export { DEFAULT_ENDPOINT } from "./http-sender.js";
+export type {
+  AnalyticsConfig,
+  DebugHook,
+  Envelope,
+  EnvelopeFields,
+  EventSource,
+  FetchLike,
+  FetchRequestInit,
+  FetchResponseLike,
+  SapiomAnalytics,
+} from "./types.js";

--- a/packages/analytics-core/src/types.ts
+++ b/packages/analytics-core/src/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Public types for `@sapiom/analytics-core`.
+ */
+
+/** Where an event was produced. */
+export type EventSource =
+  | "ui"
+  | "mcp"
+  | "tools"
+  | "cli"
+  | "orchestration"
+  | "langchain"
+  | "backend";
+
+/** Minimal response shape the sender needs — structurally satisfied by `Response`. */
+export interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+}
+
+/** Request options the sender passes to `fetch` (or an injected replacement). */
+export interface FetchRequestInit {
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Minimal fetch signature used to deliver batches. The global `fetch`
+ * satisfies it; tests can inject a fake.
+ */
+export type FetchLike = (
+  url: string,
+  init: FetchRequestInit,
+) => Promise<FetchResponseLike>;
+
+/**
+ * Optional hook for observing internal failures. Analytics never logs on its
+ * own; without this hook every internal error is silently swallowed.
+ */
+export type DebugHook = (message: string, detail?: unknown) => void;
+
+export interface AnalyticsConfig {
+  /** Which surface is emitting (e.g. `"cli"`, `"tools"`). */
+  source: EventSource;
+  /** Emitting package name, e.g. `"@sapiom/tools"`. */
+  sdkName: string;
+  /** Emitting package version. */
+  sdkVersion: string;
+  /** Collector URL. Defaults to the public Sapiom collector. */
+  endpoint?: string;
+  /** Optional API key, sent as `x-sapiom-api-key` for server-side enrichment. */
+  apiKey?: string;
+  /** Signed-in account identity. Only set when a real user identity is known. */
+  userId?: string;
+  /** Programmatic opt-out. Highest-precedence consent signal. */
+  disabled?: boolean;
+  /**
+   * Optional consent hook, consulted after the environment opt-outs.
+   * Return `true` or `false` to decide; return `undefined` (or throw) to
+   * fall through to the default (enabled).
+   */
+  consentProvider?: () => boolean | undefined;
+  /** Custom fetch implementation (dependency injection, primarily for tests). */
+  fetchImpl?: FetchLike;
+  /** See {@link DebugHook}. */
+  debug?: DebugHook;
+}
+
+/**
+ * The event envelope sent to the collector. Field names are wire-format
+ * (snake_case) by design.
+ */
+export interface Envelope {
+  /** uuid4, client-generated; the collector's dedup key. */
+  event_id: string;
+  /** Machine-scoped uuid4 persisted in the identity file; `null` when unavailable. */
+  anonymous_id: string | null;
+  /** uuid4 shared by every event from this process. */
+  session_id: string;
+  /** ISO-8601, client clock. */
+  event_timestamp: string;
+  source: EventSource;
+  event_type: string;
+  /** Present only when a signed-in identity is known. Never synthesized. */
+  user_id?: string;
+  sdk_name: string;
+  sdk_version: string;
+  schema_version: string;
+  environment?: string;
+  data: Record<string, unknown>;
+}
+
+/** Envelope fields that `track()` overrides may replace per event. */
+export type EnvelopeFields = Omit<Envelope, "data">;
+
+export interface SapiomAnalytics {
+  /**
+   * Enqueue one event. Synchronous, never throws, never blocks; a no-op
+   * when consent is denied or the instance has been shut down.
+   */
+  track(
+    eventType: string,
+    data?: Record<string, unknown>,
+    overrides?: Partial<EnvelopeFields>,
+  ): void;
+  /** Send everything buffered. Best-effort; never rejects. */
+  flush(): Promise<void>;
+  /** `flush()` + stop timers and exit hooks. Never rejects. */
+  shutdown(): Promise<void>;
+  /** Resolved consent. */
+  readonly enabled: boolean;
+  /** Persisted anonymous machine id, or `null` when disabled/unavailable. */
+  readonly anonymousId: string | null;
+  /** Per-process session uuid4. */
+  readonly sessionId: string;
+}

--- a/packages/analytics-core/tsconfig.cjs.json
+++ b/packages/analytics-core/tsconfig.cjs.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "composite": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
+  ]
+}

--- a/packages/analytics-core/tsconfig.esm.json
+++ b/packages/analytics-core/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./dist/esm",
+    "composite": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
+  ]
+}

--- a/packages/analytics-core/tsconfig.json
+++ b/packages/analytics-core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,36 @@ importers:
         specifier: ^4.1.0
         version: 4.4.3
 
+  packages/analytics-core:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.43)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.8.4
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.43))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
   packages/axios:
     dependencies:
       '@sapiom/core':


### PR DESCRIPTION
## Summary

New package `@sapiom/analytics-core`: the walking skeleton of the shared usage-analytics emitter for Sapiom SDK packages — `createAnalytics()` → `track()/flush()/shutdown()` with persisted anonymous identity, layered consent, batched delivery, and hard never-throw/never-block guarantees. Zero runtime dependencies (Node built-ins only). No existing package is touched; the only out-of-package change is the pnpm-lock workspace importer entry.

Fixes SAP-1406 — https://linear.app/sapiom/issue/SAP-1406

## Changes

- **Emitter** (`analytics.ts`): `createAnalytics(config)` returns `{ track, flush, shutdown, enabled, anonymousId, sessionId }`. `track()` is a synchronous enqueue that never throws; `flush()`/`shutdown()` never reject; every public entry is wrapped, with an optional `debug` hook for observing internal failures. `sessionId` is one uuid4 per process.
- **Consent** (`consent.ts`): precedence `disabled: true` → `SAPIOM_TELEMETRY_DISABLED=1` → `DO_NOT_TRACK=1` (both accept `1`/`true`) → injected `consentProvider` → default on. Resolved once and gating at the `track()` entry: disabled means zero disk writes and zero network calls.
- **Identity** (`identity.ts`): `~/.sapiom/analytics.json`, mode `0600`, created lazily on first use; corrupt files silently regenerated; unwritable HOME degrades to `anonymous_id: null` without breaking emission. Holds the anonymous machine uuid4 + first-run-notice marker; a one-line stderr notice prints exactly once per machine across all packages.
- **Batching** (`batch-queue.ts`): flush every 3s, at 20 events, or best-effort on `beforeExit`; all timers `unref()`ed so the queue never holds the process open; at most one jittered retry per batch, then silent drop.
- **Delivery** (`http-sender.ts`): native `fetch` POST `{events: [...]}` to the public collector, optional `x-sapiom-api-key` header, request timeout so a hung collector can never wedge a flush; 429/5xx/network → single retry, other 4xx → immediate drop.
- **Envelope** (`envelope.ts`, `data.ts`): `event_id`/`anonymous_id`/`session_id`/`event_timestamp`/`source`/`event_type`/`sdk_name`/`sdk_version`/`schema_version: "1"`/`data`, `user_id` only when provided; per-event overrides restricted to known envelope keys; per-field ~16KB cap with `data._truncated: true`, unserializable values (circular/BigInt) replaced instead of thrown on.
- Package mechanics copy `packages/tools` (dual CJS/ESM build, jest + ts-jest, eslint, MIT), README stub with the consent/opt-out summary, and a `minor` changeset for the new package.

## Test plan

48 tests across 5 suites, isolated in a temp HOME (with a tripwire that fails any test escaping the sandbox) and injected fetch — no real collector traffic except one deliberate real-`fetch` ECONNREFUSED test against a closed local port.

- Consent: each env opt-out and programmatic `disabled` → zero fetch calls, no identity file; provider precedence; hostile provider tolerated
- Identity: file created lazily with mode 0600, reused across instances, corrupt/wrong-shape regenerated; notice printed exactly once across two instances; unwritable HOME keeps emitting with `anonymous_id: null`
- Batching: 20-event immediate trigger, 3s timer (fake timers), `beforeExit` best-effort flush, listener removed on shutdown, idempotent shutdown
- Fault injection: collector down (rejecting fetch + real closed port), slow collector (hot path stays synchronous), 500/429 → exactly one retry then silent drop, 400 → no retry; endpoint resolution and api-key header

```
pnpm --filter @sapiom/analytics-core build   # exit 0 (cjs + esm + esm-pkg)
pnpm --filter @sapiom/analytics-core test
  Test Suites: 5 passed, 5 total
  Tests:       48 passed, 48 total

pnpm build && pnpm typecheck && pnpm lint    # repo-wide, all exit 0
pnpm test                                    # repo-wide, exit 0
  packages/core:           132 passed | packages/tools: 322 passed
  packages/analytics-core:  48 passed | all other packages green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)