### PR TITLE
fix(harness): exclude the harness's own infrastructure from port detection

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -41,6 +41,10 @@
  *      as a session.status frame on /ws/events, and unbinding (workflowPath:
  *      null) writes `boundWorkflow: null` to the same file rather than
  *      deleting it.
+ *  12. A tool.call event that echoes the harness's own listening port and
+ *      the analytics collector's port produces no port.detected frame at
+ *      all — proving server/index.ts's exclusion wiring, not just
+ *      PortDetector's own unit-tested filter in isolation.
  *
  * Run with: pnpm e2e:live
  */
@@ -354,6 +358,33 @@ async function testCoreFlow(): Promise<void> {
     });
     assert(portMsg.port === 5544, "port.detected frame reports port 5544 from the tool.call output");
     assert(portMsg.url === "http://localhost:5544", "port.detected frame carries the right url");
+
+    // --- 8b. the harness's own port and the collector's port must never surface as "discovered" ---
+    const portDetectedCountBefore = wsMessages.filter((m) => m.type === "port.detected").length;
+    const selfPortToolCallRes = await fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers: ingestHeaders,
+      body: JSON.stringify({
+        hookEvent: "PostToolUse",
+        harnessSessionId: sessionId,
+        payload: {
+          session_id: agentSessionId,
+          tool_name: "Bash",
+          tool_input: "echo $SAPIOM_HARNESS_INGEST_URL",
+          tool_response: `harness at http://localhost:${server.port}, collector at http://localhost:${MOCK_COLLECTOR_PORT}`,
+        },
+      }),
+    });
+    assert(selfPortToolCallRes.status === 200, "POST /ingest (self-port echo) returns 200");
+    // ingest → portDetector.feed/flush → bus.publish → ws send all happen
+    // synchronously within the request above, so a short wait is enough to
+    // let an (incorrect) broadcast have time to arrive if the filter failed.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const portDetectedCountAfter = wsMessages.filter((m) => m.type === "port.detected").length;
+    assert(
+      portDetectedCountAfter === portDetectedCountBefore,
+      "the harness's own port and the collector's port are excluded from port.detected",
+    );
 
     // --- 9. write to the session's canvas dir, assert canvas.reload arrives, and the file is served ---
     const canvasDir = path.join(projectDir, ".sapiom", "canvas");

--- a/packages/harness/src/core/port-detector.test.ts
+++ b/packages/harness/src/core/port-detector.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { PortDetector } from "./port-detector.js";
+import { PortDetector, portFromUrl } from "./port-detector.js";
 
