### PR TITLE
fix(harness): retention policy for generated per-session config dirs

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -198,6 +198,7 @@ async function testCoreFlow(): Promise<void> {
       codex: createCodexAdapter(),
     },
     sessionsPath: path.join(tmpRoot, "sessions.json"),
+    generatedRoot: path.join(tmpRoot, "generated"),
     eventStorePath,
     workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
     launchDir: projectDir,
@@ -635,6 +636,7 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
       codex: createCodexAdapter(),
     },
     sessionsPath: path.join(tmpRoot, "sessions.json"),
+    generatedRoot: path.join(tmpRoot, "generated"),
     eventStorePath: path.join(tmpRoot, "events.ndjson"),
     workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
     launchDir: projectDir,
@@ -762,6 +764,7 @@ async function testAutoSessionKindSelection(): Promise<void> {
     // passing for the wrong reason.
     adapters: { codex: createCodexAdapter({ binary: FAKE_CLAUDE }) },
     sessionsPath: path.join(tmpRoot, "sessions.json"),
+    generatedRoot: path.join(tmpRoot, "generated"),
     eventStorePath: path.join(tmpRoot, "events.ndjson"),
     workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
     launchDir: projectDir,

--- a/packages/harness/src/core/inject/mcp-config.ts
+++ b/packages/harness/src/core/inject/mcp-config.ts
@@ -16,6 +16,9 @@ export interface McpConfigOptions {
    * then 401s, same as today.
    */
   apiKey?: string | null;
+  /** Root directory generated configs live under. Defaults to
+   *  HARNESS_PATHS.generated. Override in tests to avoid the real home dir. */
+  generatedRoot?: string;
 }
 
 /**
@@ -29,7 +32,7 @@ export async function generateMcpConfig(
   harnessSessionId: string,
   options: McpConfigOptions = {},
 ): Promise<string> {
-  const dir = path.join(expandHome(HARNESS_PATHS.generated), harnessSessionId);
+  const dir = path.join(expandHome(options.generatedRoot ?? HARNESS_PATHS.generated), harnessSessionId);
   await fs.mkdir(dir, { recursive: true });
 
   const sapiomEnvironment = options.environment ?? process.env.SAPIOM_ENVIRONMENT;

--- a/packages/harness/src/core/inject/retention.test.ts
+++ b/packages/harness/src/core/inject/retention.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { access, mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  GENERATED_SWEEP_MAX_AGE_MS,
+  removeGeneratedSessionDir,
+  sweepGeneratedDirs,
+} from "./retention.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("generated-dir retention", () => {
+  let tmp: string;
+  let root: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "harness-retention-"));
+    // The safety guard requires the root's final segment to be "generated".
+    root = join(tmp, "generated");
+    await mkdir(root);
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  /** Creates root/<name>/settings.json, optionally backdating the dir's mtime. */
+  async function seedSessionDir(name: string, ageMs = 0): Promise<string> {
+    const dir = join(root, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "settings.json"), "{}\n");
+    if (ageMs > 0) {
+      const then = new Date(Date.now() - ageMs);
+      await utimes(dir, then, then);
+    }
+    return dir;
+  }
+
+  describe("removeGeneratedSessionDir", () => {
+    it("removes the session's dir and its contents", async () => {
+      const dir = await seedSessionDir("session-1");
+      await expect(removeGeneratedSessionDir("session-1", { generatedRoot: root })).resolves.toBe(true);
+      await expect(exists(dir)).resolves.toBe(false);
+      // The root itself is untouched.
+      await expect(exists(root)).resolves.toBe(true);
+    });
+
+    it("is a no-op for a dir that doesn't exist", async () => {
+      await expect(removeGeneratedSessionDir("never-created", { generatedRoot: root })).resolves.toBe(false);
+    });
+
+    it("never deletes outside the root for escaping or malformed ids", async () => {
+      const victim = join(tmp, "victim");
+      await mkdir(victim);
+      await writeFile(join(victim, "keep.txt"), "keep");
+      for (const id of ["..", ".", "", "../victim", "a/../../victim", "nested/dir", "/", tmp]) {
+        await expect(removeGeneratedSessionDir(id, { generatedRoot: root })).resolves.toBe(false);
+      }
+      await expect(exists(join(victim, "keep.txt"))).resolves.toBe(true);
+    });
+
+    it("refuses to operate under a root that doesn't look like a generated dir", async () => {
+      // tmp's final segment isn't "generated" — a misconfigured base path
+      // must fail loudly instead of recursively deleting under it.
+      await expect(removeGeneratedSessionDir("session-1", { generatedRoot: tmp })).rejects.toThrow(
+        /suspicious generated root/,
+      );
+      await expect(removeGeneratedSessionDir("session-1", { generatedRoot: "/" })).rejects.toThrow(
+        /suspicious generated root/,
+      );
+    });
+
+    it("skips a symlinked entry instead of following it", async () => {
+      const target = join(tmp, "target");
+      await mkdir(target);
+      await writeFile(join(target, "keep.txt"), "keep");
+      await symlink(target, join(root, "linked-session"));
+      await expect(removeGeneratedSessionDir("linked-session", { generatedRoot: root })).resolves.toBe(false);
+      await expect(exists(join(target, "keep.txt"))).resolves.toBe(true);
+      await expect(exists(join(root, "linked-session"))).resolves.toBe(true);
+    });
+  });
+
+  describe("sweepGeneratedDirs", () => {
+    it("removes stale dirs and keeps fresh ones", async () => {
+      const stale = await seedSessionDir("stale-session", 8 * DAY_MS);
+      const fresh = await seedSessionDir("fresh-session");
+      const removed = await sweepGeneratedDirs({ generatedRoot: root });
+      expect(removed).toEqual(["stale-session"]);
+      await expect(exists(stale)).resolves.toBe(false);
+      await expect(exists(fresh)).resolves.toBe(true);
+    });
+
+    it("keeps a live session's dir regardless of age", async () => {
+      const live = await seedSessionDir("live-session", 30 * DAY_MS);
+      const dead = await seedSessionDir("dead-session", 30 * DAY_MS);
+      const removed = await sweepGeneratedDirs({
+        generatedRoot: root,
+        isLiveSession: (id) => id === "live-session",
+      });
+      expect(removed).toEqual(["dead-session"]);
+      await expect(exists(live)).resolves.toBe(true);
+      await expect(exists(dead)).resolves.toBe(false);
+    });
+
+    it("respects a custom maxAgeMs", async () => {
+      const older = await seedSessionDir("older", 10_000);
+      const newer = await seedSessionDir("newer", 1_000);
+      const removed = await sweepGeneratedDirs({ generatedRoot: root, maxAgeMs: 5_000 });
+      expect(removed).toEqual(["older"]);
+      await expect(exists(older)).resolves.toBe(false);
+      await expect(exists(newer)).resolves.toBe(true);
+    });
+
+    it("defaults to a 7-day threshold", () => {
+      expect(GENERATED_SWEEP_MAX_AGE_MS).toBe(7 * DAY_MS);
+    });
+
+    it("leaves stray files and symlinked dirs alone (never follows a symlink)", async () => {
+      const strayFile = join(root, "stray.txt");
+      await writeFile(strayFile, "stray");
+      const then = new Date(Date.now() - 30 * DAY_MS);
+      await utimes(strayFile, then, then);
+
+      const target = join(tmp, "target");
+      await mkdir(target);
+      await writeFile(join(target, "keep.txt"), "keep");
+      const link = join(root, "linked-session");
+      await symlink(target, link);
+
+      const removed = await sweepGeneratedDirs({ generatedRoot: root, maxAgeMs: 0 });
+      expect(removed).toEqual([]);
+      await expect(exists(strayFile)).resolves.toBe(true);
+      await expect(exists(link)).resolves.toBe(true);
+      await expect(exists(join(target, "keep.txt"))).resolves.toBe(true);
+    });
+
+    it("returns empty when the root doesn't exist yet", async () => {
+      await expect(sweepGeneratedDirs({ generatedRoot: join(tmp, "nope", "generated") })).resolves.toEqual([]);
+    });
+
+    it("refuses a suspicious root", async () => {
+      await expect(sweepGeneratedDirs({ generatedRoot: tmp })).rejects.toThrow(/suspicious generated root/);
+    });
+  });
+});

