### PR TITLE
fix(harness): reorder e2e:live to simulate SessionStart before input

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -13,9 +13,11 @@
  *   1. POST /api/sessions launches with real, session-scoped generated
  *      --settings / --mcp-config / --append-system-prompt, and the pty env
  *      carries SAPIOM_HARNESS_INGEST_URL/_TOKEN/_SESSION_ID.
- *   2. POST /api/sessions/:id/input is accepted by a running session.
- *   3. A hook POST to /ingest lands in events.ndjson and reaches the mock
- *      collector as a batch.
+ *   2. A hook POST to /ingest lands in events.ndjson and reaches the mock
+ *      collector as a batch, and flips the session's `ready` flag —
+ *      "running" alone only means the pty exists, not that its TUI is
+ *      actually interactive (see SessionNotReadyError).
+ *   3. POST /api/sessions/:id/input is accepted by a ready session.
  *   4. A tool.call event's localhost:<port> reference produces a
  *      port.detected frame on /ws/events.
  *   5. Writing to the session's canvas dir produces a canvas.reload frame,
@@ -297,15 +299,14 @@ async function testCoreFlow(): Promise<void> {
     });
     console.log("session reported running");
 
-    // --- 4. write to the pty via /api/sessions/:id/input ---
-    const inputRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/input`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ text: "echo hi", submit: true }),
-    });
-    assert(inputRes.status === 200, "POST /api/sessions/:id/input returns 200");
-
-    // --- 5. simulate SessionStart + a PostToolUse (tool.call with a localhost port) hook POST to /ingest ---
+    // --- 4. simulate SessionStart + a PostToolUse (tool.call with a localhost port) hook POST to /ingest ---
+    // Fired here, before any input injection: "running" only means the pty
+    // exists — SessionManager.submitInput() (used by /input and macros) now
+    // gates on the session's `ready` flag, which only flips true once a real
+    // SessionStart(-equivalent) event lands, exactly like a real fake-claude
+    // wouldn't be interactive before its own hooks fire. Simulating that
+    // event before injecting input mirrors real production ordering, not
+    // just satisfying the script.
     const ingestHeaders = { "Content-Type": "application/json", Authorization: `Bearer ${bootToken}` };
     const agentSessionId = "e2e-agent-session-1";
 
@@ -335,6 +336,25 @@ async function testCoreFlow(): Promise<void> {
       }),
     });
     assert(toolCallRes.status === 200, "POST /ingest (PostToolUse) returns 200");
+
+    // --- 4b. wait for the session to actually flip ready — /ingest responds
+    // 200 immediately and processes the hook payload after responding (so a
+    // dead/slow harness server never blocks the agent's own hook pipeline),
+    // so `ready` isn't guaranteed true the instant the POST above resolves. ---
+    await waitFor(async () => {
+      const res = await fetch(`${baseUrl}/api/sessions`, { headers });
+      const sessions = (await res.json()) as Array<{ id: string; ready: boolean }>;
+      return sessions.find((s) => s.id === sessionId)?.ready === true ? true : undefined;
+    });
+    console.log("session reported ready");
+
+    // --- 5. write to the pty via /api/sessions/:id/input ---
+    const inputRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/input`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ text: "echo hi", submit: true }),
+    });
+    assert(inputRes.status === 200, "POST /api/sessions/:id/input returns 200");
 
     // --- 6. assert both events landed in events.ndjson ---
     const eventLines = await waitFor(async () => {


### PR DESCRIPTION
## Summary

Fast follow-up: `pnpm e2e:live` broke on merged `feat/harness` HEAD after #219 (session readiness gating) merged. `testCoreFlow` POSTed to `/api/sessions/:id/input` before ever simulating the `SessionStart` hook — an ordering that predates #219 and no longer reflects reality. `SessionManager.submitInput()` now waits for a session's `ready` flag before writing, and this session never received one until several steps later in the script, so the 8s grace period always expired and the request 409'd instead of the expected 200.

## Fix

Moved the `SessionStart` (+ `PostToolUse`) `/ingest` simulation to fire before the `/input` call, and added an explicit wait for the session to report `ready: true` before injecting. `/ingest` responds 200 immediately and processes the hook payload afterward (so a slow harness server never blocks the agent's own hook pipeline) — so the POST resolving isn't itself proof the session flipped ready yet; the script needs to actually poll for it, not just fire-and-assume. This is also the correct real-world event order now, not a script workaround: a real session's first hook genuinely fires before any macro/input injection would make sense.

## Test plan

- [x] `pnpm --filter @sapiom/harness typecheck` — clean
- [x] `pnpm --filter @sapiom/harness lint` — clean
- [x] `pnpm --filter @sapiom/harness test -- --run` — 332/332 passing
- [x] `pnpm --filter @sapiom/harness build` — clean
- [x] `pnpm e2e:live` on merged `feat/harness` HEAD (post-#219, post-#221) — full gauntlet green, all 3 phases

Co-Authored-By: Claude <noreply@anthropic.com>