### PR TITLE
fix(harness): pre-bind the boot session in mock fixtures

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -126,17 +126,20 @@ test.describe("workspace binding", () => {
     await page.screenshot({ path: "web/e2e/screenshots/workspace-tree.png", fullPage: true });
   });
 
-  test("selecting a workflow binds it to the active session and shows a chip", async ({ page }) => {
-    await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
-
-    await page.getByTestId("workflow-leasing").click();
+  test("the boot session's default binding shows a chip on load", async ({ page }) => {
+    // Fixture: sess-boot is pre-bound to leasing, so the chip renders without
+    // any interaction — useful for anyone eyeballing mock mode, not just tests.
     const chip = page.getByTestId("session-workflow-chip");
     await expect(chip).toBeVisible();
     await expect(chip).toContainText("working on leasing");
   });
 
+  test("selecting a different workflow re-binds it and updates the chip", async ({ page }) => {
+    await page.getByTestId("workflow-rfq").click();
+    await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+  });
+
   test("the binding is per-session: switching sessions shows that session's own binding", async ({ page }) => {
-    await page.getByTestId("workflow-leasing").click();
     await expect(page.getByTestId("session-workflow-chip")).toContainText("leasing");
 
     // Switch to a session that's never had anything bound.

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -15,7 +15,9 @@ export const MOCK_SESSIONS: HarnessSession[] = [
   {
     id: "sess-boot",
     agentSessionId: null,
-      boundWorkflowPath: null,
+    // Bound by default so the "working on X" chip and the workspace tree's
+    // highlight render immediately in mock mode, without requiring a click first.
+    boundWorkflowPath: "/Users/demo/acme-app/leasing",
     harness: "claude-code",
     cwd: MOCK_LAUNCH_DIR,
     // The server auto-creates and starts one session in launchDir at boot, so
@@ -28,7 +30,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
   {
     id: "sess-leasing",
     agentSessionId: "8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f",
-      boundWorkflowPath: null,
+    boundWorkflowPath: null,
     harness: "claude-code",
     cwd: "/Users/demo/acme-app",
     title: "Build the leasing pipeline",
@@ -40,7 +42,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
   {
     id: "sess-rfq",
     agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
-      boundWorkflowPath: null,
+    boundWorkflowPath: null,
     harness: "codex",
     cwd: "/Users/demo/rfq-workflows",
     title: "rfq-workflows",


### PR DESCRIPTION
## Summary

Small follow-up to #204 (already merged) per team-lead feedback: the boot session in mock mode now starts bound to "leasing" by default, so the "▸ working on X" chip and the workspace tree's active-workflow highlight render immediately in `VITE_MOCK=1` without requiring a click first — useful for anyone eyeballing mock mode or grabbing a screenshot.

Updated the workspace-binding specs to match: the default-bound chip is asserted directly (was previously asserting no chip before a click), selecting a *different* workflow re-binds and updates the chip, and the per-session-binding test (switching to a session that's never had anything bound clears the chip) is unchanged in substance.

## Test plan

- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright) — 25/25 passing
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @sapiom/harness build:web` — succeeds
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 31 files / 257 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)