--- a/packages/harness/src/core/inject/retention.ts
+++ b/packages/harness/src/core/inject/retention.ts
@@ -1,0 +1,147 @@
+/**
+ * Retention policy for the per-session generated config dirs
+ * (`~/.sapiom/harness/generated/<harnessSessionId>/` — settings.json,
+ * emit.cjs, mcp-config.json, system-prompt.txt). Without it every session
+ * launch leaves a dir behind forever (real installs accumulate thousands).
+ *
+ * Lifecycle facts the policy rests on (see the generators in this directory
+ * and server/index.ts's createDefaultBuildLaunchOpts):
+ * - Most files are consumed at launch — `--settings`/`--mcp-config` are
+ *   parsed by the agent at startup, system-prompt.txt is inlined into argv
+ *   before spawn — EXCEPT emit.cjs, which the agent re-executes as a child
+ *   process on every hook event. A session's dir must therefore survive for
+ *   as long as its pty runs.
+ * - buildLaunchOpts regenerates every file on BOTH create() and resume(),
+ *   so nothing in the dir is needed once the session has exited: deleting
+ *   at exit can never break a later resume.
+ *
+ * Two mechanisms:
+ * - removeGeneratedSessionDir(): per-session delete, wired to the session's
+ *   "exited" status transition.
+ * - sweepGeneratedDirs(): boot-time sweep for dirs the exit-time delete
+ *   never reached (crashes, force-kills, pre-retention accumulation) —
+ *   age-gated so anything plausibly still in use is left alone.
+ *
+ * Safety: deletion only ever targets a plain directory that is a direct
+ * child of a root that itself looks like a dedicated generated-config dir
+ * (resolveGeneratedRoot / childDirPath). Symlinked entries are never
+ * followed and never deleted.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { HARNESS_PATHS } from "../../shared/types.js";
+import { expandHome } from "../paths.js";
+
+/** Sweep threshold: a non-live dir must be at least this stale (mtime) to be
+ *  removed. Generous — the only cost of keeping a dead dir is disk clutter,
+ *  while a false positive on some unforeseen liveness signal is worse. */
+export const GENERATED_SWEEP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface GeneratedRetentionOptions {
+  /** Root directory generated configs live under. Defaults to
+   *  HARNESS_PATHS.generated. Override in tests to avoid the real home dir. */
+  generatedRoot?: string;
+}
+
+export interface SweepGeneratedDirsOptions extends GeneratedRetentionOptions {
+  /** Dirs named after a live session id are never removed, whatever their
+   *  age. Defaults to treating nothing as live. */
+  isLiveSession?: (harnessSessionId: string) => boolean;
+  /** Minimum staleness before a dir is swept. Defaults to
+   *  GENERATED_SWEEP_MAX_AGE_MS. */
+  maxAgeMs?: number;
+  /** Injectable clock (epoch ms) for tests. */
+  now?: () => number;
+}
+
+/**
+ * A recursive delete under a misconfigured root would be catastrophic
+ * (imagine generatedRoot resolving to the home dir, or "/"). The generators
+ * will happily *write* wherever they're pointed, but deletion demands the
+ * root at least look like a dedicated generated-config directory: a
+ * non-root absolute path whose final segment is "generated".
+ */
+function resolveGeneratedRoot(generatedRoot?: string): string {
+  const root = expandHome(generatedRoot ?? HARNESS_PATHS.generated);
+  if (!path.isAbsolute(root) || path.basename(root) !== "generated" || path.dirname(root) === root) {
+    throw new Error(`refusing to delete under suspicious generated root "${root}"`);
+  }
+  return root;
+}
+
+/**
+ * The absolute path of `name` as a direct child of `root`, or null when
+ * `name` is anything other than one plain path segment — separators, "..",
+ * absolute paths, or anything else that could resolve outside the root.
+ */
+function childDirPath(root: string, name: string): string | null {
+  if (!name || name === "." || name === "..") return null;
+  const resolved = path.resolve(root, name);
+  if (path.dirname(resolved) !== root || path.basename(resolved) !== name) return null;
+  return resolved;
+}
+
+/**
+ * Deletes one session's generated dir. Only call once the session's pty has
+ * exited — the agent re-executes emit.cjs from this dir on every hook event
+ * while it runs. Returns true if a directory was removed; a missing entry,
+ * an escaping/malformed id, or a symlink (never followed) is false.
+ */
+export async function removeGeneratedSessionDir(
+  harnessSessionId: string,
+  options: GeneratedRetentionOptions = {},
+): Promise<boolean> {
+  const root = resolveGeneratedRoot(options.generatedRoot);
+  const dir = childDirPath(root, harnessSessionId);
+  if (!dir) return false;
+  const stats = await fs.lstat(dir).catch(() => null);
+  if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) return false;
+  await fs.rm(dir, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * Removes every generated dir that (a) isn't a live session's and (b) has
+ * been stale for at least `maxAgeMs`. Covers everything the exit-time
+ * delete can't: sessions that crashed with the harness, force-killed
+ * processes, and accumulation from before retention existed. Only plain
+ * directories are candidates — symlinks and stray files are left untouched.
+ * Best-effort per entry: one undeletable dir doesn't abort the rest.
+ * Returns the names of the dirs it removed.
+ */
+export async function sweepGeneratedDirs(options: SweepGeneratedDirsOptions = {}): Promise<string[]> {
+  const root = resolveGeneratedRoot(options.generatedRoot);
+  const maxAgeMs = options.maxAgeMs ?? GENERATED_SWEEP_MAX_AGE_MS;
+  const now = options.now ? options.now() : Date.now();
+
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const removed: string[] = [];
+  for (const entry of entries) {
+    // Dirent types come from lstat semantics: a symlink to a directory is
+    // isSymbolicLink(), not isDirectory() — so this both skips symlinks and
+    // guarantees rm below never follows one out of the root.
+    if (!entry.isDirectory()) continue;
+    const dir = childDirPath(root, entry.name);
+    if (!dir) continue;
+    if (options.isLiveSession?.(entry.name)) continue;
+    const stats = await fs.lstat(dir).catch(() => null);
+    if (!stats || !stats.isDirectory()) continue;
+    if (now - stats.mtimeMs < maxAgeMs) continue;
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      removed.push(entry.name);
+    } catch {
+      // Leave it for the next boot's sweep rather than aborting the rest.
+    }
+  }
+  return removed;
+}

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -99,6 +99,7 @@ describe("codex session lifecycle (real files, no mocking)", () => {
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
       sessionsPath: join(dir, "sessions.json"),
+      generatedRoot: join(dir, "generated"),
       eventStorePath,
       workflowsRegistryPath: join(dir, "workflows.json"),
       codexHomeDir,

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -96,6 +96,7 @@ describe("codex tailer lifecycle wiring", () => {
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
       sessionsPath: join(dir, "sessions.json"),
+      generatedRoot: join(dir, "generated"),
       eventStorePath: join(dir, "events.ndjson"),
       workflowsRegistryPath: join(dir, "workflows.json"),
     });
@@ -150,6 +151,7 @@ describe("codex tailer lifecycle wiring", () => {
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
       sessionsPath: join(dir, "sessions.json"),
+      generatedRoot: join(dir, "generated"),
       eventStorePath: join(dir, "events.ndjson"),
       workflowsRegistryPath: join(dir, "workflows.json"),
     });
@@ -201,6 +203,7 @@ describe("codex tailer lifecycle wiring", () => {
         },
       },
       sessionsPath: join(dir, "sessions.json"),
+      generatedRoot: join(dir, "generated"),
       eventStorePath: join(dir, "events.ndjson"),
       workflowsRegistryPath: join(dir, "workflows.json"),
     });
