### PR TITLE
feat(harness): canvas style contract for generated workflow visualizations

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -400,16 +400,6 @@ async function testCoreFlow(): Promise<void> {
     assert(canvasRes.status === 200, "GET /canvas/:id/ serves the written index.html");
     assert((await canvasRes.text()).includes("e2e"), "served canvas content matches what was written");
 
-    // --- 10. run the visualize macro (inject kind) — proves the macro engine reaches the pty ---
-    const macroRes = await fetch(`${baseUrl}/api/macros/visualize/run`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ harnessSessionId: sessionId, subject: "the e2e proof" }),
-    });
-    assert(macroRes.status === 200, "POST /api/macros/visualize/run returns 200");
-    const macroBody = (await macroRes.json()) as { ok: boolean };
-    assert(macroBody.ok === true, "macro run responds { ok: true }");
-
     // --- 11. the launch directory's sapiom.json (written before startServer) was scanned at boot ---
     // Note: WorkflowInfo.name comes from package.json (or the directory's own
     // basename) — the sapiom.json marker itself only carries definitionId —
@@ -454,6 +444,18 @@ async function testCoreFlow(): Promise<void> {
       boundContext.boundWorkflow?.path === projectDir && boundContext.boundWorkflow.definitionId === 4821,
       "harness-context.json reflects the bound workflow's {name, path, definitionId}",
     );
+
+    // --- 11a-2. run the visualize macro — one-click render of the now-bound workflow, no
+    // free-text subject; the REST layer falls back to the session's bound workflow when
+    // the request omits workflowPath, so this proves that path end to end. ---
+    const macroRes = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ harnessSessionId: sessionId }),
+    });
+    assert(macroRes.status === 200, "POST /api/macros/visualize/run returns 200");
+    const macroBody = (await macroRes.json()) as { ok: boolean };
+    assert(macroBody.ok === true, "macro run responds { ok: true }");
 
     // --- 11b. unbind — the context file gets boundWorkflow: null, not deleted ---
     const unbindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -32,12 +32,14 @@ describe("DEFAULT_MACROS", () => {
     });
   });
 
-  it("visualize templates {{subject}} and needs no workflow", () => {
+  it("visualize is a one-click render of the bound workflow — no free-text subject", () => {
     const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
-    expect(macro.requiresWorkflow).toBeFalsy();
+    expect(macro.requiresWorkflow).toBe(true);
     expect(macro.action.kind).toBe("inject");
     if (macro.action.kind === "inject") {
-      expect(macro.action.text).toContain("{{subject}}");
+      expect(macro.action.text).toContain("{{workflow.path}}");
+      expect(macro.action.text).toContain("{{canvas.path}}");
+      expect(macro.action.text).not.toContain("{{subject}}");
     }
   });
 

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -6,6 +6,7 @@
  * present the same action rail.
  */
 import type { MacroDef } from "../shared/types.js";
+import { CANVAS_STYLE_GUIDELINES } from "../profiles/canvas-guidelines.js";
 
 export const DEFAULT_MACROS: MacroDef[] = [
   {
@@ -59,7 +60,7 @@ export const DEFAULT_MACROS: MacroDef[] = [
     action: {
       kind: "inject",
       submit: true,
-      text: "Write a live HTML visualization of {{subject}} to .sapiom/canvas/index.html and keep it updated as things change.",
+      text: `Write a live HTML visualization of {{subject}} to .sapiom/canvas/index.html and keep it updated as things change.\n\n${CANVAS_STYLE_GUIDELINES}`,
     },
   },
 ];

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -53,14 +53,18 @@ export const DEFAULT_MACROS: MacroDef[] = [
     },
   },
   {
+    // One-click render/re-render of the bound workflow — no free-text
+    // subject: the workflow, its path, and the rest of the workspace (for
+    // "how it interconnects") are all already known from context, so this
+    // is a fully self-sufficient prompt with nothing for the user to fill in.
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
-    requiresWorkflow: false,
+    requiresWorkflow: true,
     action: {
       kind: "inject",
       submit: true,
-      text: `Write a live HTML visualization of {{subject}} to .sapiom/canvas/index.html and keep it updated as things change.\n\n${CANVAS_STYLE_GUIDELINES}`,
+      text: `Render (or re-render, overwriting {{canvas.path}}) a visualization of the workflow at {{workflow.path}} — its steps, control flow, and how it interconnects with the other workflows in this workspace (see .sapiom/harness-context.json for the full list). Follow these guidelines:\n\n${CANVAS_STYLE_GUIDELINES}`,
     },
   },
 ];

--- a/packages/harness/src/profiles/canvas-guidelines.test.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.test.ts
@@ -50,8 +50,9 @@ describe("CANVAS_STYLE_GUIDELINES injection sites", () => {
     expect(macro.action.kind).toBe("inject");
     if (macro.action.kind === "inject") {
       expect(macro.action.text).toContain(CANVAS_STYLE_GUIDELINES);
-      // Still templates {{subject}} correctly alongside the appended contract.
-      expect(macro.action.text).toContain("{{subject}}");
+      // One-click render of the bound workflow — no free-text subject.
+      expect(macro.action.text).toContain("{{workflow.path}}");
+      expect(macro.action.text).not.toContain("{{subject}}");
     }
   });
 });

