### PR TITLE
fix(harness): kill live sessions on server shutdown; e2e:live actually exits

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -390,14 +390,55 @@ async function main(): Promise<void> {
 
     console.log("\nPASS — live integration proof succeeded\n");
   } finally {
+    // Runs on both success and failure — a failed assertion mid-run must not
+    // strand the fake-claude pty (or the mock collector) any more than a
+    // clean pass does. server.close() kills every live session's pty
+    // (SessionManager.killAll()).
     ws?.close();
     await server.close();
-    mockCollector.kill();
-    await fs.rm(tmpRoot, { recursive: true, force: true });
+    await killChildAndWait(mockCollector);
+
+    // A just-killed child process can still be releasing its open file
+    // handles under tmpRoot for a moment after we've resolved past killing
+    // it — rm's own maxRetries (ENOTEMPTY-safe, linear backoff) covers that
+    // race properly instead of a fixed sleep.
+    await fs.rm(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+/** Sends SIGTERM, escalates to SIGKILL if it's still alive shortly after,
+ *  and waits for the process to actually exit (or a hard timeout) before
+ *  returning — so callers can safely assume its file handles are released. */
+function killChildAndWait(child: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    const done = (): void => {
+      clearTimeout(escalation);
+      clearTimeout(hardStop);
+      resolve();
+    };
+    child.once("exit", done);
+
+    child.kill();
+    const escalation = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }, 1000);
+    const hardStop = setTimeout(done, timeoutMs);
+  });
+}
+
+// Explicit exit as a backstop: teardown above should already release every
+// handle (server, sessions, WS client, mock-collector), but a CI runner
+// hanging on a stray one is a much worse failure mode than an explicit exit
+// here masking it — `process.exitCode` alone only takes effect once the
+// event loop drains on its own, which is exactly the thing we can't fully
+// guarantee.
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -194,6 +194,25 @@ describe("SessionManager", () => {
     expect(manager.kill("unknown-id")).toBe(false);
   });
 
+  it("killAll() signals every currently-live pty", async () => {
+    const { manager, spawns } = makeManager();
+    const a = await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
+    const b = await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
+    spawns[0]?.emitExit(0); // a exits on its own before killAll() runs
+
+    manager.killAll();
+
+    expect(spawns[0]?.pty.kill).not.toHaveBeenCalled(); // already gone — nothing to signal
+    expect(spawns[1]?.pty.kill).toHaveBeenCalled();
+    expect(manager.get(a.id)?.status).toBe("exited");
+    void b;
+  });
+
+  it("killAll() is a harmless no-op with no live sessions", () => {
+    const { manager } = makeManager();
+    expect(() => manager.killAll()).not.toThrow();
+  });
+
   it("resume() requires a known agentSessionId and respawns via adapter.resume", async () => {
     const { manager, adapter, spawns } = makeManager();
     const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -279,6 +279,14 @@ export class SessionManager {
     return true;
   }
 
+  /** Kills every currently-live pty. Call this on server shutdown — without
+   *  it, spawned agent processes (claude/codex) outlive the harness server
+   *  itself, e.g. after Ctrl+C, since closing the HTTP/WS server doesn't
+   *  touch unrelated child processes on its own. */
+  killAll(): void {
+    for (const id of [...this.ptys.keys()]) this.kill(id);
+  }
+
   write(id: string, data: string): boolean {
     const handle = this.ptys.get(id);
     if (!handle) return false;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -338,6 +338,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       new Promise<void>((resolve, reject) => {
         clearInterval(workflowsCacheTimer);
         canvasWatcher.stopAll();
+        // Closing the HTTP/WS server doesn't touch unrelated child processes
+        // on its own — without this, every live claude/codex pty outlives
+        // the harness server itself (e.g. after Ctrl+C or in a script that
+        // expects the process to actually exit once close() resolves).
+        sessionManager.killAll();
         void batcher.close();
         terminalWss.close();
         eventsWss.close();


### PR DESCRIPTION
## Summary

Real bug, not just an e2e-script quirk: closing the harness server's HTTP/WS listeners never touched any live pty — every spawned claude/codex process outlived the server itself (e.g. after Ctrl+C). This is exactly why `scripts/e2e-live.ts` printed "PASS" and then hung indefinitely: the fixture process it spawns for real via node-pty kept the event loop alive with no way for the script to know.

Note: `origin/feat/harness` already picked up a shallow patch for the *symptom* (explicit `process.exit()` after `main()`, commit `fbac398`) while this was in flight — that unblocks a hanging runner but doesn't kill the underlying pty, so the fake-claude child would be silently orphaned rather than actually cleaned up. This PR fixes the root cause and folds in that patch's intent (merged, conflict resolved, kept the fuller version).

- **`core/session-manager.ts`** — add `SessionManager.killAll()`, signaling every currently-live pty.
- **`server/index.ts`** — `HarnessServer.close()` now calls `sessionManager.killAll()` alongside the existing canvas watcher/batcher/WS-server teardown.
- **`scripts/e2e-live.ts`** — explicit `process.exit(0)`/`(1)` as a hard backstop (kept, now genuinely just a backstop rather than the only thing making the process exit); a `killChildAndWait()` helper properly waits for the mock-collector child to exit (escalating to SIGKILL) before scratch-dir cleanup; `fs.rm` now sets `maxRetries` so a process still releasing a file handle at that exact moment doesn't throw `ENOTEMPTY` (hit this empirically once `killAll()` made the process fast enough to race the cleanup).

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `test` (195/195) / `lint` — all clean
- [x] `pnpm e2e:live` — 3 consecutive clean runs, each exiting in ~6s with exit code 0 and zero stray processes (`ps aux | grep fake-claude` empty afterward) — previously hung indefinitely
- [x] Forced-failure verification (temporarily broke an assertion, reverted after): a failure *before* any session exists exits in <1s with code 1; a failure *after* a session (and its live fake-claude pty) is running exits in ~1.1s with code 1 and zero stray processes — confirms the "failed assertion strands fake-claude" issue is also fixed, not just the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)