### PR TITLE
fix(harness): synthesize pty exit when node-pty misses onExit for near-instant kills

### DIFF
--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -89,6 +89,11 @@ const SCROLLBACK_BYTES = 131_072;
  * a paste, then a separate Enter.
  */
 const SUBMIT_DELAY_MS = 300;
+/** See `kill()`: how long to wait for a graceful exit before escalating to SIGKILL. */
+const KILL_ESCALATION_MS = 2_000;
+/** See `kill()`: how long after escalating to give node-pty one last chance
+ *  to report the exit itself before synthesizing it from an OS-level check. */
+const KILL_ESCALATION_CONFIRM_MS = 500;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -295,6 +300,35 @@ export class SessionManager {
     const handle = this.ptys.get(id);
     if (!handle) return false;
     handle.pty.kill();
+    // Root-caused via instrumented real-process runs: node-pty's `onExit`
+    // can simply never fire for a pty killed within milliseconds of being
+    // spawned — confirmed by `process.kill(pid, 0)` throwing ESRCH (no such
+    // process) well after the graceful signal, i.e. the OS process really
+    // is already gone; node-pty's own exit-reporting just missed it. So a
+    // stronger signal alone doesn't help (there's nothing left to signal) —
+    // the fallback below re-checks after a grace period, and if the pty is
+    // still "running" in our registry but the OS confirms the process no
+    // longer exists, synthesizes the exit ourselves rather than waiting on
+    // an event that isn't coming. If the process genuinely is still alive
+    // (the ordinary case: kill() just hasn't taken effect yet), send SIGKILL
+    // as a real escalation before the same check.
+    const escalate = setTimeout(() => {
+      if (this.ptys.get(id) !== handle) return;
+      const pid = handle.pty.pid;
+      const stillAlive = (): boolean => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+      if (stillAlive()) handle.pty.kill("SIGKILL");
+      setTimeout(() => {
+        if (this.ptys.get(id) === handle && !stillAlive()) this.markExited(id, handle, null);
+      }, KILL_ESCALATION_CONFIRM_MS).unref?.();
+    }, KILL_ESCALATION_MS);
+    escalate.unref?.();
     return true;
   }
 
@@ -458,14 +492,28 @@ export class SessionManager {
       handle.emitter.emit("data", chunk);
     });
 
-    pty.onExit(({ exitCode }) => {
-      this.ptys.delete(session.id);
-      session.status = "exited";
-      session.exitCode = exitCode;
-      session.lastActiveAt = this.now();
-      void this.persist();
-      this.emitStatus(session);
-    });
+    pty.onExit(({ exitCode }) => this.markExited(session.id, handle, exitCode));
+  }
+
+  /**
+   * Transitions a session to "exited". Shared by node-pty's own `onExit`
+   * callback and `kill()`'s missed-event fallback (see `kill()`) — both are
+   * racing to be the one that reports a given pty's death, so this is
+   * idempotent: a stale/duplicate call (`this.ptys.get(id) !== handle`,
+   * i.e. this handle was already replaced or already reported exited) is a
+   * silent no-op rather than double-transitioning or clobbering a newer
+   * session/handle that's since taken its place (e.g. a resume).
+   */
+  private markExited(id: string, handle: PtyHandle, exitCode: number | null): void {
+    if (this.ptys.get(id) !== handle) return;
+    this.ptys.delete(id);
+    const session = this.sessions.get(id);
+    if (!session) return;
+    session.status = "exited";
+    session.exitCode = exitCode;
+    session.lastActiveAt = this.now();
+    void this.persist();
+    this.emitStatus(session);
   }
 
   private emitStatus(session: HarnessSession): void {

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -22,6 +22,24 @@ import type { HarnessAdapter, LaunchOpts, SpawnSpec } from "../shared/types.js";
 
 type FakeTailerHandle = { stop: ReturnType<typeof vi.fn>; emitSessionEnd: ReturnType<typeof vi.fn> };
 
+/**
+ * `vi.waitFor`'s own default (1000ms timeout / 50ms interval — tuned for
+ * in-process, microtask-scale assertions) is too tight for the real,
+ * OS-level pty-exit transition the waits below depend on. Root-caused via
+ * instrumented real-process runs (process pid, spawn/kill/exit timestamps,
+ * and an OS-level `process.kill(pid, 0)` liveness check at the point of
+ * failure): node-pty's own `onExit` callback can simply never fire for a
+ * pty killed within milliseconds of being spawned, even though the OS
+ * process is already confirmed gone by then — a missed-event bug in
+ * node-pty itself, not a slow or lost signal. `SessionManager.kill()` now
+ * self-heals that (see its own comment) by synthesizing the exit from an
+ * OS-level liveness check ~2.5s after the graceful signal if node-pty never
+ * reports it — this bounds the wait below at that plus real
+ * scheduling/persist overhead, comfortable margin rather than an
+ * arbitrary/unexamined number.
+ */
+const PTY_EXIT_WAIT_OPTIONS = { timeout: 5_000, interval: 200 };
+
 function fakeCodexAdapter(): HarnessAdapter {
   return {
     id: "codex",
@@ -117,8 +135,11 @@ describe("codex tailer lifecycle wiring", () => {
     server.sessionManager.kill(session.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
-    });
-  });
+    }, PTY_EXIT_WAIT_OPTIONS);
+    // vitest's default per-test timeout (5000ms) leaves no margin over
+    // PTY_EXIT_WAIT_OPTIONS' own 5s allowance above — without bumping this
+    // too, the outer test timeout could fire first and mask it entirely.
+  }, 15_000);
 
   it("resumes by exact agentSessionId rather than cwd+sinceMs when one is already known", async () => {
     const cwd = join(dir, "project");
@@ -154,8 +175,9 @@ describe("codex tailer lifecycle wiring", () => {
     server.sessionManager.kill(resumed.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(resumed.id)?.status).toBe("exited");
-    });
-  });
+    }, PTY_EXIT_WAIT_OPTIONS);
+    // See the first test's comment: the outer test timeout needs the same bump.
+  }, 15_000);
 
   it("stops the tailer and does not start a new one for a non-codex session", async () => {
     server = await startServer({
@@ -196,8 +218,9 @@ describe("codex tailer lifecycle wiring", () => {
     server.sessionManager.kill(session.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
-    });
-  });
+    }, PTY_EXIT_WAIT_OPTIONS);
+    // See the first test's comment: the outer test timeout needs the same bump.
+  }, 15_000);
 
   it("emits SessionEnd and removes the tailer when the session exits", async () => {
     const cwd = join(dir, "project");
@@ -217,8 +240,12 @@ describe("codex tailer lifecycle wiring", () => {
 
     server.sessionManager.kill(session.id);
 
+    // emitSessionEnd() only fires from the onStatusChange("exited") handler
+    // — it's downstream of the same real pty-exit transition as the other
+    // waits in this file, so it needs the same allowance.
     await vi.waitFor(() => {
       expect(fakeHandle.emitSessionEnd).toHaveBeenCalled();
-    });
-  });
+    }, PTY_EXIT_WAIT_OPTIONS);
+    // See the first test's comment: the outer test timeout needs the same bump.
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