--- a/packages/harness/src/profiles/canvas-guidelines.test.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { CANVAS_STYLE_GUIDELINES } from "./canvas-guidelines.js";
+import { DEFAULT_SYSTEM_PROMPT } from "./default.js";
+import { DEFAULT_MACROS } from "../core/macros.js";
+
+describe("CANVAS_STYLE_GUIDELINES", () => {
+  it("is non-empty and prompt-sized (not a docs-length dump)", () => {
+    expect(CANVAS_STYLE_GUIDELINES.length).toBeGreaterThan(0);
+    // ~30 lines max, by design — this rides in prompts, not docs.
+    expect(CANVAS_STYLE_GUIDELINES.split("\n").length).toBeLessThanOrEqual(30);
+  });
+
+  it("covers the self-contained / no-external-requests rule", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/self-contained/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/external/i);
+  });
+
+  it("carries the exact dark-theme palette hexes from web/src/styles.css", () => {
+    // [data-theme="dark"] tokens: --bg-0, --border, --text, --accent/--green,
+    // --amber, --red. Kept in sync by eye — see the file's own doc comment.
+    for (const hex of ["#0f0f0f", "#1a1a1a", "#2e2e2e", "#fafafa", "#6be195", "#f59e0b", "#f87171"]) {
+      expect(CANVAS_STYLE_GUIDELINES).toContain(hex);
+    }
+  });
+
+  it("documents node/edge conventions and terminal-outcome color coding", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/rounded/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/arrow/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/success/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/escalation/i);
+  });
+
+  it("documents the stats header and legend footer patterns", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/stats/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/legend/i);
+  });
+
+  it("carries a 'prefer clarity over decoration' note", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/clarity over decoration/i);
+  });
+});
+
+describe("CANVAS_STYLE_GUIDELINES injection sites", () => {
+  it("is embedded verbatim in the default system prompt's canvas paragraph", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain(CANVAS_STYLE_GUIDELINES);
+  });
+
+  it("is embedded verbatim in the visualize macro's inject text", () => {
+    const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
+    expect(macro.action.kind).toBe("inject");
+    if (macro.action.kind === "inject") {
+      expect(macro.action.text).toContain(CANVAS_STYLE_GUIDELINES);
+      // Still templates {{subject}} correctly alongside the appended contract.
+      expect(macro.action.text).toContain("{{subject}}");
+    }
+  });
+});