@@ -231,6 +234,7 @@ describe("codex tailer lifecycle wiring", () => {
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
       sessionsPath: join(dir, "sessions.json"),
+      generatedRoot: join(dir, "generated"),
       eventStorePath: join(dir, "events.ndjson"),
       workflowsRegistryPath: join(dir, "workflows.json"),
     });

--- a/packages/harness/src/server/generated-retention.test.ts
+++ b/packages/harness/src/server/generated-retention.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Wiring-level proof of the generated-dir retention policy (see
+ * core/inject/retention.ts for the unit-level tests of the mechanisms
+ * themselves): the boot-time sweep runs when the server starts, and a
+ * session's generated dir — written by the real default buildLaunchOpts —
+ * survives while the pty is alive and is deleted once it exits.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { access, mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer, type HarnessServer } from "./index.js";
+import type { HarnessAdapter, LaunchOpts, SpawnSpec } from "../shared/types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A claude-code-shaped adapter that spawns bash — a real pty we can kill. */
+function fakeClaudeAdapter(): HarnessAdapter {
+  return {
+    id: "claude-code",
+    eventSource: "hooks",
+    doctor: async () => [],
+    launch: (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd }),
+    resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec => ({
+      command: "bash",
+      args: [],
+      env: {},
+      cwd: opts.cwd,
+    }),
+    listPastSessions: async () => [],
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("generated-dir retention wiring", () => {
+  let dir: string;
+  let generatedRoot: string;
+  let cwd: string;
+  let server: HarnessServer | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-retention-wiring-"));
+    generatedRoot = join(dir, "generated");
+    cwd = join(dir, "project");
+    await mkdir(cwd, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    await server?.sessionManager.flush();
+    server = undefined;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function boot(): Promise<HarnessServer> {
+    return startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { "claude-code": fakeClaudeAdapter() },
+      sessionsPath: join(dir, "sessions.json"),
+      eventStorePath: join(dir, "events.ndjson"),
+      workflowsRegistryPath: join(dir, "workflows.json"),
+      generatedRoot,
+    });
+  }
+
+  it("sweeps stale orphaned dirs at boot and keeps fresh ones", async () => {
+    const staleDir = join(generatedRoot, "orphan-from-a-crash");
+    const freshDir = join(generatedRoot, "recent-orphan");
+    await mkdir(staleDir, { recursive: true });
+    await writeFile(join(staleDir, "settings.json"), "{}\n");
+    const then = new Date(Date.now() - 8 * DAY_MS);
+    await utimes(staleDir, then, then);
+    await mkdir(freshDir, { recursive: true });
+
+    server = await boot();
+
+    await vi.waitFor(async () => {
+      expect(await exists(staleDir)).toBe(false);
+    });
+    expect(await exists(freshDir)).toBe(true);
+  });
+
+  it("keeps a running session's dir and deletes it once the session exits", async () => {
+    server = await boot();
+
+    const session = await server.sessionManager.create({ cwd, harness: "claude-code" });
+    expect(session.status).toBe("running");
+
+    // The real default buildLaunchOpts wrote this session's config dir —
+    // and it must survive for as long as the pty runs (the agent re-executes
+    // emit.cjs from it on every hook event).
+    const sessionDir = join(generatedRoot, session.id);
+    expect(await exists(join(sessionDir, "settings.json"))).toBe(true);
+    expect(await exists(join(sessionDir, "emit.cjs"))).toBe(true);
+
+    server.sessionManager.kill(session.id);
+    await vi.waitFor(
+      async () => {
+        expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
+        expect(await exists(sessionDir)).toBe(false);
+      },
+      { timeout: 10_000, interval: 100 },
+    );
+  }, 15_000);
+});

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -38,6 +38,7 @@ import type { HarnessIdentity } from "../cli/auth.js";
 import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
 import { generateSystemPromptFile } from "../core/inject/system-prompt.js";
