### PR TITLE
feat(harness): workspace-binding UI — rail tree, session chip

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -110,6 +110,42 @@ test("inject macros are enabled once the boot session and a deployed workflow ar
   await expect(page.getByTestId("macro-deploy")).toBeEnabled();
 });
 
+test.describe("workspace binding", () => {
+  test("the rail groups workflows into a tree: active session's directory first, others below", async ({ page }) => {
+    // Boot session's cwd is /Users/demo/acme-app, which owns "leasing".
+    const activeGroup = page.getByTestId("workspace-group-acme-app");
+    await expect(activeGroup).toBeVisible();
+    await expect(page.locator(".workspace-group.is-active")).toContainText("acme-app");
+
+    // "rfq" lives under /Users/demo/rfq-workflows, a different known session's directory.
+    await expect(page.getByTestId("workspace-group-rfq-workflows")).toBeVisible();
+
+    // "onboarding-flow" isn't under any known session's directory.
+    await expect(page.getByText("Other")).toBeVisible();
+
+    await page.screenshot({ path: "web/e2e/screenshots/workspace-tree.png", fullPage: true });
+  });
+
+  test("selecting a workflow binds it to the active session and shows a chip", async ({ page }) => {
+    await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
+
+    await page.getByTestId("workflow-leasing").click();
+    const chip = page.getByTestId("session-workflow-chip");
+    await expect(chip).toBeVisible();
+    await expect(chip).toContainText("working on leasing");
+  });
+
+  test("the binding is per-session: switching sessions shows that session's own binding", async ({ page }) => {
+    await page.getByTestId("workflow-leasing").click();
+    await expect(page.getByTestId("session-workflow-chip")).toContainText("leasing");
+
+    // Switch to a session that's never had anything bound.
+    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
+    await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
+  });
+});
+
 test("new-session modal: directory picker navigates and validates", async ({ page }) => {
   await page.getByTestId("new-session-btn").click();
   await expect(page.getByText("New session")).toBeVisible();

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -16,6 +16,7 @@ import { DeadSessionPane } from "./components/DeadSessionPane";
 import { SessionBar } from "./components/SessionBar";
 import { Terminal } from "./components/Terminal";
 import { WorkflowsRail } from "./components/WorkflowsRail";
+import { boundWorkflowPathOf } from "./lib/api";
 import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
@@ -46,9 +47,18 @@ export const App = (): JSX.Element => {
   const { state } = harness;
   const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
   const activeSession = state.sessions.find((session) => session.id === harness.activeSessionId) ?? null;
+  const boundWorkflowPath = boundWorkflowPathOf(activeSession);
+  const boundWorkflowName = state.workflows.find((w) => w.path === boundWorkflowPath)?.name ?? null;
 
   const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
+  };
+
+  const handleSelectWorkflow = (path: string): void => {
+    harness.setSelectedWorkflowPath(path);
+    // Selecting a workflow IS "what I'm working on" — bind it to whichever
+    // session is currently active so the chip and the agent's context stay in sync.
+    if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
   const disabledReasonFor = (macro: MacroDef): string | null => {
@@ -91,8 +101,10 @@ export const App = (): JSX.Element => {
       <div className="app">
         <WorkflowsRail
           workflows={state.workflows}
+          sessions={state.sessions}
+          activeSessionId={harness.activeSessionId}
           selectedPath={harness.selectedWorkflowPath}
-          onSelect={harness.setSelectedWorkflowPath}
+          onSelect={handleSelectWorkflow}
           onConnect={async (path) => {
             await harness.connectWorkflow(path);
           }}
@@ -111,6 +123,7 @@ export const App = (): JSX.Element => {
             launchDir={state.launchDir ?? null}
             listDir={harness.listDir}
             onCreateSession={handleCreateSession}
+            boundWorkflowName={boundWorkflowName}
             authenticated={state.authenticated}
             organizationName={state.organizationName}
             telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -19,6 +19,8 @@ interface SessionBarProps {
   launchDir: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
   onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
+  /** The active session's bound workflow name ("working on X" chip), if any. */
+  boundWorkflowName: string | null;
   authenticated: boolean;
   organizationName: string | null;
   telemetryOptIn: boolean;
@@ -37,6 +39,7 @@ export function SessionBar({
   launchDir,
   listDir,
   onCreateSession,
+  boundWorkflowName,
   authenticated,
   organizationName,
   telemetryOptIn,
@@ -67,6 +70,11 @@ export function SessionBar({
         <button className="session-dropdown-trigger" data-testid="session-dropdown-trigger" onClick={toggle}>
           <span className="session-dot" data-status={activeSession?.status ?? "none"} />
           <span className="session-title">{activeSession ? activeSession.title : "No session"}</span>
+          {boundWorkflowName && (
+            <span className="session-workflow-chip" data-testid="session-workflow-chip">
+              ▸ working on {boundWorkflowName}
+            </span>
+          )}
           <Icon name="ChevronDown" size={14} />
         </button>
 

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1,15 +1,50 @@
 import { useState } from "react";
 import type { JSX } from "react";
-import type { WorkflowInfo } from "@shared/types";
+import type { HarnessSession, WorkflowInfo } from "@shared/types";
+
+import { Icon } from "./Icon";
+import { buildWorkspaceTree } from "../lib/workspace-tree";
 
 interface WorkflowsRailProps {
   workflows: WorkflowInfo[];
+  sessions: HarnessSession[];
+  activeSessionId: string | null;
   selectedPath: string | null;
   onSelect: (path: string) => void;
   onConnect: (path: string) => Promise<void>;
 }
 
-export function WorkflowsRail({ workflows, selectedPath, onSelect, onConnect }: WorkflowsRailProps): JSX.Element {
+function WorkflowRow({
+  workflow,
+  isSelected,
+  onSelect,
+}: {
+  workflow: WorkflowInfo;
+  isSelected: boolean;
+  onSelect: (path: string) => void;
+}): JSX.Element {
+  return (
+    <button
+      className={"workflow-item" + (isSelected ? " is-selected" : "")}
+      data-testid={`workflow-${workflow.name}`}
+      onClick={() => onSelect(workflow.path)}
+      title={workflow.path}
+    >
+      <span className="workflow-caret">▸</span>
+      <span className="workflow-name">{workflow.name}</span>
+      {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
+    </button>
+  );
+}
+
+export function WorkflowsRail({
+  workflows,
+  sessions,
+  activeSessionId,
+  selectedPath,
+  onSelect,
+  onConnect,
+}: WorkflowsRailProps): JSX.Element {
   const [connecting, setConnecting] = useState(false);
   const [pathInput, setPathInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -31,24 +66,45 @@ export function WorkflowsRail({ workflows, selectedPath, onSelect, onConnect }: 
     }
   };
 
+  const { groups, ungrouped } = buildWorkspaceTree(workflows, sessions, activeSessionId);
+
   return (
     <aside className="rail rail-workflows">
-      <div className="rail-header">Workflows</div>
+      <div className="rail-header">Workspace</div>
       <div className="rail-list">
-        {workflows.length === 0 && <div className="rail-empty">No workflows yet</div>}
-        {workflows.map((workflow) => (
-          <button
-            key={workflow.path}
-            className={"workflow-item" + (workflow.path === selectedPath ? " is-selected" : "")}
-            data-testid={`workflow-${workflow.name}`}
-            onClick={() => onSelect(workflow.path)}
-            title={workflow.path}
-          >
-            <span className="workflow-caret">▸</span>
-            <span className="workflow-name">{workflow.name}</span>
-            {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
-          </button>
+        {groups.length === 0 && ungrouped.length === 0 && <div className="rail-empty">No workflows yet</div>}
+
+        {groups.map((group) => (
+          <div key={group.cwd} className={"workspace-group" + (group.isActive ? " is-active" : "")}>
+            <div className="workspace-group-header" data-testid={`workspace-group-${group.label}`}>
+              <Icon name={group.isActive ? "Radio" : "Folder"} size={11} />
+              {group.label}
+            </div>
+            {group.workflows.length === 0 && <div className="workspace-group-empty">No workflows here yet</div>}
+            {group.workflows.map((workflow) => (
+              <WorkflowRow
+                key={workflow.path}
+                workflow={workflow}
+                isSelected={workflow.path === selectedPath}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
         ))}
+
+        {ungrouped.length > 0 && (
+          <div className="workspace-group">
+            <div className="workspace-group-header">Other</div>
+            {ungrouped.map((workflow) => (
+              <WorkflowRow
+                key={workflow.path}
+                workflow={workflow}
+                isSelected={workflow.path === selectedPath}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       {connecting ? (

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -6,6 +6,7 @@
  */
 import type {
   AppState,
+  BindWorkflowRequest,
   CreateSessionRequest,
   FsDirEntry,
   FsListResponse,
@@ -26,23 +27,9 @@ export function isMockMode(): boolean {
   return import.meta.env.VITE_MOCK === "1";
 }
 
-/**
- * `PATCH /api/sessions/:id/workflow` body + the `HarnessSession.boundWorkflowPath`
- * field it sets. Mirrors the workspace-binding contract landing in parallel
- * (server side owns `.sapiom/harness-context.json` + the system-prompt
- * awareness); typed locally here rather than editing the shared contract.
- * `null` unbinds.
- */
-export interface BindWorkflowRequest {
-  workflowPath: string | null;
-}
-
-export type SessionWithBinding = HarnessSession & { boundWorkflowPath: string | null };
-
-/** Reads the binding defensively — `HarnessSession` doesn't declare the field yet. */
+/** `session.boundWorkflowPath` is nullable already, but keeps callers safe against a missing session. */
 export function boundWorkflowPathOf(session: HarnessSession | null | undefined): string | null {
-  if (!session) return null;
-  return (session as SessionWithBinding).boundWorkflowPath ?? null;
+  return session?.boundWorkflowPath ?? null;
 }
 
 /** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
@@ -305,7 +292,7 @@ class MockApi implements HarnessApi {
     await delay(150);
     const existing = this.sessions.find((session) => session.id === sessionId);
     if (!existing) throw new Error(`mock: no session to bind for ${sessionId}`);
-    const bound = { ...existing, boundWorkflowPath: workflowPath } as SessionWithBinding;
+    const bound: HarnessSession = { ...existing, boundWorkflowPath: workflowPath };
     this.sessions = this.sessions.map((session) => (session.id === sessionId ? bound : session));
     return bound;
   }

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -26,6 +26,25 @@ export function isMockMode(): boolean {
   return import.meta.env.VITE_MOCK === "1";
 }
 
+/**
+ * `PATCH /api/sessions/:id/workflow` body + the `HarnessSession.boundWorkflowPath`
+ * field it sets. Mirrors the workspace-binding contract landing in parallel
+ * (server side owns `.sapiom/harness-context.json` + the system-prompt
+ * awareness); typed locally here rather than editing the shared contract.
+ * `null` unbinds.
+ */
+export interface BindWorkflowRequest {
+  workflowPath: string | null;
+}
+
+export type SessionWithBinding = HarnessSession & { boundWorkflowPath: string | null };
+
+/** Reads the binding defensively — `HarnessSession` doesn't declare the field yet. */
+export function boundWorkflowPathOf(session: HarnessSession | null | undefined): string | null {
+  if (!session) return null;
+  return (session as SessionWithBinding).boundWorkflowPath ?? null;
+}
+
 /** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
 export function getBootToken(): string {
   const injected = (window as unknown as { __HARNESS__?: { token?: string } }).__HARNESS__;
@@ -49,6 +68,7 @@ export interface HarnessApi {
   getSettings(): Promise<HarnessSettings>;
   updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings>;
   listDir(path?: string): Promise<FsListResponse>;
+  bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession>;
 }
 
 class RealApi implements HarnessApi {
@@ -134,6 +154,14 @@ class RealApi implements HarnessApi {
   listDir(path?: string): Promise<FsListResponse> {
     const query = path ? `?path=${encodeURIComponent(path)}` : "";
     return this.request<FsListResponse>(`/api/fs/list${query}`);
+  }
+
+  bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession> {
+    const body: BindWorkflowRequest = { workflowPath };
+    return this.request<HarnessSession>(`/api/sessions/${encodeURIComponent(sessionId)}/workflow`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
   }
 }
 
@@ -270,6 +298,15 @@ class MockApi implements HarnessApi {
       parent,
       dirs: names.map((name) => ({ name, path: normalized === "/" ? `/${name}` : `${normalized}/${name}` })),
     };
+  }
+
+  async bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession> {
+    await delay(150);
+    const existing = this.sessions.find((session) => session.id === sessionId);
+    if (!existing) throw new Error(`mock: no session to bind for ${sessionId}`);
+    const bound = { ...existing, boundWorkflowPath: workflowPath } as SessionWithBinding;
+    this.sessions = this.sessions.map((session) => (session.id === sessionId ? bound : session));
+    return bound;
   }
 }
 

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -10,7 +10,7 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 
-import { createApi, getBootToken, type FsListResponse } from "./api";
+import { boundWorkflowPathOf, createApi, getBootToken, type FsListResponse } from "./api";
 import { subscribeEvents } from "./events";
 
 const api = createApi();
@@ -34,6 +34,8 @@ export interface HarnessStateHook {
   /** Dismisses an exited session (DELETE): drops it from the list and, if it was active, falls back to another running session or clears the pane. */
   closeSession: (id: string) => Promise<void>;
   connectWorkflow: (path: string) => Promise<WorkflowInfo>;
+  /** Binds a workflow to a session ("what am I working on") — null unbinds. */
+  bindWorkflow: (sessionId: string, workflowPath: string | null) => Promise<void>;
   updateSettings: (patch: Partial<HarnessSettings>) => Promise<HarnessSettings>;
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
   listDir: (path?: string) => Promise<FsListResponse>;
@@ -69,6 +71,16 @@ export function useHarnessState(): HarnessStateHook {
       cancelled = true;
     };
   }, []);
+
+  // Switching sessions follows that session's own binding (if any) rather than
+  // leaving the rail highlighted on whatever the previous session had selected.
+  useEffect(() => {
+    if (!activeSessionId) return;
+    const session = state?.sessions.find((s) => s.id === activeSessionId);
+    const bound = boundWorkflowPathOf(session);
+    if (bound) setSelectedWorkflowPath(bound);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSessionId]);
 
   const refreshWorkflows = useCallback(async () => {
     const workflows = await api.listWorkflows();
@@ -162,6 +174,13 @@ export function useHarnessState(): HarnessStateHook {
     return workflow;
   }, []);
 
+  const bindWorkflow = useCallback(async (sessionId: string, workflowPath: string | null): Promise<void> => {
+    const session = await api.bindWorkflow(sessionId, workflowPath);
+    setState((prev) =>
+      prev ? { ...prev, sessions: prev.sessions.map((s) => (s.id === session.id ? session : s)) } : prev,
+    );
+  }, []);
+
   const updateSettings = useCallback(async (patch: Partial<HarnessSettings>): Promise<HarnessSettings> => {
     const updated = await api.updateSettings(patch);
     setSettings(updated);
@@ -195,6 +214,7 @@ export function useHarnessState(): HarnessStateHook {
     resumeFromHistory,
     closeSession,
     connectWorkflow,
+    bindWorkflow,
     updateSettings,
     runMacro,
     listDir,

--- a/packages/harness/web/src/lib/workspace-tree.ts
+++ b/packages/harness/web/src/lib/workspace-tree.ts
@@ -1,0 +1,49 @@
+import type { HarnessSession, WorkflowInfo } from "@shared/types";
+
+export interface WorkspaceGroup {
+  cwd: string;
+  label: string;
+  isActive: boolean;
+  workflows: WorkflowInfo[];
+}
+
+export interface WorkspaceTree {
+  groups: WorkspaceGroup[];
+  /** Workflows that don't live under any known session's directory. */
+  ungrouped: WorkflowInfo[];
+}
+
+const basename = (path: string): string => path.split("/").filter(Boolean).pop() ?? path;
+const isUnder = (workflowPath: string, cwd: string): boolean => workflowPath === cwd || workflowPath.startsWith(`${cwd}/`);
+
+/**
+ * Groups workflows by the session directory they live under: the active
+ * session's directory always appears first (even with no workflows yet, so
+ * there's always a "you are here" root), then other known sessions' directories
+ * that actually own a workflow, then anything left over.
+ */
+export function buildWorkspaceTree(
+  workflows: WorkflowInfo[],
+  sessions: HarnessSession[],
+  activeSessionId: string | null,
+): WorkspaceTree {
+  const activeSession = sessions.find((session) => session.id === activeSessionId) ?? null;
+  const remaining = new Set(workflows);
+  const groups: WorkspaceGroup[] = [];
+
+  const seenCwds = new Set<string>();
+  const orderedCwds = [
+    ...(activeSession ? [activeSession.cwd] : []),
+    ...sessions.map((session) => session.cwd).filter((cwd) => cwd !== activeSession?.cwd),
+  ].filter((cwd) => (seenCwds.has(cwd) ? false : (seenCwds.add(cwd), true)));
+
+  for (const cwd of orderedCwds) {
+    const owned = workflows.filter((workflow) => remaining.has(workflow) && isUnder(workflow.path, cwd));
+    const isActive = cwd === activeSession?.cwd;
+    if (owned.length === 0 && !isActive) continue; // don't clutter the rail with empty inactive groups
+    owned.forEach((workflow) => remaining.delete(workflow));
+    groups.push({ cwd, label: basename(cwd), isActive, workflows: owned });
+  }
+
+  return { groups, ungrouped: Array.from(remaining) };
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -263,6 +263,33 @@ input {
   font-size: 12px;
 }
 
+.workspace-group {
+  margin-bottom: 10px;
+}
+
+.workspace-group-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 6px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.workspace-group.is-active .workspace-group-header {
+  color: var(--accent);
+}
+
+.workspace-group-empty {
+  padding: 2px 8px 4px;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-style: italic;
+}
+
 .workflow-item {
   display: flex;
   align-items: center;
@@ -454,6 +481,20 @@ input {
   white-space: nowrap;
   text-align: left;
   font-size: 12px;
+}
+
+.session-workflow-chip {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 8px;
+  border-radius: 20px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 10.5px;
+  font-weight: 500;
 }
 
 .session-dot {


### PR DESCRIPTION
## Summary

UI side of the workspace-binding design (server side landed separately as PR #202 — `boundWorkflowPath`, `PATCH /api/sessions/:id/workflow`, `.sapiom/harness-context.json`).

- **Workspace tree** (`web/src/lib/workspace-tree.ts`, a pure grouping function): the left rail groups workflows by the session directory they live under. The active session's directory is always the first group — shown even with zero workflows yet, so there's a "you are here" root — followed by other known sessions' directories that actually own a workflow, then a final "Other" group for anything left over.
- **Selecting a workflow now binds it**: the existing macro-gating selection and the new session binding are the same click — `App.tsx`'s `handleSelectWorkflow` does both. The session bar shows a "▸ working on X" chip when a binding exists (`SessionBar.tsx`), and switching sessions (dropdown / resume / create) re-syncs the rail's highlight to *that* session's own binding instead of leaving it on whatever the previous session had selected.
- Built this against the real contract: I found the server-side work in progress in a sibling worktree mid-implementation and read its uncommitted `shared/types.ts` diff directly, so I coded to the exact shape (`boundWorkflowPath`, `BindWorkflowRequest`) from the start rather than guessing. Typed a local mirror while it was still in flight; once PR #202 actually merged into this branch, deleted the mirror and switched to the real import in a follow-up commit — net diff here is clean.

## Scope note — not implemented

"Canvas switches to that workflow's viz when one exists" isn't done here. The canvas route (`/canvas/:sessionId/`) is still purely session-scoped server-side; re-targeting it to a bound workflow's own directory needs backend support this ticket didn't include (confirmed by reading `rest.ts` — no canvas-related change in the workspace-binding server PR). Flagging rather than faking a re-route that doesn't actually work.

## Screenshots

Reviewed locally (gitignored, regenerated per `test:ui` run) — `workspace-tree.png`: rail shows "WORKSPACE / ACME-APP" (active, teal radio icon) with "leasing" beneath, "RFQ-WORKFLOWS" (folder icon) with "rfq", "OTHER" with "onboarding-flow"; session bar shows the "▸ working on leasing" chip once selected, and it clears when switching to a session with no binding.

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright) — 24/24 passing (3 new: tree grouping, chip appears on selection, binding is per-session)
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 31 files / 257 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)