### PR TITLE
fix(harness): workflows auto-scan, always print the tokened URL

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -21,6 +21,9 @@
  *   5. Writing to the session's canvas dir produces a canvas.reload frame,
  *      and GET /canvas/:id/ serves what was written.
  *   6. POST /api/macros/:id/run is accepted (injects into the pty).
+ *   7. The CLI's launch directory is scanned for workflows at boot, and a
+ *      new directory is scanned when a session opens in it — both fire a
+ *      workflows.changed frame on /ws/events.
  *
  * Run with: pnpm e2e:live
  */
@@ -63,10 +66,57 @@ interface FakeClaudeCapture {
   env: Record<string, string | null>;
 }
 
+/**
+ * node-pty ships prebuilt native binaries rather than compiling from source.
+ * Observed in the wild: a pnpm-managed install (even with
+ * onlyBuiltDependencies configured) can extract the darwin/linux
+ * `spawn-helper` without its executable bit set, which fails every single
+ * pty spawn with an opaque "posix_spawnp failed" — nothing to do with this
+ * script or the harness's own code. session-manager.ts's loadDefaultSpawn()
+ * self-heals this on first real use, but this script spawns real ptys as
+ * its whole point, so fail fast here with an actionable message rather than
+ * an obscure native stack trace three layers down.
+ */
+async function preflightNodePty(): Promise<void> {
+  try {
+    const nodePty = await import("node-pty");
+    const probe = nodePty.spawn(process.execPath, ["-e", "process.exit(0)"], {
+      name: "xterm-256color",
+      cols: 80,
+      rows: 24,
+      cwd: process.cwd(),
+    });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("node-pty preflight spawn timed out")), 3000);
+      probe.onExit(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  } catch (err) {
+    console.error(
+      "\nnode-pty preflight failed — every session spawn in this run would fail the same way.\n" +
+        "This usually means the platform's spawn-helper binary landed without its executable bit\n" +
+        "set (a known pnpm + node-pty interaction, even with onlyBuiltDependencies configured).\n" +
+        "Try: pnpm rebuild node-pty — or manually chmod +x the spawn-helper under\n" +
+        "node_modules/.pnpm/node-pty*/node_modules/node-pty/prebuilds/<platform>-<arch>/spawn-helper\n",
+    );
+    console.error(`Original error: ${err instanceof Error ? err.message : String(err)}\n`);
+    throw err;
+  }
+}
+
 async function main(): Promise<void> {
+  await preflightNodePty();
+  console.log("node-pty preflight ok");
+
   const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-e2e-live-"));
   const projectDir = path.join(tmpRoot, "project");
   await fs.mkdir(projectDir, { recursive: true });
+  // A sapiom.json marker here, in the CLI's launch directory, proves the
+  // boot-time workflow scan (item 7 below) — it must be in place before
+  // startServer() runs its one-shot scan of launchDir.
+  await fs.writeFile(path.join(projectDir, "sapiom.json"), JSON.stringify({ definitionId: 4821 }));
   const collectorCwd = path.join(tmpRoot, "collector");
   await fs.mkdir(collectorCwd, { recursive: true });
   console.log(`scratch dir: ${tmpRoot}`);
@@ -110,6 +160,7 @@ async function main(): Promise<void> {
     sessionsPath: path.join(tmpRoot, "sessions.json"),
     eventStorePath,
     workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    launchDir: projectDir,
   });
   console.log(`harness server listening on http://127.0.0.1:${server.port}`);
 
