### PR TITLE
feat(harness): light mode + theme toggle

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -24,6 +24,30 @@ test("renders all four panes plus the brand header", async ({ page }) => {
   await page.screenshot({ path: "web/e2e/screenshots/app-shell.png", fullPage: true });
 });
 
+test("theme: defaults to light, toggles to dark, and the choice persists across reload", async ({ page }) => {
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await page.screenshot({ path: "web/e2e/screenshots/theme-light.png", fullPage: true });
+
+  await page.getByTestId("theme-toggle").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await page.screenshot({ path: "web/e2e/screenshots/theme-dark.png", fullPage: true });
+
+  await page.reload();
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+  await page.getByTestId("theme-toggle").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+});
+
+test.describe("theme — system preference", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("honors prefers-color-scheme when there's no stored preference yet", async ({ page }) => {
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  });
+});
+
 test("brand header shows the Sapiom wordmark and signed-in identity", async ({ page }) => {
   await expect(page.locator(".brand-name")).toHaveText("Sapiom");
   await expect(page.locator(".brand-product")).toHaveText("Harness");

--- a/packages/harness/web/index.html
+++ b/packages/harness/web/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sapiom Harness</title>
+    <script>
+      // Set the theme before first paint to avoid a flash of the wrong one.
+      // Storage key must match web/src/lib/theme.ts (this can't import it).
+      (function () {
+        var stored = localStorage.getItem("sapiom-harness-theme");
+        var theme =
+          stored === "light" || stored === "dark"
+            ? stored
+            : window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/harness/web/src/components/BrandHeader.tsx
+++ b/packages/harness/web/src/components/BrandHeader.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from "react";
 import type { JSX } from "react";
 
 import sapiomMark from "../assets/sapiom-mark.svg";
+import { getTheme, subscribeTheme, toggleTheme } from "../lib/theme";
+import { Icon } from "./Icon";
 
 interface BrandHeaderProps {
   authenticated: boolean;
@@ -8,6 +11,9 @@ interface BrandHeaderProps {
 }
 
 export function BrandHeader({ authenticated, organizationName }: BrandHeaderProps): JSX.Element {
+  const [theme, setTheme] = useState(getTheme());
+  useEffect(() => subscribeTheme(setTheme), []);
+
   return (
     <header className="brand-header">
       <div className="brand-lockup">
@@ -17,9 +23,21 @@ export function BrandHeader({ authenticated, organizationName }: BrandHeaderProp
         <span className="brand-product">Harness</span>
       </div>
 
-      <div className="brand-identity" data-testid="brand-identity">
-        <span className="identity-dot" data-authenticated={authenticated} />
-        {authenticated ? (organizationName ?? "Signed in") : "Not signed in"}
+      <div className="brand-header-right">
+        <button
+          className="theme-toggle"
+          data-testid="theme-toggle"
+          aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          onClick={toggleTheme}
+        >
+          <Icon name={theme === "dark" ? "Sun" : "Moon"} size={15} />
+        </button>
+
+        <div className="brand-identity" data-testid="brand-identity">
+          <span className="identity-dot" data-authenticated={authenticated} />
+          {authenticated ? (organizationName ?? "Signed in") : "Not signed in"}
+        </div>
       </div>
     </header>
   );

--- a/packages/harness/web/src/components/Icon.tsx
+++ b/packages/harness/web/src/components/Icon.tsx
@@ -6,11 +6,13 @@ import {
   Folder,
   HelpCircle,
   type LucideIcon,
+  Moon,
   Play,
   Plus,
   Radio,
   Settings,
   Sparkles,
+  Sun,
   Zap,
 } from "lucide-react";
 import type { JSX } from "react";
@@ -26,11 +28,13 @@ const ICONS: Record<string, LucideIcon> = {
   CornerLeftUp,
   ExternalLink,
   Folder,
+  Moon,
   Play,
   Plus,
   Radio,
   Settings,
   Sparkles,
+  Sun,
   Zap,
 };
 

--- a/packages/harness/web/src/components/Terminal.tsx
+++ b/packages/harness/web/src/components/Terminal.tsx
@@ -8,11 +8,12 @@
  */
 
 import { useEffect, useRef, useState, type JSX } from "react";
-import { Terminal as XTerm } from "@xterm/xterm";
+import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl } from "../lib/terminal-ws.js";
+import { getTheme, subscribeTheme, type Theme } from "../lib/theme.js";
 
 export interface TerminalProps {
   sessionId: string;
@@ -27,48 +28,98 @@ const MAX_RECONNECT_DELAY_MS = 15_000;
 // both are permanent for this WS instance; retrying won't help.
 const PERMANENT_CLOSE_CODES = new Set([4001, 4004]);
 
-// Palette values below are copied (values only) from Sapiom's own dark-mode
-// design tokens, so the embedded terminal reads as part of the app rather
-// than a bare xterm.js default panel.
-const PANEL_BACKGROUND = "#0E0E0E";
-const TEXT_PRIMARY = "#FAFAFA";
-const TEXT_MUTED = "#A1A1AA";
-const BRAND_ACCENT = "#6BE195";
-const BORDER_SUBTLE = "#2E2E2E";
+// Status-pill colors are global constants in Sapiom's own design system (not
+// overridden per light/dark) — kept as plain constants rather than per-theme.
 const STATUS_SUCCESS = "#10B981";
 const STATUS_WAITING = "#F59E0B";
 const STATUS_ERROR = "#EF4444";
 const MONO_FONT_STACK =
   '"SF Mono", Menlo, Monaco, Inconsolata, "Source Code Pro", Consolas, "Liberation Mono", "Ubuntu Mono", "Courier Prime", "JetBrains Mono", "Courier New", monospace';
 
-const XTERM_THEME = {
-  background: PANEL_BACKGROUND,
-  foreground: TEXT_PRIMARY,
-  cursor: BRAND_ACCENT,
-  cursorAccent: PANEL_BACKGROUND,
-  selectionBackground: "rgba(107, 225, 149, 0.25)",
-  black: "#1A1A1A",
-  red: "#f87171",
-  green: BRAND_ACCENT,
-  yellow: "#f59e0b",
-  blue: "#3b82f6",
-  magenta: "#a78bfa",
-  cyan: "#22d3ee",
-  white: TEXT_PRIMARY,
-  brightBlack: "#404040",
-  brightRed: "#ff9b96",
-  brightGreen: "#8bd4a6",
-  brightYellow: "#ffd966",
-  brightBlue: "#60a5fa",
-  brightMagenta: "#c4b5fd",
-  brightCyan: "#67e8f9",
-  brightWhite: "#ffffff",
+interface PanelPalette {
+  panelBackground: string;
+  textMuted: string;
+  borderSubtle: string;
+  xterm: ITheme;
+}
+
+// Palette values below are copied (values only) from Sapiom's own design
+// tokens for each theme, so the embedded terminal reads as part of the app
+// rather than a bare xterm.js default panel.
+const DARK_PALETTE: PanelPalette = {
+  panelBackground: "#0E0E0E",
+  textMuted: "#A1A1AA",
+  borderSubtle: "#2E2E2E",
+  xterm: {
+    background: "#0E0E0E",
+    foreground: "#FAFAFA",
+    cursor: "#6BE195",
+    cursorAccent: "#0E0E0E",
+    selectionBackground: "rgba(107, 225, 149, 0.25)",
+    black: "#1A1A1A",
+    red: "#f87171",
+    green: "#6BE195",
+    yellow: "#f59e0b",
+    blue: "#3b82f6",
+    magenta: "#a78bfa",
+    cyan: "#22d3ee",
+    white: "#FAFAFA",
+    brightBlack: "#404040",
+    brightRed: "#ff9b96",
+    brightGreen: "#8bd4a6",
+    brightYellow: "#ffd966",
+    brightBlue: "#60a5fa",
+    brightMagenta: "#c4b5fd",
+    brightCyan: "#67e8f9",
+    brightWhite: "#ffffff",
+  },
 };
+
+const LIGHT_PALETTE: PanelPalette = {
+  panelBackground: "#FFFFFF",
+  textMuted: "#737373",
+  borderSubtle: "#E5E5E5",
+  xterm: {
+    background: "#FFFFFF",
+    foreground: "#1A1A1A",
+    cursor: "#05A9BC",
+    cursorAccent: "#FFFFFF",
+    selectionBackground: "rgba(5, 169, 188, 0.18)",
+    black: "#3A3A3A",
+    red: "#dc2626",
+    green: "#05A9BC",
+    yellow: "#b45309",
+    blue: "#2563eb",
+    magenta: "#7c3aed",
+    cyan: "#0891b2",
+    white: "#d4d4d8",
+    brightBlack: "#737373",
+    brightRed: "#ef4444",
+    brightGreen: "#06b6d4",
+    brightYellow: "#f59e0b",
+    brightBlue: "#3b82f6",
+    brightMagenta: "#a78bfa",
+    brightCyan: "#22d3ee",
+    brightWhite: "#ffffff",
+  },
+};
+
+const paletteFor = (theme: Theme): PanelPalette => (theme === "dark" ? DARK_PALETTE : LIGHT_PALETTE);
 
 export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<XTerm | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("connecting");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [theme, setTheme] = useState<Theme>(getTheme());
+
+  // Re-applies live on toggle — doesn't touch the pty connection, so this is
+  // a separate effect from the one that opens the terminal/socket below.
+  useEffect(() => subscribeTheme(setTheme), []);
+
+  useEffect(() => {
+    if (termRef.current) termRef.current.options.theme = paletteFor(theme).xterm;
+  }, [theme]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -83,10 +134,11 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
       cursorBlink: true,
       fontSize: 13,
       fontFamily: MONO_FONT_STACK,
-      theme: XTERM_THEME,
+      theme: paletteFor(getTheme()).xterm,
       scrollback: 10_000,
       allowProposedApi: true,
     });
+    termRef.current = term;
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
@@ -177,6 +229,7 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
       inputDisposable.dispose();
       ws?.close();
       term.dispose();
+      termRef.current = null;
     };
   }, [sessionId, token]);
 
@@ -184,6 +237,7 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
     status === "connected" ? STATUS_SUCCESS : status === "error" ? STATUS_ERROR : STATUS_WAITING;
   const statusLabel =
     status === "connected" ? "Connected" : status === "error" ? (errorMessage ?? "Error") : "Connecting…";
+  const palette = paletteFor(theme);
 
   return (
     // Stable hook for the surrounding app shell to lay out/border this panel —
@@ -195,9 +249,9 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
         flexDirection: "column",
         height: "100%",
         width: "100%",
-        background: PANEL_BACKGROUND,
+        background: palette.panelBackground,
         borderRadius: 8,
-        border: `1px solid ${BORDER_SUBTLE}`,
+        border: `1px solid ${palette.borderSubtle}`,
         overflow: "hidden",
       }}
     >
@@ -209,7 +263,7 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
           gap: 6,
           flexShrink: 0,
           padding: "6px 10px",
-          borderBottom: `1px solid ${BORDER_SUBTLE}`,
+          borderBottom: `1px solid ${palette.borderSubtle}`,
           fontFamily: MONO_FONT_STACK,
           fontSize: 11,
         }}
@@ -225,7 +279,7 @@ export const Terminal = ({ sessionId, token }: TerminalProps): JSX.Element => {
             flexShrink: 0,
           }}
         />