-function makeDetector() {
+function makeDetector(excludedPorts?: Iterable<number>) {
   const onPort = vi.fn();
-  const detector = new PortDetector({ onPort });
+  const detector = new PortDetector({ onPort, excludedPorts });
   return { detector, onPort };
 }
 
@@ -132,5 +132,60 @@ describe("PortDetector.flush", () => {
     detector.feed("http://localhost:5544", "sess-1");
     detector.flush("sess-1");
     expect(onPort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PortDetector excludedPorts", () => {
+  it("does not fire for a port supplied at construction time", () => {
+    const { detector, onPort } = makeDetector([4100]);
+    detector.feed("localhost:4100\n", "sess-1");
+    expect(onPort).not.toHaveBeenCalled();
+  });
+
+  it("still fires for a different, non-excluded port", () => {
+    const { detector, onPort } = makeDetector([4100]);
+    detector.feed("localhost:3000\n", "sess-1");
+    expect(onPort).toHaveBeenCalledWith("sess-1", 3000, "http://localhost:3000");
+  });
+
+  it("addExcludedPort() suppresses a port added after construction", () => {
+    const { detector, onPort } = makeDetector();
+    detector.addExcludedPort(4100);
+    detector.feed("localhost:4100\n", "sess-1");
+    expect(onPort).not.toHaveBeenCalled();
+  });
+
+  it("an excluded port isn't recorded as seen, so un-excluding via a fresh detector still dedupes normally", () => {
+    // Exclusion happens before the seenPorts check — this just confirms
+    // an excluded port doesn't leave any dedupe-state side effect behind.
+    const { detector, onPort } = makeDetector([4100]);
+    detector.feed("localhost:4100\n", "sess-1");
+    detector.feed("localhost:4100\n", "sess-1");
+    expect(onPort).not.toHaveBeenCalled();
+  });
+
+  it("also suppresses an excluded port via flush()", () => {
+    const { detector, onPort } = makeDetector([4100]);
+    detector.feed("ready on http://localhost:4100", "sess-1");
+    detector.flush("sess-1");
+    expect(onPort).not.toHaveBeenCalled();
+  });
+});
+
+describe("portFromUrl", () => {
+  it("reads an explicit port", () => {
+    expect(portFromUrl("http://localhost:4199")).toBe(4199);
+  });
+
+  it("defaults to 80 for http with no explicit port", () => {
+    expect(portFromUrl("http://collector.example.com/v1/harness/events")).toBe(80);
+  });
+
+  it("defaults to 443 for https with no explicit port", () => {
+    expect(portFromUrl("https://collector.example.com/v1/harness/events")).toBe(443);
+  });
+
+  it("returns null for an unparseable URL", () => {
+    expect(portFromUrl("not a url")).toBeNull();
   });
 });

--- a/packages/harness/src/core/port-detector.ts
+++ b/packages/harness/src/core/port-detector.ts
@@ -19,6 +19,29 @@ const TAIL_SAFETY = 24;
 
 export interface PortDetectorDeps {
   onPort(harnessSessionId: string, port: number, url: string): void;
+  /** Ports considered the harness's own infrastructure — a match against one
+   *  of these is silently dropped (not even recorded as "seen") rather than
+   *  broadcast as a discovery. Known ports at construction time; more can be
+   *  added later via `addExcludedPort` (e.g. an ephemeral `port: 0` only
+   *  resolves to its real bound port after the server starts listening,
+   *  which happens after this detector is already constructed). */
+  excludedPorts?: Iterable<number>;
+}
+
+/**
+ * Extracts the port a URL string actually resolves to, including the
+ * protocol's implicit default when none is written out explicitly (`new
+ * URL(...).port` is `""` in that case, not the real port) — used to exclude
+ * the analytics collector's own port from detection.
+ */
+export function portFromUrl(rawUrl: string): number | null {
+  try {
+    const url = new URL(rawUrl);
+    if (url.port) return Number(url.port);
+    return url.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -28,13 +51,25 @@ export interface PortDetectorDeps {
  * pty output, not just complete lines). Call `flush()` after feeding a
  * discrete, already-complete string (e.g. one tool.call event's output) —
  * see its doc comment for why that's necessary. Dedupes per (session, port)
- * so a port that keeps appearing in output only ever fires `onPort` once.
+ * so a port that keeps appearing in output only ever fires `onPort` once —
+ * permanently for the session's lifetime (not a TTL): `reset()` is what
+ * clears it, on session exit, so a reused session id starts clean.
  */
 export class PortDetector {
   private readonly buffers = new Map<string, string>();
   private readonly seenPorts = new Map<string, Set<number>>();
+  private readonly excludedPorts: Set<number>;
 
-  constructor(private readonly deps: PortDetectorDeps) {}
+  constructor(private readonly deps: PortDetectorDeps) {
+    this.excludedPorts = new Set(deps.excludedPorts ?? []);
+  }
+
+  /** Exclude a port discovered after construction — e.g. the harness's own
+   *  actual bound port, which is only known once the HTTP server resolves
+   *  its `listen()` call (relevant for an ephemeral `port: 0`). */
+  addExcludedPort(port: number): void {
+    this.excludedPorts.add(port);
+  }
 
   feed(chunk: string, harnessSessionId: string): void {
     const combined = (this.buffers.get(harnessSessionId) ?? "") + chunk;
@@ -59,6 +94,9 @@ export class PortDetector {
 
   private tryEmit(harnessSessionId: string, port: number): void {
     if (!Number.isInteger(port) || port <= 0 || port > 65535) return;
+    // Never even recorded as "seen" — an excluded port isn't a real
+    // discovery, so it shouldn't consume per-session dedupe state either.
+    if (this.excludedPorts.has(port)) return;
 
     let ports = this.seenPorts.get(harnessSessionId);
     if (!ports) {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -39,7 +39,7 @@ import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
 import { generateSystemPromptFile } from "../core/inject/system-prompt.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
-import { PortDetector } from "../core/port-detector.js";
+import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
 import { writeHarnessContext } from "../core/workspace-context.js";
 import { createBootTokenMiddleware } from "./auth.js";
@@ -177,8 +177,25 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const canvasWatcher = new CanvasWatcherManager({
     onChange: (harnessSessionId) => bus.publish({ type: "canvas.reload", harnessSessionId }),
   });
+  // The harness's own infrastructure shouldn't ever show up as a "discovered"
+  // dev server in the Preview pane — a mention of our own listening port (in
+  // an agent's own output, e.g. echoing SAPIOM_HARNESS_INGEST_URL) or the
+  // analytics collector's port is not something the user started. `options
+  // .port` covers the common case (bin.ts always passes a concrete port);
+  // the actual bound port is added below once listen() resolves, covering
+  // the ephemeral `port: 0` case tests use. (There's no separate "vite dev
+  // port" to exclude beyond this — in dev mode the harness's own listening
+  // port *is* what `web/vite.config.ts`'s proxy targets, so excluding it
+  // here already covers that pairing.)
+  const excludedPorts = new Set<number>();
+  if (options.port) excludedPorts.add(options.port);
+  if (options.collectorUrl) {
+    const collectorPort = portFromUrl(options.collectorUrl);
+    if (collectorPort !== null) excludedPorts.add(collectorPort);
+  }
   const portDetector = new PortDetector({
     onPort: (harnessSessionId, port, url) => bus.publish({ type: "port.detected", harnessSessionId, port, url }),
+    excludedPorts,
   });
 
   const sessionManager = new SessionManager({
@@ -478,6 +495,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
 
   const address = httpServer.address();
   const actualPort = typeof address === "object" && address ? address.port : options.port;
+  // Covers the ephemeral `port: 0` case (tests) where `options.port` above
+  // was 0 and therefore never a real port to exclude — the actual bound
+  // port is only known now.
+  portDetector.addExcludedPort(actualPort);
 
   return {
     port: actualPort,


### PR DESCRIPTION
## Summary
- `PortDetector` was reporting the harness's own listening port and the analytics collector's port back to the user as if they were a dev server the agent had started (e.g. an agent's output echoing `SAPIOM_HARNESS_INGEST_URL` would light up the Preview pane for a port nobody actually started).
- Adds `PortDetectorDeps.excludedPorts` (constructor-time) + `addExcludedPort()` (for ports only known once the HTTP server resolves `listen()` — the ephemeral `port: 0` case tests use). An excluded port is dropped before it's even recorded as "seen", so it doesn't consume per-session dedupe state either.
- `server/index.ts` now excludes its own configured port at construction, adds the actual bound port once `listen()` resolves, and excludes the analytics collector's port (parsed via a new `portFromUrl()` helper that correctly handles the implicit-default-port case — `new URL(...).port` is `""` when the URL has no explicit port, not the real port).
- No separate "vite dev port" exclusion was needed: in dev mode, `web/vite.config.ts`'s dev-server proxy targets the harness's own listening port directly (4100 by default) — excluding that port already covers the pairing the task description flagged. Noted in a code comment so the reasoning isn't lost.
- Verified `PortDetector`'s per-`(session, port)` dedupe survived the #179 redesign — it's actually stronger than a TTL (permanent for the session's lifetime, cleared only by `reset()` on session exit), so no changes were needed there. Noted in the class doc comment.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck` (server) + strict web typecheck
- [x] `pnpm --filter @sapiom/harness test` — 267/267 (new: excludedPorts/addExcludedPort/portFromUrl unit tests in `port-detector.test.ts`)
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] `pnpm --filter @sapiom/harness e2e:live` — new end-to-end assertion: a `tool.call` event that echoes both the harness's real (ephemeral) bound port and the mock collector's port produces **no** `port.detected` frame, proving the real `server/index.ts` wiring rather than just the unit-tested class in isolation
- [x] `pnpm --filter @sapiom/harness test:ui` — 25/25 Playwright

**Unrelated flake spotted during verification:** `src/server/codex-tailer-wiring.test.ts` fails intermittently (`expected 'running' to be 'exited'`, ~1-in-6 runs) — reproduced identically on the unmodified `feat/harness` base with no changes applied, so it's pre-existing and outside this PR's scope. Not fixed here.

Co-Authored-By: Claude <noreply@anthropic.com>