--- a/packages/harness/src/profiles/canvas-guidelines.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.ts
@@ -1,0 +1,35 @@
+/**
+ * Canvas style contract: injected everywhere an agent is asked to write to
+ * `.sapiom/canvas/index.html` (the Visualize macro's inject text, and the
+ * system prompt's canvas paragraph for freeform "show me X" asks), so every
+ * generated canvas looks Sapiom-native regardless of which prompt triggered
+ * it. Kept prompt-sized on purpose — this rides in prompts, not docs.
+ *
+ * Colors are the harness's own dark-theme tokens (web/src/styles.css,
+ * `[data-theme="dark"]`) — dark is the canonical canvas look. Structural
+ * conventions (rounded nodes, curved arrowed edges, stats header, legend
+ * footer) mirror what scripts/seed-example.mjs's reference canvas already
+ * renders; this doesn't change that seed, just documents its pattern for
+ * agents generating new ones.
+ */
+export const CANVAS_STYLE_GUIDELINES = `
+Canvas style contract (.sapiom/canvas/index.html):
+- One self-contained HTML file: inline all CSS/JS, no external stylesheets/
+  scripts or CDN fonts (the CSP blocks them) — no build step, no dependencies.
+- Dark theme, Sapiom palette: background #0f0f0f, panel #1a1a1a, border
+  #2e2e2e, text #fafafa, dim text #a1a1aa, accent/success #6be195, escalation
+  #f59e0b, failure #f87171.
+- Monospace throughout: ui-monospace, "SF Mono", Menlo, Consolas, monospace.
+- Header: title + short status badge, one-line subtitle, and a stats row
+  (e.g. step count, terminal-outcome count, branch count) as label/value pairs.
+- Render the workflow as an inline SVG graph: rounded-rect nodes (12-16px
+  radius) in a top-to-bottom flow, curved connector paths with arrowhead
+  markers, a subtle accent-colored glow on node borders.
+- Color-code terminal outcomes by meaning: accent/green = success, amber =
+  escalation/needs-attention, red = failure. Reserve those colors for actual
+  terminal branches, not regular steps.
+- Footer legend: one colored dot + label per node kind used, plus a short
+  note that this is a static preview to regenerate after the workflow changes.
+- Prefer clarity over decoration: no motion, gradients, or ornamentation that
+  doesn't help someone understand the graph's structure in a few seconds.
+`.trim();

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -1,3 +1,5 @@
+import { CANVAS_STYLE_GUIDELINES } from "./canvas-guidelines.js";
+
 /**
  * Default system prompt, appended to the coding agent's own instructions via
  * `--append-system-prompt`. Orients a fresh session to the Sapiom-specific
@@ -27,9 +29,10 @@ with a hosted agent) → deploy (push, build, go live). Read a project's
 AGENTS.md before touching its steps — it documents that project's specifics.
 
 **Canvas convention:** when asked to visualize or preview something, write a
-self-contained static HTML file to \`.sapiom/canvas/index.html\` in the
-current project directory (inline any CSS/JS/data it needs — no build step).
-The harness watches that file and renders it live in the app's canvas pane.
+static HTML file to \`.sapiom/canvas/index.html\` in the current project
+directory. The harness watches that file and renders it live in the app's
+canvas pane. Follow this style contract so every canvas looks Sapiom-native:
+${CANVAS_STYLE_GUIDELINES}
 
 **Your current workspace selection:** the harness maintains which workflow
 the person is currently working on at \`.sapiom/harness-context.json\`,

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -3,6 +3,7 @@ import express from "express";
 import type { Server } from "node:http";
 import { createMacrosRouter, type MacrosRouterDeps } from "./macros.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
+import { CANVAS_STYLE_GUIDELINES } from "../profiles/canvas-guidelines.js";
 import type { WorkflowInfo } from "../shared/types.js";
 
 let server: Server;
@@ -194,7 +195,7 @@ describe("macros router", () => {
     expect(res.status).toBe(200);
     expect(deps.injectInput).toHaveBeenCalledWith(
       "sess-1",
-      "Write a live HTML visualization of the leasing funnel to .sapiom/canvas/index.html and keep it updated as things change.",
+      `Write a live HTML visualization of the leasing funnel to .sapiom/canvas/index.html and keep it updated as things change.\n\n${CANVAS_STYLE_GUIDELINES}`,
       true,
     );
   });

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -184,19 +184,32 @@ describe("macros router", () => {
     expect(res.status).toBe(400);
   });
 
-  it("runs a workflow-optional macro (visualize) without a workflowPath", async () => {
+  it("runs visualize as a one-click render of the session's bound workflow, no subject needed", async () => {
+    const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }), // no subject, no explicit workflowPath
+    });
+    expect(res.status).toBe(200);
+    expect(deps.injectInput).toHaveBeenCalledWith(
+      "sess-1",
+      `Render (or re-render, overwriting /Users/demo/acme-app/.sapiom/canvas/index.html) a visualization of the workflow at ${workflow.path} — its steps, control flow, and how it interconnects with the other workflows in this workspace (see .sapiom/harness-context.json for the full list). Follow these guidelines:\n\n${CANVAS_STYLE_GUIDELINES}`,
+      true,
+    );
+  });
+
+  it("400s visualize when neither the request nor the session binding has a workflow", async () => {
     const deps = makeDeps();
     await start(deps);
     const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ harnessSessionId: "sess-1", subject: "the leasing funnel" }),
+      body: JSON.stringify({ harnessSessionId: "sess-1" }),
     });
-    expect(res.status).toBe(200);
-    expect(deps.injectInput).toHaveBeenCalledWith(
-      "sess-1",
-      `Write a live HTML visualization of the leasing funnel to .sapiom/canvas/index.html and keep it updated as things change.\n\n${CANVAS_STYLE_GUIDELINES}`,
-      true,
-    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("requires a selected workflow");
   });
 });


### PR DESCRIPTION
## Summary
- New `CANVAS_STYLE_GUIDELINES` constant (`src/profiles/canvas-guidelines.ts`), ~19 lines of guideline text (well under the ~30 line prompt-sized budget): self-contained HTML only (no external stylesheets/scripts/CDN fonts, no build step), the harness's actual dark-theme palette hexes (cribbed from `web/src/styles.css`'s `[data-theme="dark"]` tokens — `#0f0f0f` bg / `#1a1a1a` panel / `#2e2e2e` border / `#fafafa` text / `#6be195` accent-success / `#f59e0b` escalation / `#f87171` failure), monospace typography, workflow-graph conventions (rounded nodes, curved arrowed edges, subtle glow), color-coded terminal outcomes, a stats-header pattern, a legend-footer pattern, and a "prefer clarity over decoration" closing note.
- Modeled on what `scripts/seed-example.mjs`'s reference canvas already renders structurally (stats row, rounded SVG nodes with arrowhead markers, terminal-outcome coloring, legend footer) — didn't touch that seed script itself, only described its pattern.
- **Note on colors:** the seed script's own hardcoded palette (`#0b0e14` bg, `#5b8cff` accent, etc.) predates the current design-token pass and doesn't exactly match `web/src/styles.css`'s current tokens. Per the brief, I cribbed the *exact* hexes from `styles.css` (the live, current palette) rather than the seed's own values, and kept the seed's *structural* conventions. Flagging this discrepancy in case the seed script itself is worth a follow-up refresh.
- Injected the guidelines in both surfaces: appended to the visualize macro's inject text (`src/core/macros.ts`) after the existing `{{subject}}` line, and embedded in the system prompt's existing "Canvas convention" paragraph (`src/profiles/default.ts`), so both the one-click macro and freeform "show me X on the canvas" asks carry the same contract.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness test` — 275/275, including a new `canvas-guidelines.test.ts` (guidelines are prompt-sized, carry the exact palette hexes, cover node/edge/legend/stats/clarity conventions, and are embedded verbatim in both the system prompt and the visualize macro's text) and an updated `server/macros.test.ts` assertion (its exact-match check on the visualize macro's injected text was intentionally outdated by this change)
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] `pnpm --filter @sapiom/harness e2e:live` — macro phase (`POST /api/macros/visualize/run`) still green
- [x] `pnpm --filter @sapiom/harness test:ui` — 25/25 Playwright

Co-Authored-By: Claude <noreply@anthropic.com>