### PR TITLE
feat(harness): deterministic visualization layer — dual-SDK extraction, cache, per-workflow renders

### DIFF
--- a/.changeset/dual-sdk-check-extraction.md
+++ b/.changeset/dual-sdk-check-extraction.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/agent": patch
+"@sapiom/agent-core": patch
+---
+
+`check()` now recognizes workflow definitions authored against the pre-rename SDK: `@sapiom/agent` exports `isLegacyOrchestrationDefinition`/`LEGACY_ORCHESTRATION_DEFINITION_BRAND` (the `Symbol.for('sapiom.orchestration.definition')` brand the old `defineOrchestration` attached), and `@sapiom/agent-core`'s `check()` accepts either brand in its export detection — the definition shape is unchanged by the rename, so manifests build identically. `check()` also gains a `typecheck` option (default `true`): pass `typecheck: false` to skip the project's `tsc --noEmit` when only the manifest/graph is needed (esbuild still surfaces bundle-level breakage).

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -10,7 +10,13 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { assertValidGraph, buildManifest, isAgentDefinition, agentManifestSchema } from '@sapiom/agent';
+import {
+  assertValidGraph,
+  buildManifest,
+  isAgentDefinition,
+  isLegacyOrchestrationDefinition,
+  agentManifestSchema,
+} from '@sapiom/agent';
 import * as esbuild from 'esbuild';
 
 import { AgentOperationError } from './errors.js';
