### PR TITLE
feat(harness): session tabs with per-tab busy indicator

### DIFF
--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -409,6 +409,59 @@ describe("SessionManager", () => {
     expect(received).toEqual(["hello world", "!"]);
   });
 
+  describe("onActivity", () => {
+    it("broadcasts once immediately, then throttles further data within the window", async () => {
+      vi.useFakeTimers();
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const activity: string[] = [];
+      manager.onActivity((id) => activity.push(id));
+
+      spawns[0]?.emitData("hello");
+      expect(activity).toEqual([session.id]);
+
+      // Still within the 2s throttle window — no second broadcast yet.
+      spawns[0]?.emitData("more");
+      await vi.advanceTimersByTimeAsync(1_000);
+      spawns[0]?.emitData("even more");
+      expect(activity).toEqual([session.id]);
+
+      // Past the window — the next chunk broadcasts again.
+      await vi.advanceTimersByTimeAsync(1_100);
+      spawns[0]?.emitData("after the window");
+      expect(activity).toEqual([session.id, session.id]);
+
+      vi.useRealTimers();
+    });
+
+    it("broadcasts independently per session", async () => {
+      const { manager, spawns } = makeManager();
+      const a = await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
+      const b = await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
+
+      const activity: string[] = [];
+      manager.onActivity((id) => activity.push(id));
+
+      spawns[0]?.emitData("from a");
+      spawns[1]?.emitData("from b");
+
+      expect(activity).toEqual([a.id, b.id]);
+    });
+
+    it("stops notifying an unsubscribed listener", async () => {
+      const { manager, spawns } = makeManager();
+      await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const activity: string[] = [];
+      const unsubscribe = manager.onActivity((id) => activity.push(id));
+      unsubscribe();
+
+      spawns[0]?.emitData("hello");
+      expect(activity).toEqual([]);
+    });
+  });
+
   it("marks a session exited when its pty exits, and notifies status listeners", async () => {
     const { manager, spawns } = makeManager();
     const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -117,6 +117,11 @@ const BLOCKING_PROMPT_SCAN_BYTES = 4_096;
 const READY_GRACE_MS = 8_000;
 /** Poll interval while waiting out READY_GRACE_MS. */
 const READY_POLL_MS = 150;
+/** See `recordActivity()`: minimum gap between two `onActivity` broadcasts
+ *  for the same session — pty.onData fires per chunk (often many times a
+ *  second for a busy TUI), but the SPA's busy indicator only needs "this
+ *  session produced output recently", not every individual chunk. */
+const ACTIVITY_BROADCAST_THROTTLE_MS = 2_000;
 
 /**
  * Thrown by `submitInput()` when a session's pty is alive but never became
@@ -141,6 +146,8 @@ function sleep(ms: number): Promise<void> {
 
 export type SessionStatusListener = (session: HarnessSession) => void;
 export type SessionDataListener = (chunk: string) => void;
+/** See `onActivity()`. */
+export type SessionActivityListener = (harnessSessionId: string) => void;
 
 /**
  * Builds the harness-specific part of LaunchOpts (generated system-prompt /
@@ -234,6 +241,9 @@ export class SessionManager {
   private readonly sessions = new Map<string, HarnessSession>();
   private readonly ptys = new Map<string, PtyHandle>();
   private readonly statusEmitter = new EventEmitter();
+  private readonly activityEmitter = new EventEmitter();
+  /** Epoch ms of the last `onActivity` broadcast per session — see `recordActivity()`. */
+  private readonly lastActivityBroadcast = new Map<string, number>();
   private writeQueue: Promise<void> = Promise.resolve();
   private writeSeq = 0;
   private initialized = false;
@@ -253,6 +263,7 @@ export class SessionManager {
     this.ensureCanvasTemplate = options.ensureCanvasTemplate ?? (async () => {});
     // Many WS clients (terminal + events) can subscribe over a long-running process.
     this.statusEmitter.setMaxListeners(0);
+    this.activityEmitter.setMaxListeners(0);
   }
 
   /**
@@ -528,6 +539,34 @@ export class SessionManager {
     };
   }
 
+  /**
+   * Subscribe to a session producing terminal output — throttled (see
+   * `ACTIVITY_BROADCAST_THROTTLE_MS`), not one event per pty.onData chunk.
+   * Fires for every session regardless of whether anything has its
+   * /ws/terminal socket open, unlike `attach()`.
+   */
+  onActivity(listener: SessionActivityListener): () => void {
+    this.activityEmitter.on("activity", listener);
+    return () => {
+      this.activityEmitter.off("activity", listener);
+    };
+  }
+
+  /**
+   * Leading-edge throttle: broadcasts immediately on the first byte after a
+   * quiet period, then drops everything else for this session until
+   * `ACTIVITY_BROADCAST_THROTTLE_MS` has elapsed — a busy TUI's onData fires
+   * far more often than that, and callers (the SPA's per-tab pulse) only
+   * care that the session is active right now, not each individual chunk.
+   */
+  private recordActivity(id: string): void {
+    const now = Date.now();
+    const last = this.lastActivityBroadcast.get(id) ?? 0;
+    if (now - last < ACTIVITY_BROADCAST_THROTTLE_MS) return;
+    this.lastActivityBroadcast.set(id, now);
+    this.activityEmitter.emit("activity", id);
+  }
+
   setAgentSessionId(id: string, agentSessionId: string): void {
     const session = this.sessions.get(id);
     if (!session || session.agentSessionId === agentSessionId) return;
@@ -675,6 +714,7 @@ export class SessionManager {
     pty.onData((chunk) => {
       handle.buffer = (handle.buffer + chunk).slice(-SCROLLBACK_BYTES);
       handle.emitter.emit("data", chunk);
+      this.recordActivity(session.id);
     });
 
     pty.onExit(({ exitCode }) => this.markExited(session.id, handle, exitCode));
@@ -692,6 +732,7 @@ export class SessionManager {
   private markExited(id: string, handle: PtyHandle, exitCode: number | null): void {
     if (this.ptys.get(id) !== handle) return;
     this.ptys.delete(id);
+    this.lastActivityBroadcast.delete(id);
     const session = this.sessions.get(id);
     if (!session) return;
     session.status = "exited";

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -256,6 +256,13 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     }
   });
 
+  // Background sessions have no /ws/terminal socket open to stream bytes over
+  // (only the active tab does) — this is the lightweight substitute that lets
+  // every session's tab show a busy pulse regardless of which one is active.
+  sessionManager.onActivity((harnessSessionId) => {
+    bus.publish({ type: "session.activity", harnessSessionId, at: new Date().toISOString() });
+  });
+
   // Nothing else triggers a scan (the only other entry point is the SPA's
   // manual "+ Connect"), so the rail would otherwise stay empty until a user
   // does that by hand. Scan the CLI's launch directory once at boot, and

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -196,7 +196,15 @@ export type BusMessage =
   | { type: "session.status"; session: HarnessSession }
   | { type: "canvas.reload"; harnessSessionId: string }
   | { type: "port.detected"; harnessSessionId: string; port: number; url: string }
-  | { type: "workflows.changed" };
+  | { type: "workflows.changed" }
+  /**
+   * Best-effort "this session's pty just produced output" signal, throttled
+   * server-side to at most once per session per ~2s (see SessionManager's
+   * pty.onData handler) — a lightweight substitute for byte-level streaming
+   * on /ws/events, which only the session with an open /ws/terminal socket
+   * receives. Drives the SPA's per-tab busy pulse for background sessions.
+   */
+  | { type: "session.activity"; harnessSessionId: string; at: string };
 
 // ---------------------------------------------------------------------------
 // Analytics events

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -2,9 +2,11 @@
  * Mock-mode UI smoke test — runs against `vite dev` with VITE_MOCK=1 (see
  * playwright.config.ts), no harness server required. Fixtures live in
  * ../src/lib/mock-data.ts: 3 workflows (one deployed), a running "boot"
- * session (the server auto-creates one at launch) plus 2 exited sessions
- * kept around as resumable history, 5 macros, and a small fake filesystem
- * for the new-session directory picker.
+ * session (the server auto-creates one at launch), a second running
+ * background session ("scratch", not the active tab on load — demonstrates
+ * the tab strip and busy pulse), and 2 exited sessions kept around as
+ * resumable history, 5 macros, and a small fake filesystem for the
+ * new-session directory picker.
  */
 import { expect, test } from "@playwright/test";
 
@@ -83,8 +85,59 @@ test("auto-selects the running boot session on initial load", async ({ page }) =
   // The server auto-creates a session in launchDir at boot — the app should
   // never open to an empty terminal pane.
   await expect(page.locator(".terminal-empty")).toHaveCount(0);
-  await expect(page.getByTestId("session-dropdown-trigger")).not.toContainText("No session");
-  await expect(page.locator(".session-dot[data-status='running']")).toBeVisible();
+  const bootTab = page.getByTestId("session-tab-sess-boot");
+  await expect(bootTab).toHaveClass(/is-active/);
+  await expect(bootTab.locator(".session-dot")).toHaveAttribute("data-status", "running");
+});
+
+test("session tabs: one per non-exited session, switching is instant, and the '+' opens the new-session modal", async ({
+  page,
+}) => {
+  const tabs = page.getByTestId("session-tabs").getByRole("tab");
+  // Fixture has 2 non-exited sessions ("boot" and "scratch") — the 2 exited
+  // ones live in the history menu, not the strip.
+  await expect(tabs).toHaveCount(2);
+
+  const bootTab = page.getByTestId("session-tab-sess-boot");
+  const bgTab = page.getByTestId("session-tab-sess-bg");
+  await expect(bootTab).toHaveClass(/is-active/);
+  await expect(bgTab).not.toHaveClass(/is-active/);
+
+  await bgTab.click();
+  await expect(bgTab).toHaveClass(/is-active/);
+  await expect(bootTab).not.toHaveClass(/is-active/);
+
+  await page.screenshot({ path: "web/e2e/screenshots/session-tabs-idle.png" });
+
+  await page.getByTestId("new-session-btn").click();
+  await expect(page.getByText("New session")).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+});
+
+test("session tabs: Cmd/Ctrl+1..9 switches directly to that tab", async ({ page }) => {
+  const bootTab = page.getByTestId("session-tab-sess-boot");
+  const bgTab = page.getByTestId("session-tab-sess-bg");
+  await expect(bootTab).toHaveClass(/is-active/);
+
+  // Tabs are ordered oldest-first: boot is 1, the background "scratch"
+  // session is 2 — Cmd+2 jumps straight to it, no dropdown/click needed.
+  await page.keyboard.press("Meta+2");
+  await expect(bgTab).toHaveClass(/is-active/);
+  await expect(bootTab).not.toHaveClass(/is-active/);
+
+  await page.keyboard.press("Meta+1");
+  await expect(bootTab).toHaveClass(/is-active/);
+});
+
+test("session tabs: a busy tab shows a pulse that clears once output goes quiet", async ({ page }) => {
+  // mock-data's MOCK_ACTIVITY_SESSION_ID ("sess-bg") gets one simulated
+  // session.activity ping shortly after load — see lib/events.ts.
+  const busyDot = page.getByTestId("session-tab-busy-sess-bg");
+  await expect(busyDot).toBeVisible({ timeout: 5_000 });
+  await page.screenshot({ path: "web/e2e/screenshots/session-tabs-busy.png" });
+
+  // The busy window (3s) clears once no further activity arrives.
+  await expect(busyDot).toHaveCount(0, { timeout: 6_000 });
 });
 
 test("workflows rail lists the fixtures and selecting one drives macro gating", async ({ page }) => {
@@ -147,7 +200,7 @@ test.describe("workspace binding", () => {
     await expect(page.getByTestId("session-workflow-chip")).toContainText("leasing");
 
     // Switch to a session that's never had anything bound.
-    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-trigger").click();
     await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
     await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
   });
@@ -190,17 +243,19 @@ test("new-session modal: directory picker navigates and validates", async ({ pag
   await expect(page.getByText("New session")).toBeHidden();
 });
 
-test("resuming a history entry switches the active session", async ({ page }) => {
-  await page.getByTestId("session-dropdown-trigger").click();
+test("resuming a history entry switches the active session, and it rejoins the tab strip", async ({ page }) => {
+  await page.getByTestId("history-trigger").click();
   await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
-  await expect(page.getByTestId("session-dropdown-trigger")).toContainText("Build the leasing pipeline");
+  const tab = page.getByTestId("session-tab-sess-leasing");
+  await expect(tab).toHaveClass(/is-active/);
+  await expect(tab).toContainText("Build the leasing pipeline");
 });
 
 test.describe("dead sessions never trap the user", () => {
-  test("an exited session is reachable from the dropdown and shows a dead-session pane, not a stuck terminal", async ({
+  test("an exited session is reachable from the history menu and shows a dead-session pane, not a stuck terminal", async ({
     page,
   }) => {
-    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-trigger").click();
     await page.getByTestId("exited-session-sess-leasing").click();
 
     const pane = page.getByTestId("dead-session-pane");
@@ -212,25 +267,28 @@ test.describe("dead sessions never trap the user", () => {
     await page.screenshot({ path: "web/e2e/screenshots/dead-session-pane.png", fullPage: true });
   });
 
-  test("Resume on a dead session starts it running again", async ({ page }) => {
-    await page.getByTestId("session-dropdown-trigger").click();
+  test("Resume on a dead session starts it running again and it becomes a tab", async ({ page }) => {
+    await page.getByTestId("history-trigger").click();
     await page.getByTestId("exited-session-sess-leasing").click();
     await page.getByTestId("dead-session-resume").click();
 
     await expect(page.getByTestId("dead-session-pane")).toHaveCount(0);
-    await expect(page.getByTestId("session-dropdown-trigger")).toContainText("Build the leasing pipeline");
+    const tab = page.getByTestId("session-tab-sess-leasing");
+    await expect(tab).toBeVisible();
+    await expect(tab).toContainText("Build the leasing pipeline");
   });
 
   test("Close on a dead session removes it and falls back to another running session", async ({ page }) => {
     // The boot session is running, so falling back to it is always possible here.
-    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-trigger").click();
     await page.getByTestId("exited-session-sess-leasing").click();
     await page.getByTestId("dead-session-close").click();
 
     await expect(page.getByTestId("dead-session-pane")).toHaveCount(0);
-    await expect(page.getByTestId("session-dropdown-trigger")).not.toContainText("No session");
+    await expect(page.locator(".terminal-empty")).toHaveCount(0);
+    await expect(page.getByTestId("session-tab-sess-boot")).toHaveClass(/is-active/);
 
-    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-trigger").click();
     await expect(page.getByTestId("exited-session-sess-leasing")).toHaveCount(0);
   });
 });
@@ -263,19 +321,20 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
     await page.getByTestId("palette-trigger").click();
     await page.getByTestId("command-palette-input").fill("onboarding-flow");
     await page.keyboard.press("Enter");
-    await expect(page.getByTestId("session-dropdown-trigger")).toContainText("onboarding-flow");
+    await expect(page.locator(".session-tab.is-active")).toContainText("onboarding-flow");
   });
 
   test("Enter on a session hit switches to it instead of starting a new one", async ({ page }) => {
     // Resume a different session first so switching back is observable.
-    await page.getByTestId("session-dropdown-trigger").click();
+    await page.getByTestId("history-trigger").click();
     await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
-    await expect(page.getByTestId("session-dropdown-trigger")).toContainText("Build the leasing pipeline");
+    const leasingTab = page.getByTestId("session-tab-sess-leasing");
+    await expect(leasingTab).toHaveClass(/is-active/);
 
     await page.getByTestId("palette-trigger").click();
     await page.getByTestId("command-palette-input").fill("acme-app");
     await page.getByTestId("command-palette-item-0").click();
-    await expect(page.getByTestId("session-dropdown-trigger")).not.toContainText("Build the leasing pipeline");
+    await expect(leasingTab).not.toHaveClass(/is-active/);
   });
 
   test("a path-shaped query uses live GET /api/fs/list completion instead of fuzzy matching", async ({ page }) => {
@@ -287,7 +346,7 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
     await expect(dirItem).toContainText("acme-app");
 
     await dirItem.click();
-    await expect(page.getByTestId("session-dropdown-trigger")).toContainText("acme-app");
+    await expect(page.locator(".session-tab.is-active")).toContainText("acme-app");
   });
 });
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -2,7 +2,7 @@
  * Harness SPA shell (workstream W2).
  *
  * Layout: workflows rail (left) | docked action strip (anchored to the
- * selected workflow's row) | session dropdown + terminal (center) |
+ * selected workflow's row) | session tab strip + terminal (center) |
  * canvas/preview pane (right). The strip carries the selected workflow's
  * full action set; the canvas gets a slim identity header for whichever
  * workflow is bound to the active session.
@@ -36,17 +36,32 @@ export const App = (): JSX.Element => {
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
+  // Cmd/Ctrl+1..9 switches directly to that tab — same ordering SessionBar
+  // renders its tabs in (oldest live session first), so "3" always means the
+  // third tab from the left, not an arbitrary session.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       const key = e.key.toLowerCase();
       if ((e.metaKey || e.ctrlKey) && (key === "k" || key === "p")) {
         e.preventDefault();
         setPaletteOpen(true);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && /^[1-9]$/.test(e.key)) {
+        const tabs = harness.state?.sessions
+          .filter((session) => session.status !== "exited")
+          .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+        const target = tabs?.[Number(e.key) - 1];
+        if (target) {
+          e.preventDefault();
+          harness.setActiveSessionId(target.id);
+        }
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [harness.state?.sessions]);
 
   if (harness.loading) {
     return <div className="app-status">Loading Sapiom Harness…</div>;
@@ -156,7 +171,7 @@ export const App = (): JSX.Element => {
             onResumeHistory={(summary) => void harness.resumeFromHistory(summary)}
             history={harness.history}
             historyLoading={harness.historyLoading}
-            onOpenDropdown={(cwd) => void harness.loadHistory(cwd)}
+            onOpenHistory={(cwd) => void harness.loadHistory(cwd)}
             recentDirs={harness.settings?.recentDirs ?? []}
             launchDir={state.launchDir ?? null}
             listDir={harness.listDir}
@@ -168,6 +183,7 @@ export const App = (): JSX.Element => {
             onToggleTelemetry={async (next) => {
               await harness.updateSettings({ telemetryOptIn: next });
             }}
+            busySessionIds={harness.busySessionIds}
           />
           <div className="terminal-slot">
             {activeSession?.status === "exited" ? (

--- a/packages/harness/web/src/components/Icon.tsx
+++ b/packages/harness/web/src/components/Icon.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLink,
   Folder,
   HelpCircle,
+  History,
   type LucideIcon,
   Moon,
   Play,
@@ -15,6 +16,7 @@ import {
   Settings,
   Sparkles,
   Sun,
+  X,
   Zap,
 } from "lucide-react";
 import type { JSX } from "react";
@@ -30,6 +32,7 @@ const ICONS: Record<string, LucideIcon> = {
   CornerLeftUp,
   ExternalLink,
   Folder,
+  History,
   Moon,
   Play,
   Plus,
@@ -39,6 +42,7 @@ const ICONS: Record<string, LucideIcon> = {
   Settings,
   Sparkles,
   Sun,
+  X,
   Zap,
 };
 

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { JSX } from "react";
 import type { HarnessKind, HarnessSession, SessionSummary } from "@shared/types";
 
@@ -14,7 +14,7 @@ interface SessionBarProps {
   onResumeHistory: (summary: SessionSummary) => void;
   history: SessionSummary[];
   historyLoading: boolean;
-  onOpenDropdown: (cwd: string) => void;
+  onOpenHistory: (cwd: string) => void;
   recentDirs: string[];
   launchDir: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
@@ -25,6 +25,9 @@ interface SessionBarProps {
   organizationName: string | null;
   telemetryOptIn: boolean;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  /** Session ids with terminal output in roughly the last ~3s — renders a
+   *  busy pulse on that session's tab regardless of whether it's active. */
+  busySessionIds: Set<string>;
 }
 
 export function SessionBar({
@@ -34,7 +37,7 @@ export function SessionBar({
   onResumeHistory,
   history,
   historyLoading,
-  onOpenDropdown,
+  onOpenHistory,
   recentDirs,
   launchDir,
   listDir,
@@ -44,51 +47,107 @@ export function SessionBar({
   organizationName,
   telemetryOptIn,
   onToggleTelemetry,
+  busySessionIds,
 }: SessionBarProps): JSX.Element {
-  const [open, setOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const activeSession = sessions.find((session) => session.id === activeSessionId) ?? null;
-  const runningSessions = sessions.filter((session) => session.status !== "exited");
-  // Reachable here even though they're not "running" — so a session that died stays
-  // selectable (to inspect/resume/close it) instead of only being escapable.
+  // One tab per live session, oldest-first — a stable order Cmd+1..9 relies
+  // on (App.tsx computes the same ordering for the keyboard shortcut) and
+  // that keeps a tab from jumping around the strip as sessions update.
+  const tabs = useMemo(
+    () =>
+      sessions.filter((session) => session.status !== "exited").sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    [sessions],
+  );
+  // Reachable from the history menu even though they're not "running" — so a
+  // session that died stays selectable (to inspect/resume/close it) instead
+  // of only being escapable. Kept out of the tab strip itself so it doesn't
+  // fill up with dead tabs.
   const exitedSessions = sessions.filter((session) => session.status === "exited");
 
-  const toggle = (): void => {
-    const next = !open;
-    setOpen(next);
+  const toggleHistory = (): void => {
+    const next = !historyOpen;
+    setHistoryOpen(next);
     if (next) {
+      const activeSession = sessions.find((session) => session.id === activeSessionId) ?? null;
       const cwd = activeSession?.cwd ?? recentDirs[0];
-      if (cwd) onOpenDropdown(cwd);
+      if (cwd) onOpenHistory(cwd);
     }
   };
 
   return (
     <div className="session-bar">
-      <div className="session-dropdown-wrap">
-        <button className="session-dropdown-trigger" data-testid="session-dropdown-trigger" onClick={toggle}>
-          <span className="session-dot" data-status={activeSession?.status ?? "none"} />
-          <span className="session-title">{activeSession ? activeSession.title : "No session"}</span>
-          {boundWorkflowName && (
-            <span className="session-workflow-chip" data-testid="session-workflow-chip">
-              ▸ working on {boundWorkflowName}
+      <div className="session-tabs" role="tablist" data-testid="session-tabs">
+        {tabs.map((session) => {
+          const isActive = session.id === activeSessionId;
+          return (
+            <button
+              key={session.id}
+              role="tab"
+              aria-selected={isActive}
+              className={"session-tab" + (isActive ? " is-active" : "")}
+              data-testid={`session-tab-${session.id}`}
+              onClick={() => onSelectSession(session.id)}
+            >
+              <span className="session-dot" data-status={session.status} />
+              <span className="session-tab-title">{session.title}</span>
+              {busySessionIds.has(session.id) && (
+                <span
+                  className="session-tab-busy"
+                  data-testid={`session-tab-busy-${session.id}`}
+                  aria-hidden="true"
+                />
+              )}
+              {isActive && boundWorkflowName && (
+                <span className="session-workflow-chip" data-testid="session-workflow-chip">
+                  ▸ working on {boundWorkflowName}
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        <button
+          className="session-tab-add"
+          data-testid="new-session-btn"
+          onClick={() => setModalOpen(true)}
+          aria-label="New session"
+          title="New session"
+        >
+          <Icon name="Plus" size={14} />
+        </button>
+      </div>
+
+      <div className="session-history-wrap">
+        <button
+          className="session-history-trigger"
+          data-testid="history-trigger"
+          onClick={toggleHistory}
+          aria-label="Session history"
+          title="Session history"
+        >
+          <Icon name="History" size={14} />
+          {exitedSessions.length > 0 && (
+            <span className="session-history-badge" data-testid="session-history-badge">
+              {exitedSessions.length}
             </span>
           )}
-          <Icon name="ChevronDown" size={14} />
         </button>
 
-        {open && (
-          <div className="session-dropdown-menu">
-            <div className="session-dropdown-section">Running</div>
-            {runningSessions.length === 0 && <div className="session-dropdown-empty">No running sessions</div>}
-            {runningSessions.map((session) => (
+        {historyOpen && (
+          <div className="session-dropdown-menu" data-testid="history-menu">
+            <div className="session-dropdown-section">Exited</div>
+            {exitedSessions.length === 0 && <div className="session-dropdown-empty">No exited sessions</div>}
+            {exitedSessions.map((session) => (
               <button
                 key={session.id}
+                data-testid={`exited-session-${session.id}`}
                 className={"session-dropdown-item" + (session.id === activeSessionId ? " is-selected" : "")}
                 onClick={() => {
                   onSelectSession(session.id);
-                  setOpen(false);
+                  setHistoryOpen(false);
                 }}
               >
                 <span className="session-dot" data-status={session.status} />
@@ -96,27 +155,6 @@ export function SessionBar({
                 <span className="session-item-cwd">{session.cwd}</span>
               </button>
             ))}
-
-            {exitedSessions.length > 0 && (
-              <>
-                <div className="session-dropdown-section">Exited</div>
-                {exitedSessions.map((session) => (
-                  <button
-                    key={session.id}
-                    data-testid={`exited-session-${session.id}`}
-                    className={"session-dropdown-item" + (session.id === activeSessionId ? " is-selected" : "")}
-                    onClick={() => {
-                      onSelectSession(session.id);
-                      setOpen(false);
-                    }}
-                  >
-                    <span className="session-dot" data-status={session.status} />
-                    <span className="session-item-title">{session.title}</span>
-                    <span className="session-item-cwd">{session.cwd}</span>
-                  </button>
-                ))}
-              </>
-            )}
 
             <div className="session-dropdown-section">History</div>
             {historyLoading && <div className="session-dropdown-empty">Loading…</div>}
@@ -131,7 +169,7 @@ export function SessionBar({
                   data-testid={`history-${summary.agentSessionId}`}
                   onClick={() => {
                     onResumeHistory(summary);
-                    setOpen(false);
+                    setHistoryOpen(false);
                   }}
                 >
                   <span className="session-item-title">{summary.title}</span>
@@ -143,10 +181,6 @@ export function SessionBar({
           </div>
         )}
       </div>
-
-      <button className="new-session-btn" data-testid="new-session-btn" onClick={() => setModalOpen(true)}>
-        <Icon name="Plus" size={14} /> new
-      </button>
 
       <div className="settings-wrap">
         <button

--- a/packages/harness/web/src/lib/events.ts
+++ b/packages/harness/web/src/lib/events.ts
@@ -6,12 +6,18 @@
 import type { BusMessage } from "@shared/types";
 
 import { getBootToken, isMockMode } from "./api";
+import { MOCK_ACTIVITY_SESSION_ID } from "./mock-data";
 
 export type BusListener = (message: BusMessage) => void;
 
 const RECONNECT_DELAY_MS = 2000;
+/** Delay before the one-shot simulated `session.activity` fixture fires —
+ *  see `subscribeEvents`'s mock branch. Long enough that the tab strip has
+ *  already rendered idle before the pulse appears. */
+const MOCK_ACTIVITY_DELAY_MS = 1200;
 
 const mockListeners = new Set<BusListener>();
+let mockActivitySimulated = false;
 
 /**
  * Test-only escape hatch, mock mode only: lets Playwright simulate a bus
@@ -33,6 +39,23 @@ if (isMockMode() && typeof window !== "undefined") {
 export function subscribeEvents(onMessage: BusListener): () => void {
   if (isMockMode()) {
     mockListeners.add(onMessage);
+    if (!mockActivitySimulated) {
+      mockActivitySimulated = true;
+      // Fixture nicety, not test infrastructure: shows the tab strip's busy
+      // pulse without a real pty, once, shortly after load. Playwright drives
+      // its own deterministic activity via `__HARNESS_TEST__.publish` (same
+      // pattern as canvas.reload/port.detected in the harness's own specs)
+      // rather than depending on this timer's exact fire time.
+      setTimeout(() => {
+        mockListeners.forEach((listener) =>
+          listener({
+            type: "session.activity",
+            harnessSessionId: MOCK_ACTIVITY_SESSION_ID,
+            at: new Date().toISOString(),
+          }),
+        );
+      }, MOCK_ACTIVITY_DELAY_MS);
+    }
     return () => mockListeners.delete(onMessage);
   }
 

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -54,7 +54,33 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     exitCode: 0,
     ready: false,
   },
+  {
+    id: "sess-bg",
+    agentSessionId: "1a2b3c4d-5e6f-4a71-8b2c-3d4e5f6a7b8c",
+    boundWorkflowPath: null,
+    harness: "claude-code",
+    // A second running session, not the active tab on load — demonstrates the
+    // tab strip (multiple live tabs) and the busy pulse (see
+    // MOCK_ACTIVITY_SESSION_ID in ./events), which only means anything on a
+    // tab you're not already looking at. cwd is deliberately "scratch" (no
+    // workflow lives there) so it doesn't move "onboarding-flow" out of the
+    // rail's "Other" group — see smoke.spec.ts's workspace-tree test.
+    cwd: "/Users/demo/scratch",
+    title: "scratch",
+    status: "running",
+    // Later than sess-boot's createdAt (minutesAgo(1)) — tabs sort
+    // oldest-first, so this deliberately keeps boot as tab 1, scratch as
+    // tab 2 (see smoke.spec.ts's Cmd+1/Cmd+2 test).
+    createdAt: minutesAgo(0),
+    lastActiveAt: minutesAgo(0),
+    ready: true,
+  },
 ];
+
+/** The mock session `subscribeEvents` periodically fires simulated
+ *  `session.activity` pings for — see ./events.ts. Exercises the tab strip's
+ *  busy pulse on a background (non-active) tab without a real pty. */
+export const MOCK_ACTIVITY_SESSION_ID = "sess-bg";
 
 /** Fake filesystem for the new-session directory picker (GET /api/fs/list). Keys are absolute paths. */
 export const MOCK_FS_TREE: Record<string, string[]> = {

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   AppState,
   BusMessage,
@@ -14,6 +14,14 @@ import { ApiError, boundWorkflowPathOf, createApi, getBootToken, type FsListResp
 import { subscribeEvents } from "./events";
 
 const api = createApi();
+
+/**
+ * How long a session's tab stays "busy" after its last `session.activity`
+ * ping — matches the "output in the last ~3s" busy-indicator spec. Longer
+ * than the server's own broadcast throttle (2s) so a steadily-typing session
+ * reads as continuously busy rather than flickering between pings.
+ */
+const BUSY_WINDOW_MS = 3_000;
 
 export interface HarnessStateHook {
   state: AppState | null;
@@ -46,6 +54,9 @@ export interface HarnessStateHook {
    *  instead, since its only caller today fires it without awaiting. */
   toast: string | null;
   dismissToast: () => void;
+  /** Session ids with terminal output in roughly the last `BUSY_WINDOW_MS` —
+   *  drives each session tab's busy pulse (see `session.activity` BusMessage). */
+  busySessionIds: Set<string>;
 }
 
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
@@ -60,6 +71,19 @@ export function useHarnessState(): HarnessStateHook {
   const [toast, setToast] = useState<string | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [lastMessage, setLastMessage] = useState<BusMessage | null>(null);
+  const [busySessionIds, setBusySessionIds] = useState<Set<string>>(new Set());
+  const busyTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Timers are keyed per-session and outlive individual renders — clear them
+  // all on unmount so a pending "clear busy" timeout never fires against a
+  // torn-down component.
+  useEffect(() => {
+    const timers = busyTimers.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -106,8 +130,42 @@ export function useHarnessState(): HarnessStateHook {
             : [...prev.sessions, message.session];
           return { ...prev, sessions };
         });
+        // An exited session can never produce more output — drop any pending
+        // busy state/timer for it rather than leaving a stale pulse on a tab
+        // that's about to move to the history menu.
+        if (message.session.status === "exited") {
+          const id = message.session.id;
+          const timer = busyTimers.current.get(id);
+          if (timer) {
+            clearTimeout(timer);
+            busyTimers.current.delete(id);
+          }
+          setBusySessionIds((prev) => {
+            if (!prev.has(id)) return prev;
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+          });
+        }
       } else if (message.type === "workflows.changed") {
         void refreshWorkflows();
+      } else if (message.type === "session.activity") {
+        const id = message.harnessSessionId;
+        setBusySessionIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+        const existingTimer = busyTimers.current.get(id);
+        if (existingTimer) clearTimeout(existingTimer);
+        busyTimers.current.set(
+          id,
+          setTimeout(() => {
+            busyTimers.current.delete(id);
+            setBusySessionIds((prev) => {
+              if (!prev.has(id)) return prev;
+              const next = new Set(prev);
+              next.delete(id);
+              return next;
+            });
+          }, BUSY_WINDOW_MS),
+        );
       }
     });
   }, [refreshWorkflows]);
@@ -238,5 +296,6 @@ export function useHarnessState(): HarnessStateHook {
     lastMessage,
     toast,
     dismissToast,
+    busySessionIds,
   };
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -640,36 +640,128 @@ input {
   position: relative;
 }
 
-.session-dropdown-wrap {
-  position: relative;
+.session-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   flex: 1;
   min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 
-.session-dropdown-trigger {
+.session-tab {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
-  width: 100%;
-  padding: 5px 8px;
+  flex: 0 0 auto;
+  max-width: 220px;
+  padding: 5px 10px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
+  color: var(--text-dim);
+}
+
+.session-tab:hover {
+  border-color: var(--accent);
   color: var(--text);
 }
 
-.session-dropdown-trigger:hover {
+.session-tab.is-active {
+  background: var(--bg-3);
   border-color: var(--accent);
+  color: var(--text);
 }
 
-.session-title {
-  flex: 1;
+.session-tab-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
   font-size: 12px;
+}
+
+/* Subtle pulse — a session with output in roughly the last 3s, whether or
+   not it's the tab you're currently looking at. */
+.session-tab-busy {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--accent);
+  animation: session-tab-busy-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes session-tab-busy-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+.session-tab-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+}
+
+.session-tab-add:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.session-history-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.session-history-trigger {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 30px;
+  height: 30px;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-2);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  position: relative;
+}
+
+.session-history-trigger:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.session-history-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
 }
 
 .session-workflow-chip {
@@ -709,8 +801,8 @@ input {
 .session-dropdown-menu {
   position: absolute;
   top: calc(100% + 4px);
-  left: 0;
   right: 0;
+  width: 320px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
@@ -763,24 +855,6 @@ input {
 .session-item-meta {
   font-size: 10.5px;
   color: var(--text-faint);
-}
-
-.new-session-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 5px 10px;
-  background: var(--accent-dim);
-  color: var(--text);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius);
-  font-size: 12px;
-  white-space: nowrap;
-}
-
-.new-session-btn:hover {
-  background: var(--accent-hover);
-  color: var(--accent-foreground);
 }
 
 .settings-wrap {


### PR DESCRIPTION
## Summary
- Replaces the single-terminal session dropdown with a tab strip (`packages/harness/web/src/components/SessionBar.tsx`): one tab per non-exited session, instant click-to-switch (Terminal.tsx already reconnects/replays scrollback per sessionId), Cmd/Ctrl+1..9 shortcuts (App.tsx), and a "+" tab to open the existing new-session modal.
- Exited sessions and the old resumable-history list (`GET /api/sessions/history`) move into a "History" overflow menu (clock icon, badge shows exited count) so the strip doesn't fill up with dead tabs.
- Adds a per-tab busy pulse: a session with output in the last ~3s shows a subtle pulse, including background sessions with no open `/ws/terminal` socket. Server-side, `SessionManager` now throttles a `session.activity` broadcast off the existing `pty.onData` path (at most once per session per ~2s) — the pre-approved `BusMessage` contract addition in `src/shared/types.ts`.
- Mock fixtures (`web/src/lib/mock-data.ts`, `web/src/lib/events.ts`) add a second running session ("scratch") and a one-shot simulated activity ping so mock mode demonstrates both a multi-tab strip and the busy pulse without a real pty.
- Updates all existing Playwright specs that referenced the old dropdown, and adds new coverage: tab rendering/switching, Cmd+1..9, busy pulse appear/clear, exited session → dead-session pane via the history menu.

## Test plan
- [x] `pnpm --filter @sapiom/harness typecheck` (server)
- [x] `npx tsc -p packages/harness/web/tsconfig.json --noEmit` (web)
- [x] `pnpm --filter @sapiom/harness test` — 355/355 passed (includes new `SessionManager.onActivity` throttling tests)
- [x] `pnpm --filter @sapiom/harness build`
- [x] `pnpm --filter @sapiom/harness test:ui` — 44/44 Playwright specs passed
- [x] Screenshots: `web/e2e/screenshots/session-tabs-idle.png`, `session-tabs-busy.png`, `dead-session-pane.png`

## Decisions
- Exited sessions were moved into the History overflow menu rather than rendered as ✕-able tabs in the strip — keeps the strip from filling with dead tabs; a dead session is still reachable (select from history → `DeadSessionPane` → Resume/Close).
- `shared/types.ts` was touched only for the pre-approved `session.activity` BusMessage variant, nothing else.
- No prior partial "tabs" branch existed on the remote to salvage from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)