### PR TITLE
feat(harness): surface cached-credential sign-in; mount fs.ts path-picker router

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -28,6 +28,8 @@
  *      session in launchDir without any client ever calling POST
  *      /api/sessions, AppState.launchDir reports it, and the generated
  *      mcp-config for an authenticated identity carries the x-api-key header.
+ *   9. GET /api/fs/list (the path-picker's directory autocomplete) is
+ *      mounted and boot-token-gated like the rest of /api.
  *
  * Run with: pnpm e2e:live
  */
@@ -481,6 +483,18 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
     assert(
       mcpConfigJson.mcpServers?.sapiom?.headers?.["x-api-key"] === apiKey,
       "generated mcp-config's remote sapiom entry carries the cached apiKey as x-api-key",
+    );
+
+    // --- fs.ts's directory-autocomplete router (path picker) is mounted behind the boot token ---
+    const fsUnauthedRes = await fetch(`${baseUrl}/api/fs/list?path=${encodeURIComponent(tmpRoot)}`);
+    assert(fsUnauthedRes.status === 401, "GET /api/fs/list requires the boot token, like the rest of /api");
+
+    const fsRes = await fetch(`${baseUrl}/api/fs/list?path=${encodeURIComponent(tmpRoot)}`, { headers });
+    assert(fsRes.status === 200, "GET /api/fs/list (with token) returns 200");
+    const fsBody = (await fsRes.json()) as { dirs: Array<{ name: string; path: string }> };
+    assert(
+      fsBody.dirs.some((d) => d.path === projectDir),
+      "GET /api/fs/list lists the boot project directory it was pointed at",
     );
   } finally {
     await server.close();

--- a/packages/harness/src/cli/auth.test.ts
+++ b/packages/harness/src/cli/auth.test.ts
@@ -49,6 +49,7 @@ describe("ensureAuthenticated", () => {
       tenantId: "tenant-1",
       organizationName: "Acme",
       apiKey: "key-1",
+      source: "cached",
     });
     expect(performBrowserAuth).not.toHaveBeenCalled();
   });
@@ -83,6 +84,7 @@ describe("ensureAuthenticated", () => {
       tenantId: "tenant-2",
       organizationName: "Beta",
       apiKey: "key-2",
+      source: "fresh",
     });
   });
 

--- a/packages/harness/src/cli/auth.ts
+++ b/packages/harness/src/cli/auth.ts
@@ -10,6 +10,10 @@ export interface HarnessIdentity {
   tenantId: string;
   organizationName: string;
   apiKey: string;
+  /** "cached" when resolved from ~/.sapiom/credentials.json with no login
+   *  prompt this run; "fresh" right after a browser login just completed.
+   *  Lets the CLI make a silent cached-credential sign-in visible. */
+  source: "cached" | "fresh";
 }
 
 export interface EnsureAuthenticatedOptions {
@@ -41,6 +45,7 @@ export async function ensureAuthenticated(
       tenantId: existing.tenantId,
       organizationName: existing.organizationName,
       apiKey: existing.apiKey,
+      source: "cached",
     };
   }
 
@@ -59,5 +64,6 @@ export async function ensureAuthenticated(
     tenantId: result.tenantId,
     organizationName: result.organizationName,
     apiKey: result.apiKey,
+    source: "fresh",
   };
 }

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -95,7 +95,9 @@ function printBanner(opts: {
   serverStarted: boolean;
 }): void {
   const authLine = opts.identity
-    ? `${opts.identity.organizationName} (${opts.identity.userId})`
+    ? `${opts.identity.organizationName} (${opts.identity.userId})${
+        opts.identity.source === "cached" ? " — cached" : ""
+      }`
     : "not authenticated";
 
   console.log("");
@@ -130,6 +132,12 @@ const main = async (): Promise<void> => {
   const machineId = await getOrCreateMachineId();
 
   const identity = await ensureAuthenticated({ interactive: true, noAuth: options.noAuth });
+  // A cached credential signs you in with no visible prompt at all — call it
+  // out explicitly so "auth silently worked" doesn't read as "nothing
+  // happened" (a fresh login is its own visible browser flow already).
+  if (identity?.source === "cached") {
+    console.log(`\nSigned in as ${identity.organizationName} (cached credential).`);
+  }
   const telemetryOptIn = await ensureConsent({ noTelemetry: options.noTelemetry });
   await recordRecentDir(options.dir);
 

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -42,6 +42,7 @@ import { attachWebSocketRouters } from "./ws-router.js";
 import { createIngestRouter, type IngestSessionContext } from "./ingest.js";
 import { createCanvasRouter } from "./canvas.js";
 import { createMacrosRouter } from "./macros.js";
+import { createFsRouter } from "./fs.js";
 
 /** Workflow list is refreshed off this interval for the (synchronous)
  * macro-resolution lookup — connect/scan are infrequent user actions, so a
@@ -245,6 +246,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   );
   app.use(
     createWorkflowsRouter(workflowRegistry),
+    createFsRouter(),
     createMacrosRouter({
       listMacros: () => DEFAULT_MACROS,
       findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,


### PR DESCRIPTION
## Summary

Addendum to the first-user fix round (PR #192), per follow-up feedback from Dave's live test.

- **Auth visibility** — auth was silently succeeding via a cached credential (correct behavior), but that read as "did anything happen?" during live testing since there's no browser flow to notice. `HarnessIdentity` gains a `source: "cached" | "fresh"` field; `bin.ts` prints `Signed in as <org> (cached credential).` immediately after auth resolves when it came from the cache (a fresh browser login is already its own visible flow, so no extra message there), and the startup banner's auth line appends `— cached` too.
- Re-verified `/api/state`'s `authenticated`/`userId`/`organizationName` population — already correctly derived from the resolved identity in the one place that builds `AppState` (`rest.ts`'s `/state` handler). No population bug found; the actual gap was purely visibility, now addressed above.
- **Mounted `server/fs.ts`'s `createFsRouter()`** (`GET /api/fs/list` — the path-picker's directory autocomplete, landed via PR #190 but never wired into `server/index.ts`) behind the existing `/api` boot-token middleware.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` (server + web) / `lint` — clean, including a strict `tsc --noEmit -p web/tsconfig.json` (clean now that the `launchDir` mock-fixture fix from PR #193 is merged in)
- [x] `pnpm --filter @sapiom/harness test` — 222/222 passing (updated `auth.test.ts` for the new `source` field)
- [x] `pnpm test:ui` — 10/10 Playwright smoke tests green
- [x] `pnpm e2e:live` — 36/36 assertions passing (~7s), including 3 new ones proving `GET /api/fs/list` 401s without the boot token, 200s with it, and lists the directory it's pointed at
- [x] Live smoke: `node dist/cli/bin.js --no-open --no-telemetry --no-session --dev /tmp` against this machine's real cached credential — confirmed both the immediate "Signed in as ... (cached credential)." message and the banner's "— cached" suffix appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)