### PR TITLE
feat(harness): AI enrichment layer — bounded, validated graph enrichment via sonnet

### DIFF
--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -59,8 +59,8 @@
  *      source) and index.html (live canvas, same initial content) are
  *      already on disk the moment a session is created — before any
  *      visualize run — and POST /api/macros/visualize/run succeeds both
- *      with no workflow bound (requiresWorkflow: false — workspace-overview
- *      mode) and after one is bound.
+ *      with no workflow bound (requiresWorkflow: false — a cheap no-op) and
+ *      after one is bound.
  *  14. Deterministic canvas render (zero LLM): bound to a real @sapiom/agent
  *      project, POST /api/canvas/:id/render extracts its actual step graph
  *      and writes real step names + SVG node markup to the workflow's own
@@ -71,7 +71,10 @@
  *      default path never touches the pty. A second render of the unchanged
  *      workflow is served from the extraction cache (no child process), and
  *      unbinding flips GET /canvas/:id/ back to the agent-authored
- *      index.html untouched.
+ *      index.html untouched. Binding that cleanly-extracting workflow also
+ *      auto-spawns ONE bounded AI enrichment task (--model sonnet,
+ *      --max-turns 8, graph-inline JSON-only prompt), reported in
+ *      AppState.tasks scoped to the session + workflow (item 14a).
  *  15. State isolation + registry hygiene: `stateRoot` alone (no per-file
  *      overrides, no machineId) roots every piece of persistent state under
  *      the scratch dir — machine-id included — and a pre-seeded registry
@@ -545,8 +548,8 @@ async function testCoreFlow(): Promise<void> {
       "harness-context.json embeds the session's own {id, cwd, harness}",
     );
 
-    // --- 10a. visualize with nothing bound yet — the canvas kit macro is unbound-friendly
-    // (requiresWorkflow: false), unlike every other action-rail macro. ---
+    // --- 10a. visualize with nothing bound yet — the force-refresh macro is unbound-friendly
+    // (requiresWorkflow: false, a cheap no-op), unlike every other action-rail macro. ---
     const unboundMacroRes = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers,
@@ -583,9 +586,10 @@ async function testCoreFlow(): Promise<void> {
       "harness-context.json reflects the bound workflow's {name, path, definitionId}",
     );
 
-    // --- 11a-2. also run visualize now that a workflow IS bound — same static prompt
-    // either way (the agent branches on harness-context.json's boundWorkflow at run
-    // time), so this just proves the request still succeeds once bound. ---
+    // --- 11a-2. also run visualize now that a workflow IS bound — here it's a
+    // force refresh of the bound canvas (this workflow is a bare marker, so
+    // its extraction honestly fails and no enrichment task spawns), proving
+    // the request still succeeds once bound. ---
     const macroRes = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers,
@@ -635,6 +639,47 @@ async function testCoreFlow(): Promise<void> {
       body: JSON.stringify({ workflowPath: workflowDir }),
     });
     assert(renderBindRes.status === 200, "binds the session to the real order-triage workflow");
