### PR TITLE
fix(harness): tighten 3 ambiguities in the canvas style contract

### DIFF
--- a/packages/harness/src/profiles/canvas-guidelines.test.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.test.ts
@@ -38,6 +38,24 @@ describe("CANVAS_STYLE_GUIDELINES", () => {
   it("carries a 'prefer clarity over decoration' note", () => {
     expect(CANVAS_STYLE_GUIDELINES).toMatch(/clarity over decoration/i);
   });
+
+  // Regression coverage for three ambiguities a live Visualize proof
+  // surfaced: two different runs resolved each one inconsistently because
+  // the wording left room to. See canvas-guidelines.ts's doc comment.
+  it("requires every node to get the glow, not just entry/terminal ones", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/every node/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/never reserve the glow/i);
+  });
+
+  it("specifies straight edges for sequential steps and curved only for branches", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/straight lines/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/branches into\s+multiple successors/i);
+  });
+
+  it("requires visually distinct legend markers per node kind, not just per color", () => {
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/visually distinct marker/i);
+    expect(CANVAS_STYLE_GUIDELINES).toMatch(/never reuse the identical marker/i);
+  });
 });
 
 describe("CANVAS_STYLE_GUIDELINES injection sites", () => {

--- a/packages/harness/src/profiles/canvas-guidelines.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.ts
@@ -7,10 +7,14 @@
  *
  * Colors are the harness's own dark-theme tokens (web/src/styles.css,
  * `[data-theme="dark"]`) — dark is the canonical canvas look. Structural
- * conventions (rounded nodes, curved arrowed edges, stats header, legend
- * footer) mirror what scripts/seed-example.mjs's reference canvas already
- * renders; this doesn't change that seed, just documents its pattern for
- * agents generating new ones.
+ * conventions (rounded nodes with a uniform glow, straight-then-curved
+ * arrowed edges, stats header, legend footer) mirror what
+ * scripts/seed-example.mjs's reference canvas already renders; this doesn't
+ * change that seed, just documents its pattern for agents generating new
+ * ones. Edge/glow/legend wording tightened after a live Visualize proof
+ * (see PR history) surfaced ambiguities two different agent runs resolved
+ * inconsistently — see git blame for the before/after if the wording here
+ * ever seems oddly specific.
  */
 export const CANVAS_STYLE_GUIDELINES = `
 Canvas style contract (.sapiom/canvas/index.html):
@@ -22,14 +26,22 @@ Canvas style contract (.sapiom/canvas/index.html):
 - Monospace throughout: ui-monospace, "SF Mono", Menlo, Consolas, monospace.
 - Header: title + short status badge, one-line subtitle, and a stats row
   (e.g. step count, terminal-outcome count, branch count) as label/value pairs.
-- Render the workflow as an inline SVG graph: rounded-rect nodes (12-16px
-  radius) in a top-to-bottom flow, curved connector paths with arrowhead
-  markers, a subtle accent-colored glow on node borders.
+- Render the workflow as an inline SVG graph, top-to-bottom: rounded-rect
+  nodes (12-16px radius). Every node gets the same subtle glow on its
+  border — never reserve the glow for entry/terminal nodes only; role and
+  outcome are conveyed by border/stroke color, not by which nodes glow.
+- Edges: straight lines with arrowhead markers for a single-successor step,
+  curved paths with arrowhead markers only where a step branches into
+  multiple successors — don't curve every edge, that reads as noise on a
+  simple linear chain.
 - Color-code terminal outcomes by meaning: accent/green = success, amber =
   escalation/needs-attention, red = failure. Reserve those colors for actual
   terminal branches, not regular steps.
-- Footer legend: one colored dot + label per node kind used, plus a short
-  note that this is a static preview to regenerate after the workflow changes.
+- Footer legend: one visually distinct marker per node kind used (shape
+  and/or fill vs. outline — never reuse the identical marker for two
+  different kinds just because they happen to share a color) + label, plus
+  a short note that this is a static preview to regenerate after the
+  workflow changes.
 - Prefer clarity over decoration: no motion, gradients, or ornamentation that
   doesn't help someone understand the graph's structure in a few seconds.
 `.trim();


### PR DESCRIPTION
## Summary
A live Visualize proof (`/tmp/harness-visualize-live-proof`) surfaced three places the contract's wording left room for two different agent runs to draw a visually inconsistent canvas. Confirmed each against the generated `index.html` + screenshot before deciding which way to resolve each one:

1. **Glow scope.** The agent applied the node glow only to entry/terminal nodes (`classify`/`route` had no glow, `intake`/`auto_resolve`/`escalate` did). The contract now says explicitly every node gets it — matches `scripts/seed-example.mjs`'s own CSS, where `.node rect { filter: url(#node-glow) }` is unconditional, not scoped to a terminal/entry class.
2. **Edge curvature.** The agent drew straight lines for the three sequential edges and curved paths (with colored arrowheads) only for the two branching edges. This is actually correct — it matches the seed's own edge markup exactly, and arguably reads better than curving a simple linear chain — so rather than force curves everywhere, the contract now blesses this explicitly instead of leaving it ambiguous.
3. **Legend distinctness.** The generated legend used the identical filled accent-colored dot for both "entry / active step" and "terminal · success" — visually indistinguishable despite being different concepts. The contract now requires a visually distinct marker per node kind, not just a distinct label/color pairing.

Added three regression tests (one per issue) to `canvas-guidelines.test.ts` locking in the tightened wording.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness test` — 292/292, including 3 new regression tests for the tightened wording
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] `pnpm --filter @sapiom/harness e2e:live` — green (macro/canvas phases unaffected)
- [x] `pnpm --filter @sapiom/harness test:ui` — 32/32 Playwright

Co-Authored-By: Claude <noreply@anthropic.com>