@@ -46,6 +52,14 @@ const LOCAL_SDK_VERSION = '0.0.0-local';
 export interface CheckOptions {
   /** Absolute path to the agent project directory containing index.ts. */
   sourceDir: string;
+  /**
+   * Run the project's `tsc --noEmit` before bundling (default true). Callers
+   * that only need the manifest/graph — not type safety — can pass false to
+   * skip the dominant multi-second cost (e.g. the harness's diagram
+   * extraction); esbuild still surfaces real breakage (unresolvable imports,
+   * syntax errors) as BUNDLE_FAILED.
+   */
+  typecheck?: boolean;
 }
 
 export interface CheckResult {
@@ -79,8 +93,10 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
   // Typecheck first — it's the only step that validates types and capability
   // references (the bundle is type-stripped). Throws TYPECHECK_FAILED on errors.
   const warnings: string[] = [];
-  const typecheckSkip = runTypecheck(sourceDir);
-  if (typecheckSkip) warnings.push(typecheckSkip);
+  if (opts.typecheck !== false) {
+    const typecheckSkip = runTypecheck(sourceDir);
+    if (typecheckSkip) warnings.push(typecheckSkip);
+  }
 
   const tmp = mkdtempSync(path.join(tmpdir(), 'sapiom-check-'));
   const bundlePath = path.join(tmp, 'definition.mjs');
@@ -105,11 +121,16 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
 
     // The brand survives bundling (Symbol.for keyed in the global registry), so
     // the imported definition is recognized even though it was bundled with the
-    // project's own copy of the SDK.
+    // project's own copy of the SDK. Both brands are accepted: the current
+    // `defineAgent` one and the pre-rename `defineOrchestration` one — the
+    // definition shape is identical, so everything downstream (buildManifest,
+    // graph validation) works unchanged on either.
     const mod: Record<string, unknown> = await import(`file://${bundlePath}?t=${Date.now()}`);
     const defs: unknown[] = [];
     for (const value of Object.values(mod)) {
-      if (isAgentDefinition(value) && !defs.includes(value)) defs.push(value);
+      if ((isAgentDefinition(value) || isLegacyOrchestrationDefinition(value)) && !defs.includes(value)) {
+        defs.push(value);
+      }
     }
 
     if (defs.length === 0) {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -71,6 +71,27 @@ export function isAgentDefinition(val: unknown): val is AgentDefinition {
 }
 
 /**
+ * The brand `@sapiom/orchestration`'s `defineOrchestration` attached before
+ * the agents/models rename (cc1261e). Projects still on that SDK carry this
+ * symbol instead of `AGENT_DEFINITION_BRAND`; the definition shape itself is
+ * unchanged by the rename (same name/entry/steps, same step runtime
+ * properties), so a legacy-branded definition is safe to feed to
+ * `buildManifest` as-is.
+ */
+export const LEGACY_ORCHESTRATION_DEFINITION_BRAND = Symbol.for('sapiom.orchestration.definition');
+
+/**
+ * Type guard for definitions produced by the pre-rename SDK's
+ * `defineOrchestration`. Tooling that inspects arbitrary customer projects
+ * (e.g. `@sapiom/agent-core`'s `check()`) accepts either brand so workflows
+ * authored against the old SDK keep working without a dependency bump.
+ */
+export function isLegacyOrchestrationDefinition(val: unknown): val is AgentDefinition {
+  if (val === null || typeof val !== 'object') return false;
+  return (val as Record<symbol, unknown>)[LEGACY_ORCHESTRATION_DEFINITION_BRAND] === 1;
+}
+
+/**
  * Validate and return a workflow definition. Checks done here:
  *   1. `name` is non-empty
  *   2. `entry` exists in `steps`

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -41,9 +41,15 @@ export type {
 } from './context.js';
 export { InMemoryContextStore } from './context.js';
 
-// Agent definition + defineAgent factory + brand guard
+// Agent definition + defineAgent factory + brand guards (current + pre-rename legacy)
 export type { AgentDefinition } from './agent.js';
-export { defineAgent, isAgentDefinition, AGENT_DEFINITION_BRAND } from './agent.js';
+export {
+  defineAgent,
+  isAgentDefinition,
+  AGENT_DEFINITION_BRAND,
+  isLegacyOrchestrationDefinition,
+  LEGACY_ORCHESTRATION_DEFINITION_BRAND,
+} from './agent.js';
 
 // Errors that are part of the public contract surface
 export { AgentError, UnknownStepError, StepInputValidationError, DisallowedTransitionError } from './errors.js';

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -25,6 +25,8 @@ import {
   isRetry,
   isTerminate,
   isAgentDefinition,
+  isLegacyOrchestrationDefinition,
+  LEGACY_ORCHESTRATION_DEFINITION_BRAND,
   terminate,
 } from './index.js';
 import type {
@@ -207,6 +209,49 @@ describe('isAgentDefinition', () => {
     } else {
       throw new Error('expected isAgentDefinition to return true');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLegacyOrchestrationDefinition type guard (pre-rename @sapiom/orchestration)
+// ---------------------------------------------------------------------------
+
+describe('isLegacyOrchestrationDefinition', () => {
+  // What the old SDK's defineOrchestration produced: the same definition
+  // shape, branded with Symbol.for('sapiom.orchestration.definition') = 1
+  // as a non-enumerable property.
+  function makeLegacyDefinition(): unknown {
+    const def = { name: 'legacy-wf', entry: 'start', steps: { start: makeStep('start') } };
+    Object.defineProperty(def, LEGACY_ORCHESTRATION_DEFINITION_BRAND, {
+      value: 1,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    return def;
+  }
+
+  it('returns true for a legacy-branded definition', () => {
+    expect(isLegacyOrchestrationDefinition(makeLegacyDefinition())).toBe(true);
+  });
+
+  it('returns false for a current defineAgent definition — the two brands are distinct', () => {
+    const def = defineAgent({ name: 'wf', entry: 'start', steps: { start: makeStep('start') } });
+    expect(isLegacyOrchestrationDefinition(def)).toBe(false);
+    expect(isAgentDefinition(makeLegacyDefinition())).toBe(false);
+  });
+
+  it('returns false for plain objects, null and primitives', () => {
+    expect(isLegacyOrchestrationDefinition({ name: 'wf', entry: 'start', steps: {} })).toBe(false);
+    expect(isLegacyOrchestrationDefinition(null)).toBe(false);
+    expect(isLegacyOrchestrationDefinition('workflow')).toBe(false);
+    expect(isLegacyOrchestrationDefinition(undefined)).toBe(false);
+  });
+
+  it('resolves through the global symbol registry — a brand attached via its own Symbol.for call matches', () => {
+    const def = { name: 'other-copy', entry: 's', steps: { s: makeStep('s') } };
+    Object.defineProperty(def, Symbol.for('sapiom.orchestration.definition'), { value: 1, enumerable: false });
+    expect(isLegacyOrchestrationDefinition(def)).toBe(true);
   });
 });
 

--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -63,9 +63,15 @@
  *      mode) and after one is bound.
  *  14. Deterministic canvas render (zero LLM): bound to a real @sapiom/agent
  *      project, POST /api/canvas/:id/render extracts its actual step graph
- *      and writes real step names + SVG node markup to index.html, and the
- *      write fires a canvas.reload frame exactly like an agent's own edit
- *      would — the visualize macro's default path never touches the pty.
+ *      and writes real step names + SVG node markup to the workflow's own
+ *      render file under .sapiom/canvas/renders/, GET /canvas/:id/ serves
+ *      that render for the bound session (per-request resolution — no
+ *      index.html rewrite), and the write fires a canvas.reload frame
+ *      exactly like an agent's own edit would — the visualize macro's
+ *      default path never touches the pty. A second render of the unchanged
+ *      workflow is served from the extraction cache (no child process), and
+ *      unbinding flips GET /canvas/:id/ back to the agent-authored
+ *      index.html untouched.
  *  15. State isolation + registry hygiene: `stateRoot` alone (no per-file
  *      overrides, no machineId) roots every piece of persistent state under
  *      the scratch dir — machine-id included — and a pre-seeded registry
@@ -636,11 +642,20 @@ async function testCoreFlow(): Promise<void> {
 
     const renderRes = await fetch(`${baseUrl}/api/canvas/${sessionId}/render`, { method: "POST", headers });
     assert(renderRes.status === 200, "POST /api/canvas/:id/render returns 200");
-    const renderBody = (await renderRes.json()) as { ok: boolean; mode: string; extractionFailed: string[] };
+    const renderBody = (await renderRes.json()) as {
+      ok: boolean;
+      mode: string;
+      extractionFailed: string[];
+      renderPath?: string;
+    };
     assert(renderBody.ok === true && renderBody.mode === "single", "render reports { ok: true, mode: 'single' }");
     assert(
       renderBody.extractionFailed.length === 0,
       `extraction succeeded (no degraded panels): ${JSON.stringify(renderBody.extractionFailed)}`,
+    );
+    assert(
+      (renderBody.renderPath ?? "").startsWith(path.join(projectDir, ".sapiom", "canvas", "renders") + path.sep),
+      "the render landed in the session cwd's .sapiom/canvas/renders/ (per-workflow file, not index.html)",
     );
 
     await waitFor(async () => {
@@ -651,13 +666,26 @@ async function testCoreFlow(): Promise<void> {
     });
     console.log("canvas.reload frame received for the deterministic render's write");
 
-    // Canvas is per SESSION cwd (projectDir), not per bound workflow —
-    // the workflow's own directory is only where its source lives.
-    const renderedHtml = await fs.readFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "utf8");
+    // GET /canvas/:id/ resolves the session's binding at request time and
+    // serves the bound workflow's render file.
+    const renderedHtml = await (await fetch(`${baseUrl}/canvas/${sessionId}/`)).text();
     for (const step of ["intake", "classify", "route", "auto_resolve", "escalate"]) {
-      assert(renderedHtml.includes(`>${step}<`), `rendered canvas contains the real step name '${step}'`);
+      assert(renderedHtml.includes(`>${step}<`), `served canvas contains the real step name '${step}'`);
     }
-    assert(renderedHtml.includes("canvas-node-rect"), "rendered canvas contains real SVG node markup, not just text");
+    assert(renderedHtml.includes("canvas-node-rect"), "served canvas contains real SVG node markup, not just text");
+    // index.html was NOT rewritten by the deterministic render — the agent's
+    // own canvas (written in step 9) is still exactly what it wrote.
+    const indexAfterRender = await fs.readFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "utf8");
+    assert(indexAfterRender.includes("e2e"), "index.html (the agent-authored canvas) is untouched by the render");
+
+    // A second render of the unchanged workflow comes from the extraction
+    // cache — no child check() process runs at all.
+    const cachedRenderRes = await fetch(`${baseUrl}/api/canvas/${sessionId}/render`, { method: "POST", headers });
+    const cachedRenderBody = (await cachedRenderRes.json()) as { ok: boolean; cachedExtraction?: boolean };
+    assert(
+      cachedRenderBody.ok === true && cachedRenderBody.cachedExtraction === true,
+      "re-rendering the unchanged workflow is served from the extraction cache (no child process)",
+    );
 
     // --- 11b. unbind — the context file gets boundWorkflow: null, not deleted ---
     const unbindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {
@@ -672,6 +700,14 @@ async function testCoreFlow(): Promise<void> {
       return context.boundWorkflow === null ? context : undefined;
     });
     assert(unboundContext.boundWorkflow === null, "unbinding writes boundWorkflow: null to harness-context.json");
+
+    // Unbound again, the canvas root falls back to the legacy agent-authored
+    // index.html — the render files stay on disk for the next bind.
+    const unboundCanvas = await (await fetch(`${baseUrl}/canvas/${sessionId}/`)).text();
+    assert(
+      unboundCanvas.includes("e2e") && !unboundCanvas.includes("canvas-node-rect"),
+      "unbinding flips GET /canvas/:id/ back to the agent-authored index.html",
+    );
 
     // --- 11c. binding to a path that isn't a registered workflow is rejected ---
     const badBindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {

--- a/packages/harness/src/core/__fixtures__/legacy-flow/index.ts
+++ b/packages/harness/src/core/__fixtures__/legacy-flow/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Test fixture — a workflow authored against the PRE-RENAME SDK
+ * (`@sapiom/orchestration`, before commit cc1261e renamed everything to
+ * agents/models). The `defineOrchestration`/`defineStep` stubs below are a
+ * faithful, self-contained copy of that package's runtime (same brand symbol,
+ * same step-shape normalization), so this fixture exercises the legacy-brand
+ * detection path in `@sapiom/agent-core`'s `check()` without depending on a
+ * package that is no longer in this repo. What matters to the extractor:
+ *   - the definition is branded `Symbol.for('sapiom.orchestration.definition')`,
+ *     NOT the current `sapiom.models.definition`;
+ *   - steps carry the identical runtime properties buildManifest reads
+ *     (name/next/terminal/canFail/pause), proving the old shape needs no shim.
+ */
+
+const ORCHESTRATION_DEFINITION_BRAND = Symbol.for("sapiom.orchestration.definition");
+
+interface LegacyStepDefinition {
+  name: string;
+  next?: string[];
+  terminal?: boolean;
+  canFail?: boolean;
+  pause?: { signal: string; resumeStep: string };
+  run: (input: unknown) => Promise<unknown>;
+}
+
+// Mirrors @sapiom/orchestration's defineStep: normalizes declared routing
+// capabilities into always-present runtime properties.
+function defineStep(def: LegacyStepDefinition) {
+  return {
+    name: def.name,
+    next: def.next ?? [],
+    terminal: def.terminal ?? false,
+    canFail: def.canFail ?? false,
+    ...(def.pause ? { pause: def.pause } : {}),
+    run: def.run,
+  };
+}
+
+// Mirrors @sapiom/orchestration's defineOrchestration: attaches the legacy
+// brand as a non-enumerable property, exactly like the real package did.
+function defineOrchestration(def: { name: string; entry: string; steps: Record<string, unknown> }) {
+  Object.defineProperty(def, ORCHESTRATION_DEFINITION_BRAND, {
+    value: 1,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return def;
+}
+
+const receive = defineStep({
+  name: "receive",
+  next: ["confirm"],
+  async run(input) {
+    return { kind: "continue", stepName: "confirm", output: input };
+  },
+});
+
+const confirm = defineStep({
+  name: "confirm",
+  next: ["award"],
+  pause: { signal: "vendor.confirm", resumeStep: "award" },
+  async run(input) {
+    return { kind: "pause_until_signal", signal: "vendor.confirm", output: input };
+  },
+});
+
+const award = defineStep({
+  name: "award",
+  terminal: true,
+  canFail: true,
+  async run(input) {
+    return { kind: "terminate", output: input };
+  },
+});
+
+export const workflow = defineOrchestration({
+  name: "legacy-flow",
+  entry: "receive",
+  steps: { receive, confirm, award },
+});

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -1,13 +1,13 @@
 /**
- * Assembles the `<div id="canvas-root">` body — one `<section
- * class="canvas-panel">` per workflow (header + stats + SVG diagram),
- * an optional Interconnections panel, and a shared legend footer — entirely
- * from the classes `core/canvas-template.ts`'s shell already defines. This is
- * the HTML half of the deterministic render; `core/canvas-render.ts` wraps
- * the result through `renderCanvasDocument()` and writes it to disk.
+ * Assembles the `<div id="canvas-root">` body — the bound workflow's
+ * `<section class="canvas-panel">` (header + stats + SVG diagram) and a
+ * legend footer — entirely from the classes `core/canvas-template.ts`'s shell
+ * already defines. This is the HTML half of the deterministic render;
+ * `core/canvas-render.ts` wraps the result through `renderCanvasDocument()`
+ * and writes it to the workflow's render file.
  */
 import type { CanvasEdgeKind, CanvasGraph, CanvasNodeKind } from "./canvas-graph.js";
-import { renderGraphSvg, usedKinds } from "./canvas-svg.js";
+import { renderGraphSvg } from "./canvas-svg.js";
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -61,28 +61,22 @@ export function buildErrorPanelHtml(title: string, reason: string): string {
 </section>`;
 }
 
-/** The unbound, zero-workflows-known state — a friendly explainer, not an error. */
-export function buildEmptyWorkspaceHtml(): string {
-  return `<section class="canvas-panel">
-  <header class="canvas-header">
-    <div class="canvas-title-row">
-      <h1 class="canvas-title">No workflows found</h1>
-    </div>
-  </header>
-  <div class="canvas-diagram-panel">
-    <p class="canvas-empty-note">No @sapiom/agent projects found in this workspace yet. Connect or scan a directory containing a sapiom.json, or ask your agent to create one — this pane updates automatically.</p>
-  </div>
-</section>`;
-}
-
 const NODE_KIND_LABEL: Record<CanvasNodeKind, string> = {
   entry: "entry / active step",
   step: "step",
   pause: "pause / waits for input",
   "terminal-success": "terminal · success",
   "terminal-warn": "terminal · escalation",
+  "launched-workflow": "launches another workflow",
 };
-const NODE_KIND_ORDER: CanvasNodeKind[] = ["entry", "step", "pause", "terminal-success", "terminal-warn"];
+const NODE_KIND_ORDER: CanvasNodeKind[] = [
+  "entry",
+  "step",
+  "pause",
+  "terminal-success",
+  "terminal-warn",
+  "launched-workflow",
+];
 
 /** Legend footer covering every node/edge kind actually used across every
  *  rendered panel (aggregate, not per-panel — matches the template's shape). */
@@ -99,57 +93,10 @@ export function buildLegendHtml(nodeKinds: Set<CanvasNodeKind>, edgeKinds: Set<C
   return `<div class="canvas-legend">${items.join("")}</div>`;
 }
 
-/** Aggregates used node/edge kinds across every rendered graph, for one shared legend. */
-export function aggregateUsedKinds(graphs: readonly CanvasGraph[]): {
-  nodeKinds: Set<CanvasNodeKind>;
-  edgeKinds: Set<CanvasEdgeKind>;
-} {
-  const nodeKinds = new Set<CanvasNodeKind>();
-  const edgeKinds = new Set<CanvasEdgeKind>();
-  for (const g of graphs) {
-    const used = usedKinds(g);
-    for (const k of used.nodeKinds) nodeKinds.add(k);
-    for (const k of used.edgeKinds) edgeKinds.add(k);
-  }
-  return { nodeKinds, edgeKinds };
-}
-
-export interface InterconnectionRow {
-  fromLabel: string;
-  toLabel: string;
-  tag: string;
-  label?: string;
-}
-
-/** Cross-workflow handoffs detected by the heuristic grep (core/canvas-interconnections.ts). */
-export function buildInterconnectionsPanelHtml(rows: readonly InterconnectionRow[]): string {
-  if (rows.length === 0) return "";
-  const rowsHtml = rows
-    .map(
-      (r) => `<div class="canvas-interconnection-row">
-    <span class="canvas-legend-marker canvas-legend-marker--cross"></span>
-    <span class="canvas-interconnection-title">${esc(r.fromLabel)} &rarr; ${esc(r.toLabel)}</span>
-    <span class="canvas-interconnection-tag">${esc(r.tag)}</span>
-    ${r.label ? `<p class="canvas-interconnection-desc">${esc(r.label)}</p>` : ""}
-  </div>`,
-    )
-    .join("\n");
-  return `<section class="canvas-panel canvas-interconnections">
-  <h2 class="canvas-panel-title">Interconnections</h2>
-${rowsHtml}
-</section>`;
-}
-
-/** Joins panels + optional interconnections + a footer (legend + note) into
- *  the final `#canvas-root` body — the string `renderCanvasDocument()` wraps. */
-export function assembleCanvasBody(input: {
-  panels: string[];
-  interconnections?: string;
-  legend: string;
-  note: string;
-}): string {
+/** Joins panels + a footer (legend + note) into the final `#canvas-root`
+ *  body — the string `renderCanvasDocument()` wraps. */
+export function assembleCanvasBody(input: { panels: string[]; legend: string; note: string }): string {
   const parts = [...input.panels];
-  if (input.interconnections) parts.push(input.interconnections);
   parts.push(`<footer class="canvas-footer">
 ${input.legend}
   <p class="canvas-note">${esc(input.note)}</p>

--- a/packages/harness/src/core/canvas-cache.test.ts
+++ b/packages/harness/src/core/canvas-cache.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  clearExtractionCache,
+  extractWorkflowGraphCached,
+  fingerprintWorkflowSources,
+} from "./canvas-cache.js";
+import type { CanvasGraph, ExtractionResult } from "./canvas-graph.js";
+
+const GRAPH: CanvasGraph = {
+  manifestName: "cached-flow",
+  entry: "start",
+  nodes: [{ id: "start", kind: "entry", label: "start" }],
+  edges: [],
+  warnings: [],
+};
+const OK: ExtractionResult = { ok: true, graph: GRAPH };
+const FAIL: ExtractionResult = { ok: false, reason: "run npm install first" };
+
+const tmpDirs: string[] = [];
+async function tmpWorkflow(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-cache-test-"));
+  tmpDirs.push(dir);
+  await fs.writeFile(path.join(dir, "index.ts"), "export const x = 1;\n");
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+beforeEach(() => clearExtractionCache());
+
+/** Bump index.ts's mtime far enough that mtimeMs must change even on a
+ *  coarse-granularity filesystem. */
+async function touchSource(dir: string): Promise<void> {
+  const future = new Date(Date.now() + 5_000);
+  await fs.utimes(path.join(dir, "index.ts"), future, future);
+}
+
+describe("extractWorkflowGraphCached", () => {
+  it("runs the extraction once and serves the second call from cache — no second child process", async () => {
+    const dir = await tmpWorkflow();
+    const extract = vi.fn().mockResolvedValue(OK);
+
+    const first = await extractWorkflowGraphCached(dir, extract);
+    const second = await extractWorkflowGraphCached(dir, extract);
+
+    expect(extract).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ result: OK, cached: false });
+    expect(second).toEqual({ result: OK, cached: true });
+  });
+
+  it("invalidates when a source file's mtime changes", async () => {
+    const dir = await tmpWorkflow();
+    const extract = vi.fn().mockResolvedValue(OK);
+
+    await extractWorkflowGraphCached(dir, extract);
+    await touchSource(dir);
+    const after = await extractWorkflowGraphCached(dir, extract);
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(after.cached).toBe(false);
+  });
+
+  it("invalidates when the source file count changes", async () => {
+    const dir = await tmpWorkflow();
+    const extract = vi.fn().mockResolvedValue(OK);
+
+    await extractWorkflowGraphCached(dir, extract);
+    await fs.writeFile(path.join(dir, "steps.ts"), "export const y = 2;\n");
+    const after = await extractWorkflowGraphCached(dir, extract);
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(after.cached).toBe(false);
+  });
+
+  it("never caches a failure — 'npm install' fixes don't touch any .ts file, so a cached failure would never self-invalidate", async () => {
+    const dir = await tmpWorkflow();
+    const extract = vi.fn().mockResolvedValueOnce(FAIL).mockResolvedValueOnce(OK);
+
+    const first = await extractWorkflowGraphCached(dir, extract);
+    const second = await extractWorkflowGraphCached(dir, extract);
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(first).toEqual({ result: FAIL, cached: false });
+    expect(second).toEqual({ result: OK, cached: false });
+  });
+
+  it("caches per workflow directory — two workflows never share an entry", async () => {
+    const dirA = await tmpWorkflow();
+    const dirB = await tmpWorkflow();
+    const extract = vi.fn().mockResolvedValue(OK);
+
+    await extractWorkflowGraphCached(dirA, extract);
+    const b = await extractWorkflowGraphCached(dirB, extract);
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(b.cached).toBe(false);
+  });
+});
+
+describe("fingerprintWorkflowSources", () => {
+  it("is stable for an unchanged tree and skips node_modules", async () => {
+    const dir = await tmpWorkflow();
+    await fs.mkdir(path.join(dir, "node_modules", "dep"), { recursive: true });
+    await fs.writeFile(path.join(dir, "node_modules", "dep", "index.ts"), "ignored");
+
+    const first = await fingerprintWorkflowSources(dir);
+    const second = await fingerprintWorkflowSources(dir);
+    expect(second).toBe(first);
+    expect(first.startsWith("1:")).toBe(true); // only the workflow's own index.ts counted
+  });
+
+  it("changes when a source is edited", async () => {
+    const dir = await tmpWorkflow();
+    const before = await fingerprintWorkflowSources(dir);
+    await touchSource(dir);
+    expect(await fingerprintWorkflowSources(dir)).not.toBe(before);
+  });
+});

--- a/packages/harness/src/core/canvas-cache.ts
+++ b/packages/harness/src/core/canvas-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * In-memory extraction cache: binding an unchanged workflow must never pay
+ * for a child `check()` process twice. Keyed by workflow directory, guarded
+ * by a cheap source fingerprint (file count + newest mtime over the
+ * project's own `.ts`/`.tsx` sources — the same file walk the launch grep
+ * uses, see core/canvas-interconnections.ts's `listSourceFiles`). Any source
+ * edit bumps an mtime, any add/remove changes the count; either invalidates.
+ *
+ * Only SUCCESSFUL extractions are cached: a failure like "run npm install
+ * first" gets fixed without touching any `.ts` file, so a cached failure
+ * would never self-invalidate — re-running the (already fast-failing)
+ * extraction is the honest choice there.
+ *
+ * Process-lifetime only; a server restart re-extracts once per workflow.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { extractWorkflowGraph, type ExtractionResult, type ExtractionSuccess } from "./canvas-graph.js";
+import { listSourceFiles } from "./canvas-interconnections.js";
+
+/** `<file count>:<newest mtimeMs>` over the workflow's own sources. */
+export async function fingerprintWorkflowSources(root: string): Promise<string> {
+  const files = await listSourceFiles(root);
+  let maxMtimeMs = 0;
+  for (const file of files) {
+    try {
+      const stat = await fs.stat(file);
+      if (stat.mtimeMs > maxMtimeMs) maxMtimeMs = stat.mtimeMs;
+    } catch {
+      // A file deleted mid-walk still counts toward the file count; the next
+      // fingerprint won't include it, which is invalidation working as intended.
+    }
+  }
+  return `${files.length}:${maxMtimeMs}`;
+}
+
+interface CacheEntry {
+  fingerprint: string;
+  result: ExtractionSuccess;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export interface CachedExtraction {
+  result: ExtractionResult;
+  /** True when the result came from cache — no child process ran. */
+  cached: boolean;
+}
+
+/**
+ * `extractWorkflowGraph` behind the fingerprint cache. The `extract`
+ * parameter exists for tests only (inject a spy to prove hit/miss behavior).
+ */
+export async function extractWorkflowGraphCached(
+  sourceDir: string,
+  extract: (dir: string) => Promise<ExtractionResult> = extractWorkflowGraph,
+): Promise<CachedExtraction> {
+  const key = path.resolve(sourceDir);
+  const fingerprint = await fingerprintWorkflowSources(key);
+  const hit = cache.get(key);
+  if (hit && hit.fingerprint === fingerprint) return { result: hit.result, cached: true };
+
+  const result = await extract(key);
+  if (result.ok) cache.set(key, { fingerprint, result });
+  else cache.delete(key);
+  return { result, cached: false };
+}
+
+/** Test hook — the cache is module-level state shared across a process. */
+export function clearExtractionCache(): void {
+  cache.clear();
+}

--- a/packages/harness/src/core/canvas-graph.test.ts
+++ b/packages/harness/src/core/canvas-graph.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { extractWorkflowGraph } from "./canvas-graph.js";
+import { extractWorkflowGraph, mergeLaunchesIntoGraph, type CanvasGraph } from "./canvas-graph.js";
 
 const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
 const ORDER_TRIAGE_DIR = path.join(FIXTURES_DIR, "order-triage");
@@ -71,6 +71,22 @@ describe("extractWorkflowGraph", () => {
     expect(result.graph.edges.some((e) => e.from === "escalate")).toBe(false);
   });
 
+  it("extracts a PRE-RENAME (@sapiom/orchestration) workflow via its legacy brand — old-SDK projects render without a dependency bump", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "legacy-flow"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.graph.manifestName).toBe("legacy-flow");
+    expect(result.graph.entry).toBe("receive");
+    expect(result.graph.nodes.map((n) => n.id).sort()).toEqual(["award", "confirm", "receive"]);
+    // The legacy step shape (next/terminal/canFail/pause) feeds buildManifest
+    // unchanged: the pause edge and terminal classification both survive.
+    const confirm = result.graph.nodes.find((n) => n.id === "confirm")!;
+    expect(confirm.kind).toBe("pause");
+    expect(result.graph.edges).toContainEqual({ from: "confirm", to: "award", kind: "cross", label: "vendor.confirm" });
+    expect(result.graph.nodes.find((n) => n.id === "award")!.kind).toBe("terminal-success");
+  });
+
   it("never throws: a missing project directory degrades to a typed failure", async () => {
     const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "does-not-exist"));
     expect(result.ok).toBe(false);
@@ -91,5 +107,61 @@ describe("extractWorkflowGraph", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toMatch(/no agent was exported/i);
+  });
+
+  it("merges a detected launch into the workflow's own graph as a dashed launched-workflow node", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "hub"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const launched = result.graph.nodes.find((n) => n.kind === "launched-workflow");
+    expect(launched).toEqual({ id: "launch:spoke-workflow", kind: "launched-workflow", label: "spoke-workflow" });
+    expect(result.graph.edges).toContainEqual({
+      from: "kickoff",
+      to: "launch:spoke-workflow",
+      kind: "launch",
+      label: "launch()",
+    });
+  });
+});
+
+describe("mergeLaunchesIntoGraph", () => {
+  const baseGraph: CanvasGraph = {
+    manifestName: "self",
+    entry: "start",
+    nodes: [
+      { id: "start", kind: "entry", label: "start" },
+      { id: "finish", kind: "terminal-success", label: "finish" },
+    ],
+    edges: [{ from: "start", to: "finish", kind: "sequential" }],
+    warnings: [],
+  };
+
+  it("adds one node per distinct slug and dedupes repeat launches from the same step", async () => {
+    const merged = mergeLaunchesIntoGraph(baseGraph, [
+      { slug: "other-flow", fromStepId: "finish" },
+      { slug: "other-flow", fromStepId: "finish" },
+    ]);
+    expect(merged.nodes.filter((n) => n.kind === "launched-workflow")).toHaveLength(1);
+    expect(merged.edges.filter((e) => e.kind === "launch")).toEqual([
+      { from: "finish", to: "launch:other-flow", kind: "launch", label: "launch()" },
+    ]);
+  });
+
+  it("falls back to the entry step when the launch couldn't be attributed", async () => {
+    const merged = mergeLaunchesIntoGraph(baseGraph, [{ slug: "other-flow", fromStepId: null }]);
+    expect(merged.edges).toContainEqual({ from: "start", to: "launch:other-flow", kind: "launch", label: "launch()" });
+  });
+
+  it("skips self-launches — the workflow's own steps are already the diagram", async () => {
+    const merged = mergeLaunchesIntoGraph(baseGraph, [{ slug: "self", fromStepId: "finish" }]);
+    expect(merged.nodes).toEqual(baseGraph.nodes);
+    expect(merged.edges).toEqual(baseGraph.edges);
+  });
+
+  it("does not mutate the input graph", async () => {
+    const nodesBefore = baseGraph.nodes.length;
+    mergeLaunchesIntoGraph(baseGraph, [{ slug: "other-flow", fromStepId: null }]);
+    expect(baseGraph.nodes).toHaveLength(nodesBefore);
   });
 });

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -11,9 +11,10 @@
  */
 import type { AgentManifest, AgentStepManifest } from "@sapiom/agent";
 import { runManifestCheck } from "./canvas-manifest-check.js";
+import { detectWorkflowLaunches, type DetectedLaunch } from "./canvas-interconnections.js";
 
-export type CanvasNodeKind = "entry" | "step" | "pause" | "terminal-success" | "terminal-warn";
-export type CanvasEdgeKind = "sequential" | "branching" | "cross";
+export type CanvasNodeKind = "entry" | "step" | "pause" | "terminal-success" | "terminal-warn" | "launched-workflow";
+export type CanvasEdgeKind = "sequential" | "branching" | "cross" | "launch";
 
 export interface CanvasNode {
   id: string;
@@ -116,8 +117,40 @@ export function graphFromManifest(manifest: AgentManifest, warnings: string[]): 
 }
 
 /**
- * Extracts a workflow's step graph from its project directory. Never throws:
- * any failure (no node_modules, a bundle/type error, an invalid graph, a
+ * Merges heuristically detected cross-workflow launches into the workflow's
+ * own graph: one dashed `launched-workflow` node per distinct slug, with a
+ * `launch`-kind edge from the step the call was attributed to (falling back
+ * to the entry step — the launch definitely happens somewhere downstream of
+ * it). Self-launches (a workflow re-launching itself) are skipped: the graph
+ * already shows those steps. Pure — returns a new graph.
+ */
+export function mergeLaunchesIntoGraph(graph: CanvasGraph, launches: readonly DetectedLaunch[]): CanvasGraph {
+  const stepIds = new Set(graph.nodes.map((n) => n.id));
+  const nodes = [...graph.nodes];
+  const edges = [...graph.edges];
+  const seenEdges = new Set<string>();
+
+  for (const launch of launches) {
+    if (launch.slug === graph.manifestName) continue;
+    // Prefixed id so a launched workflow can never collide with a step that
+    // happens to share its name.
+    const nodeId = `launch:${launch.slug}`;
+    if (!nodes.some((n) => n.id === nodeId)) {
+      nodes.push({ id: nodeId, kind: "launched-workflow", label: launch.slug });
+    }
+    const from = launch.fromStepId && stepIds.has(launch.fromStepId) ? launch.fromStepId : graph.entry;
+    const edgeKey = `${from}->${nodeId}`;
+    if (seenEdges.has(edgeKey)) continue;
+    seenEdges.add(edgeKey);
+    edges.push({ from, to: nodeId, kind: "launch", label: "launch()" });
+  }
+  return { ...graph, nodes, edges };
+}
+
+/**
+ * Extracts a workflow's step graph from its project directory, with detected
+ * cross-workflow launches merged in as dashed nodes. Never throws: any
+ * failure (no node_modules, a bundle/type error, an invalid graph, a
  * check-process crash or timeout) comes back as `{ ok: false, reason }` for
  * the caller to render as a degraded panel — this is the only place
  * extraction failure is allowed to happen silently instead of crashing the
@@ -127,5 +160,6 @@ export async function extractWorkflowGraph(sourceDir: string): Promise<Extractio
   const result = await runManifestCheck(sourceDir);
   if (!result.ok) return { ok: false, reason: result.reason };
   const graph = graphFromManifest(result.manifest as AgentManifest, result.warnings);
-  return { ok: true, graph };
+  const launches = await detectWorkflowLaunches(sourceDir, new Set(graph.nodes.map((n) => n.id)));
+  return { ok: true, graph: mergeLaunchesIntoGraph(graph, launches) };
 }

--- a/packages/harness/src/core/canvas-interconnections.test.ts
+++ b/packages/harness/src/core/canvas-interconnections.test.ts
@@ -1,32 +1,99 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { detectInterconnections } from "./canvas-interconnections.js";
+import { detectWorkflowLaunches } from "./canvas-interconnections.js";
 
 const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
 
-describe("detectInterconnections", () => {
-  it("finds an orchestrations.launch({ definition }) call and resolves it against a known workflow's manifest name", async () => {
-    const edges = await detectInterconnections([
-      { path: path.join(FIXTURES_DIR, "hub"), manifestName: "hub-workflow" },
-      { path: path.join(FIXTURES_DIR, "spoke"), manifestName: "spoke-workflow" },
-    ]);
-    expect(edges).toEqual([{ fromManifestName: "hub-workflow", toManifestName: "spoke-workflow", toSlug: "spoke-workflow" }]);
+const tmpDirs: string[] = [];
+async function tmpProject(files: Record<string, string>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-launches-test-"));
+  tmpDirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    await fs.mkdir(path.dirname(path.join(dir, name)), { recursive: true });
+    await fs.writeFile(path.join(dir, name), content);
+  }
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+describe("detectWorkflowLaunches", () => {
+  it("finds an old-SDK orchestrations.launch({ definition }) call and attributes it to the enclosing step", async () => {
+    const launches = await detectWorkflowLaunches(path.join(FIXTURES_DIR, "hub"), new Set(["kickoff"]));
+    expect(launches).toEqual([{ slug: "spoke-workflow", fromStepId: "kickoff" }]);
   });
 
-  it("leaves toManifestName null when the referenced slug doesn't match any known workflow", async () => {
-    const edges = await detectInterconnections([{ path: path.join(FIXTURES_DIR, "hub"), manifestName: "hub-workflow" }]);
-    expect(edges).toEqual([{ fromManifestName: "hub-workflow", toManifestName: null, toSlug: "spoke-workflow" }]);
+  it("finds a new-SDK ctx.sapiom.agents.launch({ definition }) call — the shape the rename introduced", async () => {
+    const dir = await tmpProject({
+      "index.ts": `
+const respond = defineStep({
+  name: "respond",
+  terminal: true,
+  async run(input, ctx) {
+    const child = await ctx.sapiom.agents.launch({
+      definition: 'applicant-lifecycle',
+      input: { applicantEmail: "x@example.com" },
+    });
+    return terminate({ child });
+  },
+});
+`,
+    });
+    const launches = await detectWorkflowLaunches(dir, new Set(["respond"]));
+    expect(launches).toEqual([{ slug: "applicant-lifecycle", fromStepId: "respond" }]);
   });
 
-  it("finds nothing in a project with no orchestrations.launch calls", async () => {
-    const edges = await detectInterconnections([{ path: path.join(FIXTURES_DIR, "order-triage"), manifestName: "order-triage" }]);
-    expect(edges).toEqual([]);
+  it("attributes each launch to the nearest preceding known step, ignoring name-lookalike properties", async () => {
+    const dir = await tmpProject({
+      "index.ts": `
+const classify = defineStep({
+  name: "classify",
+  next: ["respond"],
+  async run(input) {
+    // fromName / vendorName must never be mistaken for a step declaration.
+    const meta = { fromName: "Someone", vendorName: "Acme" };
+    return goto("respond", meta);
+  },
+});
+const respond = defineStep({
+  name: "respond",
+  terminal: true,
+  async run(input, ctx) {
+    await ctx.sapiom.agents.launch({ definition: "downstream-flow", input: {} });
+    return terminate({});
+  },
+});
+`,
+    });
+    const launches = await detectWorkflowLaunches(dir, new Set(["classify", "respond"]));
+    expect(launches).toEqual([{ slug: "downstream-flow", fromStepId: "respond" }]);
+  });
+
+  it("reports fromStepId null when the launch sits outside any known step (e.g. a shared helper)", async () => {
+    const dir = await tmpProject({
+      "helpers.ts": `
+export async function kickOff(agents: { launch: (spec: { definition: string }) => Promise<unknown> }) {
+  return agents.launch({ definition: "helper-launched" });
+}
+`,
+    });
+    const launches = await detectWorkflowLaunches(dir, new Set(["intake"]));
+    expect(launches).toEqual([{ slug: "helper-launched", fromStepId: null }]);
+  });
+
+  it("finds nothing in a project with no launch calls", async () => {
+    const launches = await detectWorkflowLaunches(
+      path.join(FIXTURES_DIR, "order-triage"),
+      new Set(["intake", "classify", "route", "auto_resolve", "escalate"]),
+    );
+    expect(launches).toEqual([]);
   });
 
   it("never throws for a directory that doesn't exist", async () => {
-    await expect(detectInterconnections([{ path: path.join(FIXTURES_DIR, "does-not-exist"), manifestName: "x" }])).resolves.toEqual(
-      [],
-    );
+    await expect(detectWorkflowLaunches(path.join(FIXTURES_DIR, "does-not-exist"), new Set())).resolves.toEqual([]);
   });
 });

--- a/packages/harness/src/core/canvas-interconnections.ts
+++ b/packages/harness/src/core/canvas-interconnections.ts
@@ -1,12 +1,16 @@
 /**
- * Heuristic cross-workflow interconnection detection for the workspace
- * overview render: greps every workflow project's TypeScript sources for
- * `orchestrations.launch({ definition: "<slug>" })` calls (see
- * @sapiom/tools's `orchestrations` capability) and matches the captured slug
- * against the other workflows' own manifest names. This is deliberately a
- * grep, not a type-aware analysis — a step can compute its `definition`
- * dynamically, in which case it's simply not detected; false negatives are
- * fine here, this panel is a bonus overview, not a source of truth.
+ * Heuristic cross-workflow launch detection: greps a workflow project's
+ * TypeScript sources for `orchestrations.launch({ definition: "<slug>" })`
+ * (the pre-rename SDK's capability) and `agents.launch({ definition: ... })`
+ * (the current SDK, e.g. `ctx.sapiom.agents.launch`) calls, and best-effort
+ * attributes each call to the step whose `defineStep({ name: ... })` block it
+ * sits in. The result is merged into the workflow's own rendered graph as
+ * dashed "launched workflow" nodes (see core/canvas-graph.ts).
+ *
+ * This is deliberately a grep, not a type-aware analysis — a step can compute
+ * its `definition` dynamically, in which case it's simply not detected; false
+ * negatives are fine here, the launch nodes are a bonus, not a source of
+ * truth.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -16,12 +20,25 @@ const SOURCE_EXTENSIONS = new Set([".ts", ".tsx"]);
 const MAX_FILES_PER_WORKFLOW = 200;
 const MAX_FILE_BYTES = 512 * 1024;
 
-// Matches `orchestrations.launch({ ...definition: "slug"... })`, tolerating
+// Matches `orchestrations.launch({ ...definition: "slug"... })` (old SDK) and
+// `agents.launch({ ...definition: "slug"... })` (current SDK), tolerating
 // other fields before `definition` in the object literal (bounded lookahead
 // so an unrelated huge object literal can't make this pathological).
-const LAUNCH_CALL_PATTERN = /orchestrations\s*\.\s*launch\s*\(\s*\{[\s\S]{0,400}?definition\s*:\s*(['"`])([^'"`]+)\1/g;
+const LAUNCH_CALL_PATTERN =
+  /(?:orchestrations|agents)\s*\.\s*launch\s*\(\s*\{[\s\S]{0,400}?definition\s*:\s*(['"`])([^'"`]+)\1/g;
 
-async function listSourceFiles(root: string): Promise<string[]> {
+// A `name: "..."` property declaration — the step-name key `defineStep`
+// blocks always open with. The lookbehind rejects longer identifiers ending
+// in "name" (fromName, vendorName) without consuming the preceding char.
+const STEP_NAME_PATTERN = /(?<![\w$.])name\s*:\s*(['"`])([^'"`]+)\1/g;
+
+/**
+ * Lists the workflow's own `.ts`/`.tsx` sources (skipping node_modules and
+ * friends), bounded to MAX_FILES_PER_WORKFLOW. Shared with the extraction
+ * cache's source fingerprint (core/canvas-cache.ts) so "the files this grep
+ * reads" and "the files whose mtimes invalidate the cache" can't drift.
+ */
+export async function listSourceFiles(root: string): Promise<string[]> {
   const files: string[] = [];
   async function walk(dir: string): Promise<void> {
     if (files.length >= MAX_FILES_PER_WORKFLOW) return;
@@ -45,9 +62,27 @@ async function listSourceFiles(root: string): Promise<string[]> {
   return files;
 }
 
-/** Every `orchestrations.launch({ definition: "..." })` slug referenced anywhere in `root`. */
-async function launchedSlugs(root: string): Promise<string[]> {
-  const slugs: string[] = [];
+export interface DetectedLaunch {
+  /** The `definition` slug the launch call referenced. */
+  slug: string;
+  /** The step (by declared name) the call was attributed to — the nearest
+   *  preceding `name: "<known step>"` declaration in the same file — or null
+   *  when no known step precedes it (e.g. a launch in a shared helper). */
+  fromStepId: string | null;
+}
+
+/**
+ * Every `*.launch({ definition: "..." })` call in `root`'s sources, each
+ * best-effort attributed to the step whose `defineStep` block it sits in
+ * (`knownStepIds` = the workflow's real step names, so an unrelated `name:`
+ * property can never be mistaken for a step). Never throws: unreadable
+ * files/directories simply contribute no launches.
+ */
+export async function detectWorkflowLaunches(
+  root: string,
+  knownStepIds: ReadonlySet<string>,
+): Promise<DetectedLaunch[]> {
+  const launches: DetectedLaunch[] = [];
   for (const file of await listSourceFiles(root)) {
     let content: string;
     try {
@@ -57,42 +92,16 @@ async function launchedSlugs(root: string): Promise<string[]> {
     } catch {
       continue;
     }
+
+    const stepDeclarations: Array<{ index: number; stepId: string }> = [];
+    for (const match of content.matchAll(STEP_NAME_PATTERN)) {
+      if (knownStepIds.has(match[2]!)) stepDeclarations.push({ index: match.index, stepId: match[2]! });
+    }
+
     for (const match of content.matchAll(LAUNCH_CALL_PATTERN)) {
-      slugs.push(match[2]);
+      const preceding = stepDeclarations.filter((d) => d.index < match.index).at(-1);
+      launches.push({ slug: match[2]!, fromStepId: preceding?.stepId ?? null });
     }
   }
-  return slugs;
-}
-
-export interface InterconnectionEdge {
-  fromManifestName: string;
-  /** The other workflow's manifest name, or null when the slug doesn't match any known workflow. */
-  toManifestName: string | null;
-  /** The raw slug the source referenced — shown when `toManifestName` is null. */
-  toSlug: string;
-}
-
-/**
- * Scans every workflow's sources for `orchestrations.launch` calls and
- * resolves each target slug against the other workflows in `workflows`
- * (matched by manifest name — the value `defineAgent({ name })` sets, not
- * the directory/package.json name `WorkflowInfo.name` carries). Best-effort:
- * a workflow whose sources can't be read simply contributes no edges.
- */
-export async function detectInterconnections(
-  workflows: readonly { path: string; manifestName: string }[],
-): Promise<InterconnectionEdge[]> {
-  const byName = new Map(workflows.map((w) => [w.manifestName, w.manifestName]));
-  const edges: InterconnectionEdge[] = [];
-  for (const workflow of workflows) {
-    const slugs = await launchedSlugs(workflow.path);
-    for (const slug of slugs) {
-      edges.push({
-        fromManifestName: workflow.manifestName,
-        toManifestName: byName.get(slug) ?? null,
-        toSlug: slug,
-      });
-    }
-  }
-  return edges;
+  return launches;
 }

--- a/packages/harness/src/core/canvas-manifest-check.ts
+++ b/packages/harness/src/core/canvas-manifest-check.ts
@@ -51,7 +51,10 @@ function reasonFor(err) {
 
 const sourceDir = process.env.SAPIOM_CANVAS_CHECK_SOURCE_DIR;
 try {
-  const result = await check({ sourceDir });
+  // typecheck: false — a diagram only needs the manifest/graph, and the
+  // project's own tsc --noEmit is the dominant multi-second per-render cost;
+  // esbuild still surfaces real breakage (bad imports, syntax errors).
+  const result = await check({ sourceDir, typecheck: false });
   process.stdout.write(JSON.stringify({ ok: true, manifest: result.manifest, warnings: result.warnings }));
 } catch (err) {
   process.stdout.write(JSON.stringify({ ok: false, reason: reasonFor(err) }));

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -1,16 +1,22 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { CANVAS_INDEX } from "../shared/types.js";
-import { renderCanvasForSession, type RenderableWorkflow } from "./canvas-render.js";
+import { CANVAS_DIR } from "../shared/types.js";
+import { clearExtractionCache } from "./canvas-cache.js";
+import {
+  renderCanvasForSession,
+  renderFileFor,
+  slugForWorkflowPath,
+  type RenderableWorkflow,
+} from "./canvas-render.js";
 
 const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
 const ORDER_TRIAGE = path.join(FIXTURES_DIR, "order-triage");
 const NO_DEFINITION = path.join(FIXTURES_DIR, "no-definition");
 const HUB = path.join(FIXTURES_DIR, "hub");
-const SPOKE = path.join(FIXTURES_DIR, "spoke");
+const LEGACY_FLOW = path.join(FIXTURES_DIR, "legacy-flow");
 
 const tmpDirs: string[] = [];
 async function tmpCwd(): Promise<string> {
@@ -18,27 +24,76 @@ async function tmpCwd(): Promise<string> {
   tmpDirs.push(dir);
   return dir;
 }
+beforeEach(() => clearExtractionCache());
 afterEach(async () => {
   await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
 });
 
-async function readIndex(cwd: string): Promise<string> {
-  return fs.readFile(path.join(cwd, CANVAS_INDEX), "utf8");
+async function readRender(cwd: string, workflowPath: string): Promise<string> {
+  return fs.readFile(renderFileFor(cwd, workflowPath), "utf8");
 }
 
+describe("slugForWorkflowPath", () => {
+  it("is readable, filesystem-safe and collision-proof across same-named workflows", () => {
+    const a = slugForWorkflowPath("/projects/a/order-triage");
+    const b = slugForWorkflowPath("/projects/b/order-triage");
+    expect(a).toMatch(/^order-triage-[0-9a-f]{8}$/);
+    expect(b).toMatch(/^order-triage-[0-9a-f]{8}$/);
+    expect(a).not.toBe(b);
+    expect(slugForWorkflowPath("/projects/a/order-triage")).toBe(a); // deterministic
+  });
+});
+
 describe("renderCanvasForSession", () => {
-  it("renders the bound workflow's real step names into a single panel", async () => {
+  it("renders the bound workflow's real step names into its own per-workflow render file — index.html is never touched", async () => {
     const cwd = await tmpCwd();
     const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
     const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
 
-    expect(outcome).toEqual({ mode: "single", workflowPath: ORDER_TRIAGE, extractionFailed: [] });
-    const html = await readIndex(cwd);
+    expect(outcome.mode).toBe("single");
+    expect(outcome.workflowPath).toBe(ORDER_TRIAGE);
+    expect(outcome.extractionFailed).toEqual([]);
+    expect(outcome.cachedExtraction).toBe(false);
+    expect(outcome.renderPath).toBe(renderFileFor(cwd, ORDER_TRIAGE));
+
+    const html = await readRender(cwd, ORDER_TRIAGE);
     for (const step of ["intake", "classify", "route", "auto_resolve", "escalate"]) {
       expect(html).toContain(`>${step}<`);
     }
     expect(html).toContain("canvas-legend");
-    expect(html).not.toContain('class="canvas-panel canvas-interconnections"');
+
+    await expect(fs.access(path.join(cwd, CANVAS_DIR, "index.html"))).rejects.toThrow();
+  });
+
+  it("serves the second render of an unchanged workflow from the extraction cache", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
+    await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    const second = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    expect(second.cachedExtraction).toBe(true);
+    await expect(readRender(cwd, ORDER_TRIAGE)).resolves.toContain(">intake<");
+  });
+
+  it("renders an old-SDK (legacy-branded) workflow — the dual-brand extraction end to end", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: LEGACY_FLOW, name: "legacy-flow", definitionId: null }];
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: LEGACY_FLOW }, workflows);
+
+    expect(outcome.extractionFailed).toEqual([]);
+    const html = await readRender(cwd, LEGACY_FLOW);
+    for (const step of ["receive", "confirm", "award"]) expect(html).toContain(`>${step}<`);
+  });
+
+  it("includes detected launches as dashed launched-workflow nodes in the bound workflow's own diagram", async () => {
+    const cwd = await tmpCwd();
+    const workflows: RenderableWorkflow[] = [{ path: HUB, name: "hub", definitionId: null }];
+    await renderCanvasForSession({ cwd, boundWorkflowPath: HUB }, workflows);
+
+    const html = await readRender(cwd, HUB);
+    expect(html).toContain("node--launched-workflow");
+    expect(html).toContain(">spoke-workflow<");
+    expect(html).toContain("canvas-edge--launch");
+    expect(html).toContain(">launch()<");
   });
 
   it("degrades to an honest error panel when the bound workflow fails to extract — never crashes, never falls back to an LLM prompt", async () => {
@@ -48,76 +103,27 @@ describe("renderCanvasForSession", () => {
 
     expect(outcome.mode).toBe("single");
     expect(outcome.extractionFailed).toEqual(["broken-flow"]);
-    const html = await readIndex(cwd);
+    const html = await readRender(cwd, NO_DEFINITION);
     expect(html).toContain("broken-flow");
     expect(html).toContain("render failed");
     expect(html).toContain("Could not extract this workflow's step graph");
     expect(html).not.toContain('class="canvas-node '); // no diagram — just the note
   });
 
-  it("renders the whole-workspace overview (one panel per workflow) when unbound", async () => {
+  it("is a cheap no-op when unbound: no extraction, no write — the server serves the empty state itself", async () => {
     const cwd = await tmpCwd();
-    const workflows: RenderableWorkflow[] = [
-      { path: ORDER_TRIAGE, name: "order-triage", definitionId: 42 },
-      { path: HUB, name: "hub", definitionId: null },
-    ];
+    const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
     const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
-
-    expect(outcome.mode).toBe("overview");
-    expect(outcome.workflowCount).toBe(2);
-    expect(outcome.extractionFailed).toEqual([]);
-    const html = await readIndex(cwd);
-    expect(html).toContain(">order-triage<");
-    expect(html).toContain(">hub<");
-    expect(html).toContain("deployed");
-    expect(html).toContain("local only");
-  });
-
-  it("includes an Interconnections panel when a workspace overview's workflows reference each other", async () => {
-    const cwd = await tmpCwd();
-    const workflows: RenderableWorkflow[] = [
-      { path: HUB, name: "hub", definitionId: null },
-      { path: SPOKE, name: "spoke", definitionId: null },
-    ];
-    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
-
-    expect(outcome.mode).toBe("overview");
-    const html = await readIndex(cwd);
-    expect(html).toContain('class="canvas-panel canvas-interconnections"');
-    expect(html).toContain("hub &rarr; spoke");
-    expect(html).toContain('class="canvas-interconnection-tag">launch<');
-  });
-
-  it("degrades one panel at a time in an overview — one broken workflow doesn't take down the others", async () => {
-    const cwd = await tmpCwd();
-    const workflows: RenderableWorkflow[] = [
-      { path: ORDER_TRIAGE, name: "order-triage", definitionId: null },
-      { path: NO_DEFINITION, name: "broken-flow", definitionId: null },
-    ];
-    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
-
-    expect(outcome.mode).toBe("overview");
-    expect(outcome.extractionFailed).toEqual(["broken-flow"]);
-    const html = await readIndex(cwd);
-    expect(html).toContain(">intake<"); // order-triage still rendered in full
-    expect(html).toContain("render failed"); // broken-flow degraded, not dropped
-  });
-
-  it("renders a friendly empty-workspace note (not an error) when unbound with zero known workflows", async () => {
-    const cwd = await tmpCwd();
-    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, []);
 
     expect(outcome).toEqual({ mode: "empty", extractionFailed: [] });
-    const html = await readIndex(cwd);
-    expect(html).toContain("No workflows found");
-    expect(html).not.toContain("render failed");
+    await expect(fs.access(path.join(cwd, CANVAS_DIR))).rejects.toThrow(); // nothing written at all
   });
 
-  it("falls back to the workspace overview when boundWorkflowPath doesn't match any known workflow", async () => {
+  it("treats a boundWorkflowPath that matches no known workflow as unbound", async () => {
     const cwd = await tmpCwd();
     const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
     const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: "/no/such/workflow" }, workflows);
-    expect(outcome.mode).toBe("overview");
+    expect(outcome.mode).toBe("empty");
   });
 
   it("never throws when the cwd is unwritable — reports writeError instead", async () => {
@@ -126,73 +132,54 @@ describe("renderCanvasForSession", () => {
     const notADir = path.join(parent, "not-a-directory");
     await fs.writeFile(notADir, "x");
 
-    const outcome = await renderCanvasForSession({ cwd: notADir, boundWorkflowPath: null }, []);
-    expect(outcome.mode).toBe("empty");
+    const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
+    const outcome = await renderCanvasForSession({ cwd: notADir, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    expect(outcome.mode).toBe("single");
     expect(outcome.writeError).toBeTruthy();
   });
 
   describe("preserveExistingOnFailure (unprompted auto-renders)", () => {
-    const SEEDED_CANVAS = "<!doctype html><!-- seeded opening shot -->";
+    const GOOD_RENDER = "<!doctype html><!-- previously good diagram -->";
 
-    async function seedCanvas(cwd: string): Promise<void> {
-      const indexPath = path.join(cwd, CANVAS_INDEX);
-      await fs.mkdir(path.dirname(indexPath), { recursive: true });
-      await fs.writeFile(indexPath, SEEDED_CANVAS, "utf8");
-    }
-
-    it("keeps an existing canvas when every extraction failed, instead of replacing it with error panels", async () => {
+    it("keeps this workflow's existing render when extraction failed, instead of replacing it with an error panel", async () => {
       const cwd = await tmpCwd();
-      await seedCanvas(cwd);
+      const renderPath = renderFileFor(cwd, NO_DEFINITION);
+      await fs.mkdir(path.dirname(renderPath), { recursive: true });
+      await fs.writeFile(renderPath, GOOD_RENDER, "utf8");
       const workflows: RenderableWorkflow[] = [{ path: NO_DEFINITION, name: "broken-flow", definitionId: null }];
 
-      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows, {
+      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: NO_DEFINITION }, workflows, {
         preserveExistingOnFailure: true,
       });
 
       expect(outcome.extractionFailed).toEqual(["broken-flow"]);
       expect(outcome.preservedExisting).toBe(true);
-      expect(await readIndex(cwd)).toBe(SEEDED_CANVAS);
+      expect(await readRender(cwd, NO_DEFINITION)).toBe(GOOD_RENDER);
     });
 
     it("still writes the honest error page when nothing exists to preserve", async () => {
       const cwd = await tmpCwd();
       const workflows: RenderableWorkflow[] = [{ path: NO_DEFINITION, name: "broken-flow", definitionId: null }];
 
-      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows, {
+      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: NO_DEFINITION }, workflows, {
         preserveExistingOnFailure: true,
       });
 
       expect(outcome.preservedExisting).toBeUndefined();
-      expect(await readIndex(cwd)).toContain("render failed");
+      expect(await readRender(cwd, NO_DEFINITION)).toContain("render failed");
     });
 
-    it("overwrites the existing canvas when at least one workflow rendered — a partial overview beats a stale shot", async () => {
+    it("does not change explicit-render behavior: without the option, the error panel replaces the existing render", async () => {
       const cwd = await tmpCwd();
-      await seedCanvas(cwd);
-      const workflows: RenderableWorkflow[] = [
-        { path: ORDER_TRIAGE, name: "order-triage", definitionId: null },
-        { path: NO_DEFINITION, name: "broken-flow", definitionId: null },
-      ];
-
-      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows, {
-        preserveExistingOnFailure: true,
-      });
-
-      expect(outcome.preservedExisting).toBeUndefined();
-      const html = await readIndex(cwd);
-      expect(html).toContain(">intake<");
-      expect(html).not.toBe(SEEDED_CANVAS);
-    });
-
-    it("does not change explicit-render behavior: without the option, error panels replace the existing canvas", async () => {
-      const cwd = await tmpCwd();
-      await seedCanvas(cwd);
+      const renderPath = renderFileFor(cwd, NO_DEFINITION);
+      await fs.mkdir(path.dirname(renderPath), { recursive: true });
+      await fs.writeFile(renderPath, GOOD_RENDER, "utf8");
       const workflows: RenderableWorkflow[] = [{ path: NO_DEFINITION, name: "broken-flow", definitionId: null }];
 
-      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: null }, workflows);
+      const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: NO_DEFINITION }, workflows);
 
       expect(outcome.preservedExisting).toBeUndefined();
-      expect(await readIndex(cwd)).toContain("render failed");
+      expect(await readRender(cwd, NO_DEFINITION)).toContain("render failed");
     });
   });
 });

--- a/packages/harness/src/core/canvas-render.ts
+++ b/packages/harness/src/core/canvas-render.ts
@@ -1,36 +1,40 @@
 /**
- * The deterministic render pipeline: given a session (bound or not) and the
- * workflow registry, extracts the relevant workflow graph(s) (core/
- * canvas-graph.ts), builds the SVG + panel markup (core/canvas-svg.ts,
- * core/canvas-body.ts), wraps it through the shared document shell
- * (core/canvas-template.ts's `renderCanvasDocument`), and writes
- * `<cwd>/.sapiom/canvas/index.html`. Zero LLM involvement, typically well
- * under a second for a small workflow — extraction failure degrades to an
- * honest error panel per workflow, never a crash and never a silent fallback
- * to the LLM path (see core/macros.ts's separate "ai-visualize" macro for
- * that path).
+ * The deterministic render pipeline: given a session bound to a workflow,
+ * extracts that workflow's graph (core/canvas-cache.ts — cached, so an
+ * unchanged workflow never pays for a second child process), builds the SVG +
+ * panel markup (core/canvas-svg.ts, core/canvas-body.ts), wraps it through
+ * the shared document shell (core/canvas-template.ts's
+ * `renderCanvasDocument`), and writes it to the workflow's own render file,
+ * `<cwd>/.sapiom/canvas/renders/<slug>.html`. Zero LLM involvement —
+ * extraction failure degrades to an honest error panel, never a crash.
+ *
+ * Renders are per-WORKFLOW files (not a shared index.html) so switching the
+ * binding never rewrites anything another binding depends on — the server
+ * (src/server/canvas.ts) resolves the session's current binding at request
+ * time and serves the matching render. `index.html` remains the
+ * agent-authored/custom canvas and is never touched here. An unbound session
+ * renders nothing at all (no extraction, no write): the server serves the
+ * existing empty-state/custom canvas for it.
  *
  * The write alone is enough to hot-reload an open canvas pane —
  * CanvasWatcherManager already watches the whole session cwd and treats any
  * change under `.sapiom/canvas/` as a reload signal, regardless of who wrote
  * it.
  */
+import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { CANVAS_INDEX } from "../shared/types.js";
+import { CANVAS_RENDERS_DIR } from "../shared/types.js";
 import { renderCanvasDocument } from "./canvas-template.js";
-import { extractWorkflowGraph, type CanvasGraph } from "./canvas-graph.js";
+import { extractWorkflowGraphCached } from "./canvas-cache.js";
+import type { CanvasGraph } from "./canvas-graph.js";
+import { usedKinds } from "./canvas-svg.js";
 import {
-  aggregateUsedKinds,
   assembleCanvasBody,
-  buildEmptyWorkspaceHtml,
   buildErrorPanelHtml,
-  buildInterconnectionsPanelHtml,
   buildLegendHtml,
   buildWorkflowPanelHtml,
-  type InterconnectionRow,
 } from "./canvas-body.js";
-import { detectInterconnections } from "./canvas-interconnections.js";
 
 export interface RenderableSession {
   cwd: string;
@@ -43,27 +47,54 @@ export interface RenderableWorkflow {
   definitionId: number | null;
 }
 
+/**
+ * Stable, filesystem-safe render-file name for a workflow: its directory
+ * basename (readable in `ls`) plus a short path hash (two same-named
+ * workflows at different paths can never collide). Shared by the writer here
+ * and the server's request-time resolution — must stay deterministic.
+ */
+export function slugForWorkflowPath(workflowPath: string): string {
+  const base =
+    path
+      .basename(workflowPath)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "workflow";
+  const hash = createHash("sha256").update(path.resolve(workflowPath)).digest("hex").slice(0, 8);
+  return `${base}-${hash}`;
+}
+
+/** Absolute path of `workflowPath`'s render file under `cwd`'s canvas dir. */
+export function renderFileFor(cwd: string, workflowPath: string): string {
+  return path.join(cwd, CANVAS_RENDERS_DIR, `${slugForWorkflowPath(workflowPath)}.html`);
+}
+
 export interface CanvasRenderOutcome {
-  mode: "single" | "overview" | "empty";
+  /** "single": a bound workflow was rendered to its render file. "empty":
+   *  the session is unbound (or bound to an unknown path) — nothing was
+   *  extracted or written; the server serves the empty state on its own. */
+  mode: "single" | "empty";
   workflowPath?: string;
-  workflowCount?: number;
+  /** Absolute path of the render file written (mode "single" only). */
+  renderPath?: string;
   /** Display names of workflows whose graph couldn't be extracted (still rendered as a degraded panel). */
   extractionFailed: string[];
+  /** True when the graph came from the extraction cache — no child process ran. */
+  cachedExtraction?: boolean;
   /** Set only when writing the file itself failed (e.g. an unwritable cwd) — extraction success/failure above is unaffected. */
   writeError?: string;
-  /** True when `preserveExistingOnFailure` kept the existing canvas instead of writing error panels over it. */
+  /** True when `preserveExistingOnFailure` kept the existing render instead of writing an error panel over it. */
   preservedExisting?: boolean;
 }
 
 export interface RenderCanvasOptions {
   /**
-   * For unprompted (auto) renders only — session create, boot. When every
-   * extraction failed AND a canvas index.html already exists, keep the
-   * existing file rather than replace possibly-good content (a seeded
-   * opening shot, an agent-authored view) with nothing but error panels.
-   * An explicit user-invoked render (the Visualize macro, POST
-   * /canvas/:id/render) should NOT set this: there the honest error page
-   * IS the answer the user asked for.
+   * For unprompted (auto) renders only — session create, boot. When the
+   * extraction failed AND a render file for this workflow already exists,
+   * keep the existing file rather than replace a possibly-good diagram with
+   * an error panel. An explicit user-invoked render (the Visualize macro,
+   * POST /canvas/:id/render) should NOT set this: there the honest error
+   * page IS the answer the user asked for.
    */
   preserveExistingOnFailure?: boolean;
 }
@@ -72,121 +103,57 @@ function badgesFor(workflow: RenderableWorkflow): string[] {
   return [workflow.definitionId != null ? "deployed" : "local only"];
 }
 
-async function renderOne(
-  workflow: RenderableWorkflow,
-): Promise<{ panel: string; graph: CanvasGraph | null; failed: boolean }> {
-  const result = await extractWorkflowGraph(workflow.path);
-  if (!result.ok) {
-    return { panel: buildErrorPanelHtml(workflow.name, result.reason), graph: null, failed: true };
+function buildSingleBody(workflow: RenderableWorkflow, graph: CanvasGraph | null, reason: string | null): string {
+  if (!graph) {
+    return assembleCanvasBody({
+      panels: [buildErrorPanelHtml(workflow.name, reason ?? "unknown extraction failure")],
+      legend: "",
+      note: "Static preview — this workflow has a build error; regenerate once it's fixed.",
+    });
   }
-  return {
-    panel: buildWorkflowPanelHtml(result.graph, { title: workflow.name, badges: badgesFor(workflow) }),
-    graph: result.graph,
-    failed: false,
-  };
-}
-
-async function renderSingle(workflow: RenderableWorkflow): Promise<{ body: string; failed: boolean }> {
-  const { panel, graph, failed } = await renderOne(workflow);
-  const used = graph ? aggregateUsedKinds([graph]) : null;
-  const legend = used ? buildLegendHtml(used.nodeKinds, used.edgeKinds) : "";
-  const body = assembleCanvasBody({
-    panels: [panel],
-    legend,
-    note: failed
-      ? "Static preview — this workflow has a build error; regenerate once it's fixed."
-      : "Static preview — regenerate after the workflow changes.",
+  const used = usedKinds(graph);
+  return assembleCanvasBody({
+    panels: [buildWorkflowPanelHtml(graph, { title: workflow.name, badges: badgesFor(workflow) })],
+    legend: buildLegendHtml(used.nodeKinds, used.edgeKinds),
+    note: "Static preview — re-renders automatically when the workflow changes.",
   });
-  return { body, failed };
-}
-
-async function renderOverview(workflows: readonly RenderableWorkflow[]): Promise<{ body: string; failed: string[] }> {
-  const rendered = await Promise.all(workflows.map((w) => renderOne(w)));
-  const panels = rendered.map((r) => r.panel);
-  const graphs = rendered.map((r) => r.graph).filter((g): g is CanvasGraph => g !== null);
-  const failed = workflows.filter((_, i) => rendered[i]!.failed).map((w) => w.name);
-
-  const displayByManifestName = new Map<string, string>();
-  workflows.forEach((w, i) => {
-    const graph = rendered[i]!.graph;
-    if (graph) displayByManifestName.set(graph.manifestName, w.name);
-  });
-
-  const grepInputs = workflows.map((w, i) => ({
-    path: w.path,
-    manifestName: rendered[i]!.graph?.manifestName ?? w.name,
-  }));
-  const interconnections = await detectInterconnections(grepInputs);
-  const rows: InterconnectionRow[] = interconnections.map((edge) => ({
-    fromLabel: displayByManifestName.get(edge.fromManifestName) ?? edge.fromManifestName,
-    toLabel: edge.toManifestName ? (displayByManifestName.get(edge.toManifestName) ?? edge.toManifestName) : `external ("${edge.toSlug}")`,
-    tag: "launch",
-  }));
-
-  const used = aggregateUsedKinds(graphs);
-  if (rows.length > 0) used.edgeKinds.add("cross");
-  const legend = buildLegendHtml(used.nodeKinds, used.edgeKinds);
-  const interconnectionsHtml = buildInterconnectionsPanelHtml(rows);
-
-  const body = assembleCanvasBody({
-    panels,
-    interconnections: interconnectionsHtml || undefined,
-    legend,
-    note:
-      failed.length > 0
-        ? `Static preview — regenerate after a workflow changes (${failed.length} workflow${failed.length === 1 ? "" : "s"} failed to build).`
-        : "Static preview — regenerate after a workflow changes.",
-  });
-  return { body, failed };
 }
 
 /**
- * Renders the appropriate view for `session` (its bound workflow, or the
- * whole-workspace overview when unbound) and writes it to `<cwd>/.sapiom/
- * canvas/index.html`. Never throws — every failure mode (extraction,
- * filesystem) is captured in the returned outcome instead.
+ * Renders `session`'s bound workflow to its per-workflow render file. Never
+ * throws — every failure mode (extraction, filesystem) is captured in the
+ * returned outcome instead. Unbound sessions are a cheap no-op: no
+ * extraction, no write (`mode: "empty"`).
  */
 export async function renderCanvasForSession(
   session: RenderableSession,
   workflows: readonly RenderableWorkflow[],
   options: RenderCanvasOptions = {},
 ): Promise<CanvasRenderOutcome> {
-  let body: string;
-  let outcome: CanvasRenderOutcome;
-  let renderedAnyGraph: boolean;
-
   const bound = session.boundWorkflowPath ? workflows.find((w) => w.path === session.boundWorkflowPath) : undefined;
-
-  if (bound) {
-    const { body: renderedBody, failed } = await renderSingle(bound);
-    body = renderedBody;
-    renderedAnyGraph = !failed;
-    outcome = { mode: "single", workflowPath: bound.path, extractionFailed: failed ? [bound.name] : [] };
-  } else if (workflows.length === 0) {
-    body = assembleCanvasBody({
-      panels: [buildEmptyWorkspaceHtml()],
-      legend: "",
-      note: "Nothing to visualize yet — connect a workflow to get started.",
-    });
-    // The empty-workspace panel is real content, not a degraded render.
-    renderedAnyGraph = true;
-    outcome = { mode: "empty", extractionFailed: [] };
-  } else {
-    const { body: renderedBody, failed } = await renderOverview(workflows);
-    body = renderedBody;
-    renderedAnyGraph = failed.length < workflows.length;
-    outcome = { mode: "overview", workflowCount: workflows.length, extractionFailed: failed };
+  if (!bound) {
+    return { mode: "empty", extractionFailed: [] };
   }
 
-  const indexPath = path.join(session.cwd, CANVAS_INDEX);
+  const { result, cached } = await extractWorkflowGraphCached(bound.path);
+  const failed = !result.ok;
+  const body = buildSingleBody(bound, result.ok ? result.graph : null, result.ok ? null : result.reason);
 
-  // An unprompted render that produced ONLY error panels must not destroy an
-  // existing canvas (the seeded sample's opening shot, an agent-authored
-  // view): a project that merely hasn't run `npm install` yet would
-  // otherwise open to a wall of build errors it did nothing to deserve.
-  if (options.preserveExistingOnFailure && !renderedAnyGraph) {
+  const renderPath = renderFileFor(session.cwd, bound.path);
+  const outcome: CanvasRenderOutcome = {
+    mode: "single",
+    workflowPath: bound.path,
+    renderPath,
+    extractionFailed: failed ? [bound.name] : [],
+    cachedExtraction: cached,
+  };
+
+  // An unprompted render that failed to extract must not destroy an existing
+  // (possibly good) diagram for this workflow — e.g. a project that merely
+  // hasn't run `npm install` yet after a fresh clone.
+  if (options.preserveExistingOnFailure && failed) {
     const exists = await fs
-      .access(indexPath)
+      .access(renderPath)
       .then(() => true)
       .catch(() => false);
     if (exists) {
@@ -196,8 +163,8 @@ export async function renderCanvasForSession(
   }
 
   try {
-    await fs.mkdir(path.dirname(indexPath), { recursive: true });
-    await fs.writeFile(indexPath, renderCanvasDocument(body), "utf8");
+    await fs.mkdir(path.dirname(renderPath), { recursive: true });
+    await fs.writeFile(renderPath, renderCanvasDocument(body), "utf8");
   } catch (err) {
     outcome.writeError = err instanceof Error ? err.message : String(err);
   }

--- a/packages/harness/src/core/canvas-svg.ts
+++ b/packages/harness/src/core/canvas-svg.ts
@@ -1,8 +1,9 @@
 /**
  * Server-side SVG layout for a `CanvasGraph` (see core/canvas-graph.ts),
  * emitting markup against the classes `core/canvas-template.ts`'s CSS shell
- * already defines (node--entry/step/pause/terminal-success/terminal-warn,
- * canvas-edge/--success/--warn/--cross). No DOM, no client-side script — the
+ * already defines (node--entry/step/pause/terminal-success/terminal-warn/
+ * launched-workflow, canvas-edge/--success/--warn/--cross/--launch). No DOM,
+ * no client-side script — the
  * whole diagram is a static string built once, at render time.
  *
  * Layout: longest-path-from-roots layering (a Kahn's-algorithm variant),
@@ -138,13 +139,16 @@ export function renderGraphSvg(graph: CanvasGraph): string {
       const y1 = from.y + NODE_H;
       const x2 = to.x + NODE_W / 2;
       const y2 = to.y;
-      const isCross = edge.kind === "cross";
-      const colorSuffix = isCross ? "" : edgeColorClass(nodesById, edge);
-      const classes = ["canvas-edge", isCross ? "canvas-edge--cross" : colorSuffix && `canvas-edge${colorSuffix}`]
+      // Cross (signal/handoff) and launch edges are always dashed-neutral,
+      // never colored by their destination.
+      const dashedClass =
+        edge.kind === "cross" ? "canvas-edge--cross" : edge.kind === "launch" ? "canvas-edge--launch" : null;
+      const colorSuffix = dashedClass ? "" : edgeColorClass(nodesById, edge);
+      const classes = ["canvas-edge", dashedClass ?? (colorSuffix && `canvas-edge${colorSuffix}`)]
         .filter(Boolean)
         .join(" ");
       const d = edgePath(edge.kind, x1, y1, x2, y2);
-      const marker = isCross ? "url(#canvas-arrow)" : arrowMarker(colorSuffix);
+      const marker = dashedClass ? "url(#canvas-arrow)" : arrowMarker(colorSuffix);
       const path = `<path class="${classes}" d="${d}" marker-end="${marker}" />`;
       if (!edge.label) return path;
       const dx = x2 - x1;

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -93,12 +93,13 @@ html, body {
 .canvas-empty-note { color: var(--canvas-text-dim); font-size: 13px; text-align: center; padding: 60px 20px; margin: 0; }
 .canvas-graph-svg { display: block; width: 100%; height: auto; }
 
-/* --- node kinds: entry | step | pause | terminal-success | terminal-warn --- */
+/* --- node kinds: entry | step | pause | terminal-success | terminal-warn | launched-workflow --- */
 .canvas-node .canvas-node-rect { fill: var(--canvas-panel); stroke-width: 1.5; stroke: var(--canvas-border-strong); }
 .node--entry .canvas-node-rect { stroke: var(--canvas-accent); }
 .node--pause .canvas-node-rect { stroke: var(--canvas-text-dim); stroke-dasharray: 5 4; }
 .node--terminal-success .canvas-node-rect { stroke: var(--canvas-success); }
 .node--terminal-warn .canvas-node-rect { stroke: var(--canvas-escalation); }
+.node--launched-workflow .canvas-node-rect { stroke: var(--canvas-accent); stroke-dasharray: 5 4; }
 .canvas-node-title { fill: var(--canvas-text); font-size: 13px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
 .canvas-node-sub { fill: var(--canvas-text-dim); font-size: 9.5px; text-anchor: middle; dominant-baseline: middle; }
 
@@ -107,6 +108,7 @@ html, body {
 .canvas-edge--success { stroke: var(--canvas-success); }
 .canvas-edge--warn { stroke: var(--canvas-escalation); }
 .canvas-edge--cross { stroke: var(--canvas-text-dim); stroke-dasharray: 4 4; }
+.canvas-edge--launch { stroke: var(--canvas-accent); stroke-dasharray: 4 4; }
 .canvas-edge-label { fill: var(--canvas-text-dim); font-size: 9px; }
 .canvas-arrow-fill { fill: var(--canvas-border-strong); }
 .canvas-arrow-fill--success { fill: var(--canvas-success); }
@@ -122,6 +124,7 @@ html, body {
 .canvas-legend-marker--terminal-success { background: var(--canvas-success); border-radius: 3px; }
 .canvas-legend-marker--terminal-warn { background: var(--canvas-escalation); border-radius: 3px; }
 .canvas-legend-marker--cross { border: 1.5px dashed var(--canvas-text-dim); border-radius: 2px; background: transparent; }
+.canvas-legend-marker--launched-workflow { border: 1.5px dashed var(--canvas-accent); border-radius: 3px; background: transparent; }
 .canvas-interconnections { display: flex; flex-direction: column; gap: 12px; }
 .canvas-panel-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--canvas-text-dim); }
 .canvas-interconnection-row { display: grid; grid-template-columns: 12px 1fr auto; column-gap: 8px; row-gap: 2px; align-items: baseline; }

--- a/packages/harness/src/server/canvas-render.test.ts
+++ b/packages/harness/src/server/canvas-render.test.ts
@@ -6,7 +6,7 @@ import express from "express";
 import type { Server } from "node:http";
 import { createCanvasRenderRouter, type CanvasRenderRouterDeps } from "./canvas-render.js";
 import { createBootTokenMiddleware } from "./auth.js";
-import { CANVAS_INDEX } from "../shared/types.js";
+import { CANVAS_DIR } from "../shared/types.js";
 
 const BOOT_TOKEN = "test-boot-token";
 const TOKEN_HEADER = { "X-Harness-Token": BOOT_TOKEN };
@@ -67,15 +67,16 @@ describe("canvas render router", () => {
     expect(res.status).toBe(404);
   });
 
-  it("renders the empty-workspace state and reports ok:true with mode 'empty' when no workflows are known", async () => {
+  it("reports ok:true with mode 'empty' — and writes nothing — for an unbound session", async () => {
     await start({ getSession: () => ({ cwd: projectDir, boundWorkflowPath: null }), listWorkflows: () => [] });
     const res = await fetch(`${baseUrl}/api/canvas/sess-1/render`, { method: "POST", headers: TOKEN_HEADER });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; mode: string };
     expect(body).toMatchObject({ ok: true, mode: "empty" });
 
-    const html = await fs.readFile(path.join(projectDir, CANVAS_INDEX), "utf8");
-    expect(html).toContain("No workflows found");
+    // Zero extraction, zero writes: the canvas router serves the unbound
+    // empty state on its own.
+    await expect(fs.access(path.join(projectDir, CANVAS_DIR))).rejects.toThrow();
   });
 
   it("passes the session's real binding and the live workflow list through to the render", async () => {

--- a/packages/harness/src/server/canvas-render.ts
+++ b/packages/harness/src/server/canvas-render.ts
@@ -2,9 +2,9 @@
  * `POST /api/canvas/:sessionId/render` — the deterministic, zero-LLM render
  * trigger. Mounted under the same `/api` boot-token middleware as the rest of
  * the REST surface (see server/index.ts). Renders the session's bound
- * workflow, or the whole-workspace overview when unbound; writing the file is
- * enough to hot-reload an already-open canvas pane (CanvasWatcherManager
- * picks up the change on its own).
+ * workflow to its per-workflow render file (a cheap no-op when unbound);
+ * writing the file is enough to hot-reload an already-open canvas pane
+ * (CanvasWatcherManager picks up the change on its own).
  */
 import { Router, type Router as ExpressRouter } from "express";
 import { renderCanvasForSession, type RenderableSession, type RenderableWorkflow } from "../core/canvas-render.js";

--- a/packages/harness/src/server/canvas.test.ts
+++ b/packages/harness/src/server/canvas.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import express from "express";
 import type { Server } from "node:http";
+import { renderFileFor } from "../core/canvas-render.js";
 import { createCanvasRouter, type CanvasSession } from "./canvas.js";
 
 let projectDir: string;
@@ -61,6 +62,53 @@ describe("canvas router", () => {
   it("404s when no canvas has been written yet", async () => {
     const res = await fetch(`${baseUrl}/canvas/sess-1/`, { method: "HEAD" });
     expect(res.status).toBe(404);
+  });
+
+  it("serves the bound workflow's render file at the canvas root — resolved at request time, no index.html rewrite", async () => {
+    const workflowPath = "/registered/workflows/order-triage";
+    sessions.set("sess-1", { cwd: projectDir, boundWorkflowPath: workflowPath });
+    const renderPath = renderFileFor(projectDir, workflowPath);
+    await fs.mkdir(path.dirname(renderPath), { recursive: true });
+    await fs.writeFile(renderPath, "<html><body>diagram</body></html>");
+    // A stale index.html must NOT shadow the bound render.
+    await fs.writeFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "<html><body>legacy</body></html>");
+
+    const res = await fetch(`${baseUrl}/canvas/sess-1/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("diagram");
+  });
+
+  it("switching the binding changes what the same URL serves — per-request resolution", async () => {
+    const flowA = "/registered/workflows/flow-a";
+    const flowB = "/registered/workflows/flow-b";
+    for (const [flow, body] of [
+      [flowA, "diagram A"],
+      [flowB, "diagram B"],
+    ] as const) {
+      const renderPath = renderFileFor(projectDir, flow);
+      await fs.mkdir(path.dirname(renderPath), { recursive: true });
+      await fs.writeFile(renderPath, `<html><body>${body}</body></html>`);
+    }
+
+    sessions.set("sess-1", { cwd: projectDir, boundWorkflowPath: flowA });
+    expect(await (await fetch(`${baseUrl}/canvas/sess-1/`)).text()).toContain("diagram A");
+    sessions.set("sess-1", { cwd: projectDir, boundWorkflowPath: flowB });
+    expect(await (await fetch(`${baseUrl}/canvas/sess-1/`)).text()).toContain("diagram B");
+  });
+
+  it("serves a 200 'rendering…' page for a bound session whose render file doesn't exist yet", async () => {
+    sessions.set("sess-1", { cwd: projectDir, boundWorkflowPath: "/registered/workflows/not-rendered-yet" });
+    const res = await fetch(`${baseUrl}/canvas/sess-1/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Rendering workflow diagram");
+  });
+
+  it("an unbound session keeps the legacy behavior: the canvas root serves index.html", async () => {
+    await fs.mkdir(path.join(projectDir, ".sapiom", "canvas"), { recursive: true });
+    await fs.writeFile(path.join(projectDir, ".sapiom", "canvas", "index.html"), "<html><body>custom</body></html>");
+    const res = await fetch(`${baseUrl}/canvas/sess-1/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("custom");
   });
 
   it("serves index.html at the session's canvas root", async () => {

--- a/packages/harness/src/server/canvas.ts
+++ b/packages/harness/src/server/canvas.ts
@@ -1,18 +1,24 @@
 /**
  * Canvas serving (workstream W5's backend slice).
  *
- * Serves whatever a session's agent wrote to `<cwd>/.sapiom/canvas/` (see
- * CANVAS_DIR) at `GET /canvas/:harnessSessionId/*`. The SPA's CanvasPane
- * embeds this in a sandboxed iframe and probes it with a HEAD request
- * (`fetch('/canvas/<id>/', { method: 'HEAD' })`), so this stays
- * intentionally simple and unauthenticated — the server binds 127.0.0.1
- * only, and an iframe `src` / HEAD probe can't carry the boot token anyway.
- * The integrator mounts this alongside the SessionManager.
+ * Serves files under `<cwd>/.sapiom/canvas/` (see CANVAS_DIR) at
+ * `GET /canvas/:harnessSessionId/*`. The root request resolves by binding:
+ * a session bound to a workflow gets that workflow's deterministic render
+ * (`renders/<slug>.html` — resolved at request time, so switching the
+ * binding is instant, no file rewrite involved); an unbound session gets the
+ * legacy agent-authored `index.html` (custom canvases, the seeded template)
+ * exactly as before. The SPA's CanvasPane embeds this in a sandboxed iframe
+ * and probes it with a HEAD request (`fetch('/canvas/<id>/', { method:
+ * 'HEAD' })`), so this stays intentionally simple and unauthenticated — the
+ * server binds 127.0.0.1 only, and an iframe `src` / HEAD probe can't carry
+ * the boot token anyway. The integrator mounts this alongside the
+ * SessionManager.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Router, type Router as ExpressRouter, type Request, type Response } from "express";
 import { CANVAS_DIR, CANVAS_INDEX } from "../shared/types.js";
+import { slugForWorkflowPath } from "../core/canvas-render.js";
 
 const INDEX_FILENAME = path.basename(CANVAS_INDEX);
 
@@ -53,21 +59,42 @@ const EMPTY_STATE_HTML = `<!doctype html>
 <body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
   <div>
     <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Nothing rendered yet</h1>
-    <p style="margin: 0;">Ask your agent to write HTML to <code>.sapiom/canvas/index.html</code> in this
-    project — this pane hot-reloads whenever it changes.</p>
+    <p style="margin: 0;">Bind a workflow to see its diagram here, or ask your agent to write HTML to
+    <code>.sapiom/canvas/index.html</code> in this project — this pane hot-reloads whenever it changes.</p>
+  </div>
+</body>
+</html>`;
+
+/** Served for a BOUND session whose render file hasn't been written yet
+ *  (render in flight, or a server restart before any re-render). The pane
+ *  hot-reloads the moment the render lands, so this is only ever briefly
+ *  visible. */
+const PENDING_RENDER_HTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Canvas — rendering</title></head>
+<body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
+  <div>
+    <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Rendering workflow diagram…</h1>
+    <p style="margin: 0;">This pane reloads automatically when the diagram is ready.</p>
   </div>
 </body>
 </html>`;
 
 export interface CanvasSession {
   cwd: string;
+  /** The workflow the session is bound to, if any — decides what the canvas
+   *  root request serves (the workflow's render vs. the legacy index.html). */
+  boundWorkflowPath?: string | null;
 }
 
 /** Looks up a session by harnessSessionId; undefined when unknown (the real
  *  implementation is the SessionManager, once workstream W1 lands). */
 export type CanvasSessionLookup = (harnessSessionId: string) => CanvasSession | undefined;
 
-function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Response, relative: string): void {
+/** `relative === null` means "the canvas root" — what it resolves to depends
+ *  on the session's current binding, decided per request so switching the
+ *  bound workflow needs no file rewrite at all. */
+function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Response, relative: string | null): void {
   res.setHeader("Content-Security-Policy", CANVAS_CSP);
 
   const session = getSession(req.params.harnessSessionId);
@@ -76,8 +103,16 @@ function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Respons
     return;
   }
 
+  const isRoot = relative === null;
+  const bound = isRoot ? (session.boundWorkflowPath ?? null) : null;
+  const resolved = isRoot
+    ? bound
+      ? path.join("renders", `${slugForWorkflowPath(bound)}.html`)
+      : INDEX_FILENAME
+    : relative;
+
   const canvasRoot = path.resolve(session.cwd, CANVAS_DIR);
-  const filePath = path.resolve(canvasRoot, relative);
+  const filePath = path.resolve(canvasRoot, resolved);
 
   // Path traversal guard: the resolved file must stay under canvasRoot.
   if (filePath !== canvasRoot && !filePath.startsWith(canvasRoot + path.sep)) {
@@ -87,10 +122,17 @@ function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Respons
 
   fs.stat(filePath, (err, stat) => {
     if (err || !stat.isFile()) {
+      // A bound session whose render file isn't on disk yet gets the
+      // "rendering…" page — the pane hot-reloads once the render lands.
+      if (isRoot && bound) {
+        res.status(200).setHeader("Content-Type", "text/html; charset=utf-8");
+        res.end(PENDING_RENDER_HTML);
+        return;
+      }
       // The canvas index specifically missing gets a friendly explainer
       // (useful when this URL is opened directly, e.g. in a new tab during a
       // demo); any other missing file (a referenced asset) stays a plain 404.
-      if (relative === INDEX_FILENAME) {
+      if (resolved === INDEX_FILENAME) {
         res.status(404).setHeader("Content-Type", "text/html; charset=utf-8");
         res.end(EMPTY_STATE_HTML);
         return;
@@ -111,11 +153,11 @@ export function createCanvasRouter(getSession: CanvasSessionLookup): ExpressRout
     // Express's route-param typing doesn't model the unnamed `*` wildcard —
     // it's there at runtime as params[0], just not in the inferred type.
     const wildcard = (req.params as unknown as Record<string, string>)[0];
-    serveCanvas(getSession, req, res, wildcard || INDEX_FILENAME);
+    serveCanvas(getSession, req, res, wildcard || null);
   });
 
   router.get(["/canvas/:harnessSessionId", "/canvas/:harnessSessionId/"], (req, res) => {
-    serveCanvas(getSession, req, res, INDEX_FILENAME);
+    serveCanvas(getSession, req, res, null);
   });
 
   return router;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -418,15 +418,15 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     return found;
   };
 
-  // Renders a session's canvas (its bound workflow, or the whole-workspace
-  // overview when unbound) via the deterministic pipeline — always against
-  // the live workflowsCache, never an LLM. Never throws (see core/
-  // canvas-render.ts); best-effort, like every other canvas write here.
-  // Explicit user-invoked renders (the Visualize macro, POST
-  // /canvas/:id/render) use this as-is; the UNPROMPTED call sites
-  // (session-create/boot auto-render) use autoRenderCanvas below, which
-  // won't replace an existing canvas (e.g. the sample project's seeded
-  // opening shot) with nothing but error panels when every extraction fails.
+  // Renders a session's bound workflow via the deterministic pipeline —
+  // always against the live workflowsCache, never an LLM; a cheap no-op for
+  // an unbound session (the canvas router serves the empty state on its
+  // own). Never throws (see core/canvas-render.ts); best-effort, like every
+  // other canvas write here. Explicit user-invoked renders (the Visualize
+  // macro, POST /canvas/:id/render) use this as-is; the UNPROMPTED call
+  // sites (session-create/boot auto-render) use autoRenderCanvas below,
+  // which won't replace a workflow's existing render with an error panel
+  // when its extraction fails.
   const renderCanvas = async (session: HarnessSession): Promise<void> => {
     await renderCanvasForSession(session, workflowsCache);
   };
@@ -689,7 +689,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   app.use(
     createCanvasRouter((harnessSessionId) => {
       const session = sessionManager.get(harnessSessionId);
-      return session ? { cwd: session.cwd } : undefined;
+      return session ? { cwd: session.cwd, boundWorkflowPath: session.boundWorkflowPath } : undefined;
     }),
   );
 

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -43,6 +43,16 @@ export const CANVAS_DIR = ".sapiom/canvas";
 export const CANVAS_INDEX = `${CANVAS_DIR}/index.html`;
 
 /**
+ * Deterministic per-workflow renders live here (one `<slug>.html` per
+ * workflow, slugged by `slugForWorkflowPath` in core/canvas-render.ts),
+ * relative to the session cwd. `GET /canvas/:sessionId/` serves the bound
+ * workflow's render from this directory; `index.html` above stays the
+ * agent-authored/custom canvas and is never rewritten by the deterministic
+ * pipeline.
+ */
+export const CANVAS_RENDERS_DIR = `${CANVAS_DIR}/renders`;
+
+/**
  * Workspace-state convention: the harness mirrors this session's binding,
  * the full workflow registry, and its own identity here, relative to the
  * session cwd, so the agent has an always-current, agent-legible answer to

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -634,6 +634,61 @@ test("a canvas.reload bus message swaps the empty state for the generated iframe
   await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
 });
 
+test("a pending canvas load shows a skeleton over the iframe — never a blank pane", async ({ page }) => {
+  // Stall the canvas document so the load stays pending long enough to assert
+  // on the skeleton deterministically.
+  let releaseCanvas = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    releaseCanvas = resolve;
+  });
+  await page.route("**/canvas/sess-boot/**", async (route) => {
+    await gate;
+    await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+  });
+
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+
+  // While the iframe document is in flight: skeleton visible, no bare pane.
+  await expect(page.getByTestId("canvas-loading")).toBeVisible();
+  await expect(page.getByTestId("canvas-loading")).toContainText("Rendering diagram");
+
+  releaseCanvas();
+  await expect(page.getByTestId("canvas-loading")).toHaveCount(0);
+  await expect(page.locator(".canvas-iframe")).toBeVisible();
+});
+
+test("switching the bound workflow refetches the canvas immediately — the server resolves the binding per request", async ({
+  page,
+}) => {
+  let canvasRequests = 0;
+  await page.route("**/canvas/sess-boot/**", async (route) => {
+    canvasRequests += 1;
+    await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+  });
+
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+  await expect(page.locator(".canvas-iframe")).toBeVisible();
+  await expect.poll(() => canvasRequests).toBeGreaterThan(0);
+  const requestsBeforeBind = canvasRequests;
+
+  // Re-bind to a different workflow: the pane must refetch the same URL on
+  // its own (the served document changes with the binding) — no canvas.reload
+  // round-trip required first.
+  await page.getByTestId("workflow-rfq").click();
+  await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+  await expect.poll(() => canvasRequests).toBeGreaterThan(requestsBeforeBind);
+});
+
 test.describe("background-task canvas states", () => {
   const baseTask = {
     id: "task-1",

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -34,6 +34,13 @@ export function CanvasPane({
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [theme, setTheme] = useState(getTheme());
+  // True while the initial HEAD probe for this session is still in flight —
+  // the pane shows a loading state instead of flashing "Nothing generated
+  // yet" at content that's about to appear.
+  const [probing, setProbing] = useState(false);
+  // True while the iframe is (re)loading its document — a skeleton overlays
+  // it so a load/render in progress never reads as a blank pane.
+  const [frameLoading, setFrameLoading] = useState(true);
   // Failed-task panels the user has explicitly dismissed (client-side only —
   // the task record itself stays in the server's list).
   const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(new Set());
@@ -47,11 +54,14 @@ export function CanvasPane({
   // it in an earlier turn, before this pane was around to catch a reload event.
   useEffect(() => {
     setHasGeneratedContent(false);
+    setFrameLoading(true);
     if (!sessionId || isMockMode()) return;
     let cancelled = false;
+    setProbing(true);
     fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
       .then((res) => !cancelled && setHasGeneratedContent(res.ok))
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => !cancelled && setProbing(false));
     return () => {
       cancelled = true;
     };
@@ -61,9 +71,19 @@ export function CanvasPane({
     if (!lastMessage || !sessionId) return;
     if (lastMessage.type === "canvas.reload" && lastMessage.harnessSessionId === sessionId) {
       setHasGeneratedContent(true);
+      setFrameLoading(true);
       setReloadKey((key) => key + 1);
     }
   }, [lastMessage, sessionId]);
+
+  // The server resolves the canvas root by the session's CURRENT binding, so
+  // a bind/unbind changes what the same URL serves — refetch immediately
+  // instead of waiting for the render write's canvas.reload to arrive.
+  const boundWorkflowPath = boundWorkflow?.path ?? null;
+  useEffect(() => {
+    setFrameLoading(true);
+    setReloadKey((key) => key + 1);
+  }, [boundWorkflowPath]);
 
   const visualizeMacro = findVisualizeMacro(macros);
   const visualizeDisabledReason = visualizeMacro
@@ -152,6 +172,11 @@ export function CanvasPane({
             </button>
           </div>
         </div>
+      ) : probing ? (
+        <div className="canvas-loading" data-testid="canvas-loading">
+          <span className="canvas-task-spinner" aria-hidden="true" />
+          <p className="canvas-empty-hint">Loading canvas…</p>
+        </div>
       ) : !hasGeneratedContent ? (
         <div className="canvas-empty">
           <p>Nothing generated yet.</p>
@@ -172,12 +197,21 @@ export function CanvasPane({
           </p>
         </div>
       ) : (
-        <iframe
-          key={reloadKey}
-          className="canvas-iframe"
-          src={`/canvas/${sessionId}/?theme=${theme}`}
-          sandbox="allow-scripts"
-        />
+        <div className="canvas-frame-wrap">
+          {frameLoading && (
+            <div className="canvas-loading canvas-loading--overlay" data-testid="canvas-loading">
+              <span className="canvas-task-spinner" aria-hidden="true" />
+              <p className="canvas-empty-hint">Rendering diagram…</p>
+            </div>
+          )}
+          <iframe
+            key={`${sessionId}:${reloadKey}`}
+            className="canvas-iframe"
+            src={`/canvas/${sessionId}/?theme=${theme}`}
+            sandbox="allow-scripts"
+            onLoad={() => setFrameLoading(false)}
+          />
+        </div>
       )}
     </aside>
   );

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1409,11 +1409,38 @@ input {
   border-radius: 0;
 }
 
+.canvas-frame-wrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
 .canvas-iframe {
   flex: 1;
   width: 100%;
   border: none;
   background: #fff;
+}
+
+/* Skeleton shown while the probe or an iframe (re)load is in flight — the
+   pane must never sit blank while something is pending. The overlay variant
+   sits on top of the (still-loading) iframe in the app's own theme colors. */
+.canvas-loading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-faint);
+}
+
+.canvas-loading--overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: var(--bg-1);
 }
 
 .canvas-empty {


### PR DESCRIPTION
PR 1 of 2 for visualization v3: make the base diagram deterministic, instant, and correct for every workflow — old SDK or new — before the AI enrichment layer (PR 2) builds on top of it.

## What changed

**Dual-SDK extraction** — `@sapiom/agent` exports `isLegacyOrchestrationDefinition` (the pre-rename `Symbol.for('sapiom.orchestration.definition')` brand), and `@sapiom/agent-core`'s `check()` accepts either brand in export detection. The rename changed names only — the definition/step shape is identical — so `buildManifest` works unchanged on both; a new `legacy-flow` fixture proves it end to end. Patch changesets for both packages.

**Typecheck opt-out** — `check({ typecheck: false })` skips the project's `tsc --noEmit` (the dominant multi-second per-bind cost); the harness's extraction runner passes it. esbuild still surfaces real breakage as `BUNDLE_FAILED`.

**Extraction cache** — new `core/canvas-cache.ts` caches successful extractions keyed by a cheap source fingerprint (file count + newest mtime over the project's own `.ts` sources). Binding an unchanged workflow spawns no child process at all. Failures are deliberately not cached (an `npm install` fix doesn't touch any `.ts` file, so a cached failure would never self-invalidate).

**Launch nodes** — launch detection now matches both `orchestrations.launch` (old SDK) and `agents.launch` (new SDK, e.g. `ctx.sapiom.agents.launch`), attributes each call to its enclosing step, and merges the result into the bound workflow's own graph as dashed `launched-workflow` nodes with `launch()`-labeled edges.

**Overview mode deleted; per-workflow renders** — the stacked all-workflows page (N child processes on first load) is gone. Renders write to `.sapiom/canvas/renders/<slug>.html` per workflow; `GET /canvas/:sessionId/` resolves the session's binding at request time and serves the matching render, so switching workflows is instant and involves no file rewrite. `index.html` remains the untouched agent-authored canvas (legacy watcher unchanged); unbound sessions get the cheap empty state with zero extraction.

**Pane feedback** — `CanvasPane` shows a skeleton/spinner for the initial probe and every iframe (re)load, and refetches immediately when the binding changes. Never a blank pane.

## Measured base-render times

Live check against a real local workspace (7 pre-rename-SDK workflows + 1 current-SDK), server booted with `stateRoot` isolation, three workflows bound via `PATCH /api/sessions/:id/workflow` (round-trip includes extraction + render + write):

| workflow | SDK | cold bind | cached re-bind |
|---|---|---|---|
| confirm-vendor | old | 139 ms | 1 ms |
| leasing-triage | new | 129 ms | 1 ms |
| maintenance-rfq | old | 129 ms | 1 ms |

All three rendered their real step graphs (no degraded panels); the new-SDK workflow's `agents.launch` of its downstream workflow shows as a dashed launch node with a `launch()` edge; re-binding served every diagram from the extraction cache with no child process. Before this PR, each of these binds paid a multi-second typecheck and the old-SDK workflows failed extraction entirely.

## Verification

- `pnpm typecheck` — clean across the workspace
- Unit tests: `@sapiom/agent` 77 ✓, `@sapiom/agent-core` 101 ✓, `@sapiom/harness` 496 ✓ (new: legacy-brand fixture extraction, cache hit/invalidation, launch detection/attribution/merge, per-workflow render files, request-time canvas routing)
- `build:server` + `build:web` ✓
- `sim:e2e` ✓, `e2e:live` ✓ (extended: render lands in `renders/`, served by binding, `index.html` untouched, cached re-render, unbind falls back to the agent-authored canvas)
- `test:ui` 61 ✓ (new: pending-load skeleton, instant refetch on bind switch), `test:canvas` 5 ✓
- Live check above ran with `stateRoot` in a scratch dir — `~/.sapiom/harness` untouched; nothing written outside the workspace's own `.sapiom/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaFsoArbHpWpBKzgP89zsy
