### PR TITLE
feat(harness): native setup without Claude Code

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -30,6 +30,11 @@
  *      mcp-config for an authenticated identity carries the x-api-key header.
  *   9. GET /api/fs/list (the path-picker's directory autocomplete) is
  *      mounted and boot-token-gated like the rest of /api.
+ *  10. (third, isolated server instance) `defaultHarnessKind: "codex"`
+ *      (as the CLI resolves it from doctor() when claude isn't on PATH)
+ *      makes the auto-created boot session launch via the codex adapter, and
+ *      `availableHarnesses` passed to startServer() round-trips through
+ *      GET /api/state.
  *
  * Run with: pnpm e2e:live
  */
@@ -502,6 +507,82 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
   }
 }
 
+/**
+ * Phase 9: a third isolated server instance proving `defaultHarnessKind`
+ * actually drives which agent the auto-created boot session launches — the
+ * "codex when claude-code isn't available" fallback from doctor.ts's
+ * availableHarnesses, without needing a real `codex` binary. Reuses the same
+ * fake-claude fixture in the "codex" adapter slot: the fixture doesn't care
+ * what flags it's called with, so it stands in fine to prove dispatch, not
+ * codex-specific argv shape (that's covered by codex.test.ts).
+ */
+async function testAutoSessionKindSelection(): Promise<void> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-e2e-live-kind-"));
+  const projectDir = path.join(tmpRoot, "project");
+  await fs.mkdir(projectDir, { recursive: true });
+
+  const bootToken = crypto.randomUUID();
+  const captureFile = path.join(tmpRoot, "fake-codex-capture.json");
+  process.env.FAKE_CLAUDE_CAPTURE = captureFile;
+
+  const server = await startServer({
+    port: 0,
+    bootToken,
+    telemetryOptIn: false,
+    identity: { userId: "kind-user", tenantId: "kind-tenant", organizationName: "Kind Org", apiKey: "e2e-key" },
+    machineId: "e2e-kind-machine",
+    // No claude-code adapter registered at all — if defaultHarnessKind were
+    // ignored and the auto-create fell back to its old hardcoded
+    // "claude-code", SessionManager.create() would reject with "no adapter
+    // for claude-code" and this phase would fail loudly rather than silently
+    // passing for the wrong reason.
+    adapters: { codex: createCodexAdapter({ binary: FAKE_CLAUDE }) },
+    sessionsPath: path.join(tmpRoot, "sessions.json"),
+    eventStorePath: path.join(tmpRoot, "events.ndjson"),
+    workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    launchDir: projectDir,
+    defaultHarnessKind: "codex",
+    availableHarnesses: ["codex"],
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  const headers = { "Content-Type": "application/json", "X-Harness-Token": bootToken };
+
+  try {
+    type StateLike = {
+      availableHarnesses?: string[];
+      sessions: Array<{ id: string; cwd: string; harness: string }>;
+    };
+    const state = await waitFor<StateLike>(async () => {
+      const res = await fetch(`${baseUrl}/api/state`, { headers });
+      const body = (await res.json()) as StateLike;
+      return body.sessions.some((s) => s.cwd === projectDir) ? body : undefined;
+    });
+    const bootSession = state.sessions.find((s) => s.cwd === projectDir);
+    assert(bootSession?.harness === "codex", "defaultHarnessKind: codex drives the auto-created session's harness");
+    assert(
+      state.availableHarnesses?.length === 1 && state.availableHarnesses[0] === "codex",
+      "GET /api/state reports availableHarnesses as supplied",
+    );
+
+    // The codex adapter was actually invoked (not silently no-op'd): its
+    // launch() always prepends this config-override flag (see codex.ts).
+    const capture = await waitFor<FakeClaudeCapture>(async () => {
+      try {
+        return JSON.parse(await fs.readFile(captureFile, "utf8")) as FakeClaudeCapture;
+      } catch {
+        return undefined;
+      }
+    });
+    assert(
+      capture.argv.includes("check_for_update_on_startup=false"),
+      "the auto-created session actually launched via the codex adapter, not claude-code",
+    );
+  } finally {
+    await server.close();
+    await fs.rm(tmpRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  }
+}
+
 /** Sends SIGTERM, escalates to SIGKILL if it's still alive shortly after,
  *  and waits for the process to actually exit (or a hard timeout) before
  *  returning — so callers can safely assume its file handles are released. */
@@ -529,10 +610,13 @@ async function main(): Promise<void> {
   console.log("node-pty preflight ok");
 
   await testCoreFlow();
-  console.log("phase 1/2 ok (core session/ingest/canvas/macro/workflow-scan loop)\n");
+  console.log("phase 1/3 ok (core session/ingest/canvas/macro/workflow-scan loop)\n");
 
   await testAutoSessionAndMcpAuth();
-  console.log("phase 2/2 ok (autoCreateSession + mcp-config auth headers)\n");
+  console.log("phase 2/3 ok (autoCreateSession + mcp-config auth headers)\n");
+
+  await testAutoSessionKindSelection();
+  console.log("phase 3/3 ok (defaultHarnessKind drives auto-session + availableHarnesses in AppState)\n");
 
   console.log("PASS — live integration proof succeeded\n");
 }

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -12,7 +12,13 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import open from "open";
 import { DEFAULT_PORT } from "../shared/types.js";
-import { runDoctor, printDoctorReport } from "./doctor.js";
+import {
+  runDoctor,
+  printDoctorReport,
+  pickDefaultHarness,
+  CLAUDE_INSTALL_COMMAND,
+  CODEX_INSTALL_COMMAND,
+} from "./doctor.js";
 import { ensureAuthenticated, type HarnessIdentity } from "./auth.js";
 import { ensureConsent } from "./consent.js";
 import { recordRecentDir } from "./settings.js";
@@ -124,9 +130,19 @@ const main = async (): Promise<void> => {
   printDoctorReport(doctorReport);
   if (!doctorReport.ok) {
     console.error(
-      "\nsapiom-harness requires Node >= 20 and the `claude` CLI on PATH. Fix the checks above and try again.",
+      "\nsapiom-harness requires Node >= 20 and at least one coding agent on PATH:\n" +
+        `  Claude Code:  ${CLAUDE_INSTALL_COMMAND}\n` +
+        `  Codex:        ${CODEX_INSTALL_COMMAND}\n` +
+        "Fix the checks above and try again.",
     );
     process.exit(1);
+  }
+  const defaultHarnessKind = pickDefaultHarness(doctorReport);
+  if (!doctorReport.availableHarnesses.includes("claude-code")) {
+    console.log(
+      `\n⚠ Claude Code not found — install with: ${CLAUDE_INSTALL_COMMAND}\n` +
+        "  Continuing with the Codex harness.",
+    );
   }
 
   const machineId = await getOrCreateMachineId();
@@ -153,6 +169,8 @@ const main = async (): Promise<void> => {
       machineId,
       launchDir: options.dir,
       autoCreateSession: !options.noSession,
+      defaultHarnessKind,
+      availableHarnesses: doctorReport.availableHarnesses,
     });
   } catch (err) {
     if (!options.dev) throw err;

--- a/packages/harness/src/cli/doctor.test.ts
+++ b/packages/harness/src/cli/doctor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
+// Which binaries `which`/`--version` report as present — mutated per test to
+// drive the doctor-matrix below. Reset in each test rather than beforeEach so
+// each case's setup reads top-to-bottom next to its assertions.
+let presentBinaries: Set<string>;
+
 vi.mock("node:child_process", () => ({
   execFile: (
     file: string,
@@ -9,7 +14,7 @@ vi.mock("node:child_process", () => ({
     const which = process.platform === "win32" ? "where" : "which";
     if (file === which) {
       const bin = args[0];
-      if (bin === "claude" || bin === "git") {
+      if (presentBinaries.has(bin)) {
         callback(null, { stdout: `/usr/local/bin/${bin}\n`, stderr: "" });
       } else {
         callback(new Error(`${bin}: not found`));
@@ -20,6 +25,10 @@ vi.mock("node:child_process", () => ({
       callback(null, { stdout: "1.2.3 (Claude Code)\n", stderr: "" });
       return;
     }
+    if (file === "codex" && args[0] === "--version") {
+      callback(null, { stdout: "0.134.0 (Codex)\n", stderr: "" });
+      return;
+    }
     if (file === "git" && args[0] === "--version") {
       callback(null, { stdout: "git version 2.43.0\n", stderr: "" });
       return;
@@ -28,10 +37,11 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import { runDoctor } from "./doctor.js";
+import { runDoctor, pickDefaultHarness, CLAUDE_INSTALL_COMMAND, CODEX_INSTALL_COMMAND } from "./doctor.js";
 
 describe("runDoctor", () => {
   it("passes when node, claude, and git are present and codex is absent", async () => {
+    presentBinaries = new Set(["claude", "git"]);
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
@@ -40,8 +50,53 @@ describe("runDoctor", () => {
     expect(byName.git).toEqual({ name: "git", ok: true, detail: "git version 2.43.0" });
     expect(byName.codex.ok).toBe(false);
 
-    // Overall status only hard-fails on node/claude, so a missing optional
-    // codex must not flip it.
+    // Overall status only hard-fails when neither agent is available, so a
+    // missing codex (with claude present) must not flip it.
     expect(report.ok).toBe(true);
+    expect(report.availableHarnesses).toEqual(["claude-code"]);
+  });
+
+  it("passes on codex alone, with claude's check carrying the exact install remedy", async () => {
+    presentBinaries = new Set(["codex", "git"]);
+    const report = await runDoctor();
+    const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
+
+    expect(report.ok).toBe(true);
+    expect(report.availableHarnesses).toEqual(["codex"]);
+    expect(byName.claude.ok).toBe(false);
+    expect(byName.claude.detail).toContain(CLAUDE_INSTALL_COMMAND);
+    expect(byName.codex).toEqual({ name: "codex", ok: true, detail: "0.134.0 (Codex)" });
+  });
+
+  it("fails only when neither claude nor codex is present, surfacing both install remedies", async () => {
+    presentBinaries = new Set(["git"]);
+    const report = await runDoctor();
+    const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
+
+    expect(report.ok).toBe(false);
+    expect(report.availableHarnesses).toEqual([]);
+    expect(byName.claude.detail).toContain(CLAUDE_INSTALL_COMMAND);
+    expect(byName.codex.detail).toContain(CODEX_INSTALL_COMMAND);
+  });
+
+  it("prefers claude-code when both agents are present", async () => {
+    presentBinaries = new Set(["claude", "codex", "git"]);
+    const report = await runDoctor();
+
+    expect(report.ok).toBe(true);
+    expect(report.availableHarnesses).toEqual(["claude-code", "codex"]);
+  });
+});
+
+describe("pickDefaultHarness", () => {
+  it("picks the first available harness", () => {
+    expect(pickDefaultHarness({ checks: [], ok: true, availableHarnesses: ["claude-code", "codex"] })).toBe(
+      "claude-code",
+    );
+    expect(pickDefaultHarness({ checks: [], ok: true, availableHarnesses: ["codex"] })).toBe("codex");
+  });
+
+  it("falls back to claude-code for an empty report rather than throwing", () => {
+    expect(pickDefaultHarness({ checks: [], ok: false, availableHarnesses: [] })).toBe("claude-code");
   });
 });

--- a/packages/harness/src/cli/doctor.ts
+++ b/packages/harness/src/cli/doctor.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type { DoctorCheck } from "../shared/types.js";
+import type { DoctorCheck, HarnessKind } from "../shared/types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -46,10 +46,23 @@ async function binaryCheck(
   return { name, ok: true, detail: v ?? found };
 }
 
-/** Hard requirements (node, claude) vs. optional ones (codex, git). */
+/** Exact remedies surfaced in doctor output and the fatal-exit message —
+ *  kept as named constants so bin.ts's messaging can't drift from what
+ *  doctor.ts itself tells the user to run. */
+export const CLAUDE_INSTALL_COMMAND = "npm i -g @anthropic-ai/claude-code";
+export const CODEX_INSTALL_COMMAND = "npm i -g @openai/codex";
+
+/**
+ * Node is a hard requirement. Neither coding agent is individually required —
+ * the harness runs with whichever of claude/codex is on PATH — but at least
+ * one of them must be, or there's nothing to launch.
+ */
 export interface DoctorReport {
   checks: DoctorCheck[];
   ok: boolean;
+  /** Harness kinds with a working binary on PATH, in default-preference order
+   *  (claude-code first). Empty only when `ok` is false. */
+  availableHarnesses: HarnessKind[];
 }
 
 export async function runDoctor(): Promise<DoctorReport> {
@@ -59,19 +72,28 @@ export async function runDoctor(): Promise<DoctorReport> {
       "claude",
       "claude",
       ["--version"],
-      "not found on PATH — install Claude Code: https://docs.claude.com/claude-code",
+      `not found on PATH — install: ${CLAUDE_INSTALL_COMMAND}`,
     ),
-    binaryCheck(
-      "codex",
-      "codex",
-      ["--version"],
-      "not found on PATH (optional — the Codex harness is unavailable)",
-    ),
+    binaryCheck("codex", "codex", ["--version"], `not found on PATH — install: ${CODEX_INSTALL_COMMAND}`),
     binaryCheck("git", "git", ["--version"], "not found on PATH"),
   ]);
 
+  const availableHarnesses: HarnessKind[] = [
+    ...(claude.ok ? (["claude-code"] as const) : []),
+    ...(codex.ok ? (["codex"] as const) : []),
+  ];
+
   const checks = [node, claude, codex, git];
-  return { checks, ok: node.ok && claude.ok };
+  return { checks, ok: node.ok && availableHarnesses.length > 0, availableHarnesses };
+}
+
+/** First available harness in preference order, for callers that need a
+ *  single default (e.g. the auto-created boot session). Only falls back to
+ *  "claude-code" when the report itself is empty — main() already refuses to
+ *  proceed past a report with no available harnesses, so real callers never
+ *  hit that fallback. */
+export function pickDefaultHarness(report: DoctorReport): HarnessKind {
+  return report.availableHarnesses[0] ?? "claude-code";
 }
 
 export function printDoctorReport(report: DoctorReport): void {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -74,10 +74,19 @@ export interface HarnessServerOptions {
    *  boot so the rail isn't empty until a manual "+ Connect", and (unless
    *  autoCreateSession is false) where the boot session is created. */
   launchDir?: string;
-  /** Auto-create a claude-code session in launchDir once the server is
-   *  listening, so the app doesn't open empty. Defaults to true; the CLI's
-   *  --no-session flag sets this to false. */
+  /** Auto-create a session in launchDir once the server is listening, so the
+   *  app doesn't open empty. Defaults to true; the CLI's --no-session flag
+   *  sets this to false. Uses `defaultHarnessKind` for which agent to launch. */
   autoCreateSession?: boolean;
+  /** Harness kind for the auto-created boot session. The CLI resolves this
+   *  from doctor() results (claude-code if present, else codex) before
+   *  calling startServer; defaults to "claude-code" for callers that don't
+   *  run doctor (tests, --dev flows without a real agent). */
+  defaultHarnessKind?: HarnessKind;
+  /** Harness kinds confirmed available at CLI boot (doctor()), surfaced
+   *  as-is in AppState for the SPA — see its doc comment. Omitted (not
+   *  defaulted here) when the caller doesn't supply it. */
+  availableHarnesses?: HarnessKind[];
 }
 
 export interface HarnessServer {
@@ -242,6 +251,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         });
       },
       launchDir,
+      availableHarnesses: options.availableHarnesses,
     }),
   );
   app.use(
@@ -347,7 +357,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // surfacing loudly, but also not awaited before returning: startServer()
   // resolving shouldn't wait on a real pty spawn.
   if (options.autoCreateSession ?? true) {
-    sessionManager.create({ cwd: launchDir, harness: "claude-code" }).catch((err: unknown) => {
+    const harness = options.defaultHarnessKind ?? "claude-code";
+    sessionManager.create({ cwd: launchDir, harness }).catch((err: unknown) => {
       console.error("[harness] auto-create boot session failed:", err);
     });
   }

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -88,6 +88,20 @@ describe("createRestRouter", () => {
       expect(body.launchDir).toBe("/Users/demo/acme-app");
     });
 
+    it("omits availableHarnesses when the caller doesn't supply it", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect("availableHarnesses" in body).toBe(false);
+    });
+
+    it("reports availableHarnesses (in preference order) when supplied", async () => {
+      start({ availableHarnesses: ["codex"] });
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as { availableHarnesses: string[] };
+      expect(body.availableHarnesses).toEqual(["codex"]);
+    });
+
     it("reflects identity, sessions, workflows, and macros from their sources", async () => {
       const session: HarnessSession = {
         id: "s1",

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -55,6 +55,11 @@ export interface RestRouterOptions {
   /** The directory the CLI was launched against — surfaced in AppState so the
    * SPA can prefill the new-session modal with it. */
   launchDir: string;
+  /** Harness kinds confirmed available at CLI boot (doctor()), in
+   * default-preference order. Omitted (rather than defaulted here) when the
+   * caller doesn't supply it, so AppState.availableHarnesses stays absent in
+   * that case too — see its doc comment for how consumers should treat that. */
+  availableHarnesses?: HarnessKind[];
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
@@ -75,6 +80,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
         workflows: await listWorkflows(),
         macros: listMacros(),
         launchDir: options.launchDir,
+        ...(options.availableHarnesses ? { availableHarnesses: options.availableHarnesses } : {}),
       };
       res.json(state);
     } catch (err) {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -264,6 +264,12 @@ export interface AppState {
   /** The directory the CLI was launched against — the SPA prefills the
    *  new-session modal with this instead of recentDirs[0]. */
   launchDir: string;
+  /** Harness kinds with a working binary on PATH at CLI boot (from doctor()),
+   *  in default-preference order — `[0]` is what the auto-created boot
+   *  session used. Optional: omitted by callers that construct AppState
+   *  without running doctor (tests, mocks); the SPA should treat a missing
+   *  value as "assume claude-code is available" until it's wired up. */
+  availableHarnesses?: HarnessKind[];
 }
 
 export interface HarnessSettings {


### PR DESCRIPTION
## Summary
- `doctor.ts` no longer hard-fails when `claude` is missing. It now returns `availableHarnesses: HarnessKind[]` (preference order: claude-code, then codex) and `ok` is true whenever at least one of the two agents is on PATH — fatal only when neither is found (bin.ts's exit message then prints both install commands: `npm i -g @anthropic-ai/claude-code` and `npm i -g @openai/codex`).
- When claude is missing but codex is present, the CLI prints a one-line warning with the exact install remedy and continues, defaulting to the codex harness (`pickDefaultHarness()`).
- Threaded `defaultHarnessKind` and `availableHarnesses` through `startServer()` → the auto-created boot session now launches whichever agent doctor found, instead of always hardcoding `claude-code`.
- Added `AppState.availableHarnesses` (optional field, `src/shared/types.ts`) so the SPA can eventually gate/default its harness picker on what's actually installed — wired through `rest.ts`'s `/state` handler, but **left optional and out of `web/**`**: no SPA consumer changes here (out of my task scope), so mock-mode / any caller that doesn't supply it is unaffected. Flagging this for whoever owns the New Session modal to consume next.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck` (server) + `tsc --noEmit -p web/tsconfig.json` (strict web check, unaffected but re-verified)
- [x] `pnpm --filter @sapiom/harness test` — 229/229 passed, including a new doctor-matrix suite (claude-only / codex-only / neither / both) and `pickDefaultHarness()` coverage
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness build` — server + web clean
- [x] `pnpm --filter @sapiom/harness e2e:live` — 41/41 assertions, including a new phase 3 proving `defaultHarnessKind: "codex"` actually drives the auto-created session's adapter dispatch (with no claude-code adapter registered at all, so a regression back to the old hardcoded default would fail loudly)
- [x] `pnpm --filter @sapiom/harness test:ui` — 12/12 Playwright smoke tests passed

Co-Authored-By: Claude <noreply@anthropic.com>