### PR TITLE
fix(harness): exclude __fixtures__ from ESLint

### DIFF
--- a/packages/harness/.eslintrc.cjs
+++ b/packages/harness/.eslintrc.cjs
@@ -14,7 +14,16 @@ module.exports = {
   env: {
     node: true,
   },
-  ignorePatterns: ['.eslintrc.cjs', 'vitest.config.ts', 'dist', 'node_modules', 'web'],
+  // src/**/__fixtures__ is excluded from tsconfig.json (some fixtures are
+  // deliberately broken), so typed linting cannot parse it either.
+  ignorePatterns: [
+    '.eslintrc.cjs',
+    'vitest.config.ts',
+    'dist',
+    'node_modules',
+    'web',
+    'src/**/__fixtures__',
+  ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],


### PR DESCRIPTION
## Summary

`pnpm lint` fails on `feat/harness`: the fixture workflow projects added under `packages/harness/src/core/__fixtures__/` are excluded from `tsconfig.json` (some are deliberately broken to exercise the extractor's degradation paths), so typed linting errors on all five `index.ts` files with `Parsing error: ... TSConfig does not include this file`.

Since the fixtures must never be type-checked as part of the harness source tree, exclude them from ESLint via `ignorePatterns` — same approach `packages/cli` uses for its `templates` dir. No lint rules are weakened for real source files.

## Verification

- `pnpm lint` passes from repo root (previously 5 parsing errors in `@sapiom/harness`)
- `pnpm --filter @sapiom/harness typecheck` passes
- `pnpm --filter @sapiom/harness test` — 440 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FoCm8JLXmAgrQ247Q7ehf