### PR TITLE
feat(harness): wire the codex transcript tailer into the session lifecycle

### DIFF
--- a/packages/harness/src/core/collector/codex-tailer.test.ts
+++ b/packages/harness/src/core/collector/codex-tailer.test.ts
@@ -47,8 +47,8 @@ describe("tailCodexRollout", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  function start(): CodexTailerHandle {
-    handle = tailCodexRollout({ rolloutPath, onEvent, onError, pollIntervalMs: POLL_MS });
+  function start(overrides: { startFromBeginning?: boolean } = {}): CodexTailerHandle {
+    handle = tailCodexRollout({ rolloutPath, onEvent, onError, pollIntervalMs: POLL_MS, ...overrides });
     return handle;
   }
 
@@ -156,6 +156,26 @@ describe("tailCodexRollout", () => {
 
     expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "new activity after resume" });
     expect(onEvent).not.toHaveBeenCalledWith("UserPromptSubmit", { prompt: "old history" });
+  });
+
+  it("with startFromBeginning, emits content that already existed when the tailer started", async () => {
+    // Simulates the find-then-tail race: a fresh launch's rollout file is
+    // only ever discovered once it already has content (session_meta at
+    // minimum) — startFromBeginning is what lets that be treated as new
+    // rather than swallowed as if it were resume history.
+    await writeFile(
+      rolloutPath,
+      sessionMetaLine("agent-1", "/tmp/proj", "2026-01-01T00:00:00.000Z") + userMessageLine("already there"),
+    );
+    start({ startFromBeginning: true });
+    await sleep(POLL_MS * 4);
+
+    expect(onEvent).toHaveBeenCalledWith("SessionStart", {
+      source: "codex",
+      cwd: "/tmp/proj",
+      session_id: "agent-1",
+    });
+    expect(onEvent).toHaveBeenCalledWith("UserPromptSubmit", { prompt: "already there" });
   });
 
   it("reports malformed JSON lines via onError instead of throwing, and keeps tailing", async () => {
@@ -280,5 +300,37 @@ describe("findRolloutFile", () => {
 
     const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir });
     expect(found).toBe(join(dir, "rollout-later.jsonl"));
+  });
+
+  it("with agentSessionId, matches that exact session even when a newer one shares the same cwd", async () => {
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "rollout-target.jsonl"),
+      sessionMetaLine("agent-target", "/tmp/proj", "2026-01-01T00:00:00.000Z"),
+    );
+    await sleep(20);
+    // Written (and thus more recently modified) after the target — recency
+    // alone would pick this one, which is exactly the ambiguity agentSessionId
+    // exists to resolve (the resume case).
+    await writeFile(
+      join(dir, "rollout-newer.jsonl"),
+      sessionMetaLine("agent-newer", "/tmp/proj", "2026-01-01T00:05:00.000Z"),
+    );
+
+    const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir, agentSessionId: "agent-target" });
+    expect(found).toBe(join(dir, "rollout-target.jsonl"));
+  });
+
+  it("with agentSessionId, returns null when no rollout file matches that id", async () => {
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "rollout-a.jsonl"),
+      sessionMetaLine("agent-a", "/tmp/proj", "2026-01-01T00:00:00.000Z"),
+    );
+
+    const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir, agentSessionId: "agent-does-not-exist" });
+    expect(found).toBeNull();
   });
 });

