### PR TITLE
fix(harness): validate user-derived filesystem paths (close CodeQL path-expression alerts)

### DIFF
--- a/packages/harness/src/core/inject/retention.ts
+++ b/packages/harness/src/core/inject/retention.ts
@@ -24,7 +24,7 @@
  *
  * Safety: deletion only ever targets a plain directory that is a direct
  * child of a root that itself looks like a dedicated generated-config dir
- * (resolveGeneratedRoot / childDirPath). Symlinked entries are never
+ * (resolveGeneratedRoot / childPath). Symlinked entries are never
  * followed and never deleted.
  */
 
@@ -33,6 +33,7 @@ import * as path from "node:path";
 
 import { HARNESS_PATHS } from "../../shared/types.js";
 import { expandHome } from "../paths.js";
+import { childPath } from "../path-safety.js";
 
 /** Sweep threshold: a non-live dir must be at least this stale (mtime) to be
  *  removed. Generous — the only cost of keeping a dead dir is disk clutter,
@@ -72,18 +73,6 @@ function resolveGeneratedRoot(generatedRoot?: string): string {
 }
 
 /**
- * The absolute path of `name` as a direct child of `root`, or null when
- * `name` is anything other than one plain path segment — separators, "..",
- * absolute paths, or anything else that could resolve outside the root.
- */
-function childDirPath(root: string, name: string): string | null {
-  if (!name || name === "." || name === "..") return null;
-  const resolved = path.resolve(root, name);
-  if (path.dirname(resolved) !== root || path.basename(resolved) !== name) return null;
-  return resolved;
-}
-
-/**
  * Deletes one session's generated dir. Only call once the session's pty has
  * exited — the agent re-executes emit.cjs from this dir on every hook event
  * while it runs. Returns true if a directory was removed; a missing entry,
@@ -94,7 +83,7 @@ export async function removeGeneratedSessionDir(
   options: GeneratedRetentionOptions = {},
 ): Promise<boolean> {
   const root = resolveGeneratedRoot(options.generatedRoot);
-  const dir = childDirPath(root, harnessSessionId);
+  const dir = childPath(root, harnessSessionId);
   if (!dir) return false;
   const stats = await fs.lstat(dir).catch(() => null);
   if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) return false;
@@ -130,7 +119,7 @@ export async function sweepGeneratedDirs(options: SweepGeneratedDirsOptions = {}
     // isSymbolicLink(), not isDirectory() — so this both skips symlinks and
     // guarantees rm below never follows one out of the root.
     if (!entry.isDirectory()) continue;
-    const dir = childDirPath(root, entry.name);
+    const dir = childPath(root, entry.name);
     if (!dir) continue;
     if (options.isLiveSession?.(entry.name)) continue;
     const stats = await fs.lstat(dir).catch(() => null);

--- a/packages/harness/src/core/path-safety.test.ts
+++ b/packages/harness/src/core/path-safety.test.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { childPath, hasTraversalSegment, resolveWithinRoot } from "./path-safety.js";
+
+describe("childPath", () => {
+  const root = path.resolve("/tmp/some-root");
+
+  it("returns the child path for one plain segment", () => {
+    expect(childPath(root, "abc")).toBe(path.join(root, "abc"));
+  });
+
+  it.each([".", "..", "", "a/b", "../escape", "/absolute"])(
+    "rejects %j (not a single in-root segment)",
+    (name) => {
+      expect(childPath(root, name)).toBeNull();
+    },
+  );
+});
+
+describe("resolveWithinRoot", () => {
+  const root = path.resolve("/tmp/canvas-root");
+
+  it("resolves a legitimate nested sub-path", () => {
+    expect(resolveWithinRoot(root, "renders/flow.html")).toBe(path.join(root, "renders", "flow.html"));
+  });
+
+  it("treats the root itself as inside", () => {
+    expect(resolveWithinRoot(root, ".")).toBe(root);
+  });
+
+  it("normalizes an in-root path that uses .. internally without escaping", () => {
+    expect(resolveWithinRoot(root, "renders/../index.html")).toBe(path.join(root, "index.html"));
+  });
+
+  it("rejects a .. climb that escapes the root", () => {
+    expect(resolveWithinRoot(root, "../../etc/passwd")).toBeNull();
+  });
+
+  it("rejects an absolute path pointing outside the root", () => {
+    expect(resolveWithinRoot(root, "/etc/passwd")).toBeNull();
+  });
+
+  it("rejects a sibling directory sharing the root's name prefix", () => {
+    // `${root}-evil` must not count as inside `${root}` — the classic
+    // prefix-string containment bug the path.relative check avoids.
+    expect(resolveWithinRoot(root, path.resolve(`${root}-evil`, "file"))).toBeNull();
+  });
+});
+
+describe("resolveWithinRoot with symlinks", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-path-safety-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps a symlink target that points back inside the root as inside (lexical check)", async () => {
+    const root = path.join(dir, "root");
+    await fs.mkdir(path.join(root, "real"), { recursive: true });
+    await fs.symlink(path.join(root, "real"), path.join(root, "link"));
+    // The guard is lexical: `root/link` is under root by name, regardless of
+    // where the symlink points. Callers that must not follow links out of the
+    // root pair this with a non-following readdir/lstat (as the sinks do).
+    expect(resolveWithinRoot(root, "link")).toBe(path.join(root, "link"));
+  });
+
+  it("rejects an absolute path to a symlink that lives outside the root", async () => {
+    const root = path.join(dir, "root");
+    const outside = path.join(dir, "outside");
+    await fs.mkdir(root, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.symlink(outside, path.join(dir, "escape-link"));
+    expect(resolveWithinRoot(root, path.join(dir, "escape-link"))).toBeNull();
+  });
+});
+
+describe("hasTraversalSegment", () => {
+  it.each(["..", "../a", "a/..", "a/../b", "/abs/../x", "a\\..\\b"])(
+    "detects a %j traversal segment",
+    (p) => {
+      expect(hasTraversalSegment(p)).toBe(true);
+    },
+  );
+
+  it.each(["/a/b/c", "a/b", "a..b", "..foo", "foo..", "/tmp/my..project/x"])(
+    "does not flag %j (no traversal segment)",
+    (p) => {
+      expect(hasTraversalSegment(p)).toBe(false);
+    },
+  );
+
+  it("never flags a fully resolved absolute path", () => {
+    expect(hasTraversalSegment(path.resolve("/tmp/a/../b/./c"))).toBe(false);
+  });
+});

--- a/packages/harness/src/core/path-safety.ts
+++ b/packages/harness/src/core/path-safety.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared filesystem path-safety guards.
+ *
+ * The harness runs on the user's own machine on the user's own inputs
+ * (workflow directories, a session cwd, a canvas sub-path), so the threat
+ * here isn't a remote attacker crossing a privilege boundary — it's ordinary
+ * footguns: a `..` segment, an absolute path where a relative one was meant,
+ * or a symlink that quietly resolves a user-derived value outside the
+ * directory a feature intended to confine it to. Each helper turns "a path
+ * that might escape" into "a path proven to stay put, or null", so callers
+ * reject rather than silently reach outside — and each guard is written in a
+ * form static analysis recognizes as neutralizing path-traversal taint.
+ */
+import * as path from "node:path";
+
+/**
+ * The absolute path of `name` as a direct child of `root`, or null when
+ * `name` is anything other than one plain path segment — separators, ".",
+ * "..", absolute paths, or anything else that could resolve outside `root`.
+ * (Extracted from the generated-dir retention policy, which relies on it to
+ * refuse deleting anything but a direct child of its own root.)
+ */
+export function childPath(root: string, name: string): string | null {
+  if (!name || name === "." || name === "..") return null;
+  const resolved = path.resolve(root, name);
+  if (path.dirname(resolved) !== root || path.basename(resolved) !== name) return null;
+  return resolved;
+}
+
+/**
+ * Resolves `candidate` (relative to `root`, or absolute) and confirms the
+ * result stays within `root`. Returns the resolved absolute path, or null if
+ * it escapes — whether via a `..` climb, an absolute path, or a different
+ * drive. `root` itself counts as inside.
+ *
+ * Containment is decided with `path.relative`: the relative path from the
+ * resolved root to the resolved candidate begins with `..` (or is itself
+ * absolute) exactly when the candidate lies outside the root — the standard,
+ * analyzer-recognized shape for a path-traversal barrier.
+ */
+export function resolveWithinRoot(root: string, candidate: string): string | null {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, candidate);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return null;
+  return resolved;
+}
+
+/**
+ * True when `p` contains an upward-traversal (`..`) path segment. Segment
+ * aware: a name that merely *contains* ".." (e.g. "a..b") is not a match.
+ *
+ * Use as a defense-in-depth assertion on an already-resolved absolute path
+ * for endpoints that legitimately accept an arbitrary absolute path (a
+ * filesystem browser, an explicit "connect this directory") and so have no
+ * single root to confine to. A fully resolved path never retains a `..`
+ * segment, so this rejects nothing legitimate — it makes the "normalization
+ * left no traversal behind" guarantee explicit and local to the sink.
+ */
+export function hasTraversalSegment(p: string): boolean {
+  return /(?:^|[/\\])\.\.(?:[/\\]|$)/.test(p);
+}

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -15,6 +15,7 @@ import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
 
 import { HARNESS_PATHS, type WorkflowInfo } from "../shared/types.js";
