### PR TITLE
feat(harness): Codex adapter — real launch/resume + transcript tailer

### DIFF
--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -1,0 +1,197 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CodexAdapter } from "./codex.js";
+
+/** A minimal, synthetic (not real-user-data) rollout line set matching the
+ * schema of an installed codex-cli 0.134.0 on the build machine. */
+function sessionMetaLine(id: string, cwd: string, timestamp: string): string {
+  return JSON.stringify({
+    timestamp,
+    type: "session_meta",
+    payload: { id, timestamp, cwd, originator: "codex-cli", cli_version: "0.134.0" },
+  });
+}
+
+function userMessageLine(message: string): string {
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:01.000Z",
+    type: "event_msg",
+    payload: { type: "user_message", message, images: [] },
+  });
+}
+
+describe("CodexAdapter", () => {
+  describe("launch/resume", () => {
+    it("builds a launch SpawnSpec disabling the update check and no env overrides", () => {
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.launch({ harnessSessionId: "h1", cwd: "/tmp/proj" });
+
+      expect(spec.command).toBe("fake-codex");
+      expect(spec.cwd).toBe("/tmp/proj");
+      expect(spec.env).toEqual({});
+      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
+    });
+
+    it("adds -c model_instructions_file=<path> when a systemPromptFile is given", () => {
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.launch({
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+        systemPromptFile: "/tmp/proj/.sapiom/prompt.txt",
+      });
+
+      expect(spec.args).toEqual([
+        "-c",
+        "check_for_update_on_startup=false",
+        "-c",
+        "model_instructions_file=/tmp/proj/.sapiom/prompt.txt",
+      ]);
+    });
+
+    it("builds a resume SpawnSpec with `resume <rolloutId>` as the leading args", () => {
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.resume("019e62d5-a020-75f1-b5e8-253383076f83", {
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+      });
+
+      expect(spec.command).toBe("fake-codex");
+      expect(spec.args).toEqual([
+        "resume",
+        "019e62d5-a020-75f1-b5e8-253383076f83",
+        "-c",
+        "check_for_update_on_startup=false",
+      ]);
+      expect(spec.env).toEqual({});
+    });
+
+    it("ignores mcpConfigFile/settingsFile — Codex has no per-session injection point for either", () => {
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.launch({
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+        mcpConfigFile: "/tmp/proj/.sapiom/mcp.json",
+        settingsFile: "/tmp/proj/.sapiom/settings.json",
+      });
+      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
+    });
+  });
+
+  describe("doctor", () => {
+    it("reports ok:false when the binary isn't on PATH", async () => {
+      const adapter = new CodexAdapter({ binary: "definitely-not-a-real-binary-xyz" });
+      const checks = await adapter.doctor();
+      expect(checks).toHaveLength(1);
+      expect(checks[0]).toMatchObject({ name: "codex", ok: false });
+    });
+  });
+
+  describe("listPastSessions", () => {
+    const cwd = "/Users/test/my-project";
+    let homeDir: string;
+
+    beforeEach(async () => {
+      homeDir = await mkdtemp(join(tmpdir(), "harness-codex-home-"));
+    });
+
+    afterEach(async () => {
+      await rm(homeDir, { recursive: true, force: true });
+    });
+
+    function rolloutDir(home: string): string {
+      return join(home, ".codex", "sessions", "2026", "01", "01");
+    }
+
+    it("returns [] when no sessions directory exists", async () => {
+      const adapter = new CodexAdapter({ homeDir });
+      expect(await adapter.listPastSessions("/nonexistent/project")).toEqual([]);
+    });
+
+    it("finds rollout files whose session_meta.cwd matches, ignoring others", async () => {
+      const dir = rolloutDir(homeDir);
+      await mkdir(dir, { recursive: true });
+
+      const matchingId = "019e62d5-a020-75f1-b5e8-253383076f83";
+      await writeFile(
+        join(dir, `rollout-2026-01-01T00-00-00-${matchingId}.jsonl`),
+        [
+          sessionMetaLine(matchingId, cwd, "2026-01-01T00:00:00.000Z"),
+          userMessageLine("help me build a workflow"),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+
+      const otherId = "019e62d5-a020-75f1-b5e8-253383076f84";
+      await writeFile(
+        join(dir, `rollout-2026-01-01T00-05-00-${otherId}.jsonl`),
+        sessionMetaLine(otherId, "/some/other/project", "2026-01-01T00:05:00.000Z") + "\n",
+        "utf8",
+      );
+
+      const adapter = new CodexAdapter({ homeDir });
+      const summaries = await adapter.listPastSessions(cwd);
+
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]).toMatchObject({
+        agentSessionId: matchingId,
+        harness: "codex",
+        cwd,
+        title: "help me build a workflow",
+        source: "transcript",
+      });
+    });
+
+    it("falls back to the rollout id as the title when no user message is present", async () => {
+      const dir = rolloutDir(homeDir);
+      await mkdir(dir, { recursive: true });
+      const id = "019e62d5-a020-75f1-b5e8-253383076f85";
+      await writeFile(
+        join(dir, `rollout-2026-01-01T00-00-00-${id}.jsonl`),
+        sessionMetaLine(id, cwd, "2026-01-01T00:00:00.000Z") + "\n",
+        "utf8",
+      );
+
+      const adapter = new CodexAdapter({ homeDir });
+      const summaries = await adapter.listPastSessions(cwd);
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]).toMatchObject({ agentSessionId: id, title: id });
+    });
+
+    it("skips files that don't start with a session_meta line instead of throwing", async () => {
+      const dir = rolloutDir(homeDir);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "rollout-not-a-real-session.jsonl"), "not json at all\n", "utf8");
+      await writeFile(join(dir, "notes.txt"), "irrelevant, not .jsonl", "utf8");
+
+      const adapter = new CodexAdapter({ homeDir });
+      expect(await adapter.listPastSessions(cwd)).toEqual([]);
+    });
+
+    it("recurses through the YYYY/MM/DD date-sharded directory structure", async () => {
+      const dirA = join(homeDir, ".codex", "sessions", "2026", "01", "01");
+      const dirB = join(homeDir, ".codex", "sessions", "2026", "02", "15");
+      await mkdir(dirA, { recursive: true });
+      await mkdir(dirB, { recursive: true });
+      const idA = "019e62d5-a020-75f1-b5e8-253383076fa1";
+      const idB = "019e62d5-a020-75f1-b5e8-253383076fb2";
+      await writeFile(
+        join(dirA, `rollout-2026-01-01T00-00-00-${idA}.jsonl`),
+        sessionMetaLine(idA, cwd, "2026-01-01T00:00:00.000Z") + "\n",
+        "utf8",
+      );
+      await writeFile(
+        join(dirB, `rollout-2026-02-15T00-00-00-${idB}.jsonl`),
+        sessionMetaLine(idB, cwd, "2026-02-15T00:00:00.000Z") + "\n",
+        "utf8",
+      );
+
+      const adapter = new CodexAdapter({ homeDir });
+      const summaries = await adapter.listPastSessions(cwd);
+      const ids = summaries.map((s) => s.agentSessionId).sort();
+      expect(ids).toEqual([idA, idB].sort());
+    });
+  });
+});

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -1,55 +1,253 @@
 /**
- * codex adapter — honest stub. `doctor()` reports whether the `codex` CLI is
- * on PATH; launch/resume are not implemented yet (transcript-tail event
- * source and rollout-file discovery land in a follow-up workstream).
+ * codex adapter — launches/resumes the `codex` CLI and scans its rollout
+ * store for resumable history. Codex has no hook system (see
+ * core/collector/codex-tailer.ts for how its analytics eventSource works
+ * instead); this file only covers process launch/resume/doctor/history.
+ *
+ * Verified against a locally installed `codex-cli 0.134.0` on the build
+ * machine: `codex resume [SESSION_ID] [PROMPT]` (positional UUID or thread
+ * name) and the generic `-c key=value` config-override mechanism are
+ * confirmed via `codex --help` / `codex resume --help`. The specific config
+ * keys used for system-prompt injection (`developer_instructions`,
+ * `model_instructions_file`) are NOT independently confirmed against this
+ * version — they're carried over from a known-working reference
+ * implementation targeting an earlier Codex CLI, since `--help` documents
+ * `-c` as a generic escape hatch and doesn't enumerate valid keys. Flagged
+ * in the PR description; worth a manual smoke test before relying on it for
+ * a live demo.
  */
 
 import { execFile } from "node:child_process";
