### PR TITLE
feat(harness): first-user fixes — consent opt-in, auto-session, MCP auth headers

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -24,6 +24,10 @@
  *   7. The CLI's launch directory is scanned for workflows at boot, and a
  *      new directory is scanned when a session opens in it — both fire a
  *      workflows.changed frame on /ws/events.
+ *   8. (separate, isolated server instance) autoCreateSession creates a
+ *      session in launchDir without any client ever calling POST
+ *      /api/sessions, AppState.launchDir reports it, and the generated
+ *      mcp-config for an authenticated identity carries the x-api-key header.
  *
  * Run with: pnpm e2e:live
  */
@@ -38,6 +42,7 @@ import { WebSocket } from "ws";
 import { startServer } from "../src/server/index.js";
 import { createClaudeCodeAdapter } from "../src/core/adapters/claude-code.js";
 import { createCodexAdapter } from "../src/core/adapters/codex.js";
+import { ensureSpawnHelperExecutable } from "../src/core/session-manager.js";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FAKE_CLAUDE = path.join(SCRIPT_DIR, "fixtures", "fake-claude.mjs");
@@ -72,13 +77,15 @@ interface FakeClaudeCapture {
  * onlyBuiltDependencies configured) can extract the darwin/linux
  * `spawn-helper` without its executable bit set, which fails every single
  * pty spawn with an opaque "posix_spawnp failed" — nothing to do with this
- * script or the harness's own code. session-manager.ts's loadDefaultSpawn()
- * self-heals this on first real use, but this script spawns real ptys as
- * its whole point, so fail fast here with an actionable message rather than
- * an obscure native stack trace three layers down.
+ * script or the harness's own code. Applies the same self-heal
+ * session-manager.ts's loadDefaultSpawn() does before its first real spawn
+ * (so a fresh install doesn't spuriously fail this preflight), then probes
+ * with a real spawn to fail fast with an actionable message if that wasn't
+ * enough, rather than an obscure native stack trace three layers down.
  */
 async function preflightNodePty(): Promise<void> {
   try {
+    await ensureSpawnHelperExecutable();
     const nodePty = await import("node-pty");
     const probe = nodePty.spawn(process.execPath, ["-e", "process.exit(0)"], {
       name: "xterm-256color",
@@ -106,10 +113,9 @@ async function preflightNodePty(): Promise<void> {
   }
 }
 
-async function main(): Promise<void> {
-  await preflightNodePty();
-  console.log("node-pty preflight ok");
-
+/** Phases 1–7 (see the module doc comment): the core session/ingest/canvas/
+ *  macro/workflow-scan loop, with a single explicitly-created session. */
+async function testCoreFlow(): Promise<void> {
   const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-e2e-live-"));
   const projectDir = path.join(tmpRoot, "project");
   await fs.mkdir(projectDir, { recursive: true });
@@ -161,6 +167,11 @@ async function main(): Promise<void> {
     eventStorePath,
     workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
     launchDir: projectDir,
+    // This phase explicitly creates its own session below (step 1) and
+    // asserts on its exact id/argv — autoCreateSession would spawn a second,
+    // concurrent fake-claude racing the same FAKE_CLAUDE_CAPTURE file.
+    // Covered on its own, deterministically, in the isolated phase (step 8).
+    autoCreateSession: false,
   });
   console.log(`harness server listening on http://127.0.0.1:${server.port}`);
 
@@ -387,8 +398,6 @@ async function main(): Promise<void> {
       afterSecondSession.some((w) => w.path === secondProjectDir && w.definitionId === 9001),
       "creating a session in a new directory scanned and discovered its sapiom.json",
     );
-
-    console.log("\nPASS — live integration proof succeeded\n");
   } finally {
     // Runs on both success and failure — a failed assertion mid-run must not
     // strand the fake-claude pty (or the mock collector) any more than a
@@ -402,6 +411,79 @@ async function main(): Promise<void> {
     // handles under tmpRoot for a moment after we've resolved past killing
     // it — rm's own maxRetries (ENOTEMPTY-safe, linear backoff) covers that
     // race properly instead of a fixed sleep.
+    await fs.rm(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  }
+}
+
+/**
+ * Phase 8: a second, fully isolated server instance (own tmp dir, own
+ * FAKE_CLAUDE_CAPTURE) — no client ever calls POST /api/sessions here, so a
+ * session existing at all proves autoCreateSession, and a distinct apiKey
+ * proves it flows into the generated mcp-config's auth headers.
+ */
+async function testAutoSessionAndMcpAuth(): Promise<void> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-e2e-live-boot-"));
+  const projectDir = path.join(tmpRoot, "project");
+  await fs.mkdir(projectDir, { recursive: true });
+
+  const bootToken = crypto.randomUUID();
+  const captureFile = path.join(tmpRoot, "fake-claude-capture.json");
+  const apiKey = "sk_test_e2e_boot_key";
+  process.env.FAKE_CLAUDE_CAPTURE = captureFile;
+
+  const server = await startServer({
+    port: 0,
+    bootToken,
+    telemetryOptIn: false,
+    identity: { userId: "boot-user", tenantId: "boot-tenant", organizationName: "Boot Org", apiKey },
+    machineId: "e2e-boot-machine",
+    adapters: {
+      "claude-code": createClaudeCodeAdapter({ binary: FAKE_CLAUDE }),
+      codex: createCodexAdapter(),
+    },
+    sessionsPath: path.join(tmpRoot, "sessions.json"),
+    eventStorePath: path.join(tmpRoot, "events.ndjson"),
+    workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    launchDir: projectDir,
+    // Left at its default (true) — this is exactly the behavior under test.
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  const headers = { "Content-Type": "application/json", "X-Harness-Token": bootToken };
+
+  try {
+    type StateLike = {
+      launchDir: string;
+      sessions: Array<{ id: string; cwd: string; status: string }>;
+    };
+    const state = await waitFor<StateLike>(async () => {
+      const res = await fetch(`${baseUrl}/api/state`, { headers });
+      const body = (await res.json()) as StateLike;
+      return body.sessions.some((s) => s.cwd === projectDir) ? body : undefined;
+    });
+    assert(
+      state.sessions.some((s) => s.cwd === projectDir),
+      "autoCreateSession created a session in launchDir with no client ever calling POST /api/sessions",
+    );
+    assert(state.launchDir === projectDir, "GET /api/state reports launchDir");
+
+    const capture = await waitFor<FakeClaudeCapture>(async () => {
+      try {
+        return JSON.parse(await fs.readFile(captureFile, "utf8")) as FakeClaudeCapture;
+      } catch {
+        return undefined;
+      }
+    });
+    const mcpConfigIdx = capture.argv.indexOf("--mcp-config");
+    assert(mcpConfigIdx !== -1, "boot session launched with --mcp-config");
+    const mcpConfigJson = JSON.parse(await fs.readFile(capture.argv[mcpConfigIdx + 1], "utf8")) as {
+      mcpServers?: { sapiom?: { headers?: Record<string, string> } };
+    };
+    assert(
+      mcpConfigJson.mcpServers?.sapiom?.headers?.["x-api-key"] === apiKey,
+      "generated mcp-config's remote sapiom entry carries the cached apiKey as x-api-key",
+    );
+  } finally {
+    await server.close();
     await fs.rm(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   }
 }
@@ -426,6 +508,19 @@ function killChildAndWait(child: ReturnType<typeof spawn>, timeoutMs = 3000): Pr
     }, 1000);
     const hardStop = setTimeout(done, timeoutMs);
   });
+}
+
+async function main(): Promise<void> {
+  await preflightNodePty();
+  console.log("node-pty preflight ok");
+
+  await testCoreFlow();
+  console.log("phase 1/2 ok (core session/ingest/canvas/macro/workflow-scan loop)\n");
+
+  await testAutoSessionAndMcpAuth();
+  console.log("phase 2/2 ok (autoCreateSession + mcp-config auth headers)\n");
+
+  console.log("PASS — live integration proof succeeded\n");
 }
 
 // Explicit exit as a backstop: teardown above should already release every

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -5,7 +5,8 @@
  * Flow: doctor → auth (reuse @sapiom/mcp browser OAuth) → consent (first run)
  * → generate boot token → startServer → open browser → print a startup banner.
  *
- * Flags: [dir] (default cwd), --port, --no-auth, --no-telemetry, --no-open, --dev.
+ * Flags: [dir] (default cwd), --port, --no-auth, --no-telemetry, --no-open,
+ * --no-session, --dev.
  */
 import * as path from "node:path";
 import * as crypto from "node:crypto";
@@ -24,6 +25,7 @@ interface CliOptions {
   noAuth: boolean;
   noTelemetry: boolean;
   noOpen: boolean;
+  noSession: boolean;
   dev: boolean;
 }
 
@@ -33,6 +35,7 @@ function parseArgs(argv: string[]): CliOptions {
   let noAuth = false;
   let noTelemetry = false;
   let noOpen = false;
+  let noSession = false;
   let dev = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -55,6 +58,9 @@ function parseArgs(argv: string[]): CliOptions {
       case "--no-open":
         noOpen = true;
         break;
+      case "--no-session":
+        noSession = true;
+        break;
       case "--dev":
         dev = true;
         break;
@@ -75,6 +81,7 @@ function parseArgs(argv: string[]): CliOptions {
     noAuth,
     noTelemetry,
     noOpen,
+    noSession,
     dev,
   };
 }
@@ -137,6 +144,7 @@ const main = async (): Promise<void> => {
       identity,
       machineId,
       launchDir: options.dir,
+      autoCreateSession: !options.noSession,
     });
   } catch (err) {
     if (!options.dev) throw err;

--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -10,6 +10,14 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir: () => tmpDir };
 });
 