+import { removeGeneratedSessionDir, sweepGeneratedDirs } from "../core/inject/retention.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
 import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
@@ -85,6 +86,12 @@ export interface HarnessServerOptions {
   adapters?: Partial<Record<HarnessKind, HarnessAdapter>>;
   sessionsPath?: string;
   buildLaunchOpts?: LaunchOptsBuilder;
+  /** Root directory per-session generated agent configs are written under —
+   *  and cleaned up from (exit-time delete + boot-time sweep, see
+   *  core/inject/retention.ts). Defaults to HARNESS_PATHS.generated
+   *  (`~/.sapiom/harness/generated`). Tests point this at a temp dir so they
+   *  never write to (or sweep) the real home directory. */
+  generatedRoot?: string;
   collectorUrl?: string;
   workflowsRegistryPath?: string;
   eventStorePath?: string;
@@ -147,12 +154,12 @@ function readVersion(): string {
  * so the remote `sapiom` MCP is actually authenticated — a factory rather
  * than a plain function since it's per-server-instance state.
  */
-function createDefaultBuildLaunchOpts(apiKey: string | null): LaunchOptsBuilder {
+function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: string): LaunchOptsBuilder {
   return async (harnessSessionId) => {
     const [settings, mcpConfigFile, systemPromptFile] = await Promise.all([
-      generateClaudeSettings({ harnessSessionId }),
-      generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT, apiKey }),
-      generateSystemPromptFile(harnessSessionId),
+      generateClaudeSettings({ harnessSessionId, generatedRoot }),
+      generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT, apiKey, generatedRoot }),
+      generateSystemPromptFile(harnessSessionId, { generatedRoot }),
     ]);
     return {
       settingsFile: settings.settingsPath,
@@ -231,13 +238,27 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     await writeHarnessContext(session, boundWorkflow, workflowsCache);
   };
 