-        <span style={{ color: TEXT_MUTED }}>{statusLabel}</span>
+        <span style={{ color: palette.textMuted }}>{statusLabel}</span>
       </div>
       <div ref={containerRef} style={{ flex: 1, minHeight: 0, padding: 8 }} />
     </div>

--- a/packages/harness/web/src/lib/theme.ts
+++ b/packages/harness/web/src/lib/theme.ts
@@ -1,0 +1,45 @@
+export type Theme = "light" | "dark";
+
+/**
+ * Must match the inline script in web/index.html — that copy runs before any
+ * JS module loads (avoids a flash of the wrong theme) and can't import this
+ * one, so the storage key is duplicated rather than shared.
+ */
+const STORAGE_KEY = "sapiom-harness-theme";
+
+type Listener = (theme: Theme) => void;
+const listeners = new Set<Listener>();
+
+function systemPrefersDark(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches === true;
+}
+
+/** No stored preference and no dark system signal → light, matching the Sapiom product's own default. */
+export function getInitialTheme(): Theme {
+  const stored = typeof window !== "undefined" ? window.localStorage.getItem(STORAGE_KEY) : null;
+  if (stored === "light" || stored === "dark") return stored;
+  return systemPrefersDark() ? "dark" : "light";
+}
+
+let current: Theme = getInitialTheme();
+
+export function getTheme(): Theme {
+  return current;
+}
+
+export function applyTheme(theme: Theme): void {
+  current = theme;
+  document.documentElement.dataset.theme = theme;
+  window.localStorage.setItem(STORAGE_KEY, theme);
+  listeners.forEach((listener) => listener(theme));
+}
+
+export function toggleTheme(): void {
+  applyTheme(current === "dark" ? "light" : "dark");
+}
+
+/** For components (e.g. the terminal) that need to react to a live theme change. Returns an unsubscribe function. */
+export function subscribeTheme(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1,6 +1,36 @@
 :root {
-  /* Sapiom brand palette — values ported from our design system's dark theme
-     (product name intentionally omitted from color names; these are just hex). */
+  /* Shared, theme-independent tokens. */
+  --radius: 6px;
+  --font-sans:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Sapiom brand palette, LIGHT — values ported from our design system.
+     This is the default: it's what the authenticated product itself renders
+     (the dashboard forces light), so it's the correct fallback if the
+     data-theme attribute (set by an inline script in index.html, before this
+     stylesheet is even parsed) is ever missing. See web/src/lib/theme.ts. */
+  --bg-0: #f3f4f6;
+  --bg-1: #f5f5f5;
+  --bg-2: #f5f5f5;
+  --bg-3: #f5f5f5;
+  --bg-hover: #e5e7eb;
+  --border: #e5e5e5;
+  --border-strong: #d4d4d8;
+  --text: #1a1a1a;
+  --text-dim: #737373;
+  --text-faint: #a1a1aa;
+  --accent: #05a9bc;
+  --accent-hover: #048a9a;
+  --accent-dim: rgba(5, 169, 188, 0.14);
+  --accent-foreground: #fafafa;
+  --green: #05a9bc;
+  --amber: #b45309;
+  --red: #ef4444;
+}
+
+[data-theme="dark"] {
+  /* Sapiom brand palette, DARK — values ported from our design system. */
   --bg-0: #0f0f0f;
   --bg-1: #1a1a1a;
   --bg-2: #1a1a1a;
@@ -18,10 +48,6 @@
   --green: #6be195;
   --amber: #f59e0b;
   --red: #f87171;
-  --radius: 6px;
-  --font-sans:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 * {
@@ -112,6 +138,30 @@ input {
   font-size: 13px;
   font-weight: 500;
   color: var(--text-dim);
+}
+
+.brand-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.theme-toggle {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  color: var(--text-dim);
+}
+
+.theme-toggle:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .brand-identity {
@@ -654,7 +704,7 @@ input {
   padding: 3px 8px;
   border: 1px solid var(--green);
   color: var(--green);
-  background: rgba(62, 207, 142, 0.08);
+  background: color-mix(in srgb, var(--green) 10%, transparent);
   border-radius: 20px;
   font-size: 11px;
   white-space: nowrap;


### PR DESCRIPTION
## Summary

Sapiom's product now has a light theme and it's the default (the authenticated dashboard forces light, per the design system's own `forcedTheme="light"` override) — the dark-only harness no longer matched. This ports both palettes and adds a toggle.

- **Tokens**: `styles.css`'s `:root` now holds the *light* palette (the correct fallback if `data-theme` is ever unset, since light is what the real authenticated product renders), with `[data-theme="dark"]` overriding to the dark one. Light and dark use genuinely different brand accents per the source design system — teal `#05A9BC` in light, green `#6BE195` in dark — with matching foreground colors so text stays legible on each (light mode's teal needs white text, dark mode's bright green needs black; both are correct in this PR). Found and fixed one leftover hardcoded `rgba()` (the preview-status chip) that didn't track the accent variable and would've stayed green-tinted in light mode.
- **Switch mechanism**: new `web/src/lib/theme.ts` (get/apply/toggle/subscribe), backed by `localStorage` with a `prefers-color-scheme` fallback for first-time users — light wins when there's no dark signal either way, matching the confirmed brand default. A duplicated inline script in `index.html` sets `data-theme` before first paint so there's no flash of the wrong theme on load.
- **Toggle UI**: sun/moon icon button in `BrandHeader.tsx`, next to the identity chip.
- **Terminal**: `Terminal.tsx`'s hardcoded dark xterm theme is now two theme objects (light/dark), re-applied live via `term.options.theme` when the toggle fires — the XDA/OSC-52/reconnect logic is untouched. I own this file for this task only (server-side terminal work is happening concurrently elsewhere, no conflict). The seeded canvas HTML is agent/user territory and wasn't touched, per the brief.
- **Tests**: new Playwright spec — defaults to light, toggles to dark, persists across a full reload, and honors `prefers-color-scheme` when there's no stored preference (a dedicated `test.use({ colorScheme: "dark" })` block). Screenshots of both themes saved (gitignored, regenerated per run).

## Screenshots

Both reviewed locally (`web/e2e/screenshots/theme-{light,dark}.png`, gitignored):
- **Light** (default): light gray app background, white-ish panels, teal accent on the selected workflow row / "+ new" button / identity dot.
- **Dark** (toggled): matches the existing dark palette from the rebrand round, green accent, sun icon now showing in the header (click to go back to light).
Also spot-checked the new-session modal, settings popover, and the action-rail tooltip in both themes — all legible, no leftover hardcoded colors.

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright) — 12/12 passing (2 new theme specs; all prior specs unaffected)
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 28 files / 222 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)