### PR TITLE
fix(harness): stop codex sessions from prompting for command approval

### DIFF
--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -25,14 +25,21 @@ function userMessageLine(message: string): string {
 
 describe("CodexAdapter", () => {
   describe("launch/resume", () => {
-    it("builds a launch SpawnSpec disabling the update check and no env overrides", () => {
+    it("builds a launch SpawnSpec with update check off, never-ask approvals, workspace-write sandbox, and no env overrides", () => {
       const adapter = new CodexAdapter({ binary: "fake-codex" });
       const spec = adapter.launch({ harnessSessionId: "h1", cwd: "/tmp/proj" });
 
       expect(spec.command).toBe("fake-codex");
       expect(spec.cwd).toBe("/tmp/proj");
       expect(spec.env).toEqual({});
-      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
+      expect(spec.args).toEqual([
+        "-c",
+        "check_for_update_on_startup=false",
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="workspace-write"',
+      ]);
     });
 
     it("embeds the systemPromptFile's content inline via -c developer_instructions=<value>", async () => {
@@ -54,6 +61,10 @@ describe("CodexAdapter", () => {
         "-c",
         "check_for_update_on_startup=false",
         "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="workspace-write"',
+        "-c",
         `developer_instructions=${JSON.stringify("You are a Sapiom workflow builder.\nBe concise.")}`,
       ]);
 
@@ -68,7 +79,14 @@ describe("CodexAdapter", () => {
         systemPromptFile: "/does/not/exist/prompt.txt",
       });
 
-      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
+      expect(spec.args).toEqual([
+        "-c",
+        "check_for_update_on_startup=false",
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="workspace-write"',
+      ]);
     });
 
     it("builds a resume SpawnSpec with `resume <rolloutId>` as the leading args", () => {
@@ -84,6 +102,10 @@ describe("CodexAdapter", () => {
         "019e62d5-a020-75f1-b5e8-253383076f83",
         "-c",
         "check_for_update_on_startup=false",
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="workspace-write"',
       ]);
       expect(spec.env).toEqual({});
     });
@@ -96,7 +118,14 @@ describe("CodexAdapter", () => {
         mcpConfigFile: "/tmp/proj/.sapiom/mcp.json",
         settingsFile: "/tmp/proj/.sapiom/settings.json",
       });
-      expect(spec.args).toEqual(["-c", "check_for_update_on_startup=false"]);
+      expect(spec.args).toEqual([
+        "-c",
+        "check_for_update_on_startup=false",
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="workspace-write"',
+      ]);
     });
   });
 

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -317,7 +317,25 @@ export class CodexAdapter implements HarnessAdapter {
  * process on startup.
  */
 function buildConfigArgs(opts: LaunchOpts): string[] {
-  const args = ["-c", "check_for_update_on_startup=false"];
+  const args = [
+    "-c",
+    "check_for_update_on_startup=false",
+    // Codex's default approval policy interrupts the session with "Would you
+    // like to run the following command?" prompts (even for read-only
+    // commands like `ps`). Harness sessions are expected to run without
+    // approval interruptions — the analog of Claude Code sessions, which the
+    // harness runs in auto mode — so pin codex's non-interactive pairing:
+    // never ask for approval, and confine writes to the workspace via the OS
+    // sandbox instead of via per-command human review. Both keys and their
+    // values confirmed against a locally installed codex-cli 0.134.0 (its
+    // config deserializer enumerates `never` / `workspace-write` among the
+    // accepted variants when probed with a bogus value). `-c` values parse
+    // as TOML, so the string values need the embedded quotes.
+    "-c",
+    'approval_policy="never"',
+    "-c",
+    'sandbox_mode="workspace-write"',
+  ];
   if (opts.systemPromptFile) {
     try {
       const prompt = readFileSync(opts.systemPromptFile, "utf8");


### PR DESCRIPTION
## Problem

Codex sessions launched by `@sapiom/harness` interrupt with "Would you like to run the following command?" approval prompts — even for plain read-only commands like `ps`. Claude Code sessions don't interrupt this way, and codex sessions are meant to match.

Root cause: `buildConfigArgs()` in the codex adapter only passed `-c check_for_update_on_startup=false` (plus the injected system prompt), so codex fell back to its default approval policy, which asks.

## Fix

Add two config overrides to `buildConfigArgs()`, which both the launch and resume paths share:

- `-c approval_policy="never"` — never pause for human approval; execution failures return to the model.
- `-c sandbox_mode="workspace-write"` — writes stay confined to the workspace by the OS sandbox, which is what makes never-ask safe. This is codex's analog of the mode Claude sessions run in.

Both key names and values were verified against a locally installed `codex-cli 0.134.0`: probing each key with a bogus value under `--strict-config` makes codex's config deserializer enumerate the accepted variants (`never`, `workspace-write` among them), and a real spawn with the exact arg vector the adapter builds passes strict-config validation cleanly. `-c` values parse as TOML, hence the embedded quotes on the string values.

No new setting is introduced — the harness has no permission-mode knob for Claude sessions either, so this defaults on unconditionally, keeping the two adapters symmetric.

## Testing

- `pnpm --filter @sapiom/harness typecheck` — clean
- `pnpm --filter @sapiom/harness test` — 363 passed, including the updated arg-array assertions for launch, resume, prompt-embedding, unreadable-prompt fallback, and ignored settings/mcp files
- `pnpm --filter @sapiom/harness e2e:live` — all 3 phases pass, including the codex-adapter boot-session phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5pNLPugYuPfWCBEJVQhim