### PR TITLE
fix(harness): split submitted prompt text from Enter to avoid bracketed-paste swallow

### DIFF
--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -150,6 +150,80 @@ describe("SessionManager", () => {
     expect(manager.resize("unknown-id", 1, 1)).toBe(false);
   });
 
+  describe("submitInput", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("splits non-empty submitted text into a text write, then a separate \\r after a delay", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const submitPromise = manager.submitInput(session.id, "hello world", true);
+
+      // Text lands immediately; the trailing Enter must NOT be part of the
+      // same write (that's exactly the bracketed-paste bug this fixes).
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledWith("hello world");
+      expect(spawns[0]?.pty.write).not.toHaveBeenCalledWith("\r");
+
+      await vi.advanceTimersByTimeAsync(300);
+      const ok = await submitPromise;
+
+      expect(ok).toBe(true);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(2);
+      expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(1, "hello world");
+      expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(2, "\r");
+    });
+
+    it("writes a bare \\r in a single call for submit:true with empty text (no splitting needed)", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const ok = await manager.submitInput(session.id, "", true);
+
+      expect(ok).toBe(true);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledWith("\r");
+    });
+
+    it("writes only the text, with no \\r at all, when submit is false", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const ok = await manager.submitInput(session.id, "draft text", false);
+
+      expect(ok).toBe(true);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledWith("draft text");
+    });
+
+    it("returns false for an unknown session without ever touching a pty", async () => {
+      const { manager } = makeManager();
+      expect(await manager.submitInput("unknown-id", "hello", true)).toBe(false);
+    });
+
+    it("does not write the trailing \\r if the session's pty is gone by the time the delay elapses", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const submitPromise = manager.submitInput(session.id, "hello", true);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+
+      spawns[0]?.emitExit(0);
+      await vi.advanceTimersByTimeAsync(300);
+      const ok = await submitPromise;
+
+      expect(ok).toBe(false);
+      // Still just the one write from before the pty exited — no trailing \r.
+      expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("replays the scrollback buffer to new attach()ers and streams live data", async () => {
     const { manager, spawns } = makeManager();
     const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -76,6 +76,21 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 /** Bytes of terminal output retained per session for replay on WS (re)attach. */
 const SCROLLBACK_BYTES = 131_072;
+/**
+ * Delay between writing prompt text and a trailing Enter, when submitting
+ * non-empty text in one call (see `submitInput`). Claude Code — like many
+ * bracketed-paste-aware TUIs — treats a single write containing both text
+ * and a newline as one paste event: the newline lands inside the pasted
+ * content instead of registering as a separate "submit" keypress, so the
+ * prompt sits in the input box and is never sent. Splitting the write with
+ * a short delay makes the terminal see two distinct input events instead —
+ * a paste, then a separate Enter.
+ */
+const SUBMIT_DELAY_MS = 300;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export type SessionStatusListener = (session: HarnessSession) => void;
 export type SessionDataListener = (chunk: string) => void;
@@ -283,6 +298,37 @@ export class SessionManager {
     const handle = this.ptys.get(id);
     if (!handle) return false;
     handle.pty.write(data);
+    const session = this.sessions.get(id);
+    if (session) {
+      session.lastActiveAt = this.now();
+      void this.persist();
+    }
+    return true;
+  }
+
+  /**
+   * Inject a discrete prompt (macros, the Visualize button, `/api/sessions/:id/input`)
+   * with proper submit semantics — distinct from `write()`, which is a raw
+   * passthrough for live keystrokes from the terminal WS and must never add
+   * this delay/splitting behavior. See `SUBMIT_DELAY_MS` for why non-empty
+   * submitted text can't just be written as `${text}\r` in one call.
+   */
+  async submitInput(id: string, text: string, submit = true): Promise<boolean> {
+    const handle = this.ptys.get(id);
+    if (!handle) return false;
+
+    if (!submit) {
+      handle.pty.write(text);
+    } else if (text.length === 0) {
+      handle.pty.write("\r");
+    } else {
+      handle.pty.write(text);
+      await sleep(SUBMIT_DELAY_MS);
+      // The pty may have been killed/replaced while we were waiting.
+      if (this.ptys.get(id) !== handle) return false;
+      handle.pty.write("\r");
+    }
+
     const session = this.sessions.get(id);
     if (session) {
       session.lastActiveAt = this.now();

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -184,20 +184,23 @@ export function createRestRouter(options: RestRouterOptions): Router {
     res.json({ ok: true });
   });
 
-  router.post("/sessions/:id/input", (req, res) => {
+  router.post("/sessions/:id/input", async (req, res, next) => {
     const parsed = injectInputSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: parsed.error.message });
       return;
     }
-    const submit = parsed.data.submit ?? true;
-    const payload = submit ? `${parsed.data.text}\r` : parsed.data.text;
-    const ok = sessionManager.write(req.params.id, payload);
-    if (!ok) {
-      res.status(404).json({ error: "session not found or has no live pty" });
-      return;
+    try {
+      const submit = parsed.data.submit ?? true;
+      const ok = await sessionManager.submitInput(req.params.id, parsed.data.text, submit);
+      if (!ok) {
+        res.status(404).json({ error: "session not found or has no live pty" });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      next(err);
     }
-    res.json({ ok: true });
   });
 
   return router;


### PR DESCRIPTION
## Summary

Writing prompt text and `\r` to the pty in a single `write()` call lands in Claude Code as one bracketed-paste event — the `\r` ends up inside the pasted content instead of registering as a separate "submit" keypress, so the text sits in the input box and is never sent. Proven live: `{text, submit:true}` through `POST /api/sessions/:id/input` produced zero `prompt.submitted` events; splitting it (write text, ~300ms pause, then a bare `\r`) works. This silently broke **every macro button** in real sessions (macros call `injectInput` with `submit:true`) — `fake-claude` in `e2e:live` can't catch it since it doesn't implement bracketed-paste semantics.

## Fix

Adds `SessionManager.submitInput(id, text, submit)`, distinct from the existing `write()`:
- `write()` stays a raw, unsplit passthrough — used for live terminal WS keystrokes, where splitting would be wrong (that's real per-keystroke/paste traffic already shaped correctly by the browser).
- `submitInput()` handles the three cases from the contract's `InjectInputRequest`: non-empty text + `submit:true` → write text, wait ~300ms, write `\r` separately; empty text + `submit:true` (bare Enter) → a single `\r` write, nothing to split; `submit:false` → write only the text, no `\r` at all.

Wired the one caller inside this change's file boundary: `POST /api/sessions/:id/input` (`rest.ts`) now calls `submitInput()` instead of concatenating `` `${text}\r` `` itself.

**Not wired** (out of scope per the file boundary for this change): `server/index.ts`'s macros router `injectInput` callback has the identical bug —

```ts
injectInput: async (harnessSessionId, text, submit) => {
  sessionManager.write(harnessSessionId, submit ? `${text}\r` : text);
},
```

The fix there is a one-line swap to `await sessionManager.submitInput(harnessSessionId, text, submit);`. Flagging here rather than editing it directly since that file is actively owned elsewhere right now.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `lint` — all clean
- [x] `pnpm --filter @sapiom/harness test` — 198/198 passing (5 new tests using fake timers: asserts the two-phase write with the ~300ms gap between them, the unsplit bare-Enter case, the `submit:false` case, an unknown-session no-op, and that a pty exiting mid-delay short-circuits the trailing `\r` instead of writing to a dead handle)
- [x] Live smoke test against a real spawned pty (not just fake timers) confirming the actual ~300ms gap between the two writes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)