### PR TITLE
fix(harness): re-visualize header action + canvas header clipping fix

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -401,10 +401,47 @@ test.describe("docked workflow action strip", () => {
     await page.screenshot({ path: "web/e2e/screenshots/workflow-action-strip-moved.png", fullPage: true });
   });
 
-  test("the header's refresh affordance reloads the canvas without discarding it", async ({ page }) => {
-    const refreshBtn = page.getByTestId("workflow-actions-header").getByTestId("canvas-refresh");
-    await expect(refreshBtn).toBeVisible();
+  test("the canvas header stays fully on-screen even when the app is narrower than the default pane widths", async ({
+    page,
+  }) => {
+    // Rail (220) + strip (32) + terminal floor (360) + canvas (420) = 1032px
+    // of default/preferred widths — narrower than that used to overflow
+    // .app's right edge and get silently clipped by its old overflow:hidden.
+    await page.setViewportSize({ width: 900, height: 640 });
+    await page.waitForTimeout(50);
 
+    const header = page.getByTestId("workflow-actions-header");
+    const reVisualizeBtn = header.getByTestId("canvas-revisualize");
+    await expect(reVisualizeBtn).toBeVisible();
+
+    const btnBox = await reVisualizeBtn.boundingBox();
+    expect(btnBox).not.toBeNull();
+    expect((btnBox?.x ?? 0) + (btnBox?.width ?? 0)).toBeLessThanOrEqual(900);
+
+    await page.screenshot({ path: "web/e2e/screenshots/narrow-viewport-header.png", fullPage: true });
+  });
+
+  test("the header's action is re-visualize, not a no-op iframe reload", async ({ page }) => {
+    const reVisualizeBtn = page.getByTestId("workflow-actions-header").getByTestId("canvas-revisualize");
+    await expect(reVisualizeBtn).toBeEnabled();
+    await expect(reVisualizeBtn).toHaveAttribute("data-tooltip", "Re-visualize");
+
+    await reVisualizeBtn.click();
+
+    // Clicking it fires the same one-click Visualize macro the strip and the
+    // empty-state CTA use — not a bare reload with no new content.
+    await page.waitForFunction(
+      () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
+    );
+    const lastRun = await page.evaluate(
+      () =>
+        (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
+          .__HARNESS_TEST__.lastMacroRun,
+    );
+    expect(lastRun?.id).toBe("visualize");
+
+    // The pane itself swaps in the new render once canvas.reload arrives —
+    // that part is unchanged, and still the only thing that flips the iframe in.
     await page.evaluate(() => {
       (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
         type: "canvas.reload",
@@ -412,9 +449,6 @@ test.describe("docked workflow action strip", () => {
       });
     });
     await expect(page.locator(".canvas-iframe")).toBeVisible();
-
-    await refreshBtn.click();
-    await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
   });
 });
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -22,7 +22,7 @@ import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
 import { useElementTopOffset } from "./lib/use-element-top-offset";
 import { resolveMacroUrl } from "./lib/macro-gating";
-import { usePaneWidths } from "./lib/use-pane-widths";
+import { CANVAS_MIN, RAIL_MIN, usePaneWidths } from "./lib/use-pane-widths";
 import { useHarnessState } from "./lib/use-harness-state";
 
 export const App = (): JSX.Element => {
@@ -101,7 +101,15 @@ export const App = (): JSX.Element => {
 
       <div
         className="app"
-        style={{ gridTemplateColumns: `${widths.rail}px 32px minmax(360px, 1fr) ${widths.canvas}px` }}
+        style={{
+          // minmax (not a bare px) on the rail/canvas tracks too — a laptop-
+          // width browser with generously dragged panes was overflowing off
+          // the right edge and getting silently clipped by .app's overflow;
+          // letting these shrink to their own floors under space pressure
+          // (with a horizontal scrollbar as the last resort — see .app in
+          // styles.css) keeps the canvas header from vanishing off-screen.
+          gridTemplateColumns: `minmax(${RAIL_MIN}px, ${widths.rail}px) 32px minmax(360px, 1fr) minmax(${CANVAS_MIN}px, ${widths.canvas}px)`,
+        }}
       >
         <WorkflowsRail
           workflows={state.workflows}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -56,25 +56,28 @@ export function CanvasPane({
     }
   }, [lastMessage, sessionId]);
 
-  // Manual affordance for the toolbar — no auto-refresh signal in mock mode,
-  // and even for real sessions it's a cheap way to re-check content without
-  // waiting on a canvas.reload event.
-  const handleRefresh = (): void => {
-    setReloadKey((key) => key + 1);
-    if (!sessionId || isMockMode()) return;
-    fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
-      .then((res) => setHasGeneratedContent(res.ok))
-      .catch(() => {});
-  };
-
   const visualizeMacro = findVisualizeMacro(macros);
   const visualizeDisabledReason = visualizeMacro
     ? macroDisabledReason(visualizeMacro, boundWorkflow, activeSessionId)
     : null;
 
+  // The header's action IS Visualize now — one click re-fires the same macro
+  // that generated what's already on screen; the pane itself swaps in the
+  // new render once the agent's canvas.reload event arrives above.
+  const handleReVisualize = (): void => {
+    if (!visualizeMacro) return;
+    onRunMacro(visualizeMacro);
+  };
+
   return (
     <aside className="canvas-pane">
-      {boundWorkflow && <WorkflowActionsHeader workflow={boundWorkflow} onRefresh={handleRefresh} />}
+      {boundWorkflow && (
+        <WorkflowActionsHeader
+          workflow={boundWorkflow}
+          onReVisualize={handleReVisualize}
+          reVisualizeDisabledReason={visualizeDisabledReason}
+        />
+      )}
 
       {!sessionId ? (
         <div className="canvas-empty">Start a session to see its canvas here.</div>

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -5,27 +5,34 @@ import { Icon } from "./Icon";
 
 interface WorkflowActionsHeaderProps {
   workflow: WorkflowInfo;
-  onRefresh: () => void;
+  onReVisualize: () => void;
+  reVisualizeDisabledReason: string | null;
 }
 
 /**
  * Slim identity strip above the canvas pane, shown whenever a workflow is
- * bound to the active session — name, deployed status, and a manual refresh
- * affordance. The action buttons themselves live in the docked workflow
- * action strip now (WorkflowActionStrip, next to the workspace rail), not
- * duplicated here.
+ * bound to the active session — name, deployed status, and a re-visualize
+ * affordance. Since Visualize itself moved to the docked action strip, this
+ * button IS that action for the pane you're already looking at: one click
+ * re-fires the same one-click macro; the pane swaps in the new render once
+ * the agent's canvas.reload event arrives (see CanvasPane).
  */
-export function WorkflowActionsHeader({ workflow, onRefresh }: WorkflowActionsHeaderProps): JSX.Element {
+export function WorkflowActionsHeader({
+  workflow,
+  onReVisualize,
+  reVisualizeDisabledReason,
+}: WorkflowActionsHeaderProps): JSX.Element {
   return (
     <div className="workflow-actions-header" data-testid="workflow-actions-header">
       <span className="workflow-actions-name">{workflow.name}</span>
       {workflow.definitionId != null && <span className="workflow-dot" title="Deployed" />}
       <button
         className="macro-icon-btn canvas-refresh-btn"
-        aria-label="Refresh canvas"
-        data-testid="canvas-refresh"
-        data-tooltip="Refresh canvas"
-        onClick={onRefresh}
+        aria-label="Re-visualize"
+        data-testid="canvas-revisualize"
+        data-tooltip={reVisualizeDisabledReason ?? "Re-visualize"}
+        disabled={Boolean(reVisualizeDisabledReason)}
+        onClick={onReVisualize}
       >
         <Icon name="RefreshCw" size={14} />
       </button>

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -213,10 +213,11 @@ input {
 .app {
   position: relative;
   display: grid;
-  grid-template-columns: 220px 32px minmax(360px, 1fr) 420px;
+  grid-template-columns: minmax(180px, 220px) 32px minmax(360px, 1fr) minmax(280px, 420px);
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 /* Resize handles --------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Two bug reports from live testing (a third item — strip redesign exploration — is being handled separately as mockups + a recommendation, not shipped here):

1. **Refresh = re-visualize.** The canvas header's icon button fired a plain iframe reload with no new content — visibly a no-op, since Visualize (the only thing that actually produces new content) moved to the docked action strip. The button now fires the same one-click Visualize macro the strip and the empty-state CTA use, gated the same way (`macroDisabledReason`), with an updated "Re-visualize" tooltip. The pane still only swaps in the new render once the agent's `canvas.reload` event arrives — that part was already correct and is unchanged.

2. **Canvas header clipping at narrow widths.** At a browser width narrower than the sum of the app's pane widths (rail + strip + terminal floor + canvas = 1032px by default), the canvas header — including the re-visualize button — was getting silently clipped off the right edge. Root cause: the rail and canvas grid tracks were bare px values that can't shrink under space pressure, and `.app`'s `overflow: hidden` clipped whatever didn't fit rather than degrading visibly. Switched both tracks to `minmax(floor, requested)` so they yield to their own min-widths first, and changed `.app` to `overflow-x: auto` so a horizontal scrollbar is the true last resort instead of invisible clipping.

## Test plan
- [x] `tsc -p web/tsconfig.json --noEmit` — clean
- [x] `vite build --config web/vite.config.ts` — clean
- [x] `vitest run` — 329 passed
- [x] `playwright test --config web/e2e/playwright.config.ts` — 38 passed, including an updated spec for the re-visualize behavior (asserts the macro actually fires, not just that the iframe key bumps) and a new spec reproducing the narrow-viewport clip and confirming the header stays fully on-screen