### PR TITLE
feat(harness): docked vertical action strip anchored to selected workflow

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -20,8 +20,8 @@ test("renders the three panes plus the brand header, with no separate action rai
   await expect(page.locator(".session-bar")).toBeVisible();
   await expect(page.locator(".canvas-pane")).toBeVisible();
 
-  // The action rail is retired — actions live on workflows now (row icons,
-  // bound-workflow header), not in a standalone column.
+  // The action rail is retired — actions live on the docked workflow action
+  // strip now, anchored to the selected row, not in a standalone column.
   await expect(page.locator(".rail-actions")).toHaveCount(0);
 
   await page.screenshot({ path: "web/e2e/screenshots/app-shell.png", fullPage: true });
@@ -341,40 +341,64 @@ test("visualize macro is one click — no subject dialog", async ({ page }) => {
   expect(lastRun?.req.subject).toBeUndefined();
 });
 
-test.describe("actions live on workflows, not a separate rail", () => {
-  test("workflow rows keep their action icons hidden until you hover or select the row", async ({ page }) => {
-    const row = page.getByTestId("workflow-rfq");
-    const actions = row.locator(".workflow-row-actions");
+test.describe("docked workflow action strip", () => {
+  test("rows carry no inline icons and show their full untruncated name", async ({ page }) => {
+    await expect(page.locator(".workflow-row-actions")).toHaveCount(0);
 
-    await expect(actions).toHaveCSS("opacity", "0");
-    await row.hover();
-    await expect(actions).toHaveCSS("opacity", "1");
-    await page.screenshot({ path: "web/e2e/screenshots/workflow-row-hover-actions.png" });
-
-    // Moving away hides them again — hover alone doesn't stick.
-    await page.mouse.move(0, 0);
-    await expect(actions).toHaveCSS("opacity", "0");
-
-    // Selecting the row keeps the actions visible without a hover.
-    await row.locator(".workflow-item-trigger").click();
-    await page.mouse.move(0, 0);
-    await expect(actions).toHaveCSS("opacity", "1");
+    // "onboarding-flow" is the longest fixture name — it's the one that used
+    // to get squeezed into "onboarding-fl…" by the old inline row icons.
+    const name = page.getByTestId("workflow-onboarding-flow").locator(".workflow-name");
+    await expect(name).toHaveText("onboarding-flow");
+    const overflowing = await name.evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+    expect(overflowing).toBe(false);
   });
 
-  test("the workflow bound to the active session gets an actions header above the canvas", async ({ page }) => {
-    const header = page.getByTestId("workflow-actions-header");
-    await expect(header).toBeVisible();
-    await expect(header).toContainText("leasing");
+  test("the strip renders anchored to the selected workflow's row and carries its full action set", async ({
+    page,
+  }) => {
+    const row = page.getByTestId("workflow-leasing");
+    const strip = page.getByTestId("workflow-action-strip");
+    await expect(strip).toBeVisible();
 
-    // The header carries the full macro set, including Visualize — the one
-    // macro that stays contextual to the bound workflow.
-    await expect(header.getByTestId("macro-run_local")).toBeVisible();
-    await expect(header.getByTestId("macro-deploy")).toBeVisible();
-    await expect(header.getByTestId("macro-prod_run")).toBeVisible();
-    await expect(header.getByTestId("macro-open_prod")).toBeVisible();
-    await expect(header.getByTestId("macro-visualize")).toBeVisible();
+    const rowBox = await row.boundingBox();
+    const stripBox = await strip.boundingBox();
+    expect(rowBox).not.toBeNull();
+    expect(stripBox).not.toBeNull();
+    // Top-aligned to the row, within a pixel or two of rounding.
+    expect(Math.abs((stripBox?.y ?? 0) - (rowBox?.y ?? 0))).toBeLessThan(3);
 
-    await page.screenshot({ path: "web/e2e/screenshots/workflow-actions-header.png" });
+    await expect(strip.getByTestId("macro-run_local")).toBeVisible();
+    await expect(strip.getByTestId("macro-deploy")).toBeVisible();
+    await expect(strip.getByTestId("macro-prod_run")).toBeVisible();
+    await expect(strip.getByTestId("macro-open_prod")).toBeVisible();
+    await expect(strip.getByTestId("macro-visualize")).toBeVisible();
+
+    await page.screenshot({ path: "web/e2e/screenshots/app-shell-docked-strip.png", fullPage: true });
+  });
+
+  test("the strip moves when selection changes, and the notch tracks the new row", async ({ page }) => {
+    const rfqRow = page.getByTestId("workflow-rfq");
+    await rfqRow.locator(".workflow-item-trigger").click();
+
+    const strip = page.getByTestId("workflow-action-strip");
+    const notch = page.getByTestId("workflow-action-strip-notch");
+    const rowBox = await rfqRow.boundingBox();
+
+    // The strip/notch slide to their new anchor over a short CSS transition —
+    // wait it out so the bounding box reflects the settled position, not a
+    // mid-animation frame.
+    await expect(async () => {
+      const stripBox = await strip.boundingBox();
+      expect(Math.abs((stripBox?.y ?? 0) - (rowBox?.y ?? 0))).toBeLessThan(3);
+    }).toPass({ timeout: 1000 });
+
+    const stripBox = await strip.boundingBox();
+    const notchBox = await notch.boundingBox();
+    expect(Math.abs((notchBox?.y ?? 0) - (rowBox?.y ?? 0))).toBeLessThan(3);
+    // The notch is sized to the row, not the whole multi-icon strip below it.
+    expect(notchBox?.height ?? 0).toBeLessThan(stripBox?.height ?? Infinity);
+
+    await page.screenshot({ path: "web/e2e/screenshots/workflow-action-strip-moved.png", fullPage: true });
   });
 
   test("the header's refresh affordance reloads the canvas without discarding it", async ({ page }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1,9 +1,10 @@
 /**
  * Harness SPA shell (workstream W2).
  *
- * Layout: workflows rail (left) | session dropdown + terminal (center)
- * | canvas/preview pane (right). Actions live on their workflow: inline
- * row icons in the rail, and a header strip above the canvas for whichever
+ * Layout: workflows rail (left) | docked action strip (anchored to the
+ * selected workflow's row) | session dropdown + terminal (center) |
+ * canvas/preview pane (right). The strip carries the selected workflow's
+ * full action set; the canvas gets a slim identity header for whichever
  * workflow is bound to the active session.
  */
 import { useEffect, useState } from "react";
@@ -16,14 +17,19 @@ import { CommandPalette } from "./components/CommandPalette";
 import { DeadSessionPane } from "./components/DeadSessionPane";
 import { SessionBar } from "./components/SessionBar";
 import { Terminal } from "./components/Terminal";
+import { WorkflowActionStrip } from "./components/WorkflowActionStrip";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
+import { useElementTopOffset } from "./lib/use-element-top-offset";
 import { resolveMacroUrl } from "./lib/macro-gating";
 import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
   const harness = useHarnessState();
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(null);
+  const [stripColEl, setStripColEl] = useState<HTMLDivElement | null>(null);
+  const rowAnchor = useElementTopOffset(selectedRowEl, stripColEl);
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
@@ -50,6 +56,7 @@ export const App = (): JSX.Element => {
   const activeSession = state.sessions.find((session) => session.id === harness.activeSessionId) ?? null;
   const boundWorkflowPath = boundWorkflowPathOf(activeSession);
   const boundWorkflow = state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
+  const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
 
   const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
@@ -62,13 +69,13 @@ export const App = (): JSX.Element => {
     if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
-  // Shared by workflow-row hover actions, the bound-workflow header above the
-  // canvas, and the canvas empty-state's Visualize CTA. Running a macro against
-  // a workflow also (re-)binds it, so acting on a row that isn't the current
-  // binding switches "what I'm working on" too. `workflow` is nullable for
-  // macros that don't require one (Visualize) when nothing's bound yet. Every
-  // macro is one click — there's no subject/free-text step on this side; the
-  // agent is the interface for anything more specific.
+  // Shared by the docked workflow action strip, the canvas empty-state's
+  // Visualize CTA, and anything else that fires a macro. Running a macro
+  // against a workflow also (re-)binds it, so acting on a workflow that isn't
+  // the current binding switches "what I'm working on" too. `workflow` is
+  // nullable for macros that don't require one when nothing's bound yet.
+  // Every macro is one click — there's no subject/free-text step on this
+  // side; the agent is the interface for anything more specific.
   const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef): void => {
     if (workflow) handleSelectWorkflow(workflow.path);
     if (macro.action.kind === "open-url") {
@@ -96,13 +103,25 @@ export const App = (): JSX.Element => {
           sessions={state.sessions}
           activeSessionId={harness.activeSessionId}
           selectedPath={harness.selectedWorkflowPath}
-          macros={state.macros}
           onSelect={handleSelectWorkflow}
-          onRunMacro={handleRunMacroForWorkflow}
+          onSelectedRowElement={setSelectedRowEl}
           onConnect={async (path) => {
             await harness.connectWorkflow(path);
           }}
         />
+
+        <div className="workflow-action-strip-col" ref={setStripColEl}>
+          {selectedWorkflow && rowAnchor && (
+            <WorkflowActionStrip
+              workflow={selectedWorkflow}
+              top={rowAnchor.top}
+              height={rowAnchor.height}
+              activeSessionId={harness.activeSessionId}
+              macros={state.macros}
+              onRunMacro={(macro) => handleRunMacroForWorkflow(selectedWorkflow, macro)}
+            />
+          )}
+        </div>
 
         <div className="center-pane">
           <SessionBar

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -67,15 +67,7 @@ export function CanvasPane({
 
   return (
     <aside className="canvas-pane">
-      {boundWorkflow && (
-        <WorkflowActionsHeader
-          workflow={boundWorkflow}
-          activeSessionId={activeSessionId}
-          macros={macros}
-          onRunMacro={onRunMacro}
-          onRefresh={handleRefresh}
-        />
-      )}
+      {boundWorkflow && <WorkflowActionsHeader workflow={boundWorkflow} onRefresh={handleRefresh} />}
 
       {!sessionId ? (
         <div className="canvas-empty">Start a session to see its canvas here.</div>

--- a/packages/harness/web/src/components/MacroButtons.tsx
+++ b/packages/harness/web/src/components/MacroButtons.tsx
@@ -1,4 +1,4 @@
-import type { JSX, MouseEvent } from "react";
+import type { JSX } from "react";
 import type { MacroDef, WorkflowInfo } from "@shared/types";
 
 import { macroDisabledReason } from "../lib/macro-gating";
@@ -10,31 +10,15 @@ interface MacroButtonsProps {
   activeSessionId: string | null;
   onRun: (macro: MacroDef) => void;
   size?: number;
-  /** Distinguishes repeated per-row instances (e.g. one per workflow row) — omit for a single instance (the bound-workflow header). */
-  testIdPrefix?: string;
 }
 
 /**
- * A row of macro icon buttons, config-driven from MacroDef[] — used both as
- * per-workflow-row hover actions (compact, no Visualize — see rowMacros in
- * WorkflowsRail) and as the full set in the bound-workflow header above the
- * canvas. Every macro is one click and done — the agent is the interface for
- * anything that needs more input than that. Callers control layout via their
- * own wrapping element.
+ * A row of macro icon buttons, config-driven from MacroDef[] — the docked
+ * workflow action strip's full action set (run local, deploy, prod run,
+ * open prod, visualize). Every macro is one click and done — the agent is
+ * the interface for anything that needs more input than that.
  */
-export function MacroButtons({
-  macros,
-  workflow,
-  activeSessionId,
-  onRun,
-  size = 16,
-  testIdPrefix = "",
-}: MacroButtonsProps): JSX.Element {
-  const handleClick = (e: MouseEvent, macro: MacroDef): void => {
-    e.stopPropagation(); // row actions sit inside a clickable row — don't also trigger row selection
-    onRun(macro);
-  };
-
+export function MacroButtons({ macros, workflow, activeSessionId, onRun, size = 16 }: MacroButtonsProps): JSX.Element {
   return (
     <>
       {macros.map((macro) => {
@@ -44,10 +28,10 @@ export function MacroButtons({
             key={macro.id}
             className="macro-icon-btn"
             aria-label={macro.label}
-            data-testid={`${testIdPrefix}macro-${macro.id}`}
+            data-testid={`macro-${macro.id}`}
             data-tooltip={disabledReason ?? macro.label}
             disabled={Boolean(disabledReason)}
-            onClick={(e) => handleClick(e, macro)}
+            onClick={() => onRun(macro)}
           >
             <Icon name={macro.icon} size={size} />
           </button>

--- a/packages/harness/web/src/components/WorkflowActionStrip.tsx
+++ b/packages/harness/web/src/components/WorkflowActionStrip.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties, JSX } from "react";
+import type { MacroDef, WorkflowInfo } from "@shared/types";
+
+import { MacroButtons } from "./MacroButtons";
+
+interface WorkflowActionStripProps {
+  workflow: WorkflowInfo;
+  top: number;
+  height: number;
+  activeSessionId: string | null;
+  macros: MacroDef[];
+  onRunMacro: (macro: MacroDef) => void;
+}
+
+/**
+ * A slim vertical panel docked between the workspace rail and the terminal,
+ * carrying the selected workflow's full action set (including Visualize).
+ * Top-aligned to that workflow's row and re-anchored whenever selection
+ * moves (see useElementTopOffset) — the notch below erases the rail's
+ * border for exactly the row's height so the row's highlight visually
+ * flows into the strip, reading as one connected tab.
+ */
+export function WorkflowActionStrip({
+  workflow,
+  top,
+  height,
+  activeSessionId,
+  macros,
+  onRunMacro,
+}: WorkflowActionStripProps): JSX.Element {
+  const notchStyle: CSSProperties = { top, height };
+  const stripStyle: CSSProperties = { top };
+
+  return (
+    <>
+      <div className="workflow-action-strip-notch" style={notchStyle} data-testid="workflow-action-strip-notch" />
+      <div className="workflow-action-strip" style={stripStyle} data-testid="workflow-action-strip">
+        <MacroButtons macros={macros} workflow={workflow} activeSessionId={activeSessionId} onRun={onRunMacro} size={15} />
+      </div>
+    </>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -1,46 +1,34 @@
 import type { JSX } from "react";
-import type { MacroDef, WorkflowInfo } from "@shared/types";
+import type { WorkflowInfo } from "@shared/types";
 
 import { Icon } from "./Icon";
-import { MacroButtons } from "./MacroButtons";
 
 interface WorkflowActionsHeaderProps {
   workflow: WorkflowInfo;
-  activeSessionId: string | null;
-  macros: MacroDef[];
-  onRunMacro: (macro: MacroDef) => void;
   onRefresh: () => void;
 }
 
 /**
- * The canvas pane's entire header, shown whenever a workflow is bound to the
- * active session: the full macro set (including Visualize, which stays
- * scoped to whatever's actually bound) now that the standalone action rail
- * is gone, plus a manual refresh affordance for the canvas itself.
+ * Slim identity strip above the canvas pane, shown whenever a workflow is
+ * bound to the active session — name, deployed status, and a manual refresh
+ * affordance. The action buttons themselves live in the docked workflow
+ * action strip now (WorkflowActionStrip, next to the workspace rail), not
+ * duplicated here.
  */
-export function WorkflowActionsHeader({
-  workflow,
-  activeSessionId,
-  macros,
-  onRunMacro,
-  onRefresh,
-}: WorkflowActionsHeaderProps): JSX.Element {
+export function WorkflowActionsHeader({ workflow, onRefresh }: WorkflowActionsHeaderProps): JSX.Element {
   return (
     <div className="workflow-actions-header" data-testid="workflow-actions-header">
       <span className="workflow-actions-name">{workflow.name}</span>
       {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
-      <div className="workflow-actions-buttons">
-        <MacroButtons macros={macros} workflow={workflow} activeSessionId={activeSessionId} onRun={onRunMacro} size={15} />
-        <button
-          className="macro-icon-btn canvas-refresh-btn"
-          aria-label="Refresh canvas"
-          data-testid="canvas-refresh"
-          data-tooltip="Refresh canvas"
-          onClick={onRefresh}
-        >
-          <Icon name="RefreshCw" size={14} />
-        </button>
-      </div>
+      <button
+        className="macro-icon-btn canvas-refresh-btn"
+        aria-label="Refresh canvas"
+        data-testid="canvas-refresh"
+        data-tooltip="Refresh canvas"
+        onClick={onRefresh}
+      >
+        <Icon name="RefreshCw" size={14} />
+      </button>
     </div>
   );
 }

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import type { JSX } from "react";
-import type { HarnessSession, MacroDef, WorkflowInfo } from "@shared/types";
+import type { HarnessSession, WorkflowInfo } from "@shared/types";
 
 import { Icon } from "./Icon";
-import { MacroButtons } from "./MacroButtons";
-import { isVisualizeMacro } from "../lib/macro-gating";
 import { buildWorkspaceTree } from "../lib/workspace-tree";
 
 interface WorkflowsRailProps {
@@ -12,44 +10,33 @@ interface WorkflowsRailProps {
   sessions: HarnessSession[];
   activeSessionId: string | null;
   selectedPath: string | null;
-  macros: MacroDef[];
   onSelect: (path: string) => void;
-  onRunMacro: (workflow: WorkflowInfo, macro: MacroDef) => void;
+  onSelectedRowElement: (el: HTMLDivElement | null) => void;
   onConnect: (path: string) => Promise<void>;
 }
 
 function WorkflowRow({
   workflow,
   isSelected,
-  activeSessionId,
-  rowMacros,
   onSelect,
-  onRunMacro,
+  onSelectedRowElement,
 }: {
   workflow: WorkflowInfo;
   isSelected: boolean;
-  activeSessionId: string | null;
-  rowMacros: MacroDef[];
   onSelect: (path: string) => void;
-  onRunMacro: (workflow: WorkflowInfo, macro: MacroDef) => void;
+  onSelectedRowElement: (el: HTMLDivElement | null) => void;
 }): JSX.Element {
   return (
-    <div className={"workflow-item" + (isSelected ? " is-selected" : "")} data-testid={`workflow-${workflow.name}`}>
+    <div
+      ref={isSelected ? onSelectedRowElement : undefined}
+      className={"workflow-item" + (isSelected ? " is-selected" : "")}
+      data-testid={`workflow-${workflow.name}`}
+    >
       <button className="workflow-item-trigger" onClick={() => onSelect(workflow.path)} title={workflow.path}>
         <span className="workflow-caret">▸</span>
         <span className="workflow-name">{workflow.name}</span>
         {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
       </button>
-      <div className="workflow-row-actions">
-        <MacroButtons
-          macros={rowMacros}
-          workflow={workflow}
-          activeSessionId={activeSessionId}
-          onRun={(macro) => onRunMacro(workflow, macro)}
-          size={13}
-          testIdPrefix={`${workflow.name}-`}
-        />
-      </div>
     </div>
   );
 }
@@ -59,9 +46,8 @@ export function WorkflowsRail({
   sessions,
   activeSessionId,
   selectedPath,
-  macros,
   onSelect,
-  onRunMacro,
+  onSelectedRowElement,
   onConnect,
 }: WorkflowsRailProps): JSX.Element {
   const [connecting, setConnecting] = useState(false);
@@ -85,11 +71,6 @@ export function WorkflowsRail({
     }
   };
 
-  // Row actions are compact quick-actions — Visualize renders whatever's
-  // bound to the active session, so it stays reserved for the bound-workflow
-  // header rather than every row you hover.
-  const rowMacros = macros.filter((macro) => macro.requiresWorkflow && !isVisualizeMacro(macro));
-
   const { groups, ungrouped } = buildWorkspaceTree(workflows, sessions, activeSessionId);
 
   const renderRow = (workflow: WorkflowInfo): JSX.Element => (
@@ -97,10 +78,8 @@ export function WorkflowsRail({
       key={workflow.path}
       workflow={workflow}
       isSelected={workflow.path === selectedPath}
-      activeSessionId={activeSessionId}
-      rowMacros={rowMacros}
       onSelect={onSelect}
-      onRunMacro={onRunMacro}
+      onSelectedRowElement={onSelectedRowElement}
     />
   );
 

--- a/packages/harness/web/src/lib/macro-gating.ts
+++ b/packages/harness/web/src/lib/macro-gating.ts
@@ -1,20 +1,11 @@
 import type { MacroDef, WorkflowInfo } from "@shared/types";
 
-/**
- * The macro that renders the bound workflow onto the canvas — surfaced as
- * its own CTA in the canvas empty state, and kept out of the per-row quick
- * actions (see WorkflowsRail) since it needs the header's "bound" context,
- * not just any row you happen to be hovering.
- */
+/** The macro that renders the bound workflow onto the canvas — surfaced as its own CTA in the canvas empty state. */
 export function findVisualizeMacro(macros: MacroDef[]): MacroDef | undefined {
   return macros.find((macro) => macro.id === "visualize");
 }
 
-export function isVisualizeMacro(macro: MacroDef): boolean {
-  return macro.id === "visualize";
-}
-
-/** Shared gating logic for any surface that runs a macro against a specific workflow (row actions, the bound-workflow header). */
+/** Shared gating logic for any surface that runs a macro against a specific workflow (the docked action strip, the canvas empty-state CTA). */
 export function macroDisabledReason(
   macro: MacroDef,
   workflow: WorkflowInfo | null,

--- a/packages/harness/web/src/lib/use-element-top-offset.ts
+++ b/packages/harness/web/src/lib/use-element-top-offset.ts
@@ -1,0 +1,47 @@
+import { useLayoutEffect, useState } from "react";
+
+/**
+ * Tracks `target`'s top offset and height relative to `container`, so a
+ * floating element (the workflow action strip) can stay pinned to a row that
+ * lives in a scrollable, reorderable list elsewhere in the tree. Recomputes
+ * on scroll (the row's own scroll container, if any), window resize, and any
+ * size change to either element — not just on `target`/`container` identity
+ * changes, since the row can move without unmounting (e.g. groups above it
+ * growing or shrinking).
+ */
+export function useElementTopOffset(
+  target: HTMLElement | null,
+  container: HTMLElement | null,
+): { top: number; height: number } | null {
+  const [rect, setRect] = useState<{ top: number; height: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!target || !container) {
+      setRect(null);
+      return;
+    }
+
+    const measure = (): void => {
+      const targetRect = target.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      setRect({ top: targetRect.top - containerRect.top, height: targetRect.height });
+    };
+    measure();
+
+    const scrollParent = target.closest(".rail-list");
+    scrollParent?.addEventListener("scroll", measure);
+    window.addEventListener("resize", measure);
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(target);
+    observer.observe(container);
+
+    return () => {
+      scrollParent?.removeEventListener("scroll", measure);
+      window.removeEventListener("resize", measure);
+      observer.disconnect();
+    };
+  }, [target, container]);
+
+  return rect;
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -212,10 +212,56 @@ input {
 
 .app {
   display: grid;
-  grid-template-columns: 220px 1fr minmax(280px, 40%);
+  grid-template-columns: 220px 32px 1fr minmax(280px, 40%);
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Docked workflow action strip ------------------------------------------ */
+
+.workflow-action-strip-col {
+  position: relative;
+  border-left: 1px solid var(--border);
+  background: var(--bg-1);
+}
+
+/* Erases the strip column's own border for exactly the selected row's
+   height — the row bleeds into this same space (see .workflow-item.is-
+   selected's negative margin) so the two reads as one continuous shape. */
+.workflow-action-strip-notch {
+  position: absolute;
+  left: -1px;
+  width: 5px;
+  background: var(--accent-dim);
+  transition: top 0.15s ease;
+  pointer-events: none;
+}
+
+.workflow-action-strip {
+  position: absolute;
+  left: 3px;
+  right: 4px;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 3px;
+  background: var(--accent-dim);
+  border: 1px solid var(--border-strong);
+  border-left: none;
+  border-radius: 0 8px 8px 8px;
+  transition: top 0.15s ease;
+}
+
+/* The strip is narrow and vertical — tooltips show to the side instead of
+   above, so they don't collide with the next icon up. */
+.workflow-action-strip .macro-icon-btn::after {
+  bottom: auto;
+  top: 50%;
+  left: calc(100% + 6px);
+  transform: translateY(-50%);
 }
 
 .center-pane {
@@ -302,9 +348,15 @@ input {
   color: var(--text);
 }
 
+/* Bleeds into rail-workflows' own right padding (8px) to reach the rail's
+   edge flush — meeting the action strip's notch with no gap, so the two
+   read as one connected shape (a browser-tab-style fusion). Flat on the
+   right since that's the edge doing the fusing; rounded everywhere else. */
 .workflow-item.is-selected {
   background: var(--accent-dim);
   color: var(--text);
+  margin-right: -8px;
+  border-radius: var(--radius) 0 0 var(--radius);
 }
 
 .workflow-item-trigger {
@@ -318,21 +370,6 @@ input {
   background: transparent;
   color: inherit;
   text-align: left;
-}
-
-/* VS Code tree-item style: quick actions stay invisible until you're looking at the row. */
-.workflow-row-actions {
-  display: flex;
-  align-items: center;
-  gap: 1px;
-  padding-right: 4px;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-}
-
-.workflow-item:hover .workflow-row-actions,
-.workflow-item.is-selected .workflow-row-actions {
-  opacity: 1;
 }
 
 .workflow-caret {
@@ -427,12 +464,6 @@ input {
   color: var(--text-faint);
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-/* Row actions are compact — shrink the hit target to match the tree's density. */
-.workflow-row-actions .macro-icon-btn {
-  width: 20px;
-  height: 20px;
 }
 
 /* Custom tooltip (not the native `title` bubble) — shows the macro label, or the


### PR DESCRIPTION
## Summary

Layout revision on top of the actions-layout round (screenshot feedback: inline row action icons squeezed workflow names too much, e.g. "onboarding-fl…"):

- Removed the inline row action icons entirely — rows get their full width back for names.
- Replaced them with a slim vertical action strip docked between the workspace rail and the terminal. It renders only for the selected workflow, carrying its full action set (run local, deploy, prod run, open prod, one-click visualize).
- The strip is top-aligned to the selected row and re-anchors whenever selection changes (new `useElementTopOffset` hook — ref + `ResizeObserver` + scroll/resize listeners, not a one-shot measurement, since the row can move without unmounting if groups above it resize).
- Signature detail: the selected row bleeds into the rail's own right padding (negative margin) to reach the strip, and the strip column's border gets a small "notch" painted the row's own highlight color, sized to exactly that row's height — so the row's highlight visually flows through the border gap into the strip, reading as one connected tab (browser-tab style).
- Slimmed the canvas pane's bound-workflow header to identity only (name + deployed dot + a refresh affordance) now that the strip owns the action buttons, avoiding duplicate icons between the two.

## Test plan
- [x] `tsc -p web/tsconfig.json --noEmit` — clean
- [x] `vite build --config web/vite.config.ts` — clean
- [x] `vitest run` — 289 passed
- [x] `playwright test --config web/e2e/playwright.config.ts` — 32 passed, including new specs: rows carry no inline icons and show untruncated names, the strip renders anchored to the selected row with its full action set, the strip (and its notch) move and re-anchor when selection changes, and the header's refresh affordance still works

## Screenshots

Default state (leasing selected, strip anchored to its row):
`web/e2e/screenshots/app-shell-docked-strip.png`

After selecting rfq (strip slid down to the new row, canvas header identity updated):
`web/e2e/screenshots/workflow-action-strip-moved.png`

Both confirmed visually in light and dark mode — the notch/row fusion reads as one continuous shape in both themes.