### PR TITLE
fix(harness): dismiss popovers on outside click and Escape

### DIFF
--- a/packages/harness/web/e2e/dismiss.spec.ts
+++ b/packages/harness/web/e2e/dismiss.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Light-dismiss behavior for the popovers/dropdowns (and the new-session
+ * modal): clicking anywhere outside or pressing Escape closes them, and
+ * Escape hands focus back to the trigger. Runs in the same mock mode as
+ * smoke.spec.ts.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+test.describe("session history dropdown", () => {
+  test("closes on a click anywhere outside", async ({ page }) => {
+    await page.getByTestId("history-trigger").click();
+    const menu = page.getByTestId("history-menu");
+    await expect(menu).toBeVisible();
+
+    // Clicking inside the menu must NOT dismiss it (section headers are inert).
+    await menu.getByText("Exited", { exact: true }).click();
+    await expect(menu).toBeVisible();
+
+    await page.locator(".brand-name").click();
+    await expect(menu).toBeHidden();
+  });
+
+  test("closes on Escape and returns focus to the trigger", async ({ page }) => {
+    await page.getByTestId("history-trigger").click();
+    await expect(page.getByTestId("history-menu")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("history-menu")).toBeHidden();
+    await expect(page.getByTestId("history-trigger")).toBeFocused();
+  });
+
+  test("the trigger still toggles it closed", async ({ page }) => {
+    const trigger = page.getByTestId("history-trigger");
+    await trigger.click();
+    await expect(page.getByTestId("history-menu")).toBeVisible();
+    await trigger.click();
+    await expect(page.getByTestId("history-menu")).toBeHidden();
+  });
+});
+
+test.describe("settings popover", () => {
+  test("closes on a click anywhere outside", async ({ page }) => {
+    await page.getByTestId("settings-trigger").click();
+    const popover = page.getByTestId("settings-popover");
+    await expect(popover).toBeVisible();
+
+    // Interacting inside (the telemetry toggle) must NOT dismiss it.
+    await page.getByTestId("telemetry-toggle").click();
+    await expect(popover).toBeVisible();
+
+    await page.locator(".brand-name").click();
+    await expect(popover).toBeHidden();
+  });
+
+  test("closes on Escape and returns focus to the trigger", async ({ page }) => {
+    await page.getByTestId("settings-trigger").click();
+    await expect(page.getByTestId("settings-popover")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("settings-popover")).toBeHidden();
+    await expect(page.getByTestId("settings-trigger")).toBeFocused();
+  });
+});
+
+test.describe("new-session modal", () => {
+  test("closes on Escape and returns focus to the trigger", async ({ page }) => {
+    await page.getByTestId("new-session-btn").click();
+    await expect(page.getByText("New session")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByText("New session")).toBeHidden();
+    await expect(page.getByTestId("new-session-btn")).toBeFocused();
+  });
+
+  test("still closes on a backdrop click, but not on clicks inside the panel", async ({ page }) => {
+    await page.getByTestId("new-session-btn").click();
+    await expect(page.getByText("New session")).toBeVisible();
+
+    await page.getByTestId("dir-picker-input").click();
+    await expect(page.getByText("New session")).toBeVisible();
+
+    // The panel is centered, so the backdrop's top-left corner is outside it.
+    await page.locator(".modal-backdrop").click({ position: { x: 5, y: 5 } });
+    await expect(page.getByText("New session")).toBeHidden();
+  });
+});

--- a/packages/harness/web/src/components/NewSessionModal.tsx
+++ b/packages/harness/web/src/components/NewSessionModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
-import type { JSX } from "react";
+import { useRef, useState } from "react";
+import type { JSX, RefObject } from "react";
 import type { HarnessKind } from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
