### PR TITLE
feat(harness): HarnessAdapter registry — claude-code + scaffold adapters

### DIFF
--- a/.changeset/harness-adapter-registry.md
+++ b/.changeset/harness-adapter-registry.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add the harness adapter registry: a `HarnessAdapter` contract whose embedded/external split is enforced at the type level (external adapters have no spawn path), `getAdapter`/`listAdapters` over a data-driven registry (`createHarnessRegistry`), a fully supported Claude Code adapter (interactive launch with literal-argv system-prompt append, post-launch prompt delivery, pure-Node PATH detection incl. PATHEXT on Windows), experimental scaffold adapters for codex/pi/opencode, an external companion adapter for Conductor, and per-harness `installMcpPrompt()` guidance for setting up the Sapiom MCP server (`@sapiom/mcp`).

--- a/.changeset/harness-adapter-registry.md
+++ b/.changeset/harness-adapter-registry.md
@@ -1,5 +1,5 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 ---
 
 Add the harness adapter registry: a `HarnessAdapter` contract whose embedded/external split is enforced at the type level (external adapters have no spawn path), `getAdapter`/`listAdapters` over a data-driven registry (`createHarnessRegistry`), a fully supported Claude Code adapter (interactive launch with literal-argv system-prompt append, post-launch prompt delivery, pure-Node PATH detection incl. PATHEXT on Windows), experimental scaffold adapters for codex/pi/opencode, an external companion adapter for Conductor, and per-harness `installMcpPrompt()` guidance for setting up the Sapiom MCP server (`@sapiom/mcp`).

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -4,9 +4,9 @@ Run coding agents locally under a managed session runtime — real
 pseudo-terminals, harness adapters, a local server and a browser terminal
 UI.
 
-> **Status: early preview.** The session foundation is available; harness
-> adapters, the local server/UI, analytics and doctor land incrementally.
-> APIs may change while the package is pre-1.0.
+> **Status: early preview.** The session foundation and the harness
+> adapter registry are available; the local server/UI, analytics and
+> doctor land incrementally. APIs may change while the package is pre-1.0.
 
 ## Install
 
@@ -65,6 +65,68 @@ Behavior notes:
 - **Handles outlive processes** — after exit, `isAlive()` returns `false`
   and writes are dropped; methods called with a handle the runtime never
   issued throw `UnknownSessionError`.
+
+## Harness adapters
+
+A `HarnessAdapter` describes one coding agent the harness knows how to
+work with: how to launch it (when it can), how to detect it, and how to
+guide MCP setup for it. The registry maps ids to adapters:
+
+```ts
+import { getAdapter, listAdapters, PtyRuntime } from "@sapiom/harness";
+
+for (const adapter of listAdapters()) {
+  console.log(adapter.id, adapter.mode, await adapter.detectInstalled());
+}
+
+const claude = getAdapter("claude-code");
+if (claude.mode === "embedded") {
+  const launch = claude.launchCommand({
+    env: { PATH: process.env.PATH ?? "", TERM: "xterm-256color" },
+    appendSystemPrompt: "Prefer small, verifiable steps.", // literal content
+  });
+
+  const runtime = new PtyRuntime();
+  const session = await runtime.create({
+    ...launch,
+    cwd: process.cwd(),
+    cols: 120,
+    rows: 32,
+  });
+
+  // claude-code delivers prompts post-launch: write into the session.
+  runtime.write(session, "hello\r");
+}
+```
+
+Built-in adapters:
+
+| id            | mode     | prompt delivery | status                  |
+| ------------- | -------- | --------------- | ----------------------- |
+| `claude-code` | embedded | post-launch     | fully supported         |
+| `codex`       | embedded | inline          | experimental scaffold   |
+| `pi`          | embedded | inline          | experimental scaffold   |
+| `opencode`    | embedded | inline          | experimental scaffold   |
+| `conductor`   | external | —               | detection/guidance only |
+
+Behavior notes:
+
+- **No shell, ever** — sessions spawn without a shell, so launch args
+  (including `appendSystemPrompt`, which is literal prompt _content_, not
+  a file path) reach the harness verbatim; nothing is interpolated,
+  quoted, or word-split.
+- **External means no spawn path** — `external` adapters (Conductor runs
+  its own sessions) have no `launchCommand` at the type level; narrow on
+  `mode` before launching.
+- **Pure-Node detection** — `detectInstalled()` walks `PATH` (with
+  `PATHEXT` on Windows) using Node built-ins; nothing shells out to
+  `which`. The lookup is exported as `findExecutableOnPath()`.
+- **MCP guidance per harness** — `installMcpPrompt()` returns prompt text
+  for the agent explaining how to register the Sapiom MCP server
+  (`@sapiom/mcp`) for that specific harness.
+- **One file + one line** — adding a harness is one adapter file plus one
+  entry in the registry list; enumeration, lookup and the contract tests
+  pick it up from there.
 
 ## Development
 