@@ -291,6 +342,51 @@ async function main(): Promise<void> {
     assert(macroRes.status === 200, "POST /api/macros/visualize/run returns 200");
     const macroBody = (await macroRes.json()) as { ok: boolean };
     assert(macroBody.ok === true, "macro run responds { ok: true }");
+
+    // --- 11. the launch directory's sapiom.json (written before startServer) was scanned at boot ---
+    // Note: WorkflowInfo.name comes from package.json (or the directory's own
+    // basename) — the sapiom.json marker itself only carries definitionId —
+    // so that's what distinguishes "found the real marker" from "found some
+    // other directory".
+    type WorkflowInfoLike = { name: string; path: string; definitionId: number | null };
+    const bootWorkflows = await waitFor(async () => {
+      const res = await fetch(`${baseUrl}/api/workflows`, { headers });
+      const workflows = (await res.json()) as WorkflowInfoLike[];
+      return workflows.some((w) => w.path === projectDir) ? workflows : undefined;
+    });
+    assert(
+      bootWorkflows.some((w) => w.path === projectDir && w.definitionId === 4821),
+      "boot-time scan of the CLI's launch directory discovered its sapiom.json (definitionId read from the marker)",
+    );
+
+    // --- 12. opening a session in a brand-new directory scans it too, and broadcasts workflows.changed ---
+    const secondProjectDir = path.join(tmpRoot, "second-project");
+    await fs.mkdir(secondProjectDir, { recursive: true });
+    await fs.writeFile(path.join(secondProjectDir, "sapiom.json"), JSON.stringify({ definitionId: 9001 }));
+
+    const workflowsChangedBefore = wsMessages.filter((m) => m.type === "workflows.changed").length;
+    const secondSessionRes = await fetch(`${baseUrl}/api/sessions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ cwd: secondProjectDir, harness: "claude-code" }),
+    });
+    assert(secondSessionRes.status === 201, "POST /api/sessions (second directory) returns 201");
+
+    await waitFor(async () => {
+      const count = wsMessages.filter((m) => m.type === "workflows.changed").length;
+      return count > workflowsChangedBefore ? true : undefined;
+    });
+    console.log("workflows.changed frame received for the new session directory");
+
+    const afterSecondSession = await waitFor(async () => {
+      const res = await fetch(`${baseUrl}/api/workflows`, { headers });
+      const workflows = (await res.json()) as WorkflowInfoLike[];
+      return workflows.some((w) => w.path === secondProjectDir) ? workflows : undefined;
+    });
+    assert(
+      afterSecondSession.some((w) => w.path === secondProjectDir && w.definitionId === 9001),
+      "creating a session in a new directory scanned and discovered its sapiom.json",
+    );
 
     console.log("\nPASS — live integration proof succeeded\n");
   } finally {

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -82,6 +82,7 @@ function parseArgs(argv: string[]): CliOptions {
 function printBanner(opts: {
   dir: string;
   port: number;
+  bootToken: string;
   identity: HarnessIdentity | null;
   telemetryOptIn: boolean;
   serverStarted: boolean;
@@ -96,8 +97,13 @@ function printBanner(opts: {
   console.log(`  directory   ${opts.dir}`);
   console.log(`  auth        ${authLine}`);
   console.log(`  telemetry   ${opts.telemetryOptIn ? "on" : "off"}`);
+  // Always the full tokened URL — with --no-open (or a browser that failed
+  // to launch) this is the only way to reach the app; a bare host:port
+  // 401s on every /api call and can't open the WS connections.
   console.log(
-    `  url         ${opts.serverStarted ? `http://localhost:${opts.port}` : "(server not started)"}`,
+    `  url         ${
+      opts.serverStarted ? `http://localhost:${opts.port}/?token=${opts.bootToken}` : "(server not started)"
+    }`,
   );
   console.log("");
 }
@@ -124,7 +130,14 @@ const main = async (): Promise<void> => {
 
   let server: HarnessServer | null = null;
   try {
-    server = await startServer({ port: options.port, bootToken, telemetryOptIn, identity, machineId });
+    server = await startServer({
+      port: options.port,
+      bootToken,
+      telemetryOptIn,
+      identity,
+      machineId,
+      launchDir: options.dir,
+    });
   } catch (err) {
     if (!options.dev) throw err;
     const message = err instanceof Error ? err.message : String(err);
@@ -137,6 +150,7 @@ const main = async (): Promise<void> => {
   printBanner({
     dir: options.dir,
     port: server?.port ?? options.port,
+    bootToken,
     identity,
     telemetryOptIn,
     serverStarted: server !== null,

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -69,6 +69,9 @@ export interface HarnessServerOptions {
   eventStorePath?: string;
   /** Directory the built SPA lives in. Defaults to dist/web next to this module. */
   webDir?: string;
+  /** The directory the CLI was launched against — scanned for workflows at
+   *  boot so the rail isn't empty until a manual "+ Connect". */
+  launchDir?: string;
 }
 
 export interface HarnessServer {
@@ -163,6 +166,23 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   }, WORKFLOWS_CACHE_REFRESH_MS);
   workflowsCacheTimer.unref?.();
 
+  // Nothing else triggers a scan (the only other entry point is the SPA's
+  // manual "+ Connect"), so the rail would otherwise stay empty until a user
+  // does that by hand. Scan the CLI's launch directory once at boot, and
+  // again whenever a session opens in a (possibly different) directory —
+  // and let anyone already looking at the rail know it changed.
+  const scanWorkflowsAndBroadcast = async (root: string): Promise<void> => {
+    await workflowRegistry.scan(root);
+    workflowsCache = await workflowRegistry.list();
+    bus.publish({ type: "workflows.changed" });
+  };
+
+  if (options.launchDir) {
+    scanWorkflowsAndBroadcast(options.launchDir).catch((err: unknown) => {
+      console.error("[harness] initial workflow scan failed:", err);
+    });
+  }
+
   const eventStore = createEventStore(options.eventStorePath);
   const batcher = new CollectorBatcher({
     machineId,
@@ -206,6 +226,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       listWorkflows: () => workflowRegistry.list(),
       listMacros: () => DEFAULT_MACROS,
       onTelemetryOptInChange: (optIn) => batcher.setTelemetryOptIn(optIn),
+      onSessionCreated: (cwd) => {
+        scanWorkflowsAndBroadcast(cwd).catch((err: unknown) => {
+          console.error("[harness] workflow scan on session create failed:", err);
+        });
+      },
     }),
   );
   app.use(

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -187,4 +187,41 @@ describe("createRestRouter", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([]);
   });
+
+  describe("POST /sessions", () => {
+    it("calls onSessionCreated with the new session's cwd", async () => {
+      const onSessionCreated = vi.fn();
+      const sessionManager = fakeSessionManager();
+      (sessionManager.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "sess-1",
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+        status: "starting",
+      });
+      start({ sessionManager, onSessionCreated });
+
+      const res = await fetch(`${baseUrl}/sessions`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ cwd: "/tmp/proj", harness: "claude-code" }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(onSessionCreated).toHaveBeenCalledWith("/tmp/proj");
+    });
+
+    it("does not call onSessionCreated when the request body is invalid", async () => {
+      const onSessionCreated = vi.fn();
+      start({ onSessionCreated });
+
+      const res = await fetch(`${baseUrl}/sessions`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ cwd: "" }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(onSessionCreated).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -48,6 +48,10 @@ export interface RestRouterOptions {
   /** Called after a settings PATCH persists a changed telemetryOptIn, so the
    * live collector batcher can be gated without a server restart. */
   onTelemetryOptInChange?: (optIn: boolean) => void;
+  /** Called (fire-and-forget) after a session is created, with its cwd — lets
+   * the integrator scan that directory for workflows so opening a session in
+   * a new project discovers them without a manual "+ Connect". */
+  onSessionCreated?: (cwd: string) => void;
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
@@ -113,6 +117,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
     try {
       const session = await sessionManager.create(parsed.data);
       res.status(201).json(session);
+      options.onSessionCreated?.(parsed.data.cwd);
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #182 (already merged) — two gaps from rehearsal QA, landed as a separate PR since #182 merged while this was in progress.

- **Workflows rail auto-scan (E)** — nothing ever triggered `POST /api/workflows/scan`; the registry stayed empty until a manual "+ Connect". `server/index.ts` now scans a new `launchDir` option (the CLI's launch directory, threaded from `bin.ts`) once at boot, and scans a session's `cwd` again via a new `onSessionCreated` hook on `POST /api/sessions` (`rest.ts`) — so opening a session in an unscanned directory discovers its workflows. Both broadcast `workflows.changed` on the event bus so an already-open SPA updates without a refresh.
- **CLI banner (F)** — with `--no-open`, the banner printed the URL *without* the boot token — a bare `host:port` 401s on every `/api` call and can't open the WS connections, so there was no supported way to reach the app. The banner now always prints the full tokened URL.
- **`scripts/e2e-live.ts`** — added a `preflightNodePty()` check that fails fast with an actionable message (rather than an obscure native stack trace) if the platform's `spawn-helper` isn't executable — a teammate hit this from a `node_modules` that predated the `onlyBuiltDependencies` fix. Also extended the live proof to cover both new behaviors: a `sapiom.json` in the launch directory is discovered at boot (asserted via its `definitionId`, the only field the marker actually carries — `WorkflowInfo.name` comes from `package.json` or the directory's own basename, not the marker), and opening a session in a brand-new directory scans it and broadcasts `workflows.changed`.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `build:server` — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness test` — 193/193 passing (new: `POST /sessions` `onSessionCreated` coverage in `rest.test.ts`)
- [x] `pnpm test:ui` — 7/7 Playwright smoke tests green
- [x] `pnpm e2e:live` — full pass, 31/31 assertions, including the two new workflow-scan assertions
- [x] Live smoke: `node dist/cli/bin.js --no-auth --no-open --no-telemetry --dev /tmp` — banner now prints `http://localhost:4100/?token=<realtoken>` instead of a bare host:port

🤖 Generated with [Claude Code](https://claude.com/claude-code)