### PR TITLE
feat(harness): deterministic, zero-LLM canvas render for Visualize

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -51,6 +51,7 @@
     "e2e:live": "tsx scripts/e2e-live.ts"
   },
   "dependencies": {
+    "@sapiom/agent": "workspace:^",
     "@sapiom/agent-core": "workspace:^",
     "@sapiom/mcp": "workspace:^",
     "express": "^4.21.0",

--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -61,6 +61,11 @@
  *      visualize run — and POST /api/macros/visualize/run succeeds both
  *      with no workflow bound (requiresWorkflow: false — workspace-overview
  *      mode) and after one is bound.
+ *  14. Deterministic canvas render (zero LLM): bound to a real @sapiom/agent
+ *      project, POST /api/canvas/:id/render extracts its actual step graph
+ *      and writes real step names + SVG node markup to index.html, and the
+ *      write fires a canvas.reload frame exactly like an agent's own edit
+ *      would — the visualize macro's default path never touches the pty.
  *
  * Run with: pnpm e2e:live
  */
@@ -155,7 +160,12 @@ async function testCoreFlow(): Promise<void> {
   await fs.mkdir(projectDir, { recursive: true });
   // A sapiom.json marker here, in the CLI's launch directory, proves the
   // boot-time workflow scan (item 7 below) — it must be in place before
-  // startServer() runs its one-shot scan of launchDir.
+  // startServer() runs its one-shot scan of launchDir. Deliberately just a
+  // marker (no index.ts) — projectDir doubles as the session's own cwd, and
+  // the "pristine empty template already on disk at create" assertion below
+  // reads its canvas synchronously right after creation, which would race a
+  // real workflow's auto-render. The deterministic-render proof (item 14)
+  // uses a separate, dedicated workflow directory instead — see below.
   await fs.writeFile(path.join(projectDir, "sapiom.json"), JSON.stringify({ definitionId: 4821 }));
   const collectorCwd = path.join(tmpRoot, "collector");
   await fs.mkdir(collectorCwd, { recursive: true });
@@ -536,6 +546,76 @@ async function testCoreFlow(): Promise<void> {
     assert(macroRes.status === 200, "POST /api/macros/visualize/run returns 200");
     const macroBody = (await macroRes.json()) as { ok: boolean };
     assert(macroBody.ok === true, "macro run responds { ok: true }");
+
+    // --- 14. deterministic render: bind to a REAL @sapiom/agent project (the
+    // same shape as the order-triage test fixture — copied, not
+    // reimplemented, so the two can't drift) and prove POST
+    // /api/canvas/:id/render writes the workflow's real step names to
+    // index.html and fires a canvas.reload frame, with zero LLM involvement.
+    // A separate directory from `projectDir` (which stays a bare marker —
+    // see its own comment above) so this doesn't race the "pristine empty
+    // template on create" assertion. Only `node_modules/@sapiom/agent` is
+    // symlinked (this package's own, a real workspace dependency) — NOT the
+    // whole node_modules tree, which would also expose harness's own
+    // node_modules/.bin/tsc and make check()'s typecheck step try (and fail)
+    // to run tsc with no tsconfig.json in this fixture dir; esbuild only
+    // needs the one package resolvable, exactly like any real consumer
+    // project's own install.
+    const workflowDir = path.join(tmpRoot, "order-triage");
+    await fs.mkdir(path.join(workflowDir, "node_modules", "@sapiom"), { recursive: true });
+    await fs.writeFile(path.join(workflowDir, "sapiom.json"), JSON.stringify({ definitionId: 5150 }));
+    await fs.copyFile(
+      path.join(SCRIPT_DIR, "..", "src", "core", "__fixtures__", "order-triage", "index.ts"),
+      path.join(workflowDir, "index.ts"),
+    );
+    await fs.symlink(
+      path.join(SCRIPT_DIR, "..", "node_modules", "@sapiom", "agent"),
+      path.join(workflowDir, "node_modules", "@sapiom", "agent"),
+      "dir",
+    );
+
+    const connectRes = await fetch(`${baseUrl}/api/workflows/connect`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ path: workflowDir }),
+    });
+    assert(connectRes.status === 200, "POST /api/workflows/connect registers the real order-triage project");
+
+    const renderBindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ workflowPath: workflowDir }),
+    });
+    assert(renderBindRes.status === 200, "binds the session to the real order-triage workflow");
+
+    const reloadFramesBefore = wsMessages.filter(
+      (m) => m.type === "canvas.reload" && m.harnessSessionId === sessionId,
+    ).length;
+
+    const renderRes = await fetch(`${baseUrl}/api/canvas/${sessionId}/render`, { method: "POST", headers });
+    assert(renderRes.status === 200, "POST /api/canvas/:id/render returns 200");
+    const renderBody = (await renderRes.json()) as { ok: boolean; mode: string; extractionFailed: string[] };
+    assert(renderBody.ok === true && renderBody.mode === "single", "render reports { ok: true, mode: 'single' }");
+    assert(
+      renderBody.extractionFailed.length === 0,
+      `extraction succeeded (no degraded panels): ${JSON.stringify(renderBody.extractionFailed)}`,
+    );
+
+    await waitFor(async () => {
+      const count = wsMessages.filter(
+        (m) => m.type === "canvas.reload" && m.harnessSessionId === sessionId,
+      ).length;
+      return count > reloadFramesBefore ? true : undefined;
+    });
+    console.log("canvas.reload frame received for the deterministic render's write");
+
+    // Canvas is per SESSION cwd (projectDir), not per bound workflow —
+    // the workflow's own directory is only where its source lives.
+    const renderedHtml = await fs.readFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "utf8");
+    for (const step of ["intake", "classify", "route", "auto_resolve", "escalate"]) {
+      assert(renderedHtml.includes(`>${step}<`), `rendered canvas contains the real step name '${step}'`);
+    }
+    assert(renderedHtml.includes("canvas-node-rect"), "rendered canvas contains real SVG node markup, not just text");
 
     // --- 11b. unbind — the context file gets boundWorkflow: null, not deleted ---
     const unbindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {

--- a/packages/harness/src/core/__fixtures__/broken-import/index.ts
+++ b/packages/harness/src/core/__fixtures__/broken-import/index.ts
@@ -1,0 +1,19 @@
+// Fixture: imports a package that can't be resolved — exercises the "no
+// node_modules" / unresolvable-dependency degradation path (BUNDLE_FAILED).
+import { defineAgent, defineStep, terminate } from "@sapiom/agent";
+import { somethingThatDoesNotExist } from "@sapiom/this-package-does-not-exist";
+
+const step = defineStep({
+  name: "step",
+  terminal: true,
+  async run() {
+    void somethingThatDoesNotExist;
+    return terminate({});
+  },
+});
+
+export const agent = defineAgent({
+  name: "broken-import",
+  entry: "step",
+  steps: { step },
+});

--- a/packages/harness/src/core/__fixtures__/hub/index.ts
+++ b/packages/harness/src/core/__fixtures__/hub/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Test fixture for the workspace-overview render's interconnection
+ * detection (core/canvas-interconnections.test.ts, core/canvas-render.test.ts).
+ * `orchestrations` below is a local stub, not the real `@sapiom/tools`
+ * package — the interconnection detector is a text grep, not a type-aware
+ * analysis, so it only needs a matching call shape to appear somewhere in
+ * the source; it never actually resolves or calls the referenced package.
+ */
+import { defineAgent, defineStep, terminate } from "@sapiom/agent";
+
+const orchestrations = { launch: async (_spec: { definition: string }) => ({}) };
+
+const kickoff = defineStep({
+  name: "kickoff",
+  terminal: true,
+  async run() {
+    await orchestrations.launch({ definition: "spoke-workflow" });
+    return terminate({});
+  },
+});
+
+export const agent = defineAgent({
+  name: "hub-workflow",
+  entry: "kickoff",
+  steps: { kickoff },
+});

--- a/packages/harness/src/core/__fixtures__/no-definition/index.ts
+++ b/packages/harness/src/core/__fixtures__/no-definition/index.ts
@@ -1,0 +1,3 @@
+// Fixture: a valid module that never calls defineAgent() — exercises the
+// NO_DEFINITION degradation path.
+export const notAnAgent = { hello: "world" };

--- a/packages/harness/src/core/__fixtures__/order-triage/index.ts
+++ b/packages/harness/src/core/__fixtures__/order-triage/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Test fixture — the same topology as the "order-triage" shape
+ * scripts/seed-example.mjs scaffolds for demos (5 steps, 1 branch point, 2
+ * terminal outcomes: one `terminate` and one that ALSO calls `terminate` but
+ * with an escalation-flavored payload — deliberately kept, since it's
+ * exactly what exercises the deterministic extractor's real limitation: it
+ * classifies by declared transition kind (`terminal`/`canFail`), never by a
+ * payload's runtime meaning, so this step renders as terminal-success like
+ * any other `terminate`, not terminal-warn — see core/canvas-graph.test.ts).
+ *
+ * No `inputSchema` (no zod) unlike the real seed: this monorepo has two zod
+ * majors installed across packages (a `@sapiom/agent` peer-dependency range
+ * spanning 3.25.76–4.x), and esbuild resolves each bundled file's `zod`
+ * import independently from that file's own location — a fixture's schema
+ * and @sapiom/agent's own zod/v4 introspection can land on two different
+ * physical zod instances and produce a bogus "reading 'def' of undefined"
+ * once bundled together. Real consumer projects have a single zod install
+ * and never hit this; it's purely a monorepo-fixture hazard, sidestepped by
+ * not exercising `inputSchema` here (this extractor doesn't read it anyway).
+ *
+ * No package.json / own node_modules: esbuild resolves `@sapiom/agent` by
+ * walking up to this package's own node_modules (a real workspace dependency
+ * of @sapiom/harness), which also means `check()`'s typecheck step is
+ * skipped here (no local tsc) — itself a case worth covering, distinct from
+ * a workflow that genuinely fails to bundle.
+ */
+import { defineAgent, defineStep, goto, terminate } from "@sapiom/agent";
+
+const intake = defineStep({
+  name: "intake",
+  next: ["classify"],
+  async run(input) {
+    return goto("classify", { order: input, receivedAt: new Date().toISOString() });
+  },
+});
+
+const classify = defineStep({
+  name: "classify",
+  next: ["route"],
+  async run(input: { order: { category?: string } }) {
+    const category = input.order.category ?? "general";
+    return goto("route", { ...input, category });
+  },
+});
+
+const route = defineStep({
+  name: "route",
+  next: ["auto_resolve", "escalate"],
+  async run(input: { category: string }) {
+    const needsHuman = input.category === "billing_dispute";
+    return goto(needsHuman ? "escalate" : "auto_resolve", input);
+  },
+});
+
+const auto_resolve = defineStep({
+  name: "auto_resolve",
+  next: [],
+  terminal: true,
+  async run(input: { category: string }) {
+    return terminate({ resolved: true, category: input.category });
+  },
+});
+
+const escalate = defineStep({
+  name: "escalate",
+  next: [],
+  terminal: true,
+  async run() {
+    return terminate({ resolved: false, escalated: true });
+  },
+});
+
+export const agent = defineAgent({
+  name: "order-triage",
+  entry: "intake",
+  steps: { intake, classify, route, auto_resolve, escalate },
+});

--- a/packages/harness/src/core/__fixtures__/spoke/index.ts
+++ b/packages/harness/src/core/__fixtures__/spoke/index.ts
@@ -1,0 +1,16 @@
+// Test fixture — the launch target referenced by __fixtures__/hub/index.ts.
+import { defineAgent, defineStep, terminate } from "@sapiom/agent";
+
+const run = defineStep({
+  name: "run",
+  terminal: true,
+  async run() {
+    return terminate({});
+  },
+});
+
+export const agent = defineAgent({
+  name: "spoke-workflow",
+  entry: "run",
+  steps: { run },
+});

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -1,0 +1,158 @@
+/**
+ * Assembles the `<div id="canvas-root">` body — one `<section
+ * class="canvas-panel">` per workflow (header + stats + SVG diagram),
+ * an optional Interconnections panel, and a shared legend footer — entirely
+ * from the classes `core/canvas-template.ts`'s shell already defines. This is
+ * the HTML half of the deterministic render; `core/canvas-render.ts` wraps
+ * the result through `renderCanvasDocument()` and writes it to disk.
+ */
+import type { CanvasEdgeKind, CanvasGraph, CanvasNodeKind } from "./canvas-graph.js";
+import { renderGraphSvg, usedKinds } from "./canvas-svg.js";
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export interface WorkflowPanelMeta {
+  title: string;
+  badges?: string[];
+}
+
+/** One workflow's full panel: title/badges header, step/entry stats, SVG diagram. */
+export function buildWorkflowPanelHtml(graph: CanvasGraph, meta: WorkflowPanelMeta): string {
+  const badges = (meta.badges ?? [])
+    .map((b) => `<span class="canvas-badge">${esc(b)}</span>`)
+    .join("");
+  const warningBadge =
+    graph.warnings.length > 0
+      ? `<span class="canvas-badge">${graph.warnings.length} warning${graph.warnings.length === 1 ? "" : "s"}</span>`
+      : "";
+  return `<section class="canvas-panel">
+  <header class="canvas-header">
+    <div class="canvas-title-row">
+      <h1 class="canvas-title">${esc(meta.title)}</h1>
+      ${badges}${warningBadge}
+    </div>
+    <div class="canvas-stats">
+      <div class="canvas-stat"><span class="canvas-stat-value">${graph.nodes.length}</span><span class="canvas-stat-label">steps</span></div>
+      <div class="canvas-stat"><span class="canvas-stat-value">${esc(graph.entry)}</span><span class="canvas-stat-label">entry</span></div>
+    </div>
+  </header>
+  <div class="canvas-diagram-panel">
+${renderGraphSvg(graph)}
+  </div>
+</section>`;
+}
+
+/** A degraded panel for a workflow whose graph couldn't be extracted — never
+ *  a crash, never a silent fallback to the LLM path, just an honest reason
+ *  styled through the same shell. */
+export function buildErrorPanelHtml(title: string, reason: string): string {
+  return `<section class="canvas-panel">
+  <header class="canvas-header">
+    <div class="canvas-title-row">
+      <h1 class="canvas-title">${esc(title)}</h1>
+      <span class="canvas-badge">render failed</span>
+    </div>
+  </header>
+  <div class="canvas-diagram-panel">
+    <p class="canvas-empty-note">Could not extract this workflow's step graph: ${esc(reason)}. Ask your agent to fix the issue (see the terminal for details) — this pane updates automatically once it builds cleanly.</p>
+  </div>
+</section>`;
+}
+
+/** The unbound, zero-workflows-known state — a friendly explainer, not an error. */
+export function buildEmptyWorkspaceHtml(): string {
+  return `<section class="canvas-panel">
+  <header class="canvas-header">
+    <div class="canvas-title-row">
+      <h1 class="canvas-title">No workflows found</h1>
+    </div>
+  </header>
+  <div class="canvas-diagram-panel">
+    <p class="canvas-empty-note">No @sapiom/agent projects found in this workspace yet. Connect or scan a directory containing a sapiom.json, or ask your agent to create one — this pane updates automatically.</p>
+  </div>
+</section>`;
+}
+
+const NODE_KIND_LABEL: Record<CanvasNodeKind, string> = {
+  entry: "entry / active step",
+  step: "step",
+  pause: "pause / waits for input",
+  "terminal-success": "terminal · success",
+  "terminal-warn": "terminal · escalation",
+};
+const NODE_KIND_ORDER: CanvasNodeKind[] = ["entry", "step", "pause", "terminal-success", "terminal-warn"];
+
+/** Legend footer covering every node/edge kind actually used across every
+ *  rendered panel (aggregate, not per-panel — matches the template's shape). */
+export function buildLegendHtml(nodeKinds: Set<CanvasNodeKind>, edgeKinds: Set<CanvasEdgeKind>): string {
+  const items = NODE_KIND_ORDER.filter((k) => nodeKinds.has(k)).map(
+    (k) =>
+      `<span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--${k}"></span>${NODE_KIND_LABEL[k]}</span>`,
+  );
+  if (edgeKinds.has("cross")) {
+    items.push(
+      `<span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-workflow signal/handoff</span>`,
+    );
+  }
+  return `<div class="canvas-legend">${items.join("")}</div>`;
+}
+
+/** Aggregates used node/edge kinds across every rendered graph, for one shared legend. */
+export function aggregateUsedKinds(graphs: readonly CanvasGraph[]): {
+  nodeKinds: Set<CanvasNodeKind>;
+  edgeKinds: Set<CanvasEdgeKind>;
+} {
+  const nodeKinds = new Set<CanvasNodeKind>();
+  const edgeKinds = new Set<CanvasEdgeKind>();
+  for (const g of graphs) {
+    const used = usedKinds(g);
+    for (const k of used.nodeKinds) nodeKinds.add(k);
+    for (const k of used.edgeKinds) edgeKinds.add(k);
+  }
+  return { nodeKinds, edgeKinds };
+}
+
+export interface InterconnectionRow {
+  fromLabel: string;
+  toLabel: string;
+  tag: string;
+  label?: string;
+}
+
+/** Cross-workflow handoffs detected by the heuristic grep (core/canvas-interconnections.ts). */
+export function buildInterconnectionsPanelHtml(rows: readonly InterconnectionRow[]): string {
+  if (rows.length === 0) return "";
+  const rowsHtml = rows
+    .map(
+      (r) => `<div class="canvas-interconnection-row">
+    <span class="canvas-legend-marker canvas-legend-marker--cross"></span>
+    <span class="canvas-interconnection-title">${esc(r.fromLabel)} &rarr; ${esc(r.toLabel)}</span>
+    <span class="canvas-interconnection-tag">${esc(r.tag)}</span>
+    ${r.label ? `<p class="canvas-interconnection-desc">${esc(r.label)}</p>` : ""}
+  </div>`,
+    )
+    .join("\n");
+  return `<section class="canvas-panel canvas-interconnections">
+  <h2 class="canvas-panel-title">Interconnections</h2>
+${rowsHtml}
+</section>`;
+}
+
+/** Joins panels + optional interconnections + a footer (legend + note) into
+ *  the final `#canvas-root` body — the string `renderCanvasDocument()` wraps. */
+export function assembleCanvasBody(input: {
+  panels: string[];
+  interconnections?: string;
+  legend: string;
+  note: string;
+}): string {
+  const parts = [...input.panels];
+  if (input.interconnections) parts.push(input.interconnections);
+  parts.push(`<footer class="canvas-footer">
+${input.legend}
+  <p class="canvas-note">${esc(input.note)}</p>
+</footer>`);
+  return parts.join("\n\n");
+}

--- a/packages/harness/src/core/canvas-graph.test.ts
+++ b/packages/harness/src/core/canvas-graph.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractWorkflowGraph } from "./canvas-graph.js";
+
+const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+const ORDER_TRIAGE_DIR = path.join(FIXTURES_DIR, "order-triage");
+
+describe("extractWorkflowGraph", () => {
+  it("extracts order-triage's real step graph via @sapiom/agent-core's check()", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.graph.manifestName).toBe("order-triage");
+    expect(result.graph.entry).toBe("intake");
+    expect(result.graph.nodes).toHaveLength(5);
+    expect(result.graph.nodes.map((n) => n.id).sort()).toEqual([
+      "auto_resolve",
+      "classify",
+      "escalate",
+      "intake",
+      "route",
+    ]);
+  });
+
+  it("classifies the entry step as 'entry' regardless of its other transitions", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    const intake = result.graph.nodes.find((n) => n.id === "intake")!;
+    expect(intake.kind).toBe("entry");
+  });
+
+  it("classifies a step with no continue targets and a `terminate` transition as terminal-success", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    const autoResolve = result.graph.nodes.find((n) => n.id === "auto_resolve")!;
+    expect(autoResolve.kind).toBe("terminal-success");
+  });
+
+  it("classifies a `terminate`-only step as terminal-success even when its payload implies an escalation — structural extraction reads declared transition kinds, never a runtime payload's meaning", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    const escalate = result.graph.nodes.find((n) => n.id === "escalate")!;
+    expect(escalate.kind).toBe("terminal-success");
+  });
+
+  it("mid-flow steps with only continue targets classify as 'step'", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    expect(result.graph.nodes.find((n) => n.id === "classify")!.kind).toBe("step");
+  });
+
+  it("emits one sequential edge for a single-target continue, and branching edges for multi-target continue", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+
+    const intakeToClassify = result.graph.edges.find((e) => e.from === "intake" && e.to === "classify");
+    expect(intakeToClassify?.kind).toBe("sequential");
+
+    const routeEdges = result.graph.edges.filter((e) => e.from === "route");
+    expect(routeEdges).toHaveLength(2);
+    expect(routeEdges.map((e) => e.to).sort()).toEqual(["auto_resolve", "escalate"]);
+    for (const edge of routeEdges) expect(edge.kind).toBe("branching");
+  });
+
+  it("emits no edge for terminate/fail transitions — they have no target, only a node color", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    expect(result.graph.edges.some((e) => e.from === "auto_resolve")).toBe(false);
+    expect(result.graph.edges.some((e) => e.from === "escalate")).toBe(false);
+  });
+
+  it("never throws: a missing project directory degrades to a typed failure", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "does-not-exist"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason.length).toBeGreaterThan(0);
+    expect(result.reason).toMatch(/no index\.ts/i);
+  });
+
+  it("never throws: a project whose index.ts fails to bundle (unresolvable import) degrades to a typed failure", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "broken-import"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+
+  it("never throws: a project with no defineAgent export degrades to a typed failure", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "no-definition"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toMatch(/no agent was exported/i);
+  });
+});

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -1,0 +1,131 @@
+/**
+ * Deterministic workflow graph extraction (no LLM). Runs `@sapiom/agent-core`'s
+ * `check()` pipeline (in an isolated child process — see
+ * core/canvas-manifest-check.ts for why) against a workflow project on disk
+ * — the same bundle+manifest+graph-validation path `sapiom agents check`
+ * uses — and reshapes the resulting manifest into the small node/edge model
+ * `canvas-svg.ts` renders. Never throws: extraction failure (missing
+ * node_modules, a type error, an invalid graph) is returned as a typed
+ * `ExtractionFailure` so the caller can render an honest degraded panel
+ * instead of crashing or silently falling back to an LLM.
+ */
+import type { AgentManifest, AgentStepManifest } from "@sapiom/agent";
+import { runManifestCheck } from "./canvas-manifest-check.js";
+
+export type CanvasNodeKind = "entry" | "step" | "pause" | "terminal-success" | "terminal-warn";
+export type CanvasEdgeKind = "sequential" | "branching" | "cross";
+
+export interface CanvasNode {
+  id: string;
+  kind: CanvasNodeKind;
+  label: string;
+  sublabel?: string;
+}
+
+export interface CanvasEdge {
+  from: string;
+  to: string;
+  kind: CanvasEdgeKind;
+  label?: string;
+}
+
+/** One workflow's extracted, render-ready graph. */
+export interface CanvasGraph {
+  /** The manifest's own name — used both as a display title fallback and as
+   *  the match key for cross-workflow interconnection detection. */
+  manifestName: string;
+  entry: string;
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+  /** Non-fatal graph smells from `assertValidGraph` (unreachable steps, no
+   *  path to a terminal) — surfaced as a badge, not an error. */
+  warnings: string[];
+}
+
+export interface ExtractionSuccess {
+  ok: true;
+  graph: CanvasGraph;
+}
+
+export interface ExtractionFailure {
+  ok: false;
+  /** Human-readable, terminal-safe reason — shown verbatim in the degraded panel. */
+  reason: string;
+}
+
+export type ExtractionResult = ExtractionSuccess | ExtractionFailure;
+
+/**
+ * Classifies a step for node styling. Priority: the entry step always reads
+ * as "entry" (the diagram's obvious starting point) even if it also happens
+ * to declare a pause/terminal transition; next, a declared `pause` always
+ * shows the dashed border regardless of what else the step declares; a step
+ * that can `continue` somewhere is a mid-flow "step" even if it can also
+ * terminate/fail from a different runtime branch; only a step with NO
+ * `continue` targets left resolves to a terminal color, warn (fail) over
+ * success (terminate) is not possible to prioritize both apply — success
+ * wins as the more common single-outcome shape.
+ */
+function classifyNode(
+  name: string,
+  entry: string,
+  step: AgentStepManifest,
+): { kind: CanvasNodeKind; sublabel?: string } {
+  const continueTargets = step.transitions.filter((t) => t.kind === "continue");
+  const pause = step.transitions.find((t) => t.kind === "pause");
+  const hasTerminate = step.transitions.some((t) => t.kind === "terminate");
+  const hasFail = step.transitions.some((t) => t.kind === "fail");
+
+  if (name === entry) return { kind: "entry" };
+  if (pause) return { kind: "pause", sublabel: `waits for signal "${pause.signal}"` };
+  if (continueTargets.length === 0 && hasFail && !hasTerminate) return { kind: "terminal-warn" };
+  if (continueTargets.length === 0 && hasTerminate) return { kind: "terminal-success" };
+  if (continueTargets.length > 0 && (hasTerminate || hasFail)) {
+    return { kind: "step", sublabel: hasFail ? "can also fail" : "can also terminate" };
+  }
+  return { kind: "step" };
+}
+
+/** Builds every edge a step declares — one per `continue` target plus its
+ *  `pause` edge, if any. Node kind (above) only decides border styling; every
+ *  declared transition with a target still gets its own edge. */
+function edgesForStep(name: string, step: AgentStepManifest): CanvasEdge[] {
+  const continueTargets = step.transitions.filter((t) => t.kind === "continue");
+  const edges: CanvasEdge[] = continueTargets.map((t) => ({
+    from: name,
+    to: t.target,
+    kind: continueTargets.length > 1 ? "branching" : "sequential",
+  }));
+  const pause = step.transitions.find((t) => t.kind === "pause");
+  if (pause) {
+    edges.push({ from: name, to: pause.resumeStep, kind: "cross", label: pause.signal });
+  }
+  return edges;
+}
+
+/** Reshapes a validated `AgentManifest` into the render-ready graph model. */
+export function graphFromManifest(manifest: AgentManifest, warnings: string[]): CanvasGraph {
+  const nodes: CanvasNode[] = Object.entries(manifest.steps).map(([name, step]) => {
+    const { kind, sublabel } = classifyNode(name, manifest.entry, step);
+    return { id: name, kind, label: name, ...(sublabel ? { sublabel } : {}) };
+  });
+  const edges: CanvasEdge[] = Object.entries(manifest.steps).flatMap(([name, step]) =>
+    edgesForStep(name, step),
+  );
+  return { manifestName: manifest.name, entry: manifest.entry, nodes, edges, warnings };
+}
+
+/**
+ * Extracts a workflow's step graph from its project directory. Never throws:
+ * any failure (no node_modules, a bundle/type error, an invalid graph, a
+ * check-process crash or timeout) comes back as `{ ok: false, reason }` for
+ * the caller to render as a degraded panel — this is the only place
+ * extraction failure is allowed to happen silently instead of crashing the
+ * render.
+ */
+export async function extractWorkflowGraph(sourceDir: string): Promise<ExtractionResult> {
+  const result = await runManifestCheck(sourceDir);
+  if (!result.ok) return { ok: false, reason: result.reason };
+  const graph = graphFromManifest(result.manifest as AgentManifest, result.warnings);
+  return { ok: true, graph };
+}

