### PR TITLE
feat(harness): retire the action rail, actions move onto workflows

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -13,13 +13,16 @@ test.beforeEach(async ({ page }) => {
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
-test("renders all four panes plus the brand header", async ({ page }) => {
+test("renders the three panes plus the brand header, with no separate action rail", async ({ page }) => {
   await expect(page.locator(".brand-header")).toBeVisible();
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.locator(".center-pane")).toBeVisible();
   await expect(page.locator(".session-bar")).toBeVisible();
   await expect(page.locator(".canvas-pane")).toBeVisible();
-  await expect(page.locator(".rail-actions")).toBeVisible();
+
+  // The action rail is retired — actions live on workflows now (row icons,
+  // bound-workflow header), not in a standalone column.
+  await expect(page.locator(".rail-actions")).toHaveCount(0);
 
   await page.screenshot({ path: "web/e2e/screenshots/app-shell.png", fullPage: true });
 });
@@ -288,7 +291,8 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
 });
 
 test("canvas pane shows its empty state for the active session", async ({ page }) => {
-  await expect(page.locator(".canvas-empty")).toContainText("Nothing rendered yet");
+  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+  await expect(page.locator(".canvas-empty")).toContainText(".sapiom/canvas/index.html");
 });
 
 test("settings popover: identity, telemetry toggle, and it persists across close/reopen", async ({ page }) => {
@@ -317,11 +321,96 @@ test("visualize macro prompts for a subject before running", async ({ page }) =>
   await expect(page.getByTestId("macro-visualize")).toBeEnabled();
 
   await page.getByTestId("macro-visualize").click();
-  await expect(page.getByText("Visualize")).toBeVisible();
+  await expect(page.locator(".modal-header")).toHaveText("Visualize");
   const subjectInput = page.getByPlaceholder("What should the agent visualize?");
   await expect(subjectInput).toBeVisible();
 
   await subjectInput.fill("the leasing pipeline");
   await page.getByRole("button", { name: "Run", exact: true }).click();
   await expect(subjectInput).toBeHidden();
+});
+
+test.describe("actions live on workflows, not a separate rail", () => {
+  test("workflow rows keep their action icons hidden until you hover or select the row", async ({ page }) => {
+    const row = page.getByTestId("workflow-rfq");
+    const actions = row.locator(".workflow-row-actions");
+
+    await expect(actions).toHaveCSS("opacity", "0");
+    await row.hover();
+    await expect(actions).toHaveCSS("opacity", "1");
+    await page.screenshot({ path: "web/e2e/screenshots/workflow-row-hover-actions.png" });
+
+    // Moving away hides them again — hover alone doesn't stick.
+    await page.mouse.move(0, 0);
+    await expect(actions).toHaveCSS("opacity", "0");
+
+    // Selecting the row keeps the actions visible without a hover.
+    await row.locator(".workflow-item-trigger").click();
+    await page.mouse.move(0, 0);
+    await expect(actions).toHaveCSS("opacity", "1");
+  });
+
+  test("the workflow bound to the active session gets an actions header above the canvas", async ({ page }) => {
+    const header = page.getByTestId("workflow-actions-header");
+    await expect(header).toBeVisible();
+    await expect(header).toContainText("leasing");
+
+    // The header carries the full macro set, including Visualize — the one
+    // macro that stays contextual to the bound workflow.
+    await expect(header.getByTestId("macro-run_local")).toBeVisible();
+    await expect(header.getByTestId("macro-deploy")).toBeVisible();
+    await expect(header.getByTestId("macro-prod_run")).toBeVisible();
+    await expect(header.getByTestId("macro-open_prod")).toBeVisible();
+    await expect(header.getByTestId("macro-visualize")).toBeVisible();
+
+    await page.screenshot({ path: "web/e2e/screenshots/workflow-actions-header.png" });
+  });
+});
+
+test("canvas empty state explains itself and offers a Visualize CTA", async ({ page }) => {
+  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+
+  await page.screenshot({ path: "web/e2e/screenshots/canvas-empty-state.png" });
+
+  const cta = page.getByTestId("canvas-visualize-cta");
+  await expect(cta).toBeVisible();
+  await cta.click();
+
+  const subjectInput = page.getByTestId("canvas-visualize-subject");
+  await expect(subjectInput).toBeVisible();
+  await subjectInput.fill("the leasing pipeline");
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(subjectInput).toBeHidden();
+});
+
+test("the canvas is a single controlled surface — no separate preview tab or port suggestions", async ({ page }) => {
+  await expect(page.locator(".canvas-mode-toggle")).toHaveCount(0);
+  await expect(page.getByTestId("preview-chip")).toHaveCount(0);
+
+  // A detected-port bus message must render nothing in this surface — the
+  // canvas only ever shows the session's own generated content.
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "port.detected",
+      harnessSessionId: "sess-boot",
+      port: 4000,
+      url: "http://localhost:4000",
+    });
+  });
+  await expect(page.getByTestId("preview-chip")).toHaveCount(0);
+  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+});
+
+test("a canvas.reload bus message swaps the empty state for the generated iframe", async ({ page }) => {
+  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+
+  await expect(page.locator(".canvas-empty")).toHaveCount(0);
+  await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", "/canvas/sess-boot/");
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -2,13 +2,14 @@
  * Harness SPA shell (workstream W2).
  *
  * Layout: workflows rail (left) | session dropdown + terminal (center)
- * | canvas/preview pane (right) | action icon rail (far right).
+ * | canvas/preview pane (right). Actions live on their workflow: inline
+ * row icons in the rail, and a header strip above the canvas for whichever
+ * workflow is bound to the active session.
  */
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
-import type { HarnessKind, MacroDef } from "@shared/types";
+import type { HarnessKind, MacroDef, WorkflowInfo } from "@shared/types";
 
-import { ActionRail } from "./components/ActionRail";
 import { BrandHeader } from "./components/BrandHeader";
 import { CanvasPane } from "./components/CanvasPane";
 import { CommandPalette } from "./components/CommandPalette";
@@ -17,6 +18,7 @@ import { SessionBar } from "./components/SessionBar";
 import { Terminal } from "./components/Terminal";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
+import { resolveMacroUrl } from "./lib/macro-gating";
 import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
@@ -45,10 +47,9 @@ export const App = (): JSX.Element => {
   }
 
   const { state } = harness;
-  const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
   const activeSession = state.sessions.find((session) => session.id === harness.activeSessionId) ?? null;
   const boundWorkflowPath = boundWorkflowPathOf(activeSession);
-  const boundWorkflowName = state.workflows.find((w) => w.path === boundWorkflowPath)?.name ?? null;
+  const boundWorkflow = state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
 
   const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
@@ -61,31 +62,21 @@ export const App = (): JSX.Element => {
     if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
-  const disabledReasonFor = (macro: MacroDef): string | null => {
-    if (macro.requiresWorkflow) {
-      if (!selectedWorkflow) return "Select a workflow first";
-      if (macro.action.kind === "open-url" && macro.action.url.includes("{{workflow.definitionId}}") &&
-        selectedWorkflow.definitionId == null) {
-        return "Not deployed yet";
-      }
-    }
-    if (macro.action.kind === "inject" && !harness.activeSessionId) return "Start a session first";
-    return null;
-  };
-
-  const handleRunMacro = (macro: MacroDef, subject?: string): void => {
+  // Shared by workflow-row hover actions, the bound-workflow header above the
+  // canvas, and the canvas empty-state's Visualize CTA. Running a macro against
+  // a workflow also (re-)binds it, so acting on a row that isn't the current
+  // binding switches "what I'm working on" too. `workflow` is nullable for
+  // macros that don't require one (Visualize) when nothing's bound yet.
+  const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef, subject?: string): void => {
+    if (workflow) handleSelectWorkflow(workflow.path);
     if (macro.action.kind === "open-url") {
-      const url = macro.action.url.replace(
-        "{{workflow.definitionId}}",
-        String(selectedWorkflow?.definitionId ?? ""),
-      );
-      window.open(url, "_blank", "noopener,noreferrer");
+      window.open(resolveMacroUrl(macro.action.url, workflow), "_blank", "noopener,noreferrer");
       return;
     }
     if (!harness.activeSessionId) return;
     void harness.runMacro(macro.id, {
       harnessSessionId: harness.activeSessionId,
-      workflowPath: harness.selectedWorkflowPath ?? undefined,
+      workflowPath: workflow?.path,
       subject,
     });
   };
@@ -104,7 +95,9 @@ export const App = (): JSX.Element => {
           sessions={state.sessions}
           activeSessionId={harness.activeSessionId}
           selectedPath={harness.selectedWorkflowPath}
+          macros={state.macros}
           onSelect={handleSelectWorkflow}
+          onRunMacro={handleRunMacroForWorkflow}
           onConnect={async (path) => {
             await harness.connectWorkflow(path);
           }}
@@ -123,7 +116,7 @@ export const App = (): JSX.Element => {
             launchDir={state.launchDir ?? null}
             listDir={harness.listDir}
             onCreateSession={handleCreateSession}
-            boundWorkflowName={boundWorkflowName}
+            boundWorkflowName={boundWorkflow?.name ?? null}
             authenticated={state.authenticated}
             organizationName={state.organizationName}
             telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
@@ -146,9 +139,14 @@ export const App = (): JSX.Element => {
           </div>
         </div>
 
-        <CanvasPane sessionId={harness.activeSessionId} lastMessage={harness.lastMessage} />
-
-        <ActionRail macros={state.macros} disabledReasonFor={disabledReasonFor} onRun={handleRunMacro} />
+        <CanvasPane
+          sessionId={harness.activeSessionId}
+          lastMessage={harness.lastMessage}
+          boundWorkflow={boundWorkflow}
+          activeSessionId={harness.activeSessionId}
+          macros={state.macros}
+          onRunMacro={(macro, subject) => handleRunMacroForWorkflow(boundWorkflow, macro, subject)}
+        />
       </div>
 
       {paletteOpen && (

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -1,30 +1,38 @@
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
-import type { BusMessage } from "@shared/types";
+import type { BusMessage, MacroDef, WorkflowInfo } from "@shared/types";
 
 import { isMockMode } from "../lib/api";
+import { needsSubject } from "../lib/macro-gating";
 import { Icon } from "./Icon";
-
-type CanvasMode = "generated" | "preview";
+import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 
 interface CanvasPaneProps {
   sessionId: string | null;
   lastMessage: BusMessage | null;
+  boundWorkflow: WorkflowInfo | null;
+  activeSessionId: string | null;
+  macros: MacroDef[];
+  onRunMacro: (macro: MacroDef, subject?: string) => void;
 }
 
-export function CanvasPane({ sessionId, lastMessage }: CanvasPaneProps): JSX.Element {
-  const [mode, setMode] = useState<CanvasMode>("generated");
-  const [previewUrl, setPreviewUrl] = useState("");
-  const [previewInput, setPreviewInput] = useState("");
+export function CanvasPane({
+  sessionId,
+  lastMessage,
+  boundWorkflow,
+  activeSessionId,
+  macros,
+  onRunMacro,
+}: CanvasPaneProps): JSX.Element {
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
-  const [portChip, setPortChip] = useState<{ port: number; url: string } | null>(null);
+  const [visualizing, setVisualizing] = useState(false);
+  const [visualizeSubject, setVisualizeSubject] = useState("");
 
   // Probe once per session for pre-existing content — the agent may have written
   // it in an earlier turn, before this pane was around to catch a reload event.
   useEffect(() => {
     setHasGeneratedContent(false);
-    setPortChip(null);
     if (!sessionId || isMockMode()) return;
     let cancelled = false;
     fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
@@ -40,77 +48,71 @@ export function CanvasPane({ sessionId, lastMessage }: CanvasPaneProps): JSX.Ele
     if (lastMessage.type === "canvas.reload" && lastMessage.harnessSessionId === sessionId) {
       setHasGeneratedContent(true);
       setReloadKey((key) => key + 1);
-    } else if (lastMessage.type === "port.detected" && lastMessage.harnessSessionId === sessionId) {
-      setPortChip({ port: lastMessage.port, url: lastMessage.url });
     }
   }, [lastMessage, sessionId]);
 
-  const openPreviewChip = (): void => {
-    if (!portChip) return;
-    setPreviewUrl(portChip.url);
-    setPreviewInput(portChip.url);
-    setMode("preview");
+  const visualizeMacro = macros.find(needsSubject);
+  const submitVisualize = (): void => {
+    if (!visualizeMacro) return;
+    onRunMacro(visualizeMacro, visualizeSubject.trim() || undefined);
+    setVisualizing(false);
   };
-
-  const navigatePreview = (): void => setPreviewUrl(previewInput);
 
   return (
     <aside className="canvas-pane">
-      <div className="canvas-header">
-        <div className="canvas-mode-toggle">
-          <button
-            className={"canvas-mode-btn" + (mode === "generated" ? " is-active" : "")}
-            onClick={() => setMode("generated")}
-          >
-            Generated
-          </button>
-          <button
-            className={"canvas-mode-btn" + (mode === "preview" ? " is-active" : "")}
-            onClick={() => setMode("preview")}
-          >
-            Preview
-          </button>
-        </div>
-        {portChip && mode !== "preview" && (
-          <button className="preview-chip" onClick={openPreviewChip}>
-            <Icon name="Radio" size={12} /> Preview :{portChip.port}
-          </button>
-        )}
-      </div>
+      {boundWorkflow && (
+        <WorkflowActionsHeader
+          workflow={boundWorkflow}
+          activeSessionId={activeSessionId}
+          macros={macros}
+          onRunMacro={onRunMacro}
+        />
+      )}
 
-      {mode === "preview" ? (
-        <div className="canvas-preview">
-          <div className="canvas-urlbar">
-            <input
-              className="canvas-url-input"
-              value={previewInput}
-              placeholder="http://localhost:3000"
-              onChange={(e) => setPreviewInput(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && navigatePreview()}
-            />
-            <button className="btn-ghost" onClick={navigatePreview}>
-              Go
-            </button>
-          </div>
-          {previewUrl ? (
-            <iframe
-              key={previewUrl}
-              className="canvas-iframe"
-              src={previewUrl}
-              sandbox="allow-scripts allow-forms allow-same-origin"
-            />
-          ) : (
-            <div className="canvas-empty">Enter a localhost URL to preview a running dev server.</div>
-          )}
-        </div>
-      ) : !sessionId ? (
+      {!sessionId ? (
         <div className="canvas-empty">Start a session to see its canvas here.</div>
       ) : !hasGeneratedContent ? (
         <div className="canvas-empty">
-          <p>Nothing rendered yet.</p>
-          <p>
-            Ask your agent to write HTML to <code>.sapiom/canvas/index.html</code> — this pane hot-reloads whenever
-            it changes.
+          <p>Nothing generated yet.</p>
+          {visualizeMacro &&
+            (visualizing ? (
+              <div className="canvas-visualize-inline">
+                <input
+                  autoFocus
+                  className="modal-input"
+                  data-testid="canvas-visualize-subject"
+                  placeholder="What should the agent visualize?"
+                  value={visualizeSubject}
+                  onChange={(e) => setVisualizeSubject(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") submitVisualize();
+                    if (e.key === "Escape") setVisualizing(false);
+                  }}
+                />
+                <div className="modal-actions">
+                  <button className="btn-ghost" onClick={() => setVisualizing(false)}>
+                    Cancel
+                  </button>
+                  <button className="btn-primary" onClick={submitVisualize}>
+                    Run
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                className="btn-primary canvas-visualize-cta"
+                data-testid="canvas-visualize-cta"
+                onClick={() => {
+                  setVisualizeSubject("");
+                  setVisualizing(true);
+                }}
+              >
+                <Icon name="Sparkles" size={14} /> Visualize
+              </button>
+            ))}
+          <p className="canvas-empty-hint">
+            Ask your agent to visualize, or write HTML directly to <code>.sapiom/canvas/index.html</code> — this pane
+            hot-reloads whenever it changes.
           </p>
         </div>
       ) : (

--- a/packages/harness/web/src/components/MacroButtons.tsx
+++ b/packages/harness/web/src/components/MacroButtons.tsx
@@ -1,24 +1,39 @@
 import { useState } from "react";
-import type { JSX } from "react";
-import type { MacroDef } from "@shared/types";
+import type { JSX, MouseEvent } from "react";
+import type { MacroDef, WorkflowInfo } from "@shared/types";
 
+import { macroDisabledReason, needsSubject } from "../lib/macro-gating";
 import { Icon } from "./Icon";
 
-interface ActionRailProps {
+interface MacroButtonsProps {
   macros: MacroDef[];
-  disabledReasonFor: (macro: MacroDef) => string | null;
+  workflow: WorkflowInfo | null;
+  activeSessionId: string | null;
   onRun: (macro: MacroDef, subject?: string) => void;
+  size?: number;
+  /** Distinguishes repeated per-row instances (e.g. one per workflow row) — omit for a single instance (the bound-workflow header). */
+  testIdPrefix?: string;
 }
 
-function needsSubject(macro: MacroDef): boolean {
-  return macro.action.kind === "inject" && macro.action.text.includes("{{subject}}");
-}
-
-export function ActionRail({ macros, disabledReasonFor, onRun }: ActionRailProps): JSX.Element {
+/**
+ * A row of macro icon buttons, config-driven from MacroDef[] — used both as
+ * per-workflow-row hover actions (compact, no Visualize — anything needing a
+ * subject stays out) and as the full set in the bound-workflow header above
+ * the canvas. Callers control layout via their own wrapping element.
+ */
+export function MacroButtons({
+  macros,
+  workflow,
+  activeSessionId,
+  onRun,
+  size = 16,
+  testIdPrefix = "",
+}: MacroButtonsProps): JSX.Element {
   const [subjectFor, setSubjectFor] = useState<MacroDef | null>(null);
   const [subject, setSubject] = useState("");
 
-  const handleClick = (macro: MacroDef): void => {
+  const handleClick = (e: MouseEvent, macro: MacroDef): void => {
+    e.stopPropagation(); // row actions sit inside a clickable row — don't also trigger row selection
     if (needsSubject(macro)) {
       setSubjectFor(macro);
       setSubject("");
@@ -34,20 +49,20 @@ export function ActionRail({ macros, disabledReasonFor, onRun }: ActionRailProps
   };
 
   return (
-    <aside className="rail rail-actions">
+    <>
       {macros.map((macro) => {
-        const disabledReason = disabledReasonFor(macro);
+        const disabledReason = macroDisabledReason(macro, workflow, activeSessionId);
         return (
           <button
             key={macro.id}
-            className="action-icon-btn"
+            className="macro-icon-btn"
             aria-label={macro.label}
-            data-testid={`macro-${macro.id}`}
+            data-testid={`${testIdPrefix}macro-${macro.id}`}
             data-tooltip={disabledReason ?? macro.label}
             disabled={Boolean(disabledReason)}
-            onClick={() => handleClick(macro)}
+            onClick={(e) => handleClick(e, macro)}
           >
-            <Icon name={macro.icon} size={18} />
+            <Icon name={macro.icon} size={size} />
           </button>
         );
       })}
@@ -78,6 +93,6 @@ export function ActionRail({ macros, disabledReasonFor, onRun }: ActionRailProps
           </div>
         </div>
       )}
-    </aside>
+    </>
   );
 }

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from "react";
+import type { MacroDef, WorkflowInfo } from "@shared/types";
+
+import { MacroButtons } from "./MacroButtons";
+
+interface WorkflowActionsHeaderProps {
+  workflow: WorkflowInfo;
+  activeSessionId: string | null;
+  macros: MacroDef[];
+  onRunMacro: (macro: MacroDef, subject?: string) => void;
+}
+
+/**
+ * Slim strip above the canvas pane, shown whenever a workflow is bound to the
+ * active session — the full macro set (including Visualize, which stays
+ * scoped to whatever's actually bound) lives here now that the standalone
+ * action rail is gone.
+ */
+export function WorkflowActionsHeader({
+  workflow,
+  activeSessionId,
+  macros,
+  onRunMacro,
+}: WorkflowActionsHeaderProps): JSX.Element {
+  return (
+    <div className="workflow-actions-header" data-testid="workflow-actions-header">
+      <span className="workflow-actions-name">{workflow.name}</span>
+      {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
+      <div className="workflow-actions-buttons">
+        <MacroButtons macros={macros} workflow={workflow} activeSessionId={activeSessionId} onRun={onRunMacro} size={15} />
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import type { JSX } from "react";
-import type { HarnessSession, WorkflowInfo } from "@shared/types";
+import type { HarnessSession, MacroDef, WorkflowInfo } from "@shared/types";
 
 import { Icon } from "./Icon";
+import { MacroButtons } from "./MacroButtons";
+import { needsSubject } from "../lib/macro-gating";
 import { buildWorkspaceTree } from "../lib/workspace-tree";
 
 interface WorkflowsRailProps {
@@ -10,30 +12,45 @@ interface WorkflowsRailProps {
   sessions: HarnessSession[];
   activeSessionId: string | null;
   selectedPath: string | null;
+  macros: MacroDef[];
   onSelect: (path: string) => void;
+  onRunMacro: (workflow: WorkflowInfo, macro: MacroDef, subject?: string) => void;
   onConnect: (path: string) => Promise<void>;
 }
 
 function WorkflowRow({
   workflow,
   isSelected,
+  activeSessionId,
+  rowMacros,
   onSelect,
+  onRunMacro,
 }: {
   workflow: WorkflowInfo;
   isSelected: boolean;
+  activeSessionId: string | null;
+  rowMacros: MacroDef[];
   onSelect: (path: string) => void;
+  onRunMacro: (workflow: WorkflowInfo, macro: MacroDef, subject?: string) => void;
 }): JSX.Element {
   return (
-    <button
-      className={"workflow-item" + (isSelected ? " is-selected" : "")}
-      data-testid={`workflow-${workflow.name}`}
-      onClick={() => onSelect(workflow.path)}
-      title={workflow.path}
-    >
-      <span className="workflow-caret">▸</span>
-      <span className="workflow-name">{workflow.name}</span>
-      {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
-    </button>
+    <div className={"workflow-item" + (isSelected ? " is-selected" : "")} data-testid={`workflow-${workflow.name}`}>
+      <button className="workflow-item-trigger" onClick={() => onSelect(workflow.path)} title={workflow.path}>
+        <span className="workflow-caret">▸</span>
+        <span className="workflow-name">{workflow.name}</span>
+        {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
+      </button>
+      <div className="workflow-row-actions">
+        <MacroButtons
+          macros={rowMacros}
+          workflow={workflow}
+          activeSessionId={activeSessionId}
+          onRun={(macro, subject) => onRunMacro(workflow, macro, subject)}
+          size={13}
+          testIdPrefix={`${workflow.name}-`}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -42,7 +59,9 @@ export function WorkflowsRail({
   sessions,
   activeSessionId,
   selectedPath,
+  macros,
   onSelect,
+  onRunMacro,
   onConnect,
 }: WorkflowsRailProps): JSX.Element {
   const [connecting, setConnecting] = useState(false);
@@ -66,7 +85,23 @@ export function WorkflowsRail({
     }
   };
 
+  // Row actions are compact quick-actions, not the full macro set — anything
+  // needing a subject (Visualize) stays reserved for the bound-workflow header.
+  const rowMacros = macros.filter((macro) => !needsSubject(macro));
+
   const { groups, ungrouped } = buildWorkspaceTree(workflows, sessions, activeSessionId);
+
+  const renderRow = (workflow: WorkflowInfo): JSX.Element => (
+    <WorkflowRow
+      key={workflow.path}
+      workflow={workflow}
+      isSelected={workflow.path === selectedPath}
+      activeSessionId={activeSessionId}
+      rowMacros={rowMacros}
+      onSelect={onSelect}
+      onRunMacro={onRunMacro}
+    />
+  );
 
   return (
     <aside className="rail rail-workflows">
@@ -81,28 +116,14 @@ export function WorkflowsRail({
               {group.label}
             </div>
             {group.workflows.length === 0 && <div className="workspace-group-empty">No workflows here yet</div>}
-            {group.workflows.map((workflow) => (
-              <WorkflowRow
-                key={workflow.path}
-                workflow={workflow}
-                isSelected={workflow.path === selectedPath}
-                onSelect={onSelect}
-              />
-            ))}
+            {group.workflows.map(renderRow)}
           </div>
         ))}
 
         {ungrouped.length > 0 && (
           <div className="workspace-group">
             <div className="workspace-group-header">Other</div>
-            {ungrouped.map((workflow) => (
-              <WorkflowRow
-                key={workflow.path}
-                workflow={workflow}
-                isSelected={workflow.path === selectedPath}
-                onSelect={onSelect}
-              />
-            ))}
+            {ungrouped.map(renderRow)}
           </div>
         )}
       </div>

--- a/packages/harness/web/src/lib/events.ts
+++ b/packages/harness/web/src/lib/events.ts
@@ -11,9 +11,25 @@ export type BusListener = (message: BusMessage) => void;
 
 const RECONNECT_DELAY_MS = 2000;
 
+const mockListeners = new Set<BusListener>();
+
+/**
+ * Test-only escape hatch, mock mode only: lets Playwright simulate a bus
+ * message (e.g. canvas.reload) without a real server. Never exists outside
+ * VITE_MOCK=1.
+ */
+if (isMockMode() && typeof window !== "undefined") {
+  (window as unknown as { __HARNESS_TEST__: { publish: BusListener } }).__HARNESS_TEST__ = {
+    publish: (message) => mockListeners.forEach((listener) => listener(message)),
+  };
+}
+
 /** Subscribes and returns an unsubscribe function. */
 export function subscribeEvents(onMessage: BusListener): () => void {
-  if (isMockMode()) return () => {};
+  if (isMockMode()) {
+    mockListeners.add(onMessage);
+    return () => mockListeners.delete(onMessage);
+  }
 
   const url = new URL("/ws/events", window.location.href);
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";

--- a/packages/harness/web/src/lib/macro-gating.ts
+++ b/packages/harness/web/src/lib/macro-gating.ts
@@ -1,0 +1,30 @@
+import type { MacroDef, WorkflowInfo } from "@shared/types";
+
+/** Macros carrying a `{{subject}}` placeholder prompt for free text before running (only Visualize today). */
+export function needsSubject(macro: MacroDef): boolean {
+  return macro.action.kind === "inject" && macro.action.text.includes("{{subject}}");
+}
+
+/** Shared gating logic for any surface that runs a macro against a specific workflow (row actions, the bound-workflow header). */
+export function macroDisabledReason(
+  macro: MacroDef,
+  workflow: WorkflowInfo | null,
+  activeSessionId: string | null,
+): string | null {
+  if (macro.requiresWorkflow) {
+    if (!workflow) return "Select a workflow first";
+    if (
+      macro.action.kind === "open-url" &&
+      macro.action.url.includes("{{workflow.definitionId}}") &&
+      workflow.definitionId == null
+    ) {
+      return "Not deployed yet";
+    }
+  }
+  if (macro.action.kind === "inject" && !activeSessionId) return "Start a session first";
+  return null;
+}
+
+export function resolveMacroUrl(url: string, workflow: WorkflowInfo | null): string {
+  return url.replace("{{workflow.definitionId}}", String(workflow?.definitionId ?? ""));
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -212,7 +212,7 @@ input {
 
 .app {
   display: grid;
-  grid-template-columns: 220px 1fr minmax(280px, 40%) 48px;
+  grid-template-columns: 220px 1fr minmax(280px, 40%);
   flex: 1;
   min-height: 0;
   overflow: hidden;
@@ -293,12 +293,7 @@ input {
 .workflow-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  border: none;
-  background: transparent;
   border-radius: var(--radius);
-  text-align: left;
   color: var(--text-dim);
 }
 
@@ -310,6 +305,34 @@ input {
 .workflow-item.is-selected {
   background: var(--accent-dim);
   color: var(--text);
+}
+
+.workflow-item-trigger {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 4px 6px 8px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+/* VS Code tree-item style: quick actions stay invisible until you're looking at the row. */
+.workflow-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  padding-right: 4px;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.workflow-item:hover .workflow-row-actions,
+.workflow-item.is-selected .workflow-row-actions {
+  opacity: 1;
 }
 
 .workflow-caret {
@@ -380,46 +403,46 @@ input {
   gap: 6px;
 }
 
-.rail-actions {
-  align-items: center;
-  padding: 10px 0;
-  gap: 6px;
-  border-left: 1px solid var(--border);
-}
-
-.action-icon-btn {
+.macro-icon-btn {
   position: relative;
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
   border: 1px solid transparent;
   background: transparent;
   border-radius: var(--radius);
   color: var(--text-dim);
 }
 
-.action-icon-btn:hover:not(:disabled) {
+.macro-icon-btn:hover:not(:disabled) {
   background: var(--bg-hover);
   border-color: var(--border-strong);
   color: var(--text);
 }
 
-.action-icon-btn:disabled {
+.macro-icon-btn:disabled {
   color: var(--text-faint);
   cursor: not-allowed;
   opacity: 0.5;
 }
 
+/* Row actions are compact — shrink the hit target to match the tree's density. */
+.workflow-row-actions .macro-icon-btn {
+  width: 20px;
+  height: 20px;
+}
+
 /* Custom tooltip (not the native `title` bubble) — shows the macro label, or the
-   disabled reason when it has one, to the left of the rail. */
-.action-icon-btn::after {
+   disabled reason when it has one, above the button. */
+.macro-icon-btn::after {
   content: attr(data-tooltip);
   position: absolute;
-  right: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
   color: var(--text);
@@ -434,8 +457,8 @@ input {
   z-index: 30;
 }
 
-.action-icon-btn:hover::after,
-.action-icon-btn:focus-visible::after {
+.macro-icon-btn:hover::after,
+.macro-icon-btn:focus-visible::after {
   opacity: 1;
 }
 
@@ -764,78 +787,29 @@ input {
   min-width: 0;
 }
 
-.canvas-header {
+.workflow-actions-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--border);
   gap: 8px;
-}
-
-.canvas-mode-toggle {
-  display: flex;
-  gap: 2px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
   background: var(--bg-2);
-  border-radius: var(--radius);
-  padding: 2px;
 }
 
-.canvas-mode-btn {
-  padding: 4px 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-faint);
-  border-radius: 4px;
-  font-size: 11px;
-}
-
-.canvas-mode-btn.is-active {
-  background: var(--bg-3);
+.workflow-actions-name {
+  font-size: 12px;
+  font-weight: 600;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.preview-chip {
+.workflow-actions-buttons {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  border: 1px solid var(--green);
-  color: var(--green);
-  background: color-mix(in srgb, var(--green) 10%, transparent);
-  border-radius: 20px;
-  font-size: 11px;
-  white-space: nowrap;
-}
-
-.canvas-preview {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
-.canvas-urlbar {
-  display: flex;
-  gap: 6px;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--border);
-}
-
-.canvas-url-input {
-  flex: 1;
-  background: var(--bg-2);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
-  padding: 5px 8px;
-  color: var(--text);
-  font-size: 12px;
-  font-family: var(--font-mono);
-}
-
-.canvas-url-input:focus {
-  outline: none;
-  border-color: var(--accent);
+  gap: 2px;
+  margin-left: auto;
 }
 
 .canvas-iframe {
@@ -863,6 +837,28 @@ input {
   color: var(--text-dim);
   font-family: var(--font-mono);
   font-size: 11px;
+}
+
+.canvas-empty-hint {
+  max-width: 320px;
+  color: var(--text-faint);
+  font-size: 11px;
+}
+
+.canvas-visualize-cta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0;
+}
+
+.canvas-visualize-inline {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  width: 280px;
+  margin: 4px 0;
 }
 
 /* Shared buttons ------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Actions move off the standalone 48px icon rail and onto the workflows they act on:

- **Inline row actions** — hovering or selecting a workflow row in the workspace tree reveals its action icons (run local / deploy / prod run / open prod), VS Code tree-item style.
- **Bound-workflow action header** — a slim header strip above the canvas pane shows the name, deployed status, and the full action set (including Visualize) for whichever workflow is bound to the active session. The action rail column is gone; canvas gets the space.
- **Canvas is a single controlled surface** — dropped the Generated/Preview toggle and detected-port suggestion chips entirely. The canvas only ever shows the active session's own generated output; nothing auto-navigates.
- **Canvas empty state** now explains itself ("Nothing generated yet") and offers an inline Visualize CTA, with a small-print pointer to the `.sapiom/canvas/index.html` convention, instead of a blank pane.

`macro-gating.ts` + `MacroButtons` extract the shared gating/rendering logic so row actions, the bound-workflow header, and the empty-state CTA share one implementation. `events.ts` gained a mock-mode-only bus-event publish hook so Playwright can exercise `canvas.reload` without a real server.

## Test plan
- [x] `tsc -p web/tsconfig.json --noEmit` — clean
- [x] `vite build --config web/vite.config.ts` — clean
- [x] `vitest run` — 257 passed
- [x] `playwright test --config web/e2e/playwright.config.ts` — 30 passed, including new specs for the retired rail, hover/select row actions, the bound-workflow header, the empty-state Visualize CTA, and canvas.reload swapping in the generated iframe

Screenshots (mock-mode Playwright captures, attached below): app shell with the freed-up canvas space and the bound-workflow action header, and a workflow row's inline actions revealed on hover.