### PR TITLE
refactor(harness): promote FsDirEntry/FsListResponse into shared/types.ts

### DIFF
--- a/packages/harness/src/server/fs.ts
+++ b/packages/harness/src/server/fs.ts
@@ -9,19 +9,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
+import type { FsDirEntry, FsListResponse } from "../shared/types.js";
+
+export type { FsDirEntry, FsListResponse } from "../shared/types.js";
 
 const MAX_RESULTS = 200;
-
-export interface FsDirEntry {
-  name: string;
-  path: string;
-}
-
-export interface FsListResponse {
-  path: string;
-  parent: string;
-  dirs: FsDirEntry[];
-}
 
 function expandHome(input: string): string {
   if (input === "~") return os.homedir();

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -236,6 +236,7 @@ export interface CollectorBatch {
 // POST   /api/macros/:id/run            RunMacroRequest → { ok: true }
 // GET    /api/settings                  → HarnessSettings
 // PATCH  /api/settings                  Partial<HarnessSettings> → HarnessSettings
+// GET    /api/fs/list?path=&hidden=     → FsListResponse (directory autocomplete)
 // POST   /ingest                        (hook payloads; bearer = ingest token)
 
 export interface CreateSessionRequest {
@@ -270,6 +271,27 @@ export interface HarnessSettings {
   telemetryOptIn: boolean;
   /** Most-recently-used project directories, newest first. */
   recentDirs: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem browsing (new-session directory picker autocomplete)
+// ---------------------------------------------------------------------------
+
+export interface FsDirEntry {
+  name: string;
+  path: string;
+}
+
+/**
+ * GET /api/fs/list?path= response — directories only, one level deep.
+ * `parent` is always a real path, never null: at the filesystem root it
+ * equals `path` itself (matches `path.dirname("/") === "/"`), so "no
+ * further up" is `parent === path`.
+ */
+export interface FsListResponse {
+  path: string;
+  parent: string;
+  dirs: FsDirEntry[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -7,6 +7,8 @@
 import type {
   AppState,
   CreateSessionRequest,
+  FsDirEntry,
+  FsListResponse,
   HarnessSession,
   HarnessSettings,
   InjectInputRequest,
@@ -18,6 +20,8 @@ import type {
 
 import { MOCK_FS_TREE, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_WORKFLOWS } from "./mock-data";
 
+export type { FsDirEntry, FsListResponse };
+
 export function isMockMode(): boolean {
   return import.meta.env.VITE_MOCK === "1";
 }
@@ -27,25 +31,6 @@ export function getBootToken(): string {
   const injected = (window as unknown as { __HARNESS__?: { token?: string } }).__HARNESS__;
   if (injected?.token) return injected.token;
   return new URLSearchParams(window.location.search).get("token") ?? "";
-}
-
-/**
- * GET /api/fs/list?path= response shape (directory autocomplete for the
- * new-session picker). Mirrors src/server/fs.ts's own local types — not yet
- * folded into the shared contract, so duplicated here rather than importing
- * across the client/server boundary. `parent` is always a real path, never
- * null: at the filesystem root it equals `path` itself (matches
- * `path.dirname("/") === "/"`), so "no further up" is `parent === path`.
- */
-export interface FsDirEntry {
-  name: string;
-  path: string;
-}
-
-export interface FsListResponse {
-  path: string;
-  parent: string;
-  dirs: FsDirEntry[];
 }
 
 export interface HarnessApi {


### PR DESCRIPTION
## Summary
- `server/fs.ts` and `web/src/lib/api.ts` each declared identical local copies of `FsDirEntry`/`FsListResponse` since the fs-browsing endpoint (`GET /api/fs/list`) predated the shared contract file.
- Moves both interfaces into `src/shared/types.ts` (with a doc comment on `FsListResponse.parent`'s root-path convention) and adds the endpoint to the REST API surface comment table.
- `server/fs.ts` now imports from shared types and re-exports them for backward compatibility with existing consumers (`fs.test.ts` needs no change).
- `web/src/lib/api.ts` now imports from `@shared/types` and re-exports, so `DirectoryPicker.tsx`, `SessionBar.tsx`, `NewSessionModal.tsx`, and `use-harness-state.ts` (which all import from `../lib/api`) need no changes.
- No behavior change — pure type consolidation.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck` (server)
- [x] `npx tsc --noEmit -p web/tsconfig.json` (strict web check)
- [x] `pnpm --filter @sapiom/harness test` — 222/222 passed
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness build` — server + web (vite) build clean
- [x] `pnpm --filter @sapiom/harness e2e:live` — 38/38 assertions passed, including `GET /api/fs/list` auth/content checks
- [x] `pnpm --filter @sapiom/harness test:ui` — 10/10 Playwright smoke tests passed

Co-Authored-By: Claude <noreply@anthropic.com>