+  // Exit-time deletion of generated/<id> (see the onStatusChange handler
+  // below) can race a fast resume(): resume regenerates the dir via
+  // buildLaunchOpts, and the rm scheduled at the previous exit could still
+  // be in flight. Serialize by awaiting any pending removal for this id
+  // before (re)generating its files.
+  const generatedRoot = options.generatedRoot;
+  const pendingGeneratedRemovals = new Map<string, Promise<void>>();
+  const innerBuildLaunchOpts =
+    options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
+  const buildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId, req) => {
+    await pendingGeneratedRemovals.get(harnessSessionId);
+    return innerBuildLaunchOpts(harnessSessionId, req);
+  };
+
   const sessionManager = new SessionManager({
     adapters,
     ingestUrl: `http://${host}:${options.port}`,
     ingestToken: options.bootToken,
     collectorUrl: options.collectorUrl,
     sessionsPath: options.sessionsPath,
-    buildLaunchOpts: options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null),
+    buildLaunchOpts,
     // Every session gets its initial harness-context.json regardless of
     // entry point (REST, autoCreateSession) — see SessionManager.create().
     writeWorkspaceContext: writeSessionContext,
@@ -246,6 +267,21 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   });
   await sessionManager.init();
 
+  // One boot-time sweep for generated dirs the exit-time cleanup below never
+  // reached (crashes, force-kills, accumulation from before retention
+  // existed). Age-gated (GENERATED_SWEEP_MAX_AGE_MS) and skips live
+  // sessions' dirs — fire-and-forget, boot must not wait on potentially
+  // thousands of removals.
+  void sweepGeneratedDirs({
+    generatedRoot,
+    isLiveSession: (harnessSessionId) => {
+      const session = sessionManager.get(harnessSessionId);
+      return session !== undefined && session.status !== "exited";
+    },
+  }).catch((err: unknown) => {
+    console.error("[harness] generated-dir sweep failed:", err);
+  });
+
   sessionManager.onStatusChange((session) => {
     bus.publish({ type: "session.status", session });
     if (session.status === "running") {
@@ -253,6 +289,20 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     } else if (session.status === "exited") {
       canvasWatcher.stop(session.id);
       portDetector.reset(session.id);
+      // The generated config dir is dead once the pty is: every file in it
+      // is regenerated by buildLaunchOpts on resume, and the agent's last
+      // emit.cjs execution (SessionEnd) happens before its process exits.
+      const removal = removeGeneratedSessionDir(session.id, { generatedRoot })
+        .then(() => undefined)
+        .catch((err: unknown) => {
+          console.error("[harness] generated-dir cleanup failed:", err);
+        })
+        .finally(() => {
+          if (pendingGeneratedRemovals.get(session.id) === removal) {
+            pendingGeneratedRemovals.delete(session.id);
+          }
+        });
+      pendingGeneratedRemovals.set(session.id, removal);
     }
   });
 