+import { useDismissable } from "../lib/use-dismissable";
 import { DirectoryPicker } from "./DirectoryPicker";
 
 interface NewSessionModalProps {
@@ -11,6 +12,8 @@ interface NewSessionModalProps {
   listDir: (path?: string) => Promise<FsListResponse>;
   onClose: () => void;
   onCreate: (cwd: string, harness: HarnessKind) => Promise<void>;
+  /** The button that opened the modal — Escape returns focus to it. */
+  triggerRef?: RefObject<HTMLElement | null>;
 }
 
 const HARNESS_OPTIONS: { id: HarnessKind; label: string }[] = [
@@ -24,11 +27,15 @@ export function NewSessionModal({
   listDir,
   onClose,
   onCreate,
+  triggerRef,
 }: NewSessionModalProps): JSX.Element {
   const [cwd, setCwd] = useState(launchDir ?? recentDirs[0] ?? "");
   const [harness, setHarness] = useState<HarnessKind>("claude-code");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  useDismissable(true, { onDismiss: onClose, containerRef: panelRef, triggerRef });
 
   const submit = async (): Promise<void> => {
     const trimmed = cwd.trim();
@@ -46,8 +53,8 @@ export function NewSessionModal({
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal modal-new-session" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-backdrop">
+      <div className="modal modal-new-session" ref={panelRef}>
         <div className="modal-header">New session</div>
 
         <label className="modal-label" htmlFor="new-session-cwd">

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import type { HarnessKind, HarnessSession, SessionSummary } from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
+import { useDismissable } from "../lib/use-dismissable";
 import { Icon } from "./Icon";
 import { NewSessionModal } from "./NewSessionModal";
 import { SettingsPopover } from "./SettingsPopover";
@@ -52,6 +53,25 @@ export function SessionBar({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const historyWrapRef = useRef<HTMLDivElement>(null);
+  const historyTriggerRef = useRef<HTMLButtonElement>(null);
+  const settingsWrapRef = useRef<HTMLDivElement>(null);
+  const settingsTriggerRef = useRef<HTMLButtonElement>(null);
+  const newSessionTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const closeHistory = useCallback(() => setHistoryOpen(false), []);
+  const closeSettings = useCallback(() => setSettingsOpen(false), []);
+  useDismissable(historyOpen, {
+    onDismiss: closeHistory,
+    containerRef: historyWrapRef,
+    triggerRef: historyTriggerRef,
+  });
+  useDismissable(settingsOpen, {
+    onDismiss: closeSettings,
+    containerRef: settingsWrapRef,
+    triggerRef: settingsTriggerRef,
+  });
 
   // One tab per live session, oldest-first — a stable order Cmd+1..9 relies
   // on (App.tsx computes the same ordering for the keyboard shortcut) and
@@ -110,6 +130,7 @@ export function SessionBar({
         })}
 
         <button
+          ref={newSessionTriggerRef}
           className="session-tab-add"
           data-testid="new-session-btn"
           onClick={() => setModalOpen(true)}
@@ -120,8 +141,9 @@ export function SessionBar({
         </button>
       </div>
 
-      <div className="session-history-wrap">
+      <div className="session-history-wrap" ref={historyWrapRef}>
         <button
+          ref={historyTriggerRef}
           className="session-history-trigger"
           data-testid="history-trigger"
           onClick={toggleHistory}
@@ -182,8 +204,9 @@ export function SessionBar({
         )}
       </div>
 
-      <div className="settings-wrap">
+      <div className="settings-wrap" ref={settingsWrapRef}>
         <button
+          ref={settingsTriggerRef}
           className="gear-btn"
           aria-label="Settings"
           data-testid="settings-trigger"
@@ -209,6 +232,7 @@ export function SessionBar({
           listDir={listDir}
           onClose={() => setModalOpen(false)}
           onCreate={onCreateSession}
+          triggerRef={newSessionTriggerRef}
         />
       )}
     </div>

--- a/packages/harness/web/src/components/WelcomePanel.tsx
+++ b/packages/harness/web/src/components/WelcomePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { JSX } from "react";
 import type { HarnessKind } from "@shared/types";
 
@@ -38,6 +38,7 @@ export function WelcomePanel({
   const [modalOpen, setModalOpen] = useState(false);
   const [sampleBusy, setSampleBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const startProjectRef = useRef<HTMLButtonElement>(null);
 
   const runSample = async (): Promise<void> => {
     setSampleBusy(true);
@@ -64,6 +65,7 @@ export function WelcomePanel({
 
         <div className="welcome-actions">
           <button
+            ref={startProjectRef}
             className="btn-primary welcome-action"
             data-testid="welcome-start-project"
             onClick={() => setModalOpen(true)}
@@ -113,6 +115,7 @@ export function WelcomePanel({
           listDir={listDir}
           onClose={() => setModalOpen(false)}
           onCreate={onCreateSession}
+          triggerRef={startProjectRef}
         />
       )}
     </div>

--- a/packages/harness/web/src/lib/use-dismissable.ts
+++ b/packages/harness/web/src/lib/use-dismissable.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+interface DismissableOptions {
+  onDismiss: () => void;
+  /** Wraps the trigger and the panel — a mousedown anywhere outside it dismisses. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Focus returns here on Escape, so keyboard users aren't dropped on <body>. */
+  triggerRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Standard light-dismiss for popovers/dropdowns/modals: clicking anywhere
+ * outside the container or pressing Escape closes them.
+ *
+ * Outside detection is on mousedown, not click — a click's target is the
+ * nearest common ancestor of where the press started and ended, so a drag
+ * that starts inside the panel (text selection) and releases outside would
+ * otherwise count as an outside click and dismiss mid-gesture.
+ */
+export function useDismissable(open: boolean, { onDismiss, containerRef, triggerRef }: DismissableOptions): void {
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (event: MouseEvent): void => {
+      const container = containerRef.current;
+      if (container && event.target instanceof Node && !container.contains(event.target)) {
+        onDismiss();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      onDismiss();
+      triggerRef?.current?.focus();
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onDismiss, containerRef, triggerRef]);
+}


### PR DESCRIPTION
## Problem

The session-history dropdown and the settings popover in `packages/harness/web` only closed when their trigger button was clicked again. Clicking anywhere else on the page, or pressing Escape, left them open.

## Change

- New shared `useDismissable` hook (`web/src/lib/use-dismissable.ts`): a mousedown outside the trigger+panel container, or Escape, dismisses; Escape returns focus to the trigger so keyboard users aren't dropped on `<body>`. Outside detection is on **mousedown**, not click, so a drag that starts inside the panel (e.g. text selection) and releases outside doesn't dismiss mid-gesture.
- Wired into the **history dropdown** and **settings popover** in `SessionBar`.
- Swept the rest of the app for the same gap: the **new-session modal** (only other uncovered surface — the ⌘K palette and the workflows-rail connect input already handle Escape) gets the same hook. It gains Escape-to-close, and its backdrop-click dismissal moves to the hook's mousedown path. Both call sites (SessionBar's `+` button, WelcomePanel's "Start a new project") pass a trigger ref for focus return.

## Testing

New `web/e2e/dismiss.spec.ts` (7 specs): outside-click closes history/settings, Escape closes history/settings/modal with focus returned to the trigger, clicks inside each surface don't dismiss, trigger still toggles closed, backdrop click still closes the modal.

`tsc --noEmit` clean · `vitest` 462 passed · `build:web` ok · `test:ui` 59 passed (52 pre-existing + 7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJqyVqcE2ocUJNYonxYNBh