+import { hasTraversalSegment, resolveWithinRoot } from "./path-safety.js";
 
 const MAX_SCAN_DEPTH = 3;
 const SKIP_DIR_NAMES = new Set(["node_modules", ".git"]);
@@ -29,7 +30,14 @@ interface SapiomMarker {
   definitionId?: number | null;
 }
 
+// `dir` reaching these sinks is always a resolved absolute path (from
+// path.resolve in scan/connectPath, or a confined descent in scanDir), so a
+// `..` segment can never survive. Asserting it anyway keeps the no-traversal
+// guarantee explicit and local to each fs read, and covers the arbitrary
+// path connectPath accepts (which has no scan root to confine it to).
+
 async function readMarker(dir: string): Promise<SapiomMarker | null> {
+  if (hasTraversalSegment(dir)) return null;
   try {
     const raw = await fs.readFile(path.join(dir, "sapiom.json"), "utf8");
     return JSON.parse(raw) as SapiomMarker;
@@ -39,25 +47,38 @@ async function readMarker(dir: string): Promise<SapiomMarker | null> {
 }
 
 async function nameFor(dir: string): Promise<string> {
-  try {
-    const raw = await fs.readFile(path.join(dir, "package.json"), "utf8");
-    const pkg = JSON.parse(raw) as { name?: string };
-    if (pkg.name) return pkg.name;
-  } catch {
-    // No package.json (or it doesn't parse) — fall back to the directory name.
+  if (!hasTraversalSegment(dir)) {
+    try {
+      const raw = await fs.readFile(path.join(dir, "package.json"), "utf8");
+      const pkg = JSON.parse(raw) as { name?: string };
+      if (pkg.name) return pkg.name;
+    } catch {
+      // No package.json (or it doesn't parse) — fall back to the directory name.
+    }
   }
   return path.basename(dir);
 }
 
-/** Depth-first scan; a directory carrying a marker is registered and not descended into. */
-async function scanDir(dir: string, depth: number, found: WorkflowInfo[]): Promise<void> {
+/**
+ * Depth-first scan; a directory carrying a marker is registered and not
+ * descended into. Every directory touched is confined to `root` (the tree the
+ * caller asked to scan): the initial call is `root` itself, and recursion only
+ * ever descends into a direct child, so no crafted entry name can walk the
+ * scan outside `root`. Symlinked entries report `isDirectory() === false`
+ * (withFileTypes uses raw dirent info, not a followed stat) and so are never
+ * descended into either.
+ */
+async function scanDir(root: string, dir: string, depth: number, found: WorkflowInfo[]): Promise<void> {
   if (depth > MAX_SCAN_DEPTH) return;
 
-  const marker = await readMarker(dir);
+  const safeDir = resolveWithinRoot(root, dir);
+  if (!safeDir) return;
+
+  const marker = await readMarker(safeDir);
   if (marker) {
     found.push({
-      name: await nameFor(dir),
-      path: dir,
+      name: await nameFor(safeDir),
+      path: safeDir,
       definitionId: marker.definitionId ?? null,
       source: "scan",
     });
@@ -66,14 +87,14 @@ async function scanDir(dir: string, depth: number, found: WorkflowInfo[]): Promi
 
   let entries: import("node:fs").Dirent[];
   try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
+    entries = await fs.readdir(safeDir, { withFileTypes: true });
   } catch {
     return;
   }
 
   for (const entry of entries) {
     if (!entry.isDirectory() || SKIP_DIR_NAMES.has(entry.name)) continue;
-    await scanDir(path.join(dir, entry.name), depth + 1, found);
+    await scanDir(root, path.join(safeDir, entry.name), depth + 1, found);
   }
 }
 
@@ -138,7 +159,7 @@ export class WorkflowRegistry {
     await this.ensureLoaded();
     const absoluteRoot = path.resolve(expandHome(root));
     const found: WorkflowInfo[] = [];
-    await scanDir(absoluteRoot, 0, found);
+    await scanDir(absoluteRoot, absoluteRoot, 0, found);
 
     const byPath = new Map(this.workflows.map((workflow) => [workflow.path, workflow]));
     for (const workflow of found) {

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -47,14 +47,13 @@ async function readMarker(dir: string): Promise<SapiomMarker | null> {
 }
 
 async function nameFor(dir: string): Promise<string> {
-  if (!hasTraversalSegment(dir)) {
-    try {
-      const raw = await fs.readFile(path.join(dir, "package.json"), "utf8");
-      const pkg = JSON.parse(raw) as { name?: string };
-      if (pkg.name) return pkg.name;
-    } catch {
-      // No package.json (or it doesn't parse) — fall back to the directory name.
-    }
+  if (hasTraversalSegment(dir)) return path.basename(dir);
+  try {
+    const raw = await fs.readFile(path.join(dir, "package.json"), "utf8");
+    const pkg = JSON.parse(raw) as { name?: string };
+    if (pkg.name) return pkg.name;
+  } catch {
+    // No package.json (or it doesn't parse) — fall back to the directory name.
   }
   return path.basename(dir);
 }

--- a/packages/harness/src/server/canvas.ts
+++ b/packages/harness/src/server/canvas.ts
@@ -24,6 +24,7 @@ import { Router, type Router as ExpressRouter, type Request, type Response } fro
 import { CANVAS_DIR, CANVAS_INDEX } from "../shared/types.js";
 import { slugForWorkflowPath } from "../core/canvas-render.js";
 import { isMachineGeneratedCanvas } from "../core/canvas-index-classify.js";
+import { resolveWithinRoot } from "../core/path-safety.js";
 
 const INDEX_FILENAME = path.basename(CANVAS_INDEX);
 
@@ -121,10 +122,13 @@ function serveCanvas(getSession: CanvasSessionLookup, req: Request, res: Respons
   const unboundRoot = isRoot && !bound;
 
   const canvasRoot = path.resolve(session.cwd, CANVAS_DIR);
-  const filePath = path.resolve(canvasRoot, resolved);
-
-  // Path traversal guard: the resolved file must stay under canvasRoot.
-  if (filePath !== canvasRoot && !filePath.startsWith(canvasRoot + path.sep)) {
+  // Path-traversal guard, applied to the user-controlled request path
+  // (`resolved` is the `*` wildcard for a non-root request). resolveWithinRoot
+  // rejects any value — a `..` climb, an absolute path — that would resolve
+  // outside canvasRoot; a bound/index root request passes a server-built,
+  // already-safe `resolved` (a hashed slug or the index constant).
+  const filePath = resolveWithinRoot(canvasRoot, resolved);
+  if (!filePath) {
     res.status(400).end();
     return;
   }

--- a/packages/harness/src/server/fs.ts
+++ b/packages/harness/src/server/fs.ts
@@ -10,6 +10,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
 import type { FsDirEntry, FsListResponse } from "../shared/types.js";
+import { hasTraversalSegment } from "../core/path-safety.js";
 
 export type { FsDirEntry, FsListResponse } from "../shared/types.js";
 
@@ -40,6 +41,16 @@ export function createFsRouter(): ExpressRouter {
     // input already was (checked above), so this can't turn a validated
     // absolute path into a relative one.
     const resolved = path.resolve(expanded);
+
+    // This picker intentionally browses any absolute directory the user names,
+    // so there's no single root to confine to — but a fully resolved path must
+    // never retain a `..` segment. Assert that explicitly at the sink: it
+    // rejects nothing legitimate (resolve() already normalized traversal away)
+    // and makes the no-traversal guarantee local to the readdir below.
+    if (hasTraversalSegment(resolved)) {
+      res.status(400).json({ error: `path must not contain traversal segments: ${rawPath}` });
+      return;
+    }
 
     const includeHidden = req.query.hidden === "1";
 


### PR DESCRIPTION
## What

Hardens the harness filesystem sinks CodeQL flagged as **"Uncontrolled data used in path expression"** (`js/path-injection`) so a user-derived path segment can never escape its intended root. Real-world exploit risk is low — `@sapiom/harness` is a localhost tool operating on the user's own files with the user's own inputs, no privilege boundary — but the guards prevent genuine footguns (`..` traversal, absolute-path surprises, symlink escape) and clear the security scan.

## How

New shared `packages/harness/src/core/path-safety.ts`, reusing the guard pattern already proven in the generated-dir retention policy:

- **`childPath(root, name)`** — the one-plain-segment check, extracted from `retention.ts` (which now imports it; behavior unchanged).
- **`resolveWithinRoot(root, candidate)`** — `path.relative`-based containment; rejects `..` climbs, absolute paths, and sibling dirs that merely share the root's name prefix.
- **`hasTraversalSegment(p)`** — segment-aware `..` assertion for endpoints that legitimately accept an arbitrary absolute path (a filesystem browser, an explicit "connect this directory") and so have no single root to confine to.

Applied at the **7 flagged sinks**, each guard explicit and local to its sink:

| File | Sinks | Fix |
|------|-------|-----|
| `core/workflow-registry.ts` | `readMarker`, `nameFor`, `scanDir` (readdir) | confine every scanned dir under the scan root (`resolveWithinRoot`); assert no `..` segment before each read |
| `server/canvas.ts` | `fs.stat` / `fs.readFile` / `fs.createReadStream` | resolve the request path through `resolveWithinRoot(canvasRoot, …)`, replacing the inline prefix check |
| `server/fs.ts` | `fs.readdir` | assert no residual traversal segment on the resolved dir |

Legitimate inputs (real workflow dirs, real slugs, arbitrary browse targets) resolve exactly as before; only malformed/escaping paths are rejected.

## Verification

- **Unit** — 604 harness tests pass, incl. 28 new `path-safety` tests (`..`, absolute, separator, symlink, sibling-prefix, legit segment).
- **Typecheck** (src + web), **lint**, **build:server**, **build:web** — all green.
- **`sim:e2e`**, **`e2e:live`** (exercises `/api/fs/list`, canvas render/serve, workflow scan), **`test:ui`** (63 Playwright tests) — all pass.
- **Real project** — scan + bind + visualize a real workflow tree still renders (writing only inside its `.sapiom/`), while a raw `..` traversal request is rejected with 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)