### PR DESCRIPTION
## Problem

`@sapiom/harness` writes a per-session config dir under `~/.sapiom/harness/generated/<harnessSessionId>/` (generated `--settings`, `emit.cjs`, `--mcp-config`, system prompt) on every session launch, with no cleanup — dirs accumulate forever (thousands on a long-lived install).

## Lifecycle findings

- The dir **is** needed for the whole life of the pty: `settings.json`/`mcp-config.json`/`system-prompt.txt` are consumed at launch, but `emit.cjs` is re-executed by the agent as a child process on **every hook event**.
- The dir is **not** needed after exit: `buildLaunchOpts` regenerates every file on both `create()` and `resume()`, so deleting at exit can never break a later resume.

## Changes

- **New `core/inject/retention.ts`**:
  - `removeGeneratedSessionDir()` — per-session delete, wired to the session's `"exited"` status transition in `server/index.ts`. The removal promise is serialized against `buildLaunchOpts` so a fast resume can't race a still-in-flight `rm` of its freshly regenerated files.
  - `sweepGeneratedDirs()` — boot-time sweep: removes dirs that belong to no live session and have an mtime older than 7 days. Covers crashes, force-kills, and pre-retention accumulation. Best-effort per entry; fire-and-forget so boot never waits on thousands of removals.