--- a/packages/harness/src/core/collector/codex-tailer.ts
+++ b/packages/harness/src/core/collector/codex-tailer.ts
@@ -38,6 +38,18 @@ export interface CodexTailerOptions {
   onEvent: CodexEventListener;
   onError?: (err: unknown) => void;
   pollIntervalMs?: number;
+  /**
+   * Tail from byte 0 regardless of the file's current size — for a fresh
+   * launch, where the caller discovered this rollout file *because* it
+   * already contains the session_meta line the caller cares about (a
+   * find-then-tail race: by the time a poll-based discovery step returns a
+   * path, Codex has necessarily already written to it). Without this, the
+   * default "start from current size" baseline (correct for a genuine
+   * resume, where prior content really is history to skip) would silently
+   * swallow that already-written SessionStart. Defaults to false (resume
+   * semantics: skip whatever's already there, only emit new activity).
+   */
+  startFromBeginning?: boolean;
 }
 
 export interface CodexTailerHandle {
@@ -78,23 +90,26 @@ export function tailCodexRollout(options: CodexTailerOptions): CodexTailerHandle
   const pendingCalls = new Map<string, PendingFunctionCall>();
 
   // Resolve the resume-vs-fresh baseline exactly once, immediately, before
-  // any poll reads content. If the file already exists right now, its
-  // current size becomes the "don't backfill past this" offset (resume —
-  // only new activity should be emitted, matching hook semantics). If it
+  // any poll reads content. `startFromBeginning` (see CodexTailerOptions)
+  // always wins when set. Otherwise: if the file already exists right now,
+  // its current size becomes the "don't backfill past this" offset (resume
+  // — only new activity should be emitted, matching hook semantics); if it
   // doesn't exist yet, the offset stays 0, so once Codex creates the file
-  // the very first bytes it writes (session_meta) are read as new — without
-  // this distinction, a poll-interval race between file creation and its
-  // first write would silently swallow SessionStart on every fresh launch.
+  // the very first bytes it writes are read as new.
   let baselineResolved = false;
-  void stat(options.rolloutPath).then(
-    (s) => {
-      offset = s.size;
-      baselineResolved = true;
-    },
-    () => {
-      baselineResolved = true;
-    },
-  );
+  if (options.startFromBeginning) {
+    baselineResolved = true;
+  } else {
+    void stat(options.rolloutPath).then(
+      (s) => {
+        offset = s.size;
+        baselineResolved = true;
+      },
+      () => {
+        baselineResolved = true;
+      },
+    );
+  }
 
   const timer = setInterval(() => {
     void poll();
@@ -213,13 +228,23 @@ export interface FindRolloutFileOptions {
   /** Match a rollout file whose session_meta.cwd equals this exactly. */
   cwd: string;
   /** Only consider sessions created at/after this time (ms epoch) —
-   * disambiguates a freshly-launched session from older ones sharing a cwd. */
+   * disambiguates a freshly-launched session from older ones sharing a cwd.
+   * Ignored when `agentSessionId` is given (an exact id match is a strictly
+   * stronger signal than a time-window heuristic). */
   sinceMs?: number;
+  /**
+   * Match a rollout file by its exact session_meta.id (the rollout/agent
+   * session id) instead of by recency — needed when resuming a session,
+   * where `sinceMs` can't disambiguate it from other sessions sharing the
+   * same cwd that happen to have been touched more recently.
+   */
+  agentSessionId?: string;
   /** Overridable for tests. */
   homeDir?: string;
 }
 
 interface RolloutSessionMeta {
+  id: string | null;
   cwd: string;
   timestampMs: number | null;
 }
@@ -253,8 +278,9 @@ async function readSessionMetaHead(filePath: string, maxBytes = 65_536): Promise
     if (parsed.type !== "session_meta") continue;
     const cwd = typeof parsed.payload?.cwd === "string" ? parsed.payload.cwd : undefined;
     if (!cwd) return null;
+    const id = typeof parsed.payload?.id === "string" ? parsed.payload.id : null;
     const timestamp = typeof parsed.payload?.timestamp === "string" ? Date.parse(parsed.payload.timestamp) : NaN;
-    return { cwd, timestampMs: Number.isNaN(timestamp) ? null : timestamp };
+    return { id, cwd, timestampMs: Number.isNaN(timestamp) ? null : timestamp };
   }
   return null;
 }
@@ -280,10 +306,12 @@ async function collectRolloutFiles(dir: string, depth = 0): Promise<string[]> {
 }
 
 /**
- * Finds the most-recently-modified rollout file matching `cwd` (and
- * `sinceMs`, if given). Intended to be polled by the integrator right after
- * spawning a fresh `codex` process — there's no way to know the exact
- * rollout path in advance (it's a timestamp+UUID Codex generates itself).
+ * Finds a rollout file matching `cwd`. With `agentSessionId`, matches that
+ * exact session (for resume — cwd alone is ambiguous when multiple sessions
+ * share a directory). Otherwise returns the most-recently-modified match,
+ * optionally bounded by `sinceMs`. Intended to be polled by the integrator
+ * right after spawning a fresh `codex` process — there's no way to know the
+ * exact rollout path in advance (it's a timestamp+UUID Codex generates itself).
  */
 export async function findRolloutFile(options: FindRolloutFileOptions): Promise<string | null> {
   const homeDir = options.homeDir ?? homedir();
@@ -294,6 +322,12 @@ export async function findRolloutFile(options: FindRolloutFileOptions): Promise<
   for (const filePath of files) {
     const meta = await readSessionMetaHead(filePath);
     if (!meta || meta.cwd !== options.cwd) continue;
+
+    if (options.agentSessionId !== undefined) {
+      if (meta.id !== options.agentSessionId) continue;
+      return filePath;
+    }
+
     if (options.sinceMs !== undefined && meta.timestampMs !== null && meta.timestampMs < options.sinceMs) continue;
 
     const fileStat = await stat(filePath).catch(() => null);

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Real end-to-end proof (no mocking of core/collector/codex-tailer.js):
+ * boots the real server, spawns a real pty (bash standing in for `codex`),
+ * writes a fixture rollout file the same way the real Codex CLI would, and
+ * appends to it exactly like a live session. Proves a codex-kind session's
+ * analytics land in the event store the same way a claude-code session's do
+ * — via the same normalize/store/batcher pipeline, just fed by the tailer
+ * instead of a hook POST. See codex-tailer-wiring.test.ts for the isolated,
+ * mocked unit-level test of the lifecycle glue itself.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile, appendFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer, type HarnessServer } from "./index.js";
+import type { AnalyticsEvent, HarnessAdapter, LaunchOpts, SpawnSpec } from "../shared/types.js";
+
+function fakeCodexAdapter(): HarnessAdapter {
+  return {
+    id: "codex",
+    eventSource: "transcript-tail",
+    doctor: async () => [],
+    launch: (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd }),
+    resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec => ({
+      command: "bash",
+      args: [],
+      env: {},
+      cwd: opts.cwd,
+    }),
+    listPastSessions: async () => [],
+  };
+}
+
+function sessionMetaLine(id: string, cwd: string, timestamp: string): string {
+  return JSON.stringify({ timestamp, type: "session_meta", payload: { id, timestamp, cwd } }) + "\n";
+}
+function userMessageLine(message: string): string {
+  return JSON.stringify({ type: "event_msg", payload: { type: "user_message", message } }) + "\n";
+}
+function functionCallLine(callId: string, name: string, args: string): string {
+  return (
+    JSON.stringify({ type: "response_item", payload: { type: "function_call", call_id: callId, name, arguments: args } }) +
+    "\n"
+  );
+}
+function functionCallOutputLine(callId: string, output: string): string {
+  return (
+    JSON.stringify({ type: "response_item", payload: { type: "function_call_output", call_id: callId, output } }) + "\n"
+  );
+}
+function taskCompleteLine(): string {
+  return JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }) + "\n";
+}
+
+async function readEvents(eventStorePath: string): Promise<AnalyticsEvent[]> {
+  try {
+    const content = await readFile(eventStorePath, "utf8");
+    return content
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line) as AnalyticsEvent);
+  } catch {
+    return [];
+  }
+}
+
+describe("codex session lifecycle (real files, no mocking)", () => {
+  let dir: string;
+  let codexHomeDir: string;
+  let cwd: string;
+  let eventStorePath: string;
+  let server: HarnessServer | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-codex-e2e-"));
+    codexHomeDir = join(dir, "codex-home");
+    cwd = join(dir, "project");
+    eventStorePath = join(dir, "events.ndjson");
+    await mkdir(cwd, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    server = undefined;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("produces session.start, prompt.submitted, tool.call, and turn.completed for a codex-kind session", async () => {
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { codex: fakeCodexAdapter() },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath,
+      workflowsRegistryPath: join(dir, "workflows.json"),
+      codexHomeDir,
+    });
+
+    const session = await server.sessionManager.create({ cwd, harness: "codex" });
+    expect(session.status).toBe("running");
+
+    // Simulate Codex creating its rollout file shortly after being spawned —
+    // real discovery has to poll for this, since there's no way to know the
+    // exact timestamp+UUID path in advance.
+    const agentSessionId = "019e00000000-integration-test";
+    const rolloutDir = join(codexHomeDir, ".codex", "sessions", "2026", "01", "01");
+    await mkdir(rolloutDir, { recursive: true });
+    const rolloutPath = join(rolloutDir, `rollout-2026-01-01T00-00-00-${agentSessionId}.jsonl`);
+    await writeFile(rolloutPath, sessionMetaLine(agentSessionId, cwd, new Date().toISOString()));
+
+    // --- session.start, and the rollout id links into the registry ---
+    await vi.waitFor(
+      async () => {
+        expect(server!.sessionManager.get(session.id)?.agentSessionId).toBe(agentSessionId);
+        const events = await readEvents(eventStorePath);
+        expect(events.some((e) => e.type === "session.start" && e.harnessSessionId === session.id)).toBe(true);
+      },
+      { timeout: 10_000, interval: 200 },
+    );
+
+    // --- live activity: a prompt, a tool call, and the turn completing ---
+    await appendFile(rolloutPath, userMessageLine("build me a leasing workflow"));
+    await appendFile(rolloutPath, functionCallLine("call_1", "exec_command", '{"cmd":"ls"}'));
+    await appendFile(rolloutPath, functionCallOutputLine("call_1", "file1.txt\nfile2.txt"));
+    await appendFile(rolloutPath, taskCompleteLine());
+
+    await vi.waitFor(
+      async () => {
+        const events = await readEvents(eventStorePath);
+        const forSession = events.filter((e) => e.harnessSessionId === session.id);
+        expect(forSession.some((e) => e.type === "prompt.submitted")).toBe(true);
+        expect(forSession.some((e) => e.type === "tool.call")).toBe(true);
+        expect(forSession.some((e) => e.type === "turn.completed")).toBe(true);
+      },
+      { timeout: 10_000, interval: 200 },
+    );
+
+    const events = await readEvents(eventStorePath);
+    const prompt = events.find((e) => e.harnessSessionId === session.id && e.type === "prompt.submitted");
+    expect(prompt?.payload).toMatchObject({ prompt: "build me a leasing workflow" });
+    expect(prompt?.harness).toBe("codex");
+
+    const toolCall = events.find((e) => e.harnessSessionId === session.id && e.type === "tool.call");
+    expect(toolCall?.payload).toMatchObject({
+      toolName: "exec_command",
+      toolInput: '{"cmd":"ls"}',
+    });
+
+    // --- session end: killing the pty should synthesize a SessionEnd ---
+    server.sessionManager.kill(session.id);
+    await vi.waitFor(
+      async () => {
+        const finalEvents = await readEvents(eventStorePath);
+        expect(finalEvents.some((e) => e.harnessSessionId === session.id && e.type === "session.end")).toBe(true);
+      },
+      { timeout: 5_000, interval: 200 },
+    );
+  }, 20_000);
+});

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit-level test for the codex-tailer lifecycle wiring in server/index.ts:
+ * mocks core/collector/codex-tailer.js entirely so this exercises just the
+ * glue (when discovery/tailing starts and stops, and that a tailer's emitted
+ * event actually reaches the session registry) without any real file I/O or
+ * polling delay. See codex-session-lifecycle.test.ts for the real-files,
+ * no-mocking end-to-end proof.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../core/collector/codex-tailer.js", () => ({
+  tailCodexRollout: vi.fn(),
+  findRolloutFile: vi.fn(),
+}));
+
+import { tailCodexRollout, findRolloutFile, type CodexEventListener } from "../core/collector/codex-tailer.js";
+import { startServer, type HarnessServer } from "./index.js";
+import type { HarnessAdapter, LaunchOpts, SpawnSpec } from "../shared/types.js";
+
+type FakeTailerHandle = { stop: ReturnType<typeof vi.fn>; emitSessionEnd: ReturnType<typeof vi.fn> };
+
+function fakeCodexAdapter(): HarnessAdapter {
+  return {
+    id: "codex",
+    eventSource: "transcript-tail",
+    doctor: async () => [],
+    launch: (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd }),
+    resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec => ({
+      command: "bash",
+      args: [],
+      env: {},
+      cwd: opts.cwd,
+    }),
+    listPastSessions: async () => [],
+  };
+}
+
+describe("codex tailer lifecycle wiring", () => {
+  let dir: string;
+  let server: HarnessServer | undefined;
+  let fakeHandle: FakeTailerHandle;
+  let lastTailerOnEvent: CodexEventListener | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-codex-wiring-"));
+
+    fakeHandle = { stop: vi.fn(), emitSessionEnd: vi.fn() };
+    vi.mocked(tailCodexRollout).mockReset().mockImplementation((opts) => {
+      lastTailerOnEvent = opts.onEvent;
+      return fakeHandle;
+    });
+    vi.mocked(findRolloutFile).mockReset().mockResolvedValue("/fake/rollout/path.jsonl");
+  });
+
+  afterEach(async () => {
+    // Status-change side effects (setAgentSessionId, spawn/exit) fire
+    // persist() without awaiting it — flush before removing the temp dir so
+    // a lingering write can't race the cleanup.
+    await server?.sessionManager.flush();
+    await server?.close();
+    server = undefined;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("discovers, tails, and links agentSessionId once a codex session is running", async () => {
+    const cwd = join(dir, "project");
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { codex: fakeCodexAdapter() },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath: join(dir, "events.ndjson"),
+      workflowsRegistryPath: join(dir, "workflows.json"),
+    });
+
+    const session = await server.sessionManager.create({ cwd, harness: "codex" });
+    expect(session.status).toBe("running");
+
+    await vi.waitFor(() => {
+      expect(findRolloutFile).toHaveBeenCalled();
+      expect(tailCodexRollout).toHaveBeenCalledWith(
+        expect.objectContaining({ rolloutPath: "/fake/rollout/path.jsonl" }),
+      );
+    });
+
+    // findRolloutFile should have been asked for this session's cwd, and (a
+    // fresh launch has no agentSessionId yet) bounded by sinceMs rather than
+    // an exact id.
+    expect(findRolloutFile).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd, sinceMs: expect.any(Number) }),
+    );
+
+    // Simulate the tailer emitting a SessionStart — proves the emitted event
+    // actually flows through processIngest -> normalize -> onAgentSessionResolved
+    // -> SessionManager, exactly like a real hook POST would.
+    lastTailerOnEvent!("SessionStart", { source: "codex", cwd, session_id: "agent-xyz" });
+
+    await vi.waitFor(() => {
+      expect(server!.sessionManager.get(session.id)?.agentSessionId).toBe("agent-xyz");
+    });
+  });
+
+  it("resumes by exact agentSessionId rather than cwd+sinceMs when one is already known", async () => {
+    const cwd = join(dir, "project");
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { codex: fakeCodexAdapter() },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath: join(dir, "events.ndjson"),
+      workflowsRegistryPath: join(dir, "workflows.json"),
+    });
+
+    const historical = server.sessionManager.registerHistorical({
+      agentSessionId: "agent-resumed",
+      harness: "codex",
+      cwd,
+      title: "past session",
+      lastActiveAt: new Date().toISOString(),
+    });
+
+    await server.sessionManager.resume(historical.id);
+
+    await vi.waitFor(() => {
+      expect(findRolloutFile).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd, agentSessionId: "agent-resumed" }),
+      );
+    });
+  });
+
+  it("stops the tailer and does not start a new one for a non-codex session", async () => {
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: {
+        "claude-code": {
+          id: "claude-code",
+          eventSource: "hooks",
+          doctor: async () => [],
+          launch: (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd }),
+          resume: (_id: string, opts: LaunchOpts): SpawnSpec => ({
+            command: "bash",
+            args: [],
+            env: {},
+            cwd: opts.cwd,
+          }),
+          listPastSessions: async () => [],
+        },
+      },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath: join(dir, "events.ndjson"),
+      workflowsRegistryPath: join(dir, "workflows.json"),
+    });
+
+    const session = await server.sessionManager.create({ cwd: join(dir, "project"), harness: "claude-code" });
+    expect(session.status).toBe("running");
+
+    // Give any (incorrect) codex wiring a chance to fire before asserting it didn't.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(findRolloutFile).not.toHaveBeenCalled();
+    expect(tailCodexRollout).not.toHaveBeenCalled();
+  });
+
+  it("emits SessionEnd and removes the tailer when the session exits", async () => {
+    const cwd = join(dir, "project");
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { codex: fakeCodexAdapter() },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath: join(dir, "events.ndjson"),
+      workflowsRegistryPath: join(dir, "workflows.json"),
+    });
+
+    const session = await server.sessionManager.create({ cwd, harness: "codex" });
+    await vi.waitFor(() => expect(tailCodexRollout).toHaveBeenCalled());
+
+    server.sessionManager.kill(session.id);
+
+    await vi.waitFor(() => {
+      expect(fakeHandle.emitSessionEnd).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -15,7 +15,13 @@ import express, { type Express } from "express";
 import { WebSocketServer } from "ws";
 import open from "open";
 
-import type { AnalyticsEvent, HarnessAdapter, HarnessKind, WorkflowInfo } from "../shared/types.js";
+import type {
+  AnalyticsEvent,
+  HarnessAdapter,
+  HarnessKind,
+  HarnessSession,
+  WorkflowInfo,
+} from "../shared/types.js";
 import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.js";
 import { createClaudeCodeAdapter } from "../core/adapters/claude-code.js";
 import { createCodexAdapter } from "../core/adapters/codex.js";
@@ -25,6 +31,8 @@ import { createEventStore } from "../core/collector/store.js";
 import { CollectorBatcher } from "../core/collector/batcher.js";
 import { normalizeHookEvent } from "../core/collector/normalizer.js";
 import { enrichTurnCompleted } from "../core/collector/transcript.js";
+import { createSeqCounter } from "../core/collector/seq.js";
+import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "../core/collector/codex-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
 import type { HarnessIdentity } from "../cli/auth.js";
 import { generateClaudeSettings } from "../core/inject/claude-settings.js";
@@ -39,10 +47,20 @@ import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
 import { attachWebSocketRouters } from "./ws-router.js";
-import { createIngestRouter, type IngestSessionContext } from "./ingest.js";
+import { createIngestRouter, processIngest, type IngestDeps, type IngestRequestBody, type IngestSessionContext } from "./ingest.js";
 import { createCanvasRouter } from "./canvas.js";
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
+
+/**
+ * Codex has no hook system — its rollout file is polled into existence
+ * (findRolloutFile) rather than announced, so discovery needs a bounded
+ * retry loop rather than a single lookup. 15s covers a slow process spawn
+ * with margin; if Codex still hasn't written a rollout file by then,
+ * something's wrong enough that surfacing an error beats waiting longer.
+ */
+const CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS = 15_000;
+const CODEX_ROLLOUT_DISCOVERY_POLL_MS = 300;
 
 /** Workflow list is refreshed off this interval for the (synchronous)
  * macro-resolution lookup — connect/scan are infrequent user actions, so a
@@ -68,6 +86,10 @@ export interface HarnessServerOptions {
   collectorUrl?: string;
   workflowsRegistryPath?: string;
   eventStorePath?: string;
+  /** Overrides the home directory codex rollout discovery scans
+   * (`<home>/.codex/sessions/...`). Defaults to the real OS home dir; tests
+   * point this at a fixture tree instead of touching `~/.codex` for real. */
+  codexHomeDir?: string;
   /** Directory the built SPA lives in. Defaults to dist/web next to this module. */
   webDir?: string;
   /** The directory the CLI was launched against — scanned for workflows at
@@ -262,41 +284,128 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     }),
   );
 
+  // Shared by both event sources feeding the analytics pipeline: real hook
+  // POSTs (via the /ingest router below) and the Codex transcript tailer
+  // (in-process, no HTTP round-trip — see startCodexTailerFor). One
+  // seqCounter so a given harnessSessionId gets one consistent seq space
+  // regardless of which source produced the event.
+  const seqCounter = createSeqCounter();
+  const ingestDeps: IngestDeps = {
+    ingestToken: options.bootToken,
+    normalize: normalizeHookEvent,
+    resolveSession: resolveIngestSession,
+    onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
+      sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
+    },
+    store: eventStore,
+    batcher,
+    enrichFromTranscript: enrichTurnCompleted,
+    onNormalizedEvent: (event: AnalyticsEvent) => {
+      if (event.type !== "tool.call") return;
+      const { toolInput, toolResponseSummary } = event.payload as {
+        toolInput?: unknown;
+        toolResponseSummary?: unknown;
+      };
+      // Each field is a discrete, already-complete string (not a live
+      // stream) — flush() immediately so a port landing at the very end
+      // of it (a common shape: "...started server on http://localhost:5544")
+      // isn't held back waiting for a "next chunk" that will never arrive.
+      if (typeof toolInput === "string") {
+        portDetector.feed(toolInput, event.harnessSessionId);
+        portDetector.flush(event.harnessSessionId);
+      }
+      if (typeof toolResponseSummary === "string") {
+        portDetector.feed(toolResponseSummary, event.harnessSessionId);
+        portDetector.flush(event.harnessSessionId);
+      }
+    },
+    onError: (err) => console.error("[harness] ingest processing error:", err),
+    seqCounter,
+  };
+
   // /ingest authenticates itself (bearer ingestToken, not X-Harness-Token) —
   // it must not sit behind the /api boot-token middleware above.
-  app.use(
-    createIngestRouter({
-      ingestToken: options.bootToken,
-      normalize: normalizeHookEvent,
-      resolveSession: resolveIngestSession,
-      onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
-        sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
+  app.use(createIngestRouter(ingestDeps));
+
+  // Codex has no hooks, so a live session's entire analytics eventSource is
+  // its rollout file (see core/collector/codex-tailer.ts). On "running", find
+  // that file and start tailing it, feeding each translated {hookEvent,
+  // payload} into the exact same processIngest() pipeline a hook POST would
+  // hit — same normalizer, same transcript enrichment, same store/batcher,
+  // same seqCounter. On "exited", synthesize the SessionEnd the rollout
+  // format has no line of its own for, and stop.
+  const codexTailers = new Map<string, CodexTailerHandle>();
+
+  async function discoverCodexRolloutPath(session: HarnessSession): Promise<string | null> {
+    const deadline = Date.now() + CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS;
+    const sinceMs = Date.parse(session.createdAt);
+    for (;;) {
+      const found = await findRolloutFile(
+        session.agentSessionId
+          ? { cwd: session.cwd, agentSessionId: session.agentSessionId, homeDir: options.codexHomeDir }
+          : {
+              cwd: session.cwd,
+              sinceMs: Number.isNaN(sinceMs) ? undefined : sinceMs,
+              homeDir: options.codexHomeDir,
+            },
+      );
+      if (found) return found;
+      if (Date.now() >= deadline) return null;
+      await new Promise((resolve) => setTimeout(resolve, CODEX_ROLLOUT_DISCOVERY_POLL_MS));
+    }
+  }
+
+  async function startCodexTailerFor(harnessSessionId: string): Promise<void> {
+    if (codexTailers.has(harnessSessionId)) return;
+    const session = sessionManager.get(harnessSessionId);
+    if (!session) return;
+
+    const rolloutPath = await discoverCodexRolloutPath(session);
+    if (!rolloutPath) {
+      console.error(
+        `[harness] codex tailer: no rollout file found for session ${harnessSessionId} (cwd=${session.cwd}) within ${CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS}ms`,
+      );
+      return;
+    }
+    // The session may have exited (or already started another tailer via a
+    // status-change re-entry) while discovery was polling.
+    if (codexTailers.has(harnessSessionId)) return;
+    if (sessionManager.get(harnessSessionId)?.status !== "running") return;
+
+    const tailer = tailCodexRollout({
+      rolloutPath,
+      // A fresh launch was found by cwd+sinceMs, not an exact agentSessionId
+      // match — which means it's necessarily the file THIS session just
+      // caused Codex to create, so its entire content (including the
+      // session_meta line discovery just proved exists) is new to us. A
+      // resume's agentSessionId match, by contrast, points at a file with
+      // real prior history that should stay unemitted.
+      startFromBeginning: !session.agentSessionId,
+      onEvent: (hookEvent, payload) => {
+        const body: IngestRequestBody = { hookEvent, harnessSessionId, payload };
+        void processIngest(body, ingestDeps, seqCounter).catch((err: unknown) => {
+          console.error("[harness] codex tailer ingest error:", err);
+        });
       },
-      store: eventStore,
-      batcher,
-      enrichFromTranscript: enrichTurnCompleted,
-      onNormalizedEvent: (event: AnalyticsEvent) => {
-        if (event.type !== "tool.call") return;
-        const { toolInput, toolResponseSummary } = event.payload as {
-          toolInput?: unknown;
-          toolResponseSummary?: unknown;
-        };
-        // Each field is a discrete, already-complete string (not a live
-        // stream) — flush() immediately so a port landing at the very end
-        // of it (a common shape: "...started server on http://localhost:5544")
-        // isn't held back waiting for a "next chunk" that will never arrive.
-        if (typeof toolInput === "string") {
-          portDetector.feed(toolInput, event.harnessSessionId);
-          portDetector.flush(event.harnessSessionId);
-        }
-        if (typeof toolResponseSummary === "string") {
-          portDetector.feed(toolResponseSummary, event.harnessSessionId);
-          portDetector.flush(event.harnessSessionId);
-        }
-      },
-      onError: (err) => console.error("[harness] ingest processing error:", err),
-    }),
-  );
+      onError: (err) => console.error("[harness] codex tailer parse error:", err),
+    });
+    codexTailers.set(harnessSessionId, tailer);
+  }
+
+  sessionManager.onStatusChange((session) => {
+    if (session.harness !== "codex") return;
+    if (session.status === "running") {
+      startCodexTailerFor(session.id).catch((err: unknown) => {
+        console.error("[harness] codex tailer startup failed:", err);
+      });
+    } else if (session.status === "exited") {
+      const tailer = codexTailers.get(session.id);
+      if (tailer) {
+        tailer.emitSessionEnd(session.exitCode != null ? `pty exited (code ${session.exitCode})` : undefined);
+        codexTailers.delete(session.id);
+      }
+    }
+  });
 
   // Canvas is intentionally unauthenticated (see canvas.ts) — served straight
   // off the session's cwd, no boot token required.
@@ -362,6 +471,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       new Promise<void>((resolve, reject) => {
         clearInterval(workflowsCacheTimer);
         canvasWatcher.stopAll();
+        for (const tailer of codexTailers.values()) tailer.stop();
+        codexTailers.clear();
         // Closing the HTTP/WS server doesn't touch unrelated child processes
         // on its own — without this, every live claude/codex pty outlives
         // the harness server itself (e.g. after Ctrl+C or in a script that

--- a/packages/harness/src/server/ingest.ts
+++ b/packages/harness/src/server/ingest.ts
@@ -52,7 +52,17 @@ export interface IngestDeps {
   seqCounter?: SeqCounter;
 }
 
-interface IngestRequestBody {
+/**
+ * Exported so an in-process, non-HTTP event source (currently: the Codex
+ * transcript tailer, which has no hook script to POST here) can feed the
+ * exact same normalize -> transcript-enrich -> store -> batcher pipeline
+ * that a real hook POST goes through, without a needless HTTP round-trip
+ * back into this same server. Field names deliberately match the HTTP body
+ * shape (hookEvent/harnessSessionId/payload) so callers can construct one
+ * directly from whatever `{hookEvent, payload}` pair their event source
+ * already produces.
+ */
+export interface IngestRequestBody {
   hookEvent?: string;
   receivedAt?: string;
   harnessSessionId?: string;
@@ -64,7 +74,7 @@ function bearerToken(header: string | undefined): string | null {
   return header.slice("Bearer ".length);
 }
 
-async function processIngest(
+export async function processIngest(
   body: IngestRequestBody,
   deps: IngestDeps,
   seqCounter: SeqCounter,


### PR DESCRIPTION
## Summary

Codex sessions now emit the same analytics events claude-code sessions do (`session.start`/`prompt.submitted`/`tool.call`/`turn.completed`/`session.end`), sourced from the rollout-tailer built in the codex-adapter PR instead of hooks — implementing the "Wiring this in" contract documented in that PR's description.

**`server/index.ts`:**
- On a codex session reaching `"running"`, polls `findRolloutFile()` (bounded, 15s) for its rollout file, then starts `tailCodexRollout()`, feeding each emitted `{hookEvent, payload}` into the exact same `processIngest()` pipeline a real hook POST goes through — same normalizer, same transcript enrichment, same store/batcher, same `seqCounter` (now created once and shared between the `/ingest` router and the codex path, so a given `harnessSessionId` gets one consistent seq space regardless of source).
- On resume (`agentSessionId` already known), discovery matches that exact rollout id instead of cwd+recency — cwd alone is ambiguous when multiple sessions share a directory.
- On session exit, calls the tailer's `emitSessionEnd()` and stops it — Codex's rollout format has no "session ended" line of its own.

**`ingest.ts`:** exports `processIngest()`/`IngestRequestBody` so this in-process event source can feed the pipeline directly, matching the field names of a real hook POST body. No literal HTTP round-trip back into the same server — that would add a real network hop, its own auth-token juggling, and a failure mode (the harness's own server being briefly unreachable to itself) for zero benefit over a direct function call already in the same process.

## A real bug, found and fixed while writing the end-to-end test

`core/collector/codex-tailer.ts`'s existing "resume vs fresh" baseline (skip content that existed when the tailer starts, matching hook semantics) is wrong for this integration's fresh-launch path specifically. Discovery only returns a path once Codex has already written to it (poll-then-return), so by the time `tailCodexRollout()` starts, `session_meta` already exists in the file — the old baseline logic would silently treat it as "resume history" and never emit `SessionStart`. Added `startFromBeginning` (default `false`, preserving existing behavior) and set it `true` for the fresh-launch path specifically, where "whatever's already in the file" is unambiguously new to us (this session is the reason the file exists at all).

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `lint` — all clean
- [x] `pnpm --filter @sapiom/harness test` — 237/237 passing:
  - `codex-tailer.test.ts`: +2 (agentSessionId-exact-match discovery, `startFromBeginning` reading pre-existing content)
  - `codex-tailer-wiring.test.ts` (new): mocked `codex-tailer`, proving the lifecycle glue itself — discovery called with the right query shape for fresh vs. resume, `tailCodexRollout` started/stopped at the right times, `emitSessionEnd` on exit, no codex wiring at all fires for a non-codex session
  - `codex-session-lifecycle.test.ts` (new): real files, no mocking — boots the actual server, writes a fixture rollout file the way Codex would, and proves `session.start`/`prompt.submitted`/`tool.call`/`turn.completed`/`session.end` all land in the real event store for a codex-kind session
- [x] `pnpm e2e:live` — still green end to end, including the codex-kind auto-session path from a concurrently-landed PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)