--- a/packages/harness/e2e/claude-code-adapter.e2e.test.ts
+++ b/packages/harness/e2e/claude-code-adapter.e2e.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration: the claude-code adapter's launchCommand spawned for real
+ * under PtyRuntime, resolved against a FAKE `claude` executable placed on
+ * a temporary PATH directory. Hermetic: no real Claude Code, credentials
+ * or network — and deliberately no shell between us and the child, so the
+ * fake agent can prove every argument arrives literally.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  claudeCodeAdapter,
+  findExecutableOnPath,
+  PtyRuntime,
+} from "../src/index.js";
+import type { SessionHandle } from "../src/index.js";
+
+jest.setTimeout(30_000);
+
+// The fake `claude` is a POSIX shell script; CI runs on Linux and local
+// development targets macOS. Skipped on Windows.
+const describeIf = process.platform === "win32" ? describe.skip : describe;
+
+/**
+ * A fake interactive `claude`: prints a banner, its argv (one per line)
+ * and an env marker, then echoes stdin lines at a `> ` prompt like a
+ * booted agent awaiting prompt injection.
+ */
+const FAKE_CLAUDE_SCRIPT = `#!/bin/sh
+printf 'fake-claude booted\\n'
+i=0
+for arg in "$@"; do
+  i=$((i+1))
+  printf 'argv[%s]=%s\\n' "$i" "$arg"
+done
+printf 'argc=%s\\n' "$#"
+printf 'marker=%s\\n' "\${FAKE_CLAUDE_MARKER-unset}"
+printf '> '
+while IFS= read -r line; do
+  printf 'received: %s\\n' "$line"
+  printf '> '
+done
+`;
+
+/** Collects session output and lets tests await specific content. */
+class OutputCollector {
+  private buffers: Buffer[] = [];
+  private waiters: Array<() => void> = [];
+
+  readonly listener = (chunk: Buffer): void => {
+    this.buffers.push(chunk);
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const notify of waiters) notify();
+  };
+
+  get text(): string {
+    return Buffer.concat(this.buffers).toString("utf8");
+  }
+
+  async waitFor(needle: string, timeoutMs = 10_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (!this.text.includes(needle)) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(
+          `Timed out waiting for ${JSON.stringify(needle)}. Output so far:\n${this.text}`,
+        );
+      }
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, Math.min(remaining, 250));
+        this.waiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    }
+    return this.text;
+  }
+}
+
+describeIf("claude-code adapter × PtyRuntime (fake claude on PATH)", () => {
+  let runtime: PtyRuntime;
+  let handles: SessionHandle[];
+  let binDir: string;
+  let fakeClaudePath: string;
+
+  /**
+   * PATH puts the fake first and includes only system directories after
+   * it, so a real `claude` install can never win the lookup.
+   */
+  const envFor = (
+    extra: Record<string, string> = {},
+  ): Record<string, string> => ({
+    PATH: `${binDir}:/usr/bin:/bin`,
+    TERM: "xterm-256color",
+    HOME: os.tmpdir(),
+    ...extra,
+  });
+
+  beforeAll(() => {
+    binDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "fake-claude-bin-")),
+    );
+    fakeClaudePath = path.join(binDir, "claude");
+    fs.writeFileSync(fakeClaudePath, FAKE_CLAUDE_SCRIPT, { mode: 0o755 });
+  });
+
+  afterAll(() => {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    runtime = new PtyRuntime({ killTimeoutMs: 500 });
+    handles = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      handles.map((handle) => runtime.kill(handle).catch(() => undefined)),
+    );
+  });
+
+  const spawnAdapter = async (
+    cfg: Partial<Parameters<typeof claudeCodeAdapter.launchCommand>[0]> = {},
+  ): Promise<{ handle: SessionHandle; output: OutputCollector }> => {
+    const launch = claudeCodeAdapter.launchCommand({
+      env: envFor(),
+      ...cfg,
+    });
+    const handle = await runtime.create({
+      ...launch,
+      cwd: os.tmpdir(),
+      cols: 120,
+      rows: 32,
+    });
+    handles.push(handle);
+    const output = new OutputCollector();
+    runtime.onData(handle, output.listener);
+    return { handle, output };
+  };
+
+  it("detects the fake claude through the same launch environment", async () => {
+    await expect(
+      findExecutableOnPath("claude", { env: envFor() }),
+    ).resolves.toBe(fakeClaudePath);
+  });
+
+  it("spawns interactive claude resolved via PATH, with no arguments", async () => {
+    const { handle, output } = await spawnAdapter();
+
+    await output.waitFor("fake-claude booted");
+    await output.waitFor("argc=0");
+    expect(runtime.isAlive(handle)).toBe(true);
+  });
+
+  it("plumbs the adapter env into the child", async () => {
+    const { output } = await spawnAdapter({
+      env: envFor({ FAKE_CLAUDE_MARKER: "plumbing-ok" }),
+    });
+
+    await output.waitFor("marker=plumbing-ok");
+  });
+
+  it("passes the appended system prompt as a single literal argument", async () => {
+    // Shell metacharacters throughout: if any shell ever interpreted the
+    // argv, the subshell would run (or the argument would split) and the
+    // literal match below would fail.
+    const probe =
+      "sys-probe $(echo interpolated) `whoami` \"double\" 'single' ; & | $HOME *";
+    const { output } = await spawnAdapter({ appendSystemPrompt: probe });
+
+    await output.waitFor("argv[1]=--append-system-prompt");
+    await output.waitFor(`argv[2]=${probe}`);
+    await output.waitFor("argc=2");
+  });
+
+  it("delivers prompts post-launch by writing into the booted session", async () => {
+    const { handle, output } = await spawnAdapter();
+    await output.waitFor("> ");
+
+    runtime.write(handle, "install the sapiom mcp server\r");
+
+    await output.waitFor("received: install the sapiom mcp server");
+    expect(runtime.isAlive(handle)).toBe(true);
+  });
+
+  it("kill() ends the fake claude like any other session", async () => {
+    const { handle, output } = await spawnAdapter();
+    await output.waitFor("> ");
+
+    await runtime.kill(handle);
+
+    expect(runtime.isAlive(handle)).toBe(false);
+  });
+});

--- a/packages/harness/src/harnesses/__tests__/claude-code.test.ts
+++ b/packages/harness/src/harnesses/__tests__/claude-code.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Launch-config correctness for the fully supported claude-code adapter:
+ * plain interactive launch, literal argv for the appended system prompt
+ * (no shell, no escaping), environment pass-through by copy.
+ */
+import { claudeCodeAdapter } from "../claude-code.js";
+
+describe("claudeCodeAdapter", () => {
+  it("identifies as the embedded claude-code harness with post-launch prompts", () => {
+    expect(claudeCodeAdapter.id).toBe("claude-code");
+    expect(claudeCodeAdapter.label).toBe("Claude Code");
+    expect(claudeCodeAdapter.mode).toBe("embedded");
+    expect(claudeCodeAdapter.promptDelivery).toBe("post-launch");
+    expect(claudeCodeAdapter.experimental).toBeFalsy();
+  });
+
+  it("launches plain interactive claude by default", () => {
+    const launch = claudeCodeAdapter.launchCommand({
+      env: { PATH: "/usr/bin", TERM: "xterm-256color" },
+    });
+
+    expect(launch).toEqual({
+      command: "claude",
+      args: [],
+      env: { PATH: "/usr/bin", TERM: "xterm-256color" },
+    });
+  });
+
+  it("copies the environment instead of aliasing the caller's object", () => {
+    const env = { PATH: "/usr/bin" };
+    const launch = claudeCodeAdapter.launchCommand({ env });
+
+    expect(launch.env).toEqual(env);
+    expect(launch.env).not.toBe(env);
+
+    launch.env.MUTATED = "yes";
+    expect(env).toEqual({ PATH: "/usr/bin" });
+  });
+
+  it("passes the appended system prompt as one literal argv pair", () => {
+    const content =
+      "Line one\nLine two with \"double\", 'single', $HOME, `backticks`," +
+      " $(subshells), ; & | and a trailing backslash \\";
+    const launch = claudeCodeAdapter.launchCommand({
+      env: {},
+      appendSystemPrompt: content,
+    });
+
+    // Exactly two args: the flag and the untouched content. No shell ever
+    // sees these, so no quoting/escaping may be applied.
+    expect(launch.args).toEqual(["--append-system-prompt", content]);
+  });
+
+  it("passes an empty system prompt literally too", () => {
+    const launch = claudeCodeAdapter.launchCommand({
+      env: {},
+      appendSystemPrompt: "",
+    });
+    expect(launch.args).toEqual(["--append-system-prompt", ""]);
+  });
+
+  it("omits the flag when no system prompt is configured", () => {
+    const launch = claudeCodeAdapter.launchCommand({ env: {} });
+    expect(launch.args).toEqual([]);
+  });
+
+  it("ignores inline prompts — delivery is post-launch via session write", () => {
+    const launch = claudeCodeAdapter.launchCommand({
+      env: {},
+      prompt: "do the thing",
+    });
+    expect(launch.args).toEqual([]);
+    expect(launch.command).toBe("claude");
+  });
+
+  it("install prompt teaches claude mcp add for @sapiom/mcp", () => {
+    const prompt = claudeCodeAdapter.installMcpPrompt();
+    expect(prompt).toContain("claude mcp add sapiom-dev -- npx -y @sapiom/mcp");
+    expect(prompt).toContain("sapiom-mcp");
+    expect(prompt).toContain("claude mcp list");
+  });
+});

--- a/packages/harness/src/harnesses/__tests__/conductor.test.ts
+++ b/packages/harness/src/harnesses/__tests__/conductor.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The external conductor adapter: guidance-only companion mode with
+ * deterministic app-bundle candidate paths and no spawn surface.
+ */
+import { conductorAdapter, conductorAppCandidates } from "../conductor.js";
+
+describe("conductorAdapter", () => {
+  it("is external and offers no launch command", () => {
+    expect(conductorAdapter.id).toBe("conductor");
+    expect(conductorAdapter.label).toBe("Conductor");
+    expect(conductorAdapter.mode).toBe("external");
+    expect("launchCommand" in conductorAdapter).toBe(false);
+    expect(conductorAdapter.launchCommand).toBeUndefined();
+  });
+
+  it("guides MCP setup through Claude Code project scope", () => {
+    const prompt = conductorAdapter.installMcpPrompt();
+    expect(prompt).toContain(
+      "claude mcp add --scope project sapiom-dev -- npx -y @sapiom/mcp",
+    );
+    expect(prompt).toContain(".mcp.json");
+  });
+
+  it("detectInstalled resolves to a boolean without throwing", async () => {
+    // The concrete value depends on whether this machine has the app.
+    await expect(conductorAdapter.detectInstalled()).resolves.toEqual(
+      expect.any(Boolean),
+    );
+  });
+});
+
+describe("conductorAppCandidates", () => {
+  it("returns the standard macOS app locations on darwin", () => {
+    expect(conductorAppCandidates("darwin", "/Users/someone")).toEqual([
+      "/Applications/Conductor.app",
+      "/Users/someone/Applications/Conductor.app",
+    ]);
+  });
+
+  it("returns no candidates on platforms Conductor does not ship for", () => {
+    expect(conductorAppCandidates("linux", "/home/someone")).toEqual([]);
+    expect(conductorAppCandidates("win32", "C:\\Users\\someone")).toEqual([]);
+  });
+});