- **Safety**: deletion only targets plain directories that are direct children of a root whose final path segment is `generated` — a misconfigured base path (e.g. resolving to `~` or `/`) throws instead of recursing. Escaping/malformed ids (`..`, separators, absolute paths) are rejected. Symlinked entries are never followed and never deleted.
- **Hermetic tests**: threads a `generatedRoot` option through `startServer` / `generateMcpConfig`; the server tests and e2e scripts now write to (and sweep) a temp dir instead of the real `~/.sapiom/harness/generated` — previously they contributed to the real accumulation.

## Tests

- Unit (`retention.test.ts`): removal of dir + contents, no-op on missing dir, escaping-id rejection (sibling dir survives `../victim`), suspicious-root refusal, symlink skipped with target intact; sweep removes stale / keeps fresh, **live session's dir survives regardless of age**, custom threshold, stray files and symlinks untouched, missing root is empty result.
- Wiring (`generated-retention.test.ts`): real `startServer` — boot sweep removes a stale orphan and keeps a fresh one; a running session's dir (written by the real default `buildLaunchOpts`) survives while the pty runs and is deleted on exit.

## Verification

- `pnpm --filter @sapiom/harness typecheck` ✓
- `pnpm --filter @sapiom/harness test` — 377/377 ✓
- `pnpm --filter @sapiom/harness sim:e2e` ✓
- `pnpm --filter @sapiom/harness e2e:live` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJDkb7cXsDLeNMobRTghqi