### PR TITLE
fix(harness): opaque background for hover-expanded action strip

### DIFF
--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -454,6 +454,13 @@ test.describe("docked workflow action strip", () => {
     // macro's own test id to target the deterministic-render macro exactly.
     await expect(strip.getByTestId("macro-visualize")).toBeVisible();
 
+    // Expanded, the panel floats directly over the terminal — its
+    // background must be fully opaque (`rgb(...)`, no alpha channel), not
+    // the translucent `--accent-dim` it used to render with, which let the
+    // terminal's own text bleed through and read as broken.
+    const backgroundColor = await strip.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(backgroundColor).toMatch(/^rgb\(/);
+
     await page.screenshot({ path: "web/e2e/screenshots/strip-hover-expanded.png", fullPage: true });
   });
 

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -350,28 +350,36 @@ input {
 /* Icon-only at rest; hovering it OR focusing anything inside it
    (:focus-within — keyboard tabbing gets the same reveal a mouse hover
    does) expands it into a floating icon+label panel over the terminal.
-   Full labels without permanently costing the terminal any width. */
+   Full labels without permanently costing the terminal any width.
+   Background is a fully opaque surface color (not --accent-dim, which is
+   translucent) — expanded, this panel floats directly over the terminal,
+   and a translucent fill let terminal text bleed through it. */
 .workflow-action-strip {
   position: absolute;
   left: 3px;
   width: 26px;
-  z-index: 5;
+  z-index: 10;
   display: flex;
   flex-direction: column;
   gap: 2px;
   padding: 4px 3px;
-  background: var(--accent-dim);
+  background: var(--bg-2);
   border: 1px solid var(--border-strong);
   border-left: none;
   border-radius: 0 8px 8px 8px;
   transition:
     top 0.15s ease,
-    width 0.15s ease;
+    width 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .workflow-action-strip:hover,
 .workflow-action-strip:focus-within {
   width: 200px;
+  /* Only while expanded over the terminal does it need to read as
+     floating above it — flush against the rail column at rest, no
+     shadow is needed there. */
+  box-shadow: var(--shadow-lg);
 }
 
 .strip-item {


### PR DESCRIPTION
## Summary

The hover-expanded workflow action strip floats over the terminal with an absolutely-positioned panel. Its background was `--accent-dim`, a translucent accent tint, so once expanded over the terminal the terminal's own text bled through it and it read as broken.

This is the minimal fix (superseding an earlier, over-scoped rebuild attempt into a persistent column — closed as #231): keep the existing icon-only-at-rest / hover-and-`:focus-within`-expands behavior exactly as-is, just make the expanded surface actually opaque.

## What changed

- `.workflow-action-strip`'s `background` is now `var(--bg-2)` (a solid, fully-opaque surface color already used elsewhere for panel surfaces, in both themes) instead of `var(--accent-dim)`.
- Added `box-shadow: var(--shadow-lg)` while expanded (hover/`:focus-within`) so it reads as floating above the terminal, matching the elevation treatment other floating surfaces in the app already use.
- Bumped `z-index` from 5 to 10 for a clearer, more intentional stacking order above the terminal.
- No structural changes — same component, same DOM, same testids, same gating logic, same collapsed/expanded widths and transitions.

## Playwright

Added an assertion to the existing hover-expand test that the expanded panel's computed `background-color` is a fully opaque `rgb(...)` (not a `rgba(...)` with an alpha channel), which is what was silently broken before.

## Test plan

- [x] `tsc --noEmit` (web) — green
- [x] `pnpm --filter @sapiom/harness build` — green
- [x] `pnpm --filter @sapiom/harness test` — 405 passed
- [x] `pnpm --filter @sapiom/harness test:ui` — 44 passed
- [x] Verified locally in both light and dark themes: the expanded panel is now a solid surface with a visible drop shadow, and the "Connecting…" terminal text underneath it no longer shows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)