+let nextAnswer = "";
+vi.mock("node:readline/promises", () => ({
+  createInterface: () => ({
+    question: async () => nextAnswer,
+    close: () => {},
+  }),
+}));
+
 import { ensureConsent } from "./consent.js";
 import { loadSettings } from "./settings.js";
 
@@ -30,16 +38,16 @@ describe("ensureConsent", () => {
     expect(settings.telemetryOptIn).toBe(false);
   });
 
-  it("defaults to off and persists on first run when stdin is not a TTY", async () => {
+  it("defaults to ON and persists on first run when stdin is not a TTY", async () => {
     const wasTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
     try {
       const optIn = await ensureConsent({ noTelemetry: false });
-      expect(optIn).toBe(false);
+      expect(optIn).toBe(true);
 
       const settings = await loadSettings();
-      expect(settings.telemetryOptIn).toBe(false);
+      expect(settings.telemetryOptIn).toBe(true);
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -50,15 +58,53 @@ describe("ensureConsent", () => {
     Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
     try {
-      await ensureConsent({ noTelemetry: false }); // first run persists false
+      await ensureConsent({ noTelemetry: false }); // first run persists the default (true)
       const settings = await loadSettings();
+      // Overwrite with a non-default value to prove the second call reuses
+      // whatever was persisted rather than just returning the default again.
       await fs.writeFile(
         path.join(tmpDir, ".sapiom", "harness", "settings.json"),
-        JSON.stringify({ ...settings, telemetryOptIn: true }),
+        JSON.stringify({ ...settings, telemetryOptIn: false }),
       );
 
       const optIn = await ensureConsent({ noTelemetry: false });
-      expect(optIn).toBe(true);
+      expect(optIn).toBe(false);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+    }
+  });
+
+  it("interactive prompt: a blank answer accepts the default (on)", async () => {
+    const wasTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    nextAnswer = "";
+
+    try {
+      expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+    }
+  });
+
+  it("interactive prompt: an explicit 'n' opts out", async () => {
+    const wasTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    nextAnswer = "n";
+
+    try {
+      expect(await ensureConsent({ noTelemetry: false })).toBe(false);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+    }
+  });
+
+  it("interactive prompt: an explicit 'y' opts in", async () => {
+    const wasTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    nextAnswer = "y";
+
+    try {
+      expect(await ensureConsent({ noTelemetry: false })).toBe(true);
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -1,29 +1,34 @@
 import * as readline from "node:readline/promises";
 import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 
+// Internal/friendlies phase: default to opted in (matches the on-by-default
+// prompt below and the non-TTY fallback) — flip this the other way for a
+// wider release.
+const DEFAULT_TELEMETRY_OPT_IN = true;
+
 const CONSENT_COPY = `
 Sapiom Harness collects local usage analytics to improve the product:
   - the prompts you send and the tool calls your agent makes
   - session start/stop lifecycle events
 This is always written locally to ~/.sapiom/harness/events.ndjson for your
-own inspection. With your consent, it's also sent to Sapiom — a free-credits
-program for opted-in users is coming soon.
+own inspection.
 
-You can change this any time: pass --no-telemetry, or edit
-~/.sapiom/harness/settings.json.
+Telemetry is ON to help us improve (opt out anytime in the app's settings
+gear, or run with --no-telemetry).
 `.trim();
 
 async function promptConsent(): Promise<boolean> {
   console.log(`\n${CONSENT_COPY}\n`);
 
   if (!process.stdin.isTTY) {
-    console.log("Non-interactive session — defaulting telemetry to off.\n");
-    return false;
+    console.log(`Non-interactive session — defaulting telemetry to ${DEFAULT_TELEMETRY_OPT_IN ? "on" : "off"}.\n`);
+    return DEFAULT_TELEMETRY_OPT_IN;
   }
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = (await rl.question("Enable analytics? [y/N] ")).trim().toLowerCase();
+    const answer = (await rl.question("Keep it on? [Y/n] ")).trim().toLowerCase();
+    if (answer === "") return DEFAULT_TELEMETRY_OPT_IN;
     return answer === "y" || answer === "yes";
   } finally {
     rl.close();

--- a/packages/harness/src/core/inject/mcp-config.test.ts
+++ b/packages/harness/src/core/inject/mcp-config.test.ts
@@ -57,4 +57,34 @@ describe("generateMcpConfig", () => {
     const b = await generateMcpConfig("session-b");
     expect(path.dirname(a)).not.toBe(path.dirname(b));
   });
+
+  it("adds an x-api-key header to the remote sapiom entry when an apiKey is given", async () => {
+    const filePath = await generateMcpConfig("session-auth", { apiKey: "sk_live_test123" });
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers.sapiom).toEqual({
+      type: "http",
+      url: "https://api.sapiom.ai/v1/mcp",
+      headers: { "x-api-key": "sk_live_test123" },
+    });
+    // sapiom-dev (the local stdio MCP) authenticates itself separately via
+    // its own sapiom_authenticate tool — it doesn't need the apiKey.
+    expect(config.mcpServers["sapiom-dev"].headers).toBeUndefined();
+  });
+
+  it("omits headers entirely when apiKey is null or absent", async () => {
+    const withoutOption = JSON.parse(await fs.readFile(await generateMcpConfig("session-1"), "utf-8"));
+    expect(withoutOption.mcpServers.sapiom.headers).toBeUndefined();
+
+    const withNull = JSON.parse(
+      await fs.readFile(await generateMcpConfig("session-2", { apiKey: null }), "utf-8"),
+    );
+    expect(withNull.mcpServers.sapiom.headers).toBeUndefined();
+  });
+
+  it("writes the config file with owner-only permissions (it can carry a live API key)", async () => {
+    const filePath = await generateMcpConfig("session-perm", { apiKey: "sk_live_test123" });
+    const stat = await fs.stat(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
 });

--- a/packages/harness/src/core/inject/mcp-config.ts
+++ b/packages/harness/src/core/inject/mcp-config.ts
@@ -6,6 +6,16 @@ import { expandHome } from "../../cli/paths.js";
 export interface McpConfigOptions {
   /** SAPIOM_ENVIRONMENT to pass through to the sapiom-dev child process. */
   environment?: string;
+  /**
+   * Cached Sapiom API key (from CLI auth), if signed in. Sent as
+   * `x-api-key` on the remote `sapiom` MCP — empirically verified against
+   * api.sapiom.ai/v1/mcp (both `x-api-key` and `Authorization: Bearer` are
+   * accepted for `sk_`-prefixed keys; `x-api-key` matches its CORS
+   * allow-list order and needs no prefix formatting). Omitted entirely when
+   * absent (`--no-auth`, or not yet signed in) — every remote tool call
+   * then 401s, same as today.
+   */
+  apiKey?: string | null;
 }
 
 /**
@@ -32,6 +42,7 @@ export async function generateMcpConfig(
       sapiom: {
         type: "http",
         url: "https://api.sapiom.ai/v1/mcp",
+        ...(options.apiKey ? { headers: { "x-api-key": options.apiKey } } : {}),
       },
       "sapiom-dev": {
         command: "npx",
@@ -42,6 +53,8 @@ export async function generateMcpConfig(
   };
 
   const filePath = path.join(dir, "mcp-config.json");
-  await fs.writeFile(filePath, JSON.stringify(config, null, 2) + "\n");
+  // May now carry a live API key (the `sapiom` entry's headers) — restrict
+  // to the owner, matching how ~/.sapiom/credentials.json is written.
+  await fs.writeFile(filePath, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
   return filePath;
 }

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -41,8 +41,10 @@ let defaultSpawnError: Error | undefined;
  * — nothing to do with the harness's own code, but fatal to every session
  * launch. Best-effort self-heal before the first real spawn; silently a
  * no-op if the file's missing (wrong platform/arch) or already executable.
+ * Exported so scripts/e2e-live.ts's preflight check shares this exact fix
+ * instead of duplicating it.
  */
-async function ensureSpawnHelperExecutable(): Promise<void> {
+export async function ensureSpawnHelperExecutable(): Promise<void> {
   if (process.platform === "win32") return;
   try {
     const nodePtyPkgJson = createRequire(import.meta.url).resolve("node-pty/package.json");

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -1,13 +1,17 @@
 /**
  * Default system prompt, appended to the coding agent's own instructions via
  * `--append-system-prompt`. Orients a fresh session to the Sapiom-specific
- * conventions the harness adds on top of a stock coding agent.
+ * conventions the harness adds on top of a stock coding agent. Written to be
+ * assertive, not just informative — first-user feedback showed the prompt
+ * was being injected (confirmed via ps) but behaviorally invisible, so the
+ * closing line asks for one visible signal that it actually loaded.
  */
 export const DEFAULT_SYSTEM_PROMPT = `
-You are running inside the Sapiom Harness — a local web app that wraps this
-coding session with Sapiom's developer tooling pre-wired.
+You are running in the Sapiom Harness. This is not a stock coding session —
+you have two Sapiom MCP servers pre-wired, and the conventions below are
+active for the whole session. Follow them.
 
-Two Sapiom MCP servers are available:
+**The two MCPs, and when to use each:**
 - **sapiom** (remote, HTTP) — the paid capability surface an agent calls at
   *runtime* from inside a deployed agent's step code (ctx.sapiom.*):
   repositories, sandboxes, models, and so on. You don't call this directly
@@ -16,15 +20,19 @@ Two Sapiom MCP servers are available:
   session. Use its sapiom_dev_agents_* tools to scaffold, validate, and ship
   agents, and sapiom_authenticate / sapiom_status if you need to sign in.
 
-The authoring loop, in order: **scaffold** a new agent project → **check**
-(bundle + manifest + step-graph validation, offline) → **run_local** (your
-real step code against stub capabilities, no cost) → **link** (associate the
-project with a hosted agent) → **deploy** (push, build, go live). Read a
-project's AGENTS.md before touching its steps — it documents that project's
-specifics.
+**The authoring loop, in order:** scaffold a new agent project → check
+(bundle + manifest + step-graph validation, offline) → run_local (your real
+step code against stub capabilities, no cost) → link (associate the project
+with a hosted agent) → deploy (push, build, go live). Read a project's
+AGENTS.md before touching its steps — it documents that project's specifics.
 
 **Canvas convention:** when asked to visualize or preview something, write a
 self-contained static HTML file to \`.sapiom/canvas/index.html\` in the
 current project directory (inline any CSS/JS/data it needs — no build step).
 The harness watches that file and renders it live in the app's canvas pane.
+
+**In your very first reply this session**, briefly acknowledge that you're
+running in the Sapiom Harness with these MCPs available — one line, not a
+lecture — so the person on the other end can see this loaded before you get
+to their actual request.
 `.trim();

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -70,8 +70,13 @@ export interface HarnessServerOptions {
   /** Directory the built SPA lives in. Defaults to dist/web next to this module. */
   webDir?: string;
   /** The directory the CLI was launched against — scanned for workflows at
-   *  boot so the rail isn't empty until a manual "+ Connect". */
+   *  boot so the rail isn't empty until a manual "+ Connect", and (unless
+   *  autoCreateSession is false) where the boot session is created. */
   launchDir?: string;
+  /** Auto-create a claude-code session in launchDir once the server is
+   *  listening, so the app doesn't open empty. Defaults to true; the CLI's
+   *  --no-session flag sets this to false. */
+  autoCreateSession?: boolean;
 }
 
 export interface HarnessServer {
@@ -103,25 +108,31 @@ function readVersion(): string {
  * and --append-system-prompt source files. Generated uniformly for every
  * harness kind — an adapter that doesn't use one of these fields (codex,
  * today) simply ignores it, same as the claude-code adapter already does for
- * whichever of the three a given launch doesn't set.
+ * whichever of the three a given launch doesn't set. `apiKey` (from CLI auth,
+ * null when unauthenticated / --no-auth) flows into the generated mcp-config
+ * so the remote `sapiom` MCP is actually authenticated — a factory rather
+ * than a plain function since it's per-server-instance state.
  */
-const defaultBuildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId) => {
-  const [settings, mcpConfigFile, systemPromptFile] = await Promise.all([
-    generateClaudeSettings({ harnessSessionId }),
-    generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT }),
-    generateSystemPromptFile(harnessSessionId),
-  ]);
-  return {
-    settingsFile: settings.settingsPath,
-    mcpConfigFile,
-    systemPromptFile,
+function createDefaultBuildLaunchOpts(apiKey: string | null): LaunchOptsBuilder {
+  return async (harnessSessionId) => {
+    const [settings, mcpConfigFile, systemPromptFile] = await Promise.all([
+      generateClaudeSettings({ harnessSessionId }),
+      generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT, apiKey }),
+      generateSystemPromptFile(harnessSessionId),
+    ]);
+    return {
+      settingsFile: settings.settingsPath,
+      mcpConfigFile,
+      systemPromptFile,
+    };
   };
-};
+}
 
 export const startServer = async (options: HarnessServerOptions): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
   const identity = options.identity ?? null;
   const machineId = options.machineId ?? (await getOrCreateMachineId());
+  const launchDir = options.launchDir ?? process.cwd();
   const adapters: Partial<Record<HarnessKind, HarnessAdapter>> =
     options.adapters ??
     ({
@@ -143,7 +154,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     ingestToken: options.bootToken,
     collectorUrl: options.collectorUrl,
     sessionsPath: options.sessionsPath,
-    buildLaunchOpts: options.buildLaunchOpts ?? defaultBuildLaunchOpts,
+    buildLaunchOpts: options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null),
   });
   await sessionManager.init();
 
@@ -177,11 +188,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     bus.publish({ type: "workflows.changed" });
   };
 
-  if (options.launchDir) {
-    scanWorkflowsAndBroadcast(options.launchDir).catch((err: unknown) => {
-      console.error("[harness] initial workflow scan failed:", err);
-    });
-  }
+  scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
+    console.error("[harness] initial workflow scan failed:", err);
+  });
 
   const eventStore = createEventStore(options.eventStorePath);
   const batcher = new CollectorBatcher({
@@ -231,6 +240,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
           console.error("[harness] workflow scan on session create failed:", err);
         });
       },
+      launchDir,
     }),
   );
   app.use(
@@ -329,6 +339,16 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       resolve();
     });
   });
