### PR TITLE
feat(harness): wire ingest, workflows, canvas, and macros routers into the server

### DIFF
--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -114,7 +114,7 @@ const main = async (): Promise<void> => {
     process.exit(1);
   }
 
-  await getOrCreateMachineId();
+  const machineId = await getOrCreateMachineId();
 
   const identity = await ensureAuthenticated({ interactive: true, noAuth: options.noAuth });
   const telemetryOptIn = await ensureConsent({ noTelemetry: options.noTelemetry });
@@ -124,7 +124,7 @@ const main = async (): Promise<void> => {
 
   let server: HarnessServer | null = null;
   try {
-    server = await startServer({ port: options.port, bootToken, telemetryOptIn });
+    server = await startServer({ port: options.port, bootToken, telemetryOptIn, identity, machineId });
   } catch (err) {
     if (!options.dev) throw err;
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1,9 +1,10 @@
 /**
- * Harness server (workstreams W1/W3/W5).
+ * Harness server — integration point for every workstream.
  *
- * Single process: serves the built SPA from dist/web, the REST surface, and
- * the two WebSocket endpoints (/ws/terminal, /ws/events). Binds 127.0.0.1
- * only. See src/shared/types.ts for the full protocol contract.
+ * Single process: serves the built SPA from dist/web, the REST surface, the
+ * webhook ingest endpoint, canvas file serving, and the two WebSocket
+ * endpoints (/ws/terminal, /ws/events). Binds 127.0.0.1 only. See
+ * src/shared/types.ts for the full protocol contract.
  */
 
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
@@ -12,17 +13,35 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import express, { type Express } from "express";
 import { WebSocketServer } from "ws";
+import open from "open";
 
-import type { HarnessAdapter, HarnessKind } from "../shared/types.js";
+import type { HarnessAdapter, HarnessKind, WorkflowInfo } from "../shared/types.js";
 import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.js";
 import { createClaudeCodeAdapter } from "../core/adapters/claude-code.js";
 import { createCodexAdapter } from "../core/adapters/codex.js";
+import { WorkflowRegistry, createWorkflowsRouter } from "../core/workflow-registry.js";
+import { DEFAULT_MACROS } from "../core/macros.js";
+import { createEventStore } from "../core/collector/store.js";
+import { CollectorBatcher } from "../core/collector/batcher.js";
+import { normalizeHookEvent } from "../core/collector/normalizer.js";
+import { enrichTurnCompleted } from "../core/collector/transcript.js";
+import { getOrCreateMachineId } from "../cli/machine-id.js";
+import type { HarnessIdentity } from "../cli/auth.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
 import { attachWebSocketRouters } from "./ws-router.js";
+import { createIngestRouter, type IngestSessionContext } from "./ingest.js";
+import { createCanvasRouter } from "./canvas.js";
+import { createMacrosRouter } from "./macros.js";
+
+/** Workflow list is refreshed off this interval for the (synchronous)
+ * macro-resolution lookup — connect/scan are infrequent user actions, so a
+ * few seconds of staleness there is an acceptable tradeoff for not having to
+ * thread an async registry lookup through the macro-runner's sync contract. */
+const WORKFLOWS_CACHE_REFRESH_MS = 3_000;
 
 export interface HarnessServerOptions {
   port: number;
@@ -31,11 +50,17 @@ export interface HarnessServerOptions {
   /** Per-boot secret; required on WS upgrades, /api (header) and hook scripts (bearer). */
   bootToken: string;
   telemetryOptIn: boolean;
+  /** Sapiom identity from CLI auth; omit/null when unauthenticated or --no-auth. */
+  identity?: HarnessIdentity | null;
+  /** Stable per-install id for analytics. Defaults to a freshly loaded/created one. */
+  machineId?: string;
   /** Override the adapter set (tests inject a stubbed claude-code binary). */
   adapters?: Partial<Record<HarnessKind, HarnessAdapter>>;
   sessionsPath?: string;
   buildLaunchOpts?: LaunchOptsBuilder;
   collectorUrl?: string;
+  workflowsRegistryPath?: string;
+  eventStorePath?: string;
   /** Directory the built SPA lives in. Defaults to dist/web next to this module. */
   webDir?: string;
 }
@@ -66,6 +91,8 @@ function readVersion(): string {
 
 export const startServer = async (options: HarnessServerOptions): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
+  const identity = options.identity ?? null;
+  const machineId = options.machineId ?? (await getOrCreateMachineId());
   const adapters: Partial<Record<HarnessKind, HarnessAdapter>> =
     options.adapters ??
     ({
@@ -83,17 +110,103 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   });
   await sessionManager.init();
 
+  const workflowRegistry = new WorkflowRegistry(options.workflowsRegistryPath);
+  let workflowsCache: WorkflowInfo[] = await workflowRegistry.list();
+  const workflowsCacheTimer = setInterval(() => {
+    void workflowRegistry.list().then((list) => {
+      workflowsCache = list;
+    });
+  }, WORKFLOWS_CACHE_REFRESH_MS);
+  workflowsCacheTimer.unref?.();
+
+  const eventStore = createEventStore(options.eventStorePath);
+  const batcher = new CollectorBatcher({
+    machineId,
+    telemetryOptIn: options.telemetryOptIn,
+    collectorUrl: options.collectorUrl,
+    apiKey: identity?.apiKey ?? null,
+    context: {
+      harnessVersion: readVersion(),
+      os: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+    },
+  });
+
+  const resolveIngestSession = (harnessSessionId: string): IngestSessionContext | undefined => {
+    const session = sessionManager.get(harnessSessionId);
+    if (!session) return undefined;
+    return {
+      harness: session.harness,
+      userId: identity?.userId ?? null,
+      tenantId: identity?.tenantId ?? null,
+      machineId,
+      agentSessionId: session.agentSessionId,
+    };
+  };
+
   const app: Express = express();
   app.disable("x-powered-by");
 
-  app.use("/api", createBootTokenMiddleware(options.bootToken), createRestRouter({
-    sessionManager,
-    adapters,
-    version: readVersion(),
-  }));
+  // Everything under /api requires the boot token; mounted as middleware
+  // (not a router) so it also gates the workflows/macros routers below,
+  // which declare their own absolute /api/* paths.
+  app.use("/api", createBootTokenMiddleware(options.bootToken), express.json());
+  app.use(
+    "/api",
+    createRestRouter({
+      sessionManager,
+      adapters,
+      version: readVersion(),
+      identity: identity ? { userId: identity.userId, organizationName: identity.organizationName } : null,
+      listWorkflows: () => workflowRegistry.list(),
+      listMacros: () => DEFAULT_MACROS,
+      onTelemetryOptInChange: (optIn) => batcher.setTelemetryOptIn(optIn),
+    }),
+  );
+  app.use(
+    createWorkflowsRouter(workflowRegistry),
+    createMacrosRouter({
+      listMacros: () => DEFAULT_MACROS,
+      findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
+      getSessionCwd: (harnessSessionId) => sessionManager.get(harnessSessionId)?.cwd ?? null,
+      injectInput: async (harnessSessionId, text, submit) => {
+        sessionManager.write(harnessSessionId, submit ? `${text}\r` : text);
+      },
+      openUrl: async (url) => {
+        await open(url);
+      },
+    }),
+  );
 
-  // NOTE: mount additional routers here (e.g. /ingest, /canvas) — the
-  // static/SPA fallback below is a catch-all and must stay last.
+  // /ingest authenticates itself (bearer ingestToken, not X-Harness-Token) —
+  // it must not sit behind the /api boot-token middleware above.
+  app.use(
+    createIngestRouter({
+      ingestToken: options.bootToken,
+      normalize: normalizeHookEvent,
+      resolveSession: resolveIngestSession,
+      onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
+        sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
+      },
+      store: eventStore,
+      batcher,
+      enrichFromTranscript: enrichTurnCompleted,
+      onError: (err) => console.error("[harness] ingest processing error:", err),
+    }),
+  );
+
+  // Canvas is intentionally unauthenticated (see canvas.ts) — served straight
+  // off the session's cwd, no boot token required.
+  app.use(
+    createCanvasRouter((harnessSessionId) => {
+      const session = sessionManager.get(harnessSessionId);
+      return session ? { cwd: session.cwd } : undefined;
+    }),
+  );
+
+  // NOTE: mount additional routers above this line — the static/SPA fallback
+  // below is a catch-all and must stay last.
   const webDir = options.webDir ?? join(packageRoot(), "dist", "web");
   app.use(createStaticRouter(webDir));
 
@@ -135,6 +248,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     sessionManager,
     close: () =>
       new Promise<void>((resolve, reject) => {
+        clearInterval(workflowsCacheTimer);
+        void batcher.close();
         terminalWss.close();
         eventsWss.close();
         httpServer.close((err) => {

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -1,0 +1,190 @@
+import type { AddressInfo } from "node:net";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpHome: string;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return { ...actual, homedir: () => tmpHome };
+});
+
+import type { HarnessSession, MacroDef, WorkflowInfo } from "../shared/types.js";
+import { createRestRouter, type RestRouterOptions } from "./rest.js";
+
+const TOKEN_HEADER = { "X-Harness-Token": "unused-in-router-tests" };
+
+function fakeSessionManager(initial: HarnessSession[] = []) {
+  const sessions = new Map(initial.map((s) => [s.id, s]));
+  return {
+    list: () => Array.from(sessions.values()),
+    get: (id: string) => sessions.get(id),
+    create: vi.fn(),
+    resume: vi.fn(),
+    kill: vi.fn(() => true),
+    write: vi.fn(() => true),
+  } as unknown as RestRouterOptions["sessionManager"];
+}
+
+describe("createRestRouter", () => {
+  let server: ReturnType<express.Express["listen"]>;
+  let baseUrl: string;
+  let onTelemetryOptInChange: ReturnType<typeof vi.fn>;
+
+  function start(overrides: Partial<RestRouterOptions> = {}) {
+    onTelemetryOptInChange = vi.fn();
+    const options: RestRouterOptions = {
+      sessionManager: fakeSessionManager(),
+      adapters: {},
+      version: "9.9.9-test",
+      identity: null,
+      listWorkflows: async () => [],
+      listMacros: () => [],
+      onTelemetryOptInChange,
+      ...overrides,
+    };
+    const app = express();
+    app.use(createRestRouter(options));
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "harness-rest-test-"));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  describe("GET /state", () => {
+    it("reports unauthenticated with empty workflows/macros/sessions by default", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/state`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        version: "9.9.9-test",
+        authenticated: false,
+        userId: null,
+        organizationName: null,
+        telemetryOptIn: false,
+        sessions: [],
+        workflows: [],
+        macros: [],
+      });
+    });
+
+    it("reflects identity, sessions, workflows, and macros from their sources", async () => {
+      const session: HarnessSession = {
+        id: "s1",
+        agentSessionId: null,
+        harness: "claude-code",
+        cwd: "/tmp/proj",
+        title: "proj",
+        status: "running",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+        exitCode: null,
+      };
+      const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, source: "scan" };
+      const macro: MacroDef = { id: "run_local", label: "Run local", icon: "Play", action: { kind: "inject", text: "x" } };
+
+      start({
+        sessionManager: fakeSessionManager([session]),
+        identity: { userId: "user-1", organizationName: "Acme" },
+        listWorkflows: async () => [workflow],
+        listMacros: () => [macro],
+      });
+
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.authenticated).toBe(true);
+      expect(body.userId).toBe("user-1");
+      expect(body.organizationName).toBe("Acme");
+      expect(body.sessions).toEqual([session]);
+      expect(body.workflows).toEqual([workflow]);
+      expect(body.macros).toEqual([macro]);
+    });
+
+    it("reflects the live persisted telemetryOptIn value, not a fixed default", async () => {
+      start();
+      await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telemetryOptIn: true }),
+      });
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as { telemetryOptIn: boolean };
+      expect(body.telemetryOptIn).toBe(true);
+    });
+  });
+
+  describe("GET/PATCH /settings", () => {
+    it("returns defaults before anything is persisted", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/settings`);
+      expect(await res.json()).toEqual({ telemetryOptIn: false, recentDirs: [] });
+    });
+
+    it("persists a patch and returns the merged result", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telemetryOptIn: true }),
+      });
+      expect(await res.json()).toEqual({ telemetryOptIn: true, recentDirs: [] });
+
+      const reread = await fetch(`${baseUrl}/settings`);
+      expect(await reread.json()).toEqual({ telemetryOptIn: true, recentDirs: [] });
+    });
+
+    it("calls onTelemetryOptInChange only when telemetryOptIn actually changes", async () => {
+      start();
+      await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ recentDirs: ["/tmp/a"] }),
+      });
+      expect(onTelemetryOptInChange).not.toHaveBeenCalled();
+
+      await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telemetryOptIn: true }),
+      });
+      expect(onTelemetryOptInChange).toHaveBeenCalledWith(true);
+      expect(onTelemetryOptInChange).toHaveBeenCalledTimes(1);
+
+      // Same value again — should not re-fire.
+      await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telemetryOptIn: true }),
+      });
+      expect(onTelemetryOptInChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a malformed patch body", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ telemetryOptIn: "yes" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it("sanity: session endpoints still respond (covered in depth by session-manager.test.ts)", async () => {
+    start();
+    const res = await fetch(`${baseUrl}/sessions`, { headers: TOKEN_HEADER });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+});

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -12,10 +12,14 @@ import type {
   CreateSessionRequest,
   HarnessAdapter,
   HarnessKind,
+  HarnessSettings,
   InjectInputRequest,
+  MacroDef,
   SessionSummary,
+  WorkflowInfo,
 } from "../shared/types.js";
 import type { SessionManager } from "../core/session-manager.js";