--- a/packages/harness/src/core/canvas-interconnections.test.ts
+++ b/packages/harness/src/core/canvas-interconnections.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { detectInterconnections } from "./canvas-interconnections.js";
+
+const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+
+describe("detectInterconnections", () => {
+  it("finds an orchestrations.launch({ definition }) call and resolves it against a known workflow's manifest name", async () => {
+    const edges = await detectInterconnections([
+      { path: path.join(FIXTURES_DIR, "hub"), manifestName: "hub-workflow" },
+      { path: path.join(FIXTURES_DIR, "spoke"), manifestName: "spoke-workflow" },
+    ]);
+    expect(edges).toEqual([{ fromManifestName: "hub-workflow", toManifestName: "spoke-workflow", toSlug: "spoke-workflow" }]);
+  });
+
+  it("leaves toManifestName null when the referenced slug doesn't match any known workflow", async () => {
+    const edges = await detectInterconnections([{ path: path.join(FIXTURES_DIR, "hub"), manifestName: "hub-workflow" }]);
+    expect(edges).toEqual([{ fromManifestName: "hub-workflow", toManifestName: null, toSlug: "spoke-workflow" }]);
+  });
+
+  it("finds nothing in a project with no orchestrations.launch calls", async () => {
+    const edges = await detectInterconnections([{ path: path.join(FIXTURES_DIR, "order-triage"), manifestName: "order-triage" }]);
+    expect(edges).toEqual([]);
+  });
+
+  it("never throws for a directory that doesn't exist", async () => {
+    await expect(detectInterconnections([{ path: path.join(FIXTURES_DIR, "does-not-exist"), manifestName: "x" }])).resolves.toEqual(
+      [],
+    );
+  });
+});

