### PR TITLE
feat(harness): stateRoot isolation for all persistent state + dead-path registry pruning at boot

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -66,6 +66,12 @@
  *      and writes real step names + SVG node markup to index.html, and the
  *      write fires a canvas.reload frame exactly like an agent's own edit
  *      would — the visualize macro's default path never touches the pty.
+ *  15. State isolation + registry hygiene: `stateRoot` alone (no per-file
+ *      overrides, no machineId) roots every piece of persistent state under
+ *      the scratch dir — machine-id included — and a pre-seeded registry
+ *      entry whose path doesn't exist on disk is pruned (and the prune
+ *      persisted) at boot. This whole script must leave the real
+ *      ~/.sapiom/harness untouched.
  *
  * Run with: pnpm e2e:live
  */
@@ -175,6 +181,16 @@ async function testCoreFlow(): Promise<void> {
   const captureFile = path.join(tmpRoot, "fake-claude-capture.json");
   const eventStorePath = path.join(tmpRoot, "events.ndjson");
 
+  // Pre-seed the (scratch) workflow registry with an entry whose path does
+  // not exist — a stand-in for a deleted project or a temp dir a crashed run
+  // left registered. Boot-time pruning (item 15) must drop it before the
+  // registry is ever served or mirrored into a harness-context.json.
+  const deadWorkflowPath = path.join(tmpRoot, "deleted-project");
+  await fs.writeFile(
+    path.join(tmpRoot, "workflows.json"),
+    JSON.stringify([{ name: "deleted-project", path: deadWorkflowPath, definitionId: 1, source: "scan" }]),
+  );
+
   // SessionManager builds each spawned process's env starting from this
   // script's own process.env — setting it here is how the fixture (running
   // as a totally separate process) learns where to write its capture file.
@@ -202,15 +218,15 @@ async function testCoreFlow(): Promise<void> {
     telemetryOptIn: true,
     collectorUrl: `http://127.0.0.1:${MOCK_COLLECTOR_PORT}`,
     identity: { userId: "e2e-user", tenantId: "e2e-tenant", organizationName: "E2E Org", apiKey: "e2e-key" },
-    machineId: "e2e-machine",
+    // No machineId and no per-file path overrides: stateRoot alone must be
+    // enough for a boot to leave the real ~/.sapiom/harness completely
+    // untouched — machine-id, sessions.json, workflows.json, events.ndjson,
+    // settings.json and generated/ all land under the scratch root.
     adapters: {
       "claude-code": createClaudeCodeAdapter({ binary: FAKE_CLAUDE }),
       codex: createCodexAdapter(),
     },
-    sessionsPath: path.join(tmpRoot, "sessions.json"),
-    generatedRoot: path.join(tmpRoot, "generated"),
-    eventStorePath,
-    workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    stateRoot: tmpRoot,
     launchDir: projectDir,
     // This phase explicitly creates its own session below (step 1) and
     // asserts on its exact id/argv — autoCreateSession would spawn a second,
@@ -240,6 +256,31 @@ async function testCoreFlow(): Promise<void> {
       ws!.once("error", reject);
     });
     console.log("connected to /ws/events");
+
+    // --- 15. state isolation + boot-time registry pruning: machine-id was
+    // created under the scratch stateRoot (nothing fell back to the real
+    // home dir), and the pre-seeded registry entry with a nonexistent path
+    // was pruned before the registry was ever served — persisted, not just
+    // filtered from the response. ---
+    const machineIdContent = (await fs.readFile(path.join(tmpRoot, "machine-id"), "utf8")).trim();
+    assert(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(machineIdContent),
+      "machine-id was created under the scratch stateRoot",
+    );
+    const workflowsAfterBoot = (await (
+      await fetch(`${baseUrl}/api/workflows`, { headers })
+    ).json()) as Array<{ path: string }>;
+    assert(
+      !workflowsAfterBoot.some((w) => w.path === deadWorkflowPath),
+      "boot pruned the registry entry whose path no longer exists on disk",
+    );
+    const persistedRegistry = JSON.parse(
+      await fs.readFile(path.join(tmpRoot, "workflows.json"), "utf8"),
+    ) as Array<{ path: string }>;
+    assert(
+      !persistedRegistry.some((w) => w.path === deadWorkflowPath),
+      "the prune was persisted back to workflows.json, not just filtered from the response",
+    );
 
     // --- 1. create a session; the claude-code adapter spawns FAKE_CLAUDE with the real injected flags ---
     const createRes = await fetch(`${baseUrl}/api/sessions`, {
@@ -715,10 +756,7 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
       "claude-code": createClaudeCodeAdapter({ binary: FAKE_CLAUDE }),
       codex: createCodexAdapter(),
     },
-    sessionsPath: path.join(tmpRoot, "sessions.json"),
-    generatedRoot: path.join(tmpRoot, "generated"),
-    eventStorePath: path.join(tmpRoot, "events.ndjson"),
-    workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    stateRoot: tmpRoot,
     launchDir: projectDir,
     // Left at its default (true) — this is exactly the behavior under test.
   });