+
+    // --- 14a. binding a cleanly-extracting workflow with no fresh enrichment
+    // cached auto-spawns ONE bounded enrichment task: a headless fake-claude
+    // run pinned to the enrichment model and turn cap, carrying the
+    // extracted graph inline and the JSON-only contract. The task's capture
+    // overwrites the interactive session's — every argv/env assertion on
+    // that one already ran above. (The fixture never completes its "turn",
+    // so no enrichment is ever persisted here; server.close() reaps it.) ---
+    const enrichmentCapture = await waitFor<FakeClaudeCapture>(async () => {
+      try {
+        const capture = JSON.parse(await fs.readFile(captureFile, "utf8")) as FakeClaudeCapture;
+        return capture.argv.includes("--max-turns") ? capture : undefined;
+      } catch {
+        return undefined;
+      }
+    });
+    assert(
+      enrichmentCapture.argv[enrichmentCapture.argv.indexOf("--model") + 1] === "sonnet",
+      "the auto-spawned enrichment task pins --model sonnet",
+    );
+    assert(
+      enrichmentCapture.argv[enrichmentCapture.argv.indexOf("--max-turns") + 1] === "8",
+      "the auto-spawned enrichment task caps --max-turns at 8",
+    );
+    const enrichmentPrompt = enrichmentCapture.argv[enrichmentCapture.argv.indexOf("-p") + 1] ?? "";
+    assert(enrichmentPrompt.includes("RETURN ONLY a JSON object"), "enrichment prompt demands JSON-only output");
+    assert(
+      enrichmentPrompt.includes('"manifestName": "order-triage"'),
+      "enrichment prompt carries the extracted graph inline",
+    );
+    // The fixture exits as soon as its (ignored) stdin drains, so the task
+    // may already be finished here — what matters is the SCOPING it was
+    // launched with: the pane filters its activity by exactly these fields.
+    const stateWithTask = (await (await fetch(`${baseUrl}/api/state`, { headers })).json()) as {
+      tasks?: Array<{ macroId: string; workflowPath: string | null; harnessSessionId: string; status: string }>;
+    };
+    const enrichmentTask = stateWithTask.tasks?.find((t) => t.workflowPath === workflowDir);
+    assert(
+      enrichmentTask?.macroId === "visualize" && enrichmentTask.harnessSessionId === sessionId,
+      "AppState.tasks reports the enrichment task scoped to this session + workflow",
+    );
 
     const reloadFramesBefore = wsMessages.filter(
       (m) => m.type === "canvas.reload" && m.harnessSessionId === sessionId,

--- a/packages/harness/src/core/adapters/claude-code.ts
+++ b/packages/harness/src/core/adapters/claude-code.ts
@@ -199,6 +199,9 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
    *   through a permission prompt — without it a tool call hangs forever.
    * - --output-format stream-json --verbose: line-oriented JSON progress on
    *   stdout (parsed by core/task-stream.ts) instead of a bare final answer.
+   * - --model / --max-turns: only when the caller sets them — a bounded task
+   *   (canvas enrichment) pins a cheaper model and a hard turn cap instead of
+   *   inheriting the user's interactive defaults.
    */
   launchTask(opts: LaunchOpts): SpawnSpec {
     if (!opts.prompt) {
@@ -208,6 +211,8 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     if (opts.systemPromptFile) {
       args.push("--append-system-prompt", readPromptFile(opts.systemPromptFile));
     }
+    if (opts.model) args.push("--model", opts.model);
+    if (opts.maxTurns != null) args.push("--max-turns", String(opts.maxTurns));
     args.push("--permission-mode", "acceptEdits", "--output-format", "stream-json", "--verbose");
     return {
       command: this.binary,

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -7,6 +7,7 @@
  * and writes it to the workflow's render file.
  */
 import type { CanvasEdgeKind, CanvasGraph, CanvasNodeKind } from "./canvas-graph.js";
+import type { CanvasEnrichment } from "./canvas-enrichment.js";
 import { renderGraphSvg } from "./canvas-svg.js";
 
 function esc(s: string): string {
@@ -18,8 +19,22 @@ export interface WorkflowPanelMeta {
   badges?: string[];
 }
 
-/** One workflow's full panel: title/badges header, step/entry stats, SVG diagram. */
-export function buildWorkflowPanelHtml(graph: CanvasGraph, meta: WorkflowPanelMeta): string {
+/** How enrichment content reaches the panel/footer builders: the validated
+ *  content itself plus whether its source fingerprint no longer matches the
+ *  workflow's current sources (kept displayed, marked stale). */
+export interface PanelEnrichment {
+  enrichment: CanvasEnrichment;
+  stale: boolean;
+}
+
+/** One workflow's full panel: title/badges header, step/entry stats, SVG
+ *  diagram — with any enrichment merged in (summary line, node/edge
+ *  annotations, a "stale" chip when its fingerprint no longer matches). */
+export function buildWorkflowPanelHtml(
+  graph: CanvasGraph,
+  meta: WorkflowPanelMeta,
+  panelEnrichment?: PanelEnrichment | null,
+): string {
   const badges = (meta.badges ?? [])
     .map((b) => `<span class="canvas-badge">${esc(b)}</span>`)
     .join("");
@@ -27,19 +42,24 @@ export function buildWorkflowPanelHtml(graph: CanvasGraph, meta: WorkflowPanelMe
     graph.warnings.length > 0
       ? `<span class="canvas-badge">${graph.warnings.length} warning${graph.warnings.length === 1 ? "" : "s"}</span>`
       : "";
+  const enrichment = panelEnrichment?.enrichment ?? null;
+  const staleBadge = panelEnrichment?.stale
+    ? `<span class="canvas-badge canvas-badge--stale">stale — Refresh</span>`
+    : "";
+  const summary = enrichment?.summary ? `\n    <p class="canvas-subtitle">${esc(enrichment.summary)}</p>` : "";
   return `<section class="canvas-panel">
   <header class="canvas-header">
     <div class="canvas-title-row">
       <h1 class="canvas-title">${esc(meta.title)}</h1>
-      ${badges}${warningBadge}
-    </div>
+      ${badges}${warningBadge}${staleBadge}
+    </div>${summary}
     <div class="canvas-stats">
       <div class="canvas-stat"><span class="canvas-stat-value">${graph.nodes.length}</span><span class="canvas-stat-label">steps</span></div>
       <div class="canvas-stat"><span class="canvas-stat-value">${esc(graph.entry)}</span><span class="canvas-stat-label">entry</span></div>
     </div>
   </header>
   <div class="canvas-diagram-panel">
-${renderGraphSvg(graph)}
+${renderGraphSvg(graph, enrichment)}
   </div>
 </section>`;
 }
@@ -93,11 +113,27 @@ export function buildLegendHtml(nodeKinds: Set<CanvasNodeKind>, edgeKinds: Set<C
   return `<div class="canvas-legend">${items.join("")}</div>`;
 }
 
-/** Joins panels + a footer (legend + note) into the final `#canvas-root`
- *  body — the string `renderCanvasDocument()` wraps. */
-export function assembleCanvasBody(input: { panels: string[]; legend: string; note: string }): string {
+/** Joins panels + a footer (enrichment notes/cross-workflow tie, legend,
+ *  note) into the final `#canvas-root` body — the string
+ *  `renderCanvasDocument()` wraps. */
+export function assembleCanvasBody(input: {
+  panels: string[];
+  legend: string;
+  note: string;
+  /** Enrichment footer facts (already schema-bounded), rendered as a list. */
+  notes?: string[];
+  /** Enrichment's "how this ties into the other workflows" line. */
+  crossWorkflow?: string;
+}): string {
   const parts = [...input.panels];
-  parts.push(`<footer class="canvas-footer">
+  const notesHtml =
+    input.notes && input.notes.length > 0
+      ? `\n  <ul class="canvas-notes">${input.notes.map((n) => `<li>${esc(n)}</li>`).join("")}</ul>`
+      : "";
+  const crossHtml = input.crossWorkflow
+    ? `\n  <p class="canvas-cross-workflow">${esc(input.crossWorkflow)}</p>`
+    : "";
+  parts.push(`<footer class="canvas-footer">${notesHtml}${crossHtml}
 ${input.legend}
   <p class="canvas-note">${esc(input.note)}</p>
 </footer>`);

--- a/packages/harness/src/core/canvas-cache.test.ts
+++ b/packages/harness/src/core/canvas-cache.test.ts
@@ -47,8 +47,12 @@ describe("extractWorkflowGraphCached", () => {
     const second = await extractWorkflowGraphCached(dir, extract);
 
     expect(extract).toHaveBeenCalledTimes(1);
-    expect(first).toEqual({ result: OK, cached: false });
-    expect(second).toEqual({ result: OK, cached: true });
+    expect(first).toMatchObject({ result: OK, cached: false });
+    expect(second).toMatchObject({ result: OK, cached: true });
+    // Both calls report the same fingerprint — the value the enrichment
+    // cache stores as sourceFingerprint for freshness comparison.
+    expect(first.fingerprint).toBeTruthy();
+    expect(second.fingerprint).toBe(first.fingerprint);
   });
 
   it("invalidates when a source file's mtime changes", async () => {
@@ -83,8 +87,8 @@ describe("extractWorkflowGraphCached", () => {
     const second = await extractWorkflowGraphCached(dir, extract);
 
     expect(extract).toHaveBeenCalledTimes(2);
-    expect(first).toEqual({ result: FAIL, cached: false });
-    expect(second).toEqual({ result: OK, cached: false });
+    expect(first).toMatchObject({ result: FAIL, cached: false });
+    expect(second).toMatchObject({ result: OK, cached: false });
   });
 
   it("caches per workflow directory — two workflows never share an entry", async () => {

--- a/packages/harness/src/core/canvas-cache.ts
+++ b/packages/harness/src/core/canvas-cache.ts
@@ -45,6 +45,10 @@ export interface CachedExtraction {
   result: ExtractionResult;
   /** True when the result came from cache — no child process ran. */
   cached: boolean;
+  /** The source fingerprint the result corresponds to — the same value the
+   *  enrichment cache stores as `sourceFingerprint`, so freshness checks
+   *  compare like with like. */
+  fingerprint: string;
 }
 
 /**
@@ -58,12 +62,18 @@ export async function extractWorkflowGraphCached(
   const key = path.resolve(sourceDir);
   const fingerprint = await fingerprintWorkflowSources(key);
   const hit = cache.get(key);
-  if (hit && hit.fingerprint === fingerprint) return { result: hit.result, cached: true };
+  if (hit && hit.fingerprint === fingerprint) return { result: hit.result, cached: true, fingerprint };
 
   const result = await extract(key);
   if (result.ok) cache.set(key, { fingerprint, result });
   else cache.delete(key);
-  return { result, cached: false };
+  return { result, cached: false, fingerprint };
+}
+
+/** Drops one workflow's cached extraction — the visualize macro's force
+ *  refresh, which must re-run the child process even for unchanged sources. */
+export function invalidateExtractionCache(sourceDir: string): void {
+  cache.delete(path.resolve(sourceDir));
 }
 
 /** Test hook — the cache is module-level state shared across a process. */

--- a/packages/harness/src/core/canvas-enrich.test.ts
+++ b/packages/harness/src/core/canvas-enrich.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { BackgroundTask } from "../shared/types.js";
+import type { CachedExtraction } from "./canvas-cache.js";
+import type { CanvasGraph } from "./canvas-graph.js";
+import { readEnrichmentCacheFile, writeEnrichmentCacheFile } from "./canvas-enrichment.js";
+import { enrichmentCacheFileFor, type RenderableWorkflow } from "./canvas-render.js";
+import { TaskAlreadyRunningError, TaskNotSupportedError, type RunTaskRequest } from "./task-manager.js";
+import {
+  CanvasEnrichmentCoordinator,
+  buildEnrichmentPrompt,
+  enrichmentModel,
+  extractEnrichmentJson,
+  type EnrichmentSession,
+  type EnrichmentTaskRunner,
+} from "./canvas-enrich.js";
+
+const GRAPH: CanvasGraph = {
+  manifestName: "order-triage",
+  entry: "intake",
+  warnings: [],
+  nodes: [
+    { id: "intake", kind: "entry", label: "intake" },
+    { id: "route", kind: "step", label: "route" },
+  ],
+  edges: [{ from: "intake", to: "route", kind: "sequential" }],
+};
+
+describe("buildEnrichmentPrompt", () => {
+  it("carries the graph inline, points at the workflow dir, and states the JSON-only / no-file-writes contract", () => {
+    const prompt = buildEnrichmentPrompt(GRAPH, "/proj/order-triage");
+    expect(prompt).toContain('"manifestName": "order-triage"');
+    expect(prompt).toContain("run() bodies in /proj/order-triage");
+    expect(prompt).toMatch(/RETURN ONLY a JSON object/);
+    expect(prompt).toMatch(/DO NOT write or modify any files/);
+    // The hard caps ride in the prompt so a well-behaved run needs no retry.
+    expect(prompt).toContain("max 160 chars");
+    expect(prompt).toContain("max 48 chars");
+  });
+});
+
+describe("enrichmentModel", () => {
+  it("defaults to sonnet and honors the env override", () => {
+    expect(enrichmentModel({} as NodeJS.ProcessEnv)).toBe("sonnet");
+    expect(enrichmentModel({ SAPIOM_HARNESS_VISUALIZE_MODEL: "haiku" } as unknown as NodeJS.ProcessEnv)).toBe("haiku");
+  });
+});
+
+describe("extractEnrichmentJson", () => {
+  it("parses a raw JSON object", () => {
+    expect(extractEnrichmentJson('{"summary":"hi"}')).toEqual({ summary: "hi" });
+  });
+  it("parses a fenced block, with or without the json tag", () => {
+    expect(extractEnrichmentJson('```json\n{"summary":"hi"}\n```')).toEqual({ summary: "hi" });
+    expect(extractEnrichmentJson('```\n{"summary":"hi"}\n```')).toEqual({ summary: "hi" });
+  });
+  it("recovers the outermost object from surrounding prose", () => {
+    expect(extractEnrichmentJson('Here you go:\n{"summary":"hi"}\nHope that helps!')).toEqual({ summary: "hi" });
+  });
+  it("returns null for text with no parsable object", () => {
+    expect(extractEnrichmentJson("I could not analyze the workflow.")).toBeNull();
+    expect(extractEnrichmentJson("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coordinator
+// ---------------------------------------------------------------------------
+
+interface FakeRunner extends EnrichmentTaskRunner {
+  requests: RunTaskRequest[];
+  emit(task: BackgroundTask): void;
+  lastTask(): BackgroundTask;
+}
+
+function makeRunner(): FakeRunner {
+  const listeners = new Set<(task: BackgroundTask) => void>();
+  const requests: RunTaskRequest[] = [];
+  let n = 0;
+  let last: BackgroundTask | undefined;
+  return {
+    requests,
+    async run(req) {
+      requests.push(req);
+      last = {
+        id: `task-${++n}`,
+        macroId: req.macroId,
+        label: req.label,
+        harnessSessionId: req.harnessSessionId,
+        cwd: req.cwd,
+        workflowPath: req.workflowPath ?? null,
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        endedAt: null,
+        exitCode: null,
+        statusLines: [],
+        resultText: null,
+        errorTail: null,
+      };
+      return last;
+    },
+    onStatusChange(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit(task) {
+      for (const listener of [...listeners]) listener(task);
+    },
+    lastTask() {
+      if (!last) throw new Error("no task spawned");
+      return last;
+    },
+  };
+}
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+async function tmpCwd(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-enrich-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+const WORKFLOW: RenderableWorkflow = { path: "/proj/order-triage", name: "order-triage", definitionId: null };
+
+function makeSession(cwd: string): EnrichmentSession {
+  return { id: "sess-1", cwd, harness: "claude-code", boundWorkflowPath: WORKFLOW.path };
+}
+
+function extraction(fingerprint: string): (dir: string) => Promise<CachedExtraction> {
+  return async () => ({ result: { ok: true, graph: GRAPH }, cached: true, fingerprint });
+}
+
+function makeCoordinator(runner: FakeRunner, cwd: string, overrides: Record<string, unknown> = {}) {
+  const rerender = vi.fn().mockResolvedValue(undefined);
+  const onError = vi.fn();
+  const coordinator = new CanvasEnrichmentCoordinator({
+    tasks: runner,
+    rerender,
+    extractCached: extraction("fp-1"),
+    env: {} as NodeJS.ProcessEnv,
+    now: () => "2026-01-02T00:00:00.000Z",
+    onError,
+    ...overrides,
+  });
+  return { coordinator, rerender, onError, session: makeSession(cwd) };
+}
+
+const VALID_RESULT = '```json\n{"summary":"routes orders","edgeLabels":{"intake->route":"normalized"}}\n```';
+
+describe("CanvasEnrichmentCoordinator.ensureFresh", () => {
+  it("spawns one enrichment task with the visualize macro identity, sonnet, the turn cap and the workflowPath", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, session } = makeCoordinator(runner, cwd);
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+
+    expect(runner.requests).toHaveLength(1);
+    const req = runner.requests[0];
+    expect(req.macroId).toBe("visualize");
+    expect(req.harnessSessionId).toBe("sess-1");
+    expect(req.workflowPath).toBe(WORKFLOW.path);
+    expect(req.model).toBe("sonnet");
+    expect(req.maxTurns).toBe(8);
+    expect(req.prompt).toContain('"manifestName": "order-triage"');
+  });
+
+  it("persists the validated enrichment to the cache file and re-renders on completion", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+    runner.emit({ ...runner.lastTask(), status: "completed", resultText: VALID_RESULT });
+    await vi.waitFor(async () => {
+      expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW);
+    });
+
+    const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path));
+    expect(entry).toEqual({
+      graph: GRAPH,
+      enrichment: { summary: "routes orders", edgeLabels: { "intake->route": "normalized" } },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-02T00:00:00.000Z",
+    });
+  });
+
+  it("skips the spawn when the cached enrichment's fingerprint matches the current sources", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, session } = makeCoordinator(runner, cwd);
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
+      graph: GRAPH,
+      enrichment: { summary: "already fresh" },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+    expect(runner.requests).toHaveLength(0);
+  });
+
+  it("re-spawns when the cached fingerprint is stale", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, session } = makeCoordinator(runner, cwd, { extractCached: extraction("fp-2") });
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
+      graph: GRAPH,
+      enrichment: { summary: "from older sources" },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+    expect(runner.requests).toHaveLength(1);
+  });
+
+  it("discards invalid output whole — no cache write, no re-render, base render stands", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender, onError, session } = makeCoordinator(runner, cwd);
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+    runner.emit({
+      ...runner.lastTask(),
+      status: "completed",
+      // Valid JSON, invalid enrichment: oversize summary.
+      resultText: JSON.stringify({ summary: "x".repeat(200) }),
+    });
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("invalid output"));
+    });
+
+    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
+    expect(rerender).not.toHaveBeenCalled();
+  });
+
+  it("persists nothing when the task fails — the pane's failure state owns that path", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
+
+    await coordinator.ensureFresh(session, [WORKFLOW]);
+    runner.emit({ ...runner.lastTask(), status: "failed", errorTail: "exploded" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
+    expect(rerender).not.toHaveBeenCalled();
+  });
+
+  it("is silent for unbound sessions, failed extractions, and expected spawn refusals", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, onError } = makeCoordinator(runner, cwd);
+
+    await coordinator.ensureFresh({ ...makeSession(cwd), boundWorkflowPath: null }, [WORKFLOW]);
+    expect(runner.requests).toHaveLength(0);
+
+    const failing = makeCoordinator(runner, cwd, {
+      extractCached: async (): Promise<CachedExtraction> => ({
+        result: { ok: false, reason: "run npm install first" },
+        cached: false,
+        fingerprint: "fp-1",
+      }),
+    });
+    await failing.coordinator.ensureFresh(failing.session, [WORKFLOW]);
+    expect(runner.requests).toHaveLength(0);
+
+    for (const refusal of [new TaskAlreadyRunningError("Visualize"), new TaskNotSupportedError("codex", "Visualize")]) {
+      const refusing = makeCoordinator(
+        { ...runner, run: vi.fn().mockRejectedValue(refusal) } as unknown as FakeRunner,
+        cwd,
+      );
+      await expect(refusing.coordinator.ensureFresh(refusing.session, [WORKFLOW])).resolves.toBeUndefined();
+      expect(refusing.onError).not.toHaveBeenCalled();
+    }
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe("CanvasEnrichmentCoordinator.forceRefresh", () => {
+  it("drops the enrichment cache, re-renders the base immediately, then re-spawns the task", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
+      graph: GRAPH,
+      enrichment: { summary: "even a FRESH cache is dropped — the user asked for a redo" },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+
+    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
+    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW); // base render, before the task lands
+    expect(runner.requests).toHaveLength(1);
+  });
+
+  it("propagates TaskAlreadyRunningError — the macros router turns it into a 409", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const refusing = { ...runner, run: vi.fn().mockRejectedValue(new TaskAlreadyRunningError("Visualize")) };
+    const { coordinator, session } = makeCoordinator(refusing as unknown as FakeRunner, cwd);
+
+    await expect(coordinator.forceRefresh(session, [WORKFLOW])).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+  });
+
+  it("is a no-op for an unbound session — matching the deterministic render's unbound contract", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender } = makeCoordinator(runner, cwd);
+
+    await coordinator.forceRefresh({ ...makeSession(cwd), boundWorkflowPath: null }, [WORKFLOW]);
+    expect(rerender).not.toHaveBeenCalled();
+    expect(runner.requests).toHaveLength(0);
+  });
+});

--- a/packages/harness/src/core/canvas-enrich.test.ts
+++ b/packages/harness/src/core/canvas-enrich.test.ts
@@ -229,8 +229,9 @@ describe("CanvasEnrichmentCoordinator.ensureFresh", () => {
     runner.emit({
       ...runner.lastTask(),
       status: "completed",
-      // Valid JSON, invalid enrichment: oversize summary.
-      resultText: JSON.stringify({ summary: "x".repeat(200) }),
+      // Valid JSON, structurally invalid enrichment — beyond what the
+      // bounds/nulls normalization repairs.
+      resultText: JSON.stringify({ nodeDetails: "not an object" }),
     });
     await vi.waitFor(() => {
       expect(onError).toHaveBeenCalledWith(expect.stringContaining("invalid output"));

--- a/packages/harness/src/core/canvas-enrich.ts
+++ b/packages/harness/src/core/canvas-enrich.ts
@@ -1,0 +1,260 @@
+/**
+ * The AI enrichment runner: spawns ONE bounded, headless agent task per
+ * workflow (via TaskManager) that reads the workflow's step bodies and
+ * returns the JSON `CanvasEnrichment` contract — never HTML, never a file
+ * write. On success the validated enrichment is persisted to the workflow's
+ * cache file and the render file is rebuilt with it merged in; on any
+ * parse/validation failure the enrichment is discarded whole and the base
+ * render stands (core/canvas-enrichment.ts's contract). Task-process
+ * failures surface through the task record itself (the pane's error state +
+ * Retry), never as HTML on disk.
+ *
+ * Triggering (see server/index.ts):
+ * - bind / session create → `ensureFresh`: spawn only when no cache entry
+ *   matches the current source fingerprint; every skip reason is silent.
+ * - the visualize macro → `forceRefresh`: drop the extraction + enrichment
+ *   caches, re-render the base immediately, re-enrich; refusals propagate
+ *   (an already-running enrichment for this workflow → 409 via the macros
+ *   router, exactly like any other double-fired background macro).
+ *
+ * Dedupe is per WORKFLOW, not per session: TaskManager refuses a second
+ * running task with the same macroId + workflowPath regardless of which
+ * session asked (see TaskAlreadyRunningError) — two panes bound to the same
+ * workflow can never race its cache/render files.
+ */
+import type { BackgroundTask, HarnessKind } from "../shared/types.js";
+import { extractWorkflowGraphCached, invalidateExtractionCache, type CachedExtraction } from "./canvas-cache.js";
+import type { CanvasGraph } from "./canvas-graph.js";
+import {
+  ENRICHMENT_LIMITS,
+  parseCanvasEnrichment,
+  readEnrichmentCacheFile,
+  removeEnrichmentCacheFile,
+  writeEnrichmentCacheFile,
+} from "./canvas-enrichment.js";
+import {
+  enrichmentCacheFileFor,
+  renderWorkflowRenderFile,
+  type RenderableWorkflow,
+} from "./canvas-render.js";
+import type { RunTaskRequest } from "./task-manager.js";
+import { TaskAlreadyRunningError, TaskNotSupportedError } from "./task-manager.js";
+
+/** The macro identity enrichment tasks run under — the pane's Retry re-fires
+ *  this macro, which routes back through forceRefresh. */
+export const ENRICHMENT_MACRO_ID = "visualize";
+const ENRICHMENT_TASK_LABEL = "Visualize";
+/** Hard turn cap: read a few step files, answer. A run that needs more than
+ *  this is off the rails, not thorough. */
+const ENRICHMENT_MAX_TURNS = 8;
+const DEFAULT_ENRICHMENT_MODEL = "sonnet";
+
+/** Model the enrichment task runs on — overridable per install. */
+export function enrichmentModel(env: NodeJS.ProcessEnv = process.env): string {
+  return env.SAPIOM_HARNESS_VISUALIZE_MODEL || DEFAULT_ENRICHMENT_MODEL;
+}
+
+/**
+ * Builds the one-shot enrichment prompt: the extracted graph inline (the AI
+ * annotates THIS structure — it never invents nodes), pointed at the step
+ * sources for semantics, with the JSON contract and its hard limits stated
+ * verbatim so a well-behaved run needs no retry.
+ */
+export function buildEnrichmentPrompt(graph: CanvasGraph, workflowDir: string): string {
+  const L = ENRICHMENT_LIMITS;
+  return `You are annotating an already-rendered workflow diagram. The diagram's structure below is fixed — you only supply short text annotations, as one JSON object.
+
+Extracted workflow graph:
+${JSON.stringify(graph, null, 2)}
+
+Read the step run() bodies in ${workflowDir} to understand what each step actually does (what it calls, what it decides, why it branches), then RETURN ONLY a JSON object matching this schema — no prose before or after, no markdown required, and DO NOT write or modify any files:
+
+{
+  "summary": "what this workflow does, one line (max ${L.summary} chars)",
+  "nodeDetails": { "<nodeId>": { "sublabel": "short annotation shown in the node (max ${L.sublabel} chars)", "description": "one sentence, shown on hover (max ${L.description} chars)" } },
+  "edgeLabels": { "<fromNodeId>-><toNodeId>": "intent/condition name (max ${L.edgeLabel} chars)" },
+  "notes": ["up to ${L.noteCount} facts worth knowing, each max ${L.note} chars"],
+  "layoutHints": { "groups": [{ "label": "group name (max ${L.groupLabel} chars)", "nodeIds": ["..."] }], "laneOrder": { "<layerIndex>": ["nodeId", "..."] } },
+  "crossWorkflow": "how this workflow ties into the project's other workflows, if it does (max ${L.crossWorkflow} chars)"
+}
+
+Rules:
+- Every field is optional — omit what you have nothing useful for. Empty strings are worse than omissions.
+- Use ONLY node ids that appear in the graph above.
+- Every length limit is a hard cap: any oversize string makes the whole response invalid and it will be thrown away.
+- Your final message must be exactly the JSON object.`;
+}
+
+/**
+ * Pulls the JSON object out of a task's final result text — either fenced
+ * (\`\`\`json ... \`\`\`) or raw, tolerating prose around it by falling back to
+ * the outermost {...} span. Null when nothing parses.
+ */
+export function extractEnrichmentJson(text: string): unknown | null {
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(text);
+  const candidates = [fenced?.[1], text];
+  const first = text.indexOf("{");
+  const last = text.lastIndexOf("}");
+  if (first !== -1 && last > first) candidates.push(text.slice(first, last + 1));
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const parsed: unknown = JSON.parse(candidate.trim());
+      if (typeof parsed === "object" && parsed !== null) return parsed;
+    } catch {
+      // Try the next candidate shape.
+    }
+  }
+  return null;
+}
+
+/** The slice of TaskManager the runner uses — injectable for tests. */
+export interface EnrichmentTaskRunner {
+  run(req: RunTaskRequest): Promise<BackgroundTask>;
+  onStatusChange(listener: (task: BackgroundTask) => void): () => void;
+}
+
+/** The session shape the coordinator needs — satisfied by HarnessSession. */
+export interface EnrichmentSession {
+  id: string;
+  cwd: string;
+  harness: HarnessKind;
+  boundWorkflowPath: string | null;
+}
+
+export interface EnrichmentCoordinatorOptions {
+  tasks: EnrichmentTaskRunner;
+  /** Rebuilds the workflow's render file (with the just-persisted enrichment
+   *  merged) after a successful run — the write alone hot-reloads any open
+   *  pane via the canvas watcher. */
+  rerender?: (cwd: string, workflow: RenderableWorkflow) => Promise<void>;
+  /** Injectable for tests — defaults to the real cached extraction. */
+  extractCached?: (dir: string) => Promise<CachedExtraction>;
+  env?: NodeJS.ProcessEnv;
+  now?: () => string;
+  onError?: (message: string) => void;
+}
+
+export class CanvasEnrichmentCoordinator {
+  private readonly tasks: EnrichmentTaskRunner;
+  private readonly rerender: (cwd: string, workflow: RenderableWorkflow) => Promise<void>;
+  private readonly extractCached: (dir: string) => Promise<CachedExtraction>;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly now: () => string;
+  private readonly onError: (message: string) => void;
+
+  constructor(options: EnrichmentCoordinatorOptions) {
+    this.tasks = options.tasks;
+    this.rerender = options.rerender ?? (async (cwd, workflow) => void (await renderWorkflowRenderFile(cwd, workflow)));
+    this.extractCached = options.extractCached ?? extractWorkflowGraphCached;
+    this.env = options.env ?? process.env;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.onError = options.onError ?? ((message) => console.error(`[harness] ${message}`));
+  }
+
+  /**
+   * The bind/create trigger: spawn an enrichment task unless a cached
+   * enrichment already matches the workflow's current sources. Silent on
+   * every expected refusal — unbound session, failed extraction, fresh
+   * cache, an enrichment already in flight for this workflow, a harness
+   * with no headless mode, even a spawn failure (logged) — because nothing
+   * here was user-initiated and a bind must never fail on enrichment's
+   * account.
+   */
+  async ensureFresh(session: EnrichmentSession, workflows: readonly RenderableWorkflow[]): Promise<void> {
+    const bound = this.resolveBound(session, workflows);
+    if (!bound) return;
+    try {
+      const { result, fingerprint } = await this.extractCached(bound.path);
+      if (!result.ok) return;
+      const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(session.cwd, bound.path));
+      if (entry && entry.sourceFingerprint === fingerprint) return;
+      await this.spawn(session, bound, result.graph, fingerprint);
+    } catch (err) {
+      if (err instanceof TaskAlreadyRunningError || err instanceof TaskNotSupportedError) return;
+      this.onError(`canvas enrichment (auto) failed to start: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * The visualize macro: invalidate both caches, re-render the base diagram
+   * immediately (instant feedback, honest content — no leftover enrichment
+   * from sources that may have changed), then re-enrich. Refusals propagate
+   * to the macros router (TaskAlreadyRunningError → 409,
+   * TaskNotSupportedError → 400). Unbound session: just a no-op, matching
+   * the deterministic render's own unbound contract.
+   */
+  async forceRefresh(session: EnrichmentSession, workflows: readonly RenderableWorkflow[]): Promise<void> {
+    const bound = this.resolveBound(session, workflows);
+    if (!bound) return;
+    invalidateExtractionCache(bound.path);
+    await removeEnrichmentCacheFile(enrichmentCacheFileFor(session.cwd, bound.path));
+    await this.rerender(session.cwd, bound);
+    const { result, fingerprint } = await this.extractCached(bound.path);
+    if (!result.ok) return;
+    await this.spawn(session, bound, result.graph, fingerprint);
+  }
+
+  private resolveBound(
+    session: EnrichmentSession,
+    workflows: readonly RenderableWorkflow[],
+  ): RenderableWorkflow | undefined {
+    return session.boundWorkflowPath ? workflows.find((w) => w.path === session.boundWorkflowPath) : undefined;
+  }
+
+  private async spawn(
+    session: EnrichmentSession,
+    workflow: RenderableWorkflow,
+    graph: CanvasGraph,
+    fingerprint: string,
+  ): Promise<void> {
+    const task = await this.tasks.run({
+      macroId: ENRICHMENT_MACRO_ID,
+      label: ENRICHMENT_TASK_LABEL,
+      harnessSessionId: session.id,
+      harness: session.harness,
+      cwd: session.cwd,
+      prompt: buildEnrichmentPrompt(graph, workflow.path),
+      workflowPath: workflow.path,
+      model: enrichmentModel(this.env),
+      maxTurns: ENRICHMENT_MAX_TURNS,
+    });
+
+    // Subscribed synchronously right after run() resolves — the process's
+    // exit can only arrive via a later event-loop turn, so the terminal
+    // status can't be missed.
+    const unsubscribe = this.tasks.onStatusChange((update) => {
+      if (update.id !== task.id || update.status === "running") return;
+      unsubscribe();
+      if (update.status !== "completed") return; // pane shows the failure; nothing to persist
+      void this.persist(session.cwd, workflow, graph, fingerprint, update.resultText).catch((err: unknown) => {
+        this.onError(`canvas enrichment persist failed: ${(err as Error).message}`);
+      });
+    });
+  }
+
+  /** Completed task → parse → validate → cache file → re-render. Any parse
+   *  or validation failure discards the enrichment whole; the base render
+   *  already on disk stands untouched. */
+  private async persist(
+    cwd: string,
+    workflow: RenderableWorkflow,
+    graph: CanvasGraph,
+    fingerprint: string,
+    resultText: string | null,
+  ): Promise<void> {
+    const candidate = resultText ? extractEnrichmentJson(resultText) : null;
+    const enrichment = candidate ? parseCanvasEnrichment(candidate) : null;
+    if (!enrichment) {
+      this.onError(`canvas enrichment for ${workflow.path} returned invalid output — discarded, base render stands`);
+      return;
+    }
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, workflow.path), {
+      graph,
+      enrichment,
+      sourceFingerprint: fingerprint,
+      enrichedAt: this.now(),
+    });
+    await this.rerender(cwd, workflow);
+  }
+}

--- a/packages/harness/src/core/canvas-enrich.ts
+++ b/packages/harness/src/core/canvas-enrich.ts
@@ -27,6 +27,7 @@ import { extractWorkflowGraphCached, invalidateExtractionCache, type CachedExtra
 import type { CanvasGraph } from "./canvas-graph.js";
 import {
   ENRICHMENT_LIMITS,
+  normalizeCanvasEnrichmentCandidate,
   parseCanvasEnrichment,
   readEnrichmentCacheFile,
   removeEnrichmentCacheFile,
@@ -79,9 +80,9 @@ Read the step run() bodies in ${workflowDir} to understand what each step actual
 }
 
 Rules:
-- Every field is optional — omit what you have nothing useful for. Empty strings are worse than omissions.
+- Every field is optional — omit what you have nothing useful for (omit, don't write null). Empty strings are worse than omissions.
 - Use ONLY node ids that appear in the graph above.
-- Every length limit is a hard cap: any oversize string makes the whole response invalid and it will be thrown away.
+- Length limits are hard caps and oversize strings get truncated mid-sentence — aim comfortably under each limit.
 - Your final message must be exactly the JSON object.`;
 }
 
@@ -244,7 +245,7 @@ export class CanvasEnrichmentCoordinator {
     resultText: string | null,
   ): Promise<void> {
     const candidate = resultText ? extractEnrichmentJson(resultText) : null;
-    const enrichment = candidate ? parseCanvasEnrichment(candidate) : null;
+    const enrichment = candidate ? parseCanvasEnrichment(normalizeCanvasEnrichmentCandidate(candidate)) : null;
     if (!enrichment) {
       this.onError(`canvas enrichment for ${workflow.path} returned invalid output — discarded, base render stands`);
       return;

--- a/packages/harness/src/core/canvas-enrichment.test.ts
+++ b/packages/harness/src/core/canvas-enrichment.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { CanvasGraph } from "./canvas-graph.js";
 import {
   ENRICHMENT_LIMITS,
+  normalizeCanvasEnrichmentCandidate,
   parseCanvasEnrichment,
   readEnrichmentCacheFile,
   removeEnrichmentCacheFile,
@@ -73,6 +74,55 @@ describe("parseCanvasEnrichment", () => {
     expect(parseCanvasEnrichment([FULL_ENRICHMENT])).toBeNull();
     expect(parseCanvasEnrichment({ nodeDetails: { intake: "not an object" } })).toBeNull();
     expect(parseCanvasEnrichment({ layoutHints: { groups: [{ label: "g", nodeIds: [] }] } })).toBeNull();
+  });
+});
+
+describe("normalizeCanvasEnrichmentCandidate", () => {
+  it("truncates oversize strings to their cap with an ellipsis — the repaired candidate validates", () => {
+    // The live failure shape: excellent content, one note a few words over
+    // the cap. Deterministic truncation keeps the bound without discarding
+    // the whole answer.
+    const oversizeNote = "x".repeat(ENRICHMENT_LIMITS.note + 20);
+    const normalized = normalizeCanvasEnrichmentCandidate({
+      summary: "y".repeat(ENRICHMENT_LIMITS.summary + 5),
+      notes: [oversizeNote, "fine"],
+      nodeDetails: { intake: { sublabel: "z".repeat(ENRICHMENT_LIMITS.sublabel * 2) } },
+      edgeLabels: { "a->b": "w".repeat(ENRICHMENT_LIMITS.edgeLabel + 1) },
+      layoutHints: { groups: [{ label: "g".repeat(ENRICHMENT_LIMITS.groupLabel + 9), nodeIds: ["a"] }] },
+      crossWorkflow: "c".repeat(ENRICHMENT_LIMITS.crossWorkflow + 1),
+    });
+    const parsed = parseCanvasEnrichment(normalized);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.summary).toHaveLength(ENRICHMENT_LIMITS.summary);
+    expect(parsed?.summary?.endsWith("…")).toBe(true);
+    expect(parsed?.notes?.[0]).toHaveLength(ENRICHMENT_LIMITS.note);
+    expect(parsed?.notes?.[1]).toBe("fine");
+    expect(parsed?.nodeDetails?.intake.sublabel).toHaveLength(ENRICHMENT_LIMITS.sublabel);
+    expect(parsed?.edgeLabels?.["a->b"]).toHaveLength(ENRICHMENT_LIMITS.edgeLabel);
+    expect(parsed?.layoutHints?.groups?.[0].label).toHaveLength(ENRICHMENT_LIMITS.groupLabel);
+    expect(parsed?.crossWorkflow).toHaveLength(ENRICHMENT_LIMITS.crossWorkflow);
+  });
+
+  it("drops null-valued fields (a model's 'omitted') and notes beyond the count cap", () => {
+    const normalized = normalizeCanvasEnrichmentCandidate({
+      summary: "ok",
+      crossWorkflow: null,
+      nodeDetails: { intake: { sublabel: "fine", description: null } },
+      notes: ["a", "b", "c", "d", "e"],
+      layoutHints: { groups: null, laneOrder: null },
+    });
+    expect(parseCanvasEnrichment(normalized)).toEqual({
+      summary: "ok",
+      nodeDetails: { intake: { sublabel: "fine" } },
+      notes: ["a", "b", "c"],
+      layoutHints: {},
+    });
+  });
+
+  it("leaves structurally wrong shapes for strict validation to reject — no salvage beyond bounds/nulls", () => {
+    expect(parseCanvasEnrichment(normalizeCanvasEnrichmentCandidate({ nodeDetails: "not an object" }))).toBeNull();
+    expect(parseCanvasEnrichment(normalizeCanvasEnrichmentCandidate({ notes: [42] }))).toBeNull();
+    expect(normalizeCanvasEnrichmentCandidate("just a string")).toBe("just a string");
   });
 });
 

--- a/packages/harness/src/core/canvas-enrichment.test.ts
+++ b/packages/harness/src/core/canvas-enrichment.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { CanvasGraph } from "./canvas-graph.js";
+import {
+  ENRICHMENT_LIMITS,
+  parseCanvasEnrichment,
+  readEnrichmentCacheFile,
+  removeEnrichmentCacheFile,
+  writeEnrichmentCacheFile,
+  type EnrichmentCacheEntry,
+} from "./canvas-enrichment.js";
+
+const FULL_ENRICHMENT = {
+  summary: "Triage incoming orders and route them to auto-resolution or a human",
+  nodeDetails: {
+    intake: { sublabel: "receives the order event", description: "Entry point: normalizes the incoming order payload." },
+    route: { sublabel: "priority-based split" },
+  },
+  edgeLabels: { "route->auto_resolve": "low priority", "route->escalate": "needs a human" },
+  notes: ["Orders above $10k always escalate", "Retries are handled by the runtime, not the steps"],
+  layoutHints: {
+    groups: [{ label: "decision core", nodeIds: ["classify", "route"] }],
+    laneOrder: { "3": ["escalate", "auto_resolve"] },
+  },
+  crossWorkflow: "Escalations land in the support-inbox workflow via launch()",
+};
+
+describe("parseCanvasEnrichment", () => {
+  it("round-trips a fully populated enrichment unchanged", () => {
+    expect(parseCanvasEnrichment(FULL_ENRICHMENT)).toEqual(FULL_ENRICHMENT);
+  });
+
+  it("accepts a minimal enrichment — every field is optional", () => {
+    expect(parseCanvasEnrichment({})).toEqual({});
+    expect(parseCanvasEnrichment({ summary: "just a summary" })).toEqual({ summary: "just a summary" });
+  });
+
+  it("strips unknown keys at every level instead of failing on them", () => {
+    const parsed = parseCanvasEnrichment({
+      summary: "ok",
+      html: "<script>alert(1)</script>", // top-level junk
+      nodeDetails: { intake: { sublabel: "fine", css: "position:fixed" } }, // nested junk
+      layoutHints: { groups: [{ label: "g", nodeIds: ["a"], color: "red" }], zIndex: 4 },
+    });
+    expect(parsed).toEqual({
+      summary: "ok",
+      nodeDetails: { intake: { sublabel: "fine" } },
+      layoutHints: { groups: [{ label: "g", nodeIds: ["a"] }] },
+    });
+  });
+
+  it.each([
+    ["summary", { summary: "x".repeat(ENRICHMENT_LIMITS.summary + 1) }],
+    ["sublabel", { nodeDetails: { intake: { sublabel: "x".repeat(ENRICHMENT_LIMITS.sublabel + 1) } } }],
+    ["description", { nodeDetails: { intake: { description: "x".repeat(ENRICHMENT_LIMITS.description + 1) } } }],
+    ["edge label", { edgeLabels: { "a->b": "x".repeat(ENRICHMENT_LIMITS.edgeLabel + 1) } }],
+    ["note", { notes: ["x".repeat(ENRICHMENT_LIMITS.note + 1)] }],
+    ["group label", { layoutHints: { groups: [{ label: "x".repeat(ENRICHMENT_LIMITS.groupLabel + 1), nodeIds: ["a"] }] } }],
+    ["crossWorkflow", { crossWorkflow: "x".repeat(ENRICHMENT_LIMITS.crossWorkflow + 1) }],
+  ])("rejects the WHOLE enrichment when one %s exceeds its hard cap — no partial salvage", (_field, value) => {
+    expect(parseCanvasEnrichment(value)).toBeNull();
+  });
+
+  it("rejects more notes than the cap allows", () => {
+    expect(parseCanvasEnrichment({ notes: ["a", "b", "c", "d"] })).toBeNull();
+    expect(parseCanvasEnrichment({ notes: ["a", "b", "c"] })).toEqual({ notes: ["a", "b", "c"] });
+  });
+
+  it("rejects structurally wrong shapes (arrays, strings, wrong nesting)", () => {
+    expect(parseCanvasEnrichment("just a string")).toBeNull();
+    expect(parseCanvasEnrichment([FULL_ENRICHMENT])).toBeNull();
+    expect(parseCanvasEnrichment({ nodeDetails: { intake: "not an object" } })).toBeNull();
+    expect(parseCanvasEnrichment({ layoutHints: { groups: [{ label: "g", nodeIds: [] }] } })).toBeNull();
+  });
+});
+
+describe("enrichment cache file IO", () => {
+  const tmpDirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+  });
+  async function tmpFile(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-enrichment-test-"));
+    tmpDirs.push(dir);
+    return path.join(dir, "cache", "wf.json"); // nested — write must mkdir
+  }
+
+  const GRAPH: CanvasGraph = {
+    manifestName: "order-triage",
+    entry: "intake",
+    warnings: [],
+    nodes: [{ id: "intake", kind: "entry", label: "intake" }],
+    edges: [],
+  };
+  const ENTRY: EnrichmentCacheEntry = {
+    graph: GRAPH,
+    enrichment: { summary: "hello" },
+    sourceFingerprint: "3:1700000000000",
+    enrichedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("round-trips an entry through write + read, creating parent dirs", async () => {
+    const file = await tmpFile();
+    await writeEnrichmentCacheFile(file, ENTRY);
+    await expect(readEnrichmentCacheFile(file)).resolves.toEqual(ENTRY);
+  });
+
+  it("returns null for a missing file", async () => {
+    await expect(readEnrichmentCacheFile((await tmpFile()) + ".nope")).resolves.toBeNull();
+  });
+
+  it("returns null for corrupt JSON and for a schema-invalid enrichment inside the envelope", async () => {
+    const file = await tmpFile();
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, "{not json", "utf8");
+    await expect(readEnrichmentCacheFile(file)).resolves.toBeNull();
+
+    // A hand-edited cache can't smuggle an unbounded string into a render:
+    // the enrichment inside the envelope is re-validated on every read.
+    const oversize = { ...ENTRY, enrichment: { summary: "x".repeat(999) } };
+    await fs.writeFile(file, JSON.stringify(oversize), "utf8");
+    await expect(readEnrichmentCacheFile(file)).resolves.toBeNull();
+  });
+
+  it("removeEnrichmentCacheFile deletes the file and tolerates its absence", async () => {
+    const file = await tmpFile();
+    await writeEnrichmentCacheFile(file, ENTRY);
+    await removeEnrichmentCacheFile(file);
+    await expect(readEnrichmentCacheFile(file)).resolves.toBeNull();
+    await expect(removeEnrichmentCacheFile(file)).resolves.toBeUndefined(); // already gone
+  });
+});

--- a/packages/harness/src/core/canvas-enrichment.ts
+++ b/packages/harness/src/core/canvas-enrichment.ts
@@ -92,6 +92,84 @@ export function parseCanvasEnrichment(value: unknown): CanvasEnrichment | null {
   return parsed.success ? parsed.data : null;
 }
 
+function clampString(value: unknown, max: number): unknown {
+  if (typeof value !== "string" || value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Removes null/undefined-valued properties (models write `"field": null`
+ *  to mean "omitted"; the schema means it as `undefined`). Shallow — called
+ *  per level below where object shapes are known. */
+function dropNulls(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, v]) => v != null));
+}
+
+/**
+ * Deterministic repair of the two ways an otherwise-good answer most often
+ * misses the contract, applied BEFORE strict validation:
+ * - `null` where the schema means "omit the field"
+ * - strings a few words over their cap (measured live: sonnet writes
+ *   excellent content but doesn't count characters — a single 160-char note
+ *   against the 140 cap discarded 3 of 4 real enrichments whole), truncated
+ *   to the cap with an ellipsis; extra notes beyond the count cap dropped
+ *
+ * The bound the caps exist for — the AI can never blow up the layout with
+ * unbounded text — is still enforced, just deterministically here instead
+ * of by rejection. Everything else (wrong shapes, wrong types, unknown
+ * structure) still fails `parseCanvasEnrichment` and discards the
+ * enrichment whole.
+ */
+export function normalizeCanvasEnrichmentCandidate(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  const L = ENRICHMENT_LIMITS;
+  const out: Record<string, unknown> = { ...value };
+
+  out.summary = clampString(out.summary, L.summary);
+  out.crossWorkflow = clampString(out.crossWorkflow, L.crossWorkflow);
+
+  if (isRecord(out.nodeDetails)) {
+    out.nodeDetails = Object.fromEntries(
+      Object.entries(out.nodeDetails).map(([id, details]) => {
+        if (!isRecord(details)) return [id, details];
+        return [
+          id,
+          dropNulls({
+            ...details,
+            sublabel: clampString(details.sublabel, L.sublabel),
+            description: clampString(details.description, L.description),
+          }),
+        ];
+      }),
+    );
+  }
+
+  if (isRecord(out.edgeLabels)) {
+    out.edgeLabels = Object.fromEntries(
+      Object.entries(out.edgeLabels).map(([key, label]) => [key, clampString(label, L.edgeLabel)]),
+    );
+  }
+
+  if (Array.isArray(out.notes)) {
+    out.notes = out.notes.slice(0, L.noteCount).map((note) => clampString(note, L.note));
+  }
+
+  if (isRecord(out.layoutHints)) {
+    const hints = dropNulls({ ...out.layoutHints });
+    if (Array.isArray(hints.groups)) {
+      hints.groups = hints.groups.map((group) =>
+        isRecord(group) ? dropNulls({ ...group, label: clampString(group.label, L.groupLabel) }) : group,
+      );
+    }
+    out.layoutHints = hints;
+  }
+
+  return dropNulls(out);
+}
+
 // ---------------------------------------------------------------------------
 // Per-workflow enrichment cache file (CANVAS_CACHE_DIR/<slug>.json)
 // ---------------------------------------------------------------------------

--- a/packages/harness/src/core/canvas-enrichment.ts
+++ b/packages/harness/src/core/canvas-enrichment.ts
@@ -1,0 +1,160 @@
+/**
+ * The AI enrichment contract: everything the enrichment task is allowed to
+ * add to a deterministic canvas render, as a zod schema. The AI never writes
+ * HTML — it returns one JSON object of BOUNDED plain strings (every limit
+ * below is a hard cap, not advice) and the renderer decides where they go.
+ * Unknown keys are stripped; any parse failure means the whole enrichment is
+ * discarded and the base render stands — a malformed answer can degrade
+ * nothing but itself.
+ *
+ * Layout hints are the one structural concession: named groups (rendered as
+ * subtle background bands) and per-layer ordering. The renderer applies a
+ * hint only when every node id it references actually exists in the graph
+ * (see canvas-svg.ts) — ids are validated at render time, not here, because
+ * an enrichment can outlive the graph it was written against (the "stale"
+ * cache state).
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+import type { CanvasGraph } from "./canvas-graph.js";
+
+export const ENRICHMENT_LIMITS = {
+  summary: 160,
+  sublabel: 48,
+  description: 120,
+  edgeLabel: 32,
+  noteCount: 3,
+  note: 140,
+  groupLabel: 48,
+  crossWorkflow: 160,
+} as const;
+
+const bounded = (max: number): z.ZodString => z.string().max(max);
+
+export const canvasEnrichmentSchema = z
+  .object({
+    /** One-liner under the panel header. */
+    summary: bounded(ENRICHMENT_LIMITS.summary).optional(),
+    /** Per-node annotations, keyed by node id. */
+    nodeDetails: z
+      .record(
+        z
+          .object({
+            /** Second text line inside the node box. */
+            sublabel: bounded(ENRICHMENT_LIMITS.sublabel).optional(),
+            /** Hover tooltip (SVG <title>) — room for a full sentence. */
+            description: bounded(ENRICHMENT_LIMITS.description).optional(),
+          })
+          .strip(),
+      )
+      .optional(),
+    /** Edge annotations (intent/condition names), keyed `"<from>-><to>"`. */
+    edgeLabels: z.record(bounded(ENRICHMENT_LIMITS.edgeLabel)).optional(),
+    /** Footer facts worth knowing that don't fit the diagram itself. */
+    notes: z.array(bounded(ENRICHMENT_LIMITS.note)).max(ENRICHMENT_LIMITS.noteCount).optional(),
+    layoutHints: z
+      .object({
+        /** Named clusters rendered as background bands behind member nodes. */
+        groups: z
+          .array(
+            z
+              .object({
+                label: bounded(ENRICHMENT_LIMITS.groupLabel),
+                nodeIds: z.array(z.string()).min(1),
+              })
+              .strip(),
+          )
+          .optional(),
+        /** Preferred left-to-right node order per layout layer, keyed by the
+         *  layer index as a string. Reorders WITHIN the computed layer only —
+         *  it can never move a node between layers. */
+        laneOrder: z.record(z.array(z.string()).min(1)).optional(),
+      })
+      .strip()
+      .optional(),
+    /** How this workflow ties into the workspace's other workflows. */
+    crossWorkflow: bounded(ENRICHMENT_LIMITS.crossWorkflow).optional(),
+  })
+  .strip();
+
+export type CanvasEnrichment = z.infer<typeof canvasEnrichmentSchema>;
+export type CanvasLayoutHints = NonNullable<CanvasEnrichment["layoutHints"]>;
+
+/**
+ * Validates a candidate enrichment object. Returns null on ANY schema
+ * violation (oversize string, wrong shape, too many notes) — partial
+ * salvage is deliberately not attempted, so the contract stays a hard line
+ * the prompt can state truthfully: "invalid output is thrown away whole."
+ */
+export function parseCanvasEnrichment(value: unknown): CanvasEnrichment | null {
+  const parsed = canvasEnrichmentSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-workflow enrichment cache file (CANVAS_CACHE_DIR/<slug>.json)
+// ---------------------------------------------------------------------------
+
+/**
+ * What one cache file holds. `sourceFingerprint` is canvas-cache.ts's cheap
+ * source fingerprint at the moment the enrichment task was SPAWNED — when it
+ * no longer matches the workflow's current sources, the base diagram
+ * re-renders immediately from fresh extraction while this enrichment stays
+ * displayed with a "stale" chip until a re-run replaces it.
+ */
+export interface EnrichmentCacheEntry {
+  /** The graph the enrichment was generated against (diagnostic context —
+   *  renders always use the freshly extracted graph, never this copy). */
+  graph: CanvasGraph;
+  enrichment: CanvasEnrichment;
+  sourceFingerprint: string;
+  enrichedAt: string;
+}
+
+/** Envelope validation is deliberately shallow for `graph` (it's our own
+ *  writer's serialization, not AI output) and strict for `enrichment` (it IS
+ *  AI output — re-validated on every read, so a hand-edited or corrupted
+ *  cache file can never smuggle unbounded strings into a render). */
+const cacheEntrySchema = z.object({
+  graph: z.object({
+    manifestName: z.string(),
+    entry: z.string(),
+    nodes: z.array(z.record(z.unknown())),
+    edges: z.array(z.record(z.unknown())),
+    warnings: z.array(z.string()),
+  }),
+  enrichment: canvasEnrichmentSchema,
+  sourceFingerprint: z.string(),
+  enrichedAt: z.string(),
+});
+
+/** Reads + validates one enrichment cache file. Null for missing, unparsable
+ *  or schema-invalid content — a bad cache degrades to "no enrichment". */
+export async function readEnrichmentCacheFile(filePath: string): Promise<EnrichmentCacheEntry | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = cacheEntrySchema.safeParse(JSON.parse(raw));
+    // The shallow node/edge validation above means this cast, not a full
+    // structural proof — see the schema's own comment for why that's enough.
+    return parsed.success ? (parsed.data as unknown as EnrichmentCacheEntry) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeEnrichmentCacheFile(filePath: string, entry: EnrichmentCacheEntry): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(entry, null, 2), "utf8");
+}
+
+/** Deletes one enrichment cache file (the visualize macro's force refresh).
+ *  Missing file is fine — the goal state is "no cache". */
+export async function removeEnrichmentCacheFile(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true });
+}

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -4,8 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CANVAS_DIR } from "../shared/types.js";
-import { clearExtractionCache } from "./canvas-cache.js";
+import { clearExtractionCache, fingerprintWorkflowSources } from "./canvas-cache.js";
+import { writeEnrichmentCacheFile } from "./canvas-enrichment.js";
 import {
+  enrichmentCacheFileFor,
   renderCanvasForSession,
   renderFileFor,
   slugForWorkflowPath,
@@ -181,5 +183,79 @@ describe("renderCanvasForSession", () => {
       expect(outcome.preservedExisting).toBeUndefined();
       expect(await readRender(cwd, NO_DEFINITION)).toContain("render failed");
     });
+  });
+});
+
+describe("enrichment merge in renders", () => {
+  const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
+
+  async function seedEnrichmentCache(cwd: string, sourceFingerprint: string): Promise<void> {
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, ORDER_TRIAGE), {
+      graph: { manifestName: "order-triage", entry: "intake", warnings: [], nodes: [], edges: [] },
+      enrichment: {
+        summary: "Triage incoming orders and route them",
+        nodeDetails: { intake: { sublabel: "receives the order" } },
+        notes: ["Orders above $10k always escalate"],
+        crossWorkflow: "Escalations hand off to the support workflow",
+      },
+      sourceFingerprint,
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+  }
+
+  it("merges a FRESH cached enrichment into the render — summary, sublabels, footer notes, no stale chip", async () => {
+    const cwd = await tmpCwd();
+    await seedEnrichmentCache(cwd, await fingerprintWorkflowSources(ORDER_TRIAGE));
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    expect(outcome.enrichmentApplied).toBe(true);
+    expect(outcome.enrichmentStale).toBe(false);
+
+    const html = await readRender(cwd, ORDER_TRIAGE);
+    expect(html).toContain("Triage incoming orders and route them");
+    expect(html).toContain("receives the order");
+    expect(html).toContain("Orders above $10k always escalate");
+    expect(html).toContain("Escalations hand off to the support workflow");
+    expect(html).not.toContain("stale — Refresh");
+  });
+
+  it("keeps a STALE enrichment displayed with the stale chip — the base structure is freshly extracted either way", async () => {
+    const cwd = await tmpCwd();
+    await seedEnrichmentCache(cwd, "0:0"); // never matches the real sources
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    expect(outcome.enrichmentApplied).toBe(true);
+    expect(outcome.enrichmentStale).toBe(true);
+
+    const html = await readRender(cwd, ORDER_TRIAGE);
+    expect(html).toContain("stale — Refresh");
+    expect(html).toContain("Triage incoming orders and route them"); // kept, not dropped
+    expect(html).toContain(">intake<"); // fresh base extraction still present
+  });
+
+  it("renders the plain base when no enrichment cache exists", async () => {
+    const cwd = await tmpCwd();
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, workflows);
+    expect(outcome.enrichmentApplied).toBeUndefined();
+    const html = await readRender(cwd, ORDER_TRIAGE);
+    expect(html).not.toContain("stale — Refresh");
+    expect(html).toContain(">intake<");
+  });
+
+  it("ignores the enrichment cache entirely when extraction fails — the error panel carries no annotations", async () => {
+    const cwd = await tmpCwd();
+    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, NO_DEFINITION), {
+      graph: { manifestName: "broken-flow", entry: "x", warnings: [], nodes: [], edges: [] },
+      enrichment: { summary: "should never appear on an error panel" },
+      sourceFingerprint: "any",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const broken: RenderableWorkflow[] = [{ path: NO_DEFINITION, name: "broken-flow", definitionId: null }];
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: NO_DEFINITION }, broken);
+    expect(outcome.enrichmentApplied).toBeUndefined();
+    const html = await readRender(cwd, NO_DEFINITION);
+    expect(html).toContain("render failed");
+    expect(html).not.toContain("should never appear");
   });
 });

--- a/packages/harness/src/core/canvas-render.ts
+++ b/packages/harness/src/core/canvas-render.ts
@@ -24,16 +24,18 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { CANVAS_RENDERS_DIR } from "../shared/types.js";
+import { CANVAS_CACHE_DIR, CANVAS_RENDERS_DIR } from "../shared/types.js";
 import { renderCanvasDocument } from "./canvas-template.js";
 import { extractWorkflowGraphCached } from "./canvas-cache.js";
 import type { CanvasGraph } from "./canvas-graph.js";
+import { readEnrichmentCacheFile } from "./canvas-enrichment.js";
 import { usedKinds } from "./canvas-svg.js";
 import {
   assembleCanvasBody,
   buildErrorPanelHtml,
   buildLegendHtml,
   buildWorkflowPanelHtml,
+  type PanelEnrichment,
 } from "./canvas-body.js";
 
 export interface RenderableSession {
@@ -69,6 +71,12 @@ export function renderFileFor(cwd: string, workflowPath: string): string {
   return path.join(cwd, CANVAS_RENDERS_DIR, `${slugForWorkflowPath(workflowPath)}.html`);
 }
 
+/** Absolute path of `workflowPath`'s enrichment cache file under `cwd`'s
+ *  canvas dir — same slug scheme as the render file. */
+export function enrichmentCacheFileFor(cwd: string, workflowPath: string): string {
+  return path.join(cwd, CANVAS_CACHE_DIR, `${slugForWorkflowPath(workflowPath)}.json`);
+}
+
 export interface CanvasRenderOutcome {
   /** "single": a bound workflow was rendered to its render file. "empty":
    *  the session is unbound (or bound to an unknown path) — nothing was
@@ -81,6 +89,12 @@ export interface CanvasRenderOutcome {
   extractionFailed: string[];
   /** True when the graph came from the extraction cache — no child process ran. */
   cachedExtraction?: boolean;
+  /** True when a cached enrichment was merged into the render (mode "single",
+   *  successful extraction only). */
+  enrichmentApplied?: boolean;
+  /** True when the merged enrichment's fingerprint no longer matches the
+   *  current sources — rendered with the "stale" chip. */
+  enrichmentStale?: boolean;
   /** Set only when writing the file itself failed (e.g. an unwritable cwd) — extraction success/failure above is unaffected. */
   writeError?: string;
   /** True when `preserveExistingOnFailure` kept the existing render instead of writing an error panel over it. */
@@ -103,7 +117,12 @@ function badgesFor(workflow: RenderableWorkflow): string[] {
   return [workflow.definitionId != null ? "deployed" : "local only"];
 }
 
-function buildSingleBody(workflow: RenderableWorkflow, graph: CanvasGraph | null, reason: string | null): string {
+function buildSingleBody(
+  workflow: RenderableWorkflow,
+  graph: CanvasGraph | null,
+  reason: string | null,
+  panelEnrichment: PanelEnrichment | null,
+): string {
   if (!graph) {
     return assembleCanvasBody({
       panels: [buildErrorPanelHtml(workflow.name, reason ?? "unknown extraction failure")],
@@ -113,9 +132,13 @@ function buildSingleBody(workflow: RenderableWorkflow, graph: CanvasGraph | null
   }
   const used = usedKinds(graph);
   return assembleCanvasBody({
-    panels: [buildWorkflowPanelHtml(graph, { title: workflow.name, badges: badgesFor(workflow) })],
+    panels: [buildWorkflowPanelHtml(graph, { title: workflow.name, badges: badgesFor(workflow) }, panelEnrichment)],
     legend: buildLegendHtml(used.nodeKinds, used.edgeKinds),
     note: "Static preview — re-renders automatically when the workflow changes.",
+    ...(panelEnrichment?.enrichment.notes ? { notes: panelEnrichment.enrichment.notes } : {}),
+    ...(panelEnrichment?.enrichment.crossWorkflow
+      ? { crossWorkflow: panelEnrichment.enrichment.crossWorkflow }
+      : {}),
   });
 }
 
@@ -134,18 +157,46 @@ export async function renderCanvasForSession(
   if (!bound) {
     return { mode: "empty", extractionFailed: [] };
   }
+  return renderWorkflowRenderFile(session.cwd, bound, options);
+}
 
-  const { result, cached } = await extractWorkflowGraphCached(bound.path);
+/**
+ * Renders ONE workflow to its render file under `cwd`, merging in any cached
+ * enrichment (fresh or stale — stale gets the chip; the base structure is
+ * always freshly extracted either way). This is the write path shared by
+ * bind/create/macro renders (via `renderCanvasForSession`) and by the
+ * enrichment task's own completion re-render (core/canvas-enrich.ts), which
+ * targets a workflow directly — the session may have switched bindings while
+ * the task ran, and the render file is per-workflow anyway.
+ */
+export async function renderWorkflowRenderFile(
+  cwd: string,
+  bound: RenderableWorkflow,
+  options: RenderCanvasOptions = {},
+): Promise<CanvasRenderOutcome> {
+  const { result, cached, fingerprint } = await extractWorkflowGraphCached(bound.path);
   const failed = !result.ok;
-  const body = buildSingleBody(bound, result.ok ? result.graph : null, result.ok ? null : result.reason);
 
-  const renderPath = renderFileFor(session.cwd, bound.path);
+  // The enrichment cache only ever decorates a successful extraction — an
+  // error panel with AI annotations for steps it can't show would be noise.
+  let panelEnrichment: PanelEnrichment | null = null;
+  if (result.ok) {
+    const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, bound.path));
+    if (entry) {
+      panelEnrichment = { enrichment: entry.enrichment, stale: entry.sourceFingerprint !== fingerprint };
+    }
+  }
+
+  const body = buildSingleBody(bound, result.ok ? result.graph : null, result.ok ? null : result.reason, panelEnrichment);
+
+  const renderPath = renderFileFor(cwd, bound.path);
   const outcome: CanvasRenderOutcome = {
     mode: "single",
     workflowPath: bound.path,
     renderPath,
     extractionFailed: failed ? [bound.name] : [],
     cachedExtraction: cached,
+    ...(panelEnrichment ? { enrichmentApplied: true, enrichmentStale: panelEnrichment.stale } : {}),
   };
 
   // An unprompted render that failed to extract must not destroy an existing

--- a/packages/harness/src/core/canvas-svg.test.ts
+++ b/packages/harness/src/core/canvas-svg.test.ts
@@ -150,3 +150,91 @@ describe("usedKinds", () => {
     expect([...edgeKinds].sort()).toEqual(["branching", "sequential"]);
   });
 });
+
+describe("renderGraphSvg with enrichment", () => {
+  it("prefers enrichment sublabels over structural ones and adds <title> tooltips for descriptions", () => {
+    const graph: CanvasGraph = {
+      ...ORDER_TRIAGE_GRAPH,
+      nodes: [
+        { id: "intake", kind: "entry", label: "intake" },
+        { id: "classify", kind: "pause", label: "classify", sublabel: 'waits for signal "go"' },
+      ],
+      edges: [],
+    };
+    const svg = renderGraphSvg(graph, {
+      nodeDetails: {
+        intake: { sublabel: "receives the order", description: "Entry point for order events." },
+        classify: { sublabel: "AI-written override" },
+      },
+    });
+    expect(svg).toContain(">receives the order</text>");
+    expect(svg).toContain("<title>Entry point for order events.</title>");
+    expect(svg).toContain(">AI-written override</text>");
+    expect(svg).not.toContain('waits for signal "go"');
+  });
+
+  it("labels edges by the enrichment's from->to key and ignores keys for edges that don't exist", () => {
+    const svg = renderGraphSvg(ORDER_TRIAGE_GRAPH, {
+      edgeLabels: { "route->auto_resolve": "low priority", "ghost->nowhere": "never rendered" },
+    });
+    expect(svg).toContain(">low priority</text>");
+    expect(svg).not.toContain("never rendered");
+  });
+
+  it("renders a background band + label for a group whose members all exist, behind the nodes", () => {
+    const svg = renderGraphSvg(ORDER_TRIAGE_GRAPH, {
+      layoutHints: { groups: [{ label: "decision core", nodeIds: ["classify", "route"] }] },
+    });
+    expect(svg).toContain('class="canvas-group-band"');
+    expect(svg).toContain(">decision core</text>");
+    // Behind everything: the band precedes the first node group in the markup.
+    expect(svg.indexOf("canvas-group-band")).toBeLessThan(svg.indexOf("canvas-node"));
+  });
+
+  it("silently drops a group hint that references a node id not in the graph", () => {
+    const svg = renderGraphSvg(ORDER_TRIAGE_GRAPH, {
+      layoutHints: { groups: [{ label: "phantom", nodeIds: ["classify", "not-a-node"] }] },
+    });
+    expect(svg).not.toContain("canvas-group-band");
+    expect(svg).not.toContain("phantom");
+  });
+
+  it("laneOrder reorders nodes within their computed layer only", () => {
+    // auto_resolve and escalate share the terminal layer; default order is
+    // insertion order (auto_resolve first). The hint flips them.
+    const layout = layoutGraph(ORDER_TRIAGE_GRAPH, { "3": ["escalate", "auto_resolve"] });
+    expect(layout.pos["escalate"].x).toBeLessThan(layout.pos["auto_resolve"].x);
+    // Same y — the hint may not move a node between layers.
+    expect(layout.pos["escalate"].y).toBe(layout.pos["auto_resolve"].y);
+    expect(layout.pos["escalate"].y).toBeGreaterThan(layout.pos["route"].y);
+  });
+
+  it("ignores a laneOrder entry containing a node id that doesn't exist in the graph", () => {
+    const base = layoutGraph(ORDER_TRIAGE_GRAPH);
+    const hinted = layoutGraph(ORDER_TRIAGE_GRAPH, { "3": ["escalate", "no-such-node"] });
+    expect(hinted.pos).toEqual(base.pos);
+  });
+
+  it("ignores a laneOrder entry whose listed node lives in a different layer — nodes never change layers", () => {
+    const base = layoutGraph(ORDER_TRIAGE_GRAPH);
+    // "intake" is in layer 0, listed under layer 3: every id exists, so the
+    // hint applies to layer 3's row — but intake isn't in that row, so only
+    // the row's own members reorder and intake stays exactly where it was.
+    const hinted = layoutGraph(ORDER_TRIAGE_GRAPH, { "3": ["escalate", "intake", "auto_resolve"] });
+    expect(hinted.pos["intake"]).toEqual(base.pos["intake"]);
+    expect(hinted.pos["escalate"].x).toBeLessThan(hinted.pos["auto_resolve"].x);
+  });
+
+  it("escapes every enrichment-supplied string", () => {
+    const svg = renderGraphSvg(ORDER_TRIAGE_GRAPH, {
+      nodeDetails: { intake: { sublabel: '<img src=x onerror="1">', description: "a <b>bold</b> claim" } },
+      edgeLabels: { "intake->classify": "<script>" },
+      layoutHints: { groups: [{ label: "<style>", nodeIds: ["intake"] }] },
+    });
+    expect(svg).not.toContain("<img");
+    expect(svg).not.toContain("<script>");
+    expect(svg).not.toContain("<style>");
+    expect(svg).not.toContain("<b>");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+});

--- a/packages/harness/src/core/canvas-svg.ts
+++ b/packages/harness/src/core/canvas-svg.ts
@@ -14,12 +14,15 @@
  * geometry is unchanged, only where it runs (server, not browser).
  */
 import type { CanvasEdge, CanvasEdgeKind, CanvasGraph, CanvasNode, CanvasNodeKind } from "./canvas-graph.js";
+import type { CanvasEnrichment, CanvasLayoutHints } from "./canvas-enrichment.js";
 
 export const NODE_W = 176;
 export const NODE_H = 56;
 const LAYER_GAP = 96;
 const COL_GAP = 32;
 const MARGIN = 40;
+/** How far a group band extends past its member nodes' boxes. */
+const GROUP_PAD = 10;
 
 export interface GraphLayout {
   pos: Record<string, { x: number; y: number }>;
@@ -71,8 +74,10 @@ export function computeLayers(nodes: readonly CanvasNode[], edges: readonly Canv
 }
 
 /** Computes (x, y) for every node and the overall canvas size. Nodes in the
- *  same layer are centered as a row; layers stack top to bottom. */
-export function layoutGraph(graph: CanvasGraph): GraphLayout {
+ *  same layer are centered as a row; layers stack top to bottom. An
+ *  enrichment's `laneOrder` hint reorders nodes WITHIN their computed layer
+ *  only — layer assignment itself stays purely structural. */
+export function layoutGraph(graph: CanvasGraph, laneOrder?: CanvasLayoutHints["laneOrder"]): GraphLayout {
   const layer = computeLayers(graph.nodes, graph.edges);
   const byLayer = new Map<number, string[]>();
   for (const n of graph.nodes) {
@@ -81,6 +86,7 @@ export function layoutGraph(graph: CanvasGraph): GraphLayout {
     arr.push(n.id);
     byLayer.set(l, arr);
   }
+  applyLaneOrder(byLayer, graph, laneOrder);
   const layers = [...byLayer.keys()].sort((a, b) => a - b);
   const maxCols = layers.reduce((m, l) => Math.max(m, byLayer.get(l)!.length), 1);
   const width = MARGIN * 2 + maxCols * NODE_W + (maxCols - 1) * COL_GAP;
@@ -96,6 +102,31 @@ export function layoutGraph(graph: CanvasGraph): GraphLayout {
   }
   const height = MARGIN * 2 + (layers.length - 1) * (NODE_H + LAYER_GAP) + NODE_H;
   return { pos, width, height: Math.max(height, MARGIN * 2 + NODE_H) };
+}
+
+/**
+ * Reorders each hinted layer's nodes in place. A hint entry is applied only
+ * when every node id it lists exists in the graph (the schema's contract —
+ * a stale enrichment must degrade to "no hint", never to a broken layout);
+ * listed ids that live in a DIFFERENT layer are simply not in this layer's
+ * row and are ignored, since laneOrder can never move a node between layers.
+ */
+function applyLaneOrder(
+  byLayer: Map<number, string[]>,
+  graph: CanvasGraph,
+  laneOrder: CanvasLayoutHints["laneOrder"],
+): void {
+  if (!laneOrder) return;
+  const nodeIds = new Set(graph.nodes.map((n) => n.id));
+  for (const [layerKey, order] of Object.entries(laneOrder)) {
+    const layerIndex = Number(layerKey);
+    const row = byLayer.get(layerIndex);
+    if (!row || !order.every((id) => nodeIds.has(id))) continue;
+    const inRow = new Set(row);
+    const ordered = order.filter((id) => inRow.has(id));
+    const rest = row.filter((id) => !ordered.includes(id));
+    byLayer.set(layerIndex, [...ordered, ...rest]);
+  }
 }
 
 function esc(s: string): string {
@@ -123,12 +154,47 @@ function edgePath(kind: CanvasEdgeKind, x1: number, y1: number, x2: number, y2: 
   return `M${x1},${y1} L${x2},${y2}`;
 }
 
-/** Renders one graph's `<svg>` diagram. Assumes the shared `<defs>` (glow
- *  filter + arrow markers) are already present once at the document level —
- *  see `renderCanvasDocument`'s `SVG_DEFS` — so this never emits its own. */
-export function renderGraphSvg(graph: CanvasGraph): string {
-  const layout = layoutGraph(graph);
+/**
+ * Group-hint background bands: one subtle rect per group whose member nodes
+ * ALL exist, sized to their bounding box, labeled at its top-left. Rendered
+ * before edges/nodes so it sits behind everything.
+ */
+function groupBandMarkup(
+  groups: CanvasLayoutHints["groups"],
+  graph: CanvasGraph,
+  layout: GraphLayout,
+): string {
+  if (!groups || groups.length === 0) return "";
+  const nodeIds = new Set(graph.nodes.map((n) => n.id));
+  return groups
+    .map((group) => {
+      if (!group.nodeIds.every((id) => nodeIds.has(id))) return "";
+      const positions = group.nodeIds.map((id) => layout.pos[id]).filter(Boolean);
+      if (positions.length === 0) return "";
+      const minX = Math.min(...positions.map((p) => p.x)) - GROUP_PAD;
+      const minY = Math.min(...positions.map((p) => p.y)) - GROUP_PAD;
+      const maxX = Math.max(...positions.map((p) => p.x + NODE_W)) + GROUP_PAD;
+      const maxY = Math.max(...positions.map((p) => p.y + NODE_H)) + GROUP_PAD;
+      return (
+        `<rect class="canvas-group-band" x="${minX}" y="${minY}" width="${maxX - minX}" height="${maxY - minY}" rx="18" />` +
+        `<text class="canvas-group-label" x="${minX + 8}" y="${minY - 4}">${esc(group.label)}</text>`
+      );
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Renders one graph's `<svg>` diagram, merging in any enrichment content
+ *  (node sublabels/descriptions, edge labels, group bands, lane order) — all
+ *  of it pre-bounded plain strings (core/canvas-enrichment.ts), escaped here
+ *  like every other text. Assumes the shared `<defs>` (glow filter + arrow
+ *  markers) are already present once at the document level — see
+ *  `renderCanvasDocument`'s `SVG_DEFS` — so this never emits its own. */
+export function renderGraphSvg(graph: CanvasGraph, enrichment?: CanvasEnrichment | null): string {
+  const layout = layoutGraph(graph, enrichment?.layoutHints?.laneOrder);
   const nodesById = new Map(graph.nodes.map((n) => [n.id, n]));
+
+  const bandMarkup = groupBandMarkup(enrichment?.layoutHints?.groups, graph, layout);
 
   const edgeMarkup = graph.edges
     .map((edge) => {
@@ -150,11 +216,14 @@ export function renderGraphSvg(graph: CanvasGraph): string {
       const d = edgePath(edge.kind, x1, y1, x2, y2);
       const marker = dashedClass ? "url(#canvas-arrow)" : arrowMarker(colorSuffix);
       const path = `<path class="${classes}" d="${d}" marker-end="${marker}" />`;
-      if (!edge.label) return path;
+      // An enriched label (an intent/condition name the AI read out of the
+      // step body) wins over the structural default (e.g. "launch()").
+      const labelText = enrichment?.edgeLabels?.[`${edge.from}->${edge.to}`] ?? edge.label;
+      if (!labelText) return path;
       const dx = x2 - x1;
       const anchor = dx > 4 ? "start" : dx < -4 ? "end" : "middle";
       const labelX = x1 + (dx > 0 ? 10 : dx < 0 ? -10 : 0);
-      const label = `<text class="canvas-edge-label" x="${labelX}" y="${y1 + 20}" text-anchor="${anchor}">${esc(edge.label)}</text>`;
+      const label = `<text class="canvas-edge-label" x="${labelX}" y="${y1 + 20}" text-anchor="${anchor}">${esc(labelText)}</text>`;
       return path + label;
     })
     .join("\n");
@@ -163,12 +232,18 @@ export function renderGraphSvg(graph: CanvasGraph): string {
     .map((node) => {
       const p = layout.pos[node.id];
       if (!p) return "";
-      const titleY = node.sublabel ? 22 : NODE_H / 2;
-      const sub = node.sublabel
-        ? `<text class="canvas-node-sub" x="${NODE_W / 2}" y="40">${esc(node.sublabel)}</text>`
+      const details = enrichment?.nodeDetails?.[node.id];
+      const sublabel = details?.sublabel ?? node.sublabel;
+      const titleY = sublabel ? 22 : NODE_H / 2;
+      const sub = sublabel
+        ? `<text class="canvas-node-sub" x="${NODE_W / 2}" y="40">${esc(sublabel)}</text>`
         : "";
+      // SVG <title> = native hover tooltip; the only enrichment slot with
+      // room for a full sentence.
+      const description = details?.description ? `<title>${esc(details.description)}</title>` : "";
       return (
         `<g class="canvas-node node--${node.kind}" filter="url(#canvas-glow)" transform="translate(${p.x},${p.y})">` +
+        description +
         `<rect class="canvas-node-rect" width="${NODE_W}" height="${NODE_H}" rx="14" />` +
         `<text class="canvas-node-title" x="${NODE_W / 2}" y="${titleY}">${esc(node.label)}</text>` +
         sub +
@@ -179,6 +254,7 @@ export function renderGraphSvg(graph: CanvasGraph): string {
 
   return (
     `<svg viewBox="0 0 ${layout.width} ${layout.height}" class="canvas-graph-svg">\n` +
+    (bandMarkup ? bandMarkup + "\n" : "") +
     edgeMarkup +
     "\n" +
     nodeMarkup +

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -84,6 +84,7 @@ html, body {
   font-size: 11px; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--canvas-border-strong);
   color: var(--canvas-text-dim);
 }
+.canvas-badge--stale { color: var(--canvas-escalation); border-color: var(--canvas-escalation); }
 .canvas-subtitle { margin: 0; color: var(--canvas-text-dim); font-size: 12.5px; }
 .canvas-stats { display: flex; gap: 22px; margin-top: 2px; }
 .canvas-stat { display: flex; flex-direction: column; }
@@ -102,6 +103,10 @@ html, body {
 .node--launched-workflow .canvas-node-rect { stroke: var(--canvas-accent); stroke-dasharray: 5 4; }
 .canvas-node-title { fill: var(--canvas-text); font-size: 13px; font-weight: 600; text-anchor: middle; dominant-baseline: middle; }
 .canvas-node-sub { fill: var(--canvas-text-dim); font-size: 9.5px; text-anchor: middle; dominant-baseline: middle; }
+
+/* --- enrichment layout hints: group bands sit behind edges and nodes --- */
+.canvas-group-band { fill: var(--canvas-accent); fill-opacity: 0.06; stroke: var(--canvas-border); stroke-dasharray: 3 5; }
+.canvas-group-label { fill: var(--canvas-text-dim); font-size: 9px; text-transform: uppercase; letter-spacing: 0.06em; }
 
 /* --- edge kinds: sequential (base) | branching (--success/--warn) | cross-workflow signal/handoff (--cross) --- */
 .canvas-edge { fill: none; stroke-width: 1.8; stroke: var(--canvas-border-strong); }
@@ -133,6 +138,8 @@ html, body {
 .canvas-interconnection-desc { grid-column: 2 / -1; margin: 0; font-size: 11.5px; color: var(--canvas-text-dim); }
 .canvas-footer { display: flex; flex-direction: column; gap: 10px; padding: 4px 2px 2px; }
 .canvas-note { margin: 0; font-size: 11px; color: var(--canvas-text-dim); font-style: italic; }
+.canvas-notes { margin: 0; padding-left: 16px; display: flex; flex-direction: column; gap: 3px; font-size: 11.5px; color: var(--canvas-text-dim); }
+.canvas-cross-workflow { margin: 0; font-size: 11.5px; color: var(--canvas-text-dim); }
 template { display: none; }
 `.trim();
 }

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect } from "vitest";
 import { DEFAULT_MACROS } from "./macros.js";
 
 describe("DEFAULT_MACROS", () => {
-  it("defines exactly the 6 action-rail macros, matching the SPA's MOCK_MACROS ids", () => {
+  it("defines exactly the 5 action-rail macros, matching the SPA's MOCK_MACROS ids", () => {
     expect(DEFAULT_MACROS.map((m) => m.id)).toEqual([
       "run_local",
       "deploy",
       "prod_run",
       "open_prod",
       "visualize",
-      "ai-visualize",
     ]);
   });
 
@@ -33,30 +32,17 @@ describe("DEFAULT_MACROS", () => {
     });
   });
 
-  it("visualize is a one-click, unbound-friendly deterministic render — no LLM, no pty involved", () => {
+  it("visualize is the ONE canvas macro — a server-side force refresh, unbound-friendly, no pty involved", () => {
     const macro = DEFAULT_MACROS.find((m) => m.id === "visualize")!;
-    // Works whether or not a workflow is bound — the render pipeline reads
+    // Works whether or not a workflow is bound — the refresh pipeline reads
     // the session's actual binding server-side, so there's no prompt text
     // (and therefore no {{workflow.path}} to throw on when unbound).
     expect(macro.requiresWorkflow).toBeFalsy();
     expect(macro.action).toEqual({ kind: "render-canvas" });
   });
 
-  it("ai-visualize is the LLM fallback — same unbound-friendly template-clone prompt visualize used to run", () => {
-    const macro = DEFAULT_MACROS.find((m) => m.id === "ai-visualize")!;
-    expect(macro.requiresWorkflow).toBeFalsy();
-    expect(macro.action.kind).toBe("inject");
-    if (macro.action.kind === "inject") {
-      expect(macro.action.text).toContain("{{canvas.path}}");
-      expect(macro.action.text).not.toContain("{{workflow.path}}");
-      expect(macro.action.text).not.toContain("{{subject}}");
-      // Clone-and-fill, not a JSON data edit and not "write HTML from
-      // scratch" — the whole point of the template-clone canvas kit.
-      expect(macro.action.text).toMatch(/_template\.html/);
-      expect(macro.action.text).toMatch(/canvas-patterns/);
-      expect(macro.action.text).toMatch(/harness-context\.json/);
-      expect(macro.action.text).toMatch(/do not write new css/i);
-    }
+  it("the old ai-visualize macro (LLM writes the whole HTML page) is gone — enrichment replaced it", () => {
+    expect(DEFAULT_MACROS.find((m) => m.id === "ai-visualize")).toBeUndefined();
   });
 
   it("every macro has a non-empty label and icon", () => {

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -52,37 +52,16 @@ export const DEFAULT_MACROS: MacroDef[] = [
     },
   },
   {
-    // One-click render/re-render, unbound-friendly: runs the deterministic,
-    // zero-LLM pipeline (core/canvas-render.ts) server-side — extracts the
-    // bound workflow's real step graph (or every registered workflow, for a
-    // workspace overview) via @sapiom/agent-core's `check()` and lays it out
-    // itself, typically well under a second, without touching the session's
-    // pty at all. See "ai-visualize" below for the narrative/custom path.
+    // One-click force refresh of the bound workflow's canvas: re-runs the
+    // deterministic, zero-LLM structure render (core/canvas-render.ts —
+    // instant, cache-invalidated) AND re-spawns the bounded AI enrichment
+    // task (core/canvas-enrich.ts, a headless background run that returns
+    // validated JSON annotations, never HTML) — all server-side, without
+    // touching the session's pty. A cheap no-op when the session is unbound.
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
     requiresWorkflow: false,
     action: { kind: "render-canvas" },
-  },
-  {
-    // The pre-deterministic-render behavior, kept as an explicit fallback for
-    // custom/narrative views the structural extraction can't produce (e.g. a
-    // description of *why* a step branches, not just that it does). Clones
-    // the canvas kit template and asks the agent to hand-write the SVG using
-    // its documented patterns — the same ~1-2 minute LLM round-trip
-    // "visualize" used to always pay. That round-trip is exactly why it runs
-    // as a background task (TaskManager) rather than injecting into the
-    // user's own session: injecting a minutes-long prompt hijacks whatever
-    // they were doing.
-    id: "ai-visualize",
-    label: "AI Visualize",
-    icon: "Wand2",
-    requiresWorkflow: false,
-    execution: "background",
-    action: {
-      kind: "inject",
-      submit: true,
-      text: `Recreate .sapiom/canvas/index.html (that's {{canvas.path}}) from the canvas kit template. First read BOTH .sapiom/canvas/_template.html and the existing .sapiom/canvas/index.html — reading the current index.html before overwriting it is required, the Write tool refuses to overwrite a file it hasn't read. Then write index.html as a copy of the template, keeping the <style> block and every structural/pattern class untouched. Do not write new CSS. Then fill in the content: title, badges, subtitle, and stats values, and build the SVG graph using the template's node/edge markup patterns — see the <template id="canvas-patterns"> block in the cloned file for one example of each, and delete that block once you've copied what you need. Read .sapiom/harness-context.json first: if it has a boundWorkflow, draw that workflow's steps, control flow, and terminal outcomes; if boundWorkflow is null, draw one canvas-panel per workflow in its workflows list, plus an Interconnections panel showing how they hand off or signal to each other.`,
-    },
   },
 ];

--- a/packages/harness/src/core/task-manager.test.ts
+++ b/packages/harness/src/core/task-manager.test.ts
@@ -77,8 +77,8 @@ function makeManager(options: {
 }
 
 const runRequest = {
-  macroId: "ai-visualize",
-  label: "AI Visualize",
+  macroId: "visualize",
+  label: "Visualize",
   harnessSessionId: "sess-1",
   harness: "claude-code" as const,
   cwd: "/tmp/proj",
@@ -141,6 +141,59 @@ describe("TaskManager", () => {
     expect(statuses.at(-1)?.status).toBe("completed");
   });
 
+  it("captures the success result event's text on the finished task as resultText", async () => {
+    const { manager, spawned, statuses } = makeManager();
+    const task = await manager.run(runRequest);
+
+    spawned[0].proc.stdout.write(
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: '{"summary":"hi"}' }) + "\n",
+    );
+    await tick();
+    // Not published while still running — only the terminal snapshot carries it.
+    expect(manager.get(task.id)?.resultText).toBeNull();
+
+    spawned[0].proc.emit("exit", 0);
+    await tick();
+
+    const finished = manager.get(task.id);
+    expect(finished?.status).toBe("completed");
+    expect(finished?.resultText).toBe('{"summary":"hi"}');
+    expect(statuses.at(-1)?.resultText).toBe('{"summary":"hi"}');
+  });
+
+  it("leaves resultText null on failure — the error path speaks through errorTail", async () => {
+    const { manager, spawned } = makeManager();
+    const task = await manager.run(runRequest);
+
+    spawned[0].proc.stdout.write(
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "partial answer" }) + "\n",
+    );
+    await tick();
+    spawned[0].proc.emit("exit", 1);
+
+    const finished = manager.get(task.id);
+    expect(finished?.status).toBe("failed");
+    expect(finished?.resultText).toBeNull();
+  });
+
+  it("passes model/maxTurns/workflowPath through to the adapter's LaunchOpts and the task record", async () => {
+    const launchTask = vi.fn(
+      (opts: LaunchOpts): SpawnSpec => ({ command: "claude", args: [], env: {}, cwd: opts.cwd }),
+    );
+    const { manager } = makeManager({ adapter: makeAdapter({ launchTask }) });
+    const task = await manager.run({
+      ...runRequest,
+      workflowPath: "/tmp/proj/wf-a",
+      model: "sonnet",
+      maxTurns: 8,
+    });
+
+    expect(task.workflowPath).toBe("/tmp/proj/wf-a");
+    const opts = launchTask.mock.calls[0][0];
+    expect(opts.model).toBe("sonnet");
+    expect(opts.maxTurns).toBe(8);
+  });
+
   it("fails on non-zero exit with the stderr tail as the error", async () => {
     const { manager, spawned } = makeManager();
     const task = await manager.run(runRequest);
@@ -193,7 +246,7 @@ describe("TaskManager", () => {
     expect(manager.list()).toHaveLength(0);
   });
 
-  it("rejects a duplicate run of the same macro for the same session while one is in flight", async () => {
+  it("rejects a duplicate run of the same workflow-less macro for the same session while one is in flight", async () => {
     const { manager, spawned } = makeManager();
     await manager.run(runRequest);
     await expect(manager.run(runRequest)).rejects.toBeInstanceOf(TaskAlreadyRunningError);
@@ -202,6 +255,24 @@ describe("TaskManager", () => {
     // And once the first finishes, the same session can run it again.
     spawned[0].proc.emit("exit", 0);
     await expect(manager.run(runRequest)).resolves.toBeDefined();
+  });
+
+  it("dedupes workflow-targeted tasks per WORKFLOW: same workflow rejected across sessions, different workflows fine in one session", async () => {
+    const { manager, spawned } = makeManager();
+    const wfA = { ...runRequest, workflowPath: "/tmp/proj/wf-a" };
+    await manager.run(wfA);
+
+    // Same workflow, same macro — refused no matter which session asks.
+    await expect(manager.run(wfA)).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+    await expect(manager.run({ ...wfA, harnessSessionId: "sess-2" })).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+
+    // A DIFFERENT workflow from the same session runs concurrently — a
+    // workflow switch mid-enrichment must not block the new binding's own run.
+    await expect(manager.run({ ...wfA, workflowPath: "/tmp/proj/wf-b" })).resolves.toBeDefined();
+
+    // Once the first finishes, the same workflow can run again.
+    spawned[0].proc.emit("exit", 0);
+    await expect(manager.run(wfA)).resolves.toBeDefined();
   });
 
   it("runs cleanup even when spawning itself throws (generated config files already exist)", async () => {

--- a/packages/harness/src/core/task-manager.test.ts
+++ b/packages/harness/src/core/task-manager.test.ts
@@ -275,6 +275,40 @@ describe("TaskManager", () => {
     await expect(manager.run(wfA)).resolves.toBeDefined();
   });
 
+  it("dedupes two CONCURRENT run() calls for the same target — the check→register window contains an await", async () => {
+    // Real buildLaunchOpts writes config files (async). Two near-simultaneous
+    // spawns for one workflow (observed live: the bind path and the
+    // session-create scan racing) must not both pass the dedupe check.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const spawned: Spawned[] = [];
+    const manager = new TaskManager({
+      adapters: { "claude-code": makeAdapter() },
+      ingestUrl: "http://127.0.0.1:4100",
+      ingestToken: "tok",
+      spawnProcess: (command, args, options) => {
+        const proc = new FakeProcess();
+        spawned.push({ command, args, options, proc });
+        return proc;
+      },
+      buildLaunchOpts: async () => {
+        await gate;
+        return {};
+      },
+    });
+
+    const wfA = { ...runRequest, workflowPath: "/tmp/proj/wf-a" };
+    const first = manager.run(wfA);
+    const second = manager.run({ ...wfA, harnessSessionId: "sess-2" });
+    release();
+
+    await expect(first).resolves.toBeDefined();
+    await expect(second).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+    expect(spawned).toHaveLength(1);
+  });
+
   it("runs cleanup even when spawning itself throws (generated config files already exist)", async () => {
     const onCleanup = vi.fn();
     const spawnProcess: TaskSpawnFn = () => {

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -29,6 +29,7 @@ import {
   type HarnessAdapter,
   type HarnessKind,
   type LaunchOpts,
+  type SpawnSpec,
 } from "../shared/types.js";
 import type { LaunchOptsBuilder } from "./session-manager.js";
 import { parseTaskStreamLine } from "./task-stream.js";
@@ -137,6 +138,11 @@ export class TaskManager {
   private readonly generateId: () => string;
 
   private readonly tasks = new Map<string, BackgroundTask>();
+  /** Runs admitted past the dedupe check but not yet registered in `tasks`
+   *  — the check→register window contains an await (buildLaunchOpts), so
+   *  without this reservation two near-simultaneous run() calls for the
+   *  same target both pass the check and both spawn. */
+  private readonly pendingRuns: Array<{ macroId: string; harnessSessionId: string; workflowPath: string | null }> = [];
   private readonly processes = new Map<string, TaskProcess>();
   private readonly stderrTails = new Map<string, string>();
   /** The final result event's error text, when the stream produced one —
@@ -188,28 +194,43 @@ export class TaskManager {
     if (!adapter.launchTask) throw new TaskNotSupportedError(req.harness, req.label);
 
     const reqWorkflowPath = req.workflowPath ?? null;
+    // Workflow-targeted tasks dedupe on the workflow (never two enrichments
+    // of one workflow, from any session); workflow-less tasks keep the old
+    // per-session key. Checked against running tasks AND runs still being
+    // admitted (pendingRuns — see its comment).
+    const sameTarget = (other: { macroId: string; harnessSessionId: string; workflowPath: string | null }): boolean =>
+      other.macroId === req.macroId &&
+      (other.workflowPath !== null && reqWorkflowPath !== null
+        ? other.workflowPath === reqWorkflowPath
+        : other.harnessSessionId === req.harnessSessionId);
     for (const task of this.tasks.values()) {
-      if (task.status !== "running" || task.macroId !== req.macroId) continue;
-      // Workflow-targeted tasks dedupe on the workflow (never two enrichments
-      // of one workflow, from any session); workflow-less tasks keep the old
-      // per-session key.
-      const sameTarget =
-        task.workflowPath !== null && reqWorkflowPath !== null
-          ? task.workflowPath === reqWorkflowPath
-          : task.harnessSessionId === req.harnessSessionId;
-      if (sameTarget) throw new TaskAlreadyRunningError(req.label);
+      if (task.status === "running" && sameTarget(task)) throw new TaskAlreadyRunningError(req.label);
     }
+    if (this.pendingRuns.some(sameTarget)) throw new TaskAlreadyRunningError(req.label);
+
+    const pending = { macroId: req.macroId, harnessSessionId: req.harnessSessionId, workflowPath: reqWorkflowPath };
+    this.pendingRuns.push(pending);
+    const releasePending = (): void => {
+      const index = this.pendingRuns.indexOf(pending);
+      if (index !== -1) this.pendingRuns.splice(index, 1);
+    };
 
     const id = this.generateId();
-    const opts: LaunchOpts = {
-      harnessSessionId: id,
-      cwd: req.cwd,
-      prompt: req.prompt,
-      ...(req.model !== undefined ? { model: req.model } : {}),
-      ...(req.maxTurns !== undefined ? { maxTurns: req.maxTurns } : {}),
-      ...(await this.buildLaunchOpts(id, { cwd: req.cwd, harness: req.harness })),
-    };
-    const spec = adapter.launchTask(opts);
+    let spec: SpawnSpec;
+    try {
+      const opts: LaunchOpts = {
+        harnessSessionId: id,
+        cwd: req.cwd,
+        prompt: req.prompt,
+        ...(req.model !== undefined ? { model: req.model } : {}),
+        ...(req.maxTurns !== undefined ? { maxTurns: req.maxTurns } : {}),
+        ...(await this.buildLaunchOpts(id, { cwd: req.cwd, harness: req.harness })),
+      };
+      spec = adapter.launchTask(opts);
+    } catch (err) {
+      releasePending();
+      throw err;
+    }
 
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
@@ -246,11 +267,14 @@ export class TaskManager {
     } catch (err) {
       // Never launched — nothing to track, but the generated config files
       // buildLaunchOpts just wrote still need their exit-time cleanup.
+      releasePending();
       this.onCleanup(id);
       throw err;
     }
 
     this.tasks.set(id, task);
+    // Registered — the running-task check owns dedupe from here.
+    releasePending();
     this.processes.set(id, child);
     this.trimFinished();
     this.emitStatus(task);

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -1,6 +1,6 @@
 /**
  * TaskManager — registry of headless one-shot agent runs (BackgroundTask in
- * shared/types.ts). A "background" macro (ai-visualize today; deploy/run
+ * shared/types.ts). A background task (canvas enrichment today; deploy/run
  * candidates later) runs here instead of being injected into the user's
  * interactive session, so a long LLM turn can't hijack their thread.
  *
@@ -73,11 +73,15 @@ export class TaskNotSupportedError extends Error {
   }
 }
 
-/** Thrown when the same macro is already running for the same session —
- *  two concurrent ai-visualize runs would race on the same index.html. */
+/** Thrown when the same macro is already running against the same target —
+ *  two concurrent enrichment runs for one workflow would race on the same
+ *  render/cache files. The target is the workflow when both tasks carry one
+ *  (so one session CAN enrich two different workflows concurrently, and two
+ *  sessions can NEVER double-enrich the same workflow), falling back to the
+ *  session for workflow-less tasks. */
 export class TaskAlreadyRunningError extends Error {
   constructor(label: string) {
-    super(`${label} is already running for this session.`);
+    super(`${label} is already running.`);
     this.name = "TaskAlreadyRunningError";
   }
 }
@@ -89,6 +93,13 @@ export interface RunTaskRequest {
   harness: HarnessKind;
   cwd: string;
   prompt: string;
+  /** The workflow the task targets, when it has one — carried onto
+   *  BackgroundTask.workflowPath (pane scoping) and used as the dedupe key. */
+  workflowPath?: string | null;
+  /** Model override for the headless run (LaunchOpts.model). */
+  model?: string;
+  /** Turn cap for the headless run (LaunchOpts.maxTurns). */
+  maxTurns?: number;
 }
 
 export interface TaskManagerOptions {
@@ -131,6 +142,9 @@ export class TaskManager {
   /** The final result event's error text, when the stream produced one —
    *  preferred over a raw stderr tail for failure display. */
   private readonly resultErrors = new Map<string, string>();
+  /** The final result event's success text — published on the finished task
+   *  as `resultText`, so a structured task's caller can parse the answer. */
+  private readonly resultTexts = new Map<string, string>();
   private readonly statusEmitter = new EventEmitter();
 
   constructor(options: TaskManagerOptions) {
@@ -173,10 +187,17 @@ export class TaskManager {
     if (!adapter) throw new Error(`No adapter registered for harness "${req.harness}"`);
     if (!adapter.launchTask) throw new TaskNotSupportedError(req.harness, req.label);
 
+    const reqWorkflowPath = req.workflowPath ?? null;
     for (const task of this.tasks.values()) {
-      if (task.status === "running" && task.macroId === req.macroId && task.harnessSessionId === req.harnessSessionId) {
-        throw new TaskAlreadyRunningError(req.label);
-      }
+      if (task.status !== "running" || task.macroId !== req.macroId) continue;
+      // Workflow-targeted tasks dedupe on the workflow (never two enrichments
+      // of one workflow, from any session); workflow-less tasks keep the old
+      // per-session key.
+      const sameTarget =
+        task.workflowPath !== null && reqWorkflowPath !== null
+          ? task.workflowPath === reqWorkflowPath
+          : task.harnessSessionId === req.harnessSessionId;
+      if (sameTarget) throw new TaskAlreadyRunningError(req.label);
     }
 
     const id = this.generateId();
@@ -184,6 +205,8 @@ export class TaskManager {
       harnessSessionId: id,
       cwd: req.cwd,
       prompt: req.prompt,
+      ...(req.model !== undefined ? { model: req.model } : {}),
+      ...(req.maxTurns !== undefined ? { maxTurns: req.maxTurns } : {}),
       ...(await this.buildLaunchOpts(id, { cwd: req.cwd, harness: req.harness })),
     };
     const spec = adapter.launchTask(opts);
@@ -207,11 +230,13 @@ export class TaskManager {
       label: req.label,
       harnessSessionId: req.harnessSessionId,
       cwd: req.cwd,
+      workflowPath: reqWorkflowPath,
       status: "running",
       startedAt: this.now(),
       endedAt: null,
       exitCode: null,
       statusLines: [],
+      resultText: null,
       errorTail: null,
     };
 
@@ -272,6 +297,8 @@ export class TaskManager {
     if (!update) return;
     if (update.result?.isError && update.result.text) {
       this.resultErrors.set(id, update.result.text);
+    } else if (update.result && !update.result.isError) {
+      this.resultTexts.set(id, update.result.text);
     }
     if (update.statusLines.length === 0) return;
     task.statusLines = [...task.statusLines, ...update.statusLines].slice(-MAX_STATUS_LINES);
@@ -291,10 +318,13 @@ export class TaskManager {
     if (failed) {
       const stderrTail = this.stderrTails.get(id)?.trim();
       task.errorTail = resultError ?? (stderrTail || `exited with code ${exitCode ?? "unknown"}`);
+    } else {
+      task.resultText = this.resultTexts.get(id) ?? null;
     }
     this.processes.delete(id);
     this.stderrTails.delete(id);
     this.resultErrors.delete(id);
+    this.resultTexts.delete(id);
     this.emitStatus(task);
     this.onCleanup(id);
   }

--- a/packages/harness/src/profiles/canvas-guidelines.test.ts
+++ b/packages/harness/src/profiles/canvas-guidelines.test.ts
@@ -63,11 +63,11 @@ describe("CANVAS_STYLE_GUIDELINES injection sites", () => {
     expect(DEFAULT_SYSTEM_PROMPT).toContain(CANVAS_STYLE_GUIDELINES);
   });
 
-  it("is NOT embedded in the ai-visualize macro's inject text — the canvas kit's prebuilt template already carries the style, so the macro path only ever asks for a data edit", () => {
-    const macro = DEFAULT_MACROS.find((m) => m.id === "ai-visualize")!;
-    expect(macro.action.kind).toBe("inject");
-    if (macro.action.kind === "inject") {
-      expect(macro.action.text).not.toContain(CANVAS_STYLE_GUIDELINES);
+  it("is NOT embedded in any macro's inject text — no macro asks an agent to write canvas HTML anymore", () => {
+    for (const macro of DEFAULT_MACROS) {
+      if (macro.action.kind === "inject") {
+        expect(macro.action.text).not.toContain(CANVAS_STYLE_GUIDELINES);
+      }
     }
   });
 

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -48,7 +48,8 @@ import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
 import { writeHarnessContext, harnessContextFileExists } from "../core/workspace-context.js";
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
-import { renderCanvasForSession } from "../core/canvas-render.js";
+import { renderCanvasForSession, renderWorkflowRenderFile } from "../core/canvas-render.js";
+import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
@@ -325,8 +326,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const sessionSweepTimer = setInterval(() => sessionManager.sweepDeadSessions(), SESSION_LIVENESS_SWEEP_MS);
   sessionSweepTimer.unref?.();
 
-  // Background tasks ("background" macros, ai-visualize today): headless
-  // one-shot agent runs that never touch a user's interactive session. They
+  // Background tasks (canvas enrichment today): headless one-shot agent
+  // runs that never touch a user's interactive session. They
   // reuse the exact same per-id config generation as sessions — a task's
   // generated/<taskId> dir gets the same exit-time removal below, and (via
   // sweepGeneratedDirs above; a task id is never a live session id, so the
@@ -418,20 +419,35 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     return found;
   };
 
+  // The AI enrichment layer over the deterministic renders: one bounded
+  // headless task per workflow (spawned on bind when no fresh cache exists,
+  // or by the visualize macro's force refresh), whose validated JSON output
+  // is persisted per-workflow and merged into the render on completion —
+  // the render write alone hot-reloads any open pane via the canvas watcher.
+  const enrichment = new CanvasEnrichmentCoordinator({
+    tasks: taskManager,
+    rerender: async (cwd, workflow) => {
+      await renderWorkflowRenderFile(cwd, workflow);
+    },
+  });
+
   // Renders a session's bound workflow via the deterministic pipeline —
-  // always against the live workflowsCache, never an LLM; a cheap no-op for
-  // an unbound session (the canvas router serves the empty state on its
-  // own). Never throws (see core/canvas-render.ts); best-effort, like every
-  // other canvas write here. Explicit user-invoked renders (the Visualize
-  // macro, POST /canvas/:id/render) use this as-is; the UNPROMPTED call
-  // sites (session-create/boot auto-render) use autoRenderCanvas below,
-  // which won't replace a workflow's existing render with an error panel
-  // when its extraction fails.
+  // always against the live workflowsCache, never an LLM in the render
+  // itself; a cheap no-op for an unbound session (the canvas router serves
+  // the empty state on its own). Never throws (see core/canvas-render.ts);
+  // best-effort, like every other canvas write here. The bind path
+  // (PATCH /sessions/:id/workflow → rest.ts) and the UNPROMPTED call sites
+  // (session-create/boot auto-render, via autoRenderCanvas — which won't
+  // replace a workflow's existing render with an error panel when its
+  // extraction fails) also kick the enrichment freshness check afterwards:
+  // instant base diagram now, annotations merged in when the task lands.
   const renderCanvas = async (session: HarnessSession): Promise<void> => {
     await renderCanvasForSession(session, workflowsCache);
+    await enrichment.ensureFresh(session, workflowsCache);
   };
   const autoRenderCanvas = async (session: HarnessSession): Promise<void> => {
     await renderCanvasForSession(session, workflowsCache, { preserveExistingOnFailure: true });
+    await enrichment.ensureFresh(session, workflowsCache);
   };
 
   const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
@@ -528,9 +544,14 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
       getSessionCwd: (harnessSessionId) => sessionManager.get(harnessSessionId)?.cwd ?? null,
       getBoundWorkflowPath: (harnessSessionId) => sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
+      // The visualize macro is a FORCE refresh, not a plain re-render:
+      // invalidate the extraction + enrichment caches, re-render the base
+      // instantly, re-spawn the enrichment task. Its refusals map to the
+      // router's existing error handling (already running → 409, codex
+      // session → 400).
       renderCanvas: async (harnessSessionId) => {
         const session = sessionManager.get(harnessSessionId);
-        if (session) await renderCanvas(session);
+        if (session) await enrichment.forceRefresh(session, workflowsCache);
       },
       injectInput: async (harnessSessionId, text, submit) => {
         // Two-phase write: a combined text+\r lands in Claude Code as a

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -187,7 +187,7 @@ describe("macros router", () => {
     expect(res.status).toBe(400);
   });
 
-  it("runs visualize with no workflow bound at all — renders server-side, never touches the pty", async () => {
+  it("runs visualize with no workflow bound at all — refreshes server-side, never touches the pty", async () => {
     const deps = makeDeps(); // getBoundWorkflowPath defaults to () => null
     await start(deps);
     const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
@@ -201,7 +201,7 @@ describe("macros router", () => {
     expect(deps.injectInput).not.toHaveBeenCalled();
   });
 
-  it("also runs visualize when a workflow IS bound — same deterministic render either way", async () => {
+  it("also runs visualize when a workflow IS bound — same server-side refresh either way", async () => {
     const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
     await start(deps);
     const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
@@ -214,10 +214,17 @@ describe("macros router", () => {
     expect(deps.injectInput).not.toHaveBeenCalled();
   });
 
-  it("ai-visualize runs as a background task with the canvas-kit prompt — never touches the session's pty", async () => {
-    const deps = makeDeps();
+  it("routes an inject macro marked execution: 'background' to runBackgroundTask, never the pty", async () => {
+    const backgroundMacro = {
+      id: "bg-macro",
+      label: "Background macro",
+      icon: "Wand2",
+      execution: "background" as const,
+      action: { kind: "inject" as const, text: "do something in {{session.cwd}}", submit: true },
+    };
+    const deps = makeDeps({ listMacros: () => [...DEFAULT_MACROS, backgroundMacro] });
     await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/ai-visualize/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/bg-macro/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
@@ -229,22 +236,17 @@ describe("macros router", () => {
       string,
     ];
     expect(sessionId).toBe("sess-1");
-    expect(macro.id).toBe("ai-visualize");
-    expect(prompt).toContain("/Users/demo/acme-app/.sapiom/canvas/index.html"); // {{canvas.path}} substituted
-    // The Write tool refuses blind overwrites of unread files — the prompt
-    // must tell the agent to read the existing index.html before writing it.
-    expect(prompt).toMatch(/read BOTH \.sapiom\/canvas\/_template\.html and the existing \.sapiom\/canvas\/index\.html/);
-    expect(prompt).toContain("canvas-patterns");
-    expect(deps.renderCanvas).not.toHaveBeenCalled();
+    expect(macro.id).toBe("bg-macro");
+    expect(prompt).toBe("do something in /Users/demo/acme-app"); // {{session.cwd}} substituted
     expect(deps.injectInput).not.toHaveBeenCalled();
   });
 
-  it("400s a background macro on a harness with no headless mode (TaskNotSupportedError)", async () => {
+  it("400s visualize on a harness with no headless mode (TaskNotSupportedError from the enrichment spawn)", async () => {
     const deps = makeDeps({
-      runBackgroundTask: vi.fn().mockRejectedValue(new TaskNotSupportedError("codex", "AI Visualize")),
+      renderCanvas: vi.fn().mockRejectedValue(new TaskNotSupportedError("codex", "Visualize")),
     });
     await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/ai-visualize/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
@@ -254,12 +256,12 @@ describe("macros router", () => {
     expect(body.error).toMatch(/don't support/i);
   });
 
-  it("409s a background macro that's already running for the session (TaskAlreadyRunningError)", async () => {
+  it("409s visualize when this workflow's enrichment is already running (TaskAlreadyRunningError)", async () => {
     const deps = makeDeps({
-      runBackgroundTask: vi.fn().mockRejectedValue(new TaskAlreadyRunningError("AI Visualize")),
+      renderCanvas: vi.fn().mockRejectedValue(new TaskAlreadyRunningError("Visualize")),
     });
     await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/ai-visualize/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }),

--- a/packages/harness/src/server/macros.ts
+++ b/packages/harness/src/server/macros.ts
@@ -36,9 +36,12 @@ export interface MacrosRouterDeps {
   runBackgroundTask(harnessSessionId: string, macro: MacroDef, prompt: string): Promise<void>;
   /** Opens a URL in the user's default browser (the `open` package). */
   openUrl(url: string): Promise<void>;
-  /** Runs the deterministic canvas render for a session (the "visualize"
-   *  macro's `render-canvas` action) — never throws (core/canvas-render.ts's
-   *  contract), so this has no error path of its own to report. */
+  /** The "visualize" macro's `render-canvas` action: force refresh of the
+   *  session's bound canvas — deterministic re-render plus an enrichment
+   *  task re-spawn (see core/canvas-enrich.ts). May throw
+   *  TaskAlreadyRunningError (an enrichment for this workflow is already in
+   *  flight → 409) or TaskNotSupportedError (the session's harness has no
+   *  headless mode → 400), same as any other background-task launch. */
   renderCanvas(harnessSessionId: string): Promise<void>;
 }
 

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -53,6 +53,15 @@ export const CANVAS_INDEX = `${CANVAS_DIR}/index.html`;
 export const CANVAS_RENDERS_DIR = `${CANVAS_DIR}/renders`;
 
 /**
+ * Per-workflow enrichment cache lives here (one `<slug>.json` per workflow,
+ * same slug scheme as CANVAS_RENDERS_DIR), relative to the session cwd:
+ * `{ graph, enrichment, sourceFingerprint, enrichedAt }`. A stale
+ * sourceFingerprint keeps the enrichment displayed (with a "stale" chip)
+ * until a re-run replaces it — see core/canvas-enrich.ts.
+ */
+export const CANVAS_CACHE_DIR = `${CANVAS_DIR}/cache`;
+
+/**
  * Workspace-state convention: the harness mirrors this session's binding,
  * the full workflow registry, and its own identity here, relative to the
  * session cwd, so the agent has an always-current, agent-legible answer to
@@ -160,6 +169,12 @@ export interface LaunchOpts {
   /** Only consulted by `launchTask` — the one-shot prompt a headless
    *  background task runs, then exits. Unused by `launch`/`resume`. */
   prompt?: string;
+  /** Only consulted by `launchTask` — model override (`--model`), e.g.
+   *  "sonnet". Interactive sessions keep the user's own default. */
+  model?: string;
+  /** Only consulted by `launchTask` — hard cap on agent turns
+   *  (`--max-turns`), so a bounded task can't run away. */
+  maxTurns?: number;
 }
 
 /**
@@ -208,8 +223,8 @@ export interface HarnessAdapter {
 export type BackgroundTaskStatus = "running" | "completed" | "failed";
 
 /**
- * One headless agent run, spawned by a macro marked `execution: "background"`
- * (today: ai-visualize). Deliberately NOT a HarnessSession: tasks never
+ * One headless agent run (today: canvas enrichment, spawned on bind or by
+ * the visualize macro). Deliberately NOT a HarnessSession: tasks never
  * appear in the session registry (so no tab, no resume, no ghost-record
  * reconciliation to worry about) and live only in TaskManager's memory —
  * the pty-less process exits on its own when its single turn completes.
@@ -221,12 +236,17 @@ export interface BackgroundTask {
   id: string;
   /** The macro that spawned it (retry re-runs this id). */
   macroId: string;
-  /** Display label, e.g. "AI Visualize". */
+  /** Display label, e.g. "Visualize". */
   label: string;
   /** The interactive session the macro was triggered from — the canvas pane
    *  showing that session renders this task's live status. */
   harnessSessionId: string;
   cwd: string;
+  /** The workflow this task was launched for, when it targets one — the
+   *  canvas pane scopes its activity view to the session's CURRENT binding
+   *  via this, so switching workflows mid-task never bleeds another
+   *  workflow's progress into the pane. Null for workflow-less tasks. */
+  workflowPath: string | null;
   status: BackgroundTaskStatus;
   startedAt: string;
   endedAt: string | null;
@@ -234,6 +254,10 @@ export interface BackgroundTask {
   /** Rolling tail of compact human-readable progress lines derived from the
    *  task's stream-json stdout (see core/task-stream.ts), oldest first. */
   statusLines: string[];
+  /** The final result event's text when the task completed successfully —
+   *  the payload a structured task (canvas enrichment) parses. Null while
+   *  running and on failure. */
+  resultText: string | null;
   /** On failure: the result error / stderr tail worth showing a user. */
   errorTail: string | null;
 }
@@ -502,10 +526,10 @@ export interface WorkflowInfo {
 /**
  * A macro injects text into the active session's pty, opens a URL, or (the
  * one exception to "always goes through the agent's session") runs the
- * deterministic canvas render server-side. Template placeholders, substituted
- * server-side before "inject"/"open-url" execution:
+ * deterministic canvas render + AI enrichment refresh server-side. Template
+ * placeholders, substituted server-side before "inject"/"open-url" execution:
  *   {{workflow.path}} {{workflow.name}} {{workflow.definitionId}}
- *   {{session.cwd}}   {{canvas.path}}   {{subject}}   (ai-visualize free-text)
+ *   {{session.cwd}}   {{canvas.path}}   {{subject}}
  */
 export interface MacroDef {
   id: string;
@@ -515,9 +539,11 @@ export interface MacroDef {
   action:
     | { kind: "inject"; text: string; submit?: boolean }
     | { kind: "open-url"; url: string }
-    /** Zero-LLM, instant: runs core/canvas-render.ts against the session's
-     *  bound workflow (or the workspace overview when unbound) and writes
-     *  .sapiom/canvas/index.html directly — no prompt, no pty involved. */
+    /** Force refresh of the bound workflow's canvas: invalidates the
+     *  extraction + enrichment caches, re-renders the deterministic diagram
+     *  instantly, and re-spawns the bounded AI enrichment task (see
+     *  core/canvas-enrich.ts) — no pty involved. A cheap no-op when the
+     *  session is unbound. */
     | { kind: "render-canvas" };
   /** Macro requires a selected workflow to be enabled. */
   requiresWorkflow?: boolean;
@@ -527,7 +553,7 @@ export interface MacroDef {
    * their terminal and occupying their thread — same as always.
    * `"background"`: run headless in a one-shot task process via
    * TaskManager (the user's session is never touched), so a long-running
-   * macro like ai-visualize can't interrupt whatever the user was doing.
+   * macro can't interrupt whatever the user was doing.
    * Ignored for non-"inject" actions.
    */
   execution?: "inject" | "background";

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -9,6 +9,8 @@
  * new-session directory picker.
  */
 import { expect, test } from "@playwright/test";
+import { buildWorkflowPanelHtml } from "../../src/core/canvas-body.js";
+import { renderCanvasDocument } from "../../src/core/canvas-template.js";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
@@ -432,6 +434,10 @@ test.describe("docked workflow action strip", () => {
     await expect(strip.getByTestId("macro-prod_run")).toBeVisible();
     await expect(strip.getByTestId("macro-open_prod")).toBeVisible();
     await expect(strip.getByTestId("macro-visualize")).toBeVisible();
+    // ONE canvas macro: the old two-button visualize / ai-visualize split is
+    // gone — Visualize alone covers structure + AI enrichment server-side.
+    await expect(strip.getByTestId("macro-ai-visualize")).toHaveCount(0);
+    await expect(strip.locator(".strip-item")).toHaveCount(5);
 
     await page.screenshot({ path: "web/e2e/screenshots/app-shell-docked-strip.png", fullPage: true });
   });
@@ -450,8 +456,6 @@ test.describe("docked workflow action strip", () => {
     }).toPass({ timeout: 1000 });
     await expect(page.locator(".strip-item-label").first()).toBeVisible();
     await expect(strip.getByText("Run local")).toBeVisible();
-    // getByText("Visualize") would also match "AI Visualize" — use the
-    // macro's own test id to target the deterministic-render macro exactly.
     await expect(strip.getByTestId("macro-visualize")).toBeVisible();
 
     // Expanded, the panel floats directly over the terminal — its
@@ -634,6 +638,42 @@ test("a canvas.reload bus message swaps the empty state for the generated iframe
   await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
 });
 
+test("a stale enrichment renders with the 'stale — Refresh' chip in the served canvas document", async ({ page }) => {
+  // The chip is server-rendered (core/canvas-render.ts marks an enrichment
+  // whose fingerprint no longer matches the sources) — serve the REAL
+  // renderer's output for that state into the pane's iframe and assert the
+  // chip actually displays through the sandboxed-iframe pipeline.
+  const staleDocument = renderCanvasDocument(
+    buildWorkflowPanelHtml(
+      {
+        manifestName: "leasing",
+        entry: "intake",
+        warnings: [],
+        nodes: [{ id: "intake", kind: "entry", label: "intake" }],
+        edges: [],
+      },
+      { title: "leasing", badges: ["local only"] },
+      { enrichment: { summary: "Handles lease applications end to end" }, stale: true },
+    ),
+  );
+  await page.route("**/canvas/sess-boot/**", async (route) => {
+    await route.fulfill({ contentType: "text/html", body: staleDocument });
+  });
+
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+
+  const frame = page.frameLocator(".canvas-iframe");
+  await expect(frame.locator(".canvas-badge--stale")).toHaveText("stale — Refresh");
+  // The stale enrichment stays DISPLAYED — the chip marks it, never hides it.
+  await expect(frame.locator(".canvas-subtitle")).toHaveText("Handles lease applications end to end");
+  await page.screenshot({ path: "web/e2e/screenshots/canvas-stale-chip.png" });
+});
+
 test("a pending canvas load shows a skeleton over the iframe — never a blank pane", async ({ page }) => {
   // Stall the canvas document so the load stays pending long enough to assert
   // on the skeleton deterministically.
@@ -692,14 +732,18 @@ test("switching the bound workflow refetches the canvas immediately — the serv
 test.describe("background-task canvas states", () => {
   const baseTask = {
     id: "task-1",
-    macroId: "ai-visualize",
-    label: "AI Visualize",
+    macroId: "visualize",
+    label: "Visualize",
     harnessSessionId: "sess-boot",
     cwd: "/Users/demo/acme-app",
+    // The mock boot session's bound workflow (MOCK_WORKFLOWS "leasing") —
+    // enrichment tasks always carry the workflow they target.
+    workflowPath: "/Users/demo/acme-app/leasing" as string | null,
     startedAt: new Date().toISOString(),
     endedAt: null as string | null,
     exitCode: null as number | null,
     statusLines: [] as string[],
+    resultText: null as string | null,
     errorTail: null as string | null,
   };
 
@@ -716,15 +760,15 @@ test.describe("background-task canvas states", () => {
 
     const activity = page.getByTestId("canvas-task-activity");
     await expect(activity).toBeVisible();
-    await expect(activity).toContainText("AI Visualize is running");
+    await expect(activity).toContainText("Visualize is running");
     await expect(activity.locator(".canvas-task-spinner")).toBeVisible();
 
     await publish(page, {
       ...baseTask,
       status: "running",
-      statusLines: ["Agent started", "Read .sapiom/canvas/_template.html"],
+      statusLines: ["Agent started", "Read steps/route.ts"],
     });
-    await expect(page.getByTestId("canvas-task-lines")).toContainText("Read .sapiom/canvas/_template.html");
+    await expect(page.getByTestId("canvas-task-lines")).toContainText("Read steps/route.ts");
 
     await page.screenshot({ path: "web/e2e/screenshots/canvas-task-activity.png" });
 
@@ -749,6 +793,26 @@ test.describe("background-task canvas states", () => {
     await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
   });
 
+  test("activity is scoped to the BOUND WORKFLOW — another workflow's task never bleeds into this pane", async ({
+    page,
+  }) => {
+    // Same session, but the task targets a workflow that is NOT the pane's
+    // current binding (sess-boot is bound to leasing) — hidden.
+    await publish(page, { ...baseTask, workflowPath: "/Users/demo/onboarding-flow", status: "running" });
+    await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
+    await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+
+    // The bound workflow's own task shows...
+    await publish(page, { ...baseTask, id: "task-2", status: "running" });
+    await expect(page.getByTestId("canvas-task-activity")).toBeVisible();
+
+    // ...and switching the binding mid-run hides it again: the rfq pane must
+    // not show leasing's enrichment progress.
+    await page.getByTestId("workflow-rfq").click();
+    await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+    await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
+  });
+
   test("a failed task shows the error tail with retry and dismiss affordances", async ({ page }) => {
     await publish(page, {
       ...baseTask,
@@ -760,11 +824,12 @@ test.describe("background-task canvas states", () => {
 
     const failed = page.getByTestId("canvas-task-failed");
     await expect(failed).toBeVisible();
-    await expect(failed).toContainText("AI Visualize failed");
+    await expect(failed).toContainText("Visualize failed");
     await expect(failed).toContainText("API connection lost");
     await page.screenshot({ path: "web/e2e/screenshots/canvas-task-failed.png" });
 
-    // Retry re-fires the same macro (MockApi records it for us to read back).
+    // Retry re-fires the same macro (MockApi records it for us to read back)
+    // — for an enrichment task that's the visualize force refresh.
     await page.getByTestId("canvas-task-retry").click();
     await page.waitForFunction(
       () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
@@ -773,7 +838,7 @@ test.describe("background-task canvas states", () => {
       () =>
         (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string } } }).__HARNESS_TEST__.lastMacroRun,
     );
-    expect(lastRun?.id).toBe("ai-visualize");
+    expect(lastRun?.id).toBe("visualize");
 
     // Dismiss hides the failure panel and returns the pane to its usual state.
     await page.getByTestId("canvas-task-dismiss").click();

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -90,10 +90,19 @@ export function CanvasPane({
     ? macroDisabledReason(visualizeMacro, boundWorkflow, activeSessionId)
     : null;
 
-  // Background-task state for THIS session's pane: a running task shows the
-  // live activity view; otherwise the most recently finished task, if it
-  // failed and hasn't been dismissed, shows the failure view with a retry.
-  const sessionTasks = tasks.filter((task) => task.harnessSessionId === sessionId);
+  // Background-task state for THIS session's pane, scoped to the CURRENT
+  // binding: a task that carries a workflowPath only surfaces while the pane
+  // is showing that workflow — switching the binding mid-run must not bleed
+  // another workflow's activity (or failure) into this one's pane. Tasks
+  // without a workflowPath keep the plain per-session scoping. A running
+  // task shows the live activity view; otherwise the most recently finished
+  // task, if it failed and hasn't been dismissed, shows the failure view
+  // with a retry.
+  const sessionTasks = tasks.filter(
+    (task) =>
+      task.harnessSessionId === sessionId &&
+      (task.workflowPath == null || task.workflowPath === boundWorkflowPath),
+  );
   const runningTask = sessionTasks.find((task) => task.status === "running") ?? null;
   const latestFinished = sessionTasks
     .filter((task) => task.status !== "running")

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -173,28 +173,13 @@ export const MOCK_MACROS: MacroDef[] = [
     requiresWorkflow: true,
   },
   {
-    // One-click, unbound-friendly deterministic render — no LLM, no pty
+    // One-click force refresh: deterministic re-render + AI enrichment task
+    // re-spawn, all server-side — no LLM in the render itself, no pty
     // involved. Matches the real DEFAULT_MACROS contract (src/core/macros.ts).
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",
     action: { kind: "render-canvas" },
-    requiresWorkflow: false,
-  },
-  {
-    // The LLM-authored fallback for custom/narrative views — runs as a
-    // headless background task, never in the user's own session. Matches the
-    // real DEFAULT_MACROS contract (src/core/macros.ts); the mock text is
-    // abbreviated, only the shape matters here.
-    id: "ai-visualize",
-    label: "AI Visualize",
-    icon: "Wand2",
-    execution: "background",
-    action: {
-      kind: "inject",
-      text: "Recreate {{canvas.path}} from the canvas kit template (read both files first, then overwrite index.html).",
-      submit: true,
-    },
     requiresWorkflow: false,
   },
 ];


### PR DESCRIPTION
PR 2 of 2 of the visualization rework (PR 1, #243, shipped the deterministic layer). The AI never writes canvas HTML anymore: the diagram structure is rendered deterministically from the extracted graph, and a bounded, headless enrichment task adds validated text annotations on top.

## What's in here

**Enrichment contract** (`core/canvas-enrichment.ts`) — a zod schema of hard-capped plain strings: `summary` ≤160, per-node `sublabel` ≤48 / `description` ≤120, `edgeLabels` ≤32, ≤3 `notes` of ≤140, `layoutHints` (named groups + per-layer ordering), `crossWorkflow` ≤160. Unknown keys are stripped; structurally invalid output is discarded whole and the base render stands.

**Task plumbing** — `LaunchOpts.model`/`maxTurns` → `--model`/`--max-turns` in the claude-code adapter's `launchTask()`; TaskManager now publishes the success result event's text as `BackgroundTask.resultText`; tasks carry the `workflowPath` they target and dedupe per workflow (one workflow can never be double-enriched from any session, while one session can enrich two workflows concurrently).

**Runner** (`core/canvas-enrich.ts`) — one headless task per workflow: the extracted `CanvasGraph` inline, pointed at the step `run()` bodies for semantics, JSON-only / no-file-writes contract, pinned to `--model sonnet` (`SAPIOM_HARNESS_VISUALIZE_MODEL` overrides) with `--max-turns 8`. On completion: extract JSON from `resultText` (fenced or raw), normalize (see below), validate, persist, re-render.

**Per-workflow cache** — `.sapiom/canvas/cache/<slug>.json` `{graph, enrichment, sourceFingerprint, enrichedAt}` (PR 1's source fingerprint reused). A stale fingerprint re-renders the base immediately from fresh extraction while the enrichment stays displayed with a subtle "stale — Refresh" chip until a re-run replaces it.

**Renderer merge** — summary line under the header, node sublabels + hover descriptions (SVG `<title>`), edge labels along paths, group hints as subtle background bands behind member nodes, `laneOrder` reordering within the computed layer only, notes + cross-workflow tie in the footer. A hint referencing a node that doesn't exist is silently ignored. All styling stays in `themeStyleBlock()`; enrichment supplies escaped strings only.

**UX** — binding a workflow renders the base diagram instantly and auto-spawns ONE enrichment task when no fresh cache exists; activity streams in the pane, scoped to the bound workflow (`CanvasPane` filters tasks by the current binding — switching workflows mid-run no longer bleeds another workflow's progress in). ONE macro: `visualize` = force refresh (invalidate caches, re-extract, re-enrich). `ai-visualize` (LLM rewrites the whole HTML page) is deleted everywhere. Failures are pane UI state (error tail + Retry) — never HTML on disk.

## Two findings from the live check, both fixed here

1. **Hard-cap discard made the feature a coin flip.** Sonnet's enrichment content was consistently good, but it doesn't count characters — a single 160-char note against the 140 cap discarded 3 of 4 real enrichments whole. The runner now deterministically normalizes before strict validation: oversize strings truncate to their cap with an ellipsis, `null`-valued fields drop (a model's "omitted"), notes beyond the count cap drop. The bound the caps exist for is still enforced — by truncation instead of whole-discard — and anything structurally wrong still discards whole.
2. **A dedupe race in TaskManager.** `run()` checked for an already-running task, then awaited config-file generation before registering the new task — the bind path and the session-create scan racing 9ms apart both passed the check and both spawned. Admission now reserves the target synchronously (`pendingRuns`) until the task is registered.

## Verification

- `typecheck` (src + web), 548 unit tests (schema round-trip/rejection incl. oversize strings + unknown node ids in hints, normalization, resultText capture, per-workflow + concurrent dedupe, cache staleness, renderer merge/escaping), `build:server`, `build:web`, `sim:e2e`, `e2e:live`, `test:ui` (63 specs, incl. single macro, workflow-scoped activity, stale chip through the real renderer, failure state) — all green.
- `e2e:live` now also proves the auto-spawn end to end against the real `startServer()`: binding a cleanly-extracting workflow launches the enrichment task with `--model sonnet --max-turns 8` and the graph-inline JSON-only prompt, reported in `AppState.tasks` scoped to the session + workflow. All live checks run under `stateRoot` isolation (#240) — the real `~/.sapiom/harness` is never touched.
- **Live check against a local multi-workflow project (7 old-SDK + 1 new-SDK workflows), real `claude` + sonnet:** bound an old-SDK workflow → base diagram on disk within the bind round-trip (**~150–160ms** incl. extraction) → enrichment task auto-spawned, streamed activity in the pane, merged summary/sublabels/edge-labels/notes in on completion. **Measured end-to-end enrichment time: 24.8s** (three real runs: 24.5s / 33.1s / 24.8s — call it ~25–35s). Switching the binding mid-enrichment kept the running task scoped to its own workflow (no activity bleed into the other pane), and the other workflow's own enrichment ran concurrently — dedupe is per workflow, not per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7JyvHCzoHfGLVoFiW9H36