Root-causes the intermittent flake in `codex-tailer-wiring.test.ts` (~1-in-6 on unmodified `feat/harness`, per w4's report): `"expected 'running' to be 'exited'"` / `"expected spy to be called"`.

## Root cause

Instrumented real-process runs (spawn/kill/exit timestamps plus an OS-level `process.kill(pid, 0)` liveness check at the point of failure) show that **node-pty's own `onExit` callback can simply never fire** for a pty killed within milliseconds of being spawned — even though the OS process is already confirmed gone by then. This is a missed-event bug in node-pty itself, not a slow or lost signal: at the moment of failure, `process.kill(pid, 0)` was already throwing `ESRCH` (no such process), well before any test timeout would have fired. Sending a stronger signal doesn't help either, since there's nothing left alive to receive one — confirmed by testing a SIGKILL escalation first, which (correctly) had no effect on an already-dead process.

This ruled out my first two hypotheses along the way:
- Not `vi.waitFor`'s default timeout being too tight for ordinary OS scheduling jitter (measured real kill-to-exit latency is single-digit ms once a process has settled, and a consistent ~200ms — never open-ended — even for immediate kills, in isolation).
- Not a stuck/zombie process needing a stronger signal (SIGKILL escalation didn't change anything, because the process was already gone).

## Fix

`SessionManager.kill()` now self-heals:
1. Send the graceful kill as before.
2. After a 2s grace period, if the pty is still registered as running: escalate to SIGKILL if the OS reports the process is still alive (the ordinary "signal just hasn't taken effect yet" case).
3. Either way, after a further 500ms, do one last OS-level liveness check. If the process is confirmed gone (`ESRCH`) but node-pty never reported it, synthesize the "exited" transition ourselves rather than waiting on an event that isn't coming.

Extracted the exit-transition logic (previously inline in the `onExit` callback) into a shared, idempotent `markExited()` so both node-pty's real callback and this fallback funnel through the same code — whichever gets there first wins, the other is a silent no-op.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean (1 pre-existing, unrelated warning)
- [x] `pnpm --filter @sapiom/harness test -- --run` — 267/267 passing
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] Reproduced the original flake first (caught it live via instrumentation, multiple times, across isolated-file and full-suite runs) before fixing, to confirm the actual mechanism rather than guessing
- [x] After the fix: `codex-tailer-wiring.test.ts` held at **0/80 failures** across two verification batches (20, then 60 consecutive runs) — the same loop that reproduced the original failure beforehand

Co-Authored-By: Claude <noreply@anthropic.com>