--- a/packages/harness/src/core/canvas-interconnections.ts
+++ b/packages/harness/src/core/canvas-interconnections.ts
@@ -1,0 +1,98 @@
+/**
+ * Heuristic cross-workflow interconnection detection for the workspace
+ * overview render: greps every workflow project's TypeScript sources for
+ * `orchestrations.launch({ definition: "<slug>" })` calls (see
+ * @sapiom/tools's `orchestrations` capability) and matches the captured slug
+ * against the other workflows' own manifest names. This is deliberately a
+ * grep, not a type-aware analysis — a step can compute its `definition`
+ * dynamically, in which case it's simply not detected; false negatives are
+ * fine here, this panel is a bonus overview, not a source of truth.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", "dist", "build", ".sapiom"]);
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx"]);
+const MAX_FILES_PER_WORKFLOW = 200;
+const MAX_FILE_BYTES = 512 * 1024;
+
+// Matches `orchestrations.launch({ ...definition: "slug"... })`, tolerating
+// other fields before `definition` in the object literal (bounded lookahead
+// so an unrelated huge object literal can't make this pathological).
+const LAUNCH_CALL_PATTERN = /orchestrations\s*\.\s*launch\s*\(\s*\{[\s\S]{0,400}?definition\s*:\s*(['"`])([^'"`]+)\1/g;
+
+async function listSourceFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    if (files.length >= MAX_FILES_PER_WORKFLOW) return;
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (files.length >= MAX_FILES_PER_WORKFLOW) return;
+      if (entry.isDirectory()) {
+        if (SKIP_DIR_NAMES.has(entry.name)) continue;
+        await walk(path.join(dir, entry.name));
+      } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(path.join(dir, entry.name));
+      }
+    }
+  }
+  await walk(root);
+  return files;
+}
+
+/** Every `orchestrations.launch({ definition: "..." })` slug referenced anywhere in `root`. */
+async function launchedSlugs(root: string): Promise<string[]> {
+  const slugs: string[] = [];
+  for (const file of await listSourceFiles(root)) {
+    let content: string;
+    try {
+      const stat = await fs.stat(file);
+      if (stat.size > MAX_FILE_BYTES) continue;
+      content = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const match of content.matchAll(LAUNCH_CALL_PATTERN)) {
+      slugs.push(match[2]);
+    }
+  }
+  return slugs;
+}
+
+export interface InterconnectionEdge {
+  fromManifestName: string;
+  /** The other workflow's manifest name, or null when the slug doesn't match any known workflow. */
+  toManifestName: string | null;
+  /** The raw slug the source referenced — shown when `toManifestName` is null. */
+  toSlug: string;
+}
+
+/**
+ * Scans every workflow's sources for `orchestrations.launch` calls and
+ * resolves each target slug against the other workflows in `workflows`
+ * (matched by manifest name — the value `defineAgent({ name })` sets, not
+ * the directory/package.json name `WorkflowInfo.name` carries). Best-effort:
+ * a workflow whose sources can't be read simply contributes no edges.
+ */
+export async function detectInterconnections(
+  workflows: readonly { path: string; manifestName: string }[],
+): Promise<InterconnectionEdge[]> {
+  const byName = new Map(workflows.map((w) => [w.manifestName, w.manifestName]));
+  const edges: InterconnectionEdge[] = [];
+  for (const workflow of workflows) {
+    const slugs = await launchedSlugs(workflow.path);
+    for (const slug of slugs) {
+      edges.push({
+        fromManifestName: workflow.manifestName,
+        toManifestName: byName.get(slug) ?? null,
+        toSlug: slug,
+      });
+    }
+  }
+  return edges;
+}

