### PR TITLE
fix(harness): codex sessions dying instantly at spawn

### DIFF
--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -35,20 +35,40 @@ describe("CodexAdapter", () => {
       expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
     });
 
-    it("adds -c model_instructions_file=<path> when a systemPromptFile is given", () => {
-      const adapter = new CodexAdapter({ binary: "fake-codex" });
-      const spec = adapter.launch({
-        harnessSessionId: "h1",
-        cwd: "/tmp/proj",
-        systemPromptFile: "/tmp/proj/.sapiom/prompt.txt",
-      });
+    it("embeds the systemPromptFile's content inline via -c developer_instructions=<value>", async () => {
+      const promptDir = await mkdtemp(join(tmpdir(), "harness-codex-prompt-"));
+      const promptFile = join(promptDir, "prompt.txt");
+      await writeFile(promptFile, "You are a Sapiom workflow builder.\nBe concise.", "utf8");
 
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.launch({ harnessSessionId: "h1", cwd: "/tmp/proj", systemPromptFile: promptFile });
+
+      // Reading the file's content in and embedding it (rather than passing
+      // codex a path to re-read at its own startup) is the actual fix here —
+      // an unreadable model_instructions_file path kills codex instantly
+      // with no trust prompt, no TUI, which is exactly the "session has no
+      // live pty" symptom a user sees with no indication why. -c values
+      // parse as TOML; JSON.stringify produces a valid TOML string literal
+      // for a value with embedded newlines/quotes.
       expect(spec.args).toEqual([
         "-c",
         "check_for_update_on_startup=false",
         "-c",
-        "model_instructions_file=/tmp/proj/.sapiom/prompt.txt",
+        `developer_instructions=${JSON.stringify("You are a Sapiom workflow builder.\nBe concise.")}`,
       ]);
+
+      await rm(promptDir, { recursive: true, force: true });
+    });
+
+    it("launches without a system prompt (rather than a guaranteed-crashing arg) when systemPromptFile can't be read", () => {
+      const adapter = new CodexAdapter({ binary: "fake-codex" });
+      const spec = adapter.launch({
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+        systemPromptFile: "/does/not/exist/prompt.txt",
+      });
+
+      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
     });
 
     it("builds a resume SpawnSpec with `resume <rolloutId>` as the leading args", () => {

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -4,20 +4,22 @@
  * core/collector/codex-tailer.ts for how its analytics eventSource works
  * instead); this file only covers process launch/resume/doctor/history.
  *
- * Verified against a locally installed `codex-cli 0.134.0` on the build
- * machine: `codex resume [SESSION_ID] [PROMPT]` (positional UUID or thread
- * name) and the generic `-c key=value` config-override mechanism are
- * confirmed via `codex --help` / `codex resume --help`. The specific config
- * keys used for system-prompt injection (`developer_instructions`,
- * `model_instructions_file`) are NOT independently confirmed against this
- * version — they're carried over from a known-working reference
- * implementation targeting an earlier Codex CLI, since `--help` documents
- * `-c` as a generic escape hatch and doesn't enumerate valid keys. Flagged
- * in the PR description; worth a manual smoke test before relying on it for
- * a live demo.
+ * Verified against a locally installed `codex-cli 0.134.0`: `codex resume
+ * [SESSION_ID] [PROMPT]` (positional UUID or thread name) via `codex resume
+ * --help`; the generic `-c key=value` config-override mechanism via `codex
+ * --help`; and, via real spawns with `--strict-config`, that both
+ * `developer_instructions` and `model_instructions_file` are real,
+ * recognized keys (an earlier version of this file used the latter and
+ * flagged both as unconfirmed — see buildConfigArgs below for why the
+ * adapter now uses `developer_instructions` instead: `model_instructions_file`
+ * makes codex's own startup depend on re-reading a file we already have the
+ * content of, and an unreadable path there kills the process instantly with
+ * no trust prompt, no TUI — precisely the "session has no live pty" a user
+ * sees with zero indication why).
  */
 
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { open, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
@@ -239,13 +241,38 @@ export class CodexAdapter implements HarnessAdapter {
  * (a persistent config.toml mutation, which the harness's "zero config
  * mutation" design deliberately avoids), so `opts.mcpConfigFile` /
  * `opts.settingsFile` are intentionally unused here. System-prompt injection
- * uses the generic `-c key=value` override mechanism instead (see the
- * module-level doc comment for the verification caveat on the exact keys).
+ * uses the generic `-c key=value` override mechanism instead.
+ *
+ * Confirmed against a locally installed codex-cli 0.134.0: `-c
+ * model_instructions_file=<path>` is a real, recognized key — but if that
+ * path is missing/unreadable at codex's own startup (a moment we don't
+ * control, in a separate process), codex exits immediately with a config
+ * error, no trust prompt, no TUI — which reads to a user as the session
+ * dying instantly. Since we already have the prompt's content in hand
+ * (we're the ones who generated the file), embedding it inline via
+ * `developer_instructions=<value>` instead removes that dependency
+ * entirely: nothing for codex to fail to (re)read. `-c` values parse as
+ * TOML, and TOML basic strings share JSON's escaping rules for control
+ * characters/quotes/backslashes, so `JSON.stringify` produces a valid TOML
+ * string literal here — confirmed with a real multiline prompt.
+ *
+ * If even this read fails (the file we just generated is somehow gone by
+ * the time we get here — a narrow race, but still no reason to crash the
+ * whole session over an optional prompt), fall back to launching without
+ * one rather than passing a broken reference that's guaranteed to kill the
+ * process on startup.
  */
 function buildConfigArgs(opts: LaunchOpts): string[] {
   const args = ["-c", "check_for_update_on_startup=false"];
   if (opts.systemPromptFile) {
-    args.push("-c", `model_instructions_file=${opts.systemPromptFile}`);
+    try {
+      const prompt = readFileSync(opts.systemPromptFile, "utf8");
+      args.push("-c", `developer_instructions=${JSON.stringify(prompt)}`);
+    } catch (err) {
+      console.error(
+        `[codex adapter] could not read systemPromptFile "${opts.systemPromptFile}" — launching without an injected system prompt: ${(err as Error).message}`,
+      );
+    }
   }
   return args;
 }

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -81,8 +81,12 @@ describe("codex session lifecycle (real files, no mocking)", () => {
   });
 
   afterEach(async () => {
+    // server.close() resolves once the HTTP server stops listening —
+    // independent of whether killAll()'s asynchronous pty-exit events have
+    // finished their own persist() writes — so flush before AND after.
     await server?.sessionManager.flush();
     await server?.close();
+    await server?.sessionManager.flush();
     server = undefined;
     await rm(dir, { recursive: true, force: true });
   });

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -58,9 +58,13 @@ describe("codex tailer lifecycle wiring", () => {
   afterEach(async () => {
     // Status-change side effects (setAgentSessionId, spawn/exit) fire
     // persist() without awaiting it — flush before removing the temp dir so
-    // a lingering write can't race the cleanup.
+    // a lingering write can't race the cleanup. server.close() itself
+    // resolves once the HTTP server stops listening — independent of
+    // whether killAll()'s asynchronous pty-exit events have finished their
+    // own persist() writes — so flush a second time afterward too.
     await server?.sessionManager.flush();
     await server?.close();
+    await server?.sessionManager.flush();
     server = undefined;
     await rm(dir, { recursive: true, force: true });
   });
@@ -103,6 +107,17 @@ describe("codex tailer lifecycle wiring", () => {
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(session.id)?.agentSessionId).toBe("agent-xyz");
     });
+
+    // kill() only sends the signal — it doesn't wait for the real bash
+    // process to actually terminate. Waiting for "exited" here (rather than
+    // leaving that to afterEach's close()) avoids a real race: close()
+    // resolves once the HTTP server stops listening, independent of whether
+    // this session's exit-triggered persist() has landed yet, which can
+    // still be mid-write when the test's temp dir gets removed.
+    server.sessionManager.kill(session.id);
+    await vi.waitFor(() => {
+      expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
+    });
   });
 
   it("resumes by exact agentSessionId rather than cwd+sinceMs when one is already known", async () => {
@@ -126,12 +141,19 @@ describe("codex tailer lifecycle wiring", () => {
       lastActiveAt: new Date().toISOString(),
     });
 
-    await server.sessionManager.resume(historical.id);
+    const resumed = await server.sessionManager.resume(historical.id);
 
     await vi.waitFor(() => {
       expect(findRolloutFile).toHaveBeenCalledWith(
         expect.objectContaining({ cwd, agentSessionId: "agent-resumed" }),
       );
+    });
+
+    // See the first test's comment: wait for the real spawned process to
+    // actually exit rather than leaving that race to afterEach's close().
+    server.sessionManager.kill(resumed.id);
+    await vi.waitFor(() => {
+      expect(server!.sessionManager.get(resumed.id)?.status).toBe("exited");
     });
   });
 
@@ -168,6 +190,13 @@ describe("codex tailer lifecycle wiring", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(findRolloutFile).not.toHaveBeenCalled();
     expect(tailCodexRollout).not.toHaveBeenCalled();
+
+    // See the first test's comment: wait for the real spawned process to
+    // actually exit rather than leaving that race to afterEach's close().
+    server.sessionManager.kill(session.id);
+    await vi.waitFor(() => {
+      expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
+    });
   });
 
   it("emits SessionEnd and removes the tailer when the session exits", async () => {


### PR DESCRIPTION
## Summary

Root cause, confirmed empirically against a locally installed `codex-cli 0.134.0`: the adapter passed the session's generated system prompt to codex as `-c model_instructions_file=<path>` — a real, recognized config key, but one that makes codex's own process startup depend on successfully **re-reading that file itself**, in a separate process, at a moment we don't control. Spawning codex with that flag pointing at any momentarily unreadable path (confirmed: even a simply-missing file) makes it exit immediately with a config-loading error — no trust prompt, no TUI, nothing for the harness to show. From the browser this reads exactly like the reported symptom: `POST /api/sessions` returns 201, then the terminal WS closes with "session has no live pty" before the user sees anything happen.

## Fix

Read the prompt file's content once — we already generated it, we have it in hand — and embed it inline via `-c developer_instructions=<value>` instead of handing codex a path to re-read on its own. `-c` values parse as TOML; `JSON.stringify` produces a valid TOML string literal for a value with embedded newlines/quotes, confirmed with a real ~1.6KB multiline prompt. This removes the file dependency from codex's startup path entirely — nothing left for it to fail to (re)read, regardless of why the original file might have been momentarily unavailable. If even reading our own just-generated file fails, launch without an injected system prompt rather than passing a guaranteed-crashing argument — a working session without the prompt beats no session at all.

## Also fixed: two newly-flaky tests uncovered while verifying this

Three tests in `codex-tailer-wiring.test.ts` left a real spawned `bash` process alive at test end, relying on `afterEach`'s `server.close()` to clean it up. But `close()` resolves once the HTTP server stops listening — independent of whether `killAll()`'s asynchronous pty-exit event has actually fired and finished its own `persist()` write, which can still be mid-flight when the test's temp dir gets removed (`ENOTEMPTY`, ~15-20% of runs). Fixed by explicitly killing and waiting for `"exited"` status before the test ends, rather than leaving process cleanup entirely to `afterEach`.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` / `build` / `lint` — all clean
- [x] `pnpm --filter @sapiom/harness test` — 257/257, stable across 8 repeated full-suite runs and 20 repeated runs of the two previously-flaky files (0 failures either way, vs. ~15-20% before the fix)
- [x] Verified directly against the real `codex` binary: with the old `model_instructions_file` arg, deleting the prompt file **after** `launch()` reads it (simulating any transient unavailability) reliably kills the process in well under a second; with the fix, deleting that same file has no effect at all — codex launches and reaches its interactive trust prompt normally, proving the dependency is actually gone
- [x] `pnpm e2e:live` — still green end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)