### PR TITLE
feat(harness): resizable panes + canvas follows app theme

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -414,7 +414,7 @@ test.describe("docked workflow action strip", () => {
     await expect(page.locator(".canvas-iframe")).toBeVisible();
 
     await refreshBtn.click();
-    await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", "/canvas/sess-boot/");
+    await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
   });
 });
 
@@ -471,5 +471,99 @@ test("a canvas.reload bus message swaps the empty state for the generated iframe
   });
 
   await expect(page.locator(".canvas-empty")).toHaveCount(0);
-  await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", "/canvas/sess-boot/");
+  await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
+});
+
+test.describe("resizable panes", () => {
+  test("dragging the rail handle resizes the rail and persists across reload", async ({ page }) => {
+    const handle = page.getByTestId("resize-handle-rail");
+    const railBefore = await page.locator(".rail-workflows").boundingBox();
+    const handleBox = await handle.boundingBox();
+    if (!railBefore || !handleBox) throw new Error("expected bounding boxes");
+
+    const y = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 80, y, { steps: 5 });
+    await page.mouse.up();
+
+    const railAfter = await page.locator(".rail-workflows").boundingBox();
+    expect((railAfter?.width ?? 0) - railBefore.width).toBeGreaterThan(60);
+
+    await page.reload();
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    const railReloaded = await page.locator(".rail-workflows").boundingBox();
+    expect(Math.abs((railReloaded?.width ?? 0) - (railAfter?.width ?? 0))).toBeLessThan(3);
+  });
+
+  test("dragging the canvas handle resizes the canvas pane", async ({ page }) => {
+    const handle = page.getByTestId("resize-handle-canvas");
+    const canvasBefore = await page.locator(".canvas-pane").boundingBox();
+    const handleBox = await handle.boundingBox();
+    if (!canvasBefore || !handleBox) throw new Error("expected bounding boxes");
+
+    const y = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+    await page.mouse.down();
+    // Dragging the canvas handle toward the terminal (left) grows the canvas.
+    await page.mouse.move(handleBox.x + handleBox.width / 2 - 80, y, { steps: 5 });
+    await page.mouse.up();
+
+    const canvasAfter = await page.locator(".canvas-pane").boundingBox();
+    expect((canvasAfter?.width ?? 0) - canvasBefore.width).toBeGreaterThan(60);
+  });
+
+  test("rail and canvas widths cannot be dragged past their min-width floors", async ({ page }) => {
+    const railHandle = page.getByTestId("resize-handle-rail");
+    let box = await railHandle.boundingBox();
+    if (!box) throw new Error("expected bounding box");
+    await page.mouse.move(box.x, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x - 1000, box.y + box.height / 2, { steps: 5 });
+    await page.mouse.up();
+    const railWidth = (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
+    expect(railWidth).toBeGreaterThanOrEqual(178); // RAIL_MIN = 180, small rounding slack
+    expect(railWidth).toBeLessThan(195);
+
+    const canvasHandle = page.getByTestId("resize-handle-canvas");
+    box = await canvasHandle.boundingBox();
+    if (!box) throw new Error("expected bounding box");
+    await page.mouse.move(box.x, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 1000, box.y + box.height / 2, { steps: 5 });
+    await page.mouse.up();
+    const canvasWidth = (await page.locator(".canvas-pane").boundingBox())?.width ?? 0;
+    expect(canvasWidth).toBeGreaterThanOrEqual(278); // CANVAS_MIN = 280, small rounding slack
+    expect(canvasWidth).toBeLessThan(295);
+  });
+
+  test("double-clicking a handle resets it to its default width", async ({ page }) => {
+    const handle = page.getByTestId("resize-handle-rail");
+    const box = await handle.boundingBox();
+    if (!box) throw new Error("expected bounding box");
+    const y = box.y + box.height / 2;
+    await page.mouse.move(box.x, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 100, y, { steps: 5 });
+    await page.mouse.up();
+
+    await handle.dblclick();
+    const railWidth = (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
+    expect(Math.abs(railWidth - 220)).toBeLessThan(3);
+  });
+});
+
+test("the canvas iframe carries the app's theme and flips on toggle", async ({ page }) => {
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+
+  const iframe = page.locator(".canvas-iframe");
+  await expect(iframe).toHaveAttribute("src", /theme=light/);
+
+  await page.getByTestId("theme-toggle").click();
+  await expect(iframe).toHaveAttribute("src", /theme=dark/);
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -22,6 +22,7 @@ import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
 import { useElementTopOffset } from "./lib/use-element-top-offset";
 import { resolveMacroUrl } from "./lib/macro-gating";
+import { usePaneWidths } from "./lib/use-pane-widths";
 import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
@@ -30,6 +31,7 @@ export const App = (): JSX.Element => {
   const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(null);
   const [stripColEl, setStripColEl] = useState<HTMLDivElement | null>(null);
   const rowAnchor = useElementTopOffset(selectedRowEl, stripColEl);
+  const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
@@ -97,7 +99,10 @@ export const App = (): JSX.Element => {
         onOpenPalette={() => setPaletteOpen(true)}
       />
 
-      <div className="app">
+      <div
+        className="app"
+        style={{ gridTemplateColumns: `${widths.rail}px 32px minmax(360px, 1fr) ${widths.canvas}px` }}
+      >
         <WorkflowsRail
           workflows={state.workflows}
           sessions={state.sessions}
@@ -122,6 +127,17 @@ export const App = (): JSX.Element => {
             />
           )}
         </div>
+
+        <div
+          className="pane-resize-handle pane-resize-handle-rail"
+          style={{ left: widths.rail + 32 }}
+          onPointerDown={startRailDrag}
+          onDoubleClick={resetRail}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize workspace rail"
+          data-testid="resize-handle-rail"
+        />
 
         <div className="center-pane">
           <SessionBar
@@ -158,6 +174,17 @@ export const App = (): JSX.Element => {
             )}
           </div>
         </div>
+
+        <div
+          className="pane-resize-handle pane-resize-handle-canvas"
+          style={{ right: widths.canvas }}
+          onPointerDown={startCanvasDrag}
+          onDoubleClick={resetCanvas}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize canvas pane"
+          data-testid="resize-handle-canvas"
+        />
 
         <CanvasPane
           sessionId={harness.activeSessionId}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -4,6 +4,7 @@ import type { BusMessage, MacroDef, WorkflowInfo } from "@shared/types";
 
 import { isMockMode } from "../lib/api";
 import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
+import { getTheme, subscribeTheme } from "../lib/theme";
 import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 
@@ -26,6 +27,12 @@ export function CanvasPane({
 }: CanvasPaneProps): JSX.Element {
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
+  const [theme, setTheme] = useState(getTheme());
+
+  // Passed through to the served canvas so a kit-based template can match the
+  // app's current theme instead of always rendering dark. Legacy canvases
+  // that don't read the param are unaffected.
+  useEffect(() => subscribeTheme(setTheme), []);
 
   // Probe once per session for pre-existing content — the agent may have written
   // it in an earlier turn, before this pane was around to catch a reload event.
@@ -91,7 +98,12 @@ export function CanvasPane({
           </p>
         </div>
       ) : (
-        <iframe key={reloadKey} className="canvas-iframe" src={`/canvas/${sessionId}/`} sandbox="allow-scripts" />
+        <iframe
+          key={reloadKey}
+          className="canvas-iframe"
+          src={`/canvas/${sessionId}/?theme=${theme}`}
+          sandbox="allow-scripts"
+        />
       )}
     </aside>
   );

--- a/packages/harness/web/src/lib/use-pane-widths.ts
+++ b/packages/harness/web/src/lib/use-pane-widths.ts
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+export interface PaneWidths {
+  rail: number;
+  canvas: number;
+}
+
+const STORAGE_KEY = "sapiom-harness-pane-widths";
+
+export const RAIL_MIN = 180;
+export const RAIL_MAX = 480;
+export const RAIL_DEFAULT = 220;
+export const CANVAS_MIN = 280;
+export const CANVAS_MAX = 720;
+export const CANVAS_DEFAULT = 420;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function loadStoredWidths(): PaneWidths {
+  const fallback: PaneWidths = { rail: RAIL_DEFAULT, canvas: CANVAS_DEFAULT };
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<PaneWidths>;
+    return {
+      rail: clamp(typeof parsed.rail === "number" ? parsed.rail : RAIL_DEFAULT, RAIL_MIN, RAIL_MAX),
+      canvas: clamp(typeof parsed.canvas === "number" ? parsed.canvas : CANVAS_DEFAULT, CANVAS_MIN, CANVAS_MAX),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function persist(widths: PaneWidths): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(widths));
+}
+
+/**
+ * Drives the two resize handles between the app's main columns (rail |
+ * docked strip | terminal | canvas — the strip rides along at a fixed
+ * width right next to the rail, so only rail and canvas are independently
+ * draggable). Uses pointer capture on the handle itself rather than window-
+ * level listeners, so the drag keeps tracking even if the cursor leaves the
+ * thin handle mid-move. Widths persist to localStorage on release; a
+ * double-click resets a handle to its default.
+ */
+export function usePaneWidths(): {
+  widths: PaneWidths;
+  startRailDrag: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  startCanvasDrag: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  resetRail: () => void;
+  resetCanvas: () => void;
+} {
+  const [widths, setWidths] = useState<PaneWidths>(loadStoredWidths);
+
+  const startDrag =
+    (key: keyof PaneWidths, sign: 1 | -1, min: number, max: number) =>
+    (e: ReactPointerEvent<HTMLDivElement>): void => {
+      const handle = e.currentTarget;
+      handle.setPointerCapture(e.pointerId);
+      const startX = e.clientX;
+      const startValue = widths[key];
+
+      const handleMove = (moveEvent: PointerEvent): void => {
+        const next = clamp(startValue + (moveEvent.clientX - startX) * sign, min, max);
+        setWidths((prev) => (prev[key] === next ? prev : { ...prev, [key]: next }));
+      };
+      const handleUp = (): void => {
+        handle.removeEventListener("pointermove", handleMove);
+        handle.removeEventListener("pointerup", handleUp);
+        setWidths((current) => {
+          persist(current);
+          return current;
+        });
+      };
+      handle.addEventListener("pointermove", handleMove);
+      handle.addEventListener("pointerup", handleUp);
+    };
+
+  const reset = (key: keyof PaneWidths, value: number): void => {
+    setWidths((prev) => {
+      const next = { ...prev, [key]: value };
+      persist(next);
+      return next;
+    });
+  };
+
+  return {
+    widths,
+    startRailDrag: startDrag("rail", 1, RAIL_MIN, RAIL_MAX),
+    startCanvasDrag: startDrag("canvas", -1, CANVAS_MIN, CANVAS_MAX),
+    resetRail: () => reset("rail", RAIL_DEFAULT),
+    resetCanvas: () => reset("canvas", CANVAS_DEFAULT),
+  };
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -211,11 +211,41 @@ input {
 }
 
 .app {
+  position: relative;
   display: grid;
-  grid-template-columns: 220px 32px 1fr minmax(280px, 40%);
+  grid-template-columns: 220px 32px minmax(360px, 1fr) 420px;
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Resize handles --------------------------------------------------------- */
+
+/* Absolutely positioned over the boundary they resize (left/right set via
+   inline style, tied to the same state driving .app's grid-template-columns)
+   rather than being their own grid track — keeps the grid's column count
+   fixed regardless of how many handles exist. */
+.pane-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 7px;
+  cursor: col-resize;
+  z-index: 20;
+  touch-action: none;
+}
+
+.pane-resize-handle:hover,
+.pane-resize-handle:active {
+  background: var(--accent-dim);
+}
+
+.pane-resize-handle-rail {
+  transform: translateX(-50%);
+}
+
+.pane-resize-handle-canvas {
+  transform: translateX(50%);
 }
 
 /* Docked workflow action strip ------------------------------------------ */


### PR DESCRIPTION
## Summary

1. **Resizable panes** — drag handles between the workspace rail and the terminal, and between the terminal and the canvas pane. The docked action strip rides along at its fixed 32px width next to the rail rather than getting its own handle.
   - Pointer-capture-based drag (`usePaneWidths`), not window-level listeners — the drag keeps tracking even if the cursor leaves the thin handle mid-move.
   - Min-widths enforced: rail >= 180px, canvas >= 280px (generous max ceilings too, so a runaway drag can't blow out the layout).
   - Widths persist to `localStorage` on release; double-click a handle resets it to its default (220px rail / 420px canvas).
   - Verified — not assumed — that the terminal's existing `ResizeObserver`-driven fit addon re-fits during drag: `.xterm-screen`'s rendered width visibly tracked the container through a full drag in a throwaway check (587px → 337px). No changes needed there.

2. **Canvas theme passthrough** — the canvas iframe's `src` now carries `?theme=light|dark`, read from the same theme module (`lib/theme.ts`) the rest of the app subscribes to, and updates live on toggle. A kit-based canvas template can read this to match the app instead of always rendering dark; legacy canvases that ignore the param are unaffected.

## Test plan
- [x] `tsc -p web/tsconfig.json --noEmit` — clean
- [x] `vite build --config web/vite.config.ts` — clean
- [x] `vitest run` — 292 passed
- [x] `playwright test --config web/e2e/playwright.config.ts` — 37 passed, including new specs: dragging the rail handle resizes it and persists across reload, dragging the canvas handle resizes it, both handles clamp at their min-width floors, double-click resets to default, and the canvas iframe's theme param is present and flips with the toggle

## Screenshots

Default pane widths:
`web/e2e/screenshots/panes-default-widths.png`

After dragging both handles (rail widened, canvas widened, strip stayed anchored to the rail's new edge):
`web/e2e/screenshots/panes-resized-widths.png`