+import { open, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
 import { promisify } from "node:util";
 
-import type { DoctorCheck, HarnessAdapter, LaunchOpts, SessionSummary, SpawnSpec } from "../../shared/types.js";
+import type {
+  DoctorCheck,
+  HarnessAdapter,
+  LaunchOpts,
+  SessionSummary,
+  SpawnSpec,
+} from "../../shared/types.js";
 
 const execFileAsync = promisify(execFile);
 
+/** Bytes read from the head of a rollout file to find its session_meta line
+ * and an early title candidate. Unlike Claude's transcripts (where a summary
+ * lands near the end), Codex has no end-of-session summary line, so the
+ * earliest user message is the best available title — and it's always near
+ * the start of the file. */
+const ROLLOUT_HEAD_BYTES = 65_536;
+const MAX_SCAN_DEPTH = 4; // ~/.codex/sessions/YYYY/MM/DD/*.jsonl
+
 export interface CodexAdapterOptions {
+  /** Overridable for tests. */
   binary?: string;
+  /** Overridable for tests. Defaults to the real home directory. */
+  homeDir?: string;
+}
+
+interface RolloutSessionMeta {
+  id: string;
+  cwd: string;
+  timestampMs: number | null;
+}
+
+interface RolloutLine {
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+/** Read only the head of a (possibly huge) rollout file and extract its
+ * `session_meta` entry. Codex always writes `session_meta` as the first
+ * line, but this tolerates a few leading blank/malformed lines defensively. */
+async function readSessionMeta(filePath: string, maxBytes = ROLLOUT_HEAD_BYTES): Promise<RolloutSessionMeta | null> {
+  let content: string;
+  try {
+    const handle = await open(filePath, "r");
+    try {
+      const { size } = await handle.stat();
+      const length = Math.min(size, maxBytes);
+      const buffer = Buffer.allocUnsafe(length);
+      await handle.read(buffer, 0, length, 0);
+      content = buffer.toString("utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+
+  for (const line of content.split("\n").slice(0, 20)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: RolloutLine;
+    try {
+      parsed = JSON.parse(trimmed) as RolloutLine;
+    } catch {
+      continue;
+    }
+    if (parsed.type !== "session_meta") continue;
+    const payload = parsed.payload;
+    const id = typeof payload?.id === "string" ? payload.id : undefined;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : undefined;
+    if (!id || !cwd) return null;
+    const timestamp = typeof payload?.timestamp === "string" ? Date.parse(payload.timestamp) : NaN;
+    return { id, cwd, timestampMs: Number.isNaN(timestamp) ? null : timestamp };
+  }
+  return null;
+}
+
+/** First `event_msg`/`user_message` found in the head of the file, truncated
+ * for use as a session title. Falls back to `fallback` when none is found
+ * within the head window (long system-prompt-only sessions, mid-tail-cut). */
+function extractTitleFromHead(content: string, fallback: string): string {
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: RolloutLine;
+    try {
+      parsed = JSON.parse(trimmed) as RolloutLine;
+    } catch {
+      continue;
+    }
+    if (parsed.type !== "event_msg" || parsed.payload?.type !== "user_message") continue;
+    const message = parsed.payload.message;
+    if (typeof message === "string" && message.trim()) {
+      const text = message.trim();
+      return text.length > 120 ? `${text.slice(0, 120)}...` : text;
+    }
+  }
+  return fallback;
+}
+
+/** Recursively collect `.jsonl` files under Codex's date-sharded sessions
+ * root (`YYYY/MM/DD/rollout-*.jsonl`). Bounded depth as a safety guard
+ * against unexpectedly deep/cyclical directory structures. */
+async function collectRolloutFiles(dir: string, depth = 0): Promise<string[]> {
+  if (depth > MAX_SCAN_DEPTH) return [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await collectRolloutFiles(fullPath, depth + 1)));
+    } else if (entry.name.endsWith(".jsonl")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
 }
 
 export class CodexAdapter implements HarnessAdapter {
   readonly id = "codex" as const;
   readonly eventSource = "transcript-tail" as const;
   private readonly binary: string;
+  private readonly homeDir: string;
 
   constructor(options: CodexAdapterOptions = {}) {
     this.binary = options.binary ?? "codex";
+    this.homeDir = options.homeDir ?? homedir();
   }
 
   async doctor(): Promise<DoctorCheck[]> {
     try {
-      await execFileAsync(this.binary, ["--version"], { timeout: 5_000 });
-      return [{ name: "codex", ok: true, detail: "installed (Codex support coming soon)" }];
+      const { stdout } = await execFileAsync(this.binary, ["--version"], { timeout: 5_000 });
+      return [{ name: "codex", ok: true, detail: stdout.trim() || "installed" }];
     } catch {
       return [
         {
           name: "codex",
           ok: false,
-          detail: `\`${this.binary}\` not found on PATH. Codex support is coming soon.`,
+          detail: `\`${this.binary}\` not found on PATH. Install: https://github.com/openai/codex`,
         },
       ];
     }
   }
 
-  launch(_opts: LaunchOpts): SpawnSpec {
-    throw new Error("codex support coming soon");
+  launch(opts: LaunchOpts): SpawnSpec {
+    return {
+      command: this.binary,
+      args: buildConfigArgs(opts),
+      // Codex has no analog to Claude's CLAUDECODE nested-agent guard; no env
+      // overrides are needed for a fresh launch.
+      env: {},
+      cwd: opts.cwd,
+    };
   }
 
-  resume(_agentSessionId: string, _opts: LaunchOpts): SpawnSpec {
-    throw new Error("codex support coming soon");
+  resume(agentSessionId: string, opts: LaunchOpts): SpawnSpec {
+    return {
+      command: this.binary,
+      args: ["resume", agentSessionId, ...buildConfigArgs(opts)],
+      env: {},
+      cwd: opts.cwd,
+    };
   }
 
-  async listPastSessions(_cwd: string): Promise<SessionSummary[]> {
-    return [];
+  async listPastSessions(cwd: string): Promise<SessionSummary[]> {
+    const root = join(this.homeDir, ".codex", "sessions");
+    const files = await collectRolloutFiles(root);
+
+    const summaries: SessionSummary[] = [];
+    for (const filePath of files) {
+      const meta = await readSessionMeta(filePath);
+      if (!meta || meta.cwd !== cwd) continue;
+
+      const fileStat = await stat(filePath).catch(() => undefined);
+      const lastActiveAt = fileStat ? fileStat.mtime.toISOString() : new Date(0).toISOString();
+
+      let title = basename(filePath, ".jsonl");
+      try {
+        const handle = await open(filePath, "r");
+        try {
+          const { size } = await handle.stat();
+          const length = Math.min(size, ROLLOUT_HEAD_BYTES);
+          const buffer = Buffer.allocUnsafe(length);
+          await handle.read(buffer, 0, length, 0);
+          title = extractTitleFromHead(buffer.toString("utf8"), meta.id);
+        } finally {
+          await handle.close();
+        }
+      } catch {
+        // Fall back to the rollout id as the title.
+      }
+
+      summaries.push({
+        agentSessionId: meta.id,
+        harness: "codex",
+        cwd,
+        title,
+        lastActiveAt,
+        source: "transcript",
+      });
+    }
+
+    return summaries.sort((a, b) => (a.lastActiveAt < b.lastActiveAt ? 1 : -1));
   }
+}
+
+/**
+ * Codex has no single-flag equivalent to Claude's `--append-system-prompt` /
+ * `--mcp-config` — MCP servers are registered globally via `codex mcp add`
+ * (a persistent config.toml mutation, which the harness's "zero config
+ * mutation" design deliberately avoids), so `opts.mcpConfigFile` /
+ * `opts.settingsFile` are intentionally unused here. System-prompt injection
+ * uses the generic `-c key=value` override mechanism instead (see the
+ * module-level doc comment for the verification caveat on the exact keys).
+ */
+function buildConfigArgs(opts: LaunchOpts): string[] {
+  const args = ["-c", "check_for_update_on_startup=false"];
+  if (opts.systemPromptFile) {
+    args.push("-c", `model_instructions_file=${opts.systemPromptFile}`);
+  }
+  return args;
 }
 
 export function createCodexAdapter(options?: CodexAdapterOptions): HarnessAdapter {

--- a/packages/harness/src/core/collector/codex-tailer.test.ts
+++ b/packages/harness/src/core/collector/codex-tailer.test.ts
@@ -1,0 +1,284 @@
+import { mkdir, mkdtemp, rm, writeFile, appendFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "./codex-tailer.js";
+import type { RawHookPayload } from "./normalizer.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const POLL_MS = 20;
+
+function sessionMetaLine(id: string, cwd: string, timestamp: string): string {
+  return JSON.stringify({ timestamp, type: "session_meta", payload: { id, timestamp, cwd } }) + "\n";
+}
+function userMessageLine(message: string): string {
+  return JSON.stringify({ type: "event_msg", payload: { type: "user_message", message } }) + "\n";
+}
+function functionCallLine(callId: string, name: string, args: string): string {
+  return JSON.stringify({ type: "response_item", payload: { type: "function_call", call_id: callId, name, arguments: args } }) + "\n";
+}
+function functionCallOutputLine(callId: string, output: string): string {
+  return JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: callId, output } }) + "\n";
+}
+function taskCompleteLine(): string {
+  return JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }) + "\n";
+}
+function taskStartedLine(): string {
+  return JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) + "\n";
+}
+
+describe("tailCodexRollout", () => {
+  let dir: string;
+  let rolloutPath: string;
+  let handle: CodexTailerHandle | undefined;
+  let onEvent: ReturnType<typeof vi.fn<(hookEvent: string, payload: RawHookPayload) => void>>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-codex-tailer-"));
+    rolloutPath = join(dir, "rollout-test.jsonl");
+    onEvent = vi.fn();
+    onError = vi.fn();
+  });
+
+  afterEach(async () => {
+    handle?.stop();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function start(): CodexTailerHandle {
+    handle = tailCodexRollout({ rolloutPath, onEvent, onError, pollIntervalMs: POLL_MS });
+    return handle;
+  }
+
+  it("waits for the file to appear before emitting anything", async () => {
+    start();
+    await sleep(POLL_MS * 4);
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    await sleep(POLL_MS * 4);
+    expect(onEvent).toHaveBeenCalledWith("SessionStart", {
+      source: "codex",
+      cwd: "/tmp/proj",
+      session_id: "agent-1",
+    });
+  });
+
+  it("emits SessionStart only once even if session_meta somehow reappears", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+    await appendFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    await sleep(POLL_MS * 4);
+
+    const sessionStartCalls = onEvent.mock.calls.filter(([event]) => event === "SessionStart");
+    expect(sessionStartCalls).toHaveLength(1);
+  });
+
+  it("translates a user_message into UserPromptSubmit", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(rolloutPath, userMessageLine("build me a leasing workflow"));
+    await sleep(POLL_MS * 4);
+
+    expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "build me a leasing workflow" });
+  });
+
+  it("pairs function_call + function_call_output into a single PostToolUse", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(rolloutPath, functionCallLine("call_1", "exec_command", '{"cmd":"ls"}'));
+    await sleep(POLL_MS * 4);
+    // No PostToolUse yet — still waiting on the matching output.
+    expect(onEvent).not.toHaveBeenCalledWith("PostToolUse", expect.anything());
+
+    await appendFile(rolloutPath, functionCallOutputLine("call_1", "file1.txt\nfile2.txt"));
+    await sleep(POLL_MS * 4);
+
+    expect(onEvent).toHaveBeenCalledWith("PostToolUse", {
+      tool_name: "exec_command",
+      tool_input: '{"cmd":"ls"}',
+      tool_response: "file1.txt\nfile2.txt",
+    });
+  });
+
+  it("translates task_complete into Stop and ignores task_started", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(rolloutPath, taskStartedLine());
+    await appendFile(rolloutPath, taskCompleteLine());
+    await sleep(POLL_MS * 4);
+
+    expect(onEvent).toHaveBeenCalledWith("Stop", { stop_hook_active: false });
+    expect(onEvent.mock.calls.filter(([event]) => event !== "SessionStart")).toEqual([
+      ["Stop", { stop_hook_active: false }],
+    ]);
+  });
+
+  it("processes lines in file order across multiple poll cycles", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    const h = start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(rolloutPath, userMessageLine("first"));
+    await sleep(POLL_MS * 4);
+    await appendFile(rolloutPath, userMessageLine("second"));
+    await sleep(POLL_MS * 4);
+
+    const prompts = onEvent.mock.calls
+      .filter(([event]) => event === "UserPromptSubmit")
+      .map(([, payload]) => (payload as { prompt: string }).prompt);
+    expect(prompts).toEqual(["first", "second"]);
+    h.stop();
+  });
+
+  it("does not backfill content that existed before the tailer started (resume semantics)", async () => {
+    await writeFile(
+      rolloutPath,
+      sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z") + userMessageLine("old history"),
+    );
+    start();
+    await sleep(POLL_MS * 6);
+
+    expect(onEvent).not.toHaveBeenCalled();
+
+    await appendFile(rolloutPath, userMessageLine("new activity after resume"));
+    await sleep(POLL_MS * 4);
+
+    expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "new activity after resume" });
+    expect(onEvent).not.toHaveBeenCalledWith("UserPromptSubmit", { prompt: "old history" });
+  });
+
+  it("reports malformed JSON lines via onError instead of throwing, and keeps tailing", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(rolloutPath, "not valid json at all\n");
+    await appendFile(rolloutPath, userMessageLine("still works after garbage"));
+    await sleep(POLL_MS * 4);
+
+    expect(onError).toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "still works after garbage" });
+  });
+
+  it("handles a line split across two poll cycles (partial trailing write)", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    start();
+    await sleep(POLL_MS * 4);
+
+    const fullLine = userMessageLine("split across polls");
+    const splitPoint = Math.floor(fullLine.length / 2);
+    await appendFile(rolloutPath, fullLine.slice(0, splitPoint));
+    await sleep(POLL_MS * 4);
+    expect(onEvent).not.toHaveBeenCalledWith("UserPromptSubmit", expect.anything());
+
+    await appendFile(rolloutPath, fullLine.slice(splitPoint));
+    await sleep(POLL_MS * 4);
+    expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "split across polls" });
+  });
+
+  it("emitSessionEnd() emits a SessionEnd event and stops further polling", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    const h = start();
+    await sleep(POLL_MS * 4);
+
+    h.emitSessionEnd("pty exited");
+    expect(onEvent).toHaveBeenCalledWith("SessionEnd", { reason: "pty exited" });
+
+    onEvent.mockClear();
+    await appendFile(rolloutPath, userMessageLine("after end, should be ignored"));
+    await sleep(POLL_MS * 4);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("stop() halts polling without emitting a SessionEnd", async () => {
+    await writeFile(rolloutPath, sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z"));
+    const h = start();
+    await sleep(POLL_MS * 4);
+    onEvent.mockClear();
+
+    h.stop();
+    await appendFile(rolloutPath, userMessageLine("after stop, should be ignored"));
+    await sleep(POLL_MS * 4);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("findRolloutFile", () => {
+  let homeDir: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "harness-codex-find-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  function rolloutDir(): string {
+    return join(homeDir, ".codex", "sessions", "2026", "01", "01");
+  }
+
+  it("returns null when no sessions directory exists", async () => {
+    expect(await findRolloutFile({ cwd: "/tmp/proj", homeDir })).toBeNull();
+  });
+
+  it("finds the file whose session_meta.cwd matches", async () => {
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "rollout-a.jsonl"),
+      sessionMetaLine("agent-a", "/tmp/proj", "2026-01-01T00:00:00.000Z"),
+    );
+    await writeFile(
+      join(dir, "rollout-b.jsonl"),
+      sessionMetaLine("agent-b", "/tmp/other", "2026-01-01T00:01:00.000Z"),
+    );
+
+    const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir });
+    expect(found).toBe(join(dir, "rollout-a.jsonl"));
+  });
+
+  it("excludes sessions started before sinceMs", async () => {
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "rollout-old.jsonl"),
+      sessionMetaLine("agent-old", "/tmp/proj", "2026-01-01T00:00:00.000Z"),
+    );
+
+    const found = await findRolloutFile({
+      cwd: "/tmp/proj",
+      homeDir,
+      sinceMs: Date.parse("2026-01-01T00:10:00.000Z"),
+    });
+    expect(found).toBeNull();
+  });
+
+  it("picks the most recently modified match when multiple sessions share a cwd", async () => {
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "rollout-earlier.jsonl"),
+      sessionMetaLine("agent-earlier", "/tmp/proj", "2026-01-01T00:00:00.000Z"),
+    );
+    await sleep(20);
+    await writeFile(
+      join(dir, "rollout-later.jsonl"),
+      sessionMetaLine("agent-later", "/tmp/proj", "2026-01-01T00:05:00.000Z"),
+    );
+
+    const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir });
+    expect(found).toBe(join(dir, "rollout-later.jsonl"));
+  });
+});

