### PR TITLE
fix(harness): canvas diagram sizing + node subtitles — stop single-column upscale blowup

### DIFF
--- a/packages/harness/src/core/canvas-graph.test.ts
+++ b/packages/harness/src/core/canvas-graph.test.ts
@@ -51,6 +51,24 @@ describe("extractWorkflowGraph", () => {
     expect(result.graph.nodes.find((n) => n.id === "classify")!.kind).toBe("step");
   });
 
+  it("populates a deterministic sublabel on every node, derived from its kind/transitions — no AI needed", async () => {
+    const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    const sub = (id: string) => result.graph.nodes.find((n) => n.id === id)!.sublabel;
+    expect(sub("intake")).toBe("entry");
+    expect(sub("classify")).toBe("step");
+    expect(sub("auto_resolve")).toBe("terminal · success");
+    expect(sub("escalate")).toBe("terminal · success");
+    // Every node carries one — the diagram reads as titled cards before enrichment.
+    expect(result.graph.nodes.every((n) => typeof n.sublabel === "string" && n.sublabel.length > 0)).toBe(true);
+  });
+
+  it("gives a pause step a `pause · <signal>` sublabel naming the signal it waits on", async () => {
+    const result = await extractWorkflowGraph(path.join(FIXTURES_DIR, "legacy-flow"));
+    if (!result.ok) throw new Error("expected extraction to succeed");
+    expect(result.graph.nodes.find((n) => n.id === "confirm")!.sublabel).toBe("pause · vendor.confirm");
+  });
+
   it("emits one sequential edge for a single-target continue, and branching edges for multi-target continue", async () => {
     const result = await extractWorkflowGraph(ORDER_TRIAGE_DIR);
     if (!result.ok) throw new Error("expected extraction to succeed");
@@ -115,7 +133,12 @@ describe("extractWorkflowGraph", () => {
     if (!result.ok) return;
 
     const launched = result.graph.nodes.find((n) => n.kind === "launched-workflow");
-    expect(launched).toEqual({ id: "launch:spoke-workflow", kind: "launched-workflow", label: "spoke-workflow" });
+    expect(launched).toEqual({
+      id: "launch:spoke-workflow",
+      kind: "launched-workflow",
+      label: "spoke-workflow",
+      sublabel: "launched workflow",
+    });
     expect(result.graph.edges).toContainEqual({
       from: "kickoff",
       to: "launch:spoke-workflow",

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -66,25 +66,33 @@ export type ExtractionResult = ExtractionSuccess | ExtractionFailure;
  * `continue` targets left resolves to a terminal color, warn (fail) over
  * success (terminate) is not possible to prioritize both apply — success
  * wins as the more common single-outcome shape.
+ *
+ * Every branch also carries a deterministic `sublabel` — a one-line role
+ * derived purely from the step's declared transitions (entry / step / pause ·
+ * <signal> / terminal · success / terminal · needs attention) — so each node
+ * renders as a titled card even before any AI enrichment. `renderGraphSvg`
+ * prefers an enrichment-supplied sublabel over this default when present.
  */
 function classifyNode(
   name: string,
   entry: string,
   step: AgentStepManifest,
-): { kind: CanvasNodeKind; sublabel?: string } {
+): { kind: CanvasNodeKind; sublabel: string } {
   const continueTargets = step.transitions.filter((t) => t.kind === "continue");
   const pause = step.transitions.find((t) => t.kind === "pause");
   const hasTerminate = step.transitions.some((t) => t.kind === "terminate");
   const hasFail = step.transitions.some((t) => t.kind === "fail");
 
-  if (name === entry) return { kind: "entry" };
-  if (pause) return { kind: "pause", sublabel: `waits for signal "${pause.signal}"` };
-  if (continueTargets.length === 0 && hasFail && !hasTerminate) return { kind: "terminal-warn" };
-  if (continueTargets.length === 0 && hasTerminate) return { kind: "terminal-success" };
+  if (name === entry) return { kind: "entry", sublabel: "entry" };
+  if (pause) return { kind: "pause", sublabel: `pause · ${pause.signal}` };
+  if (continueTargets.length === 0 && hasFail && !hasTerminate)
+    return { kind: "terminal-warn", sublabel: "terminal · needs attention" };
+  if (continueTargets.length === 0 && hasTerminate)
+    return { kind: "terminal-success", sublabel: "terminal · success" };
   if (continueTargets.length > 0 && (hasTerminate || hasFail)) {
-    return { kind: "step", sublabel: hasFail ? "can also fail" : "can also terminate" };
+    return { kind: "step", sublabel: hasFail ? "step · can also fail" : "step · can also terminate" };
   }
-  return { kind: "step" };
+  return { kind: "step", sublabel: "step" };
 }
 
 /** Builds every edge a step declares — one per `continue` target plus its
@@ -108,7 +116,7 @@ function edgesForStep(name: string, step: AgentStepManifest): CanvasEdge[] {
 export function graphFromManifest(manifest: AgentManifest, warnings: string[]): CanvasGraph {
   const nodes: CanvasNode[] = Object.entries(manifest.steps).map(([name, step]) => {
     const { kind, sublabel } = classifyNode(name, manifest.entry, step);
-    return { id: name, kind, label: name, ...(sublabel ? { sublabel } : {}) };
+    return { id: name, kind, label: name, sublabel };
   });
   const edges: CanvasEdge[] = Object.entries(manifest.steps).flatMap(([name, step]) =>
     edgesForStep(name, step),
@@ -136,7 +144,7 @@ export function mergeLaunchesIntoGraph(graph: CanvasGraph, launches: readonly De
     // happens to share its name.
     const nodeId = `launch:${launch.slug}`;
     if (!nodes.some((n) => n.id === nodeId)) {
-      nodes.push({ id: nodeId, kind: "launched-workflow", label: launch.slug });
+      nodes.push({ id: nodeId, kind: "launched-workflow", label: launch.slug, sublabel: "launched workflow" });
     }
     const from = launch.fromStepId && stepIds.has(launch.fromStepId) ? launch.fromStepId : graph.entry;
     const edgeKey = `${from}->${nodeId}`;

--- a/packages/harness/src/core/canvas-svg.test.ts
+++ b/packages/harness/src/core/canvas-svg.test.ts
@@ -116,6 +116,36 @@ describe("renderGraphSvg", () => {
     expect(svg).toMatch(/M\d+(\.\d+)?,\d+(\.\d+)? C\d+/); // branching: M...C...
   });
 
+  it("pins the svg to its natural intrinsic size — explicit width/height, not just a viewBox — so a narrow single-column graph can't stretch/upscale to fill the pane", () => {
+    const layout = layoutGraph(ORDER_TRIAGE_GRAPH);
+    expect(svg).toContain(`width="${layout.width}"`);
+    expect(svg).toContain(`height="${layout.height}"`);
+    expect(svg).toContain(`viewBox="0 0 ${layout.width} ${layout.height}"`);
+  });
+
+  it("keeps a single-column (linear) workflow at natural width — the pane, not the svg, absorbs extra space", () => {
+    const linear: CanvasGraph = {
+      manifestName: "linear",
+      entry: "a",
+      warnings: [],
+      nodes: [
+        { id: "a", kind: "entry", label: "a" },
+        { id: "b", kind: "step", label: "b" },
+        { id: "c", kind: "terminal-success", label: "c" },
+      ],
+      edges: [
+        { from: "a", to: "b", kind: "sequential" },
+        { from: "b", to: "c", kind: "sequential" },
+      ],
+    };
+    const layout = layoutGraph(linear);
+    // maxCols === 1 → width is just margins + one node box, ~256px. A width
+    // attribute this size means the browser renders it 1× and the CSS only
+    // ever scales it DOWN, never up.
+    expect(layout.width).toBeLessThan(300);
+    expect(renderGraphSvg(linear)).toContain(`width="${layout.width}"`);
+  });
+
   it("never emits its own <defs> — the shared document shell provides glow filter + arrow markers once", () => {
     expect(svg).not.toContain("<defs>");
     expect(svg).toContain('filter="url(#canvas-glow)"');

--- a/packages/harness/src/core/canvas-svg.ts
+++ b/packages/harness/src/core/canvas-svg.ts
@@ -17,8 +17,8 @@ import type { CanvasEdge, CanvasEdgeKind, CanvasGraph, CanvasNode, CanvasNodeKin
 import type { CanvasEnrichment, CanvasLayoutHints } from "./canvas-enrichment.js";
 
 export const NODE_W = 176;
-export const NODE_H = 56;
-const LAYER_GAP = 96;
+export const NODE_H = 64;
+const LAYER_GAP = 72;
 const COL_GAP = 32;
 const MARGIN = 40;
 /** How far a group band extends past its member nodes' boxes. */
@@ -234,9 +234,9 @@ export function renderGraphSvg(graph: CanvasGraph, enrichment?: CanvasEnrichment
       if (!p) return "";
       const details = enrichment?.nodeDetails?.[node.id];
       const sublabel = details?.sublabel ?? node.sublabel;
-      const titleY = sublabel ? 22 : NODE_H / 2;
+      const titleY = sublabel ? 26 : NODE_H / 2;
       const sub = sublabel
-        ? `<text class="canvas-node-sub" x="${NODE_W / 2}" y="40">${esc(sublabel)}</text>`
+        ? `<text class="canvas-node-sub" x="${NODE_W / 2}" y="44">${esc(sublabel)}</text>`
         : "";
       // SVG <title> = native hover tooltip; the only enrichment slot with
       // room for a full sentence.
@@ -252,8 +252,14 @@ export function renderGraphSvg(graph: CanvasGraph, enrichment?: CanvasEnrichment
     })
     .join("\n");
 
+  // Explicit width/height pin the diagram to its NATURAL (1×) size. Without
+  // them, the CSS `width:100%` used to stretch a single-column workflow's
+  // tiny viewBox to fill the pane, ballooning every node and its font (~4×).
+  // The CSS now only centers the svg (`margin: 0 auto`); a graph wider than
+  // the pane keeps full size and scrolls (`.canvas-diagram-panel`'s
+  // overflow-x) rather than shrinking to an illegible size.
   return (
-    `<svg viewBox="0 0 ${layout.width} ${layout.height}" class="canvas-graph-svg">\n` +
+    `<svg viewBox="0 0 ${layout.width} ${layout.height}" width="${layout.width}" height="${layout.height}" class="canvas-graph-svg">\n` +
     (bandMarkup ? bandMarkup + "\n" : "") +
     edgeMarkup +
     "\n" +

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -92,7 +92,12 @@ html, body {
 .canvas-stat-label { font-size: 10px; color: var(--canvas-text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
 .canvas-diagram-panel { overflow-x: auto; }
 .canvas-empty-note { color: var(--canvas-text-dim); font-size: 13px; text-align: center; padding: 60px 20px; margin: 0; }
-.canvas-graph-svg { display: block; width: 100%; height: auto; }
+/* The <svg> carries explicit width/height, so it always renders at its
+   NATURAL (1×) size — a narrow single-column graph can never stretch to fill
+   the pane (the old width:100% did that, ballooning nodes ~4×). Centered when
+   it fits; a graph wider than the pane keeps full size and scrolls via
+   .canvas-diagram-panel's overflow-x, staying legible instead of shrinking. */
+.canvas-graph-svg { display: block; margin: 0 auto; }
 
 /* --- node kinds: entry | step | pause | terminal-success | terminal-warn | launched-workflow --- */
 .canvas-node .canvas-node-rect { fill: var(--canvas-panel); stroke-width: 1.5; stroke: var(--canvas-border-strong); }

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -165,7 +165,7 @@ const ORDER_TRIAGE_CANVAS_BODY = `
     </div>
   </header>
   <div class="canvas-diagram-panel">
-    <svg class="canvas-graph-svg" viewBox="0 0 960 500" xmlns="http://www.w3.org/2000/svg">
+    <svg class="canvas-graph-svg" viewBox="0 0 960 500" width="960" height="500" xmlns="http://www.w3.org/2000/svg">
       <path class="canvas-edge" d="M480,96 L480,150" marker-end="url(#canvas-arrow)" />
       <path class="canvas-edge" d="M480,206 L480,260" marker-end="url(#canvas-arrow)" />
       <path class="canvas-edge canvas-edge--success" d="M480,316 C480,360 288,360 288,410" marker-end="url(#canvas-arrow-success)" />


### PR DESCRIPTION
## Problem

The deterministic workflow diagram renders the right graph, edges, and launch nodes — but a **single-column (linear) workflow looked broken**: one node filled the whole pane, monospace labels ballooned to ~50px, with cavernous empty space and no subtitles.

**Root cause:** `canvas-svg.ts` emitted `<svg viewBox="0 0 W H" class="canvas-graph-svg">` and the CSS was `.canvas-graph-svg { width: 100%; height: auto }`. For a linear graph `maxCols=1` → viewBox width = `MARGIN*2 + NODE_W = 256`. Stretched to a ~1000px pane that's a **~4× upscale**, inflating every node and its 13px font. Wide branching graphs happened to look okay; narrow ones blew up.

## Fix

1. **Stop the upscale (core).** `canvas-svg.ts` now emits explicit `width`/`height` on the `<svg>` so it always renders at its **natural (1×) size**. CSS drops `width: 100%` for `margin: 0 auto` (center only). A narrow graph can no longer stretch; a graph **wider** than the pane keeps full size and **scrolls** via `.canvas-diagram-panel`'s existing `overflow-x` — legible, rather than shrinking illegibly.
2. **Deterministic node subtitles.** `graphFromManifest`/`classifyNode` now populate a `sublabel` on **every** node from its kind/manifest — `entry` / `step` / `pause · <signal>` / `terminal · success` / `terminal · needs attention` / `launched workflow` — so nodes read as titled cards even before AI enrichment. The renderer still prefers an enrichment-supplied sublabel when present.
3. **Density polish.** `NODE_H` 56→64 (two comfortable lines), `LAYER_GAP` 96→72. All styling stays in `themeStyleBlock()` — no second style system.

## Visual proof

Rendered through the real pipeline (`renderWorkflowRenderFile`) and measured in a headless Chromium.

| case | pane | node box (before → after) | title font | behavior |
|---|---|---|---|---|
| `logo-flow` (linear, 2 nodes) | 1000px | **~700px → 178×66px** | ~50px → **13px** | natural, centered ✓ |
| `leasing-triage` (4 nodes + launch) | 1000px | ~700px → **178×66px** | → 13px | natural, dashed launch node + `launch()` edge ✓ |
| synthetic 7-way fan-out (1504px svg) | 700px | → **178×66px** | 13px | **scrolls** (not shrunk to 73px) ✓ |

Each node now shows a **title + subtitle**, teal accent on entry, color-coded terminals, dashed launched-workflow node.

## Verification

`pnpm --filter "@sapiom/mcp..." build` then, in `packages/harness`: typecheck ✓ · unit tests **552 passed** (added specs for sublabel population + natural-width svg) ✓ · `build:server` ✓ · `build:web` ✓ · `sim:e2e` ✓ · `e2e:live` ✓ · `test:ui` **63 passed** ✓ · `test:canvas` **5 passed** ✓. Live checks used `stateRoot`; no real `~/.sapiom/harness` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)