### PR TITLE
rename to agentName

### DIFF
--- a/.changeset/ctx-agent-name.md
+++ b/.changeset/ctx-agent-name.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/agent": minor
+"@sapiom/agent-core": minor
+---
+
+Rename the execution-context field `ctx.workflowName` → `ctx.agentName`.
+
+**Breaking:** a step that reads `ctx.workflowName` must now read `ctx.agentName`. The value is unchanged — the agent's name (slug).

--- a/packages/agent-core/src/local/dispatcher.ts
+++ b/packages/agent-core/src/local/dispatcher.ts
@@ -118,7 +118,7 @@ export class LocalStubDispatcher implements StepDispatcher {
 
     const ctx = {
       executionId: request.executionId,
-      workflowName: request.workflowName,
+      agentName: request.workflowName,
       organizationId: request.organizationId,
       tenantId: request.tenantId,
       input: request.workflowInput,

--- a/packages/agent/src/context.ts
+++ b/packages/agent/src/context.ts
@@ -56,9 +56,10 @@ export type FinishedStepStatus = 'dispatched' | 'succeeded' | 'failed';
  * needs it, put it in `shared`.
  */
 export interface AgentExecutionContext<TShared extends Record<string, unknown> = Record<string, unknown>> {
-  /** Stable id; the workflow_executions row primary key. */
+  /** Stable id for this execution. */
   readonly executionId: string;
-  readonly workflowName: string;
+  /** The name (slug) of the agent this execution belongs to. */
+  readonly agentName: string;
 
   /**
    * Tenant scope, stamped on the execution at creation and immutable for


### PR DESCRIPTION
This pull request introduces a breaking change by renaming the execution context field from `workflowName` to `agentName` throughout the codebase. This change clarifies that the field refers to the agent's name (slug), not a workflow, and requires any code referencing the old field name to be updated accordingly.

**Breaking API Change:**

* Renamed the execution context field `workflowName` to `agentName` in both `AgentExecutionContext` (in `packages/agent/src/context.ts`) and in the local dispatcher context construction (in `packages/agent-core/src/local/dispatcher.ts`). Any step or code referencing `ctx.workflowName` must now use `ctx.agentName`. The value remains the agent's name (slug). [[1]](diffhunk://#diff-4ae1bb61c541dc652e3fb70102fed5d35afd8605e0b01113990b43d29dbf592eL59-R62) [[2]](diffhunk://#diff-55d477e62c80f34f2f986fd1b48ada8c48693e9b7f92ec4bb76e85c58f5d8a4eL121-R121)

**Documentation and Release Notes:**

* Added a changeset (`.changeset/ctx-agent-name.md`) documenting the breaking change and its impact.