--- a/packages/harness/src/harnesses/__tests__/detect.test.ts
+++ b/packages/harness/src/harnesses/__tests__/detect.test.ts
@@ -1,0 +1,219 @@
+/**
+ * PATH-based executable detection: the pure-Node lookup helper under
+ * manipulated PATH/PATHEXT environments (POSIX and emulated Windows
+ * rules), and the adapters' detectInstalled() built on top of it.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { findExecutableOnPath } from "../detect.js";
+import { claudeCodeAdapter } from "../claude-code.js";
+import { codexAdapter } from "../codex.js";
+import { opencodeAdapter } from "../opencode.js";
+import { piAdapter } from "../pi.js";
+
+const onPosix = process.platform !== "win32";
+const itPosix = onPosix ? it : it.skip;
+
+let tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "harness-detect-")),
+  );
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeBin(dir: string, name: string, mode = 0o755): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, "#!/bin/sh\nexit 0\n", { mode });
+  return file;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tmpDirs = [];
+});
+
+describe("findExecutableOnPath (POSIX rules)", () => {
+  itPosix("finds an executable file on PATH", async () => {
+    const dir = tmpDir();
+    const file = writeBin(dir, "claude");
+
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: dir } }),
+    ).resolves.toBe(file);
+  });
+
+  itPosix("honors PATH order — the first match wins", async () => {
+    const first = tmpDir();
+    const second = tmpDir();
+    const expected = writeBin(first, "claude");
+    writeBin(second, "claude");
+
+    await expect(
+      findExecutableOnPath("claude", {
+        env: { PATH: `${first}:${second}` },
+      }),
+    ).resolves.toBe(expected);
+  });
+
+  itPosix("skips files without the execute bit", async () => {
+    const dir = tmpDir();
+    writeBin(dir, "claude", 0o644);
+
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: dir } }),
+    ).resolves.toBeNull();
+  });
+
+  itPosix("skips directories that merely share the name", async () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, "claude"));
+
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: dir } }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the binary is absent", async () => {
+    const dir = tmpDir();
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: dir } }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a missing or empty PATH", async () => {
+    await expect(
+      findExecutableOnPath("claude", { env: {} }),
+    ).resolves.toBeNull();
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: "" } }),
+    ).resolves.toBeNull();
+  });
+
+  it("skips empty PATH segments instead of searching the current directory", async () => {
+    const dir = tmpDir();
+    await expect(
+      findExecutableOnPath("claude", { env: { PATH: `:${dir}:` } }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("findExecutableOnPath (Windows rules, emulated)", () => {
+  it("resolves binaries via PATHEXT", async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "claude.CMD");
+    fs.writeFileSync(file, "@echo off\r\n"); // note: no execute bit needed
+
+    await expect(
+      findExecutableOnPath("claude", {
+        env: { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        platform: "win32",
+      }),
+    ).resolves.toBe(file);
+  });
+
+  it("falls back to the OS default PATHEXT when unset", async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "claude.EXE");
+    fs.writeFileSync(file, "");
+
+    await expect(
+      findExecutableOnPath("claude", {
+        env: { PATH: dir },
+        platform: "win32",
+      }),
+    ).resolves.toBe(file);
+  });
+
+  it("matches a name that already carries an extension as-is", async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "claude.cmd");
+    fs.writeFileSync(file, "@echo off\r\n");
+
+    await expect(
+      findExecutableOnPath("claude.cmd", {
+        env: { PATH: dir, PATHEXT: ".EXE" },
+        platform: "win32",
+      }),
+    ).resolves.toBe(file);
+  });
+
+  it("does not match a bare extensionless file", async () => {
+    const dir = tmpDir();
+    writeBin(dir, "claude"); // executable, but no PATHEXT extension
+
+    await expect(
+      findExecutableOnPath("claude", {
+        env: { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        platform: "win32",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("splits PATH on the Windows delimiter", async () => {
+    const first = tmpDir();
+    const second = tmpDir();
+    const file = path.join(second, "claude.EXE");
+    fs.writeFileSync(file, "");
+
+    await expect(
+      findExecutableOnPath("claude", {
+        env: { PATH: `${first};${second}`, PATHEXT: ".EXE" },
+        platform: "win32",
+      }),
+    ).resolves.toBe(file);
+  });
+});
+
+// Adapters read the real process environment, so these tests swap PATH
+// out and restore it afterwards. Jest runs test files in isolated
+// processes, so this cannot leak into other suites.
+(onPosix ? describe : describe.skip)(
+  "adapter detectInstalled() under a manipulated PATH",
+  () => {
+    const ORIGINAL_PATH = process.env.PATH;
+
+    afterEach(() => {
+      process.env.PATH = ORIGINAL_PATH;
+    });
+
+    const CASES = [
+      ["claude-code", claudeCodeAdapter, "claude"],
+      ["codex", codexAdapter, "codex"],
+      ["pi", piAdapter, "pi"],
+      ["opencode", opencodeAdapter, "opencode"],
+    ] as const;
+
+    it.each(CASES)(
+      "%s: true when its binary is on PATH",
+      async (_id, adapter, binary) => {
+        const dir = tmpDir();
+        writeBin(dir, binary);
+        process.env.PATH = dir;
+
+        await expect(adapter.detectInstalled()).resolves.toBe(true);
+      },
+    );
+
+    it.each(CASES)(
+      "%s: false when PATH has no such binary",
+      async (_id, adapter, _binary) => {
+        process.env.PATH = tmpDir(); // empty directory
+
+        await expect(adapter.detectInstalled()).resolves.toBe(false);
+      },
+    );
+
+    it("other adapters' binaries do not cause a false positive", async () => {
+      const dir = tmpDir();
+      writeBin(dir, "codex");
+      process.env.PATH = dir;
+
+      await expect(claudeCodeAdapter.detectInstalled()).resolves.toBe(false);
+      await expect(codexAdapter.detectInstalled()).resolves.toBe(true);
+    });
+  },
+);

--- a/packages/harness/src/harnesses/__tests__/registry.test.ts
+++ b/packages/harness/src/harnesses/__tests__/registry.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Registry behavior: enumeration and lookup are driven purely by the
+ * adapter list, adapters all satisfy the shared contract, and external
+ * adapters expose no spawn path (at runtime and in the type system).
+ */
+import {
+  createHarnessRegistry,
+  getAdapter,
+  HARNESS_ADAPTERS,
+  listAdapters,
+  UnknownHarnessError,
+} from "../index.js";
+import type {
+  EmbeddedHarnessAdapter,
+  ExternalHarnessAdapter,
+  HarnessAdapter,
+  HarnessId,
+} from "../index.js";
+import { conductorAdapter } from "../conductor.js";
+
+const EXPECTED_IDS: HarnessId[] = [
+  "claude-code",
+  "codex",
+  "pi",
+  "opencode",
+  "conductor",
+];
+
+describe("harness registry", () => {
+  it("lists the built-in adapters in registration order", () => {
+    expect(listAdapters().map((a) => a.id)).toEqual(EXPECTED_IDS);
+    expect(listAdapters()).toEqual([...HARNESS_ADAPTERS]);
+  });
+
+  it("resolves every listed adapter by id, to the same instance", () => {
+    for (const adapter of listAdapters()) {
+      expect(getAdapter(adapter.id)).toBe(adapter);
+    }
+  });
+
+  it("throws a typed UnknownHarnessError for unknown ids", () => {
+    expect(() => getAdapter("not-a-harness")).toThrow(UnknownHarnessError);
+    expect(() => getAdapter("not-a-harness")).toThrow(
+      /Unknown harness: "not-a-harness"/,
+    );
+    try {
+      getAdapter("not-a-harness");
+      throw new Error("expected getAdapter to throw");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "UNKNOWN_HARNESS" });
+      // The error names the known ids so callers can self-correct.
+      expect((error as Error).message).toContain("claude-code");
+    }
+  });
+
+  it("rejects duplicate adapter ids at construction time", () => {
+    expect(() =>
+      createHarnessRegistry([...HARNESS_ADAPTERS, HARNESS_ADAPTERS[0]]),
+    ).toThrow(/Duplicate harness adapter id: claude-code/);
+  });
+
+  it("a fictional adapter appears everywhere with a single registry entry", () => {
+    // If this test ever needs more than the one-line array change below to
+    // make the adapter enumerable and resolvable, the registry has stopped
+    // being data-driven.
+    const fictional: EmbeddedHarnessAdapter = {
+      id: "fictional" as HarnessId,
+      label: "Fictional Harness",
+      mode: "embedded",
+      promptDelivery: "inline",
+      experimental: true,
+      launchCommand: (cfg) => ({
+        command: "fictional",
+        args: [],
+        env: { ...cfg.env },
+      }),
+      installMcpPrompt: () => "Install @sapiom/mcp for Fictional Harness.",
+      detectInstalled: async () => false,
+    };
+
+    const registry = createHarnessRegistry([...HARNESS_ADAPTERS, fictional]);
+
+    expect(registry.list()).toHaveLength(HARNESS_ADAPTERS.length + 1);
+    expect(registry.list()[registry.list().length - 1]).toBe(fictional);
+    expect(registry.get("fictional")).toBe(fictional);
+    // The built-ins are untouched.
+    for (const adapter of HARNESS_ADAPTERS) {
+      expect(registry.get(adapter.id)).toBe(adapter);
+    }
+  });
+
+  it("returns a frozen adapter list", () => {
+    const list = listAdapters();
+    expect(Object.isFrozen(list)).toBe(true);
+  });
+});
+
+describe("adapter contract", () => {
+  it.each(listAdapters().map((adapter) => [adapter.id, adapter] as const))(
+    "%s has the full HarnessAdapter shape",
+    async (_id, adapter) => {
+      expect(EXPECTED_IDS).toContain(adapter.id);
+      expect(typeof adapter.label).toBe("string");
+      expect(adapter.label.length).toBeGreaterThan(0);
+      expect(["embedded", "external"]).toContain(adapter.mode);
+      expect(["inline", "post-launch"]).toContain(adapter.promptDelivery);
+      if (adapter.experimental !== undefined) {
+        expect(typeof adapter.experimental).toBe("boolean");
+      }
+
+      const prompt = adapter.installMcpPrompt();
+      expect(typeof prompt).toBe("string");
+      expect(prompt.length).toBeGreaterThan(0);
+      // Every install prompt names the Sapiom MCP server package.
+      expect(prompt).toContain("@sapiom/mcp");
+
+      const installed = await adapter.detectInstalled();
+      expect(typeof installed).toBe("boolean");
+    },
+  );
+
+  it("embedded adapters expose launchCommand; external adapters have no spawn path", () => {
+    expect.hasAssertions();
+    for (const adapter of listAdapters()) {
+      if (adapter.mode === "embedded") {
+        expect(typeof adapter.launchCommand).toBe("function");
+        const launch = adapter.launchCommand({
+          env: { PATH: "/usr/bin", TERM: "xterm-256color" },
+        });
+        expect(typeof launch.command).toBe("string");
+        expect(launch.command.length).toBeGreaterThan(0);
+        expect(Array.isArray(launch.args)).toBe(true);
+        // The provided environment survives (adapters may add to it).
+        expect(launch.env).toMatchObject({
+          PATH: "/usr/bin",
+          TERM: "xterm-256color",
+        });
+      } else {
+        expect("launchCommand" in adapter).toBe(false);
+        expect(adapter.launchCommand).toBeUndefined();
+      }
+    }
+  });
+
+  it("marks exactly the scaffold adapters as experimental", () => {
+    const experimentalIds = listAdapters()
+      .filter((adapter) => adapter.experimental === true)
+      .map((adapter) => adapter.id);
+    expect(experimentalIds).toEqual(["codex", "pi", "opencode"]);
+    expect(getAdapter("claude-code").experimental).toBeFalsy();
+    expect(getAdapter("conductor").experimental).toBeFalsy();
+  });
+
+  it("conductor is the external, spawn-free adapter", () => {
+    const conductor = getAdapter("conductor");
+    expect(conductor.mode).toBe("external");
+    expect("launchCommand" in conductor).toBe(false);
+  });
+});
+
+describe("type-level enforcement", () => {
+  it("rejects a launchCommand on an external adapter", () => {
+    // `launchCommand` is typed `never` on ExternalHarnessAdapter, so a
+    // spawn path is a compile error, not a convention.
+    const invalid: ExternalHarnessAdapter = {
+      ...conductorAdapter,
+      // @ts-expect-error — external adapters must not define a spawn path.
+      launchCommand: () => ({ command: "x", args: [], env: {} }),
+    };
+    void invalid;
+    expect(true).toBe(true);
+  });
+
+  it("requires narrowing on mode before calling launchCommand", () => {
+    // Via getAdapter() so the compiler sees the full union, not conductor.
+    const adapter: HarnessAdapter = getAdapter("conductor");
+    // @ts-expect-error — launchCommand may be absent until mode is narrowed.
+    const call = () => adapter.launchCommand({ env: {} });
+    void call;
+
+    if (adapter.mode === "embedded") {
+      // Narrowed: this compiles (and is unreachable for conductor).
+      adapter.launchCommand({ env: {} });
+    }
+    expect(adapter.mode).toBe("external");
+  });
+});

