### PR TITLE
fix(harness): resolve symlinked cwd before matching codex rollout files

### DIFF
--- a/packages/harness/src/core/collector/codex-tailer.test.ts
+++ b/packages/harness/src/core/collector/codex-tailer.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile, appendFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile, appendFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -332,5 +332,35 @@ describe("findRolloutFile", () => {
 
     const found = await findRolloutFile({ cwd: "/tmp/proj", homeDir, agentSessionId: "agent-does-not-exist" });
     expect(found).toBeNull();
+  });
+
+  it("matches when the caller's cwd is a symlink to the directory Codex recorded (e.g. macOS /tmp -> /private/tmp)", async () => {
+    // Reproduces a real bug: Codex's own session_meta.cwd is the OS-resolved
+    // (symlink-free) path, but callers here generally hand us whatever a
+    // freshly-created session's cwd literally is — on macOS that's routinely
+    // a `/tmp/...` or `/var/folders/...` path, both of which are symlinks
+    // into `/private`. An exact string comparison never matches, even though
+    // it's the same directory, so the tailer never finds a real rollout file.
+    const realProjectDir = await mkdtemp(join(tmpdir(), "harness-codex-real-"));
+    const linkParent = await mkdtemp(join(tmpdir(), "harness-codex-link-"));
+    const symlinkedCwd = join(linkParent, "proj-link");
+    await symlink(realProjectDir, symlinkedCwd);
+    const resolvedCwd = await realpath(realProjectDir);
+
+    const dir = rolloutDir();
+    await mkdir(dir, { recursive: true });
+    // What Codex actually writes: the canonicalized path, not the symlink.
+    await writeFile(
+      join(dir, "rollout-a.jsonl"),
+      sessionMetaLine("agent-a", resolvedCwd, "2026-01-01T00:00:00.000Z"),
+    );
+
+    try {
+      const found = await findRolloutFile({ cwd: symlinkedCwd, homeDir });
+      expect(found).toBe(join(dir, "rollout-a.jsonl"));
+    } finally {
+      await rm(realProjectDir, { recursive: true, force: true });
+      await rm(linkParent, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/harness/src/core/collector/codex-tailer.ts
+++ b/packages/harness/src/core/collector/codex-tailer.ts
@@ -15,7 +15,7 @@
  * contract (what to call, and when).
  */
 
-import { open, readdir, stat } from "node:fs/promises";
+import { open, readdir, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -318,10 +318,20 @@ export async function findRolloutFile(options: FindRolloutFileOptions): Promise<
   const root = join(homeDir, ".codex", "sessions");
   const files = await collectRolloutFiles(root);
 
+  // Codex records session_meta.cwd as the OS-canonicalized path (symlinks
+  // resolved) — on macOS in particular, `/tmp` and `/var` are themselves
+  // symlinks into `/private`, so a cwd like `/var/folders/.../T/foo` (what
+  // `os.tmpdir()` and most callers hand us) never string-equals what Codex
+  // wrote (`/private/var/folders/.../T/foo`), even though it's the same
+  // directory. Resolve our side the same way before comparing. Falls back
+  // to the raw value if the directory is gone (a session that already
+  // exited, or a test double that never touches the real filesystem).
+  const resolvedCwd = await realpath(options.cwd).catch(() => options.cwd);
+
   let best: { path: string; mtimeMs: number } | null = null;
   for (const filePath of files) {
     const meta = await readSessionMetaHead(filePath);
-    if (!meta || meta.cwd !== options.cwd) continue;
+    if (!meta || meta.cwd !== resolvedCwd) continue;
 
     if (options.agentSessionId !== undefined) {
       if (meta.id !== options.agentSessionId) continue;

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -9,7 +9,7 @@
  * mocked unit-level test of the lifecycle glue itself.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, readFile, rm, writeFile, appendFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile, appendFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -114,7 +114,11 @@ describe("codex session lifecycle (real files, no mocking)", () => {
     const rolloutDir = join(codexHomeDir, ".codex", "sessions", "2026", "01", "01");
     await mkdir(rolloutDir, { recursive: true });
     const rolloutPath = join(rolloutDir, `rollout-2026-01-01T00-00-00-${agentSessionId}.jsonl`);
-    await writeFile(rolloutPath, sessionMetaLine(agentSessionId, cwd, new Date().toISOString()));
+    // Real Codex records the OS-canonicalized cwd (symlinks resolved) — on
+    // this machine's tmpdir that differs from the raw path (e.g. macOS's
+    // /var -> /private/var), so mirror that here rather than the raw value,
+    // to actually exercise findRolloutFile's realpath-normalized matching.
+    await writeFile(rolloutPath, sessionMetaLine(agentSessionId, await realpath(cwd), new Date().toISOString()));
 
     // --- session.start, and the rollout id links into the registry ---
     await vi.waitFor(


### PR DESCRIPTION
## Summary

Follow-up to #203 (merged). While verifying the full real chain that PR's fix was supposed to complete — a UI-created codex session reaching "running" *and* emitting analytics through the tailer — a second, distinct bug surfaced: the tailer never actually found a real codex session's rollout file.

Real `codex-cli` records `session_meta.cwd` in its rollout JSONL as the OS-canonicalized path (symlinks resolved). The harness compares that against the raw `cwd` a session was created with. On macOS, both `/tmp` and `/var` (and therefore `os.tmpdir()`, which most callers' working directories live under) are themselves symlinks into `/private`, so the exact-string match in `findRolloutFile()` never matched a real session — the tailer gave up after its 15s discovery window logging "no rollout file found" even though the file existed the whole time.

Net effect before this fix: #203 alone gets a codex session to *survive*, but its `eventSource: "transcript-tail"` still silently produces zero events for any session whose cwd resolves through a symlink — which is the common case on macOS.

## Fix

`findRolloutFile()` now resolves the caller's `cwd` via `fs.realpath()` before comparing it against each rollout file's recorded `session_meta.cwd` (falling back to the raw value if the directory is gone, e.g. an already-exited session or a test double with no real filesystem backing).

## Test plan

- [x] New regression test: creates a real directory + a real symlink pointing at it, writes a rollout fixture with the *canonicalized* path (mirroring what real Codex writes), and confirms `findRolloutFile` matches it via the *symlinked* path a caller would actually pass.
- [x] Updated `codex-session-lifecycle.test.ts`'s fixture to record the realpath-resolved cwd in its `session_meta` line, matching real Codex's behavior (previously wrote the raw path, which happened to already match because the bug existed on both sides of that specific test).
- [x] `pnpm --filter @sapiom/harness typecheck` — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean (1 pre-existing, unrelated warning)
- [x] `pnpm --filter @sapiom/harness test -- --run` — 258/258 passing
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] **Full real-chain verification against the actual installed `codex-cli` binary** (not fixtures): booted the real server, created a codex session via `sessionManager.create()` exactly as the UI's session-creation flow does, accepted Codex's real trust prompt, submitted a real prompt over the pty. Confirmed: session reaches and stays "running" (proving #203's fix holds), `agentSessionId` links, and `session.start` + `prompt.submitted` land in the real `events.ndjson` — the tailer discovering the real rollout file Codex actually wrote. This is the "UI codex session → running → events in ndjson" chain in full, for the first time with a real (non-fake) codex process.

Co-Authored-By: Claude <noreply@anthropic.com>