@@ -843,10 +881,7 @@ async function testAutoSessionKindSelection(): Promise<void> {
     // for claude-code" and this phase would fail loudly rather than silently
     // passing for the wrong reason.
     adapters: { codex: createCodexAdapter({ binary: FAKE_CLAUDE }) },
-    sessionsPath: path.join(tmpRoot, "sessions.json"),
-    generatedRoot: path.join(tmpRoot, "generated"),
-    eventStorePath: path.join(tmpRoot, "events.ndjson"),
-    workflowsRegistryPath: path.join(tmpRoot, "workflows.json"),
+    stateRoot: tmpRoot,
     launchDir: projectDir,
     defaultHarnessKind: "codex",
     availableHarnesses: ["codex"],

--- a/packages/harness/src/cli/machine-id.ts
+++ b/packages/harness/src/cli/machine-id.ts
@@ -18,10 +18,14 @@ const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
  * server boot over an analytics nicety. Kept as our own plain-text
  * `~/.sapiom/harness/machine-id` file for now; converging onto her
  * `~/.sapiom/analytics.json` identity is a separate, later conversation.
+ *
+ * @param filePath Where the id file lives. Defaults to the real
+ *   `HARNESS_PATHS.machineId`; tests and scripted checks pass a path under
+ *   their scratch state root so a boot never writes to the real home dir.
  */
-export async function getOrCreateMachineId(): Promise<string> {
-  const filePath = expandHome(HARNESS_PATHS.machineId);
-
+export async function getOrCreateMachineId(
+  filePath: string = expandHome(HARNESS_PATHS.machineId),
+): Promise<string> {
   try {
     const existing = await readMachineId(filePath);
     if (existing) {

--- a/packages/harness/src/cli/settings.test.ts
+++ b/packages/harness/src/cli/settings.test.ts
@@ -10,7 +10,7 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir: () => tmpDir };
 });
 
-import { hasStoredSettings, loadSettings, saveSettings, recordRecentDir } from "./settings.js";
+import { hasStoredSettings, loadSettings, saveSettings, recordRecentDir, pruneDeadRecentDirs } from "./settings.js";
 
 /** A real, existing directory to use as a valid recent-dir candidate. */
 async function makeRealDir(name: string): Promise<string> {
@@ -145,6 +145,54 @@ describe("settings persistence", () => {
 
       const settings = await loadSettings();
       expect(settings.recentDirs).toEqual([survivor]);
+    });
+  });
+
+  describe("explicit settingsPath", () => {
+    it("reads and writes the given file instead of the home-dir default", async () => {
+      const customPath = path.join(tmpDir, "custom-root", "settings.json");
+      const a = await makeRealDir("a");
+      await saveSettings({ telemetryOptIn: true, recentDirs: [a] }, customPath);
+
+      expect(await hasStoredSettings(customPath)).toBe(true);
+      expect(await loadSettings(customPath)).toEqual({ telemetryOptIn: true, recentDirs: [a] });
+      // The (mocked-home) default location was never touched.
+      expect(await hasStoredSettings()).toBe(false);
+    });
+  });
+
+  describe("pruneDeadRecentDirs", () => {
+    it("persists the removal of entries whose path no longer exists", async () => {
+      const survivor = await makeRealDir("survivor");
+      const doomed = await makeRealDir("doomed");
+      await saveSettings({ telemetryOptIn: true, recentDirs: [doomed, survivor] });
+      await fs.rm(doomed, { recursive: true, force: true });
+
+      expect(await pruneDeadRecentDirs()).toEqual([doomed]);
+
+      // Persisted on disk, not just filtered by loadSettings' own sanitize.
+      const raw = JSON.parse(await fs.readFile(settingsFilePathFor(tmpDir), "utf-8")) as {
+        telemetryOptIn: boolean;
+        recentDirs: string[];
+      };
+      expect(raw.recentDirs).toEqual([survivor]);
+      expect(raw.telemetryOptIn).toBe(true);
+    });
+
+    it("does not rewrite the file when every entry still exists", async () => {
+      const a = await makeRealDir("a");
+      await saveSettings({ telemetryOptIn: false, recentDirs: [a] });
+      const before = await fs.stat(settingsFilePathFor(tmpDir));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(await pruneDeadRecentDirs()).toEqual([]);
+      const after = await fs.stat(settingsFilePathFor(tmpDir));
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+    });
+
+    it("does not create a settings file where none exists (first-run detection stays intact)", async () => {
+      expect(await pruneDeadRecentDirs()).toEqual([]);
+      expect(await hasStoredSettings()).toBe(false);
     });
   });
 });

