### PR TITLE
fix(harness): respect DO_NOT_TRACK/SAPIOM_TELEMETRY_DISABLED, harden machine-id file

### DIFF
--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -11,19 +11,24 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 let nextAnswer = "";
+let questionCallCount = 0;
 vi.mock("node:readline/promises", () => ({
   createInterface: () => ({
-    question: async () => nextAnswer,
+    question: async () => {
+      questionCallCount++;
+      return nextAnswer;
+    },
     close: () => {},
   }),
 }));
 
 import { ensureConsent } from "./consent.js";
-import { loadSettings } from "./settings.js";
+import { hasStoredSettings, loadSettings } from "./settings.js";
 
 describe("ensureConsent", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-consent-"));
+    questionCallCount = 0;
   });
 
   afterEach(async () => {
@@ -108,5 +113,86 @@ describe("ensureConsent", () => {
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
+  });
+
+  describe("environment opt-out (SAPIOM_TELEMETRY_DISABLED / DO_NOT_TRACK)", () => {
+    const ENV_KEYS = ["SAPIOM_TELEMETRY_DISABLED", "DO_NOT_TRACK"] as const;
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        saved[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      }
+    });
+
+    it.each([
+      ["SAPIOM_TELEMETRY_DISABLED", "1"],
+      ["SAPIOM_TELEMETRY_DISABLED", "true"],
+      ["SAPIOM_TELEMETRY_DISABLED", "TRUE"],
+      ["DO_NOT_TRACK", "1"],
+      ["DO_NOT_TRACK", "true"],
+    ])("%s=%s forces telemetry off without prompting, on a first run", async (envVar, value) => {
+      process.env[envVar] = value;
+
+      const optIn = await ensureConsent({ noTelemetry: false });
+
+      expect(optIn).toBe(false);
+      expect(questionCallCount).toBe(0);
+      // Nothing persisted: hasStoredSettings() must still say "no" so a
+      // later run without the env var gets a genuine first-run prompt,
+      // rather than silently inheriting a fabricated opt-out answer.
+      expect(await hasStoredSettings()).toBe(false);
+    });
+
+    it("overrides a previously persisted opt-in for this run, without rewriting it", async () => {
+      // Establish a stored opt-in from an earlier, env-free run.
+      const wasTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+      try {
+        expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+      } finally {
+        Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      }
+      expect((await loadSettings()).telemetryOptIn).toBe(true);
+
+      process.env.DO_NOT_TRACK = "1";
+      const optIn = await ensureConsent({ noTelemetry: false });
+
+      expect(optIn).toBe(false);
+      expect(questionCallCount).toBe(0);
+      // The stored preference is untouched — a run without DO_NOT_TRACK set
+      // still honors what the user actually answered.
+      expect((await loadSettings()).telemetryOptIn).toBe(true);
+    });
+
+    it.each([
+      ["SAPIOM_TELEMETRY_DISABLED", "0"],
+      ["SAPIOM_TELEMETRY_DISABLED", "no"],
+      ["DO_NOT_TRACK", "false"],
+      ["DO_NOT_TRACK", ""],
+    ])("%s=%s is not treated as an opt-out", async (envVar, value) => {
+      process.env[envVar] = value;
+      const wasTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+      try {
+        expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+      } finally {
+        Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      }
+    });
+
+    it("--no-telemetry still wins even without any env var set", async () => {
+      expect(await ensureConsent({ noTelemetry: true })).toBe(false);
+      expect(questionCallCount).toBe(0);
+    });
   });
 });

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -41,12 +41,43 @@ export interface EnsureConsentOptions {
 }
 
 /**
+ * Environment opt-out, same precedence and value-parsing as
+ * `@sapiom/analytics-core`'s `resolveConsent()`: `SAPIOM_TELEMETRY_DISABLED`
+ * (Sapiom-specific) before `DO_NOT_TRACK` (the ecosystem-wide convention),
+ * both accepting `1`/`true` case-insensitively. Checked ahead of any stored
+ * settings — an operator setting either at the OS/shell level always wins
+ * for that run, regardless of a previously persisted opt-in.
+ */
+function isEnvFlagSet(value: string | undefined): boolean {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+/** Which env var (if any) forces telemetry off this run, for the printed reason. */
+function envDisableReason(): string | null {
+  if (isEnvFlagSet(process.env.SAPIOM_TELEMETRY_DISABLED)) return "SAPIOM_TELEMETRY_DISABLED";
+  if (isEnvFlagSet(process.env.DO_NOT_TRACK)) return "DO_NOT_TRACK";
+  return null;
+}
+
+/**
  * Resolves the telemetry opt-in state. Prompts once on first run and persists
  * the answer; subsequent runs reuse the stored value silently. `--no-telemetry`
- * always wins and never prompts.
+ * always wins and never prompts. `SAPIOM_TELEMETRY_DISABLED`/`DO_NOT_TRACK`
+ * force telemetry off for this run — overriding a persisted opt-in and
+ * skipping the prompt entirely — without touching what's actually stored, so
+ * a later run without the env var set sees whatever the user answered (or
+ * will still be asked, if this env-vetoed run was their first).
  */
 export async function ensureConsent(options: EnsureConsentOptions): Promise<boolean> {
   if (options.noTelemetry) return false;
+
+  const envReason = envDisableReason();
+  if (envReason) {
+    console.log(`Telemetry disabled via ${envReason} — skipping the consent prompt.\n`);
+    return false;
+  }
 
   const isFirstRun = !(await hasStoredSettings());
   const settings = await loadSettings();

--- a/packages/harness/src/cli/machine-id.test.ts
+++ b/packages/harness/src/cli/machine-id.test.ts
@@ -4,10 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 let tmpDir: string;
+/** Lets a single test point `os.homedir()` somewhere unwritable without
+ *  disturbing `tmpDir` itself, which `afterEach` always cleans up. */
+let homeOverride: string | null = null;
 
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof os>();
-  return { ...actual, homedir: () => tmpDir };
+  return { ...actual, homedir: () => homeOverride ?? tmpDir };
 });
 
 import { getOrCreateMachineId } from "./machine-id.js";