--- a/packages/harness/src/harnesses/__tests__/scaffold-adapters.test.ts
+++ b/packages/harness/src/harnesses/__tests__/scaffold-adapters.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The embedded scaffold adapters (codex, pi, opencode): best-effort
+ * launch commands with inline prompt delivery, honest per-harness MCP
+ * install prompts, and the `experimental` marker.
+ */
+import type { EmbeddedHarnessAdapter } from "../adapter.js";
+import { codexAdapter } from "../codex.js";
+import { opencodeAdapter } from "../opencode.js";
+import { piAdapter } from "../pi.js";
+
+interface ScaffoldCase {
+  adapter: EmbeddedHarnessAdapter;
+  binary: string;
+  /** argv expected when an inline prompt is provided. */
+  promptArgs: (prompt: string) => string[];
+  /** A string the MCP install prompt must contain (its config surface). */
+  installPromptMentions: string;
+}
+
+const CASES: ScaffoldCase[] = [
+  {
+    adapter: codexAdapter,
+    binary: "codex",
+    promptArgs: (prompt) => [prompt],
+    installPromptMentions: "config.toml",
+  },
+  {
+    adapter: piAdapter,
+    binary: "pi",
+    promptArgs: (prompt) => [prompt],
+    installPromptMentions: "npx -y @sapiom/mcp",
+  },
+  {
+    adapter: opencodeAdapter,
+    binary: "opencode",
+    promptArgs: (prompt) => ["--prompt", prompt],
+    installPromptMentions: "opencode.json",
+  },
+];
+
+describe.each(CASES.map((c) => [c.adapter.id, c] as const))(
+  "%s scaffold adapter",
+  (_id, { adapter, binary, promptArgs, installPromptMentions }) => {
+    it("is an experimental embedded adapter with inline prompt delivery", () => {
+      expect(adapter.mode).toBe("embedded");
+      expect(adapter.promptDelivery).toBe("inline");
+      expect(adapter.experimental).toBe(true);
+    });
+
+    it(`launches the ${binary} binary without arguments by default`, () => {
+      const launch = adapter.launchCommand({ env: { PATH: "/usr/bin" } });
+      expect(launch).toEqual({
+        command: binary,
+        args: [],
+        env: { PATH: "/usr/bin" },
+      });
+    });
+
+    it("delivers an inline prompt as literal argv", () => {
+      const prompt = 'fix the bug in "src" — $(echo untouched)';
+      const launch = adapter.launchCommand({ env: {}, prompt });
+      expect(launch.args).toEqual(promptArgs(prompt));
+    });
+
+    it("copies the environment instead of aliasing it", () => {
+      const env = { PATH: "/usr/bin" };
+      const launch = adapter.launchCommand({ env });
+      expect(launch.env).toEqual(env);
+      expect(launch.env).not.toBe(env);
+    });
+
+    it("has an honest, harness-specific MCP install prompt", () => {
+      const prompt = adapter.installMcpPrompt();
+      expect(prompt).toContain("@sapiom/mcp");
+      expect(prompt).toContain(installPromptMentions);
+    });
+  },
+);