--- a/packages/harness/src/core/canvas-manifest-check.ts
+++ b/packages/harness/src/core/canvas-manifest-check.ts
@@ -1,0 +1,107 @@
+/**
+ * Runs `@sapiom/agent-core`'s `check()` in an isolated child process, rather
+ * than importing it in-process. Two independent reasons:
+ *
+ *  1. `check()` dynamically `import()`s an esbuild-bundled copy of whatever
+ *     TypeScript the target workflow's `index.ts` contains — a workflow
+ *     project the harness doesn't control. Running that inside the harness's
+ *     own long-lived server process would let a stray top-level side effect,
+ *     infinite loop, or crash in someone else's workflow code take the whole
+ *     harness down. A child process bounds the blast radius to one failed
+ *     render.
+ *  2. It sidesteps a real Vite/Vitest limitation: `check()`'s own dynamic
+ *     `import(\`file://${tmpPath}\`)` gets intercepted by Vite's SSR
+ *     dynamic-import-vars transform when anything imports `check` directly
+ *     into a Vitest-run module graph, and mishandles the tmpdir's `file://`
+ *     URL on darwin ("File URL host must be 'localhost' or empty"),
+ *     corrupting every extraction. A plain child `node` process never goes
+ *     through that transform.
+ *
+ * The child process is a short inline ESM script (no separate file to keep
+ * in sync across dev/build) run with `cwd` set to this package's own root,
+ * so `import { check } from "@sapiom/agent-core"` resolves against the
+ * harness's real dependency — exactly like the CLI's own `sapiom agents
+ * check` already runs it, just invoked programmatically instead of as a
+ * subcommand.
+ */
+import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Hard ceiling, not the performance target — bundling a small workflow is
+ *  typically well under a second; this only guards against a pathological
+ *  project (a huge dependency tree, a hanging top-level side effect) from
+ *  blocking a render indefinitely. */
+const CHECK_TIMEOUT_MS = 15_000;
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+// This module lives at either src/core/ (tsx dev, vitest) or dist/core/
+// (built) — both two directories below the package root.
+function packageRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+}
+
+const RUNNER_SOURCE = `
+import { check, AgentOperationError } from "@sapiom/agent-core";
+
+function reasonFor(err) {
+  if (err instanceof AgentOperationError) return err.hint ? \`\${err.message} \${err.hint}\` : err.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+const sourceDir = process.env.SAPIOM_CANVAS_CHECK_SOURCE_DIR;
+try {
+  const result = await check({ sourceDir });
+  process.stdout.write(JSON.stringify({ ok: true, manifest: result.manifest, warnings: result.warnings }));
+} catch (err) {
+  process.stdout.write(JSON.stringify({ ok: false, reason: reasonFor(err) }));
+}
+`;
+
+export interface ManifestCheckSuccess {
+  ok: true;
+  manifest: unknown;
+  warnings: string[];
+}
+
+export interface ManifestCheckFailure {
+  ok: false;
+  reason: string;
+}
+
+export type ManifestCheckResult = ManifestCheckSuccess | ManifestCheckFailure;
+
+/** Runs `check({ sourceDir })` in a child `node` process; never throws or
+ *  rejects — a crash, timeout, or unparsable output all come back as a
+ *  `ManifestCheckFailure` with a human-readable reason. */
+export function runManifestCheck(sourceDir: string): Promise<ManifestCheckResult> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      ["--input-type=module", "-e", RUNNER_SOURCE],
+      {
+        cwd: packageRoot(),
+        env: { ...process.env, SAPIOM_CANVAS_CHECK_SOURCE_DIR: sourceDir },
+        timeout: CHECK_TIMEOUT_MS,
+        maxBuffer: MAX_BUFFER_BYTES,
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          const timedOut = (err as NodeJS.ErrnoException & { killed?: boolean }).killed && err.signal === "SIGTERM";
+          resolve({
+            ok: false,
+            reason: timedOut
+              ? `Extraction timed out after ${CHECK_TIMEOUT_MS / 1000}s.`
+              : (stderr.trim() || err.message),
+          });
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout) as ManifestCheckResult);
+        } catch {
+          resolve({ ok: false, reason: `Unexpected output from the check process: ${stdout.slice(0, 500)}` });
+        }
+      },
+    );
+  });
+}

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CANVAS_INDEX } from "../shared/types.js";
+import { renderCanvasForSession, type RenderableWorkflow } from "./canvas-render.js";
+
+const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+const ORDER_TRIAGE = path.join(FIXTURES_DIR, "order-triage");
+const NO_DEFINITION = path.join(FIXTURES_DIR, "no-definition");
+const HUB = path.join(FIXTURES_DIR, "hub");
+const SPOKE = path.join(FIXTURES_DIR, "spoke");
+
+const tmpDirs: string[] = [];
+async function tmpCwd(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-render-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+async function readIndex(cwd: string): Promise<string> {
+  return fs.readFile(path.join(cwd, CANVAS_INDEX), "utf8");
+}
+
+describe("renderCanvasForSession", () => {
+  it("renders the bound workflow's real step names into a single panel", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+
+    expect(outcome).toEqual({ mode: "single", workflowPath: ORDER_TRIAGE, extractionFailed: [] });
+    const html = await readIndex(cwd);
+    for (const step of ["intake", "classify", "route", "auto_resolve", "escalate"]) {
+      expect(html).toContain(`>${step}<`);
+    }
+    expect(html).toContain("canvas-legend");
+    expect(html).not.toContain('class="canvas-panel canvas-interconnections"');
+  });
+
+  it("degrades to an honest error panel when the bound workflow fails to extract — never crashes, never falls back to an LLM prompt", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: NO_DEFINITION, name: "broken-flow", definitionId: null }];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: NO_DEFINITION }, workflows);
+
+    expect(outcome.mode).toBe("single");
+    expect(outcome.extractionFailed).toEqual(["broken-flow"]);
+    const html = await readIndex(cwd);
+    expect(html).toContain("broken-flow");
+    expect(html).toContain("render failed");
+    expect(html).toContain("Could not extract this workflow's step graph");
+    expect(html).not.toContain('class="canvas-node '); // no diagram — just the note
+  });
+
+  it("renders the whole-workspace overview (one panel per workflow) when unbound", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [
+      { path: ORDER_TRIAGE, name: "order-triage", definitionId: 42 },
+      { path: HUB, name: "hub", definitionId: null },
+    ];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
+
+    expect(outcome.mode).toBe("overview");
+    expect(outcome.workflowCount).toBe(2);
+    expect(outcome.extractionFailed).toEqual([]);
+    const html = await readIndex(cwd);
+    expect(html).toContain(">order-triage<");
+    expect(html).toContain(">hub<");
+    expect(html).toContain("deployed");
+    expect(html).toContain("local only");
+  });
+
+  it("includes an Interconnections panel when a workspace overview's workflows reference each other", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [
+      { path: HUB, name: "hub", definitionId: null },
+      { path: SPOKE, name: "spoke", definitionId: null },
+    ];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
+
+    expect(outcome.mode).toBe("overview");
+    const html = await readIndex(cwd);
+    expect(html).toContain('class="canvas-panel canvas-interconnections"');
+    expect(html).toContain("hub &rarr; spoke");
+    expect(html).toContain('class="canvas-interconnection-tag">launch<');
+  });
+
+  it("degrades one panel at a time in an overview — one broken workflow doesn't take down the others", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [
+      { path: ORDER_TRIAGE, name: "order-triage", definitionId: null },
+      { path: NO_DEFINITION, name: "broken-flow", definitionId: null },
+    ];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
+
+    expect(outcome.mode).toBe("overview");
+    expect(outcome.extractionFailed).toEqual(["broken-flow"]);
+    const html = await readIndex(cwd);
+    expect(html).toContain(">intake<"); // order-triage still rendered in full
+    expect(html).toContain("render failed"); // broken-flow degraded, not dropped
+  });
+
+  it("renders a friendly empty-workspace note (not an error) when unbound with zero known workflows", async () => {
+    const cwd = await tmpCwd();
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, []);
+
+    expect(outcome).toEqual({ mode: "empty", extractionFailed: [] });
+    const html = await readIndex(cwd);
+    expect(html).toContain("No workflows found");
+    expect(html).not.toContain("render failed");
+  });
+
+  it("falls back to the workspace overview when boundWorkflowPath doesn't match any known workflow", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: "/no/such/workflow" }, workflows);
+    expect(outcome.mode).toBe("overview");
+  });
+
+  it("never throws when the cwd is unwritable — reports writeError instead", async () => {
+    // A file, not a directory, as the "cwd" — mkdir underneath it must fail.
+    const parent = await tmpCwd();
+    const notADir = path.join(parent, "not-a-directory");
+    await fs.writeFile(notADir, "x");
+
+    const outcome = await renderCanvasForSession({ cwd: notADir, boundWorkflowPath: null }, []);
+    expect(outcome.mode).toBe("empty");
+    expect(outcome.writeError).toBeTruthy();
+  });
+});

--- a/packages/harness/src/core/canvas-render.ts
+++ b/packages/harness/src/core/canvas-render.ts
@@ -1,0 +1,168 @@
+/**
+ * The deterministic render pipeline: given a session (bound or not) and the
+ * workflow registry, extracts the relevant workflow graph(s) (core/
+ * canvas-graph.ts), builds the SVG + panel markup (core/canvas-svg.ts,
+ * core/canvas-body.ts), wraps it through the shared document shell
+ * (core/canvas-template.ts's `renderCanvasDocument`), and writes
+ * `<cwd>/.sapiom/canvas/index.html`. Zero LLM involvement, typically well
+ * under a second for a small workflow — extraction failure degrades to an
+ * honest error panel per workflow, never a crash and never a silent fallback
+ * to the LLM path (see core/macros.ts's separate "ai-visualize" macro for
+ * that path).
+ *
+ * The write alone is enough to hot-reload an open canvas pane —
+ * CanvasWatcherManager already watches the whole session cwd and treats any
+ * change under `.sapiom/canvas/` as a reload signal, regardless of who wrote
+ * it.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { CANVAS_INDEX } from "../shared/types.js";
+import { renderCanvasDocument } from "./canvas-template.js";
+import { extractWorkflowGraph, type CanvasGraph } from "./canvas-graph.js";
+import {
+  aggregateUsedKinds,
+  assembleCanvasBody,
+  buildEmptyWorkspaceHtml,
+  buildErrorPanelHtml,
+  buildInterconnectionsPanelHtml,
+  buildLegendHtml,
+  buildWorkflowPanelHtml,
+  type InterconnectionRow,
+} from "./canvas-body.js";
+import { detectInterconnections } from "./canvas-interconnections.js";
+
+export interface RenderableSession {
+  cwd: string;
+  boundWorkflowPath: string | null;
+}
+
+export interface RenderableWorkflow {
+  path: string;
+  name: string;
+  definitionId: number | null;
+}
+
+export interface CanvasRenderOutcome {
+  mode: "single" | "overview" | "empty";
+  workflowPath?: string;
+  workflowCount?: number;
+  /** Display names of workflows whose graph couldn't be extracted (still rendered as a degraded panel). */
+  extractionFailed: string[];
+  /** Set only when writing the file itself failed (e.g. an unwritable cwd) — extraction success/failure above is unaffected. */
+  writeError?: string;
+}
+
+function badgesFor(workflow: RenderableWorkflow): string[] {
+  return [workflow.definitionId != null ? "deployed" : "local only"];
+}
+
+async function renderOne(
+  workflow: RenderableWorkflow,
+): Promise<{ panel: string; graph: CanvasGraph | null; failed: boolean }> {
+  const result = await extractWorkflowGraph(workflow.path);
+  if (!result.ok) {
+    return { panel: buildErrorPanelHtml(workflow.name, result.reason), graph: null, failed: true };
+  }
+  return {
+    panel: buildWorkflowPanelHtml(result.graph, { title: workflow.name, badges: badgesFor(workflow) }),
+    graph: result.graph,
+    failed: false,
+  };
+}
+
+async function renderSingle(workflow: RenderableWorkflow): Promise<{ body: string; failed: boolean }> {
+  const { panel, graph, failed } = await renderOne(workflow);
+  const used = graph ? aggregateUsedKinds([graph]) : null;
+  const legend = used ? buildLegendHtml(used.nodeKinds, used.edgeKinds) : "";
+  const body = assembleCanvasBody({
+    panels: [panel],
+    legend,
+    note: failed
+      ? "Static preview — this workflow has a build error; regenerate once it's fixed."
+      : "Static preview — regenerate after the workflow changes.",
+  });
+  return { body, failed };
+}
+
+async function renderOverview(workflows: readonly RenderableWorkflow[]): Promise<{ body: string; failed: string[] }> {
+  const rendered = await Promise.all(workflows.map((w) => renderOne(w)));
+  const panels = rendered.map((r) => r.panel);
+  const graphs = rendered.map((r) => r.graph).filter((g): g is CanvasGraph => g !== null);
+  const failed = workflows.filter((_, i) => rendered[i]!.failed).map((w) => w.name);
+
+  const displayByManifestName = new Map<string, string>();
+  workflows.forEach((w, i) => {
+    const graph = rendered[i]!.graph;
+    if (graph) displayByManifestName.set(graph.manifestName, w.name);
+  });
+
+  const grepInputs = workflows.map((w, i) => ({
+    path: w.path,
+    manifestName: rendered[i]!.graph?.manifestName ?? w.name,
+  }));
+  const interconnections = await detectInterconnections(grepInputs);
+  const rows: InterconnectionRow[] = interconnections.map((edge) => ({
+    fromLabel: displayByManifestName.get(edge.fromManifestName) ?? edge.fromManifestName,
+    toLabel: edge.toManifestName ? (displayByManifestName.get(edge.toManifestName) ?? edge.toManifestName) : `external ("${edge.toSlug}")`,
+    tag: "launch",
+  }));
+
+  const used = aggregateUsedKinds(graphs);
+  if (rows.length > 0) used.edgeKinds.add("cross");
+  const legend = buildLegendHtml(used.nodeKinds, used.edgeKinds);
+  const interconnectionsHtml = buildInterconnectionsPanelHtml(rows);
+
+  const body = assembleCanvasBody({
+    panels,
+    interconnections: interconnectionsHtml || undefined,
+    legend,
+    note:
+      failed.length > 0
+        ? `Static preview — regenerate after a workflow changes (${failed.length} workflow${failed.length === 1 ? "" : "s"} failed to build).`
+        : "Static preview — regenerate after a workflow changes.",
+  });
+  return { body, failed };
+}
+
+/**
+ * Renders the appropriate view for `session` (its bound workflow, or the
+ * whole-workspace overview when unbound) and writes it to `<cwd>/.sapiom/
+ * canvas/index.html`. Never throws — every failure mode (extraction,
+ * filesystem) is captured in the returned outcome instead.
+ */
+export async function renderCanvasForSession(
+  session: RenderableSession,
+  workflows: readonly RenderableWorkflow[],
+): Promise<CanvasRenderOutcome> {
+  let body: string;
+  let outcome: CanvasRenderOutcome;
+
+  const bound = session.boundWorkflowPath ? workflows.find((w) => w.path === session.boundWorkflowPath) : undefined;
+
+  if (bound) {
+    const { body: renderedBody, failed } = await renderSingle(bound);
+    body = renderedBody;
+    outcome = { mode: "single", workflowPath: bound.path, extractionFailed: failed ? [bound.name] : [] };
+  } else if (workflows.length === 0) {
+    body = assembleCanvasBody({
+      panels: [buildEmptyWorkspaceHtml()],
+      legend: "",
+      note: "Nothing to visualize yet — connect a workflow to get started.",
+    });
+    outcome = { mode: "empty", extractionFailed: [] };
+  } else {
+    const { body: renderedBody, failed } = await renderOverview(workflows);
+    body = renderedBody;
+    outcome = { mode: "overview", workflowCount: workflows.length, extractionFailed: failed };
+  }
+
+  const indexPath = path.join(session.cwd, CANVAS_INDEX);
+  try {
+    await fs.mkdir(path.dirname(indexPath), { recursive: true });
+    await fs.writeFile(indexPath, renderCanvasDocument(body), "utf8");
+  } catch (err) {
+    outcome.writeError = err instanceof Error ? err.message : String(err);
+  }
+  return outcome;
+}