@@ -15,9 +18,11 @@ import { getOrCreateMachineId } from "./machine-id.js";
 describe("getOrCreateMachineId", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-machine-id-"));
+    homeOverride = null;
   });
 
   afterEach(async () => {
+    homeOverride = null;
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -36,5 +41,59 @@ describe("getOrCreateMachineId", () => {
     const first = await getOrCreateMachineId();
     const second = await getOrCreateMachineId();
     expect(second).toBe(first);
+  });
+
+  const idFilePath = () => path.join(tmpDir, ".sapiom", "harness", "machine-id");
+
+  it("creates the file with mode 0600", async () => {
+    await getOrCreateMachineId();
+    const stat = await fs.stat(idFilePath());
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("hardens a pre-existing, loosely-permissioned file to 0600 without changing its id", async () => {
+    const first = await getOrCreateMachineId();
+    await fs.chmod(idFilePath(), 0o644);
+    expect((await fs.stat(idFilePath())).mode & 0o777).toBe(0o644);
+
+    const second = await getOrCreateMachineId();
+    expect(second).toBe(first);
+    expect((await fs.stat(idFilePath())).mode & 0o777).toBe(0o600);
+  });
+
+  it("silently regenerates a corrupt (non-uuid) file", async () => {
+    await fs.mkdir(path.dirname(idFilePath()), { recursive: true });
+    await fs.writeFile(idFilePath(), "not-a-uuid-at-all {{{");
+
+    const id = await getOrCreateMachineId();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+    expect((await fs.readFile(idFilePath(), "utf-8")).trim()).toBe(id);
+  });
+
+  it("silently regenerates an empty file", async () => {
+    await fs.mkdir(path.dirname(idFilePath()), { recursive: true });
+    await fs.writeFile(idFilePath(), "");
+
+    const id = await getOrCreateMachineId();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("degrades gracefully (still returns a usable id, never rejects) when HOME is unwritable", async () => {
+    // Point homedir() below a regular file so mkdir must fail — same
+    // technique as analytics-core's identity.test.ts unwritable-HOME case.
+    // Uses homeOverride, not tmpDir itself, so afterEach still cleans up
+    // the real temp dir this test ran in.
+    const blocker = path.join(tmpDir, "blocker");
+    await fs.writeFile(blocker, "i am a file");
+    homeOverride = path.join(blocker, "nested");
+
+    const id = await getOrCreateMachineId();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+
+    // Not persisted (there was nowhere to persist it to) — a second call in
+    // the same broken environment gets a *different* id, since there's no
+    // stable location to read one back from. Still never throws.
+    const second = await getOrCreateMachineId();
+    expect(second).toMatch(/^[0-9a-f-]{36}$/);
   });
 });

--- a/packages/harness/src/cli/machine-id.ts
+++ b/packages/harness/src/cli/machine-id.ts
@@ -4,23 +4,72 @@ import * as crypto from "node:crypto";
 import { HARNESS_PATHS } from "../shared/types.js";
 import { expandHome } from "./paths.js";
 
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Stable anonymous install id, used to tag every analytics event
  * (`AnalyticsEvent.machineId`) regardless of which Sapiom user is signed in.
  * Created once on first run and reused forever after.
+ *
+ * Hardened per `@sapiom/analytics-core`'s `identity.ts` pattern: private
+ * file permissions (mode 0600, on both create and a pre-existing file),
+ * silent regeneration when the stored content is missing/corrupt, and
+ * graceful degradation — an unreadable/unwritable HOME must never crash
+ * server boot over an analytics nicety. Kept as our own plain-text
+ * `~/.sapiom/harness/machine-id` file for now; converging onto her
+ * `~/.sapiom/analytics.json` identity is a separate, later conversation.
  */
 export async function getOrCreateMachineId(): Promise<string> {
   const filePath = expandHome(HARNESS_PATHS.machineId);
 
   try {
-    const existing = (await fs.readFile(filePath, "utf-8")).trim();
-    if (existing) return existing;
-  } catch {
-    // No file yet — fall through and create one.
-  }
+    const existing = await readMachineId(filePath);
+    if (existing) {
+      // Re-assert privacy even when we're not writing: a file created by a
+      // pre-hardening version of the harness (default `fs.writeFile` perms,
+      // typically 0644) would otherwise stay loosely-permissioned forever,
+      // since its content never needs to change again once it exists.
+      await hardenPermissions(filePath);
+      return existing;
+    }
 
-  const id = crypto.randomUUID();
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, id + "\n");
-  return id;
+    const id = crypto.randomUUID();
+    await writeMachineId(filePath, id);
+    return id;
+  } catch {
+    // Persistence is impossible (unwritable/unreadable HOME, permissions,
+    // whatever) — hand back a fresh id for this process rather than taking
+    // the server down over it. It won't be stable across runs, but every
+    // event within this run is at least internally consistent.
+    return crypto.randomUUID();
+  }
+}
+
+/** Reads and validates the persisted id. Missing, empty, or malformed
+ *  content returns `undefined` so the caller regenerates — same recovery
+ *  posture as `identity.ts`'s corrupt/wrong-shape handling. */
+async function readMachineId(filePath: string): Promise<string | undefined> {
+  try {
+    const raw = (await fs.readFile(filePath, "utf-8")).trim();
+    return UUID_SHAPE.test(raw) ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeMachineId(filePath: string, id: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  // `mode` on writeFile only applies when creating the file — the follow-up
+  // hardenPermissions() covers the (unlikely but possible) case of writing
+  // over a pre-existing file at this path with looser permissions.
+  await fs.writeFile(filePath, id + "\n", { mode: 0o600 });
+  await hardenPermissions(filePath);
+}
+
+async function hardenPermissions(filePath: string): Promise<void> {
+  try {
+    await fs.chmod(filePath, 0o600);
+  } catch {
+    // Best effort.
+  }
 }


### PR DESCRIPTION
## Summary

Two gaps surfaced while reviewing a new, unrelated analytics package built in parallel to this one: our own consent and identity handling were both behind its more mature patterns for the same problems.

**Consent** (`cli/consent.ts`): `SAPIOM_TELEMETRY_DISABLED` and the ecosystem-wide `DO_NOT_TRACK` convention now force telemetry off for the run — overriding a previously persisted opt-in and skipping the prompt entirely, with a printed reason — using the same precedence and value-parsing (`1`/`true`, case-insensitive) as the sibling package's consent resolution. The override is never persisted, so a later run without the env var set still sees whatever the user actually answered (or gets a genuine first-run prompt, if this run was their first ever).

**Machine id** (`cli/machine-id.ts`): hardened to the same pattern — mode `0600` on both a freshly created file and a pre-existing one (so a file written before this change doesn't stay loosely-permissioned forever), silent regeneration when the stored content is missing or not a valid uuid, and graceful degradation to an unpersisted per-process id when the file can't be read or written at all. That last one fixes a real, if narrow, existing bug: an unwritable HOME previously made `getOrCreateMachineId()` reject its promise, which would have crashed server boot entirely over an analytics nicety. Kept our own file path (`~/.sapiom/harness/machine-id`) — converging identity storage across packages is a separate, later conversation.

## Test plan

- [x] New env-matrix coverage in `consent.test.ts`: each var/value forces telemetry off without prompting on a first run; overrides a previously persisted opt-in without rewriting it; non-matching values (`"0"`, `"no"`, empty string) are correctly not treated as opt-outs; `--no-telemetry` still wins with no env var set at all.
- [x] New coverage in `machine-id.test.ts` with real temp files (no mocked fs): mode `0600` on create; a pre-existing file with looser permissions gets hardened without its id changing; a corrupt (non-uuid) or empty file is silently regenerated; an unwritable HOME (a real directory blocked by a real file, same technique as the sibling package's test) still returns a usable id and never rejects.
- [x] `pnpm --filter @sapiom/harness typecheck` / `lint` / `build` — clean
- [x] `pnpm --filter @sapiom/harness test` — 308/308
- [x] `pnpm --filter @sapiom/harness e2e:live` — all 3 phases green

🤖 Generated with [Claude Code](https://claude.com/claude-code)