--- a/packages/harness/src/cli/settings.ts
+++ b/packages/harness/src/cli/settings.ts
@@ -10,7 +10,10 @@ const DEFAULT_SETTINGS: HarnessSettings = {
 
 const MAX_RECENT_DIRS = 8;
 
-function settingsFilePath(): string {
+/** The real settings file. Every function below accepts an explicit path so
+ *  tests and scripted checks can point at a scratch state root instead —
+ *  omitted, they operate on the real file, unchanged for CLI users. */
+function defaultSettingsFilePath(): string {
   return expandHome(HARNESS_PATHS.settings);
 }
 
@@ -55,18 +58,18 @@ export async function sanitizeRecentDirs(candidates: string[]): Promise<string[]
 }
 
 /** Whether settings have ever been persisted — used to detect first run. */
-export async function hasStoredSettings(): Promise<boolean> {
+export async function hasStoredSettings(settingsPath: string = defaultSettingsFilePath()): Promise<boolean> {
   try {
-    await fs.access(settingsFilePath());
+    await fs.access(settingsPath);
     return true;
   } catch {
     return false;
   }
 }
 
-export async function loadSettings(): Promise<HarnessSettings> {
+export async function loadSettings(settingsPath: string = defaultSettingsFilePath()): Promise<HarnessSettings> {
   try {
-    const raw = await fs.readFile(settingsFilePath(), "utf-8");
+    const raw = await fs.readFile(settingsPath, "utf-8");
     const parsed = { ...DEFAULT_SETTINGS, ...(JSON.parse(raw) as Partial<HarnessSettings>) };
     return { ...parsed, recentDirs: await sanitizeRecentDirs(parsed.recentDirs) };
   } catch {
@@ -74,18 +77,49 @@ export async function loadSettings(): Promise<HarnessSettings> {
   }
 }
 
-export async function saveSettings(settings: HarnessSettings): Promise<void> {
-  const filePath = settingsFilePath();
+export async function saveSettings(
+  settings: HarnessSettings,
+  settingsPath: string = defaultSettingsFilePath(),
+): Promise<void> {
   const sanitized: HarnessSettings = {
     ...settings,
     recentDirs: await sanitizeRecentDirs(settings.recentDirs),
   };
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, JSON.stringify(sanitized, null, 2) + "\n");
+  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+  await fs.writeFile(settingsPath, JSON.stringify(sanitized, null, 2) + "\n");
 }
 
 /** Record `cwd` as the most-recently-used project directory (validated, deduped, capped). */
-export async function recordRecentDir(cwd: string): Promise<void> {
-  const settings = await loadSettings();
-  await saveSettings({ ...settings, recentDirs: [cwd, ...settings.recentDirs] });
+export async function recordRecentDir(cwd: string, settingsPath: string = defaultSettingsFilePath()): Promise<void> {
+  const settings = await loadSettings(settingsPath);
+  await saveSettings({ ...settings, recentDirs: [cwd, ...settings.recentDirs] }, settingsPath);
+}
+
+/**
+ * Boot-time hygiene: persist the removal of recent-dir entries whose path no
+ * longer exists on disk. sanitizeRecentDirs() already drops them from every
+ * in-memory read, but a read alone never rewrites the file — so a dead entry
+ * (deleted project, a crashed check's temp dir) would otherwise sit in
+ * settings.json indefinitely. Returns the entries that were dropped; leaves
+ * the file completely untouched (not even created) when there is nothing to
+ * prune, so this can never break first-run detection (hasStoredSettings).
+ */
+export async function pruneDeadRecentDirs(settingsPath: string = defaultSettingsFilePath()): Promise<string[]> {
+  let stored: Partial<HarnessSettings>;
+  try {
+    stored = JSON.parse(await fs.readFile(settingsPath, "utf-8")) as Partial<HarnessSettings>;
+  } catch {
+    return []; // no settings file yet (or unreadable) — nothing to prune
+  }
+  const recentDirs = Array.isArray(stored.recentDirs)
+    ? stored.recentDirs.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const dead: string[] = [];
+  for (const entry of recentDirs) {
+    if ((await normalizeRecentDir(entry)) === null) dead.push(entry);
+  }
+  if (dead.length === 0) return [];
+  // saveSettings' own sanitize pass is what actually drops the dead entries.
+  await saveSettings({ ...DEFAULT_SETTINGS, ...stored, recentDirs }, settingsPath);
+  return dead;
 }

--- a/packages/harness/src/core/paths.test.ts
+++ b/packages/harness/src/core/paths.test.ts
@@ -1,0 +1,51 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const FAKE_HOME = "/fake-home";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+import { expandHome, resolveStatePaths } from "./paths.js";
+
+describe("expandHome", () => {
+  it("expands ~ and ~/ against the home dir and resolves everything else", () => {
+    expect(expandHome("~")).toBe(FAKE_HOME);
+    expect(expandHome("~/x/y")).toBe(path.join(FAKE_HOME, "x", "y"));
+    expect(expandHome("/abs/path")).toBe("/abs/path");
+  });
+});
+
+describe("resolveStatePaths", () => {
+  it("defaults to the real harness home", () => {
+    const paths = resolveStatePaths();
+    const root = path.join(FAKE_HOME, ".sapiom", "harness");
+    expect(paths.root).toBe(root);
+    expect(paths.machineId).toBe(path.join(root, "machine-id"));
+    expect(paths.sessions).toBe(path.join(root, "sessions.json"));
+    expect(paths.workflows).toBe(path.join(root, "workflows.json"));
+    expect(paths.events).toBe(path.join(root, "events.ndjson"));
+    expect(paths.settings).toBe(path.join(root, "settings.json"));
+    expect(paths.generated).toBe(path.join(root, "generated"));
+    expect(paths.sampleProject).toBe(path.join(root, "sample-project"));
+  });
+
+  it("roots every path under a given stateRoot", () => {
+    const paths = resolveStatePaths("/scratch/state");
+    expect(paths.root).toBe("/scratch/state");
+    expect(paths.machineId).toBe("/scratch/state/machine-id");
+    expect(paths.sessions).toBe("/scratch/state/sessions.json");
+    expect(paths.workflows).toBe("/scratch/state/workflows.json");
+    expect(paths.events).toBe("/scratch/state/events.ndjson");
+    expect(paths.settings).toBe("/scratch/state/settings.json");
+    expect(paths.generated).toBe("/scratch/state/generated");
+    expect(paths.sampleProject).toBe("/scratch/state/sample-project");
+  });
+
+  it("expands a ~-prefixed stateRoot", () => {
+    expect(resolveStatePaths("~/elsewhere").root).toBe(path.join(FAKE_HOME, "elsewhere"));
+  });
+});

--- a/packages/harness/src/core/paths.ts
+++ b/packages/harness/src/core/paths.ts
@@ -5,11 +5,54 @@
  */
 
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
+
+import { HARNESS_HOME, HARNESS_PATHS } from "../shared/types.js";
 
 /** Expand a leading `~` (home directory) in a path, then resolve to absolute. */
 export function expandHome(path: string): string {
   if (path === "~") return homedir();
   if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
   return resolve(path);
+}
+
+/** Absolute locations of every piece of persistent harness state, all rooted
+ *  under one directory. See resolveStatePaths(). */
+export interface HarnessStatePaths {
+  root: string;
+  machineId: string;
+  sessions: string;
+  workflows: string;
+  events: string;
+  settings: string;
+  generated: string;
+  sampleProject: string;
+}
+
+/** The path of `entry` relative to HARNESS_HOME — HARNESS_PATHS expresses
+ *  every well-known file as `${HARNESS_HOME}/<name>`, and deriving the name
+ *  here (instead of repeating it) keeps HARNESS_PATHS the single source of
+ *  truth for what the files are called. */
+function relativeToHome(entry: string): string {
+  return entry.slice(HARNESS_HOME.length + 1);
+}
+
+/**
+ * Resolves the full set of persistent-state locations under a single root.
+ * Defaults to the real HARNESS_HOME (`~/.sapiom/harness`) — the CLI's
+ * behavior is unchanged — while tests and scripted checks pass a scratch
+ * directory so a server boot can never touch the developer's real state.
+ */
+export function resolveStatePaths(stateRoot?: string): HarnessStatePaths {
+  const root = expandHome(stateRoot ?? HARNESS_HOME);
+  return {
+    root,
+    machineId: join(root, relativeToHome(HARNESS_PATHS.machineId)),
+    sessions: join(root, relativeToHome(HARNESS_PATHS.sessions)),
+    workflows: join(root, relativeToHome(HARNESS_PATHS.workflows)),
+    events: join(root, relativeToHome(HARNESS_PATHS.events)),
+    settings: join(root, relativeToHome(HARNESS_PATHS.settings)),
+    generated: join(root, relativeToHome(HARNESS_PATHS.generated)),
+    sampleProject: join(root, relativeToHome(HARNESS_PATHS.sampleProject)),
+  };
 }

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -112,4 +112,51 @@ describe("WorkflowRegistry", () => {
     const entry = list.find((workflow) => workflow.path === projectDir);
     expect(entry?.source).toBe("connect");
   });
+
+  describe("prune", () => {
+    it("drops entries whose path no longer exists and persists the result", async () => {
+      const liveDir = path.join(tmpRoot, "live");
+      const deadDir = path.join(tmpRoot, "dead");
+      await writeMarker(liveDir, 1);
+      await writeMarker(deadDir, 2);
+      await registry.scan(tmpRoot);
+      await fs.rm(deadDir, { recursive: true, force: true });
+
+      const pruned = await registry.prune();
+      expect(pruned.map((workflow) => workflow.path)).toEqual([deadDir]);
+      expect((await registry.list()).map((workflow) => workflow.path)).toEqual([liveDir]);
+
+      // Persisted, not just dropped from the in-memory list.
+      const reloaded = new WorkflowRegistry(registryPath);
+      expect((await reloaded.list()).map((workflow) => workflow.path)).toEqual([liveDir]);
+    });
+
+    it("keeps an existing-but-unbuilt project (only nonexistent paths are pruned)", async () => {
+      // A bare directory with a marker and nothing else — no node_modules,
+      // no build output. Deleting nothing: prune must keep it.
+      const unbuiltDir = path.join(tmpRoot, "unbuilt");
+      await writeMarker(unbuiltDir, 3);
+      await registry.scan(tmpRoot);
+
+      expect(await registry.prune()).toEqual([]);
+      expect((await registry.list()).map((workflow) => workflow.path)).toEqual([unbuiltDir]);
+    });
+
+    it("does not rewrite the registry file when nothing was pruned", async () => {
+      const liveDir = path.join(tmpRoot, "live");
+      await writeMarker(liveDir, 1);
+      await registry.scan(tmpRoot);
+      const before = await fs.stat(registryPath);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(await registry.prune()).toEqual([]);
+      const after = await fs.stat(registryPath);
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+    });
+
+    it("is a no-op when no registry file exists yet", async () => {
+      expect(await registry.prune()).toEqual([]);
+      await expect(fs.access(registryPath)).rejects.toThrow();
+    });
+  });
 });

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -104,6 +104,35 @@ export class WorkflowRegistry {
     return this.workflows;
   }
 
+  /**
+   * Drops entries whose `path` no longer exists on disk and persists the
+   * result — users delete projects, and a crashed run can leave a temp
+   * directory registered. Deliberately narrow: only a confirmed-missing
+   * path (ENOENT/ENOTDIR) is pruned. A directory that exists but is
+   * merely unbuilt, unreadable (permissions), or temporarily unstattable
+   * stays registered. Returns what was pruned so the caller can log it.
+   */
+  async prune(): Promise<WorkflowInfo[]> {
+    await this.ensureLoaded();
+    const kept: WorkflowInfo[] = [];
+    const pruned: WorkflowInfo[] = [];
+    for (const workflow of this.workflows) {
+      try {
+        await fs.stat(workflow.path);
+        kept.push(workflow);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT" || code === "ENOTDIR") pruned.push(workflow);
+        else kept.push(workflow);
+      }
+    }
+    if (pruned.length > 0) {
+      this.workflows = kept;
+      await this.persist();
+    }
+    return pruned;
+  }
+
   /** Scans `root` and merges discovered projects into the persisted registry. */
   async scan(root: string): Promise<WorkflowInfo[]> {
     await this.ensureLoaded();

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -98,10 +98,7 @@ describe("codex session lifecycle (real files, no mocking)", () => {
       telemetryOptIn: false,
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
-      sessionsPath: join(dir, "sessions.json"),
-      generatedRoot: join(dir, "generated"),
-      eventStorePath,
-      workflowsRegistryPath: join(dir, "workflows.json"),
+      stateRoot: dir,
       codexHomeDir,
     });
 

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -95,10 +95,7 @@ describe("codex tailer lifecycle wiring", () => {
       telemetryOptIn: false,
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
-      sessionsPath: join(dir, "sessions.json"),
-      generatedRoot: join(dir, "generated"),
-      eventStorePath: join(dir, "events.ndjson"),
-      workflowsRegistryPath: join(dir, "workflows.json"),
+      stateRoot: dir,
     });
 
     const session = await server.sessionManager.create({ cwd, harness: "codex" });
@@ -150,10 +147,7 @@ describe("codex tailer lifecycle wiring", () => {
       telemetryOptIn: false,
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
-      sessionsPath: join(dir, "sessions.json"),
-      generatedRoot: join(dir, "generated"),
-      eventStorePath: join(dir, "events.ndjson"),
-      workflowsRegistryPath: join(dir, "workflows.json"),
+      stateRoot: dir,
     });
 
     const historical = server.sessionManager.registerHistorical({
@@ -202,10 +196,7 @@ describe("codex tailer lifecycle wiring", () => {
           listPastSessions: async () => [],
         },
       },
-      sessionsPath: join(dir, "sessions.json"),
-      generatedRoot: join(dir, "generated"),
-      eventStorePath: join(dir, "events.ndjson"),
-      workflowsRegistryPath: join(dir, "workflows.json"),
+      stateRoot: dir,
     });
 
     const session = await server.sessionManager.create({ cwd: join(dir, "project"), harness: "claude-code" });
@@ -233,10 +224,7 @@ describe("codex tailer lifecycle wiring", () => {
       telemetryOptIn: false,
       autoCreateSession: false,
       adapters: { codex: fakeCodexAdapter() },
-      sessionsPath: join(dir, "sessions.json"),
-      generatedRoot: join(dir, "generated"),
-      eventStorePath: join(dir, "events.ndjson"),
-      workflowsRegistryPath: join(dir, "workflows.json"),
+      stateRoot: dir,
     });
 
     const session = await server.sessionManager.create({ cwd, harness: "codex" });

--- a/packages/harness/src/server/generated-retention.test.ts
+++ b/packages/harness/src/server/generated-retention.test.ts
@@ -69,10 +69,7 @@ describe("generated-dir retention wiring", () => {
       telemetryOptIn: false,
       autoCreateSession: false,
       adapters: { "claude-code": fakeClaudeAdapter() },
-      sessionsPath: join(dir, "sessions.json"),
-      eventStorePath: join(dir, "events.ndjson"),
-      workflowsRegistryPath: join(dir, "workflows.json"),
-      generatedRoot,
+      stateRoot: dir,
     });
   }
 

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -22,8 +22,7 @@ import type {
   HarnessSession,
   WorkflowInfo,
 } from "../shared/types.js";
-import { HARNESS_PATHS } from "../shared/types.js";
-import { expandHome } from "../core/paths.js";
+import { resolveStatePaths } from "../core/paths.js";
 import { seedExampleProject } from "../core/example-seed.js";
 import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.js";
 import { TaskManager } from "../core/task-manager.js";
@@ -38,6 +37,7 @@ import { enrichTurnCompleted } from "../core/collector/transcript.js";
 import { createSeqCounter } from "../core/collector/seq.js";
 import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "../core/collector/codex-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
+import { pruneDeadRecentDirs } from "../cli/settings.js";
 import type { HarnessIdentity } from "../cli/auth.js";
 import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
@@ -98,16 +98,26 @@ export interface HarnessServerOptions {
   machineId?: string;
   /** Override the adapter set (tests inject a stubbed claude-code binary). */
   adapters?: Partial<Record<HarnessKind, HarnessAdapter>>;
+  /** Root directory ALL persistent harness state lives under: machine-id,
+   *  sessions.json, workflows.json, events.ndjson, settings.json, generated/
+   *  and sample-project/. Defaults to the real HARNESS_HOME
+   *  (`~/.sapiom/harness`) — unchanged for CLI users. Tests, e2e scripts and
+   *  live checks MUST pass a scratch directory here so a server boot never
+   *  registers its temp projects (or anything else) into the developer's
+   *  real state. The per-file options below still override individual
+   *  locations; each now defaults under this root. */
+  stateRoot?: string;
+  /** Session registry file. Defaults to `<stateRoot>/sessions.json`. */
   sessionsPath?: string;
   buildLaunchOpts?: LaunchOptsBuilder;
   /** Root directory per-session generated agent configs are written under —
    *  and cleaned up from (exit-time delete + boot-time sweep, see
-   *  core/inject/retention.ts). Defaults to HARNESS_PATHS.generated
-   *  (`~/.sapiom/harness/generated`). Tests point this at a temp dir so they
-   *  never write to (or sweep) the real home directory. */
+   *  core/inject/retention.ts). Defaults to `<stateRoot>/generated`. */
   generatedRoot?: string;
   collectorUrl?: string;
+  /** Workflow registry file. Defaults to `<stateRoot>/workflows.json`. */
   workflowsRegistryPath?: string;
+  /** Local analytics ndjson sink. Defaults to `<stateRoot>/events.ndjson`. */
   eventStorePath?: string;
   /** Overrides the home directory codex rollout discovery scans
    * (`<home>/.codex/sessions/...`). Defaults to the real OS home dir; tests
@@ -137,7 +147,7 @@ export interface HarnessServerOptions {
    *  AppState.firstRun (see its doc comment). Omitted → absent there too. */
   firstRun?: boolean;
   /** Where POST /api/sample-project seeds the bundled example. Defaults to
-   *  HARNESS_PATHS.sampleProject; tests point it at a temp dir. */
+   *  `<stateRoot>/sample-project`. */
   sampleProjectRoot?: string;
 }
 
@@ -193,7 +203,8 @@ function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: str
 export const startServer = async (options: HarnessServerOptions): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
   const identity = options.identity ?? null;
-  const machineId = options.machineId ?? (await getOrCreateMachineId());
+  const statePaths = resolveStatePaths(options.stateRoot);
+  const machineId = options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
   const launchDir = options.launchDir ?? process.cwd();
   const adapters: Partial<Record<HarnessKind, HarnessAdapter>> =
     options.adapters ??
@@ -234,7 +245,30 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // itself (to rewrite every open session's context file on a registry change) —
   // no circularity, since only writeSessionContext is threaded into SessionManager's
   // constructor, and it doesn't need sessionManager.
-  const workflowRegistry = new WorkflowRegistry(options.workflowsRegistryPath);
+  const workflowRegistry = new WorkflowRegistry(options.workflowsRegistryPath ?? statePaths.workflows);
+  // Boot-time hygiene, before the first list(): drop registry entries whose
+  // path no longer exists on disk (deleted projects, temp dirs a crashed run
+  // left registered) so the rail — and every harness-context.json written
+  // below — never resurrects a dead project. Deliberately awaited: nothing
+  // downstream should ever observe the pre-prune list.
+  try {
+    const prunedWorkflows = await workflowRegistry.prune();
+    for (const workflow of prunedWorkflows) {
+      console.error(`[harness] pruned workflow registry entry with missing path: ${workflow.path}`);
+    }
+  } catch (err) {
+    console.error("[harness] workflow registry prune failed:", err);
+  }
+  // Same hygiene for settings.json's recentDirs — dead entries are already
+  // filtered from every read, but pruning here persists their removal.
+  // Awaited so it can't race a settings PATCH once the server is listening.
+  try {
+    for (const dir of await pruneDeadRecentDirs(statePaths.settings)) {
+      console.error(`[harness] pruned recent dir with missing path: ${dir}`);
+    }
+  } catch (err) {
+    console.error("[harness] recent-dirs prune failed:", err);
+  }
   let workflowsCache: WorkflowInfo[] = await workflowRegistry.list();
   const workflowsCacheTimer = setInterval(() => {
     void workflowRegistry.list().then((list) => {
@@ -264,7 +298,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // buildLaunchOpts, and the rm scheduled at the previous exit could still
   // be in flight. Serialize by awaiting any pending removal for this id
   // before (re)generating its files.
-  const generatedRoot = options.generatedRoot;
+  const generatedRoot = options.generatedRoot ?? statePaths.generated;
   const pendingGeneratedRemovals = new Map<string, Promise<void>>();
   const innerBuildLaunchOpts =
     options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
@@ -278,7 +312,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     ingestUrl: `http://${host}:${options.port}`,
     ingestToken: options.bootToken,
     collectorUrl: options.collectorUrl,
-    sessionsPath: options.sessionsPath,
+    sessionsPath: options.sessionsPath ?? statePaths.sessions,
     buildLaunchOpts,
     // Every session gets its initial harness-context.json regardless of
     // entry point (REST, autoCreateSession) — see SessionManager.create().
@@ -405,7 +439,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     return [] as WorkflowInfo[];
   });
 
-  const eventStore = createEventStore(options.eventStorePath);
+  const eventStore = createEventStore(options.eventStorePath ?? statePaths.events);
   const batcher = new CollectorBatcher({
     machineId,
     telemetryOptIn: options.telemetryOptIn,
@@ -472,10 +506,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       firstRun: options.firstRun,
       seedSampleProject: async () => {
         const { root, projectDir, created } = await seedExampleProject({
-          targetRoot: options.sampleProjectRoot ?? expandHome(HARNESS_PATHS.sampleProject),
+          targetRoot: options.sampleProjectRoot ?? statePaths.sampleProject,
         });
         return { root, projectDir, created };
       },
+      settingsPath: statePaths.settings,
     }),
   );
   app.use(

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -101,6 +101,11 @@ export interface RestRouterOptions {
    * sample project"). Optional so callers without the real seeder (tests)
    * get a 501 from the route instead of having to stub one. */
   seedSampleProject?: () => Promise<SampleProjectSeedResponse>;
+  /** Where GET/PATCH /settings (and /state's settings read) persist to.
+   * Omitted, the real `~/.sapiom/harness/settings.json` — the integrator
+   * (server/index.ts) passes the path under its resolved state root so an
+   * isolated boot never reads or writes the developer's real settings. */
+  settingsPath?: string;
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
@@ -110,7 +115,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
 
   router.get("/state", async (_req, res, next) => {
     try {
-      const settings = await loadSettings();
+      const settings = await loadSettings(options.settingsPath);
       const state: AppState = {
         version,
         authenticated: identity !== null,
@@ -133,7 +138,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
 
   router.get("/settings", async (_req, res, next) => {
     try {
-      res.json(await loadSettings());
+      res.json(await loadSettings(options.settingsPath));
     } catch (err) {
       next(err);
     }
@@ -146,9 +151,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
       return;
     }
     try {
-      const current = await loadSettings();
+      const current = await loadSettings(options.settingsPath);
       const updated: HarnessSettings = { ...current, ...parsed.data };
-      await saveSettings(updated);
+      await saveSettings(updated, options.settingsPath);
       if (
         parsed.data.telemetryOptIn !== undefined &&
         parsed.data.telemetryOptIn !== current.telemetryOptIn

--- a/packages/harness/src/server/state-isolation.test.ts
+++ b/packages/harness/src/server/state-isolation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Proves `stateRoot` actually isolates every piece of persistent state a
+ * server boot (plus the settings REST surface) touches — machine-id,
+ * workflows.json, settings.json — and that with no stateRoot the same files
+ * land under the real home-dir default, unchanged. The home dir is mocked so
+ * neither case can touch the developer's real ~/.sapiom/harness.
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let fakeHome: string;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return { ...actual, homedir: () => fakeHome };
+});
+
+import { startServer, type HarnessServer } from "./index.js";
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("state-root isolation", () => {
+  let dir: string;
+  let launchDir: string;
+  let server: HarnessServer | undefined;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-state-isolation-"));
+    fakeHome = path.join(dir, "home");
+    launchDir = path.join(dir, "project");
+    await fs.mkdir(fakeHome, { recursive: true });
+    await fs.mkdir(launchDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("roots machine-id, workflows.json and settings.json under stateRoot and leaves the home dir untouched", async () => {
+    const stateRoot = path.join(dir, "state");
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      adapters: {},
+      stateRoot,
+      launchDir,
+      autoCreateSession: false,
+    });
+
+    const baseUrl = `http://127.0.0.1:${server.port}`;
+    const headers = { "Content-Type": "application/json", "X-Harness-Token": "test-token" };
+
+    // machine-id was created at boot (no machineId option passed), under stateRoot.
+    const machineId = (await fs.readFile(path.join(stateRoot, "machine-id"), "utf-8")).trim();
+    expect(machineId).toMatch(/^[0-9a-f-]{36}$/);
+
+    // The boot-time launch-dir scan persisted the registry under stateRoot.
+    // The scan is fire-and-forget — poll rather than racing it.
+    await vi.waitFor(async () => {
+      expect(await exists(path.join(stateRoot, "workflows.json"))).toBe(true);
+    });
+
+    // The settings REST surface reads and writes under stateRoot too.
+    const patchRes = await fetch(`${baseUrl}/api/settings`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ telemetryOptIn: true }),
+    });
+    expect(patchRes.status).toBe(200);
+    const stored = JSON.parse(await fs.readFile(path.join(stateRoot, "settings.json"), "utf-8")) as {
+      telemetryOptIn: boolean;
+    };
+    expect(stored.telemetryOptIn).toBe(true);
+
+    // Nothing anywhere in the (fake) home dir.
+    expect(await fs.readdir(fakeHome)).toEqual([]);
+  });
+
+  it("defaults every path under ~/.sapiom/harness when no stateRoot is given", async () => {
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      adapters: {},
+      launchDir,
+      autoCreateSession: false,
+    });
+
+    const harnessHome = path.join(fakeHome, ".sapiom", "harness");
+    expect(await exists(path.join(harnessHome, "machine-id"))).toBe(true);
+    // The boot-time launch-dir scan (which persists the registry) is
+    // fire-and-forget — poll rather than racing it.
+    await vi.waitFor(async () => {
+      expect(await exists(path.join(harnessHome, "workflows.json"))).toBe(true);
+    });
+  });
+
+  it("prunes a registry entry whose path no longer exists, at boot, and persists it", async () => {
+    const stateRoot = path.join(dir, "state");
+    const deadPath = path.join(dir, "deleted-project");
+    await fs.mkdir(stateRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(stateRoot, "workflows.json"),
+      JSON.stringify([
+        { name: "deleted-project", path: deadPath, definitionId: 1, source: "scan" },
+        { name: "project", path: launchDir, definitionId: null, source: "connect" },
+      ]),
+    );
+
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      adapters: {},
+      stateRoot,
+      launchDir,
+      autoCreateSession: false,
+    });
+
+    const baseUrl = `http://127.0.0.1:${server.port}`;
+    const headers = { "X-Harness-Token": "test-token" };
+    const workflows = (await (await fetch(`${baseUrl}/api/workflows`, { headers })).json()) as Array<{
+      path: string;
+    }>;
+    expect(workflows.some((w) => w.path === deadPath)).toBe(false);
+    expect(workflows.some((w) => w.path === launchDir)).toBe(true);
+
+    // The boot-time launch-dir scan re-persists the registry concurrently
+    // with this read (fs.writeFile isn't atomic) — poll until a complete,
+    // parseable write is on disk.
+    await vi.waitFor(async () => {
+      const persisted = JSON.parse(await fs.readFile(path.join(stateRoot, "workflows.json"), "utf-8")) as Array<{
+        path: string;
+      }>;
+      expect(persisted.some((w) => w.path === deadPath)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Booting `startServer()` against a temp project could pollute the developer's real `~/.sapiom/harness`. #234 fixed this class of leak for `generated/` via the `generatedRoot` option, but the rest of the persistent state had no equivalent: `machine-id` and `settings.json` had **no** injection point at all, and a temp project registered into `workflows.json` / `recentDirs` by a scripted check would resurface in the next real UI session as a broken entry (its temp dir gone or unbuilt → a "render failed" card for a first-run user).

## Changes

### 1. State-root isolation (`stateRoot`)

- `startServer()` takes a single **`stateRoot`** option; every persistent path derives from it: `machine-id`, `sessions.json`, `workflows.json`, `events.ndjson`, `settings.json`, `generated/`, `sample-project/` (`resolveStatePaths()` in `core/paths.ts`, deriving filenames from `HARNESS_PATHS` so there's one source of truth).
- Default is the real `~/.sapiom/harness` — **CLI behavior unchanged**. The existing per-file options (`sessionsPath`, `generatedRoot`, `workflowsRegistryPath`, `eventStorePath`, `sampleProjectRoot`) remain as overrides, now defaulting under `stateRoot`.
- New injection points for the two paths that had none: `getOrCreateMachineId(filePath?)`, and the settings module (`loadSettings`/`saveSettings`/`hasStoredSettings`/`recordRecentDir` take an explicit path). The REST router threads `settingsPath` through so `GET/PATCH /api/settings` (and `/api/state`'s settings read) never touch the real file on an isolated boot.
- Every entry point that boots a server now passes a scratch root: `scripts/e2e-live.ts` (all three phases; phase 1 also drops its explicit `machineId` so machine-id isolation is actually exercised) and the three server test suites. `sim:e2e` and the Playwright suites were already isolated (hand-assembled paths / mock mode).

### 2. Dead-path registry hygiene at boot

- `WorkflowRegistry.prune()`: drops entries whose `path` no longer exists on disk and persists the result. Deliberately narrow — only a confirmed-missing path (`ENOENT`/`ENOTDIR`) is pruned; merely-unbuilt, unreadable, or temporarily unstattable projects stay registered.
- `pruneDeadRecentDirs()`: persists the removal of dead `recentDirs` entries (`sanitizeRecentDirs` already filtered them from every read, but never rewrote the file). Never creates a settings file where none existed, so first-run detection stays intact.
- Both run at boot in `startServer()`, awaited before the registry is first served, and log what they pruned.

## Verification

- `typecheck` (src + web), **477** unit tests (incl. new suites: `paths.test.ts`, `state-isolation.test.ts`, prune coverage in `workflow-registry.test.ts` / `settings.test.ts`), `build:server` + `build:web`, `sim:e2e`, `e2e:live` (new item 15 proves machine-id lands under the scratch root and a pre-seeded dead registry entry is pruned and persisted), `test:ui` (52 passed), `lint`.
- **Isolation proof:** snapshotted the real `~/.sapiom/harness` before running the full `e2e:live` suite (twice) — `workflows.json`, `settings.json`, `machine-id`, and `sessions.json` are byte-identical afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8X6PywxyEyQGXZj3LKPQ1