### PR TITLE
style(harness): design fidelity pass + recent-dirs hygiene

### DIFF
--- a/packages/harness/src/cli/settings.test.ts
+++ b/packages/harness/src/cli/settings.test.ts
@@ -12,6 +12,13 @@ vi.mock("node:os", async (importOriginal) => {
 
 import { hasStoredSettings, loadSettings, saveSettings, recordRecentDir } from "./settings.js";
 
+/** A real, existing directory to use as a valid recent-dir candidate. */
+async function makeRealDir(name: string): Promise<string> {
+  const dir = path.join(tmpDir, name);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
 describe("settings persistence", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-settings-"));
@@ -30,25 +37,119 @@ describe("settings persistence", () => {
   });
 
   it("round-trips saved settings", async () => {
-    await saveSettings({ telemetryOptIn: true, recentDirs: ["/a"] });
+    const a = await makeRealDir("a");
+    await saveSettings({ telemetryOptIn: true, recentDirs: [a] });
     expect(await hasStoredSettings()).toBe(true);
-    expect(await loadSettings()).toEqual({ telemetryOptIn: true, recentDirs: ["/a"] });
+    expect(await loadSettings()).toEqual({ telemetryOptIn: true, recentDirs: [a] });
   });
 
-  it("recordRecentDir prepends and dedupes", async () => {
-    await recordRecentDir("/a");
-    await recordRecentDir("/b");
-    await recordRecentDir("/a");
-    const settings = await loadSettings();
-    expect(settings.recentDirs).toEqual(["/a", "/b"]);
+  describe("recordRecentDir", () => {
+    it("prepends and dedupes", async () => {
+      const a = await makeRealDir("a");
+      const b = await makeRealDir("b");
+      await recordRecentDir(a);
+      await recordRecentDir(b);
+      await recordRecentDir(a);
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([a, b]);
+    });
+
+    it("caps history at 8 entries", async () => {
+      const dirs: string[] = [];
+      for (let i = 0; i < 12; i++) {
+        dirs.push(await makeRealDir(`dir-${i}`));
+      }
+      for (const dir of dirs) {
+        await recordRecentDir(dir);
+      }
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toHaveLength(8);
+      expect(settings.recentDirs[0]).toBe(dirs[11]);
+    });
+
+    it("silently drops entries that aren't absolute paths", async () => {
+      const valid = await makeRealDir("valid");
+      await recordRecentDir(valid);
+      await recordRecentDir("this /Users/someone/project");
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([valid]);
+    });
+
+    it("silently drops entries that don't exist on disk", async () => {
+      const valid = await makeRealDir("valid");
+      await recordRecentDir(valid);
+      await recordRecentDir(path.join(tmpDir, "does-not-exist"));
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([valid]);
+    });
+
+    it("silently drops entries that resolve to a file, not a directory", async () => {
+      const valid = await makeRealDir("valid");
+      const filePath = path.join(tmpDir, "a-file.txt");
+      await fs.writeFile(filePath, "not a directory");
+      await recordRecentDir(valid);
+      await recordRecentDir(filePath);
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([valid]);
+    });
+
+    it("expands a leading ~ before validating", async () => {
+      const nested = await makeRealDir("nested");
+      await recordRecentDir(`~/${path.basename(nested)}`);
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([nested]);
+    });
+
+    it("normalizes trailing slashes and .. segments to the same entry", async () => {
+      const a = await makeRealDir("a");
+      await recordRecentDir(`${a}/`);
+      await recordRecentDir(`${a}/../${path.basename(a)}`);
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([a]);
+    });
+
+    it("dedupes case-sensitively", async () => {
+      // Two distinct real directories differing only by case — both are kept
+      // since the filesystem (here) treats them as different entries.
+      const lower = await makeRealDir("case-test");
+      const upper = await makeRealDir("CASE-TEST");
+      await recordRecentDir(lower);
+      await recordRecentDir(upper);
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([upper, lower]);
+    });
   });
 
-  it("recordRecentDir caps history at 10 entries", async () => {
-    for (let i = 0; i < 15; i++) {
-      await recordRecentDir(`/dir-${i}`);
-    }
-    const settings = await loadSettings();
-    expect(settings.recentDirs).toHaveLength(10);
-    expect(settings.recentDirs[0]).toBe("/dir-14");
+  describe("loadSettings self-healing", () => {
+    it("drops previously-recorded entries that no longer exist", async () => {
+      const survivor = await makeRealDir("survivor");
+      const doomed = await makeRealDir("doomed");
+      await saveSettings({ telemetryOptIn: false, recentDirs: [doomed, survivor] });
+      await fs.rm(doomed, { recursive: true, force: true });
+
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([survivor]);
+    });
+
+    it("drops junk that was written before validation existed", async () => {
+      const survivor = await makeRealDir("survivor");
+      const filePath = settingsFilePathFor(tmpDir);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          telemetryOptIn: false,
+          recentDirs: ["this /Users/someone/project", survivor, "relative/path"],
+        }),
+      );
+
+      const settings = await loadSettings();
+      expect(settings.recentDirs).toEqual([survivor]);
+    });
   });
 });
+
+/** Mirrors settingsFilePath()'s HARNESS_PATHS.settings location for direct-write test setup. */
+function settingsFilePathFor(home: string): string {
+  return path.join(home, ".sapiom", "harness", "settings.json");
+}

--- a/packages/harness/src/cli/settings.ts
+++ b/packages/harness/src/cli/settings.ts
@@ -8,10 +8,50 @@ const DEFAULT_SETTINGS: HarnessSettings = {
   recentDirs: [],
 };
 
-const MAX_RECENT_DIRS = 10;
+const MAX_RECENT_DIRS = 8;
 
 function settingsFilePath(): string {
   return expandHome(HARNESS_PATHS.settings);
+}
+
+/**
+ * Resolves a candidate recent-dir entry to an absolute, existing directory
+ * path, or null if it doesn't qualify. Rejects anything that isn't a real
+ * directory on disk right now — relative paths, stray free text (e.g. typed
+ * into the directory field by mistake), and directories that have since been
+ * deleted all fall out here rather than accumulating in the list.
+ */
+async function normalizeRecentDir(candidate: string): Promise<string | null> {
+  const expanded = expandHome(candidate.trim());
+  if (!path.isAbsolute(expanded)) return null;
+  const resolved = path.resolve(expanded);
+  try {
+    const stat = await fs.stat(resolved);
+    if (!stat.isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
+}
+
+/**
+ * Validates, normalizes, case-sensitively dedupes (first occurrence wins —
+ * callers order newest-first), and caps a candidate recent-dirs list.
+ * Applied on every write (via saveSettings) and on every read (via
+ * loadSettings), so junk already on disk self-heals the next time it's
+ * loaded instead of requiring a migration.
+ */
+export async function sanitizeRecentDirs(candidates: string[]): Promise<string[]> {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    if (result.length >= MAX_RECENT_DIRS) break;
+    const normalized = await normalizeRecentDir(candidate);
+    if (normalized === null || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
 }
 
 /** Whether settings have ever been persisted — used to detect first run. */
@@ -27,7 +67,8 @@ export async function hasStoredSettings(): Promise<boolean> {
 export async function loadSettings(): Promise<HarnessSettings> {
   try {
     const raw = await fs.readFile(settingsFilePath(), "utf-8");
-    return { ...DEFAULT_SETTINGS, ...(JSON.parse(raw) as Partial<HarnessSettings>) };
+    const parsed = { ...DEFAULT_SETTINGS, ...(JSON.parse(raw) as Partial<HarnessSettings>) };
+    return { ...parsed, recentDirs: await sanitizeRecentDirs(parsed.recentDirs) };
   } catch {
     return { ...DEFAULT_SETTINGS };
   }
@@ -35,16 +76,16 @@ export async function loadSettings(): Promise<HarnessSettings> {
 
 export async function saveSettings(settings: HarnessSettings): Promise<void> {
   const filePath = settingsFilePath();
+  const sanitized: HarnessSettings = {
+    ...settings,
+    recentDirs: await sanitizeRecentDirs(settings.recentDirs),
+  };
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, JSON.stringify(settings, null, 2) + "\n");
+  await fs.writeFile(filePath, JSON.stringify(sanitized, null, 2) + "\n");
 }
 
-/** Record `cwd` as the most-recently-used project directory (deduped, capped). */
+/** Record `cwd` as the most-recently-used project directory (validated, deduped, capped). */
 export async function recordRecentDir(cwd: string): Promise<void> {
   const settings = await loadSettings();
-  const recentDirs = [cwd, ...settings.recentDirs.filter((dir) => dir !== cwd)].slice(
-    0,
-    MAX_RECENT_DIRS,
-  );
-  await saveSettings({ ...settings, recentDirs });
+  await saveSettings({ ...settings, recentDirs: [cwd, ...settings.recentDirs] });
 }

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -125,11 +125,22 @@ export function useHarnessState(): HarnessStateHook {
     const session = await api.createSession(req);
     setState((prev) => (prev ? { ...prev, sessions: [...prev.sessions, session] } : prev));
     setActiveSessionId(session.id);
+
+    let optimisticRecentDirs: string[] = [];
     setSettings((prev) => {
-      const recentDirs = [req.cwd, ...(prev?.recentDirs ?? []).filter((dir) => dir !== req.cwd)].slice(0, 10);
-      void api.updateSettings({ recentDirs });
-      return prev ? { ...prev, recentDirs } : prev;
+      optimisticRecentDirs = [req.cwd, ...(prev?.recentDirs ?? []).filter((dir) => dir !== req.cwd)].slice(0, 8);
+      return prev ? { ...prev, recentDirs: optimisticRecentDirs } : prev;
     });
+    // The server is the source of truth for what actually qualifies as a
+    // recent dir (must resolve to a real, existing directory) — replace the
+    // optimistic guess with its sanitized response so invalid input (e.g.
+    // stray free text typed into the directory field) never lingers in the UI.
+    try {
+      const updated = await api.updateSettings({ recentDirs: optimisticRecentDirs });
+      setSettings((prev) => (prev ? { ...prev, recentDirs: updated.recentDirs } : prev));
+    } catch {
+      // Non-fatal — session creation itself already succeeded.
+    }
     return session;
   }, []);
 

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -5,6 +5,29 @@
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
+  /* Border-radius scale — mirrors the product's own (base --radius: 6px,
+     with sm/md/lg/xl derived from it): buttons/inputs/badges/popovers use
+     md, dialogs use lg, cards would use xl. Kept as separate steps (rather
+     than every surface sharing one --radius) since that's what makes small
+     controls read as "the same design system" instead of merely reusing one
+     rounded corner everywhere. */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-xl: 10px;
+  --radius-full: 9999px;
+
+  /* Elevation — the same fixed (theme-independent) black-alpha shadows the
+     product's dialog/popover/dropdown primitives use. */
+  --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.1);
+
+  /* Matches Tailwind's default transition-all duration/easing, used
+     everywhere the product animates hover/focus/disabled state. */
+  --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+
   /* Sapiom brand palette, LIGHT — values ported from our design system.
      This is the default: it's what the authenticated product itself renders
      (the dashboard forces light), so it's the correct fallback if the
@@ -23,7 +46,15 @@
   --accent: #05a9bc;
   --accent-hover: #048a9a;
   --accent-dim: rgba(5, 169, 188, 0.14);
+  --accent-border: rgba(5, 169, 188, 0.3);
   --accent-foreground: #fafafa;
+  /* 3px focus-visible ring — accent at 50% alpha, matching the product's
+     `focus-visible:ring-accent/50` on inputs and `ring-ring/50` on buttons. */
+  --focus-ring: rgba(5, 169, 188, 0.5);
+  /* Switch thumb: light mode keeps the same background-colored thumb in
+     both states (per the product's Switch, which doesn't recolor it here). */
+  --toggle-knob-off: #ffffff;
+  --toggle-knob-on: #ffffff;
   --green: #05a9bc;
   --amber: #b45309;
   --red: #ef4444;
@@ -44,10 +75,32 @@
   --accent: #6be195;
   --accent-hover: #8bd4a6;
   --accent-dim: rgba(107, 225, 149, 0.16);
+  --accent-border: rgba(107, 225, 149, 0.3);
   --accent-foreground: #000000;
+  --focus-ring: rgba(107, 225, 149, 0.5);
+  /* Switch thumb: dark mode swaps thumb color with state — off is
+     near-white (foreground), on is black (matches --accent-foreground)
+     for contrast against the mint-green track. */
+  --toggle-knob-off: #fafafa;
+  --toggle-knob-on: #000000;
   --green: #6be195;
   --amber: #f59e0b;
   --red: #f87171;
+}
+
+/* Shared entrance animation for floating surfaces (dialogs, popovers,
+   dropdown menus) — mirrors the product's Radix `animate-in fade-in-0
+   zoom-in-95`, kept subtle (no opacity dip below 0.4) so it never reads as
+   the element being briefly hidden. */
+@keyframes pop-in {
+  from {
+    opacity: 0.4;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 * {
@@ -157,14 +210,25 @@ input {
   padding: 4px 8px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   color: var(--text-dim);
   font-size: 11.5px;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .palette-trigger:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.palette-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .palette-trigger-hint {
@@ -173,6 +237,8 @@ input {
   font-size: 10px;
 }
 
+/* Icon-only "ghost" button: no border at rest — matches the product's
+   Button variant="ghost" (transparent, fills with the brand accent on hover). */
 .theme-toggle {
   width: 26px;
   height: 26px;
@@ -181,14 +247,26 @@ input {
   justify-content: center;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   color: var(--text-dim);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
-.theme-toggle:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-strong);
+[data-theme="light"] .theme-toggle:hover {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+[data-theme="dark"] .theme-toggle:hover {
+  background: var(--accent-dim);
   color: var(--text);
+}
+
+.theme-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .brand-identity {
@@ -549,15 +627,18 @@ input {
 .connect-input {
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   padding: 6px 8px;
   color: var(--text);
   font-size: 12px;
+  transition: border-color var(--transition-fast);
 }
 
-.connect-input:focus {
+.connect-input:focus-visible {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .connect-error {
@@ -581,14 +662,23 @@ input {
   flex: 0 0 auto;
   border: 1px solid transparent;
   background: transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   color: var(--text-dim);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .macro-icon-btn:hover:not(:disabled) {
   background: var(--bg-hover);
   border-color: var(--border-strong);
   color: var(--text);
+}
+
+.macro-icon-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .macro-icon-btn:disabled {
@@ -654,12 +744,20 @@ input {
   padding: 5px 8px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   color: var(--text);
+  transition: border-color var(--transition-fast);
 }
 
 .session-dropdown-trigger:hover {
   border-color: var(--accent);
+}
+
+.session-dropdown-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .session-title {
@@ -672,6 +770,9 @@ input {
   font-size: 12px;
 }
 
+/* Badge recipe (variant="active"): tinted fill + matching border + accent
+   text, rounded-md rather than a pill — the product's status chips are
+   small rounded rectangles, not fully-rounded tags. */
 .session-workflow-chip {
   flex: 0 1 auto;
   min-width: 0;
@@ -679,8 +780,9 @@ input {
   text-overflow: ellipsis;
   white-space: nowrap;
   padding: 2px 8px;
-  border-radius: 20px;
+  border-radius: var(--radius-md);
   background: var(--accent-dim);
+  border: 1px solid var(--accent-border);
   color: var(--accent);
   font-size: 10.5px;
   font-weight: 500;
@@ -713,12 +815,13 @@ input {
   right: 0;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
   z-index: 20;
   max-height: 360px;
   overflow-y: auto;
   padding: 6px;
+  animation: pop-in var(--transition-fast) ease-out;
 }
 
 .session-dropdown-section {
@@ -745,13 +848,17 @@ input {
   padding: 6px 8px;
   border: none;
   background: transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-sm);
   text-align: left;
+  transition: background-color var(--transition-fast);
 }
 
+/* DropdownMenuItem recipe: a solid accent fill on hover/selection, not a
+   neutral gray — the brand-accent hover is the product's signature for
+   list-style menu items (session switcher, command palette, dir picker). */
 .session-dropdown-item:hover,
 .session-dropdown-item.is-selected {
-  background: var(--bg-hover);
+  background: var(--accent);
 }
 
 .session-item-title {
@@ -765,28 +872,50 @@ input {
   color: var(--text-faint);
 }
 
+.session-dropdown-item:hover .session-item-title,
+.session-dropdown-item.is-selected .session-item-title,
+.session-dropdown-item:hover .session-item-cwd,
+.session-dropdown-item.is-selected .session-item-cwd,
+.session-dropdown-item:hover .session-item-meta,
+.session-dropdown-item.is-selected .session-item-meta {
+  color: var(--accent-foreground);
+}
+
+/* Matches Button variant="accent" — a solid, always-teal primary action
+   (distinct from the outline treatment on Cancel/Close), since "+ new" is
+   this bar's one high-emphasis action. */
 .new-session-btn {
   display: flex;
   align-items: center;
   gap: 4px;
   padding: 5px 10px;
-  background: var(--accent-dim);
-  color: var(--text);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius);
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-weight: 500;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   font-size: 12px;
   white-space: nowrap;
+  transition: background-color var(--transition-fast);
 }
 
 .new-session-btn:hover {
   background: var(--accent-hover);
-  color: var(--accent-foreground);
+}
+
+.new-session-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .settings-wrap {
   position: relative;
 }
 
+/* Matches Button variant="outline" size="icon": a persistent border,
+   subtle shadow, and — in light mode — a solid accent fill on hover (the
+   product's `hover:bg-accent`); dark mode keeps the more restrained neutral
+   hover the outline variant uses there. */
 .gear-btn {
   width: 30px;
   height: 30px;
@@ -795,13 +924,30 @@ input {
   justify-content: center;
   border: 1px solid var(--border-strong);
   background: var(--bg-2);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   color: var(--text-dim);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
-.gear-btn:hover {
+[data-theme="light"] .gear-btn:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+[data-theme="dark"] .gear-btn:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.gear-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .settings-popover {
@@ -811,10 +957,11 @@ input {
   width: 280px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  padding: 12px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 16px;
   z-index: 20;
+  animation: pop-in var(--transition-fast) ease-out;
 }
 
 .settings-identity {
@@ -839,16 +986,23 @@ input {
   flex: 0 0 auto;
   width: 34px;
   height: 20px;
-  border-radius: 20px;
+  border-radius: var(--radius-full);
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
   position: relative;
   padding: 0;
+  transition: background-color var(--transition-fast);
 }
 
 .toggle-switch.is-on {
   background: var(--accent);
   border-color: var(--accent);
+}
+
+.toggle-switch:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .toggle-switch:disabled {
@@ -863,11 +1017,12 @@ input {
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: var(--text);
-  transition: transform 0.12s ease;
+  background: var(--toggle-knob-off);
+  transition: transform var(--transition-fast);
 }
 
 .toggle-switch.is-on .toggle-knob {
+  background: var(--toggle-knob-on);
   transform: translateX(14px);
 }
 
@@ -1020,32 +1175,62 @@ input {
 
 /* Shared buttons ------------------------------------------------------- */
 
+/* Matches Button variant="outline": persistent border + shadow-xs; hover
+   fills solid accent in light mode (the product's `hover:bg-accent`) but
+   stays a neutral, more restrained hover in dark mode — same asymmetry the
+   real Button component has between its light/dark outline treatments. */
 .btn-ghost {
   background: transparent;
   border: 1px solid var(--border-strong);
   color: var(--text-dim);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   padding: 5px 10px;
   font-size: 12px;
+  font-weight: 500;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
-.btn-ghost:hover:not(:disabled) {
+[data-theme="light"] .btn-ghost:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+[data-theme="dark"] .btn-ghost:hover:not(:disabled) {
   color: var(--text);
   border-color: var(--text-faint);
 }
 
+.btn-ghost:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Matches Button variant="default": solid accent fill, no border. */
 .btn-primary {
   background: var(--accent);
-  border: 1px solid var(--accent);
+  border: 1px solid transparent;
   color: var(--accent-foreground);
   font-weight: 500;
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   padding: 5px 10px;
   font-size: 12px;
+  transition: background-color var(--transition-fast);
 }
 
 .btn-primary:hover:not(:disabled) {
-  filter: brightness(1.1);
+  background: var(--accent-hover);
+}
+
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .btn-ghost:disabled,
@@ -1059,21 +1244,32 @@ input {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
+  animation: fade-in var(--transition-fast) ease-out;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .modal {
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  padding: 16px;
+  border-radius: var(--radius-lg);
+  padding: 24px;
   width: 380px;
   max-width: calc(100vw - 32px);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
+  animation: pop-in var(--transition-fast) ease-out;
 }
 
 .command-palette {
@@ -1090,10 +1286,12 @@ input {
   background: transparent;
   color: var(--text);
   font-size: 14px;
+  transition: border-color var(--transition-fast);
 }
 
 .command-palette-input:focus {
   outline: none;
+  border-bottom-color: var(--accent);
 }
 
 .command-palette-list {
@@ -1108,6 +1306,8 @@ input {
   font-size: 12px;
 }
 
+/* DropdownMenuItem recipe (same solid-accent hover/selection as the session
+   dropdown and directory listing — see the note on .session-dropdown-item). */
 .command-palette-item {
   display: flex;
   align-items: center;
@@ -1116,13 +1316,16 @@ input {
   padding: 7px 10px;
   border: none;
   background: transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-sm);
   color: var(--text-dim);
   text-align: left;
+  transition: background-color var(--transition-fast);
 }
 
 .command-palette-item.is-selected {
-  background: var(--accent-dim);
+  background: var(--accent);
+  /* The icon has no color of its own — it inherits this via currentColor. */
+  color: var(--accent-foreground);
 }
 
 .command-palette-item-label {
@@ -1145,10 +1348,18 @@ input {
   flex: 1;
 }
 
+.command-palette-item.is-selected .command-palette-item-label,
+.command-palette-item.is-selected .command-palette-item-meta {
+  color: var(--accent-foreground);
+}
+
+/* DialogHeader recipe: a hairline separator under the title. */
 .modal-header {
   font-size: 13px;
   font-weight: 600;
+  padding-bottom: 16px;
   margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
 }
 
 .modal-label {
@@ -1164,15 +1375,18 @@ input {
   width: 100%;
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   padding: 7px 9px;
   color: var(--text);
   font-size: 12.5px;
+  transition: border-color var(--transition-fast);
 }
 
 .modal-input:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .modal-error {
@@ -1181,11 +1395,14 @@ input {
   margin-top: 8px;
 }
 
+/* DialogFooter recipe: a hairline separator above the actions row. */
 .modal-actions {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 16px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
 }
 
 .recent-dirs {
@@ -1199,18 +1416,27 @@ input {
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
   color: var(--text-dim);
-  border-radius: 20px;
+  border-radius: var(--radius-md);
   padding: 3px 9px;
   font-size: 10.5px;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .recent-dir-chip:hover {
   color: var(--text);
   border-color: var(--accent);
+}
+
+.recent-dir-chip:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .harness-picker {
@@ -1223,15 +1449,25 @@ input {
   padding: 8px;
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   color: var(--text-dim);
   font-size: 12px;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .harness-option.is-selected {
   border-color: var(--accent);
   color: var(--text);
   background: var(--accent-dim);
+}
+
+.harness-option:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .modal-new-session {
@@ -1245,6 +1481,7 @@ input {
   gap: 6px;
 }
 
+/* Matches Button variant="outline" size="icon" — see .gear-btn. */
 .dir-picker-up {
   flex: 0 0 auto;
   width: 30px;
@@ -1254,13 +1491,30 @@ input {
   justify-content: center;
   background: var(--bg-3);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
   color: var(--text-dim);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
-.dir-picker-up:hover:not(:disabled) {
+[data-theme="light"] .dir-picker-up:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+[data-theme="dark"] .dir-picker-up:hover:not(:disabled) {
   color: var(--text);
   border-color: var(--accent);
+}
+
+.dir-picker-up:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .dir-picker-up:disabled {
@@ -1276,7 +1530,7 @@ input {
 .dir-picker-listing {
   margin-top: 8px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   background: var(--bg-3);
   max-height: 150px;
   overflow-y: auto;
@@ -1299,6 +1553,7 @@ input {
   color: var(--text-faint);
 }
 
+/* Same DropdownMenuItem-style solid-accent hover as the other list surfaces. */
 .dir-picker-item {
   display: flex;
   align-items: center;
@@ -1307,14 +1562,16 @@ input {
   padding: 6px 9px;
   border: none;
   background: transparent;
+  border-radius: var(--radius-sm);
   color: var(--text-dim);
   font-size: 12px;
   text-align: left;
+  transition: background-color var(--transition-fast);
 }
 
 .dir-picker-item:hover {
-  background: var(--bg-hover);
-  color: var(--text);
+  background: var(--accent);
+  color: var(--accent-foreground);
 }
 
 .toast {
@@ -1330,9 +1587,10 @@ input {
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
   border-left: 3px solid var(--red);
-  border-radius: var(--radius);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
   z-index: 100;
+  animation: pop-in var(--transition-fast) ease-out;
 }
 
 .toast-message {
@@ -1349,8 +1607,40 @@ input {
   line-height: 1;
   cursor: pointer;
   padding: 0 2px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
 }
 
 .toast-dismiss:hover {
   color: var(--text);
+}
+
+.toast-dismiss:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Scrollbars — thin thumb-only styling, matching the product's own
+   (rgba(161, 161, 170, 0.75), 8px, no visible track) in both themes. */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(161, 161, 170, 0.75);
+  border-radius: var(--radius-sm);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(161, 161, 170, 0.9);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(161, 161, 170, 0.75) transparent;
 }


### PR DESCRIPTION
## Summary
- Ports over the design system's exact component recipes (radii scale, elevation/shadows, focus-visible rings, hover treatments, transitions) so the harness SPA's modal, buttons, inputs, chips, popovers, and dropdown menus read as the same product in both light and dark themes, instead of generic-looking controls with one shared border-radius and flat gray hovers.
- Notably: list-style menu items (session switcher, command palette, directory listing) now get a solid accent-color hover/selection fill, matching the product's dropdown-menu-item recipe — this was the single biggest visual "tell" that it wasn't the same product.
- Status chips ("working on X", recent-dir suggestions) switch from full pill shapes to bordered rounded-rectangles matching the badge component.
- The New Session dialog gets header/footer hairline separators (matching dialog header/footer chrome) and correctly-styled outline/solid button variants.
- Small, in-scope server fix: `recentDirs` in `~/.sapiom/harness/settings.json` could accumulate invalid entries (e.g. free text typed into the directory field) because neither `recordRecentDir` nor the settings PATCH route validated them. Validation is now centralized in `saveSettings`/`loadSettings`: each entry must resolve to an absolute, currently-existing directory; entries are normalized, case-sensitively deduped, and capped at 8. `loadSettings` applies the same check on read, so previously-recorded junk self-heals. The SPA now awaits the server's sanitized response after creating a session instead of trusting its own optimistic computation indefinitely.
- Pure CSS/markup-class-level changes — no component restructuring, no class renames, no `src/shared/types.ts` changes.

## Test plan
- [x] `pnpm --filter @sapiom/harness test` (vitest) — 360/360 passing, including new `settings.test.ts` coverage for validation/normalization/dedup/cap/self-heal-on-read
- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright, mock mode) — 41/41 passing, no selector changes needed since no class names changed
- [x] `tsc --noEmit` (server + web) — clean
- [x] `vite build` — clean
- [x] `eslint src --ext .ts` — clean
- [x] Manual screenshot comparison in both themes (modal, buttons, chips, popover, session dropdown, command palette) against the design system's own recipes

## Remaining deltas (honest gaps)
- Font sizes stay at the harness's existing compact scale (11–14px) rather than the design system's default text-sm/text-base (14–16px) — matching those literally would blow out density in this terminal-hub layout, so only the *shape* recipes (radius/shadow/ring/hover) were ported, not absolute type scale.
- No close (X) button was added to the New Session dialog chrome, to avoid touching interactive markup/test surface area beyond what's needed for a pure skin pass — Cancel/backdrop-click remain the only dismiss paths.
- Entrance animations (fade/scale-in on dialogs and popovers) are a simplified approximation of the Radix `animate-in fade-in-0 zoom-in-95` used by the real components, not a byte-for-byte port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)