### PR TITLE
feat(harness): settings popover with telemetry opt-in toggle

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -74,6 +74,28 @@ test("canvas pane shows its empty state when there's no active session", async (
   await expect(page.locator(".canvas-empty")).toContainText("Start a session to see its canvas here");
 });
 
+test("settings popover: identity, telemetry toggle, and it persists across close/reopen", async ({ page }) => {
+  const trigger = page.getByTestId("settings-trigger");
+  const toggle = page.getByTestId("telemetry-toggle");
+
+  await trigger.click();
+  const popover = page.getByTestId("settings-popover");
+  await expect(popover).toBeVisible();
+  await expect(popover).toContainText("Acme (mock)");
+  await expect(popover).toContainText("events.ndjson");
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(popover).toBeHidden();
+
+  // Reopening should reflect the same (mutated) state, not reset to the fixture default.
+  await trigger.click();
+  await expect(page.getByTestId("telemetry-toggle")).toHaveAttribute("aria-checked", "true");
+});
+
 test("visualize macro prompts for a subject before running", async ({ page }) => {
   // Resume a history entry so the session-gated macro is enabled.
   await page.getByTestId("session-dropdown-trigger").click();

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -82,6 +82,12 @@ export const App = (): JSX.Element => {
           onOpenDropdown={(cwd) => void harness.loadHistory(cwd)}
           recentDirs={harness.settings?.recentDirs ?? []}
           onCreateSession={handleCreateSession}
+          authenticated={state.authenticated}
+          organizationName={state.organizationName}
+          telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+          onToggleTelemetry={async (next) => {
+            await harness.updateSettings({ telemetryOptIn: next });
+          }}
         />
         <div className="terminal-slot">
           {harness.activeSessionId ? (

--- a/packages/harness/web/src/components/Icon.tsx
+++ b/packages/harness/web/src/components/Icon.tsx
@@ -7,6 +7,7 @@ import {
   Play,
   Plus,
   Radio,
+  Settings,
   Sparkles,
   Zap,
 } from "lucide-react";
@@ -24,6 +25,7 @@ const ICONS: Record<string, LucideIcon> = {
   Play,
   Plus,
   Radio,
+  Settings,
   Sparkles,
   Zap,
 };

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -4,6 +4,7 @@ import type { HarnessKind, HarnessSession, SessionSummary } from "@shared/types"
 
 import { Icon } from "./Icon";
 import { NewSessionModal } from "./NewSessionModal";
+import { SettingsPopover } from "./SettingsPopover";
 
 interface SessionBarProps {
   sessions: HarnessSession[];
@@ -15,6 +16,10 @@ interface SessionBarProps {
   onOpenDropdown: (cwd: string) => void;
   recentDirs: string[];
   onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
+  authenticated: boolean;
+  organizationName: string | null;
+  telemetryOptIn: boolean;
+  onToggleTelemetry: (next: boolean) => Promise<void>;
 }
 
 export function SessionBar({
@@ -27,9 +32,14 @@ export function SessionBar({
   onOpenDropdown,
   recentDirs,
   onCreateSession,
+  authenticated,
+  organizationName,
+  telemetryOptIn,
+  onToggleTelemetry,
 }: SessionBarProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const activeSession = sessions.find((session) => session.id === activeSessionId) ?? null;
   const runningSessions = sessions.filter((session) => session.status !== "exited");
@@ -100,6 +110,26 @@ export function SessionBar({
       <button className="new-session-btn" data-testid="new-session-btn" onClick={() => setModalOpen(true)}>
         <Icon name="Plus" size={14} /> new
       </button>
+
+      <div className="settings-wrap">
+        <button
+          className="gear-btn"
+          aria-label="Settings"
+          data-testid="settings-trigger"
+          onClick={() => setSettingsOpen((prev) => !prev)}
+        >
+          <Icon name="Settings" size={16} />
+        </button>
+        {settingsOpen && (
+          <SettingsPopover
+            authenticated={authenticated}
+            organizationName={organizationName}
+            telemetryOptIn={telemetryOptIn}
+            onToggleTelemetry={onToggleTelemetry}
+            onClose={() => setSettingsOpen(false)}
+          />
+        )}
+      </div>
 
       {modalOpen && (
         <NewSessionModal

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import { HARNESS_PATHS } from "@shared/types";
+
+interface SettingsPopoverProps {
+  authenticated: boolean;
+  organizationName: string | null;
+  telemetryOptIn: boolean;
+  onToggleTelemetry: (next: boolean) => Promise<void>;
+  onClose: () => void;
+}
+
+export function SettingsPopover({
+  authenticated,
+  organizationName,
+  telemetryOptIn,
+  onToggleTelemetry,
+  onClose,
+}: SettingsPopoverProps): JSX.Element {
+  const [busy, setBusy] = useState(false);
+
+  const handleToggle = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      await onToggleTelemetry(!telemetryOptIn);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-popover" data-testid="settings-popover">
+      <div className="settings-identity">{authenticated ? (organizationName ?? "Signed in") : "Not signed in"}</div>
+
+      <label className="settings-toggle-row">
+        <span>Send usage analytics to Sapiom</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={telemetryOptIn}
+          data-testid="telemetry-toggle"
+          className={"toggle-switch" + (telemetryOptIn ? " is-on" : "")}
+          disabled={busy}
+          onClick={() => void handleToggle()}
+        >
+          <span className="toggle-knob" />
+        </button>
+      </label>
+
+      <p className="settings-note">
+        Prompts, tool calls, and session lifecycle events are always written locally to{" "}
+        <code>{HARNESS_PATHS.events}</code>. With your consent, they&rsquo;re also sent to Sapiom.
+      </p>
+
+      <button className="btn-ghost settings-close" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -32,6 +32,7 @@ export interface HarnessStateHook {
   resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
   resumeFromHistory: (summary: SessionSummary) => Promise<HarnessSession>;
   connectWorkflow: (path: string) => Promise<WorkflowInfo>;
+  updateSettings: (patch: Partial<HarnessSettings>) => Promise<HarnessSettings>;
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
   lastMessage: BusMessage | null;
 }
@@ -145,6 +146,15 @@ export function useHarnessState(): HarnessStateHook {
     return workflow;
   }, []);
 
+  const updateSettings = useCallback(async (patch: Partial<HarnessSettings>): Promise<HarnessSettings> => {
+    const updated = await api.updateSettings(patch);
+    setSettings(updated);
+    if (patch.telemetryOptIn !== undefined) {
+      setState((prev) => (prev ? { ...prev, telemetryOptIn: updated.telemetryOptIn } : prev));
+    }
+    return updated;
+  }, []);
+
   const runMacro = useCallback(async (id: string, req: RunMacroRequest): Promise<void> => {
     await api.runMacro(id, req);
   }, []);
@@ -166,6 +176,7 @@ export function useHarnessState(): HarnessStateHook {
     resumeSession,
     resumeFromHistory,
     connectWorkflow,
+    updateSettings,
     runMacro,
     lastMessage,
   };

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -403,6 +403,112 @@ input {
   background: var(--accent);
 }
 
+.settings-wrap {
+  position: relative;
+}
+
+.gear-btn {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-2);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+}
+
+.gear-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.settings-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 280px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  padding: 12px;
+  z-index: 20;
+}
+
+.settings-identity {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.toggle-switch {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 20px;
+  border-radius: 20px;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  position: relative;
+  padding: 0;
+}
+
+.toggle-switch.is-on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.toggle-switch:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text);
+  transition: transform 0.12s ease;
+}
+
+.toggle-switch.is-on .toggle-knob {
+  transform: translateX(14px);
+}
+
+.settings-note {
+  margin: 10px 0 12px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-faint);
+}
+
+.settings-note code {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.settings-close {
+  width: 100%;
+  text-align: center;
+}
+
 /* Terminal slot ------------------------------------------------------ */
 
 .terminal-slot {

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -6,6 +6,13 @@ import { fileURLToPath } from "node:url";
 export default defineConfig({
   root: fileURLToPath(new URL(".", import.meta.url)),
   plugins: [react()],
+  resolve: {
+    // Mirrors the "@shared/*" path in web/tsconfig.json — needed for actual value
+    // imports (not just types) from the shared contract to resolve at build time.
+    alias: {
+      "@shared": fileURLToPath(new URL("../src/shared", import.meta.url)),
+    },
+  },
   build: {
     outDir: fileURLToPath(new URL("../dist/web", import.meta.url)),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

- Gear icon at the right edge of the session bar opens a compact popover (no full-screen backdrop, closes via its own Close button — same pattern as the session dropdown, which also has no click-outside handling):
  - Identity line: organization name when authenticated, "Not signed in" otherwise (from `AppState`).
  - Telemetry toggle (`role="switch"`) wired to `PATCH /api/settings {telemetryOptIn}` — the contract already specified this endpoint; coded against it while the server side is wired in parallel.
  - A note on what's collected, with the local sink path shown via `HARNESS_PATHS.events` (`~/.sapiom/harness/events.ndjson`) imported directly from the shared contract rather than hardcoded, so it can't drift.
- Works in mock mode: `MockApi.updateSettings` already persisted patches to its in-memory fixture; the popover just needed a `useHarnessState().updateSettings()` method to call it and update local `settings`/`state.telemetryOptIn`.
- New Playwright spec: popover opens, shows identity + local-path text, toggle flips (`aria-checked` false → true), and the state survives closing and reopening the popover (proves it's driven by the shared hook's state, not popover-local state that would reset).

## A real bug this surfaced

`web/vite.config.ts` had no `resolve.alias` for `@shared/*` — only the TypeScript `paths` mapping existed (in `web/tsconfig.json`). Every prior usage across the SPA was `import type { ... } from "@shared/types"`, and type-only imports get erased before Rollup ever sees them, so the missing alias was silently masked. The popover's `HARNESS_PATHS` import is the first *value* import from the shared contract, and `vite build` failed outright until I added the alias. Fixed by aliasing `@shared` to `../src/shared` in `web/vite.config.ts`, mirroring the tsconfig path.

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright) — 7/7 passing (6 existing + 1 new)
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds (bundle size jump to ~517 KB / gzip 143 KB is from the real xterm.js terminal merged in from the terminal-core workstream, not this change — this PR only adds ~1.5 KB gzip)
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 21 files / 131 tests passing

Screenshot (not committed — gitignored, taken for evidence during review):

Popover shows "Acme (mock)" identity, toggle off by default, and the note text: "Prompts, tool calls, and session lifecycle events are always written locally to `~/.sapiom/harness/events.ndjson`. With your consent, they're also sent to Sapiom."

🤖 Generated with [Claude Code](https://claude.com/claude-code)