--- a/packages/harness/src/harnesses/adapter.ts
+++ b/packages/harness/src/harnesses/adapter.ts
@@ -1,0 +1,136 @@
+/**
+ * The harness adapter contract.
+ *
+ * A "harness" is a coding agent app (Claude Code, Codex CLI, …) that the
+ * Sapiom harness can launch, detect, or guide the user through configuring.
+ * Each supported harness ships as one adapter file registered in
+ * `./index.ts`; adding a harness is one adapter file plus one registry
+ * line.
+ */
+
+/** Identifier of a harness the registry knows about. */
+export type HarnessId =
+  | "claude-code"
+  | "codex"
+  | "pi"
+  | "opencode"
+  | "conductor";
+
+/**
+ * How a harness runs:
+ *
+ * - `embedded` — spawned and owned by the harness inside a pty session
+ *   (`SessionRuntime`).
+ * - `external` — runs in its own app outside our process. The adapter
+ *   offers detection and setup guidance only; it has no spawn path.
+ */
+export type HarnessMode = "embedded" | "external";
+
+/**
+ * How a prompt reaches an embedded harness:
+ *
+ * - `inline` — passed on the command line at launch
+ *   ({@link HarnessLaunchConfig.prompt}).
+ * - `post-launch` — injected into the running session (a pty write) after
+ *   the harness has booted.
+ */
+export type PromptDelivery = "inline" | "post-launch";
+
+/** Inputs an adapter uses to compute its launch invocation. */
+export interface HarnessLaunchConfig {
+  /**
+   * Full environment for the child session — not merged with
+   * `process.env`, mirroring `SessionRuntime.create()`. Adapters copy it
+   * through, adding harness-specific variables when needed.
+   */
+  env: Record<string, string>;
+  /**
+   * Initial prompt for adapters with `promptDelivery: "inline"`, included
+   * in the launch arguments as a literal. Adapters with `"post-launch"`
+   * delivery ignore it — deliver the prompt by writing to the session
+   * once it has booted.
+   */
+  prompt?: string;
+  /**
+   * Extra system-prompt text appended to the harness's own system prompt,
+   * for harnesses that support it (claude-code:
+   * `--append-system-prompt`). This is the literal prompt content — if
+   * yours lives in a file, read the file yourself and pass the text.
+   * Sessions spawn without a shell, so the value is handed to the harness
+   * verbatim as a single argument; no quoting or escaping is applied or
+   * required.
+   */
+  appendSystemPrompt?: string;
+}
+
+/**
+ * A concrete invocation, ready to spread into `SessionRuntime.create()`
+ * (which adds `cwd`/`cols`/`rows`). `command` is resolved via `env.PATH`;
+ * `args` are passed to the process as literals — no shell is involved at
+ * any point, so nothing is interpolated, quoted, or word-split.
+ */
+export interface HarnessLaunch {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/** Fields shared by every adapter, embedded or external. */
+export interface HarnessAdapterCommon {
+  /** Stable identifier used in APIs and config files. */
+  id: HarnessId;
+  /** Human-readable name for pickers and logs. */
+  label: string;
+  /** See {@link HarnessMode}. */
+  mode: HarnessMode;
+  /**
+   * See {@link PromptDelivery}. Only consulted for embedded adapters —
+   * external harnesses own their prompt input entirely, so the value is
+   * nominal there.
+   */
+  promptDelivery: PromptDelivery;
+  /**
+   * Marks adapters whose launch behavior is best-effort and not yet
+   * hardened by an end-to-end suite. Absent (or `false`) for fully
+   * supported harnesses.
+   */
+  experimental?: boolean;
+  /**
+   * Prompt text — words for the coding agent, not a script to execute —
+   * guiding installation and configuration of the Sapiom MCP server
+   * (npm package `@sapiom/mcp`, binary `sapiom-mcp`) for this harness.
+   */
+  installMcpPrompt(): string;
+  /**
+   * Whether the harness looks installed on this machine. Best-effort and
+   * never throws.
+   */
+  detectInstalled(): Promise<boolean>;
+}
+
+/** An adapter the harness spawns inside a pty session. */
+export interface EmbeddedHarnessAdapter extends HarnessAdapterCommon {
+  mode: "embedded";
+  /**
+   * Compute the invocation for `SessionRuntime.create()`. Pure: no I/O,
+   * no side effects, safe to call repeatedly.
+   */
+  launchCommand(cfg: HarnessLaunchConfig): HarnessLaunch;
+}
+
+/**
+ * An adapter for a harness that runs in its own app (companion mode).
+ * There is deliberately no way to spawn it: `launchCommand` is typed
+ * `never`, so a spawn path is unrepresentable rather than merely
+ * discouraged.
+ */
+export interface ExternalHarnessAdapter extends HarnessAdapterCommon {
+  mode: "external";
+  launchCommand?: never;
+}
+
+/**
+ * Every registry entry satisfies this union. Narrow on `mode` before
+ * calling `launchCommand` — it exists only for embedded adapters.
+ */
+export type HarnessAdapter = EmbeddedHarnessAdapter | ExternalHarnessAdapter;

--- a/packages/harness/src/harnesses/claude-code.ts
+++ b/packages/harness/src/harnesses/claude-code.ts
@@ -1,0 +1,59 @@
+/**
+ * Claude Code — Anthropic's coding agent CLI (`claude`). Fully supported:
+ * launched embedded in a pty session, with prompts injected post-launch.
+ */
+import type { EmbeddedHarnessAdapter } from "./adapter.js";
+import { isExecutableOnPath } from "./detect.js";
+
+const INSTALL_MCP_PROMPT = [
+  "Set up the Sapiom MCP server for Claude Code.",
+  "",
+  "1. Register it under the server name `sapiom-dev`:",
+  "",
+  "   claude mcp add sapiom-dev -- npx -y @sapiom/mcp",
+  "",
+  "   The `@sapiom/mcp` npm package ships the `sapiom-mcp` binary, a local",
+  "   MCP server that speaks stdio — no global install or daemon needed.",
+  "2. Verify the registration: `claude mcp list` should show `sapiom-dev`.",
+  "3. Restart Claude Code (or start a new session) so the server is loaded.",
+  "4. Networked Sapiom tools need an API key: run the `sapiom_authenticate`",
+  "   tool once and complete the browser login it opens.",
+].join("\n");
+
+/**
+ * The claude-code adapter.
+ *
+ * - `launchCommand` starts the plain interactive TUI. Sessions spawn
+ *   without a shell (node-pty passes argv directly), so every argument —
+ *   including the optional appended system prompt, which is literal
+ *   content, not a file path — reaches `claude` exactly as provided;
+ *   nothing is interpolated, quoted, or word-split.
+ * - `promptDelivery` is `post-launch`: the interactive TUI takes no
+ *   pre-submitted prompt flag, so the prompt is written into the pty once
+ *   the session has booted.
+ * - `detectInstalled` is a pure-Node `PATH` lookup for the `claude`
+ *   binary (with `PATHEXT` handling on Windows).
+ */
+export const claudeCodeAdapter: EmbeddedHarnessAdapter = {
+  id: "claude-code",
+  label: "Claude Code",
+  mode: "embedded",
+  promptDelivery: "post-launch",
+
+  launchCommand(cfg) {
+    const args: string[] = [];
+    if (cfg.appendSystemPrompt !== undefined) {
+      args.push("--append-system-prompt", cfg.appendSystemPrompt);
+    }
+    // cfg.prompt is intentionally unused: delivery is post-launch.
+    return { command: "claude", args, env: { ...cfg.env } };
+  },
+
+  installMcpPrompt() {
+    return INSTALL_MCP_PROMPT;
+  },
+
+  detectInstalled() {
+    return isExecutableOnPath("claude");
+  },
+};

--- a/packages/harness/src/harnesses/codex.ts
+++ b/packages/harness/src/harnesses/codex.ts
@@ -1,0 +1,56 @@
+/**
+ * Codex CLI — OpenAI's coding agent (`codex`). Scaffold adapter: detection
+ * is real; launch support is best-effort and marked `experimental` until
+ * it is exercised by an end-to-end suite.
+ */
+import type { EmbeddedHarnessAdapter } from "./adapter.js";
+import { isExecutableOnPath } from "./detect.js";
+
+const INSTALL_MCP_PROMPT = [
+  "Set up the Sapiom MCP server for the Codex CLI.",
+  "",
+  "1. Register it under the server name `sapiom-dev`. Recent Codex versions",
+  "   support:",
+  "",
+  "   codex mcp add sapiom-dev -- npx -y @sapiom/mcp",
+  "",
+  "   Otherwise add it to `~/.codex/config.toml` yourself:",
+  "",
+  "   [mcp_servers.sapiom-dev]",
+  '   command = "npx"',
+  '   args = ["-y", "@sapiom/mcp"]',
+  "",
+  "   The `@sapiom/mcp` npm package ships the `sapiom-mcp` binary, a local",
+  "   MCP server that speaks stdio.",
+  "2. Restart Codex so the server is loaded, then confirm the Sapiom tools",
+  "   are listed.",
+].join("\n");
+
+/**
+ * The codex adapter. `promptDelivery` is `inline`: `codex` takes an
+ * initial prompt as its first positional argument and opens its
+ * interactive UI with or without one.
+ */
+export const codexAdapter: EmbeddedHarnessAdapter = {
+  id: "codex",
+  label: "Codex CLI",
+  mode: "embedded",
+  promptDelivery: "inline",
+  experimental: true,
+
+  launchCommand(cfg) {
+    const args: string[] = [];
+    if (cfg.prompt !== undefined) {
+      args.push(cfg.prompt);
+    }
+    return { command: "codex", args, env: { ...cfg.env } };
+  },
+
+  installMcpPrompt() {
+    return INSTALL_MCP_PROMPT;
+  },
+
+  detectInstalled() {
+    return isExecutableOnPath("codex");
+  },
+};

--- a/packages/harness/src/harnesses/conductor.ts
+++ b/packages/harness/src/harnesses/conductor.ts
@@ -1,0 +1,70 @@
+/**
+ * Conductor — a macOS app (conductor.build) that runs Claude Code agents
+ * in parallel workspaces. Conductor owns its sessions entirely, so this
+ * adapter is external/companion mode: detection and setup guidance only.
+ * The type gives it no spawn path.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExternalHarnessAdapter } from "./adapter.js";
+
+const INSTALL_MCP_PROMPT = [
+  "Set up the Sapiom MCP server for Conductor.",
+  "",
+  "Conductor workspaces run Claude Code, so register the server with Claude",
+  "Code at project scope — every workspace of the repository then inherits",
+  "it:",
+  "",
+  "1. From the repository root, run:",
+  "",
+  "   claude mcp add --scope project sapiom-dev -- npx -y @sapiom/mcp",
+  "",
+  "   This writes the server into the repository's `.mcp.json`, which",
+  "   Conductor workspaces pick up. The `@sapiom/mcp` npm package ships the",
+  "   `sapiom-mcp` binary, a local MCP server that speaks stdio.",
+  "2. Commit `.mcp.json` if the whole team should get the server.",
+  "3. Restart the Conductor workspace so the new server is loaded.",
+].join("\n");
+
+/**
+ * Where the Conductor app bundle can live. Exposed for tests; returns an
+ * empty list on platforms Conductor does not ship for.
+ */
+export function conductorAppCandidates(
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = os.homedir(),
+): string[] {
+  if (platform !== "darwin") return [];
+  return [
+    "/Applications/Conductor.app",
+    path.join(homeDir, "Applications", "Conductor.app"),
+  ];
+}
+
+/**
+ * The conductor adapter. `mode: "external"` — Conductor launches and
+ * drives its own agent sessions, so there is deliberately no
+ * `launchCommand` and `promptDelivery` is nominal. `detectInstalled`
+ * looks for the app bundle in the standard macOS locations.
+ */
+export const conductorAdapter: ExternalHarnessAdapter = {
+  id: "conductor",
+  label: "Conductor",
+  mode: "external",
+  promptDelivery: "inline",
+
+  installMcpPrompt() {
+    return INSTALL_MCP_PROMPT;
+  },
+
+  async detectInstalled() {
+    return conductorAppCandidates().some((candidate) => {
+      try {
+        return fs.existsSync(candidate);
+      } catch {
+        return false;
+      }
+    });
+  },
+};

--- a/packages/harness/src/harnesses/detect.ts
+++ b/packages/harness/src/harnesses/detect.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure-Node executable detection: locate a binary on `PATH` without
+ * shelling out to `which`/`where.exe`, so `detectInstalled()` works the
+ * same on every platform and never depends on a user's shell.
+ */
+import { constants as fsConstants } from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+
+/** Options for {@link findExecutableOnPath}; injectable for tests. */
+export interface FindExecutableOptions {
+  /**
+   * Environment to read `PATH` (and, on Windows, `PATHEXT`) from.
+   * Default: `process.env`.
+   */
+  env?: Record<string, string | undefined>;
+  /** Platform whose lookup rules apply. Default: `process.platform`. */
+  platform?: NodeJS.Platform;
+}
+
+/** Windows fallback when `PATHEXT` is unset, matching the OS default. */
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * Find an executable on `PATH`, returning the full path of the first
+ * match in `PATH` order, or `null` when there is none. Never throws.
+ *
+ * - POSIX: a match must be a regular file with execute permission.
+ * - Windows (`win32`): candidates are `name + ext` for each `PATHEXT`
+ *   entry — plus the bare name when it already carries an extension —
+ *   and existing as a regular file is enough, mirroring how the OS
+ *   resolves commands (execute bits are meaningless there).
+ *
+ * Empty `PATH` segments are skipped rather than treated as the current
+ * directory.
+ */
+export async function findExecutableOnPath(
+  name: string,
+  options: FindExecutableOptions = {},
+): Promise<string | null> {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const isWindows = platform === "win32";
+  const delimiter = isWindows ? ";" : ":";
+
+  const searchPath = env.PATH ?? env.Path ?? "";
+  const dirs = searchPath.split(delimiter).filter((dir) => dir.length > 0);
+
+  const extensions = isWindows
+    ? (env.PATHEXT ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0)
+    : [];
+
+  for (const dir of dirs) {
+    const base = path.join(dir, name);
+    const candidates = isWindows
+      ? // A name that already has an extension can match as-is.
+        name.includes(".")
+        ? [base, ...extensions.map((ext) => base + ext)]
+        : extensions.map((ext) => base + ext)
+      : [base];
+
+    for (const candidate of candidates) {
+      if (await isExecutableFile(candidate, isWindows)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Convenience wrapper for adapters: `true` when {@link
+ * findExecutableOnPath} finds the binary on the current process's `PATH`.
+ */
+export async function isExecutableOnPath(name: string): Promise<boolean> {
+  return (await findExecutableOnPath(name)) !== null;
+}
+
+async function isExecutableFile(
+  file: string,
+  isWindows: boolean,
+): Promise<boolean> {
+  try {
+    const stat = await fsp.stat(file);
+    if (!stat.isFile()) return false;
+    if (isWindows) return true;
+    await fsp.access(file, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/harness/src/harnesses/index.ts
+++ b/packages/harness/src/harnesses/index.ts
@@ -1,7 +1,62 @@
 /**
- * Harness adapters (claude-code, codex, …) will live here: one adapter file
- * per harness plus a registry, so adding a harness is a single-file change.
+ * Harness adapter registry.
  *
- * Placeholder module — intentionally empty for now.
+ * One adapter file per harness plus one line in {@link HARNESS_ADAPTERS}
+ * — that is the whole cost of supporting a new harness. `getAdapter` and
+ * `listAdapters` read the default registry; `createHarnessRegistry`
+ * builds custom registries from any adapter list (which is also how the
+ * tests prove that registration is purely data-driven).
  */
-export {};
+import type { HarnessAdapter } from "./adapter.js";
+import { createHarnessRegistry } from "./registry.js";
+import { claudeCodeAdapter } from "./claude-code.js";
+import { codexAdapter } from "./codex.js";
+import { piAdapter } from "./pi.js";
+import { opencodeAdapter } from "./opencode.js";
+import { conductorAdapter } from "./conductor.js";
+
+/** Every built-in adapter, in presentation order. */
+export const HARNESS_ADAPTERS: readonly HarnessAdapter[] = [
+  claudeCodeAdapter,
+  codexAdapter,
+  piAdapter,
+  opencodeAdapter,
+  conductorAdapter,
+];
+
+const defaultRegistry = createHarnessRegistry(HARNESS_ADAPTERS);
+
+/** All registered adapters, in registration order. */
+export function listAdapters(): readonly HarnessAdapter[] {
+  return defaultRegistry.list();
+}
+
+/**
+ * The adapter with the given id. Accepts any string (ids often arrive
+ * from config files or HTTP) and throws `UnknownHarnessError` when
+ * nothing matches.
+ */
+export function getAdapter(id: string): HarnessAdapter {
+  return defaultRegistry.get(id);
+}
+
+export type {
+  EmbeddedHarnessAdapter,
+  ExternalHarnessAdapter,
+  HarnessAdapter,
+  HarnessAdapterCommon,
+  HarnessId,
+  HarnessLaunch,
+  HarnessLaunchConfig,
+  HarnessMode,
+  PromptDelivery,
+} from "./adapter.js";
+export { createHarnessRegistry, UnknownHarnessError } from "./registry.js";
+export type { HarnessRegistry } from "./registry.js";
+export { findExecutableOnPath, isExecutableOnPath } from "./detect.js";
+export type { FindExecutableOptions } from "./detect.js";
+export { claudeCodeAdapter } from "./claude-code.js";
+export { codexAdapter } from "./codex.js";
+export { piAdapter } from "./pi.js";
+export { opencodeAdapter } from "./opencode.js";
+export { conductorAdapter, conductorAppCandidates } from "./conductor.js";

--- a/packages/harness/src/harnesses/opencode.ts
+++ b/packages/harness/src/harnesses/opencode.ts
@@ -1,0 +1,57 @@
+/**
+ * opencode — an open-source coding agent TUI (`opencode`). Scaffold
+ * adapter: detection is real; launch support is best-effort and marked
+ * `experimental` until it is exercised by an end-to-end suite.
+ */
+import type { EmbeddedHarnessAdapter } from "./adapter.js";
+import { isExecutableOnPath } from "./detect.js";
+
+const INSTALL_MCP_PROMPT = [
+  "Set up the Sapiom MCP server for opencode.",
+  "",
+  "1. Add it to opencode's config — the project's `opencode.json`, or the",
+  "   global `~/.config/opencode/opencode.json`:",
+  "",
+  "   {",
+  '     "mcp": {',
+  '       "sapiom-dev": {',
+  '         "type": "local",',
+  '         "command": ["npx", "-y", "@sapiom/mcp"],',
+  '         "enabled": true',
+  "       }",
+  "     }",
+  "   }",
+  "",
+  "   The `@sapiom/mcp` npm package ships the `sapiom-mcp` binary, a local",
+  "   MCP server that speaks stdio.",
+  "2. Restart opencode so the server is loaded, then confirm the Sapiom",
+  "   tools are listed.",
+].join("\n");
+
+/**
+ * The opencode adapter. `promptDelivery` is `inline`: the TUI accepts an
+ * initial prompt via `--prompt` and opens normally without one.
+ */
+export const opencodeAdapter: EmbeddedHarnessAdapter = {
+  id: "opencode",
+  label: "opencode",
+  mode: "embedded",
+  promptDelivery: "inline",
+  experimental: true,
+
+  launchCommand(cfg) {
+    const args: string[] = [];
+    if (cfg.prompt !== undefined) {
+      args.push("--prompt", cfg.prompt);
+    }
+    return { command: "opencode", args, env: { ...cfg.env } };
+  },
+
+  installMcpPrompt() {
+    return INSTALL_MCP_PROMPT;
+  },
+
+  detectInstalled() {
+    return isExecutableOnPath("opencode");
+  },
+};

--- a/packages/harness/src/harnesses/pi.ts
+++ b/packages/harness/src/harnesses/pi.ts
@@ -1,0 +1,47 @@
+/**
+ * pi — a minimal open-source coding agent CLI (`pi`). Scaffold adapter:
+ * detection is real; launch support is best-effort and marked
+ * `experimental` until it is exercised by an end-to-end suite.
+ */
+import type { EmbeddedHarnessAdapter } from "./adapter.js";
+import { isExecutableOnPath } from "./detect.js";
+
+const INSTALL_MCP_PROMPT = [
+  "Set up the Sapiom MCP server for pi.",
+  "",
+  "The Sapiom MCP server is the `sapiom-mcp` binary from the `@sapiom/mcp`",
+  "npm package — a local stdio MCP server started with `npx -y @sapiom/mcp`.",
+  "MCP support varies between pi versions: check `pi --help` and pi's",
+  "documentation for how your version registers stdio MCP servers, and",
+  "register the command above under the name `sapiom-dev`. If your pi",
+  "version has no MCP support, say so instead of guessing.",
+].join("\n");
+
+/**
+ * The pi adapter. `promptDelivery` is `inline`: `pi` accepts an initial
+ * prompt as its first positional argument and runs interactively with or
+ * without one.
+ */
+export const piAdapter: EmbeddedHarnessAdapter = {
+  id: "pi",
+  label: "pi",
+  mode: "embedded",
+  promptDelivery: "inline",
+  experimental: true,
+
+  launchCommand(cfg) {
+    const args: string[] = [];
+    if (cfg.prompt !== undefined) {
+      args.push(cfg.prompt);
+    }
+    return { command: "pi", args, env: { ...cfg.env } };
+  },
+
+  installMcpPrompt() {
+    return INSTALL_MCP_PROMPT;
+  },
+
+  detectInstalled() {
+    return isExecutableOnPath("pi");
+  },
+};

--- a/packages/harness/src/harnesses/registry.ts
+++ b/packages/harness/src/harnesses/registry.ts
@@ -1,0 +1,58 @@
+/**
+ * Registry mechanics for harness adapters: id-based lookup with a typed
+ * error, plus a factory so the adapter set stays pure data — registering
+ * a harness is appending one entry to an array.
+ */
+import { HarnessError } from "../runtime/errors.js";
+import type { HarnessAdapter } from "./adapter.js";
+
+/** Thrown by registry lookups when no adapter has the requested id. */
+export class UnknownHarnessError extends HarnessError {
+  readonly code = "UNKNOWN_HARNESS";
+
+  constructor(id: string, knownIds: readonly string[]) {
+    super(
+      `Unknown harness: ${JSON.stringify(id)}. ` +
+        `Known harnesses: ${knownIds.join(", ")}.`,
+    );
+  }
+}
+
+/** Enumeration and lookup over a fixed set of adapters. */
+export interface HarnessRegistry {
+  /** All adapters, in registration order. The array is frozen. */
+  list(): readonly HarnessAdapter[];
+  /**
+   * The adapter with the given id. Accepts any string (ids often arrive
+   * from config files or HTTP) and throws {@link UnknownHarnessError}
+   * when nothing matches.
+   */
+  get(id: string): HarnessAdapter;
+}
+
+/**
+ * Build a registry from an adapter list. Duplicate ids are a programming
+ * error and throw immediately.
+ */
+export function createHarnessRegistry(
+  adapters: readonly HarnessAdapter[],
+): HarnessRegistry {
+  const byId = new Map<string, HarnessAdapter>();
+  for (const adapter of adapters) {
+    if (byId.has(adapter.id)) {
+      throw new HarnessError(`Duplicate harness adapter id: ${adapter.id}`);
+    }
+    byId.set(adapter.id, adapter);
+  }
+
+  const frozen = Object.freeze([...adapters]);
+
+  return {
+    list: () => frozen,
+    get: (id) => {
+      const adapter = byId.get(id);
+      if (!adapter) throw new UnknownHarnessError(id, [...byId.keys()]);
+      return adapter;
+    },
+  };
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,8 +2,9 @@
  * `@sapiom/harness` — run coding agents locally under a managed session
  * runtime.
  *
- * Early preview: the session foundation (pty-backed `SessionRuntime`) is
- * available; harness adapters, the local server/UI, analytics and doctor
- * live in sibling modules and land incrementally.
+ * Early preview: the session foundation (pty-backed `SessionRuntime`) and
+ * the harness adapter registry are available; the local server/UI,
+ * analytics and doctor live in sibling modules and land incrementally.
  */
 export * from "./runtime/index.js";
+export * from "./harnesses/index.js";


### PR DESCRIPTION
## Summary

Adds the harness adapter registry to `@sapiom/harness`: a `HarnessAdapter` contract plus a data-driven registry where supporting a new harness costs **one adapter file + one registry line**. Claude Code is fully supported; codex/pi/opencode ship as experimental embedded scaffolds; Conductor is an external/companion adapter (detection + guidance only, no spawn path — enforced by the types).

Fixes SAP-1408 — https://linear.app/sapiom/issue/SAP-1408

> **Stacked on #177 — retarget to main after it merges.**

## Changes

- **Contract** (`src/harnesses/adapter.ts`) — `HarnessAdapter = EmbeddedHarnessAdapter | ExternalHarnessAdapter`, discriminated on `mode`. External adapters declare `launchCommand?: never`, so a spawn path is unrepresentable rather than merely discouraged. `HarnessLaunchConfig` carries `env`, an optional inline `prompt` (for `promptDelivery: "inline"` adapters), and optional `appendSystemPrompt` — literal prompt *content* (not a file path), passed verbatim as a single argv entry since sessions spawn without a shell.
- **Registry** (`src/harnesses/index.ts`, replacing the 1407 placeholder) — `HARNESS_ADAPTERS` (the one-line-per-harness list), `listAdapters()`, `getAdapter(id)` with a typed `UnknownHarnessError` on miss, and `createHarnessRegistry()` (also how tests prove registration is purely data-driven).
- **claude-code (complete)** — embedded, `promptDelivery: "post-launch"`. `launchCommand` runs interactive `claude`, adding `--append-system-prompt <content>` as a literal argv pair when configured. `detectInstalled()` is a pure-Node PATH lookup (executable-bit check on POSIX, `PATHEXT` candidates on win32 — no shelling out to `which`). `installMcpPrompt()` walks the agent through `claude mcp add sapiom-dev -- npx -y @sapiom/mcp`, verification, and authentication.
- **codex / pi / opencode (embedded scaffolds, `experimental: true`)** — real binary detection, inline prompt delivery, best-effort launch commands (`codex [prompt]`, `pi [prompt]`, `opencode --prompt <prompt>`), honest per-harness MCP setup prompts (codex: `codex mcp add` / `~/.codex/config.toml`; opencode: `opencode.json` mcp block; pi: points at its own docs rather than guessing).
- **conductor (external)** — Conductor owns its sessions, so the adapter offers macOS app-bundle detection and MCP guidance via Claude Code project scope (`claude mcp add --scope project …` → `.mcp.json`, which workspaces inherit). No launch surface exists on the type.
- **Detection helper** (`src/harnesses/detect.ts`) — `findExecutableOnPath()` exported for reuse (doctor, later epics).
- Package README section, exports from the package root, and a changeset (**patch** on `@sapiom/harness` — the package is pre-1.0/unpublished with 1407's pending minor changeset; ticket calls for patch).

## Test plan

- `pnpm --filter @sapiom/harness build` — dual cjs/esm build green.
- `pnpm --filter @sapiom/harness test` — new suites plus all pre-existing 1407 suites.
- Repo-wide `pnpm build && pnpm typecheck && pnpm lint && pnpm test` (CI order).
- Hygiene grep over `src/harnesses` for anything non-public — clean.

New coverage:

- `registry.test.ts` — registry-driven enumeration (a fictional adapter added to a registry list shows up in list/get with zero other changes), per-adapter contract shape driven off `listAdapters()` (future adapters are auto-covered), duplicate-id rejection, typed unknown-id error, and external-has-no-spawn-path at **runtime and compile time** (`@ts-expect-error` assertions that fail the build if the types ever loosen).
- `claude-code.test.ts` — launch-config correctness: bare interactive launch, env copied not aliased, literal `--append-system-prompt` pair (quotes/newlines/`$( )`/backticks/backslash preserved), empty-content edge, inline `prompt` ignored per post-launch delivery, install-prompt content.
- `scaffold-adapters.test.ts` / `conductor.test.ts` — stub launch args + experimental markers + honest install prompts; conductor app-bundle candidates and spawn-free shape.
- `detect.test.ts` — PATH manipulation: hit/miss/order/exec-bit/dir-collision/empty-segment on POSIX, `PATHEXT` + `;`-delimiter emulation for win32, and each adapter's `detectInstalled()` under a swapped `process.env.PATH` (true with the binary present, false without, no cross-adapter false positives).
- `e2e/claude-code-adapter.e2e.test.ts` — integration: the adapter's `launchCommand` spawned under the existing `PtyRuntime` against a **fake `claude` script on a temp PATH dir**. Proves command resolution through the child env's PATH, literal argv delivery of a shell-metacharacter probe (`$(echo interpolated)` arrives uninterpolated), env plumbing, post-launch prompt injection via `runtime.write`, and kill.

### Results

```
$ pnpm --filter @sapiom/harness test
PASS src/harnesses/__tests__/conductor.test.ts
PASS src/harnesses/__tests__/scaffold-adapters.test.ts
PASS src/harnesses/__tests__/claude-code.test.ts
PASS src/runtime/__tests__/pty-unavailable.test.ts
PASS src/harnesses/__tests__/detect.test.ts
PASS src/harnesses/__tests__/registry.test.ts
PASS e2e/claude-code-adapter.e2e.test.ts
PASS e2e/pty-runtime.e2e.test.ts

Test Suites: 8 passed, 8 total
Tests:       83 passed, 83 total

$ pnpm build      # all packages: Done, exit 0
$ pnpm typecheck  # all packages: Done, exit 0
$ pnpm lint       # all packages: Done, exit 0
$ pnpm test       # exit 0 — core 132, tools 322, harness 83, agent 73, fetch 43,
                  # node-http 33, axios 33, agent-runtime 20, sandbox 58,
                  # agent-core 101, cli 19 — all passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
