### PR TITLE
fix(harness): turn.completed assistantText no longer depends on transcript file

### DIFF
--- a/packages/harness/src/core/collector/normalizer.test.ts
+++ b/packages/harness/src/core/collector/normalizer.test.ts
@@ -94,7 +94,7 @@ describe("normalizeHookEvent", () => {
     expect(event?.payload.toolResponseSummary).toBe("short output");
   });
 
-  it("normalizes Stop to turn.completed", () => {
+  it("normalizes Stop to turn.completed, with no assistantText when the hook omits it", () => {
     const event = normalizeHookEvent(
       "Stop",
       { session_id: "agent-uuid-1", stop_hook_active: true },
@@ -102,7 +102,20 @@ describe("normalizeHookEvent", () => {
     );
 
     expect(event?.type).toBe("turn.completed");
-    expect(event?.payload).toEqual({ stopHookActive: true });
+    expect(event?.payload).toEqual({ stopHookActive: true, assistantText: null });
+  });
+
+  it("normalizes Stop and captures last_assistant_message as assistantText directly off the hook payload", () => {
+    // Claude Code's real Stop payload carries this field itself — the
+    // transcript file may not exist on disk yet (or ever) when Stop fires,
+    // so this must not depend on any file read.
+    const event = normalizeHookEvent(
+      "Stop",
+      { session_id: "agent-uuid-1", stop_hook_active: false, last_assistant_message: "HARNESS OK" },
+      baseContext,
+    );
+
+    expect(event?.payload).toEqual({ stopHookActive: false, assistantText: "HARNESS OK" });
   });
 
   it("normalizes SessionEnd", () => {

--- a/packages/harness/src/core/collector/normalizer.ts
+++ b/packages/harness/src/core/collector/normalizer.ts
@@ -83,8 +83,13 @@ function buildEventPayload(
         toolResponseSummary: truncateForPayload(hookPayload.tool_response, MAX_TOOL_RESPONSE_LENGTH),
       };
     case "Stop":
+      // Claude Code's own Stop payload already carries the final assistant
+      // message — no need to wait on the transcript file for this field (it
+      // may not exist on disk yet, or at all, when Stop fires; see
+      // enrichTurnCompleted for the model/usage backfill that DOES need it).
       return {
         stopHookActive: hookPayload.stop_hook_active === true,
+        assistantText: stringField(hookPayload, "last_assistant_message") ?? null,
       };
     case "SessionEnd":
       return {

--- a/packages/harness/src/core/collector/transcript.test.ts
+++ b/packages/harness/src/core/collector/transcript.test.ts
@@ -167,4 +167,45 @@ describe("enrichTurnCompleted", () => {
     const enriched = await enrichTurnCompleted(baseEvent, undefined);
     expect(enriched).toBe(baseEvent);
   });
+
+  it("does not clobber an assistantText the Stop hook payload already supplied", async () => {
+    // Regression test: the Stop hook's own last_assistant_message (normalizer.ts)
+    // is authoritative and must survive even when the transcript file exists
+    // and disagrees (e.g. stale/partial content) — only model/usage get merged in.
+    const eventWithHookText = {
+      ...baseEvent,
+      payload: { stopHookActive: false, assistantText: "HARNESS OK" },
+    };
+    const filePath = path.join(tmpDir, "transcript.jsonl");
+    await fs.writeFile(
+      filePath,
+      line({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-5",
+          content: "a different, stale message",
+          usage: { input_tokens: 10, output_tokens: 3 },
+        },
+      }),
+      "utf8",
+    );
+
+    const enriched = await enrichTurnCompleted(eventWithHookText, filePath);
+    expect(enriched.payload.assistantText).toBe("HARNESS OK");
+    expect(enriched.payload.model).toBe("claude-sonnet-5");
+    expect(enriched.payload.usage).toEqual({ inputTokens: 10, outputTokens: 3 });
+  });
+
+  it("does not clobber the hook's assistantText when the transcript file doesn't exist yet", async () => {
+    // The real-world case that motivated this fix: Stop can fire before the
+    // transcript is written to disk at all.
+    const eventWithHookText = {
+      ...baseEvent,
+      payload: { stopHookActive: false, assistantText: "HARNESS OK" },
+    };
+    const enriched = await enrichTurnCompleted(eventWithHookText, path.join(tmpDir, "never-written.jsonl"));
+    expect(enriched.payload.assistantText).toBe("HARNESS OK");
+    expect(enriched.payload.model).toBeUndefined();
+  });
 });

--- a/packages/harness/src/core/collector/transcript.ts
+++ b/packages/harness/src/core/collector/transcript.ts
@@ -1,12 +1,16 @@
 /**
- * Backfills `turn.completed` events with the full assistant turn (last
- * message text, model, token usage) by tail-reading the Claude Code
- * transcript JSONL named in the hook payload's `transcript_path`.
+ * Backfills `turn.completed` events with model + token usage by tail-reading
+ * the Claude Code transcript JSONL named in the hook payload's
+ * `transcript_path`. The assistant's message text itself comes straight off
+ * the Stop hook payload (`last_assistant_message`, see normalizer.ts) — it's
+ * available synchronously and doesn't depend on the transcript file, which
+ * may not exist on disk yet (or at all) at the moment Stop fires. This
+ * module only ever *supplements* that with model/usage, and falls back to
+ * its own transcript-derived text if the hook payload somehow didn't have
+ * one.
  *
- * Hooks only see edges (a prompt went in, a tool ran, the turn stopped) —
- * the transcript has the actual conversation. Transcripts can grow to
- * hundreds of MB over a long session, so this only ever reads the last
- * ~2MB from the end of the file.
+ * Transcripts can grow to hundreds of MB over a long session, so this only
+ * ever reads the last ~2MB from the end of the file.
  */
 
 import * as fs from "node:fs/promises";
@@ -115,8 +119,11 @@ export async function readLastAssistantTurn(
 }
 
 /**
- * Enrich a `turn.completed` event's payload with transcript data. No-op for
- * any other event type, or when no transcript path is available.
+ * Enrich a `turn.completed` event's payload with transcript data (model,
+ * usage, and a fallback assistantText). No-op for any other event type, or
+ * when no transcript path is available, or when the transcript can't be
+ * read (e.g. not written to disk yet) — none of that should ever clobber
+ * the assistantText the Stop hook payload already supplied.
  */
 export async function enrichTurnCompleted(
   event: AnalyticsEvent,
@@ -128,12 +135,15 @@ export async function enrichTurnCompleted(
   const turn = await readLastAssistantTurn(transcriptPath, maxBytes);
   if (!turn) return event;
 
+  const existingAssistantText =
+    typeof event.payload.assistantText === "string" ? event.payload.assistantText : null;
+
   return {
     ...event,
     payload: {
       ...event.payload,
       model: turn.model,
-      assistantText: turn.assistantText,
+      assistantText: existingAssistantText ?? turn.assistantText,
       usage: turn.usage,
     },
   };


### PR DESCRIPTION
## Summary

Live e2e testing against a real `claude-code` session showed `turn.completed` payloads only ever contained `{stopHookActive}` — no `assistantText`/`model`/`usage` — even though the rest of the pipeline (hooks → `/ingest` → store → collector) worked end to end.

**Root cause**: `enrichTurnCompleted` only backfills `assistantText`/`model`/`usage` by tail-reading the transcript JSONL named in the Stop hook's `transcript_path`. In the live repro, that file simply does not exist on disk at the moment the Stop hook fires for a short/simple turn — confirmed with a live instrumented run (10 retries × 500ms, directory listing showed only a `memory/` subfolder, never the transcript). Not a timing race; the file isn't written for a turn like this at all in this window.

**Fix**: Claude Code's own Stop hook payload already carries the final assistant message directly, as `last_assistant_message`. `normalizer.ts` now reads that straight onto the `turn.completed` payload synchronously — no file I/O, no race. `enrichTurnCompleted` keeps supplementing `model`/`usage` from the transcript when it's available, but now only fills in `assistantText` as a *fallback* if the hook payload didn't have one — it never overwrites a value that's already there.

## Verification

- Root-caused via a live instrumented run against a real `claude-code` session (temporarily logged the raw Stop hook payload and directory contents — removed before this diff; final diff has no debug code).
- Added regression tests:
  - `normalizeHookEvent` on `Stop` captures `last_assistant_message` as `assistantText` directly off the hook payload (no file dependency).
  - `enrichTurnCompleted` does not clobber an existing `assistantText` even when the transcript file exists and disagrees, or doesn't exist at all.
- `pnpm --filter @sapiom/harness test` — 203/203 passing.
- `pnpm --filter @sapiom/harness typecheck` and `build:server` clean (via a full `pnpm --filter "./packages/*" build` first, for cross-package type resolution).
- **Re-ran the live proof end to end against a clean rebuild of this fix** (real `claude-code` session, real hooks, real mock collector): `turn.completed` payload now shows `assistantText: "HARNESS OK"` for a prompt asking Claude to reply with exactly that.

## Scope

Kept to the enrichment wiring only, as requested — `normalizer.ts` and `transcript.ts` (+ their tests). No changes to `ingest.ts`'s wiring, which was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)