### PR TITLE
fix(harness): reconcile ghost session records whose pty is gone

### DIFF
--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -6,11 +6,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HarnessAdapter, HarnessSession, SpawnSpec } from "../shared/types.js";
 import { SessionManager, type PtySpawnFn, type SessionManagerOptions } from "./session-manager.js";
 
-/** Minimal fake IPty: lets tests drive onData/onExit and observe write/resize/kill. */
-function createFakePty() {
+/** Minimal fake IPty: lets tests drive onData/onExit and observe write/resize/kill.
+ *  `pid` is only set when a test passes one explicitly — sweep tests need a
+ *  numeric pid to probe (always paired with an injected isPidAlive so the
+ *  fake pid is never checked against real OS processes); everything else
+ *  leaves it undefined, which the sweep must treat as "can't tell, hands off". */
+function createFakePty(pid?: number) {
   const dataListeners: Array<(chunk: string) => void> = [];
   const exitListeners: Array<(e: { exitCode: number; signal?: number }) => void> = [];
   const pty = {
+    pid,
     onData: (cb: (chunk: string) => void) => {
       dataListeners.push(cb);
       return { dispose: () => {} };
@@ -83,6 +88,9 @@ describe("SessionManager", () => {
       writeWorkspaceContext?: SessionManagerOptions["writeWorkspaceContext"];
       workspaceContextExists?: SessionManagerOptions["workspaceContextExists"];
       ensureCanvasTemplate?: SessionManagerOptions["ensureCanvasTemplate"];
+      isPidAlive?: SessionManagerOptions["isPidAlive"];
+      /** Pid given to every fake pty this manager spawns — see createFakePty(). */
+      fakePid?: number;
     } = {},
   ) {
     const adapter = opts.adapter ?? createFakeAdapter();
@@ -90,7 +98,7 @@ describe("SessionManager", () => {
     const spawnPty: PtySpawnFn =
       opts.spawnPty ??
       ((file, args) => {
-        const fake = createFakePty();
+        const fake = createFakePty(opts.fakePid);
         spawns.push(fake);
         void file;
         void args;
@@ -106,6 +114,7 @@ describe("SessionManager", () => {
       writeWorkspaceContext: opts.writeWorkspaceContext,
       workspaceContextExists: opts.workspaceContextExists,
       ensureCanvasTemplate: opts.ensureCanvasTemplate,
+      isPidAlive: opts.isPidAlive,
     });
     managers.push(manager);
     return { manager, adapter, spawns };
@@ -621,13 +630,18 @@ describe("SessionManager", () => {
       expect(order).toEqual(["write", "spawn"]);
     });
 
-    it("create() still creates and spawns the session even if writeWorkspaceContext rejects", async () => {
+    it("create() surfaces a writeWorkspaceContext rejection and reconciles the record to exited", async () => {
       const writeWorkspaceContext = vi.fn(async () => {
         throw new Error("disk full");
       });
       const { manager } = makeManager({ writeWorkspaceContext });
 
       await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow("disk full");
+      // The record was persisted as "starting" before the failing write — it
+      // must not stay that way (a non-exited record with no pty behind it
+      // renders as a ghost tab forever).
+      expect(manager.list()).toHaveLength(1);
+      expect(manager.list()[0]?.status).toBe("exited");
     });
 
     it("resume() backfills the workspace context only when it's missing", async () => {
@@ -748,6 +762,143 @@ describe("SessionManager", () => {
     it("defaults to a no-op so tests with fake cwds never touch the real filesystem", async () => {
       const { manager } = makeManager();
       await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).resolves.toBeDefined();
+    });
+  });
+
+  describe("ghost-session reconciliation (non-exited records with no live pty)", () => {
+    it("create() reconciles the record to exited when ensureCanvasTemplate rejects", async () => {
+      const ensureCanvasTemplate = vi.fn(async () => {
+        throw new Error("read-only fs");
+      });
+      const { manager } = makeManager({ ensureCanvasTemplate });
+
+      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow("read-only fs");
+      expect(manager.list()[0]?.status).toBe("exited");
+    });
+
+    it("create() reconciles the record to exited when the pty spawn itself throws", async () => {
+      const spawnPty: PtySpawnFn = () => {
+        throw new Error("posix_spawnp failed");
+      };
+      const { manager } = makeManager({ spawnPty });
+      const statuses: string[] = [];
+      manager.onStatusChange((s) => statuses.push(s.status));
+
+      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow(
+        "posix_spawnp failed",
+      );
+      expect(manager.list()[0]?.status).toBe("exited");
+      expect(statuses).toContain("exited");
+
+      // The reconciliation must be durable, not just in-memory — a persisted
+      // "starting" record would still ghost after the SPA refetches state.
+      await manager.flush();
+      const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
+      expect(raw[0]?.status).toBe("exited");
+    });
+
+    it("resume() reconciles the record back to exited when a pre-spawn step rejects", async () => {
+      const ensureCanvasTemplate = vi.fn(async () => {
+        throw new Error("read-only fs");
+      });
+      const { manager } = makeManager({ ensureCanvasTemplate });
+      const session = manager.registerHistorical({
+        agentSessionId: "agent-uuid-9",
+        harness: "claude-code",
+        cwd: "/tmp/proj",
+        title: "past session",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      await expect(manager.resume(session.id)).rejects.toThrow("read-only fs");
+      // resume() flipped it to "starting" and persisted before failing — it
+      // must land back on "exited", not stay stranded mid-transition.
+      expect(manager.get(session.id)?.status).toBe("exited");
+    });
+
+    it("kill() transitions a stale non-exited record with no pty to exited instead of failing", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitExit(0);
+      // Simulate the ghost state directly (the transitions that used to
+      // produce it are all reconciled now): a record stuck non-exited whose
+      // pty handle is long gone.
+      const record = manager.get(session.id)!;
+      record.status = "running";
+
+      const statuses: string[] = [];
+      manager.onStatusChange((s) => statuses.push(s.status));
+      expect(manager.kill(session.id)).toBe(true);
+      expect(manager.get(session.id)?.status).toBe("exited");
+      expect(statuses).toEqual(["exited"]);
+
+      // A genuinely exited record is still a no-op false, as before.
+      expect(manager.kill(session.id)).toBe(false);
+      expect(manager.kill("unknown-id")).toBe(false);
+    });
+
+    describe("sweepDeadSessions", () => {
+      it("synthesizes an exit for a running session whose process died without onExit ever firing", async () => {
+        // The node-pty missed-exit bug (see kill()'s fallback), but for a
+        // process that died on its own — no kill() call means no fallback
+        // was ever armed, which is exactly what the sweep exists to catch.
+        const { manager } = makeManager({ fakePid: 4242, isPidAlive: () => false });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        expect(session.status).toBe("running");
+
+        const statuses: string[] = [];
+        manager.onStatusChange((s) => statuses.push(s.status));
+        manager.sweepDeadSessions();
+
+        expect(manager.get(session.id)?.status).toBe("exited");
+        expect(manager.get(session.id)?.exitCode).toBeNull();
+        expect(statuses).toEqual(["exited"]);
+        // The dead handle is fully released, same as a real onExit.
+        expect(manager.attach(session.id, () => {})).toBeUndefined();
+
+        await manager.flush();
+        const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
+        expect(raw[0]?.status).toBe("exited");
+      });
+
+      it("leaves sessions whose process is alive untouched", async () => {
+        const { manager } = makeManager({ fakePid: 4242, isPidAlive: () => true });
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        manager.sweepDeadSessions();
+
+        expect(manager.get(session.id)?.status).toBe("running");
+      });
+
+      it("never probes a pty without a numeric pid, and never declares it dead", async () => {
+        const isPidAlive = vi.fn(() => false);
+        const { manager } = makeManager({ isPidAlive }); // fake pty with pid: undefined
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+        manager.sweepDeadSessions();
+
+        expect(isPidAlive).not.toHaveBeenCalled();
+        expect(manager.get(session.id)?.status).toBe("running");
+      });
+
+      it("reconciles a non-exited record with no pty only after it outlives the grace window", async () => {
+        const { manager, spawns } = makeManager();
+        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        spawns[0]?.emitExit(0);
+        const record = manager.get(session.id)!;
+        record.status = "starting"; // simulate the stale mid-transition ghost
+
+        // Fresh record (lastActiveAt just now): could be a create()/resume()
+        // still inside its legitimate pre-spawn window — hands off.
+        record.lastActiveAt = new Date().toISOString();
+        manager.sweepDeadSessions();
+        expect(manager.get(session.id)?.status).toBe("starting");
+
+        // Same record well past any plausible spawn window: dead, reconcile.
+        record.lastActiveAt = new Date(Date.now() - 60_000).toISOString();
+        manager.sweepDeadSessions();
+        expect(manager.get(session.id)?.status).toBe("exited");
+      });
     });
   });
 

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -122,6 +122,31 @@ const READY_POLL_MS = 150;
  *  second for a busy TUI), but the SPA's busy indicator only needs "this
  *  session produced output recently", not every individual chunk. */
 const ACTIVITY_BROADCAST_THROTTLE_MS = 2_000;
+/**
+ * See `sweepDeadSessions()`: how long a non-exited session record may sit
+ * with no pty handle at all before the sweep declares it dead. There is one
+ * legitimate window where that state exists — inside `create()`/`resume()`,
+ * between persisting the record and attaching the freshly-spawned pty (a few
+ * awaited config-file writes plus the spawn itself, normally well under a
+ * second) — so this just needs to comfortably exceed that window, not be
+ * fast: the sweep is a backstop, not the primary reconciliation.
+ */
+const NO_PTY_SWEEP_GRACE_MS = 30_000;
+
+/**
+ * OS-level "does this process exist" check — the same probe `kill()`'s
+ * missed-exit fallback has always used, factored out so the liveness sweep
+ * shares it. EPERM means the process exists but isn't ours to signal, i.e.
+ * alive; anything else (ESRCH) means it's gone.
+ */
+const defaultIsPidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
 
 /**
  * Thrown by `submitInput()` when a session's pty is alive but never became
@@ -214,6 +239,11 @@ export interface SessionManagerOptions {
    * touch the real filesystem unless they opt in.
    */
   ensureCanvasTemplate?: (cwd: string) => Promise<void>;
+  /**
+   * Injectable for tests (fake ptys carry fake pids that must never be
+   * probed against real OS processes). Defaults to `defaultIsPidAlive`.
+   */
+  isPidAlive?: (pid: number) => boolean;
 }
 
 interface PtyHandle {
@@ -237,6 +267,7 @@ export class SessionManager {
   private readonly writeWorkspaceContext: (session: HarnessSession) => Promise<void>;
   private readonly workspaceContextExists: (cwd: string) => Promise<boolean>;
   private readonly ensureCanvasTemplate: (cwd: string) => Promise<void>;
+  private readonly isPidAlive: (pid: number) => boolean;
 
   private readonly sessions = new Map<string, HarnessSession>();
   private readonly ptys = new Map<string, PtyHandle>();
@@ -261,6 +292,7 @@ export class SessionManager {
     this.writeWorkspaceContext = options.writeWorkspaceContext ?? (async () => {});
     this.workspaceContextExists = options.workspaceContextExists ?? (async () => true);
     this.ensureCanvasTemplate = options.ensureCanvasTemplate ?? (async () => {});
+    this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
     // Many WS clients (terminal + events) can subscribe over a long-running process.
     this.statusEmitter.setMaxListeners(0);
     this.activityEmitter.setMaxListeners(0);
@@ -330,15 +362,23 @@ export class SessionManager {
     };
     this.sessions.set(id, session);
     await this.persist();
-    // Before spawning, not fire-and-forget: the agent's very first read of
-    // HARNESS_CONTEXT_FILE must never race session creation with an ENOENT,
-    // regardless of which entry point called create() (REST, autoCreateSession).
-    await this.writeWorkspaceContext(session);
-    // Same reasoning: the canvas pane opens immediately once the session is
-    // "running" — it must never show a bare empty iframe because nothing's
-    // been written to .sapiom/canvas/index.html yet.
-    await this.ensureCanvasTemplate(session.cwd);
-    await this.spawn(session, spec);
+    try {
+      // Before spawning, not fire-and-forget: the agent's very first read of
+      // HARNESS_CONTEXT_FILE must never race session creation with an ENOENT,
+      // regardless of which entry point called create() (REST, autoCreateSession).
+      await this.writeWorkspaceContext(session);
+      // Same reasoning: the canvas pane opens immediately once the session is
+      // "running" — it must never show a bare empty iframe because nothing's
+      // been written to .sapiom/canvas/index.html yet.
+      await this.ensureCanvasTemplate(session.cwd);
+      await this.spawn(session, spec);
+    } catch (err) {
+      // The record was already persisted as "starting" above; a failure
+      // anywhere before the pty is live must reconcile it to "exited" or it
+      // lingers forever as a ghost tab (non-exited status, no pty behind it).
+      await this.transitionExited(session, null);
+      throw err;
+    }
     return session;
   }
 
@@ -394,24 +434,43 @@ export class SessionManager {
     session.lastActiveAt = this.now();
     await this.persist();
     this.emitStatus(session);
-    // Backfill only — never overwrite a file that could already reflect a
-    // real binding. The caller resolves session.boundWorkflowPath against
-    // the live registry, so unlike the old cwd-only signature this actually
-    // reconstructs the real binding on backfill, not just `null`.
-    if (!(await this.workspaceContextExists(session.cwd))) {
-      await this.writeWorkspaceContext(session);
+    try {
+      // Backfill only — never overwrite a file that could already reflect a
+      // real binding. The caller resolves session.boundWorkflowPath against
+      // the live registry, so unlike the old cwd-only signature this actually
+      // reconstructs the real binding on backfill, not just `null`.
+      if (!(await this.workspaceContextExists(session.cwd))) {
+        await this.writeWorkspaceContext(session);
+      }
+      // Also backfill-only (ensureCanvasTemplate does its own existence check)
+      // — a session from before the canvas kit existed, or one whose canvas
+      // file was somehow deleted, still gets a live pane on resume.
+      await this.ensureCanvasTemplate(session.cwd);
+      await this.spawn(session, spec);
+    } catch (err) {
+      // Same reconciliation as create(): the record just went back to
+      // "starting" and was persisted — a failure before the new pty is live
+      // must not leave it stranded there with nothing behind it.
+      await this.transitionExited(session, null);
+      throw err;
     }
-    // Also backfill-only (ensureCanvasTemplate does its own existence check)
-    // — a session from before the canvas kit existed, or one whose canvas
-    // file was somehow deleted, still gets a live pane on resume.
-    await this.ensureCanvasTemplate(session.cwd);
-    await this.spawn(session, spec);
     return session;
   }
 
   kill(id: string): boolean {
     const handle = this.ptys.get(id);
-    if (!handle) return false;
+    if (!handle) {
+      // A non-exited record with no pty behind it has nothing left to kill —
+      // it's a ghost (its pty died without the exit ever being recorded).
+      // Reconcile it here so closing the tab actually closes it, instead of
+      // returning false and leaving an unclosable non-exited record.
+      const session = this.sessions.get(id);
+      if (session && session.status !== "exited") {
+        void this.transitionExited(session, null);
+        return true;
+      }
+      return false;
+    }
     handle.pty.kill();
     // Root-caused via instrumented real-process runs: node-pty's `onExit`
     // can simply never fire for a pty killed within milliseconds of being
@@ -428,17 +487,9 @@ export class SessionManager {
     const escalate = setTimeout(() => {
       if (this.ptys.get(id) !== handle) return;
       const pid = handle.pty.pid;
-      const stillAlive = (): boolean => {
-        try {
-          process.kill(pid, 0);
-          return true;
-        } catch {
-          return false;
-        }
-      };
-      if (stillAlive()) handle.pty.kill("SIGKILL");
+      if (this.isPidAlive(pid)) handle.pty.kill("SIGKILL");
       setTimeout(() => {
-        if (this.ptys.get(id) === handle && !stillAlive()) this.markExited(id, handle, null);
+        if (this.ptys.get(id) === handle && !this.isPidAlive(pid)) this.markExited(id, handle, null);
       }, KILL_ESCALATION_CONFIRM_MS).unref?.();
     }, KILL_ESCALATION_MS);
     escalate.unref?.();
@@ -451,6 +502,39 @@ export class SessionManager {
    *  touch unrelated child processes on its own. */
   killAll(): void {
     for (const id of [...this.ptys.keys()]) this.kill(id);
+  }
+
+  /**
+   * Defensive liveness backstop, run periodically by the server: any
+   * non-exited session whose pty process is provably gone gets its exit
+   * synthesized. The specific transitions are already reconciled at their
+   * source (create/resume pre-pty failures, kill()'s missed-exit fallback),
+   * but node-pty has been observed to simply never fire `onExit` for a
+   * process that died moments after spawning (see `kill()`) — and a process
+   * that dies *on its own* that way has no kill()-style fallback watching
+   * it. This sweep is the catch-all for that and any transition not yet
+   * root-caused: a stale record shows as a ghost tab (non-exited status, no
+   * live pty) until something reconciles it.
+   */
+  sweepDeadSessions(): void {
+    for (const session of [...this.sessions.values()]) {
+      if (session.status === "exited") continue;
+      const handle = this.ptys.get(session.id);
+      if (handle) {
+        // Guard against non-numeric pids (test fakes) — never probe the OS
+        // with a garbage value, and never declare a session dead on one.
+        if (typeof handle.pty.pid === "number" && !this.isPidAlive(handle.pty.pid)) {
+          this.markExited(session.id, handle, null);
+        }
+        continue;
+      }
+      // No pty handle at all. Within create()/resume() there's a legitimate
+      // pre-spawn window where the persisted record briefly looks like this,
+      // so only sweep records older than the grace period (an unparseable
+      // lastActiveAt is garbage and sweeps immediately).
+      const ageMs = Date.now() - Date.parse(session.lastActiveAt);
+      if (!(ageMs < NO_PTY_SWEEP_GRACE_MS)) void this.transitionExited(session, null);
+    }
   }
 
   write(id: string, data: string): boolean {
@@ -680,22 +764,17 @@ export class SessionManager {
     env[ENV.sessionId] = session.id;
     if (this.collectorUrl) env[ENV.collectorUrl] = this.collectorUrl;
 
-    let pty: IPty;
-    try {
-      pty = spawnFn(spec.command, spec.args, {
-        name: "xterm-256color",
-        cols: DEFAULT_COLS,
-        rows: DEFAULT_ROWS,
-        cwd: spec.cwd,
-        env,
-      });
-    } catch (err) {
-      session.status = "exited";
-      session.exitCode = null;
-      await this.persist();
-      this.emitStatus(session);
-      throw err;
-    }
+    // A throw here — spawnFn itself, or loadDefaultSpawn() above (a broken
+    // node-pty prebuild surfaces there, not at import time) — propagates to
+    // create()/resume(), which own reconciling the session record to
+    // "exited" for every pre-pty failure, not just this one.
+    const pty: IPty = spawnFn(spec.command, spec.args, {
+      name: "xterm-256color",
+      cols: DEFAULT_COLS,
+      rows: DEFAULT_ROWS,
+      cwd: spec.cwd,
+      env,
+    });
 
     const emitter = new EventEmitter();
     emitter.setMaxListeners(0);
@@ -735,11 +814,24 @@ export class SessionManager {
     this.lastActivityBroadcast.delete(id);
     const session = this.sessions.get(id);
     if (!session) return;
+    void this.transitionExited(session, exitCode);
+  }
+
+  /**
+   * The single place a session record flips to "exited" — shared by
+   * `markExited()` (live-pty deaths), `create()`/`resume()`'s pre-pty
+   * failure reconciliation, `kill()`'s stale-record path, and
+   * `sweepDeadSessions()`. Returns the persist promise so callers that need
+   * the registry durably updated before rethrowing (create/resume) can
+   * await it; event-driven callers fire-and-forget it like any other write.
+   */
+  private transitionExited(session: HarnessSession, exitCode: number | null): Promise<void> {
     session.status = "exited";
     session.exitCode = exitCode;
     session.lastActiveAt = this.now();
-    void this.persist();
+    const persisted = this.persist();
     this.emitStatus(session);
+    return persisted;
   }
 
   private emitStatus(session: HarnessSession): void {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -70,6 +70,14 @@ const CODEX_ROLLOUT_DISCOVERY_POLL_MS = 300;
  * thread an async registry lookup through the macro-runner's sync contract. */
 const WORKFLOWS_CACHE_REFRESH_MS = 3_000;
 
+/** How often SessionManager.sweepDeadSessions() runs — the backstop that
+ * reconciles any non-exited session record whose pty process is actually
+ * gone (node-pty's occasionally-missed onExit, or a transition nothing else
+ * reconciled), so a ghost tab self-heals within seconds instead of sitting
+ * in the tab strip until the server restarts. The sweep is a cheap in-memory
+ * walk plus a signal-0 probe per live pty. */
+const SESSION_LIVENESS_SWEEP_MS = 10_000;
+
 export interface HarnessServerOptions {
   port: number;
   /** Bind address. Defaults to 127.0.0.1 — the server must never listen on 0.0.0.0. */
@@ -245,6 +253,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     ensureCanvasTemplate,
   });
   await sessionManager.init();
+
+  const sessionSweepTimer = setInterval(() => sessionManager.sweepDeadSessions(), SESSION_LIVENESS_SWEEP_MS);
+  sessionSweepTimer.unref?.();
 
   sessionManager.onStatusChange((session) => {
     bus.publish({ type: "session.status", session });
@@ -554,6 +565,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     close: () =>
       new Promise<void>((resolve, reject) => {
         clearInterval(workflowsCacheTimer);
+        clearInterval(sessionSweepTimer);
         canvasWatcher.stopAll();
         for (const tailer of codexTailers.values()) tailer.stop();
         codexTailers.clear();


### PR DESCRIPTION
## Problem

The session tab strip renders every session whose `status !== "exited"`. A record could get stuck non-exited with no live pty behind it — a ghost tab (seen in the wild as two "codex" tabs for one real codex session). Boot-time reconciliation only covers server restarts; these ghosts arose within one server lifetime, and `kill()` returned `false` for them (no pty handle), so the tab couldn't even be closed.

## Root cause

Three server-side paths left a non-exited record with no live pty:

1. **`create()`**: the record was registered and persisted as `"starting"`, but `writeWorkspaceContext`, `ensureCanvasTemplate`, and node-pty's lazy `loadDefaultSpawn()` all ran outside the mark-exited-on-failure guard — only the `spawnFn(...)` call itself was guarded. A throw in any of them (e.g. a broken node-pty prebuild, an fs error) left the record stranded at `"starting"` forever.
2. **`resume()`**: same shape — status flipped to `"starting"` and persisted, then the pre-spawn backfills + spawn could throw with no reconciliation.
3. **Missed `onExit` for a natural death**: node-pty can simply never fire `onExit` for a process that dies moments after spawning (the confirmed missed-exit bug that #214's `kill()` fallback works around). But that fallback is only armed by `kill()` — a pty process that dies *on its own* in that window had nothing watching it, so the record stayed `"running"` with a dead pid. This is the most likely producer of the observed codex ghost: the dead codex record lingered while a fresh codex session added a second tab.

## Fix

- `create()`/`resume()` reconcile the record to `"exited"` (durably, before rethrowing) on any failure between persisting it and having a live pty. All exit paths now share one `transitionExited()` helper.
- `kill()` on a non-exited record with no pty handle synthesizes the exit instead of returning `false` — a ghost tab is always closable, even if one slips through.
- **Defensive liveness sweep** (`sweepDeadSessions()`, run every 10s by the server, reusing the existing exit-synthesis machinery): any non-exited session whose pid fails a signal-0 probe gets its exit synthesized; a record with no pty at all is reconciled once it outlives a 30s grace window covering the legitimate pre-spawn state. `isPidAlive` is injectable for tests, and the sweep never probes a pty without a numeric pid (test fakes must never be matched against real OS processes).

## Verification

- `pnpm --filter @sapiom/harness typecheck` / `lint` — clean
- `pnpm --filter @sapiom/harness test` — 371 passed (7 new regression tests: each failing transition, ghost `kill()`, and the sweep's synthesize/leave-alive/no-pid-guard/grace-window behaviors)
- `sim:e2e` and `e2e:live` — PASS
- Ad-hoc live check against real node-pty: the sweep leaves a live pty untouched, and coexists idempotently with node-pty's own exit reporting after an external SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtjkHkA1Sm2DFBY2gBayFW