+
+  // The app otherwise opens to an empty terminal pane — not fire-and-forget
+  // because a spawn failure here (e.g. claude not on PATH) is worth
+  // surfacing loudly, but also not awaited before returning: startServer()
+  // resolving shouldn't wait on a real pty spawn.
+  if (options.autoCreateSession ?? true) {
+    sessionManager.create({ cwd: launchDir, harness: "claude-code" }).catch((err: unknown) => {
+      console.error("[harness] auto-create boot session failed:", err);
+    });
+  }
 
   const address = httpServer.address();
   const actualPort = typeof address === "object" && address ? address.port : options.port;

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -44,6 +44,7 @@ describe("createRestRouter", () => {
       listWorkflows: async () => [],
       listMacros: () => [],
       onTelemetryOptInChange,
+      launchDir: "/tmp/launch-dir",
       ...overrides,
     };
     const app = express();
@@ -76,7 +77,15 @@ describe("createRestRouter", () => {
         sessions: [],
         workflows: [],
         macros: [],
+        launchDir: "/tmp/launch-dir",
       });
+    });
+
+    it("reports the server's launchDir", async () => {
+      start({ launchDir: "/Users/demo/acme-app" });
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as { launchDir: string };
+      expect(body.launchDir).toBe("/Users/demo/acme-app");
     });
 
     it("reflects identity, sessions, workflows, and macros from their sources", async () => {

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -52,6 +52,9 @@ export interface RestRouterOptions {
    * the integrator scan that directory for workflows so opening a session in
    * a new project discovers them without a manual "+ Connect". */
   onSessionCreated?: (cwd: string) => void;
+  /** The directory the CLI was launched against — surfaced in AppState so the
+   * SPA can prefill the new-session modal with it. */
+  launchDir: string;
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
@@ -71,6 +74,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
         sessions: sessionManager.list(),
         workflows: await listWorkflows(),
         macros: listMacros(),
+        launchDir: options.launchDir,
       };
       res.json(state);
     } catch (err) {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -261,6 +261,9 @@ export interface AppState {
   sessions: HarnessSession[];
   workflows: WorkflowInfo[];
   macros: MacroDef[];
+  /** The directory the CLI was launched against — the SPA prefills the
+   *  new-session modal with this instead of recentDirs[0]. */
+  launchDir: string;
 }
 
 export interface HarnessSettings {


### PR DESCRIPTION
## Summary

High-priority live-testing feedback round. Five scoped items, one PR:

1. **Consent default → opt-in** (internal/friendlies phase): copy now reads "Telemetry is ON to help us improve..." with a `[Y/n]` prompt defaulting to yes on a blank answer; the non-TTY fallback also defaults to true. `--no-telemetry` is unchanged (still forces off, no prompt either way).
2. **Auto-session on boot**: `HarnessServerOptions.autoCreateSession` (default `true`) creates a claude-code session in `launchDir` right after the server starts listening — fire-and-forget (a spawn failure is logged loudly, but `startServer()` doesn't block on a real pty spawn). The CLI's new `--no-session` flag sets it `false`. The SPA's auto-select-on-load is a separate, already-in-progress task (confirmed against the board) — nothing to coordinate there beyond making sure a session actually exists by the time it loads.
3. **`AppState.launchDir: string`** — added to `src/shared/types.ts` by agreement (server-owned state), threaded through `rest.ts`'s `/state` handler and `server/index.ts`, so the SPA can prefill the new-session modal with it instead of `recentDirs[0]`.
4. **MCP auth headers** — the fix blocking live testing ("3 MCP servers need authentication"). Verified empirically against the real `api.sapiom.ai/v1/mcp` (both `x-api-key` and `Authorization: Bearer` are accepted for `sk_`-prefixed keys; picked `x-api-key` — matches its CORS allow-list order, no prefix formatting needed). `generateMcpConfig` now takes an `apiKey` option and adds it as an `x-api-key` header on the remote `sapiom` MCP entry only (`sapiom-dev` authenticates itself separately via its own tool); omitted entirely when unauthenticated. Threaded from the cached identity through a new `createDefaultBuildLaunchOpts` factory in `server/index.ts`. The generated `mcp-config.json` can now carry a live API key, so it's written with `0o600` permissions, matching `~/.sapiom/credentials.json`.
5. **System prompt punch-up** (`profiles/default.ts`) — more assertive framing up top, and an explicit instruction to briefly acknowledge the harness context in the session's first reply (one visible line, not a lecture) so first-time users can actually see it loaded.

Also: exported `SessionManager.ensureSpawnHelperExecutable()` so `scripts/e2e-live.ts`'s preflight check applies the same node-pty spawn-helper self-heal before probing, instead of spuriously failing on a fresh install that hasn't triggered the self-heal via a real session yet.

## Known ripple — not fixed here, needs routing to whoever owns `web/` right now

`AppState.launchDir` is a required field, so `web/src/lib/api.ts`'s `MockApi.getState()` fixture needs one more line (`launchDir: "<any mock path>"`, around line 140-149) to satisfy a strict `tsc --noEmit -p web/tsconfig.json`. This does **not** break `vite build` or `pnpm test:ui` (esbuild doesn't type-check), so nothing currently gated in CI is broken — but it's a real gap for the next full typecheck of `web/`. Left untouched per scope (`web/` is out of bounds, actively being worked on by another workstream).

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` (server + web via vite) / `lint` — clean
- [x] `pnpm --filter @sapiom/harness test` — 222/222 passing across 28 files (new/extended: `consent.test.ts` for the opt-in default + interactive Y/n prompt via a mocked `readline`, `mcp-config.test.ts` for the `x-api-key` header + `0o600` permissions, `rest.test.ts` for `launchDir` in `/api/state`)
- [x] `pnpm test:ui` — 7/7 Playwright smoke tests still green
- [x] `pnpm e2e:live` — full pass, two phases: the existing core loop (now with `autoCreateSession: false` to stay deterministic against its own explicitly-created session) plus a new isolated phase proving `autoCreateSession` creates a session in `launchDir` with **no client ever calling `POST /api/sessions`**, `AppState.launchDir` reports it, and the generated `mcp-config` for an authenticated identity carries the `x-api-key` header. Exits in ~7s.
- [x] Empirically verified the real `api.sapiom.ai/v1/mcp` accepts `x-api-key` (curl'd against a real cached credential — see commit message for the full picture; never committed the real key, only a `sk_live_test123` placeholder in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)