+import { loadSettings, saveSettings } from "../cli/settings.js";
 
 const createSessionSchema = z.object({
   cwd: z.string().min(1),
@@ -28,31 +32,76 @@ const injectInputSchema = z.object({
   submit: z.boolean().optional(),
 }) satisfies z.ZodType<InjectInputRequest>;
 
+const settingsPatchSchema = z.object({
+  telemetryOptIn: z.boolean().optional(),
+  recentDirs: z.array(z.string()).optional(),
+}) satisfies z.ZodType<Partial<HarnessSettings>>;
+
 export interface RestRouterOptions {
   sessionManager: SessionManager;
   adapters: Partial<Record<HarnessKind, HarnessAdapter>>;
   version: string;
+  /** Sapiom identity from CLI auth; null when unauthenticated / --no-auth. */
+  identity: { userId: string; organizationName: string } | null;
+  listWorkflows: () => Promise<WorkflowInfo[]>;
+  listMacros: () => MacroDef[];
+  /** Called after a settings PATCH persists a changed telemetryOptIn, so the
+   * live collector batcher can be gated without a server restart. */
+  onTelemetryOptInChange?: (optIn: boolean) => void;
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
-  const { sessionManager, adapters, version } = options;
+  const { sessionManager, adapters, version, identity, listWorkflows, listMacros } = options;
   const router = Router();
   router.use(express.json());
 
-  router.get("/state", (_req, res) => {
-    // Non-W1 fields (auth, workflows, macros, telemetry) default until their
-    // owning workstreams mount alongside this router.
-    const state: AppState = {
-      version,
-      authenticated: false,
-      userId: null,
-      organizationName: null,
-      telemetryOptIn: false,
-      sessions: sessionManager.list(),
-      workflows: [],
-      macros: [],
-    };
-    res.json(state);
+  router.get("/state", async (_req, res, next) => {
+    try {
+      const settings = await loadSettings();
+      const state: AppState = {
+        version,
+        authenticated: identity !== null,
+        userId: identity?.userId ?? null,
+        organizationName: identity?.organizationName ?? null,
+        telemetryOptIn: settings.telemetryOptIn,
+        sessions: sessionManager.list(),
+        workflows: await listWorkflows(),
+        macros: listMacros(),
+      };
+      res.json(state);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get("/settings", async (_req, res, next) => {
+    try {
+      res.json(await loadSettings());
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.patch("/settings", async (req, res, next) => {
+    const parsed = settingsPatchSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+    try {
+      const current = await loadSettings();
+      const updated: HarnessSettings = { ...current, ...parsed.data };
+      await saveSettings(updated);
+      if (
+        parsed.data.telemetryOptIn !== undefined &&
+        parsed.data.telemetryOptIn !== current.telemetryOptIn
+      ) {
+        options.onTelemetryOptInChange?.(parsed.data.telemetryOptIn);
+      }
+      res.json(updated);
+    } catch (err) {
+      next(err);
+    }
   });
 
   router.post("/sessions", async (req, res, next) => {
@@ -86,6 +135,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       for (const session of sessionManager.list()) {
         if (session.cwd !== cwd || !session.agentSessionId) continue;
         byAgentSessionId.set(session.agentSessionId, {
+          harnessSessionId: session.id,
           agentSessionId: session.agentSessionId,
           harness: session.harness,
           cwd: session.cwd,


### PR DESCRIPTION
## Summary

`startServer` only mounted the session REST/WS surface (from the terminal-core PR). The ingest (analytics), workflows, canvas, and macros routers each workstream built already existed on `feat/harness` but weren't mounted anywhere — nothing actually served `/ingest`, `/api/workflows*`, `/api/macros*`, or `/canvas/*`. This wires them all together into one running server.

- `/ingest` — bearer-token auth (separate secret path from the `/api` boot-token gate), backed by the real hook normalizer, local event store, and collector batcher.
- `/api/workflows*` and `/api/macros*` — mounted behind the same boot-token middleware as `/api/*`. They declare absolute paths internally, so they're root-mounted alongside (not nested under) the session REST router.
- `/canvas/:harnessSessionId` — intentionally unauthenticated per its own design doc, looking up the session's cwd via the SessionManager.
- Added `GET`/`PATCH /api/settings` to `rest.ts` — no workstream had built this endpoint yet, but the SPA already calls it. A `telemetryOptIn` change flows live into the running `CollectorBatcher` without a server restart.
- `GET /api/state` now reflects real identity, workflows, and macros instead of hardcoded empty/false defaults.
- `bin.ts` now actually passes the `identity` and `machineId` it already computes through to `startServer` (previously computed and silently discarded).

One design wrinkle worth flagging: the macros router's `findWorkflow()` is synchronous, but `WorkflowRegistry.list()` is async. Rather than thread an async lookup through the macro-runner's sync contract, workflow lookups for macro resolution go through a small cache refreshed every 3s. Acceptable staleness for an infrequent user action (connect/scan a workflow); flagging in case someone wants a tighter fix later.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `lint` — all clean
- [x] `pnpm --filter @sapiom/harness test` — 139/139 passing (8 new in `rest.test.ts` covering `/api/state` and `/api/settings`, including the "telemetryOptIn change notifies the batcher exactly once" case)
- [x] Expanded live smoke test booting the real server and exercising every newly-wired endpoint over the network: workflow scan + list from a seeded `sapiom.json`, macros list, settings get/patch with live batcher gating, authenticated `/ingest` plus a 401 without a bearer token, and unauthenticated canvas file serving from a session's `.sapiom/canvas/`. All existing terminal/session endpoints re-verified alongside the new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)