--- a/packages/harness/src/core/collector/codex-tailer.ts
+++ b/packages/harness/src/core/collector/codex-tailer.ts
@@ -1,0 +1,304 @@
+/**
+ * Codex transcript tailer — Codex has no hook system, so this file *is* its
+ * entire analytics eventSource (see HarnessAdapter.eventSource ===
+ * "transcript-tail" on CodexAdapter). It incrementally reads a rollout JSONL
+ * file as Codex appends to it and translates each entry into the same
+ * `{hookEvent, payload}` shape Claude Code's hooks would have produced for
+ * equivalent activity — so the existing ingest pipeline
+ * (core/collector/normalizer.ts's `normalizeHookEvent`) can consume both
+ * harnesses unchanged, with zero Codex-specific branching in the normalizer.
+ *
+ * Self-contained by design: no imports from server/, session-manager.ts, or
+ * the rest of core/collector/ (only types, imported for shape-compatibility
+ * with the normalizer this feeds). Not wired into the server — see the
+ * "Wiring this in" section of the PR description for the integration
+ * contract (what to call, and when).
+ */
+
+import { open, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { ClaudeHookEvent, RawHookPayload } from "./normalizer.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 300;
+const MAX_SCAN_DEPTH = 4; // ~/.codex/sessions/YYYY/MM/DD/*.jsonl
+
+// ---------------------------------------------------------------------------
+// Live tailing
+// ---------------------------------------------------------------------------
+
+export type CodexEventListener = (hookEvent: ClaudeHookEvent, payload: RawHookPayload) => void;
+
+export interface CodexTailerOptions {
+  /** Path to the rollout JSONL file. It's fine if this doesn't exist yet —
+   * the tailer polls until Codex creates it (there's an unavoidable race
+   * between spawning `codex` and it creating its rollout file). */
+  rolloutPath: string;
+  onEvent: CodexEventListener;
+  onError?: (err: unknown) => void;
+  pollIntervalMs?: number;
+}
+
+export interface CodexTailerHandle {
+  /** Stop polling without emitting anything further. */
+  stop(): void;
+  /**
+   * Synthesize a SessionEnd hook-shaped event and stop polling. Codex's
+   * rollout format has no "session ended" line of its own — call this when
+   * the harness detects the underlying pty has exited.
+   */
+  emitSessionEnd(reason?: string): void;
+}
+
+interface RolloutLine {
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface PendingFunctionCall {
+  name: string;
+  argumentsRaw: string;
+}
+
+/**
+ * Incrementally tail a Codex rollout file, translating each new line into a
+ * Claude-hook-shaped `(hookEvent, payload)` pair via `onEvent`. Only emits
+ * for content appended *after* the tailer starts (matching hook semantics —
+ * hooks only fire for new activity, never backfill); use
+ * `CodexAdapter.listPastSessions` for history.
+ */
+export function tailCodexRollout(options: CodexTailerOptions): CodexTailerHandle {
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let offset = 0;
+  let carry = "";
+  let sessionStartEmitted = false;
+  let stopped = false;
+  let polling = false;
+  const pendingCalls = new Map<string, PendingFunctionCall>();
+
+  // Resolve the resume-vs-fresh baseline exactly once, immediately, before
+  // any poll reads content. If the file already exists right now, its
+  // current size becomes the "don't backfill past this" offset (resume —
+  // only new activity should be emitted, matching hook semantics). If it
+  // doesn't exist yet, the offset stays 0, so once Codex creates the file
+  // the very first bytes it writes (session_meta) are read as new — without
+  // this distinction, a poll-interval race between file creation and its
+  // first write would silently swallow SessionStart on every fresh launch.
+  let baselineResolved = false;
+  void stat(options.rolloutPath).then(
+    (s) => {
+      offset = s.size;
+      baselineResolved = true;
+    },
+    () => {
+      baselineResolved = true;
+    },
+  );
+
+  const timer = setInterval(() => {
+    void poll();
+  }, pollIntervalMs);
+  timer.unref?.();
+
+  async function poll(): Promise<void> {
+    if (stopped || polling || !baselineResolved) return;
+    polling = true;
+    try {
+      const fileStat = await stat(options.rolloutPath);
+      if (fileStat.size <= offset) return;
+
+      const handle = await open(options.rolloutPath, "r");
+      try {
+        const length = fileStat.size - offset;
+        const buffer = Buffer.allocUnsafe(length);
+        await handle.read(buffer, 0, length, offset);
+        offset = fileStat.size;
+
+        const chunk = carry + buffer.toString("utf8");
+        const lines = chunk.split("\n");
+        carry = lines.pop() ?? "";
+        for (const line of lines) processLine(line);
+      } finally {
+        await handle.close();
+      }
+    } catch (err) {
+      // ENOENT is the expected steady-state before Codex has created the
+      // file yet — anything else is a real read/parse failure worth surfacing.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        options.onError?.(err);
+      }
+    } finally {
+      polling = false;
+    }
+  }
+
+  function processLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let entry: RolloutLine;
+    try {
+      entry = JSON.parse(trimmed) as RolloutLine;
+    } catch (err) {
+      options.onError?.(err);
+      return;
+    }
+    translate(entry);
+  }
+
+  function translate(entry: RolloutLine): void {
+    const payload = entry.payload;
+
+    if (entry.type === "session_meta") {
+      if (sessionStartEmitted) return;
+      sessionStartEmitted = true;
+      options.onEvent("SessionStart", {
+        source: "codex",
+        cwd: typeof payload?.cwd === "string" ? payload.cwd : null,
+        // Claude's normalizer resolves agentSessionId from a `session_id`
+        // field on the hook payload — matching that field name here is what
+        // lets normalizeHookEvent() pick up the rollout id unchanged.
+        session_id: typeof payload?.id === "string" ? payload.id : undefined,
+      });
+      return;
+    }
+
+    if (entry.type === "event_msg") {
+      if (payload?.type === "user_message" && typeof payload.message === "string") {
+        options.onEvent("UserPromptSubmit", { prompt: payload.message });
+      } else if (payload?.type === "task_complete") {
+        options.onEvent("Stop", { stop_hook_active: false });
+      }
+      return;
+    }
+
+    if (entry.type === "response_item") {
+      if (payload?.type === "function_call" && typeof payload.call_id === "string") {
+        pendingCalls.set(payload.call_id, {
+          name: typeof payload.name === "string" ? payload.name : "unknown",
+          argumentsRaw: typeof payload.arguments === "string" ? payload.arguments : "",
+        });
+      } else if (payload?.type === "function_call_output" && typeof payload.call_id === "string") {
+        const call = pendingCalls.get(payload.call_id);
+        pendingCalls.delete(payload.call_id);
+        options.onEvent("PostToolUse", {
+          tool_name: call?.name ?? "unknown",
+          tool_input: call?.argumentsRaw ?? "",
+          tool_response: payload.output ?? "",
+        });
+      }
+      return;
+    }
+  }
+
+  return {
+    stop(): void {
+      stopped = true;
+      clearInterval(timer);
+    },
+    emitSessionEnd(reason?: string): void {
+      if (stopped) return;
+      options.onEvent("SessionEnd", { reason: reason ?? null });
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery: find the rollout file for a freshly-launched or resumed session
+// ---------------------------------------------------------------------------
+
+export interface FindRolloutFileOptions {
+  /** Match a rollout file whose session_meta.cwd equals this exactly. */
+  cwd: string;
+  /** Only consider sessions created at/after this time (ms epoch) —
+   * disambiguates a freshly-launched session from older ones sharing a cwd. */
+  sinceMs?: number;
+  /** Overridable for tests. */
+  homeDir?: string;
+}
+
+interface RolloutSessionMeta {
+  cwd: string;
+  timestampMs: number | null;
+}
+
+async function readSessionMetaHead(filePath: string, maxBytes = 65_536): Promise<RolloutSessionMeta | null> {
+  let content: string;
+  try {
+    const handle = await open(filePath, "r");
+    try {
+      const { size } = await handle.stat();
+      const length = Math.min(size, maxBytes);
+      const buffer = Buffer.allocUnsafe(length);
+      await handle.read(buffer, 0, length, 0);
+      content = buffer.toString("utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+
+  for (const line of content.split("\n").slice(0, 20)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: RolloutLine;
+    try {
+      parsed = JSON.parse(trimmed) as RolloutLine;
+    } catch {
+      continue;
+    }
+    if (parsed.type !== "session_meta") continue;
+    const cwd = typeof parsed.payload?.cwd === "string" ? parsed.payload.cwd : undefined;
+    if (!cwd) return null;
+    const timestamp = typeof parsed.payload?.timestamp === "string" ? Date.parse(parsed.payload.timestamp) : NaN;
+    return { cwd, timestampMs: Number.isNaN(timestamp) ? null : timestamp };
+  }
+  return null;
+}
+
+async function collectRolloutFiles(dir: string, depth = 0): Promise<string[]> {
+  if (depth > MAX_SCAN_DEPTH) return [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await collectRolloutFiles(fullPath, depth + 1)));
+    } else if (entry.name.endsWith(".jsonl")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Finds the most-recently-modified rollout file matching `cwd` (and
+ * `sinceMs`, if given). Intended to be polled by the integrator right after
+ * spawning a fresh `codex` process — there's no way to know the exact
+ * rollout path in advance (it's a timestamp+UUID Codex generates itself).
+ */
+export async function findRolloutFile(options: FindRolloutFileOptions): Promise<string | null> {
+  const homeDir = options.homeDir ?? homedir();
+  const root = join(homeDir, ".codex", "sessions");
+  const files = await collectRolloutFiles(root);
+
+  let best: { path: string; mtimeMs: number } | null = null;
+  for (const filePath of files) {
+    const meta = await readSessionMetaHead(filePath);
+    if (!meta || meta.cwd !== options.cwd) continue;
+    if (options.sinceMs !== undefined && meta.timestampMs !== null && meta.timestampMs < options.sinceMs) continue;
+
+    const fileStat = await stat(filePath).catch(() => null);
+    if (!fileStat) continue;
+    if (!best || fileStat.mtimeMs > best.mtimeMs) best = { path: filePath, mtimeMs: fileStat.mtimeMs };
+  }
+  return best?.path ?? null;
+}


### PR DESCRIPTION
## Summary

Replaces the Codex adapter stub with a real implementation, plus a new transcript tailer since Codex has no hook system of its own (its entire analytics `eventSource` is transcript-tail).

- `core/adapters/codex.ts`:
  - `launch()` disables the update-check prompt and injects the system prompt via a `-c` config override when a `systemPromptFile` is given.
  - `resume()` uses `codex resume <rolloutId>`.
  - `doctor()` honestly reports binary presence/version.
  - `listPastSessions()` scans the date-sharded `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` tree, reading only the head of each file — `session_meta` is always the first line, and unlike Claude there's no end-of-session summary line, so the earliest user message is the best available title.
- `core/collector/codex-tailer.ts`: incrementally tails a *live* rollout file and translates each new entry into the same `{hookEvent, payload}` shape Claude Code's hooks produce, so the existing ingest normalizer (`normalizeHookEvent`) can consume both harnesses unchanged with zero Codex-specific branching. **Not wired into the server** — this PR is scoped to the adapter + tailer only, per the file boundaries below.

## Verification of assumptions (per the ticket's request to check against the real CLI)

`codex` is installed locally (`codex-cli 0.134.0`). Verified directly:
- `codex resume [SESSION_ID] [PROMPT]` (positional UUID or thread name) — confirmed via `codex resume --help`.
- The generic `-c key=value` config-override mechanism — confirmed via `codex --help`.
- The rollout JSONL schema (`session_meta` / `event_msg` / `response_item`, each wrapping its real fields under a `payload` key) — confirmed against this machine's real `~/.codex/sessions/**/*.jsonl` files, not just a reference implementation. (Worth noting: the reference implementation I was pointed at assumes an **older**, flatter schema without the `payload` wrapper — it's drifted from what's actually on disk today.)

**Not independently verified** — flagging per instructions: the specific config keys used for system-prompt injection (`developer_instructions` for inline text, `model_instructions_file` for a file path) are carried over from that same reference implementation. `codex --help` documents `-c` as a generic escape hatch and doesn't enumerate valid keys, and I didn't want to trigger a real (billed) model turn just to validate a key name via `--strict-config`. Recommend a quick manual smoke test before relying on this for a live demo.

## Wiring this in (not done here — out of scope per file boundaries)

- On session create for `harness === "codex"`: after spawning, poll `findRolloutFile({ cwd, sinceMs: launchTimestamp })` until it resolves, then call `tailCodexRollout({ rolloutPath, onEvent })` where `onEvent(hookEvent, payload)` calls the same `normalizeHookEvent(hookEvent, payload, context)` already used for Claude's `/ingest` path, then `store.append` + `batcher.enqueue` the result exactly like `ingest.ts`'s `processIngest` does.
- On resuming a Codex session: `agentSessionId` is already known, so skip discovery-by-`sinceMs` — poll `findRolloutFile({ cwd })` once, or reuse whatever path the original tailer resolved if the harness session's in-memory state carries it forward.
- On the SessionManager detecting the pty exited: call the tailer handle's `emitSessionEnd()` so a `SessionEnd` analytics event is recorded — Codex's rollout format has no "session ended" line of its own to detect this from file content alone.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `lint` — all clean
- [x] `pnpm --filter @sapiom/harness test` — 170/170 passing (25 new: 10 for `codex.ts` covering SpawnSpec shapes, doctor, and `listPastSessions` against a fixture `YYYY/MM/DD` tree; 15 for `codex-tailer.ts` covering live tailing — `SessionStart` dedup, user-message/tool-call/task-complete translation, resume-vs-fresh backfill semantics, a poll-boundary split-line case, malformed-line tolerance, and `emitSessionEnd`/`stop` lifecycle — plus discovery logic for `findRolloutFile`'s cwd/sinceMs/mtime-ordering)
- [x] Spot-verified `listPastSessions` and `findRolloutFile` against this machine's real `~/.codex/sessions` tree (55 real sessions found, correctly parsed cwd/title/id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)