### PR TITLE
feat(harness): gate programmatic input on real session readiness, not just pty status

### DIFF
--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -100,6 +100,55 @@ describe("CodexAdapter", () => {
     });
   });
 
+  describe("detectBlockingPrompt", () => {
+    // Real capture from a locally installed codex-cli 0.134.0's trust-dialog
+    // screen: it positions each *word* with its own cursor-addressing escape
+    // sequence instead of emitting literal spaces between them, and other
+    // frames interleave OSC title-setting sequences using both BEL and ST
+    // terminators.
+    const REAL_TRUST_PROMPT_CAPTURE =
+      "\x1b[1;1H\x1b[J\x1b[1;3H\x1b[1mYou are in \x1b[22m/private/tmp/proj" +
+      "\x1b[3;3HDo\x1b[3;6Hyou\x1b[3;10Htrust\x1b[3;16Hthe\x1b[3;20Hcontents" +
+      "\x1b[3;29Hof\x1b[3;32Hthis\x1b[3;37Hdirectory?\x1b[3;48HWorking" +
+      "\x1b[3;56Hwith\x1b[3;61Huntrusted\x1b[4;3Hinjection." +
+      "\x1b[6;1H\x1b[38;5;6;49m› 1. Yes, continue\x1b[7;3H\x1b[39;49m2." +
+      "\x1b[7;6HNo,\x1b[7;10Hquit\x1b[9;3H\x1b[2mPress enter to continue";
+
+    it("detects the trust prompt in a real, unmodified pty capture", () => {
+      const adapter = new CodexAdapter();
+      expect(adapter.detectBlockingPrompt(REAL_TRUST_PROMPT_CAPTURE)).toBe(true);
+    });
+
+    it("does not false-positive on ordinary composer/output text", () => {
+      const adapter = new CodexAdapter();
+      const composer =
+        "\x1b]0;my-project\x07\x1b[1;1H\x1b[38;2;231;231;231;49m› Find and fix a bug in @filename" +
+        "\x1b[3;1Hgpt-5.5 xhigh · /private/tmp/proj";
+      expect(adapter.detectBlockingPrompt(composer)).toBe(false);
+    });
+
+    it("does not false-positive on an OSC sequence terminated by ST (ESC \\\\) rather than BEL", () => {
+      // Regression: a greedy (not lazy) OSC-stripping pattern doesn't
+      // exclude ST (`\x1b\\`) from what it can consume, so it backtracks to
+      // the LAST reachable terminator in the whole string instead of the
+      // next one — silently swallowing real content (including this exact
+      // trust-prompt text) in between. Confirmed against this real capture
+      // shape: two OSC 10/11 color queries (ST-terminated) followed later by
+      // an OSC 0 title (BEL-terminated), then the trust prompt.
+      const capture =
+        "\x1b]10;?\x1b\\\x1b]11;?\x1b\\\x1b]0;proj\x07" +
+        "\x1b[3;3HDo\x1b[3;6Hyou\x1b[3;10Htrust\x1b[3;16Hthe\x1b[3;20Hcontents" +
+        "\x1b[3;29Hof\x1b[3;32Hthis\x1b[3;37Hdirectory?";
+      const adapter = new CodexAdapter();
+      expect(adapter.detectBlockingPrompt(capture)).toBe(true);
+    });
+
+    it("returns false for plain text with no escape sequences at all", () => {
+      const adapter = new CodexAdapter();
+      expect(adapter.detectBlockingPrompt("just some ordinary agent output, nothing special")).toBe(false);
+    });
+  });
+
   describe("doctor", () => {
     it("reports ok:false when the binary isn't on PATH", async () => {
       const adapter = new CodexAdapter({ binary: "definitely-not-a-real-binary-xyz" });

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -43,6 +43,44 @@ const execFileAsync = promisify(execFile);
 const ROLLOUT_HEAD_BYTES = 65_536;
 const MAX_SCAN_DEPTH = 4; // ~/.codex/sessions/YYYY/MM/DD/*.jsonl
 
+/**
+ * Matches Codex's directory-trust confirmation prompt ("Do you trust the
+ * contents of this directory? ... 1. Yes, continue  2. No, quit"), after
+ * `stripAnsi` — confirmed against a real capture: Codex's TUI positions
+ * each *word* with its own cursor-addressing escape sequence instead of
+ * emitting literal spaces between them (`trust\x1b[3;16Hthe\x1b[3;20H...`),
+ * so even a stripped buffer runs the words together with no separator at
+ * all; `\s*` between them tolerates that (and ordinary whitespace, in case
+ * a future TUI revision renders differently). See `detectBlockingPrompt`
+ * for why this exists at all (Codex's own structured readiness signal can't
+ * be relied on standalone, unlike Claude Code's).
+ */
+const TRUST_PROMPT_PATTERN = /trust\s*the\s*contents\s*of\s*this\s*directory/i;
+
+/** Strips ANSI/CSI/OSC control sequences a pty stream is otherwise full of,
+ *  so text pattern-matching (e.g. `TRUST_PROMPT_PATTERN`) sees the words a
+ *  human would actually read rather than raw terminal-control bytes. Not
+ *  exhaustive of every escape sequence a TUI could emit, but covers what
+ *  Codex's TUI is confirmed (via real captures) to use: CSI (cursor moves,
+ *  SGR color/style) and OSC (window title) sequences. */
+export function stripAnsi(text: string): string {
+  /* eslint-disable no-control-regex -- matching literal ESC (\x1b) / BEL
+   * (\x07) bytes is the entire point of an ANSI-sequence stripper; there's
+   * no non-control-character way to express "a real escape sequence". */
+  return text
+    // Lazy (`*?`), not greedy: a greedy `[^\x07]*` doesn't exclude `\x1b\\`
+    // (ST) from what it can consume, so it backtracks from the END of the
+    // whole string looking for the last reachable terminator instead of the
+    // next one — silently swallowing everything (including real prompt
+    // text) between an OSC sequence and some unrelated, much-later BEL/ST.
+    // Confirmed against a real capture: this exact bug made the trust-
+    // prompt regex below never match a full multi-KB scrollback buffer.
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "") // OSC ... BEL or ST
+    .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "") // CSI sequences
+    .replace(/\x1b[()>=][A-Za-z0-9]?/g, ""); // charset/keypad-mode selection
+  /* eslint-enable no-control-regex */
+}
+
 export interface CodexAdapterOptions {
   /** Overridable for tests. */
   binary?: string;
@@ -191,6 +229,22 @@ export class CodexAdapter implements HarnessAdapter {
       env: {},
       cwd: opts.cwd,
     };
+  }
+
+  /**
+   * See `HarnessAdapter.detectBlockingPrompt`. Codex needs this (Claude Code
+   * doesn't) because its rollout file — and therefore the SessionStart-
+   * equivalent event `SessionManager` otherwise waits on — isn't written
+   * until the *first* turn is actually submitted, confirmed empirically
+   * against a real `codex-cli 0.134.0`: an idle, fully-interactive session
+   * (trust prompt already accepted, composer visibly ready) produces zero
+   * files under `~/.codex/sessions` for as long as nothing is submitted.
+   * That real signal therefore can't arrive before the very first
+   * injection that needs it — a scrollback check is the only thing that
+   * can stand in for it up to that point.
+   */
+  detectBlockingPrompt(scrollback: string): boolean {
+    return TRUST_PROMPT_PATTERN.test(stripAnsi(scrollback));
   }
 
   async listPastSessions(cwd: string): Promise<SessionSummary[]> {

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -166,6 +166,7 @@ describe("SessionManager", () => {
     it("splits non-empty submitted text into a text write, then a separate \\r after a delay", async () => {
       const { manager, spawns } = makeManager();
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setReady(session.id);
 
       const submitPromise = manager.submitInput(session.id, "hello world", true);
 
@@ -187,6 +188,7 @@ describe("SessionManager", () => {
     it("writes a bare \\r in a single call for submit:true with empty text (no splitting needed)", async () => {
       const { manager, spawns } = makeManager();
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setReady(session.id);
 
       const ok = await manager.submitInput(session.id, "", true);
 
@@ -198,6 +200,7 @@ describe("SessionManager", () => {
     it("writes only the text, with no \\r at all, when submit is false", async () => {
       const { manager, spawns } = makeManager();
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setReady(session.id);
 
       const ok = await manager.submitInput(session.id, "draft text", false);
 
@@ -214,6 +217,7 @@ describe("SessionManager", () => {
     it("does not write the trailing \\r if the session's pty is gone by the time the delay elapses", async () => {
       const { manager, spawns } = makeManager();
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setReady(session.id);
 
       const submitPromise = manager.submitInput(session.id, "hello", true);
       expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
@@ -225,6 +229,162 @@ describe("SessionManager", () => {
       expect(ok).toBe(false);
       // Still just the one write from before the pty exited — no trailing \r.
       expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("readiness gating (SessionNotReadyError / setReady / detectBlockingPrompt)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("a fresh session starts not-ready even though its pty is already \"running\"", async () => {
+      const { manager } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      expect(session.status).toBe("running");
+      expect(session.ready).toBe(false);
+    });
+
+    it("write() (raw keystrokes) is never gated on readiness — a human must be able to answer a blocking prompt themselves", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      expect(session.ready).toBe(false);
+
+      expect(manager.write(session.id, "1\r")).toBe(true);
+      expect(spawns[0]?.pty.write).toHaveBeenCalledWith("1\r");
+    });
+
+    it(
+      "THE RACE REPRO: submitInput() against a not-yet-ready session queues and succeeds once " +
+        "setReady() fires before the grace period elapses (macro fired a beat before onboarding finished)",
+      async () => {
+        const { manager, spawns } = makeManager();
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        const submitPromise = manager.submitInput(session.id, "hello", true);
+        // Not ready yet — must NOT have written anything, this is exactly the
+        // bug: input landing on a TUI that isn't listening yet.
+        expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+
+        // The real SessionStart hook lands a moment later.
+        await vi.advanceTimersByTimeAsync(500);
+        manager.setReady(session.id);
+
+        // Generous, not tightly matched to SUBMIT_DELAY_MS: the readiness
+        // poll loop's own in-flight tick can eat into part of a
+        // precisely-sized advance before SUBMIT_DELAY_MS's sleep even
+        // starts, since setReady() above only flips a flag — the loop still
+        // has to wake up and notice it on its own schedule.
+        await vi.advanceTimersByTimeAsync(1_000);
+        const ok = await submitPromise;
+
+        expect(ok).toBe(true);
+        expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(1, "hello");
+        expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(2, "\r");
+      },
+    );
+
+    it("throws SessionNotReadyError (never silently proceeds) when a session never becomes ready within the grace period", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const submitPromise = manager.submitInput(session.id, "hello", true);
+      const assertion = expect(submitPromise).rejects.toThrow(/not ready yet/i);
+      await vi.advanceTimersByTimeAsync(8_000);
+      await assertion;
+
+      // The whole point: nothing was ever written into the not-listening TUI.
+      expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+    });
+
+    it("resuming resets ready back to false, even for a session that was ready before its pty exited", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setAgentSessionId(session.id, "agent-1");
+      manager.setReady(session.id);
+      expect(manager.get(session.id)?.ready).toBe(true);
+
+      spawns[0]?.emitExit(0);
+      expect(manager.get(session.id)?.status).toBe("exited");
+
+      await manager.resume(session.id);
+      expect(manager.get(session.id)?.status).toBe("running");
+      // Trust dialogs can reappear on resume (e.g. different sandbox flags)
+      // — a fresh pty hasn't proven itself interactive yet either way.
+      expect(manager.get(session.id)?.ready).toBe(false);
+    });
+
+    it("setReady is idempotent and a silent no-op for an unknown session id", () => {
+      const { manager } = makeManager();
+      expect(() => manager.setReady("unknown-id")).not.toThrow();
+    });
+
+    describe("harnesses with detectBlockingPrompt (Codex's lazy-rollout-file bridge)", () => {
+      it("is not ready before the settle window elapses, even with a clean scrollback", async () => {
+        const detectBlockingPrompt = vi.fn(() => false);
+        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        const submitPromise = manager.submitInput(session.id, "hello", true);
+        expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+
+        // Generous, not tightly matched to READY_SETTLE_MS + SUBMIT_DELAY_MS:
+        // the settle window is checked once per READY_POLL_MS poll tick, not
+        // the instant it elapses, so the actual crossing (and the fresh
+        // SUBMIT_DELAY_MS sleep that only starts once it does) can land
+        // meaningfully later than the nominal 700ms.
+        await vi.advanceTimersByTimeAsync(1_500);
+        expect(await submitPromise).toBe(true);
+      });
+
+      it("becomes ready enough after the settle window when the scrollback shows no blocking prompt (the common already-trusted case)", async () => {
+        const detectBlockingPrompt = vi.fn(() => false);
+        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        await vi.advanceTimersByTimeAsync(700);
+        const submitPromise = manager.submitInput(session.id, "hello", true);
+        await vi.advanceTimersByTimeAsync(1_000);
+        const ok = await submitPromise;
+
+        expect(ok).toBe(true);
+        expect(spawns[0]?.pty.write).toHaveBeenCalledWith("hello");
+        // Only the tail of retained scrollback is scanned, not the full history.
+        expect(detectBlockingPrompt).toHaveBeenCalledWith(expect.any(String));
+      });
+
+      it("stays not-ready while the scrollback shows a blocking prompt, then proceeds once it clears", async () => {
+        let showingPrompt = true;
+        const detectBlockingPrompt = vi.fn(() => showingPrompt);
+        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        const submitPromise = manager.submitInput(session.id, "hello", true);
+        await vi.advanceTimersByTimeAsync(700);
+        expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+
+        // Simulated: a human answers the prompt directly in the terminal.
+        showingPrompt = false;
+        await vi.advanceTimersByTimeAsync(150); // one READY_POLL_MS tick
+        await vi.advanceTimersByTimeAsync(300);
+        expect(await submitPromise).toBe(true);
+      });
+
+      it("throws SessionNotReadyError if the blocking prompt never clears within the grace period", async () => {
+        const detectBlockingPrompt = vi.fn(() => true);
+        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        const submitPromise = manager.submitInput(session.id, "hello", true);
+        const assertion = expect(submitPromise).rejects.toThrow(/not ready yet/i);
+        await vi.advanceTimersByTimeAsync(8_000);
+        await assertion;
+
+        expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -94,6 +94,46 @@ const KILL_ESCALATION_MS = 2_000;
 /** See `kill()`: how long after escalating to give node-pty one last chance
  *  to report the exit itself before synthesizing it from an OS-level check. */
 const KILL_ESCALATION_CONFIRM_MS = 500;
+/**
+ * See `isReadyEnough()`: for a harness with `detectBlockingPrompt`, how long
+ * to give the pty to render its first real frame before trusting a clean
+ * scrollback (no known blocking prompt) as a genuine "no prompt showing"
+ * rather than just "hasn't drawn anything yet".
+ */
+const READY_SETTLE_MS = 700;
+/** See `isReadyEnough()`: how much of the tail of retained scrollback to
+ *  scan for a blocking prompt — recent output only, not the full history a
+ *  full-screen TUI never truly clears. Generous relative to one redraw
+ *  frame (confirmed against a real capture: a single Codex trust-prompt
+ *  frame is well under 2KB) without re-scanning unbounded history. */
+const BLOCKING_PROMPT_SCAN_BYTES = 4_096;
+/**
+ * See `submitInput()`: how long to wait for a not-yet-ready session to
+ * become ready before giving up and throwing `SessionNotReadyError`. Covers
+ * the ordinary "macro fired a beat before onboarding finished" case without
+ * making a genuinely stuck session (real trust prompt sitting unanswered)
+ * hang the caller for long before surfacing something actionable.
+ */
+const READY_GRACE_MS = 8_000;
+/** Poll interval while waiting out READY_GRACE_MS. */
+const READY_POLL_MS = 150;
+
+/**
+ * Thrown by `submitInput()` when a session's pty is alive but never became
+ * ready (see `HarnessSession.ready`) within `READY_GRACE_MS` — the trust-
+ * dialog race this whole readiness mechanism exists to catch. Callers
+ * (rest.ts, macros.ts) catch this specifically and surface it as a 409 with
+ * a UI-visible reason, rather than letting it fall into a generic 500 or
+ * (worse, the bug this fixes) silently writing into a non-interactive TUI.
+ */
+export class SessionNotReadyError extends Error {
+  constructor(id: string) {
+    super(
+      `Session "${id}" is not ready yet — check the terminal, it may be asking to trust the folder.`,
+    );
+    this.name = "SessionNotReadyError";
+  }
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -162,6 +202,8 @@ interface PtyHandle {
   pty: IPty;
   buffer: string;
   emitter: EventEmitter;
+  /** Epoch ms this pty was spawned — see `isReadyEnough`'s settle window. */
+  spawnedAt: number;
 }
 
 export class SessionManager {
@@ -260,6 +302,7 @@ export class SessionManager {
       lastActiveAt: this.now(),
       exitCode: null,
       boundWorkflowPath: null,
+      ready: false,
     };
     this.sessions.set(id, session);
     await this.persist();
@@ -295,6 +338,7 @@ export class SessionManager {
       lastActiveAt: input.lastActiveAt,
       exitCode: null,
       boundWorkflowPath: null,
+      ready: false,
     };
     this.sessions.set(id, session);
     void this.persist();
@@ -395,10 +439,29 @@ export class SessionManager {
    * passthrough for live keystrokes from the terminal WS and must never add
    * this delay/splitting behavior. See `SUBMIT_DELAY_MS` for why non-empty
    * submitted text can't just be written as `${text}\r` in one call.
+   *
+   * Gated on readiness (see `HarnessSession.ready` / `isReadyEnough`): a
+   * "running" pty can still be sitting on a blocking prompt that swallows
+   * whatever's written to it. Briefly waits out `READY_GRACE_MS` for the
+   * ordinary "fired a beat too early" case; throws `SessionNotReadyError`
+   * — never silently proceeds — if the session still isn't ready after
+   * that, so the caller (rest.ts, macros.ts) can surface a clear reason
+   * instead of the input just vanishing.
    */
   async submitInput(id: string, text: string, submit = true): Promise<boolean> {
     const handle = this.ptys.get(id);
     if (!handle) return false;
+
+    const session = this.sessions.get(id);
+    if (!session) return false;
+    if (!this.isReadyEnough(session, handle)) {
+      const becameReady = await this.waitUntilReady(id, READY_GRACE_MS);
+      if (!becameReady) throw new SessionNotReadyError(id);
+      // waitUntilReady only confirms readiness, not that the same pty is
+      // still the live one — re-fetch in case it was killed/replaced (e.g.
+      // a resume) while we were waiting, same as the mid-write race below.
+      if (this.ptys.get(id) !== handle) return false;
+    }
 
     if (!submit) {
       handle.pty.write(text);
@@ -412,11 +475,8 @@ export class SessionManager {
       handle.pty.write("\r");
     }
 
-    const session = this.sessions.get(id);
-    if (session) {
-      session.lastActiveAt = this.now();
-      void this.persist();
-    }
+    session.lastActiveAt = this.now();
+    void this.persist();
     return true;
   }
 
@@ -453,6 +513,69 @@ export class SessionManager {
     session.agentSessionId = agentSessionId;
     void this.persist();
     this.emitStatus(session);
+  }
+
+  /**
+   * Marks a session's TUI as genuinely interactive — see `HarnessSession.ready`.
+   * Called from the ingest pipeline when a SessionStart(-equivalent) event
+   * is processed for this session (real hook for Claude Code, tailer-
+   * translated for Codex). Idempotent; a session that's exited or already
+   * ready is a silent no-op.
+   */
+  setReady(id: string): void {
+    const session = this.sessions.get(id);
+    if (!session || session.ready) return;
+    session.ready = true;
+    void this.persist();
+    this.emitStatus(session);
+  }
+
+  /**
+   * Whether `id` should be treated as ready to receive programmatic input
+   * right now — `session.ready` (the real signal), OR, for a harness that
+   * declares `detectBlockingPrompt` (currently: Codex, whose rollout file —
+   * and therefore its SessionStart-equivalent — isn't written until the
+   * *first* turn is submitted, so the real signal can never arrive before
+   * the very first injection that needs it): the pty has had a moment to
+   * render its first real frame (`READY_SETTLE_MS`) and that frame doesn't
+   * show a known blocking prompt. A harness without `detectBlockingPrompt`
+   * (Claude Code) gets no such fallback — its SessionStart hook is reliable
+   * standalone, and a scrollback guess would just reopen the exact race
+   * this mechanism exists to close.
+   */
+  private isReadyEnough(session: HarnessSession, handle: PtyHandle): boolean {
+    if (session.ready) return true;
+    const adapter = this.adapters[session.harness];
+    if (!adapter?.detectBlockingPrompt) return false;
+    if (Date.now() - handle.spawnedAt < READY_SETTLE_MS) return false;
+    // Only the tail: `handle.buffer` is the full retained scrollback
+    // (up to SCROLLBACK_BYTES) and full-screen TUIs never truly "clear" it
+    // — a dismissed prompt's text sits in there forever. A full-screen
+    // redraw re-touches its whole visible frame on every update though
+    // (confirmed against a real capture), so recent output alone reflects
+    // what's actually on screen right now; checking the whole history would
+    // make a session that dismissed its trust prompt minutes ago look
+    // permanently stuck.
+    return !adapter.detectBlockingPrompt(handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES));
+  }
+
+  /**
+   * Polls `isReadyEnough` until it's true, the session's pty goes away
+   * (killed/exited — it's never going to become ready now), or `timeoutMs`
+   * elapses. Used by `submitInput()` only — `write()` (raw terminal
+   * keystrokes) must never wait on this, since a human answering the very
+   * prompt this is waiting out is exactly how a session becomes ready.
+   */
+  private async waitUntilReady(id: string, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const handle = this.ptys.get(id);
+      const session = this.sessions.get(id);
+      if (!handle || !session) return false;
+      if (this.isReadyEnough(session, handle)) return true;
+      if (Date.now() >= deadline) return false;
+      await sleep(Math.min(READY_POLL_MS, Math.max(0, deadline - Date.now())));
+    }
   }
 
   /** Waits for all in-flight registry writes to settle. Useful before process
@@ -516,10 +639,14 @@ export class SessionManager {
 
     const emitter = new EventEmitter();
     emitter.setMaxListeners(0);
-    const handle: PtyHandle = { pty, buffer: "", emitter };
+    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now() };
     this.ptys.set(session.id, handle);
 
     session.status = "running";
+    // A resumed session may carry `ready: true` from its previous life —
+    // this is a fresh pty that hasn't proven itself interactive yet either
+    // way (trust dialogs can reappear, e.g. under different sandbox flags).
+    session.ready = false;
     session.lastActiveAt = this.now();
     await this.persist();
     this.emitStatus(session);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -364,6 +364,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
       sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
     },
+    onSessionReady: (harnessSessionId) => {
+      sessionManager.setReady(harnessSessionId);
+    },
     store: eventStore,
     batcher,
     enrichFromTranscript: enrichTurnCompleted,

--- a/packages/harness/src/server/ingest.test.ts
+++ b/packages/harness/src/server/ingest.test.ts
@@ -131,6 +131,34 @@ describe("createIngestRouter", () => {
     expect(resolved[0]).toEqual({ harnessSessionId: "session-1", agentSessionId: "agent-42" });
   });
 
+  it("calls onSessionReady on session.start — the readiness signal SessionManager gates programmatic input on", async () => {
+    const ready: string[] = [];
+    start({ onSessionReady: (harnessSessionId) => ready.push(harnessSessionId) });
+
+    const res = await postIngest(baseUrl, {
+      hookEvent: "SessionStart",
+      harnessSessionId: "session-1",
+      payload: { session_id: "agent-42", source: "startup" },
+    });
+    expect(res.status).toBe(200);
+
+    await vi.waitFor(() => expect(ready).toEqual(["session-1"]));
+  });
+
+  it("does not call onSessionReady for events other than SessionStart", async () => {
+    const ready: string[] = [];
+    start({ onSessionReady: (harnessSessionId) => ready.push(harnessSessionId) });
+
+    await postIngest(baseUrl, {
+      hookEvent: "UserPromptSubmit",
+      harnessSessionId: "session-1",
+      payload: { session_id: "agent-1", prompt: "hello" },
+    });
+
+    await vi.waitFor(() => expect(stored).toHaveLength(1));
+    expect(ready).toEqual([]);
+  });
+
   it("drops events for unknown sessions without storing anything", async () => {
     const res = await postIngest(baseUrl, {
       hookEvent: "UserPromptSubmit",

--- a/packages/harness/src/server/ingest.ts
+++ b/packages/harness/src/server/ingest.ts
@@ -36,6 +36,15 @@ export interface IngestDeps {
   resolveSession: (harnessSessionId: string) => IngestSessionContext | undefined;
   /** Called once a session.start event reveals the agent's own session id. */
   onAgentSessionResolved: (harnessSessionId: string, agentSessionId: string) => void;
+  /**
+   * Called once a SessionStart(-equivalent) event is actually processed for
+   * a session — the signal that its TUI is genuinely interactive, not just
+   * that its pty exists. See `SessionManager.setReady`/`HarnessSession.ready`
+   * for what this gates. Fires alongside `onAgentSessionResolved` (same
+   * event), kept separate since "ready" and "agent session id known" are
+   * conceptually distinct even though they happen to co-occur today.
+   */
+  onSessionReady?: (harnessSessionId: string) => void;
   store: { append(event: AnalyticsEvent): Promise<void> };
   batcher: { enqueue(event: AnalyticsEvent): void };
   /** Optional transcript backfill for turn.completed / session.end. */
@@ -106,8 +115,9 @@ export async function processIngest(
     finalEvent = await deps.enrichFromTranscript(event, transcriptPath);
   }
 
-  if (hookEvent === "SessionStart" && finalEvent.agentSessionId) {
-    deps.onAgentSessionResolved(harnessSessionId, finalEvent.agentSessionId);
+  if (hookEvent === "SessionStart") {
+    if (finalEvent.agentSessionId) deps.onAgentSessionResolved(harnessSessionId, finalEvent.agentSessionId);
+    deps.onSessionReady?.(harnessSessionId);
   }
 
   deps.onNormalizedEvent?.(finalEvent);

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -4,6 +4,7 @@ import type { Server } from "node:http";
 import { createMacrosRouter, type MacrosRouterDeps } from "./macros.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
 import { CANVAS_STYLE_GUIDELINES } from "../profiles/canvas-guidelines.js";
+import { SessionNotReadyError } from "../core/session-manager.js";
 import type { WorkflowInfo } from "../shared/types.js";
 
 let server: Server;
@@ -211,5 +212,23 @@ describe("macros router", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("requires a selected workflow");
+  });
+
+  it("409s with a UI-visible reason when the session isn't ready yet (SessionNotReadyError) — never silently swallows the macro", async () => {
+    const deps = makeDeps({
+      injectInput: vi.fn().mockRejectedValue(new SessionNotReadyError("sess-1")),
+    });
+    await start(deps);
+
+    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/not ready yet/i);
+    expect(body.error).toMatch(/trust the folder/i);
   });
 });

--- a/packages/harness/src/server/macros.ts
+++ b/packages/harness/src/server/macros.ts
@@ -11,6 +11,7 @@ import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
 import { CANVAS_INDEX, type MacroDef, type RunMacroRequest, type WorkflowInfo } from "../shared/types.js";
 import { MacroValidationError, resolveMacro } from "../core/macro-runner.js";
+import { SessionNotReadyError } from "../core/session-manager.js";
 
 export interface MacrosRouterDeps {
   listMacros(): MacroDef[];
@@ -76,6 +77,10 @@ export function createMacrosRouter(deps: MacrosRouterDeps): ExpressRouter {
     } catch (err) {
       if (err instanceof MacroValidationError) {
         res.status(400).json({ error: err.message });
+        return;
+      }
+      if (err instanceof SessionNotReadyError) {
+        res.status(409).json({ error: err.message });
         return;
       }
       res.status(500).json({ error: (err as Error).message });

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -13,6 +13,7 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 import type { HarnessSession, MacroDef, WorkflowInfo } from "../shared/types.js";
+import { SessionNotReadyError } from "../core/session-manager.js";
 import { createRestRouter, type RestRouterOptions } from "./rest.js";
 
 const TOKEN_HEADER = { "X-Harness-Token": "unused-in-router-tests" };
@@ -26,6 +27,7 @@ function fakeSessionManager(initial: HarnessSession[] = []) {
     resume: vi.fn(),
     kill: vi.fn(() => true),
     write: vi.fn(() => true),
+    submitInput: vi.fn(async () => true),
     setBoundWorkflowPath: vi.fn((id: string, workflowPath: string | null) => {
       const session = sessions.get(id);
       if (session) session.boundWorkflowPath = workflowPath;
@@ -122,6 +124,7 @@ describe("createRestRouter", () => {
         lastActiveAt: "2026-01-01T00:00:00.000Z",
         exitCode: null,
         boundWorkflowPath: null,
+        ready: true,
       };
       const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, source: "scan" };
       const macro: MacroDef = { id: "run_local", label: "Run local", icon: "Play", action: { kind: "inject", text: "x" } };
@@ -284,6 +287,65 @@ describe("createRestRouter", () => {
     });
   });
 
+  describe("POST /sessions/:id/input", () => {
+    it("submits input and returns ok:true", async () => {
+      const sessionManager = fakeSessionManager();
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ text: "hello", submit: true }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(sessionManager.submitInput).toHaveBeenCalledWith("sess-1", "hello", true);
+    });
+
+    it("400s a malformed body (missing text)", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ submit: true }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("404s when submitInput reports no live pty for the session", async () => {
+      const sessionManager = fakeSessionManager();
+      (sessionManager.submitInput as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ text: "hello" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("409s with a UI-visible reason when the session isn't ready yet (SessionNotReadyError) — never silently swallows the input", async () => {
+      const sessionManager = fakeSessionManager();
+      (sessionManager.submitInput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new SessionNotReadyError("sess-1"),
+      );
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify({ text: "hello" }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/not ready yet/i);
+      expect(body.error).toMatch(/trust the folder/i);
+    });
+  });
+
   describe("PATCH /sessions/:id/workflow", () => {
     const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, source: "scan" };
     const baseSession: HarnessSession = {
@@ -297,6 +359,7 @@ describe("createRestRouter", () => {
       lastActiveAt: "2026-01-01T00:00:00.000Z",
       exitCode: null,
       boundWorkflowPath: null,
+      ready: true,
     };
 
     it("binds a known workflow: validates it, updates the session, and writes the context file", async () => {

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -20,7 +20,7 @@ import type {
   SessionSummary,
   WorkflowInfo,
 } from "../shared/types.js";
-import type { SessionManager } from "../core/session-manager.js";
+import { SessionNotReadyError, type SessionManager } from "../core/session-manager.js";
 import { loadSettings, saveSettings } from "../cli/settings.js";
 
 const createSessionSchema = z.object({
@@ -266,6 +266,10 @@ export function createRestRouter(options: RestRouterOptions): Router {
       }
       res.json({ ok: true });
     } catch (err) {
+      if (err instanceof SessionNotReadyError) {
+        res.status(409).json({ error: err.message });
+        return;
+      }
       next(err);
     }
   });

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -88,6 +88,20 @@ export interface HarnessSession {
    *  via `PATCH /api/sessions/:id/workflow`; mirrored into
    *  HARNESS_CONTEXT_FILE in the session's cwd so the agent can read it. */
   boundWorkflowPath: string | null;
+  /**
+   * `status === "running"` only means the pty is alive — the agent's TUI
+   * can still be sitting on a blocking prompt (most commonly: "trust this
+   * directory?") that isn't accepting real input yet. `ready` is the
+   * stronger signal: this pty is actually interactive. Reset to `false` on
+   * every fresh spawn (including resume) and only ever set by
+   * `SessionManager.setReady()` — see there for what flips it. Injecting
+   * input (macros, `/sessions/:id/input`) against a not-ready session
+   * queues briefly then fails loudly (`SessionNotReadyError`) rather than
+   * silently writing into a TUI that isn't listening; raw terminal
+   * keystrokes (`write()`) are deliberately never gated on this, since a
+   * human must always be able to answer the blocking prompt themselves.
+   */
+  ready: boolean;
 }
 
 /** A resumable past session discovered from agent transcripts or our registry. */
@@ -145,6 +159,17 @@ export interface HarnessAdapter {
   eventSource: "hooks" | "transcript-tail";
   /** Resumable sessions for a directory (agent-side history). */
   listPastSessions(cwd: string): Promise<SessionSummary[]>;
+  /**
+   * Best-effort scrollback check for this harness's own known blocking
+   * prompts (e.g. "trust this directory?"), for harnesses whose real
+   * readiness signal (SessionStart-equivalent) can't be trusted to arrive
+   * before the very first input is worth injecting — see CodexAdapter's
+   * implementation for why. Optional: a harness whose readiness signal IS
+   * trustworthy standalone (Claude Code's SessionStart hook) should leave
+   * this unimplemented rather than have SessionManager fall back to a
+   * scrollback heuristic it doesn't need.
+   */
+  detectBlockingPrompt?(scrollback: string): boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -17,6 +17,7 @@ import { CommandPalette } from "./components/CommandPalette";
 import { DeadSessionPane } from "./components/DeadSessionPane";
 import { SessionBar } from "./components/SessionBar";
 import { Terminal } from "./components/Terminal";
+import { Toast } from "./components/Toast";
 import { WorkflowActionStrip } from "./components/WorkflowActionStrip";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
@@ -207,6 +208,8 @@ export const App = (): JSX.Element => {
           onClose={() => setPaletteOpen(false)}
         />
       )}
+
+      {harness.toast && <Toast message={harness.toast} onDismiss={harness.dismissToast} />}
     </div>
   );
 };

--- a/packages/harness/web/src/components/Toast.tsx
+++ b/packages/harness/web/src/components/Toast.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import type { JSX } from "react";
+
+interface ToastProps {
+  message: string;
+  onDismiss: () => void;
+}
+
+/** Auto-dismiss delay — long enough to read a sentence, short enough not to
+ *  linger and get mistaken for a persistent state indicator. */
+const AUTO_DISMISS_MS = 8_000;
+
+/**
+ * A single transient, dismissible message anchored to the bottom of the
+ * viewport. There's exactly one slot (see `useHarnessState`'s `toast`) —
+ * this app doesn't queue/stack multiple errors, it just always shows the
+ * most recent one, which is enough for what currently produces one (a
+ * failed macro run).
+ */
+export function Toast({ message, onDismiss }: ToastProps): JSX.Element {
+  useEffect(() => {
+    const timer = window.setTimeout(onDismiss, AUTO_DISMISS_MS);
+    return () => window.clearTimeout(timer);
+  }, [message, onDismiss]);
+
+  return (
+    <div className="toast" role="alert" data-testid="toast">
+      <span className="toast-message">{message}</span>
+      <button className="toast-dismiss" aria-label="Dismiss" onClick={onDismiss}>
+        ×
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -32,6 +32,26 @@ export function boundWorkflowPathOf(session: HarnessSession | null | undefined):
   return session?.boundWorkflowPath ?? null;
 }
 
+/**
+ * Thrown by `RealApi.request()` for any non-2xx response. `.message` keeps
+ * the full "METHOD path → status: body" shape for logs/devtools; `.reason`
+ * is the server's own `{ error: "..." }` message when the body parses as
+ * that shape (e.g. `SessionNotReadyError`'s UI-facing text) — callers that
+ * want to show something a user should actually read (not a debug string)
+ * should prefer `.reason` and fall back to `.message`.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly reason: string | undefined;
+
+  constructor(status: number, message: string, reason: string | undefined) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.reason = reason;
+  }
+}
+
 /** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
 export function getBootToken(): string {
   const injected = (window as unknown as { __HARNESS__?: { token?: string } }).__HARNESS__;
@@ -70,7 +90,20 @@ class RealApi implements HarnessApi {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      throw new Error(`${init?.method ?? "GET"} ${path} → ${res.status}${body ? `: ${body}` : ""}`);
+      let reason: string | undefined;
+      try {
+        const parsed: unknown = body ? JSON.parse(body) : undefined;
+        if (parsed && typeof parsed === "object" && typeof (parsed as { error?: unknown }).error === "string") {
+          reason = (parsed as { error: string }).error;
+        }
+      } catch {
+        // Not JSON — reason stays undefined, callers fall back to .message.
+      }
+      throw new ApiError(
+        res.status,
+        `${init?.method ?? "GET"} ${path} → ${res.status}${body ? `: ${body}` : ""}`,
+        reason,
+      );
     }
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
@@ -187,6 +220,7 @@ class MockApi implements HarnessApi {
       status: "starting",
       createdAt: new Date().toISOString(),
       lastActiveAt: new Date().toISOString(),
+      ready: false,
     };
     this.sessions = [...this.sessions, session];
     return session;

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -26,6 +26,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     status: "running",
     createdAt: minutesAgo(1),
     lastActiveAt: minutesAgo(1),
+    ready: true,
   },
   {
     id: "sess-leasing",
@@ -38,6 +39,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     createdAt: minutesAgo(42),
     lastActiveAt: minutesAgo(20),
     exitCode: 0,
+    ready: false,
   },
   {
     id: "sess-rfq",
@@ -50,6 +52,7 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     createdAt: daysAgo(2),
     lastActiveAt: daysAgo(1),
     exitCode: 0,
+    ready: false,
   },
 ];
 

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -10,7 +10,7 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 
-import { boundWorkflowPathOf, createApi, getBootToken, type FsListResponse } from "./api";
+import { ApiError, boundWorkflowPathOf, createApi, getBootToken, type FsListResponse } from "./api";
 import { subscribeEvents } from "./events";
 
 const api = createApi();
@@ -40,6 +40,12 @@ export interface HarnessStateHook {
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
   listDir: (path?: string) => Promise<FsListResponse>;
   lastMessage: BusMessage | null;
+  /** A user-facing message from the most recent failed action (e.g. a macro
+   *  run against a not-yet-ready session) — null when there's nothing to
+   *  show. `runMacro` never rejects on this kind of failure; it sets this
+   *  instead, since its only caller today fires it without awaiting. */
+  toast: string | null;
+  dismissToast: () => void;
 }
 
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
@@ -51,6 +57,7 @@ export function useHarnessState(): HarnessStateHook {
   const [selectedWorkflowPath, setSelectedWorkflowPath] = useState<string | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [history, setHistory] = useState<SessionSummary[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [lastMessage, setLastMessage] = useState<BusMessage | null>(null);
 
@@ -191,8 +198,18 @@ export function useHarnessState(): HarnessStateHook {
   }, []);
 
   const runMacro = useCallback(async (id: string, req: RunMacroRequest): Promise<void> => {
-    await api.runMacro(id, req);
+    try {
+      await api.runMacro(id, req);
+    } catch (err) {
+      // App.tsx fires this without awaiting — surface failures as a toast
+      // instead of an invisible unhandled rejection (which is exactly how
+      // the trust-dialog race originally went unnoticed: the macro's input
+      // vanished and nothing told the user why).
+      setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
+    }
   }, []);
+
+  const dismissToast = useCallback(() => setToast(null), []);
 
   const listDir = useCallback((path?: string): Promise<FsListResponse> => api.listDir(path), []);
 
@@ -219,5 +236,7 @@ export function useHarnessState(): HarnessStateHook {
     runMacro,
     listDir,
     lastMessage,
+    toast,
+    dismissToast,
   };
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1223,3 +1223,41 @@ input {
   background: var(--bg-hover);
   color: var(--text);
 }
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 480px;
+  padding: 10px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--red);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+}
+
+.toast-message {
+  color: var(--text);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.toast-dismiss {
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.toast-dismiss:hover {
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary

Fixes a real silent-failure w3 found in live testing: a macro fired while Claude Code was still showing its trust-the-folder prompt, and the injected input was eaten — the pty was `"running"` (spawned), but the TUI wasn't interactive yet, so nothing happened and nothing said why.

## Design

Adds `HarnessSession.ready` (default `false`, reset on every fresh spawn including resume — trust dialogs can reappear under different sandbox flags) and gates `SessionManager.submitInput()` (macros, `/sessions/:id/input`) on it:
- Briefly queues (waits up to 8s) for the ordinary "fired a beat before onboarding finished" case.
- Throws `SessionNotReadyError` — **never silently proceeds** — if the session is still not ready after that. `rest.ts` and `macros.ts` catch it specifically and return a 409 with a UI-visible reason.
- Raw terminal keystrokes (`write()`) are **deliberately never gated** — a human must always be able to answer the blocking prompt themselves, and doing so is exactly how a session becomes ready.

For Claude Code, `ready` is set from the real `SessionStart` hook event (wired through `ingest.ts`'s new `onSessionReady` callback) — this is the "cleanest signal" both harnesses were expected to share per the original design.

**Codex needed a different bridge.** I confirmed empirically against a real `codex-cli 0.134.0` that its rollout file — and therefore its `SessionStart`-equivalent — isn't written until the *first* turn is actually submitted. Gating strictly on that signal would make every fresh Codex session fail its own first macro call forever (a regression, not a fix, and a genuine chicken-and-egg problem: nothing can ever submit the first turn that would create the file). Added an optional `HarnessAdapter.detectBlockingPrompt` seam instead: `CodexAdapter` implements it with a scrollback check for its own known trust-dialog text, gated by a short settle window and scanning only the *tail* of retained scrollback (a full-screen TUI never truly "clears" old frames — scanning full history would make a session that answered its prompt minutes ago look permanently stuck). Claude Code doesn't implement this seam, so it isn't tempted to fall back to a scrollback guess that would reopen the exact race this fixes.

Also surfaces failures to the UI for the first time: `runMacro` (`App.tsx`'s only caller today fires it without awaiting) previously let any failure — this one included — vanish as an unhandled promise rejection. It now shows a dismissible toast with the server's own error message.

## Two bugs found and fixed along the way

1. Codex's lazy rollout-file creation (above) — confirmed via direct, repeated empirical testing against the real binary rather than trusting the suggested "tailer session_meta" design at face value.
2. A greedy (not lazy) OSC-stripping regex in the new `stripAnsi` helper that doesn't exclude ST (`\x1b\\`) from what it consumes, so it backtracks to the *last* reachable terminator in the whole scrollback instead of the next one — silently swallowing the real trust-prompt text in between a very common scrollback shape (color-query OSC sequences followed later by a title-setting one). Covered by a regression test using a real capture shape.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` (backend + `tsc --noEmit --project web/tsconfig.json` for the frontend) — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness test -- --run` — 329/329 passing, including:
  - The race repro: `submitInput()` against a not-yet-ready session queues and succeeds once the real readiness signal fires before the grace period elapses
  - Throws `SessionNotReadyError` (never silently proceeds) when a session never becomes ready
  - `write()` is never gated on readiness
  - Resume resets `ready` back to `false`
  - Full `detectBlockingPrompt` coverage for Codex: settle-window timing, the common already-trusted case, a prompt that clears mid-wait, and one that never does
  - `stripAnsi`/`detectBlockingPrompt` against real pty capture shapes, including the OSC-terminator regression
  - `ingest.ts`'s `onSessionReady` wiring
  - `rest.ts` / `macros.ts` 409 responses with the UI-visible message
- [x] `pnpm --filter @sapiom/harness build` — clean

Co-Authored-By: Claude <noreply@anthropic.com>