### PR TITLE
fix(harness): align fs/list client with the real router's contract

### DIFF
--- a/packages/harness/web/src/components/DirectoryPicker.tsx
+++ b/packages/harness/web/src/components/DirectoryPicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
 
-import type { FsListEntry, FsListResponse } from "../lib/api";
+import type { FsDirEntry, FsListResponse } from "../lib/api";
 import { Icon } from "./Icon";
 
 interface DirectoryPickerProps {
@@ -21,8 +21,10 @@ interface DirectoryPickerProps {
  */
 export function DirectoryPicker({ value, onChange, onSubmit, recentDirs, listDir }: DirectoryPickerProps): JSX.Element {
   const [browsePath, setBrowsePath] = useState(value);
-  const [dirs, setDirs] = useState<FsListEntry[]>([]);
-  const [parent, setParent] = useState<string | null>(null);
+  const [dirs, setDirs] = useState<FsDirEntry[]>([]);
+  // Always a real path (root's parent is itself, per path.dirname("/") === "/") —
+  // "no further up" is `parent === browsePath`, not null.
+  const [parent, setParent] = useState(value);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -70,8 +72,8 @@ export function DirectoryPicker({ value, onChange, onSubmit, recentDirs, listDir
           type="button"
           className="dir-picker-up"
           data-testid="dir-picker-up"
-          disabled={!parent}
-          onClick={() => parent && navigate(parent)}
+          disabled={parent === browsePath}
+          onClick={() => navigate(parent)}
           title="Up to parent directory"
         >
           <Icon name="CornerLeftUp" size={14} />

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -30,26 +30,26 @@ export function getBootToken(): string {
 }
 
 /**
- * AppState + `launchDir` (the directory the harness was launched from — the
- * default seed for the new-session directory picker). Not yet in the shared
- * contract (landing in parallel); typed locally here rather than editing it.
+ * GET /api/fs/list?path= response shape (directory autocomplete for the
+ * new-session picker). Mirrors src/server/fs.ts's own local types — not yet
+ * folded into the shared contract, so duplicated here rather than importing
+ * across the client/server boundary. `parent` is always a real path, never
+ * null: at the filesystem root it equals `path` itself (matches
+ * `path.dirname("/") === "/"`), so "no further up" is `parent === path`.
  */
-export type AppStateEx = AppState & { launchDir?: string | null };
-
-/** GET /api/fs/list?path= response shape (directory autocomplete for the new-session picker). */
-export interface FsListEntry {
+export interface FsDirEntry {
   name: string;
   path: string;
 }
 
 export interface FsListResponse {
   path: string;
-  parent: string | null;
-  dirs: FsListEntry[];
+  parent: string;
+  dirs: FsDirEntry[];
 }
 
 export interface HarnessApi {
-  getState(): Promise<AppStateEx>;
+  getState(): Promise<AppState>;
   createSession(req: CreateSessionRequest): Promise<HarnessSession>;
   listSessions(): Promise<HarnessSession[]>;
   sessionHistory(cwd: string): Promise<SessionSummary[]>;
@@ -84,8 +84,8 @@ class RealApi implements HarnessApi {
     return (await res.json()) as T;
   }
 
-  getState(): Promise<AppStateEx> {
-    return this.request<AppStateEx>("/api/state");
+  getState(): Promise<AppState> {
+    return this.request<AppState>("/api/state");
   }
 
   createSession(req: CreateSessionRequest): Promise<HarnessSession> {
@@ -160,11 +160,10 @@ class MockApi implements HarnessApi {
   private workflows = MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
   private settings: HarnessSettings = { ...MOCK_SETTINGS, recentDirs: [...MOCK_SETTINGS.recentDirs] };
 
-  async getState(): Promise<AppStateEx> {
+  async getState(): Promise<AppState> {
     await delay();
     return {
       version: "0.0.1-mock",
-      launchDir: "/Users/demo/acme-app",
       authenticated: true,
       userId: "user_mock",
       organizationName: "Acme (mock)",
@@ -279,7 +278,8 @@ class MockApi implements HarnessApi {
 
     const names = MOCK_FS_TREE[normalized] ?? [];
     const segments = normalized.split("/").filter(Boolean);
-    const parent = normalized === "/" ? null : segments.length <= 1 ? "/" : "/" + segments.slice(0, -1).join("/");
+    // Matches path.dirname("/") === "/" — root's own parent is itself, never null.
+    const parent = normalized === "/" ? "/" : segments.length <= 1 ? "/" : "/" + segments.slice(0, -1).join("/");
     return {
       path: normalized,
       parent,

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type {
+  AppState,
   BusMessage,
   CreateSessionRequest,
   HarnessSession,
@@ -9,13 +10,13 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 
-import { createApi, getBootToken, type AppStateEx, type FsListResponse } from "./api";
+import { createApi, getBootToken, type FsListResponse } from "./api";
 import { subscribeEvents } from "./events";
 
 const api = createApi();
 
 export interface HarnessStateHook {
-  state: AppStateEx | null;
+  state: AppState | null;
   loading: boolean;
   error: string | null;
   settings: HarnessSettings | null;
@@ -39,7 +40,7 @@ export interface HarnessStateHook {
 
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
 export function useHarnessState(): HarnessStateHook {
-  const [state, setState] = useState<AppStateEx | null>(null);
+  const [state, setState] = useState<AppState | null>(null);
   const [settings, setSettings] = useState<HarnessSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Small follow-up now that `src/server/fs.ts` (the real `/api/fs/list` router) and the real `AppState.launchDir` have landed on `feat/harness` — PR #193 shipped the rebrand/picker/identity work against a locally-typed guess at both contracts; this reconciles the client with what actually landed.

- `FsListResponse.parent` is always a real path, never `null` — the real router returns `path.dirname(resolved)`, and `path.dirname("/") === "/"`, so the filesystem root's parent is itself. Updated the client type and `DirectoryPicker`'s "up" button to disable on `parent === browsePath` instead of a falsy check.
- Renamed the local `FsListEntry` type to `FsDirEntry` to match the real router's own naming (`src/server/fs.ts`), since these aren't (yet) folded into the shared contract and having them read the same reduces confusion for whoever consolidates them later.
- `AppState.launchDir` is a real, required field now — dropped the local `AppStateEx` workaround type and switched `getState()`/`useHarnessState`'s state back to plain `AppState`.
- Removed a duplicate `launchDir` key in `MockApi.getState()` that a 3-way merge produced (both this branch and a direct commit on `feat/harness` independently added the same field around the same time — merged cleanly once both landed).

No behavior change for the mock-mode demo path; this only tightens the real-mode contract alignment and simplifies the types.

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright) — 10/10 passing, unchanged from PR #193
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 28 files / 222 tests passing (includes the newly-merged `fs.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)