--- a/packages/harness/src/core/canvas-svg.test.ts
+++ b/packages/harness/src/core/canvas-svg.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { CanvasGraph } from "./canvas-graph.js";
+import { computeLayers, layoutGraph, renderGraphSvg, usedKinds } from "./canvas-svg.js";
+
+const ORDER_TRIAGE_GRAPH: CanvasGraph = {
+  manifestName: "order-triage",
+  entry: "intake",
+  warnings: [],
+  nodes: [
+    { id: "intake", kind: "entry", label: "intake" },
+    { id: "classify", kind: "step", label: "classify" },
+    { id: "route", kind: "step", label: "route" },
+    { id: "auto_resolve", kind: "terminal-success", label: "auto_resolve" },
+    { id: "escalate", kind: "terminal-success", label: "escalate" },
+  ],
+  edges: [
+    { from: "intake", to: "classify", kind: "sequential" },
+    { from: "classify", to: "route", kind: "sequential" },
+    { from: "route", to: "auto_resolve", kind: "branching" },
+    { from: "route", to: "escalate", kind: "branching" },
+  ],
+};
+
+describe("computeLayers", () => {
+  it("assigns sequential layers to a straight chain", () => {
+    const layers = computeLayers(
+      [{ id: "a" } as never, { id: "b" } as never, { id: "c" } as never],
+      [
+        { from: "a", to: "b" } as never,
+        { from: "b", to: "c" } as never,
+      ],
+    );
+    expect(layers.get("a")).toBe(0);
+    expect(layers.get("b")).toBe(1);
+    expect(layers.get("c")).toBe(2);
+  });
+
+  it("assigns the longest-path layer when branches reconverge (a diamond)", () => {
+    // a -> b -> d, a -> c -> ... -> d (longer path), d should land past both.
+    const layers = computeLayers(
+      [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "e" }, { id: "d" }].map((n) => n as never),
+      [
+        { from: "a", to: "b" },
+        { from: "a", to: "c" },
+        { from: "c", to: "e" },
+        { from: "b", to: "d" },
+        { from: "e", to: "d" },
+      ].map((e) => e as never),
+    );
+    expect(layers.get("a")).toBe(0);
+    expect(layers.get("b")).toBe(1);
+    expect(layers.get("c")).toBe(1);
+    expect(layers.get("e")).toBe(2);
+    // d is reachable via a->b->d (layer 2) and a->c->e->d (layer 3) — longest wins.
+    expect(layers.get("d")).toBe(3);
+  });
+
+  it("never hangs on a cycle — bounded iteration still assigns every node a layer", () => {
+    const layers = computeLayers(
+      [{ id: "a" }, { id: "b" }].map((n) => n as never),
+      [
+        { from: "a", to: "b" },
+        { from: "b", to: "a" },
+      ].map((e) => e as never),
+    );
+    expect(layers.size).toBe(2);
+  });
+
+  it("gives a node unreachable from any root (a disconnected 2-cycle with no in-degree-0 entry) a layer past the deepest known one, instead of vanishing", () => {
+    // a -> b is the main chain (layers 0, 1); x <-> y is a disconnected
+    // island where both nodes have in-degree > 0, so neither starts a BFS.
+    const layers = computeLayers(
+      [{ id: "a" }, { id: "b" }, { id: "x" }, { id: "y" }].map((n) => n as never),
+      [
+        { from: "a", to: "b" },
+        { from: "x", to: "y" },
+        { from: "y", to: "x" },
+      ].map((e) => e as never),
+    );
+    expect(layers.get("x")).toBe(2);
+    expect(layers.get("y")).toBe(2);
+  });
+});
+
+describe("layoutGraph", () => {
+  it("centers each layer's row and stacks layers top to bottom", () => {
+    const layout = layoutGraph(ORDER_TRIAGE_GRAPH);
+    // intake, classify, route are each alone in their layer — same x (centered).
+    expect(layout.pos.intake!.x).toBe(layout.pos.classify!.x);
+    expect(layout.pos.classify!.x).toBe(layout.pos.route!.x);
+    expect(layout.pos.intake!.y).toBeLessThan(layout.pos.classify!.y);
+    expect(layout.pos.classify!.y).toBeLessThan(layout.pos.route!.y);
+    // auto_resolve and escalate share a layer — same y, different x.
+    expect(layout.pos.auto_resolve!.y).toBe(layout.pos.escalate!.y);
+    expect(layout.pos.auto_resolve!.x).not.toBe(layout.pos.escalate!.x);
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
+  });
+});
+
+describe("renderGraphSvg", () => {
+  const svg = renderGraphSvg(ORDER_TRIAGE_GRAPH);
+
+  it("emits one <g class=\"canvas-node ...\"> per node, tagged with its kind", () => {
+    expect((svg.match(/class="canvas-node node--entry"/g) ?? []).length).toBe(1);
+    expect((svg.match(/class="canvas-node node--step"/g) ?? []).length).toBe(2);
+    expect((svg.match(/class="canvas-node node--terminal-success"/g) ?? []).length).toBe(2);
+  });
+
+  it("emits one <path class=\"canvas-edge...\"> per edge", () => {
+    expect((svg.match(/<path class="canvas-edge/g) ?? []).length).toBe(4);
+  });
+
+  it("uses a straight line for a sequential edge and a curve for branching edges", () => {
+    expect(svg).toMatch(/M\d+(\.\d+)?,\d+(\.\d+)? L\d+/); // sequential: M...L...
+    expect(svg).toMatch(/M\d+(\.\d+)?,\d+(\.\d+)? C\d+/); // branching: M...C...
+  });
+
+  it("never emits its own <defs> — the shared document shell provides glow filter + arrow markers once", () => {
+    expect(svg).not.toContain("<defs>");
+    expect(svg).toContain('filter="url(#canvas-glow)"');
+    expect(svg).toContain('marker-end="url(#canvas-arrow)"');
+  });
+
+  it("escapes node labels", () => {
+    const graph: CanvasGraph = {
+      ...ORDER_TRIAGE_GRAPH,
+      nodes: [{ id: "a", kind: "entry", label: '<script>alert("x")</script>' }],
+      edges: [],
+    };
+    const rendered = renderGraphSvg(graph);
+    expect(rendered).not.toContain("<script>");
+    expect(rendered).toContain("&lt;script&gt;");
+  });
+
+  it("silently skips an edge whose endpoint isn't in the node set, rather than crashing", () => {
+    const graph: CanvasGraph = {
+      ...ORDER_TRIAGE_GRAPH,
+      nodes: [{ id: "a", kind: "entry", label: "a" }],
+      edges: [{ from: "a", to: "does-not-exist", kind: "sequential" }],
+    };
+    expect(() => renderGraphSvg(graph)).not.toThrow();
+  });
+});
+
+describe("usedKinds", () => {
+  it("collects every distinct node and edge kind present in the graph", () => {
+    const { nodeKinds, edgeKinds } = usedKinds(ORDER_TRIAGE_GRAPH);
+    expect([...nodeKinds].sort()).toEqual(["entry", "step", "terminal-success"]);
+    expect([...edgeKinds].sort()).toEqual(["branching", "sequential"]);
+  });
+});

--- a/packages/harness/src/core/canvas-svg.ts
+++ b/packages/harness/src/core/canvas-svg.ts
@@ -1,0 +1,191 @@
+/**
+ * Server-side SVG layout for a `CanvasGraph` (see core/canvas-graph.ts),
+ * emitting markup against the classes `core/canvas-template.ts`'s CSS shell
+ * already defines (node--entry/step/pause/terminal-success/terminal-warn,
+ * canvas-edge/--success/--warn/--cross). No DOM, no client-side script — the
+ * whole diagram is a static string built once, at render time.
+ *
+ * Layout: longest-path-from-roots layering (a Kahn's-algorithm variant),
+ * robust to reconverging branches (diamonds) and defensively bounded against
+ * a cycle (a malformed/adversarial manifest should degrade, not hang). Ported
+ * from the layout math in an earlier client-side renderer (see git history of
+ * canvas-template.ts, commit "canvas kit — LLM writes data, not HTML") — the
+ * geometry is unchanged, only where it runs (server, not browser).
+ */
+import type { CanvasEdge, CanvasEdgeKind, CanvasGraph, CanvasNode, CanvasNodeKind } from "./canvas-graph.js";
+
+export const NODE_W = 176;
+export const NODE_H = 56;
+const LAYER_GAP = 96;
+const COL_GAP = 32;
+const MARGIN = 40;
+
+export interface GraphLayout {
+  pos: Record<string, { x: number; y: number }>;
+  width: number;
+  height: number;
+}
+
+/** Assigns each node the longest-path layer reachable from a root (an
+ *  in-degree-0 node). Nodes never reached by a root (only possible on a
+ *  disconnected/cyclic fragment) fall to the layer just past the deepest
+ *  known one, so they still render instead of vanishing. */
+export function computeLayers(nodes: readonly CanvasNode[], edges: readonly CanvasEdge[]): Map<string, number> {
+  const ids = nodes.map((n) => n.id);
+  const idSet = new Set(ids);
+  const indeg = new Map<string, number>(ids.map((id) => [id, 0]));
+  const adj = new Map<string, string[]>(ids.map((id) => [id, []]));
+  for (const e of edges) {
+    if (!idSet.has(e.from) || !idSet.has(e.to)) continue;
+    adj.get(e.from)!.push(e.to);
+    indeg.set(e.to, (indeg.get(e.to) ?? 0) + 1);
+  }
+
+  const layer = new Map<string, number>();
+  let queue = ids.filter((id) => indeg.get(id) === 0);
+  const seen = new Set(queue);
+  for (const id of queue) layer.set(id, 0);
+
+  const maxIterations = ids.length * 2 + 2;
+  let iterations = 0;
+  while (queue.length > 0 && iterations++ < maxIterations) {
+    const next: string[] = [];
+    for (const id of queue) {
+      for (const child of adj.get(id) ?? []) {
+        const candidate = (layer.get(id) ?? 0) + 1;
+        if (!layer.has(child) || candidate > layer.get(child)!) layer.set(child, candidate);
+        if (!seen.has(child)) {
+          seen.add(child);
+          next.push(child);
+        }
+      }
+    }
+    queue = next;
+  }
+
+  let maxLayer = 0;
+  for (const l of layer.values()) if (l > maxLayer) maxLayer = l;
+  for (const id of ids) if (!layer.has(id)) layer.set(id, maxLayer + 1);
+  return layer;
+}
+
+/** Computes (x, y) for every node and the overall canvas size. Nodes in the
+ *  same layer are centered as a row; layers stack top to bottom. */
+export function layoutGraph(graph: CanvasGraph): GraphLayout {
+  const layer = computeLayers(graph.nodes, graph.edges);
+  const byLayer = new Map<number, string[]>();
+  for (const n of graph.nodes) {
+    const l = layer.get(n.id) ?? 0;
+    const arr = byLayer.get(l) ?? [];
+    arr.push(n.id);
+    byLayer.set(l, arr);
+  }
+  const layers = [...byLayer.keys()].sort((a, b) => a - b);
+  const maxCols = layers.reduce((m, l) => Math.max(m, byLayer.get(l)!.length), 1);
+  const width = MARGIN * 2 + maxCols * NODE_W + (maxCols - 1) * COL_GAP;
+
+  const pos: Record<string, { x: number; y: number }> = {};
+  for (const l of layers) {
+    const idsInLayer = byLayer.get(l)!;
+    const rowWidth = idsInLayer.length * NODE_W + (idsInLayer.length - 1) * COL_GAP;
+    const startX = (width - rowWidth) / 2;
+    idsInLayer.forEach((id, i) => {
+      pos[id] = { x: startX + i * (NODE_W + COL_GAP), y: MARGIN + l * (NODE_H + LAYER_GAP) };
+    });
+  }
+  const height = MARGIN * 2 + (layers.length - 1) * (NODE_H + LAYER_GAP) + NODE_H;
+  return { pos, width, height: Math.max(height, MARGIN * 2 + NODE_H) };
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function edgeColorClass(nodesById: Map<string, CanvasNode>, edge: CanvasEdge): "" | "--success" | "--warn" {
+  const target = nodesById.get(edge.to);
+  if (target?.kind === "terminal-success") return "--success";
+  if (target?.kind === "terminal-warn") return "--warn";
+  return "";
+}
+
+function arrowMarker(colorSuffix: "" | "--success" | "--warn"): string {
+  if (colorSuffix === "--success") return "url(#canvas-arrow-success)";
+  if (colorSuffix === "--warn") return "url(#canvas-arrow-warn)";
+  return "url(#canvas-arrow)";
+}
+
+function edgePath(kind: CanvasEdgeKind, x1: number, y1: number, x2: number, y2: number): string {
+  if (kind === "branching") {
+    const midY = (y1 + y2) / 2;
+    return `M${x1},${y1} C${x1},${midY} ${x2},${midY} ${x2},${y2}`;
+  }
+  return `M${x1},${y1} L${x2},${y2}`;
+}
+
+/** Renders one graph's `<svg>` diagram. Assumes the shared `<defs>` (glow
+ *  filter + arrow markers) are already present once at the document level —
+ *  see `renderCanvasDocument`'s `SVG_DEFS` — so this never emits its own. */
+export function renderGraphSvg(graph: CanvasGraph): string {
+  const layout = layoutGraph(graph);
+  const nodesById = new Map(graph.nodes.map((n) => [n.id, n]));
+
+  const edgeMarkup = graph.edges
+    .map((edge) => {
+      const from = layout.pos[edge.from];
+      const to = layout.pos[edge.to];
+      if (!from || !to) return "";
+      const x1 = from.x + NODE_W / 2;
+      const y1 = from.y + NODE_H;
+      const x2 = to.x + NODE_W / 2;
+      const y2 = to.y;
+      const isCross = edge.kind === "cross";
+      const colorSuffix = isCross ? "" : edgeColorClass(nodesById, edge);
+      const classes = ["canvas-edge", isCross ? "canvas-edge--cross" : colorSuffix && `canvas-edge${colorSuffix}`]
+        .filter(Boolean)
+        .join(" ");
+      const d = edgePath(edge.kind, x1, y1, x2, y2);
+      const marker = isCross ? "url(#canvas-arrow)" : arrowMarker(colorSuffix);
+      const path = `<path class="${classes}" d="${d}" marker-end="${marker}" />`;
+      if (!edge.label) return path;
+      const dx = x2 - x1;
+      const anchor = dx > 4 ? "start" : dx < -4 ? "end" : "middle";
+      const labelX = x1 + (dx > 0 ? 10 : dx < 0 ? -10 : 0);
+      const label = `<text class="canvas-edge-label" x="${labelX}" y="${y1 + 20}" text-anchor="${anchor}">${esc(edge.label)}</text>`;
+      return path + label;
+    })
+    .join("\n");
+
+  const nodeMarkup = graph.nodes
+    .map((node) => {
+      const p = layout.pos[node.id];
+      if (!p) return "";
+      const titleY = node.sublabel ? 22 : NODE_H / 2;
+      const sub = node.sublabel
+        ? `<text class="canvas-node-sub" x="${NODE_W / 2}" y="40">${esc(node.sublabel)}</text>`
+        : "";
+      return (
+        `<g class="canvas-node node--${node.kind}" filter="url(#canvas-glow)" transform="translate(${p.x},${p.y})">` +
+        `<rect class="canvas-node-rect" width="${NODE_W}" height="${NODE_H}" rx="14" />` +
+        `<text class="canvas-node-title" x="${NODE_W / 2}" y="${titleY}">${esc(node.label)}</text>` +
+        sub +
+        `</g>`
+      );
+    })
+    .join("\n");
+
+  return (
+    `<svg viewBox="0 0 ${layout.width} ${layout.height}" class="canvas-graph-svg">\n` +
+    edgeMarkup +
+    "\n" +
+    nodeMarkup +
+    `\n</svg>`
+  );
+}
+
+/** Every node/edge kind actually used, for the shared legend footer. */
+export function usedKinds(graph: CanvasGraph): { nodeKinds: Set<CanvasNodeKind>; edgeKinds: Set<CanvasEdgeKind> } {
+  return {
+    nodeKinds: new Set(graph.nodes.map((n) => n.kind)),
+    edgeKinds: new Set(graph.edges.map((e) => e.kind)),
+  };
+}

--- a/packages/harness/src/core/macro-runner.ts
+++ b/packages/harness/src/core/macro-runner.ts
@@ -18,7 +18,8 @@ export interface MacroContext {
 
 export type ResolvedMacroAction =
   | { kind: "inject"; text: string; submit: boolean }
-  | { kind: "open-url"; url: string };
+  | { kind: "open-url"; url: string }
+  | { kind: "render-canvas" };
 
 export class MacroValidationError extends Error {
   constructor(message: string) {
@@ -89,6 +90,9 @@ export function resolveMacro(macro: MacroDef, ctx: MacroContext): ResolvedMacroA
 
   if (macro.action.kind === "open-url") {
     return { kind: "open-url", url: substitute(macro.action.url, ctx) };
+  }
+  if (macro.action.kind === "render-canvas") {
+    return { kind: "render-canvas" };
   }
 
   return {

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -2,13 +2,14 @@ import { describe, it, expect } from "vitest";
 import { DEFAULT_MACROS } from "./macros.js";
 
 describe("DEFAULT_MACROS", () => {
-  it("defines exactly the 5 action-rail macros, matching the SPA's MOCK_MACROS ids", () => {
+  it("defines exactly the 6 action-rail macros, matching the SPA's MOCK_MACROS ids", () => {
     expect(DEFAULT_MACROS.map((m) => m.id)).toEqual([
       "run_local",
       "deploy",
       "prod_run",
       "open_prod",
       "visualize",
+      "ai-visualize",
     ]);
   });
 
@@ -32,12 +33,17 @@ describe("DEFAULT_MACROS", () => {
     });
   });
 
-  it("visualize is a one-click, unbound-friendly template clone — no free-text subject, no workflow required", () => {
+  it("visualize is a one-click, unbound-friendly deterministic render — no LLM, no pty involved", () => {
     const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
-    // Works whether or not a workflow is bound — the agent reads
-    // harness-context.json at run time to decide single-workflow vs.
-    // workspace-overview mode, so the static prompt can't reference
-    // {{workflow.path}} (it'd throw when unbound).
+    // Works whether or not a workflow is bound — the render pipeline reads
+    // the session's actual binding server-side, so there's no prompt text
+    // (and therefore no {{workflow.path}} to throw on when unbound).
+    expect(macro.requiresWorkflow).toBeFalsy();
+    expect(macro.action).toEqual({ kind: "render-canvas" });
+  });
+
+  it("ai-visualize is the LLM fallback — same unbound-friendly template-clone prompt visualize used to run", () => {
+    const macro = DEFAULT_MACROS.find((m) => m.id === "ai-visualize")!;
     expect(macro.requiresWorkflow).toBeFalsy();
     expect(macro.action.kind).toBe("inject");
     if (macro.action.kind === "inject") {

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -52,18 +52,28 @@ export const DEFAULT_MACROS: MacroDef[] = [
     },
   },
   {
-    // One-click render/re-render, unbound-friendly: the canvas kit
-    // (core/canvas-template.ts) has already dropped a prebuilt, pristine
-    // _template.html plus a live index.html into .sapiom/canvas/ — the
-    // agent clones the template and fills it in with real markup, using the
-    // classes/patterns the template documents, rather than hand-rolling CSS
-    // or a whole document from scratch. No free-text subject and no
-    // {{workflow.path}} reference: whether there's a bound workflow is
-    // something the agent reads out of harness-context.json at run time, so
-    // the same static prompt works whether or not one is selected.
+    // One-click render/re-render, unbound-friendly: runs the deterministic,
+    // zero-LLM pipeline (core/canvas-render.ts) server-side — extracts the
+    // bound workflow's real step graph (or every registered workflow, for a
+    // workspace overview) via @sapiom/agent-core's `check()` and lays it out
+    // itself, typically well under a second, without touching the session's
+    // pty at all. See "ai-visualize" below for the narrative/custom path.
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
+    requiresWorkflow: false,
+    action: { kind: "render-canvas" },
+  },
+  {
+    // The pre-deterministic-render behavior, kept as an explicit fallback for
+    // custom/narrative views the structural extraction can't produce (e.g. a
+    // description of *why* a step branches, not just that it does). Clones
+    // the canvas kit template and asks the agent to hand-write the SVG using
+    // its documented patterns — the same ~1-2 minute LLM round-trip
+    // "visualize" used to always pay.
+    id: "ai-visualize",
+    label: "AI Visualize",
+    icon: "Wand2",
     requiresWorkflow: false,
     action: {
       kind: "inject",

--- a/packages/harness/src/profiles/canvas-guidelines.test.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.test.ts
@@ -63,11 +63,16 @@ describe("CANVAS_STYLE_GUIDELINES injection sites", () => {
     expect(DEFAULT_SYSTEM_PROMPT).toContain(CANVAS_STYLE_GUIDELINES);
   });
 
-  it("is NOT embedded in the visualize macro's inject text — the canvas kit's prebuilt template already carries the style, so the macro path only ever asks for a data edit", () => {
-    const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
+  it("is NOT embedded in the ai-visualize macro's inject text — the canvas kit's prebuilt template already carries the style, so the macro path only ever asks for a data edit", () => {
+    const macro = DEFAULT_MACROS.find((m) => m.id === "ai-visualize")!;
     expect(macro.action.kind).toBe("inject");
     if (macro.action.kind === "inject") {
       expect(macro.action.text).not.toContain(CANVAS_STYLE_GUIDELINES);
     }
+  });
+
+  it("the default visualize macro doesn't touch a prompt at all — it's a server-side deterministic render", () => {
+    const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
+    expect(macro.action).toEqual({ kind: "render-canvas" });
   });
 });

--- a/packages/harness/src/server/canvas-render.test.ts
+++ b/packages/harness/src/server/canvas-render.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import type { Server } from "node:http";
+import { createCanvasRenderRouter, type CanvasRenderRouterDeps } from "./canvas-render.js";
+import { createBootTokenMiddleware } from "./auth.js";
+import { CANVAS_INDEX } from "../shared/types.js";
+
+const BOOT_TOKEN = "test-boot-token";
+const TOKEN_HEADER = { "X-Harness-Token": BOOT_TOKEN };
+
+let projectDir: string;
+let server: Server;
+let baseUrl: string;
+
+async function start(deps: CanvasRenderRouterDeps): Promise<void> {
+  const app = express();
+  // Mirrors the real wiring in server/index.ts: the boot-token middleware
+  // gates every /api path, mounted ahead of the router itself.
+  app.use("/api", createBootTokenMiddleware(BOOT_TOKEN));
+  app.use("/api", createCanvasRenderRouter(deps));
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  baseUrl = `http://127.0.0.1:${port}`;
+}
+
+async function stop(): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("canvas render router", () => {
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-canvas-render-"));
+  });
+
+  afterEach(async () => {
+    await stop();
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("401s without the boot token", async () => {
+    await start({ getSession: () => ({ cwd: projectDir, boundWorkflowPath: null }), listWorkflows: () => [] });
+    const res = await fetch(`${baseUrl}/api/canvas/sess-1/render`, { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s with the wrong boot token", async () => {
+    await start({ getSession: () => ({ cwd: projectDir, boundWorkflowPath: null }), listWorkflows: () => [] });
+    const res = await fetch(`${baseUrl}/api/canvas/sess-1/render`, {
+      method: "POST",
+      headers: { "X-Harness-Token": "wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("404s for an unknown session", async () => {
+    await start({ getSession: () => undefined, listWorkflows: () => [] });
+    const res = await fetch(`${baseUrl}/api/canvas/no-such-session/render`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("renders the empty-workspace state and reports ok:true with mode 'empty' when no workflows are known", async () => {
+    await start({ getSession: () => ({ cwd: projectDir, boundWorkflowPath: null }), listWorkflows: () => [] });
+    const res = await fetch(`${baseUrl}/api/canvas/sess-1/render`, { method: "POST", headers: TOKEN_HEADER });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; mode: string };
+    expect(body).toMatchObject({ ok: true, mode: "empty" });
+
+    const html = await fs.readFile(path.join(projectDir, CANVAS_INDEX), "utf8");
+    expect(html).toContain("No workflows found");
+  });
+
+  it("passes the session's real binding and the live workflow list through to the render", async () => {
+    const listWorkflows = vi.fn().mockReturnValue([]);
+    const getSession = vi.fn().mockReturnValue({ cwd: projectDir, boundWorkflowPath: "/some/workflow" });
+    await start({ getSession, listWorkflows });
+
+    await fetch(`${baseUrl}/api/canvas/sess-42/render`, { method: "POST", headers: TOKEN_HEADER });
+
+    expect(getSession).toHaveBeenCalledWith("sess-42");
+    expect(listWorkflows).toHaveBeenCalled();
+  });
+});

--- a/packages/harness/src/server/canvas-render.ts
+++ b/packages/harness/src/server/canvas-render.ts
@@ -1,0 +1,33 @@
+/**
+ * `POST /api/canvas/:sessionId/render` — the deterministic, zero-LLM render
+ * trigger. Mounted under the same `/api` boot-token middleware as the rest of
+ * the REST surface (see server/index.ts). Renders the session's bound
+ * workflow, or the whole-workspace overview when unbound; writing the file is
+ * enough to hot-reload an already-open canvas pane (CanvasWatcherManager
+ * picks up the change on its own).
+ */
+import { Router, type Router as ExpressRouter } from "express";
+import { renderCanvasForSession, type RenderableSession, type RenderableWorkflow } from "../core/canvas-render.js";
+
+export interface CanvasRenderRouterDeps {
+  /** Look up a session's cwd + current binding; undefined when unknown. */
+  getSession(harnessSessionId: string): RenderableSession | undefined;
+  /** The live workflow registry snapshot. */
+  listWorkflows(): RenderableWorkflow[];
+}
+
+export function createCanvasRenderRouter(deps: CanvasRenderRouterDeps): ExpressRouter {
+  const router = Router();
+
+  router.post("/canvas/:sessionId/render", async (req, res) => {
+    const session = deps.getSession(req.params.sessionId);
+    if (!session) {
+      res.status(404).json({ error: `Unknown session '${req.params.sessionId}'` });
+      return;
+    }
+    const outcome = await renderCanvasForSession(session, deps.listWorkflows());
+    res.json({ ok: true, ...outcome });
+  });
+
+  return router;
+}

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -43,6 +43,7 @@ import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
 import { writeHarnessContext, harnessContextFileExists } from "../core/workspace-context.js";
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
+import { renderCanvasForSession } from "../core/canvas-render.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
@@ -51,6 +52,7 @@ import { createEventsWebSocketHandler } from "./events-ws.js";
 import { attachWebSocketRouters } from "./ws-router.js";
 import { createIngestRouter, processIngest, type IngestDeps, type IngestRequestBody, type IngestSessionContext } from "./ingest.js";
 import { createCanvasRouter } from "./canvas.js";
+import { createCanvasRenderRouter } from "./canvas-render.js";
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 
@@ -272,8 +274,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // workflow registry is shared across the whole harness instance, so a
   // scan/connect anywhere changes what every session's `workflows` list
   // should say, not just the session that triggered the scan.
-  const scanWorkflowsAndBroadcast = async (root: string): Promise<void> => {
-    await workflowRegistry.scan(root);
+  // Returns the workflows freshly discovered under `root` (not the whole
+  // merged registry) — callers use this to decide whether THIS scan turned
+  // up something new worth an unprompted canvas render, without conflating
+  // it with unrelated workflows some earlier scan already found elsewhere.
+  const scanWorkflowsAndBroadcast = async (root: string): Promise<WorkflowInfo[]> => {
+    const found = await workflowRegistry.scan(root);
     workflowsCache = await workflowRegistry.list();
     // Rewrite every open session's context file before broadcasting — a
     // listener reacting to workflows.changed (the SPA, or an agent that
@@ -281,10 +287,20 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     // notification before the file it describes is actually updated.
     await Promise.all(sessionManager.list().map((session) => writeSessionContext(session)));
     bus.publish({ type: "workflows.changed" });
+    return found;
   };
 
-  scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
+  // Renders a session's canvas (its bound workflow, or the whole-workspace
+  // overview when unbound) via the deterministic pipeline — always against
+  // the live workflowsCache, never an LLM. Never throws (see core/
+  // canvas-render.ts); best-effort, like every other canvas write here.
+  const renderCanvas = async (session: HarnessSession): Promise<void> => {
+    await renderCanvasForSession(session, workflowsCache);
+  };
+
+  const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
     console.error("[harness] initial workflow scan failed:", err);
+    return [] as WorkflowInfo[];
   });
 
   const eventStore = createEventStore(options.eventStorePath);
@@ -331,14 +347,32 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       listMacros: () => DEFAULT_MACROS,
       findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
       writeWorkspaceContext: writeSessionContext,
+      renderCanvas,
       onTelemetryOptInChange: (optIn) => batcher.setTelemetryOptIn(optIn),
-      onSessionCreated: (cwd) => {
-        scanWorkflowsAndBroadcast(cwd).catch((err: unknown) => {
-          console.error("[harness] workflow scan on session create failed:", err);
-        });
+      onSessionCreated: (cwd, harnessSessionId) => {
+        scanWorkflowsAndBroadcast(cwd)
+          .then((found) => {
+            // Only auto-render when THIS session's own directory turned up a
+            // workflow — an unrelated project scanned earlier elsewhere in
+            // the registry shouldn't unprompt-render into a brand new,
+            // unrelated session's pane.
+            if (found.length === 0) return;
+            const session = sessionManager.get(harnessSessionId);
+            if (session) return renderCanvas(session);
+          })
+          .catch((err: unknown) => {
+            console.error("[harness] workflow scan on session create failed:", err);
+          });
       },
       launchDir,
       availableHarnesses: options.availableHarnesses,
+    }),
+  );
+  app.use(
+    "/api",
+    createCanvasRenderRouter({
+      getSession: (harnessSessionId) => sessionManager.get(harnessSessionId),
+      listWorkflows: () => workflowsCache,
     }),
   );
   app.use(
@@ -349,6 +383,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
       getSessionCwd: (harnessSessionId) => sessionManager.get(harnessSessionId)?.cwd ?? null,
       getBoundWorkflowPath: (harnessSessionId) => sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
+      renderCanvas: async (harnessSessionId) => {
+        const session = sessionManager.get(harnessSessionId);
+        if (session) await renderCanvas(session);
+      },
       injectInput: async (harnessSessionId, text, submit) => {
         // Two-phase write: a combined text+\r lands in Claude Code as a
         // bracketed paste and never submits.
@@ -536,9 +574,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // resolving shouldn't wait on a real pty spawn.
   if (options.autoCreateSession ?? true) {
     const harness = options.defaultHarnessKind ?? "claude-code";
-    sessionManager.create({ cwd: launchDir, harness }).catch((err: unknown) => {
-      console.error("[harness] auto-create boot session failed:", err);
-    });
+    sessionManager
+      .create({ cwd: launchDir, harness })
+      .then(async (session) => {
+        // Reuses the scan already kicked off above rather than scanning
+        // launchDir twice — only renders when it actually found something,
+        // same "discoverable" gate as the REST onSessionCreated path.
+        const found = await initialWorkflowScan;
+        if (found.length > 0) await renderCanvas(session);
+      })
+      .catch((err: unknown) => {
+        console.error("[harness] auto-create boot session failed:", err);
+      });
   }
 
   const address = httpServer.address();

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -24,6 +24,7 @@ function makeDeps(overrides: Partial<MacrosRouterDeps> = {}): MacrosRouterDeps {
     getBoundWorkflowPath: () => null,
     injectInput: vi.fn().mockResolvedValue(undefined),
     openUrl: vi.fn().mockResolvedValue(undefined),
+    renderCanvas: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -184,7 +185,7 @@ describe("macros router", () => {
     expect(res.status).toBe(400);
   });
 
-  it("runs visualize with no workflow bound at all — the canvas kit's data-edit prompt needs none", async () => {
+  it("runs visualize with no workflow bound at all — renders server-side, never touches the pty", async () => {
     const deps = makeDeps(); // getBoundWorkflowPath defaults to () => null
     await start(deps);
     const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
@@ -193,13 +194,12 @@ describe("macros router", () => {
       body: JSON.stringify({ harnessSessionId: "sess-1" }), // no subject, no workflowPath, no binding
     });
     expect(res.status).toBe(200);
-    const [, text] = (deps.injectInput as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string, boolean];
-    expect(text).toContain("/Users/demo/acme-app/.sapiom/canvas/index.html"); // {{canvas.path}} substituted
-    expect(text).toContain("Clone .sapiom/canvas/_template.html to .sapiom/canvas/index.html");
-    expect(text).toContain("canvas-patterns");
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
+    expect(deps.injectInput).not.toHaveBeenCalled();
   });
 
-  it("also runs visualize when a workflow IS bound — same static prompt either way", async () => {
+  it("also runs visualize when a workflow IS bound — same deterministic render either way", async () => {
     const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
     await start(deps);
     const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
@@ -208,11 +208,24 @@ describe("macros router", () => {
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
     });
     expect(res.status).toBe(200);
+    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("ai-visualize still injects the canvas-kit hand-authoring prompt (the pre-deterministic-render fallback)", async () => {
+    const deps = makeDeps();
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/ai-visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }),
+    });
+    expect(res.status).toBe(200);
     const [, text] = (deps.injectInput as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string, boolean];
-    // Same text regardless of binding — the agent branches on
-    // harness-context.json's boundWorkflow at run time, not on macro text.
-    expect(text).toContain("_template.html");
-    expect(text).not.toContain(workflow.path); // no {{workflow.path}} substitution baked in
+    expect(text).toContain("/Users/demo/acme-app/.sapiom/canvas/index.html"); // {{canvas.path}} substituted
+    expect(text).toContain("Clone .sapiom/canvas/_template.html to .sapiom/canvas/index.html");
+    expect(text).toContain("canvas-patterns");
+    expect(deps.renderCanvas).not.toHaveBeenCalled();
   });
 
   it("409s with a UI-visible reason when the session isn't ready yet (SessionNotReadyError) — never silently swallows the macro", async () => {

--- a/packages/harness/src/server/macros.ts
+++ b/packages/harness/src/server/macros.ts
@@ -27,6 +27,10 @@ export interface MacrosRouterDeps {
   injectInput(harnessSessionId: string, text: string, submit: boolean): Promise<void>;
   /** Opens a URL in the user's default browser (the `open` package). */
   openUrl(url: string): Promise<void>;
+  /** Runs the deterministic canvas render for a session (the "visualize"
+   *  macro's `render-canvas` action) — never throws (core/canvas-render.ts's
+   *  contract), so this has no error path of its own to report. */
+  renderCanvas(harnessSessionId: string): Promise<void>;
 }
 
 export function createMacrosRouter(deps: MacrosRouterDeps): ExpressRouter {
@@ -69,6 +73,8 @@ export function createMacrosRouter(deps: MacrosRouterDeps): ExpressRouter {
 
       if (resolved.kind === "open-url") {
         await deps.openUrl(resolved.url);
+      } else if (resolved.kind === "render-canvas") {
+        await deps.renderCanvas(body.harnessSessionId);
       } else {
         await deps.injectInput(body.harnessSessionId, resolved.text, resolved.submit);
       }

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -224,7 +224,7 @@ describe("createRestRouter", () => {
   });
 
   describe("POST /sessions", () => {
-    it("calls onSessionCreated with the new session's cwd", async () => {
+    it("calls onSessionCreated with the new session's cwd and id", async () => {
       const onSessionCreated = vi.fn();
       const sessionManager = fakeSessionManager();
       (sessionManager.create as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -242,7 +242,7 @@ describe("createRestRouter", () => {
       });
 
       expect(res.status).toBe(201);
-      expect(onSessionCreated).toHaveBeenCalledWith("/tmp/proj");
+      expect(onSessionCreated).toHaveBeenCalledWith("/tmp/proj", "sess-1");
     });
 
     it("does not call onSessionCreated when the request body is invalid", async () => {

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -62,13 +62,21 @@ export interface RestRouterOptions {
    *  successful bind/unbind. Never throws — a write failure is logged by the
    *  implementation, not surfaced as a request error. */
   writeWorkspaceContext: (session: HarnessSession) => Promise<void>;
+  /** Re-renders the session's canvas (its bound workflow, or the workspace
+   *  overview when unbound) via the deterministic pipeline — called after a
+   *  successful bind/unbind so the pane reflects the new selection without
+   *  waiting on the agent to run the Visualize macro itself. Never throws
+   *  (core/canvas-render.ts's contract); defaults to a no-op for tests that
+   *  don't care about canvas output. */
+  renderCanvas?: (session: HarnessSession) => Promise<void>;
   /** Called after a settings PATCH persists a changed telemetryOptIn, so the
    * live collector batcher can be gated without a server restart. */
   onTelemetryOptInChange?: (optIn: boolean) => void;
-  /** Called (fire-and-forget) after a session is created, with its cwd — lets
-   * the integrator scan that directory for workflows so opening a session in
-   * a new project discovers them without a manual "+ Connect". */
-  onSessionCreated?: (cwd: string) => void;
+  /** Called (fire-and-forget) after a session is created, with its cwd and id
+   * — lets the integrator scan that directory for workflows (so opening a
+   * session in a new project discovers them without a manual "+ Connect")
+   * and, when the scan discovers one, render the new session's canvas. */
+  onSessionCreated?: (cwd: string, harnessSessionId: string) => void;
   /** The directory the CLI was launched against — surfaced in AppState so the
    * SPA can prefill the new-session modal with it. */
   launchDir: string;
@@ -147,7 +155,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       // this REST route — see SessionManager.create().
       const session = await sessionManager.create(parsed.data);
       res.status(201).json(session);
-      options.onSessionCreated?.(parsed.data.cwd);
+      options.onSessionCreated?.(parsed.data.cwd, session.id);
     } catch (err) {
       next(err);
     }
@@ -179,6 +187,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       // `session` here already reflects the new boundWorkflowPath — the
       // callee resolves it against the live registry itself.
       await options.writeWorkspaceContext(session);
+      await (options.renderCanvas ?? (async () => {}))(session);
       res.json(sessionManager.get(req.params.id));
     } catch (err) {
       next(err);

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -403,10 +403,12 @@ export interface WorkflowInfo {
 // ---------------------------------------------------------------------------
 
 /**
- * A macro either injects text into the active session's pty or opens a URL.
- * Template placeholders, substituted server-side before execution:
+ * A macro injects text into the active session's pty, opens a URL, or (the
+ * one exception to "always goes through the agent's session") runs the
+ * deterministic canvas render server-side. Template placeholders, substituted
+ * server-side before "inject"/"open-url" execution:
  *   {{workflow.path}} {{workflow.name}} {{workflow.definitionId}}
- *   {{session.cwd}}   {{canvas.path}}   {{subject}}   (Visualize free-text)
+ *   {{session.cwd}}   {{canvas.path}}   {{subject}}   (ai-visualize free-text)
  */
 export interface MacroDef {
   id: string;
@@ -415,7 +417,11 @@ export interface MacroDef {
   icon: string;
   action:
     | { kind: "inject"; text: string; submit?: boolean }
-    | { kind: "open-url"; url: string };
+    | { kind: "open-url"; url: string }
+    /** Zero-LLM, instant: runs core/canvas-render.ts against the session's
+     *  bound workflow (or the workspace overview when unbound) and writes
+     *  .sapiom/canvas/index.html directly — no prompt, no pty involved. */
+    | { kind: "render-canvas" };
   /** Macro requires a selected workflow to be enabled. */
   requiresWorkflow?: boolean;
 }

--- a/packages/harness/tsconfig.build.json
+++ b/packages/harness/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "web", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "web", "src/**/*.test.ts", "src/**/__fixtures__/**"]
 }

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -8,5 +8,10 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "web"]
+  // __fixtures__ trees are bundled independently by esbuild inside
+  // core/canvas-graph.ts's `check()` call (its own module resolution root) —
+  // some are deliberately broken (unresolvable import, no defineAgent
+  // export) to exercise the extractor's degradation paths, so they must
+  // never be type-checked as part of the harness's own source tree.
+  "exclude": ["node_modules", "dist", "web", "src/**/__fixtures__/**"]
 }

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -450,7 +450,9 @@ test.describe("docked workflow action strip", () => {
     }).toPass({ timeout: 1000 });
     await expect(page.locator(".strip-item-label").first()).toBeVisible();
     await expect(strip.getByText("Run local")).toBeVisible();
-    await expect(strip.getByText("Visualize")).toBeVisible();
+    // getByText("Visualize") would also match "AI Visualize" — use the
+    // macro's own test id to target the deterministic-render macro exactly.
+    await expect(strip.getByTestId("macro-visualize")).toBeVisible();
 
     await page.screenshot({ path: "web/e2e/screenshots/strip-hover-expanded.png", fullPage: true });
   });

--- a/packages/harness/web/src/lib/macro-gating.ts
+++ b/packages/harness/web/src/lib/macro-gating.ts
@@ -21,7 +21,9 @@ export function macroDisabledReason(
       return "Not deployed yet";
     }
   }
-  if (macro.action.kind === "inject" && !activeSessionId) return "Start a session first";
+  // Both "inject" (types into the pty) and "render-canvas" (the deterministic
+  // Visualize path) need a real session to act against — only "open-url" doesn't.
+  if (macro.action.kind !== "open-url" && !activeSessionId) return "Start a session first";
   return null;
 }
 

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -169,11 +169,19 @@ export const MOCK_MACROS: MacroDef[] = [
     requiresWorkflow: true,
   },
   {
-    // One-click render/re-render of the bound workflow — no free-text subject,
-    // matches the real DEFAULT_MACROS contract (src/core/macros.ts).
+    // One-click, unbound-friendly deterministic render — no LLM, no pty
+    // involved. Matches the real DEFAULT_MACROS contract (src/core/macros.ts).
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
+    action: { kind: "render-canvas" },
+    requiresWorkflow: false,
+  },
+  {
+    // The LLM-authored fallback for custom/narrative views.
+    id: "ai-visualize",
+    label: "AI Visualize",
+    icon: "Wand2",
     action: {
       kind: "inject",
       text: "Render (or re-render, overwriting {{canvas.path}}) a visualization of the workflow at {{workflow.path}} — its steps, control flow, and how it interconnects with the other workflows in this workspace.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
 
   packages/harness:
     dependencies:
+      '@sapiom/agent':
+        specifier: workspace:^
+        version: link:../agent
       '@sapiom/agent-core':
         specifier: workspace:^
         version: link:../agent-core


### PR DESCRIPTION
## Summary

The one-click **Visualize** macro used to prompt-inject the LLM to hand-write an SVG diagram every time (~2 minutes, hijacked the user's session, and always risked drifting from the style contract). This replaces the default path with a deterministic, server-side pipeline:

- **Extraction**: `core/canvas-graph.ts` runs `@sapiom/agent-core`'s `check()` (bundle → manifest → graph-validate — the same pipeline `sapiom agents check` uses) against the bound workflow's project directory, in an **isolated child process** (`core/canvas-manifest-check.ts`). Two independent reasons for the subprocess, not just an in-process call: (1) it bounds the blast radius of a malformed/hostile workflow project's top-level code from the long-lived harness server, and (2) it sidesteps a real Vite/Vitest limitation — `check()`'s own `import(\`file://${tmp}\`)` gets mangled by Vite's SSR dynamic-import-vars transform when called in-process from a Vitest-run module graph.
- **Layout + SVG**: `core/canvas-svg.ts` ports the longest-path layering algorithm from an earlier client-side renderer (see git history of `canvas-template.ts`, commit "canvas kit — LLM writes data, not HTML") to run server-side, emitting markup against the *existing* CSS classes (`node--entry/step/pause/terminal-success/terminal-warn`, `canvas-edge--success/--warn/--cross`) untouched.
- **Interconnections**: `core/canvas-interconnections.ts` greps every workflow's sources for `orchestrations.launch({ definition: "..." })` and resolves the slug against the other workflows' manifest names — a heuristic, not a type-aware analysis, by design.
- **Wiring**: new `POST /api/canvas/:sessionId/render`; auto-render on `PATCH /api/sessions/:id/workflow` (bind) and on session create when a workflow is discoverable in that directory. Writing straight to `.sapiom/canvas/index.html` is enough — `CanvasWatcherManager` already treats any change under `.sapiom/canvas/` as a reload signal, so no new broadcast plumbing was needed.
- **Macro split**: `visualize` now runs the deterministic render (`{ kind: "render-canvas" }`, no LLM at all); the old prompt-injection path is preserved as a separate `ai-visualize` macro for custom/narrative views.
- **Degradation**: extraction never crashes. A missing `node_modules`, a bundle failure, or an invalid graph renders an honest per-workflow error card (styled through the same shell) instead — never a silent fallback to the LLM path.

## Extraction API used

`@sapiom/agent-core`'s `check({ sourceDir })` → `{ name, stepCount, warnings, manifest }`, where `manifest.steps[name].transitions` is the tagged edge list (`continue|terminate|fail|pause`) `buildManifest`/`assertValidGraph` (from `@sapiom/agent`) already derive and validate. `core/canvas-graph.ts` reshapes that directly into nodes/edges — no new graph-derivation logic duplicated from the SDK.

## Live verification evidence

Ran extraction against all 7 real `@sapiom/agent`-marked projects under `~/sapiom/hackathon-local`. All 7 currently import from **`@sapiom/orchestration`** (the pre-`0.5.0`-rename package name/API — `defineOrchestration` etc.), which predates this repo's `defineAgent`/`@sapiom/agent` rename, so `check()` correctly reports "no agent was exported" for all of them — a real, pre-existing SDK-version gap in this dev branch's fixtures, not a bug in this PR. To prove the happy path against real, non-synthetic workflow code, I took an unmodified copy of `hackathon-local`'s `leasing-triage` (a real 3-step LLM-classification → resolve → respond flow) and mechanically renamed it to the current SDK per the `0.5.0` changelog (`defineOrchestration`→`defineAgent`, package name, context type) — no step logic touched.

- `single-success-{light,dark}.png` — the migrated `leasing-triage`'s real steps (`classify` entry, `resolve`, `respond` terminal-success), correct glow/colors in both themes.
- `single-degraded-{light,dark}.png` — an unmodified real `hackathon-local` workflow (`tenant-screening`, still on `@sapiom/orchestration`) renders a clean "render failed" card with the real reason, no crash.
- `overview-{light,dark}.png` — a 3-workflow workspace overview (1 migrated success + 2 real degraded) — proves per-panel degradation doesn't take down the other panels, **and** the interconnection grep found real `leasing-triage → applicant-lifecycle` and `applicant-lifecycle → tenant-screening` launch references straight out of the actual (unmigrated) source, independent of whether extraction of those workflows' own graphs succeeded.

(Screenshots available on request — captured via `playwright screenshot` against the rendered `index.html` files, `?theme=light|dark`.)

Also extended `scripts/e2e-live.ts` (`pnpm e2e:live`) with a real end-to-end phase: connect a real `@sapiom/agent` project (copied from the new `order-triage` test fixture, `@sapiom/agent` resolved via a scoped `node_modules/@sapiom` symlink) → bind → `POST /api/canvas/:id/render` → asserts `index.html` contains the real step names and a `canvas.reload` frame was observed.

## Test plan
- [x] `pnpm --filter @sapiom/harness test` — 405 passed (0 failed), including new suites: `canvas-graph.test.ts`, `canvas-svg.test.ts`, `canvas-body` (via render tests), `canvas-interconnections.test.ts`, `canvas-render.test.ts`, `server/canvas-render.test.ts`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness build`
- [x] `pnpm --filter @sapiom/harness e2e:live` — full live proof including the new deterministic-render phase
- [x] `pnpm --filter @sapiom/harness test:canvas` (Playwright, canvas template shell) — 5 passed
- [x] `pnpm --filter @sapiom/harness test:ui` (Playwright, SPA smoke) — 44 passed (one pre-existing assertion updated: `getByText("Visualize")` was ambiguous against the new "AI Visualize" label, switched to `getByTestId("macro-visualize")`)
- [x] Live extraction + render verified against all 7 real `hackathon-local` workflow projects (see evidence above)

## Decisions / things worth flagging
- **`shared/types.ts` was modified** (per team convention, flagging explicitly): added the `{ kind: "render-canvas" }` macro action variant. Everything else in that file is unchanged.
- **Node classification is structural, not semantic**: a step that only ever calls `terminate()` renders as `terminal-success` regardless of what its payload says (e.g., `terminate({ escalated: true })` still reads as success) — the extractor only reads the manifest's declared transition *kind* (`terminate` vs `fail`), never a runtime payload. Documented in `canvas-graph.ts` and covered by a test.
- **Subprocess isolation for `check()`**: not just a test workaround — running arbitrary workflow project code (via `check()`'s dynamic `import()` of an esbuild bundle) in-process inside the long-lived harness server risked a hostile/broken workflow taking the whole server down. Now bounded to a 15s-ceiling child process per extraction.
- **Interconnection matching key**: cross-workflow edges match on the manifest's own `name` (what `defineAgent({ name })` sets, and what `orchestrations.launch({ definition })` targets), not `WorkflowInfo.name` (which can be the package.json name or directory basename) — these can differ.
- Left `MOCK_MACROS` (web/src/lib/mock-data.ts) in sync with the real `DEFAULT_MACROS` shape while touching that file for `macro-gating.ts`'s fix (see below) — was already drifted before this PR per an earlier commit's own "known follow-up" note.
- Small `web/src/lib/macro-gating.ts` fix: the "Start a session first" disabled-reason only checked `action.kind === "inject"`, which silently missed the new `"render-canvas"` kind (the button would look enabled but no-op). Extended the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)