### PR TITLE
feat(cli): emit command.run usage analytics via analytics-core

### DIFF
--- a/.changeset/cli-command-run-analytics.md
+++ b/.changeset/cli-command-run-analytics.md
@@ -1,0 +1,19 @@
+---
+"@sapiom/cli": minor
+---
+
+Emit anonymous `command.run` usage analytics via `@sapiom/analytics-core`.
+
+- One `command.run` event per executed command (commander `preAction`/`postAction`
+  hooks), carrying the command path (e.g. `agents deploy`), the names of the
+  flags used — never their values or positional arguments — the duration, and
+  the exit status. Tokens and emails never reach event payloads; a signed-in
+  credential (from `SAPIOM_API_KEY` or the stored session) is only attached as
+  a delivery header for server-side identity enrichment.
+- Ships dark: without an explicitly configured collector endpoint the emitter
+  is a silent no-op — zero network calls, zero disk writes, no notice. When
+  enabled, analytics-core's one-time first-run notice explains the collection
+  and the opt-outs (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`).
+- Zero behavior change: enqueue-only delivery (best-effort flush on process
+  exit), identical command output and exit codes, and no new required
+  configuration.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,3 +31,14 @@ sapiom agents schedule cancel <scheduleId>
 
 Run `sapiom agents --help` for the full command set. Every command accepts
 `--json` for machine-readable output.
+
+## Usage analytics
+
+The CLI can emit anonymous usage events through
+[`@sapiom/analytics-core`](https://github.com/sapiom/sapiom-js/tree/main/packages/analytics-core):
+one `command.run` event per executed command, carrying the command name, the
+names of the flags used (never their values or arguments), the duration, and
+the exit status. Nothing is sent unless a collector endpoint is explicitly
+configured, and delivery is best-effort in the background — analytics can
+never slow down or fail a command. Opt out at any time with
+`SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,8 @@ The CLI can emit anonymous usage events through
 [`@sapiom/analytics-core`](https://github.com/sapiom/sapiom-js/tree/main/packages/analytics-core):
 one `command.run` event per executed command, carrying the command name, the
 names of the flags used (never their values or arguments), the duration, and
-the exit status. Nothing is sent unless a collector endpoint is explicitly
-configured, and delivery is best-effort in the background — analytics can
-never slow down or fail a command. Opt out at any time with
-`SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
+the exit status. Nothing is currently sent anywhere. When delivery is
+enabled, it is best-effort and can never fail a command: it never slows
+command execution, and on exit a final flush is bounded by the emitter's
+5-second request timeout — retries never hold the process open. Opt out at
+any time with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   testEnvironment: 'node',
   passWithNoTests: true,
+  // Builds this package (and missing workspace deps) so the analytics e2e
+  // suite always runs the current dist/bin.js.
+  globalSetup: '<rootDir>/jest.global-setup.cjs',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/cli/jest.global-setup.cjs
+++ b/packages/cli/jest.global-setup.cjs
@@ -1,0 +1,25 @@
+/**
+ * The analytics suites need built artifacts before test files load: the unit
+ * suite imports @sapiom/analytics-core, and the e2e suite runs the BUILT CLI
+ * (dist/bin.js) against a mock collector.
+ *
+ * CI builds before testing, so the common case is a fast rebuild of this
+ * package only (keeping dist/bin.js in sync with src for the e2e); a bare
+ * `pnpm test` on a fresh clone triggers the full dependency build instead.
+ */
+const { execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const path = require('node:path');
+
+module.exports = function globalSetup() {
+  const packageRoot = __dirname;
+  const dependencyArtifacts = [
+    path.join('@sapiom', 'analytics-core', 'dist', 'cjs', 'index.js'),
+    path.join('@sapiom', 'analytics-core', 'dist', 'esm', 'index.js'),
+    path.join('@sapiom', 'agent-core', 'dist', 'esm', 'index.js'),
+  ].map((artifact) => path.join(packageRoot, 'node_modules', artifact));
+
+  const dependenciesMissing = dependencyArtifacts.some((artifact) => !existsSync(artifact));
+  const filter = dependenciesMissing ? '@sapiom/cli...' : '@sapiom/cli';
+  execFileSync('pnpm', ['--filter', filter, 'build'], { cwd: packageRoot, stdio: 'inherit' });
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@sapiom/agent": "workspace:^",
     "@sapiom/agent-core": "workspace:^",
+    "@sapiom/analytics-core": "workspace:^",
     "commander": "^14.0.2",
     "zod": "^3.25.76"
   },

--- a/packages/cli/src/__tests__/command-analytics.e2e.test.ts
+++ b/packages/cli/src/__tests__/command-analytics.e2e.test.ts
@@ -327,4 +327,31 @@ describe('command.run analytics (built CLI against a mock collector)', () => {
     expect(serverError.code).toBe(0);
     expect(serverError.stdout).toBe(baseline.stdout);
   }, 40_000);
+
+  it('a slow collector delays exit boundedly and never changes command output', async () => {
+    const args = ['config', 'set-target', 'local', '--json'];
+    const baseline = await runCli(args, cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
+    expect(baseline.code).toBe(0);
+
+    // Respond only after 8s — past the sender's 5s per-attempt timeout — so
+    // the exit flush runs its worst case: one timed-out delivery attempt.
+    collector.reset();
+    collector.setMode({ kind: 'slow', delayMs: 8_000 });
+
+    const startedAt = Date.now();
+    const slow = await runCli(args, cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
+    const wallMs = Date.now() - startedAt;
+
+    expect(slow.code).toBe(0);
+    expect(slow.stdout).toBe(baseline.stdout);
+    // The exit flush genuinely waits through the timed-out attempt (measured
+    // ≈5.1s locally: 5s request timeout + process startup)…
+    expect(wallMs).toBeGreaterThan(4_500);
+    // …but exit latency stays bounded — generous ceiling to absorb CI noise.
+    expect(wallMs).toBeLessThan(12_000);
+    // Exactly one attempt reaches the wire: after it times out, the retry
+    // backoff timer is unref'd inside analytics-core, so it cannot hold the
+    // exiting process open — the batch is dropped instead of retried.
+    expect(collector.requests).toHaveLength(1);
+  }, 45_000);
 });

--- a/packages/cli/src/__tests__/command-analytics.e2e.test.ts
+++ b/packages/cli/src/__tests__/command-analytics.e2e.test.ts
@@ -1,0 +1,330 @@
+/**
+ * End-to-end analytics tests: run the BUILT CLI (dist/bin.js) as a real
+ * subprocess against an in-process mock collector and assert what actually
+ * crosses the wire — envelopes, consent, the first-run notice, identity
+ * placement (header, never payload), and fault tolerance.
+ *
+ * Built artifacts are guaranteed by jest.global-setup.cjs. Every run gets a
+ * fresh temp HOME so machine identity, config, and credentials are isolated.
+ */
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { FIRST_RUN_NOTICE } from '@sapiom/analytics-core';
+import { startMockCollector, type MockCollector } from '@sapiom/analytics-core/testing';
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..', '..');
+const BIN = path.join(PACKAGE_ROOT, 'dist', 'bin.js');
+const CLI_VERSION = (
+  JSON.parse(readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8')) as { version: string }
+).version;
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Run the built CLI. Async so the in-process mock collector can respond. */
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    execFile(process.execPath, [BIN, ...args], { env, timeout: 20_000 }, (error, stdout, stderr) => {
+      if (error && (error.killed || typeof error.code !== 'number')) {
+        // Spawn failure or hang — not a CLI exit; fail loudly.
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr, code: error ? (error.code as number) : 0 });
+    });
+  });
+}
+
+/** A throwaway HOME so identity, config, and credentials never touch the real machine. */
+function freshHome(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'sapiom-cli-analytics-e2e-'));
+}
+
+/**
+ * A hermetic environment for one CLI run: every SAPIOM_* variable and
+ * consent flag from the host is stripped, HOME/XDG point into the temp dir.
+ */
+function cliEnv(home: string, overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith('SAPIOM_') || key === 'DO_NOT_TRACK' || key === 'NODE_OPTIONS') continue;
+    env[key] = value;
+  }
+  env.HOME = home;
+  env.USERPROFILE = home;
+  env.XDG_CONFIG_HOME = path.join(home, 'xdg');
+  return { ...env, ...overrides };
+}
+
+const settle = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('command.run analytics (built CLI against a mock collector)', () => {
+  let collector: MockCollector;
+
+  beforeAll(async () => {
+    expect(existsSync(BIN)).toBe(true);
+    collector = await startMockCollector();
+  });
+
+  beforeEach(() => {
+    collector.reset();
+  });
+
+  afterAll(async () => {
+    await collector.close();
+  });
+
+  it('emits one command.run envelope with command path, flag names, duration, and exit status', async () => {
+    const home = freshHome();
+    const result = await runCli(
+      ['config', 'set-target', 'staging', '--json'],
+      cliEnv(home, { SAPIOM_ANALYTICS_ENDPOINT: collector.url }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ ok: true, target: 'staging' });
+
+    await collector.waitForRequests(1);
+    const events = collector.events();
+    expect(events).toHaveLength(1);
+
+    const envelope = events[0];
+    expect(envelope.event_type).toBe('command.run');
+    expect(envelope.source).toBe('cli');
+    expect(envelope.sdk_name).toBe('@sapiom/cli');
+    expect(envelope.sdk_version).toBe(CLI_VERSION);
+    expect(envelope.schema_version).toBe('1');
+    expect(typeof envelope.anonymous_id).toBe('string');
+    expect(typeof envelope.session_id).toBe('string');
+    expect(envelope.user_id).toBeUndefined();
+
+    expect(Object.keys(envelope.data).sort()).toEqual(['command', 'duration_ms', 'exit_code', 'flags']);
+    expect(envelope.data.command).toBe('config set-target');
+    expect(envelope.data.flags).toEqual(['--json']);
+    expect(typeof envelope.data.duration_ms).toBe('number');
+    expect(envelope.data.exit_code).toBe(0);
+
+    // The positional value never reaches the wire in any form.
+    expect(collector.requests[0].rawBody).not.toContain('staging');
+  }, 20_000);
+
+  it('reports the real exit code on failure and never the offending value', async () => {
+    const home = freshHome();
+    const result = await runCli(
+      ['config', 'set-target', 'bogus-target-e2e-value'],
+      cliEnv(home, { SAPIOM_ANALYTICS_ENDPOINT: collector.url }),
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Unknown target');
+
+    await collector.waitForRequests(1);
+    const [envelope] = collector.events();
+    expect(envelope.data.command).toBe('config set-target');
+    expect(envelope.data.exit_code).toBe(1);
+    expect(envelope.data.flags).toEqual([]);
+    expect(collector.requests[0].rawBody).not.toContain('bogus-target-e2e-value');
+  }, 20_000);
+
+  it('login: tokens, codes, and org identifiers never reach the payload; identity travels as a header', async () => {
+    const ACCESS_TOKEN = 'sk_e2e_login_secret_token';
+    const DEVICE_CODE = 'e2e-device-code-secret';
+    const USER_CODE = 'WXYZ-1234';
+    const ORG_MARKER = 'e2e-org-user@example.com';
+
+    // Minimal RFC 8628 stub that approves on the first poll. The verification
+    // URL is deliberately non-https so the CLI's browser-opening guard skips it.
+    const authServer = http.createServer((request, response) => {
+      request.on('data', () => {});
+      request.on('end', () => {
+        response.setHeader('content-type', 'application/json');
+        if (request.url === '/auth/device') {
+          response.end(
+            JSON.stringify({
+              device_code: DEVICE_CODE,
+              user_code: USER_CODE,
+              verification_uri: 'http://127.0.0.1/activate',
+              verification_uri_complete: `http://127.0.0.1/activate?code=${USER_CODE}`,
+              expires_in: 60,
+              interval: 1,
+            }),
+          );
+        } else if (request.url === '/auth/device/token') {
+          response.end(
+            JSON.stringify({
+              access_token: ACCESS_TOKEN,
+              token_type: 'bearer',
+              tenant_id: 'e2e-tenant',
+              organization_name: ORG_MARKER,
+            }),
+          );
+        } else {
+          response.statusCode = 404;
+          response.end('{}');
+        }
+      });
+    });
+    await new Promise<void>((resolve) => authServer.listen(0, '127.0.0.1', resolve));
+    const { port } = authServer.address() as AddressInfo;
+
+    try {
+      const home = freshHome();
+      const env = cliEnv(home, {
+        SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+        SAPIOM_API_HOST: `http://127.0.0.1:${port}`,
+      });
+      const result = await runCli(['login', '--json'], env);
+
+      expect(result.code).toBe(0);
+      // Sanity: the flow really completed and stored the credential.
+      const credentials = readFileSync(path.join(home, 'xdg', 'sapiom', 'credentials.json'), 'utf8');
+      expect(credentials).toContain(ACCESS_TOKEN);
+
+      await collector.waitForRequests(1);
+      const [envelope] = collector.events();
+      expect(envelope.data.command).toBe('login');
+      expect(envelope.data.exit_code).toBe(0);
+      expect(envelope.data.flags).toEqual(['--json']);
+
+      for (const request of collector.requests) {
+        expect(request.rawBody).not.toContain(ACCESS_TOKEN);
+        expect(request.rawBody).not.toContain(DEVICE_CODE);
+        expect(request.rawBody).not.toContain(USER_CODE);
+        expect(request.rawBody).not.toContain(ORG_MARKER);
+      }
+      // The credential enriches server-side identity as a header, never as payload.
+      expect(collector.requests[0].headers['x-sapiom-api-key']).toBe(ACCESS_TOKEN);
+    } finally {
+      await new Promise<void>((resolve) => authServer.close(() => resolve()));
+    }
+  }, 30_000);
+
+  it('SAPIOM_API_KEY and stored credentials enrich the header but never the payload', async () => {
+    const ENV_KEY = 'sk_e2e_env_key_secret';
+    const STORED_KEY = 'sk_e2e_stored_credential_secret';
+
+    const home = freshHome();
+    const sapiomConfigDir = path.join(home, 'xdg', 'sapiom');
+    mkdirSync(sapiomConfigDir, { recursive: true });
+    writeFileSync(
+      path.join(sapiomConfigDir, 'credentials.json'),
+      JSON.stringify({ profiles: { default: { apiKey: STORED_KEY } } }),
+    );
+
+    const result = await runCli(
+      ['logout', '--json'],
+      cliEnv(home, { SAPIOM_ANALYTICS_ENDPOINT: collector.url, SAPIOM_API_KEY: ENV_KEY }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ ok: true, cleared: true });
+
+    await collector.waitForRequests(1);
+    expect(collector.events()[0].data.command).toBe('logout');
+    expect(collector.requests[0].headers['x-sapiom-api-key']).toBe(ENV_KEY);
+    for (const request of collector.requests) {
+      expect(request.rawBody).not.toContain(ENV_KEY);
+      expect(request.rawBody).not.toContain(STORED_KEY);
+    }
+  }, 20_000);
+
+  it('SAPIOM_TELEMETRY_DISABLED=1 and DO_NOT_TRACK=1 send nothing, with identical command output', async () => {
+    const enabled = await runCli(
+      ['logout', '--json'],
+      cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }),
+    );
+    await collector.waitForRequests(1);
+    expect(collector.requests).toHaveLength(1);
+
+    collector.reset();
+    const optedOut = await runCli(
+      ['logout', '--json'],
+      cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url, SAPIOM_TELEMETRY_DISABLED: '1' }),
+    );
+    const doNotTrack = await runCli(
+      ['logout', '--json'],
+      cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url, DO_NOT_TRACK: '1' }),
+    );
+    await settle(250);
+
+    expect(collector.requests).toHaveLength(0);
+    expect(optedOut.code).toBe(0);
+    expect(doNotTrack.code).toBe(0);
+    expect(optedOut.stdout).toBe(enabled.stdout);
+    expect(doNotTrack.stdout).toBe(enabled.stdout);
+    expect(optedOut.stderr).toBe('');
+  }, 30_000);
+
+  it('ships dark: without an endpoint nothing is sent, written, or printed', async () => {
+    const home = freshHome();
+    const result = await runCli(['logout', '--json'], cliEnv(home));
+    await settle(250);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ ok: true, cleared: false });
+    expect(result.stderr).toBe('');
+    expect(collector.requests).toHaveLength(0);
+    // No identity file, no first-run marker — zero disk writes.
+    expect(existsSync(path.join(home, '.sapiom', 'analytics.json'))).toBe(false);
+  }, 20_000);
+
+  it('prints the first-run notice exactly once per machine and stamps the marker', async () => {
+    const home = freshHome();
+    const env = cliEnv(home, { SAPIOM_ANALYTICS_ENDPOINT: collector.url });
+
+    const first = await runCli(['logout', '--json'], env);
+    expect(first.stderr).toContain(FIRST_RUN_NOTICE);
+
+    const identity = JSON.parse(readFileSync(path.join(home, '.sapiom', 'analytics.json'), 'utf8')) as {
+      anonymous_id: string;
+      first_run_notice_at: string | null;
+    };
+    expect(typeof identity.anonymous_id).toBe('string');
+    expect(typeof identity.first_run_notice_at).toBe('string');
+
+    const second = await runCli(['logout', '--json'], env);
+    expect(second.stderr).not.toContain(FIRST_RUN_NOTICE);
+
+    await collector.waitForRequests(2);
+    expect(collector.events()).toHaveLength(2);
+    // Same machine identity across runs, distinct sessions.
+    const [a, b] = collector.events();
+    expect(a.anonymous_id).toBe(b.anonymous_id);
+    expect(a.session_id).not.toBe(b.session_id);
+  }, 30_000);
+
+  it('collector faults never change command output or exit code', async () => {
+    const args = ['config', 'set-target', 'local', '--json'];
+    const baseline = await runCli(args, cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
+    expect(baseline.code).toBe(0);
+
+    // The collector kills every connection before responding.
+    collector.setMode({ kind: 'down' });
+    const whileDown = await runCli(args, cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
+    expect(whileDown.code).toBe(0);
+    expect(whileDown.stdout).toBe(baseline.stdout);
+
+    // Nothing is listening at all (connection refused).
+    collector.setMode({ kind: 'ok' });
+    const refused = await runCli(
+      args,
+      cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: 'http://127.0.0.1:9/v1/analytics/collector' }),
+    );
+    expect(refused.code).toBe(0);
+    expect(refused.stdout).toBe(baseline.stdout);
+
+    // The collector responds with a server error.
+    collector.setMode({ kind: 'status', status: 500 });
+    const serverError = await runCli(args, cliEnv(freshHome(), { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
+    expect(serverError.code).toBe(0);
+    expect(serverError.stdout).toBe(baseline.stdout);
+  }, 40_000);
+});

--- a/packages/cli/src/__tests__/command-analytics.test.ts
+++ b/packages/cli/src/__tests__/command-analytics.test.ts
@@ -49,7 +49,11 @@ function buildTestProgram(
 
   json(program.command('login').description('top-level command')).action(action(act));
 
-  const group = program.command('things').alias('th').description('nested group');
+  const group = program
+    .command('things')
+    .alias('th')
+    .description('nested group')
+    .option('--level <n>', 'group-level option');
   json(
     group
       .command('push [dir]')
@@ -114,8 +118,21 @@ describe('command.run analytics hooks', () => {
     const { tracker, events } = recordingTracker();
     await buildTestProgram(tracker).parseAsync(['things', 'push'], { from: 'user' });
 
-    // --branch has a default of 'main' but was not passed.
+    // --branch has a default of 'main' but was not passed; the group-level
+    // --level was not passed either.
     expect(events[0].data.flags).toEqual([]);
+  });
+
+  it('captures group-level flags passed before the subcommand — names only, root-to-leaf order', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(
+      ['things', '--level', 'secret-level-value', 'push', '--json'],
+      { from: 'user' },
+    );
+
+    expect(events[0].data.command).toBe('things push');
+    expect(events[0].data.flags).toEqual(['--level', '--json']);
+    expect(JSON.stringify(events[0].data)).not.toContain('secret-level-value');
   });
 
   it('resolves group aliases to their canonical command path', async () => {

--- a/packages/cli/src/__tests__/command-analytics.test.ts
+++ b/packages/cli/src/__tests__/command-analytics.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the `command.run` analytics hooks: command-path resolution,
+ * flag-name extraction (names only — never values), duration/exit capture,
+ * and the guarantee that analytics can never affect a command.
+ *
+ * These run the hooks in-process against a synthetic program wired with the
+ * same `action()`/`json()` helpers as the real CLI; the real built binary is
+ * covered end-to-end in command-analytics.e2e.test.ts.
+ */
+import { Command } from 'commander';
+
+import { action, json } from '../commands/shared.js';
+import {
+  commandPath,
+  registerCommandAnalytics,
+  specifiedFlagNames,
+  type CommandRunTracker,
+} from '../lib/analytics.js';
+import { CliError } from '../lib/output.js';
+
+interface TrackedEvent {
+  eventType: string;
+  data: Record<string, unknown>;
+}
+
+function recordingTracker(): { tracker: CommandRunTracker; events: TrackedEvent[] } {
+  const events: TrackedEvent[] = [];
+  return {
+    events,
+    tracker: {
+      track(eventType: string, data?: Record<string, unknown>) {
+        events.push({ eventType, data: data ?? {} });
+      },
+    },
+  };
+}
+
+/**
+ * A miniature program mirroring the real CLI's wiring: a root program with
+ * analytics hooks, a nested command group, and actions wrapped with the
+ * shared `action()` error handling.
+ */
+function buildTestProgram(
+  tracker: CommandRunTracker,
+  act: (...args: unknown[]) => Promise<void> = async () => {},
+): Command {
+  const program = new Command('sapiom');
+  registerCommandAnalytics(program, () => tracker);
+
+  json(program.command('login').description('top-level command')).action(action(act));
+
+  const group = program.command('things').alias('th').description('nested group');
+  json(
+    group
+      .command('push [dir]')
+      .description('nested command with a defaulted value option')
+      .option('-b, --branch <branch>', 'branch to push to', 'main'),
+  ).action(action(act));
+
+  return program;
+}
+
+describe('command.run analytics hooks', () => {
+  let stdoutSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    // `fail()` sets process.exitCode; leaving it set would fail the jest run.
+    process.exitCode = originalExitCode;
+  });
+
+  it('tracks a nested command with its canonical path and exit code 0', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(['things', 'push'], { from: 'user' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe('command.run');
+    expect(events[0].data.command).toBe('things push');
+    expect(events[0].data.exit_code).toBe(0);
+    expect(typeof events[0].data.duration_ms).toBe('number');
+    expect(events[0].data.duration_ms as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits exactly the documented data fields', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(['things', 'push'], { from: 'user' });
+
+    expect(Object.keys(events[0].data).sort()).toEqual(['command', 'duration_ms', 'exit_code', 'flags']);
+  });
+
+  it('records the names of user-passed flags only — no defaults, no values, no positionals', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(
+      ['things', 'push', 'secret-positional-dir', '--branch', 'secret-branch-value', '--json'],
+      { from: 'user' },
+    );
+
+    expect(events[0].data.flags).toEqual(['--branch', '--json']);
+    const serialized = JSON.stringify(events[0].data);
+    expect(serialized).not.toContain('secret-positional-dir');
+    expect(serialized).not.toContain('secret-branch-value');
+  });
+
+  it('excludes defaulted options that the user did not pass', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(['things', 'push'], { from: 'user' });
+
+    // --branch has a default of 'main' but was not passed.
+    expect(events[0].data.flags).toEqual([]);
+  });
+
+  it('resolves group aliases to their canonical command path', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(['th', 'push'], { from: 'user' });
+
+    expect(events[0].data.command).toBe('things push');
+  });
+
+  it('tracks top-level commands without a root-program prefix', async () => {
+    const { tracker, events } = recordingTracker();
+    await buildTestProgram(tracker).parseAsync(['login'], { from: 'user' });
+
+    expect(events[0].data.command).toBe('login');
+  });
+
+  it('captures exit code 1 when the action fails through fail()', async () => {
+    const { tracker, events } = recordingTracker();
+    const program = buildTestProgram(tracker, async () => {
+      throw new CliError({ code: 'BOOM', message: 'it broke' });
+    });
+    await program.parseAsync(['things', 'push'], { from: 'user' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data.exit_code).toBe(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('a throwing tracker never breaks the command', async () => {
+    let actionRan = false;
+    const tracker: CommandRunTracker = {
+      track() {
+        throw new Error('analytics exploded');
+      },
+    };
+    const program = buildTestProgram(tracker, async () => {
+      actionRan = true;
+    });
+
+    await expect(program.parseAsync(['things', 'push'], { from: 'user' })).resolves.toBeDefined();
+    expect(actionRan).toBe(true);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  describe('helpers', () => {
+    it('commandPath returns an empty string for the root program', () => {
+      expect(commandPath(new Command('sapiom'))).toBe('');
+    });
+
+    it('specifiedFlagNames returns an empty list for a command with no options', () => {
+      expect(specifiedFlagNames(new Command('bare'))).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerAuthCommands } from './commands/auth/index.js';
 import { registerConfigCommands } from './commands/config/index.js';
 import { registerAgentsCommands } from './commands/agents/index.js';
+import { registerCommandAnalytics } from './lib/analytics.js';
 
 /**
  * Build the root `sapiom` program. Account-level commands (login/logout) sit at
@@ -12,6 +13,9 @@ import { registerAgentsCommands } from './commands/agents/index.js';
  */
 export function buildProgram(): Command {
   const program = new Command('sapiom').description('The Sapiom command-line interface.');
+
+  // Program-level hooks cover every command group registered below.
+  registerCommandAnalytics(program);
 
   registerAuthCommands(program);
   registerConfigCommands(program);

--- a/packages/cli/src/lib/analytics.ts
+++ b/packages/cli/src/lib/analytics.ts
@@ -65,8 +65,11 @@ let cachedVersion: string | null = null;
  * The CLI's own version, read from the package.json that ships next to the
  * running `dist/bin.js`. Resolved from the entry script (argv[1]) rather than
  * `import.meta` so this module stays loadable under CJS test runners; the
- * name check guarantees we never report some other package's version. Falls
- * back to `0.0.0` when the CLI is not the process entrypoint.
+ * name check guarantees we never report some other package's version.
+ *
+ * `0.0.0` is the expected, non-error state whenever the CLI is not the
+ * process entrypoint — e.g. under Jest, argv[1] is the worker script, so the
+ * name check fails by design; likewise for library imports of buildProgram().
  */
 function cliVersion(): string {
   if (cachedVersion !== null) return cachedVersion;
@@ -79,7 +82,7 @@ function cliVersion(): string {
       if (pkg.name === '@sapiom/cli' && typeof pkg.version === 'string') cachedVersion = pkg.version;
     }
   } catch {
-    // Keep the fallback — a wrong-but-honest 0.0.0 beats a wrong guess.
+    // Unreadable entry path — keep the honest fallback rather than guess.
   }
   return cachedVersion;
 }
@@ -97,14 +100,29 @@ export function commandPath(command: Command): string {
 
 /**
  * The long names of the options the user actually passed on the command line
- * (`--json`, `--host`, …). Defaults, env-derived, and implied values are
- * excluded, and option VALUES are never read — names only.
+ * (`--json`, `--host`, …), collected across the whole command chain (root
+ * program → groups → leaf) so group-level options are captured too. Defaults,
+ * env-derived, and implied values are excluded, and option VALUES are never
+ * read — names only.
  */
 export function specifiedFlagNames(command: Command): string[] {
+  // Root-to-leaf, mirroring the command-path order; a name that appears on
+  // both an ancestor and the leaf is recorded once.
+  const chain: Command[] = [];
+  for (let current: Command | null = command; current; current = current.parent) {
+    chain.unshift(current);
+  }
+
+  const seen = new Set<string>();
   const flags: string[] = [];
-  for (const option of command.options) {
-    if (command.getOptionValueSource(option.attributeName()) !== 'cli') continue;
-    flags.push(option.long ?? option.short ?? option.name());
+  for (const owner of chain) {
+    for (const option of owner.options) {
+      if (owner.getOptionValueSource(option.attributeName()) !== 'cli') continue;
+      const name = option.long ?? option.short ?? option.name();
+      if (seen.has(name)) continue;
+      seen.add(name);
+      flags.push(name);
+    }
   }
   return flags;
 }

--- a/packages/cli/src/lib/analytics.ts
+++ b/packages/cli/src/lib/analytics.ts
@@ -1,0 +1,161 @@
+/**
+ * Usage analytics for the CLI: one `command.run` event per executed command,
+ * emitted through @sapiom/analytics-core via commander lifecycle hooks.
+ *
+ * Ships dark: unless a collector endpoint is explicitly configured (the
+ * `SAPIOM_ANALYTICS_ENDPOINT` environment variable), the emitter is a silent
+ * no-op — zero network calls, zero disk writes, no notice. Opt out any time
+ * with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
+ *
+ * Privacy: an event carries the command path (canonical command names only),
+ * the NAMES of the flags that were passed, the duration, and the exit status.
+ * Flag values, positional arguments, tokens, and emails are never recorded.
+ * Delivery is enqueue-only — nothing in the command path ever awaits the
+ * network; batches flush best-effort on process exit inside analytics-core.
+ */
+import { readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+import { createAnalytics, type SapiomAnalytics } from '@sapiom/analytics-core';
+import { Command } from 'commander';
+
+import { readCredential } from './session.js';
+
+/** The slice of the analytics client the hooks need (injectable in tests). */
+export type CommandRunTracker = Pick<SapiomAnalytics, 'track'>;
+
+let sharedAnalytics: SapiomAnalytics | null = null;
+
+/**
+ * Lazy process-wide analytics instance. Created on the first completed
+ * command, never at import time, so `--help`, parse errors, and library use
+ * of `buildProgram()` touch nothing.
+ */
+function getAnalytics(): SapiomAnalytics {
+  if (sharedAnalytics === null) {
+    sharedAnalytics = createAnalytics({
+      source: 'cli',
+      sdkName: '@sapiom/cli',
+      sdkVersion: cliVersion(),
+      apiKey: resolveTelemetryApiKey(),
+    });
+  }
+  return sharedAnalytics;
+}
+
+/**
+ * Identity for server-side enrichment (sent as a header by analytics-core,
+ * never placed in event payloads). Environment first, then the stored
+ * session — same precedence as the API client, but non-throwing: no
+ * credential simply means anonymous events.
+ */
+function resolveTelemetryApiKey(): string | undefined {
+  try {
+    if (process.env.SAPIOM_API_KEY) return process.env.SAPIOM_API_KEY;
+    const stored = readCredential();
+    return stored?.accessToken ?? stored?.apiKey ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+let cachedVersion: string | null = null;
+
+/**
+ * The CLI's own version, read from the package.json that ships next to the
+ * running `dist/bin.js`. Resolved from the entry script (argv[1]) rather than
+ * `import.meta` so this module stays loadable under CJS test runners; the
+ * name check guarantees we never report some other package's version. Falls
+ * back to `0.0.0` when the CLI is not the process entrypoint.
+ */
+function cliVersion(): string {
+  if (cachedVersion !== null) return cachedVersion;
+  cachedVersion = '0.0.0';
+  try {
+    const entry = process.argv[1];
+    if (entry) {
+      const pkgPath = path.resolve(path.dirname(realpathSync(entry)), '..', 'package.json');
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: unknown; version?: unknown };
+      if (pkg.name === '@sapiom/cli' && typeof pkg.version === 'string') cachedVersion = pkg.version;
+    }
+  } catch {
+    // Keep the fallback — a wrong-but-honest 0.0.0 beats a wrong guess.
+  }
+  return cachedVersion;
+}
+
+/** Space-joined canonical command names from the root down, e.g. `agents deploy`. */
+export function commandPath(command: Command): string {
+  const names: string[] = [];
+  // Stop before the root program so the path is `agents deploy`, not
+  // `sapiom agents deploy`. Aliases resolve to canonical names via name().
+  for (let current: Command | null = command; current && current.parent; current = current.parent) {
+    names.unshift(current.name());
+  }
+  return names.join(' ');
+}
+
+/**
+ * The long names of the options the user actually passed on the command line
+ * (`--json`, `--host`, …). Defaults, env-derived, and implied values are
+ * excluded, and option VALUES are never read — names only.
+ */
+export function specifiedFlagNames(command: Command): string[] {
+  const flags: string[] = [];
+  for (const option of command.options) {
+    if (command.getOptionValueSource(option.attributeName()) !== 'cli') continue;
+    flags.push(option.long ?? option.short ?? option.name());
+  }
+  return flags;
+}
+
+/**
+ * The exit status the process will report. Commands signal failure by setting
+ * `process.exitCode` (see `fail()` in output.ts) rather than throwing, so the
+ * post-action hook still runs and can record it.
+ */
+function currentExitCode(): number {
+  const code: unknown = process.exitCode;
+  if (typeof code === 'number' && Number.isFinite(code)) return code;
+  if (typeof code === 'string') {
+    const parsed = Number(code);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+/**
+ * Instrument a commander program with `command.run` usage analytics. Program-
+ * level hooks fire for every (nested) subcommand action: `preAction` stamps a
+ * start time, `postAction` enqueues one event. Analytics must never change
+ * command behavior — every hook body is fully guarded, `track()` is a
+ * synchronous enqueue, and nothing here awaits delivery.
+ */
+export function registerCommandAnalytics(
+  program: Command,
+  getTracker: () => CommandRunTracker = getAnalytics,
+): void {
+  const startedAt = new WeakMap<Command, number>();
+
+  program.hook('preAction', (_thisCommand, actionCommand) => {
+    try {
+      startedAt.set(actionCommand, Date.now());
+    } catch {
+      // Analytics must never affect the command.
+    }
+  });
+
+  program.hook('postAction', (_thisCommand, actionCommand) => {
+    try {
+      const start = startedAt.get(actionCommand);
+      getTracker().track('command.run', {
+        command: commandPath(actionCommand),
+        flags: specifiedFlagNames(actionCommand),
+        duration_ms: start === undefined ? null : Date.now() - start,
+        exit_code: currentExitCode(),
+      });
+    } catch {
+      // Analytics must never affect the command.
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@sapiom/agent-core':
         specifier: workspace:^
         version: link:../agent-core
+      '@sapiom/analytics-core':
+        specifier: workspace:^
+        version: link:../analytics-core
       commander:
         specifier: ^14.0.2
         version: 14.0.3


### PR DESCRIPTION
Instruments `@sapiom/cli` with usage analytics via the merged `@sapiom/analytics-core` emitter. **Zero-regression ticket**: identical command output and exit codes, no new required configuration, enqueue-only delivery.

Fixes SAP-1418
https://linear.app/sapiom/issue/SAP-1418

## What

- **`command.run` events** (dot canon) via commander `preAction`/`postAction` hooks on the root program (`packages/cli/src/lib/analytics.ts`, wired in `buildProgram()`): `source: "cli"`, `sdkName: "@sapiom/cli"`, and a fixed data shape — `command` (canonical path, e.g. `agents deploy`), `flags` (user-passed flag **names only**, never values or positional arguments), `duration_ms`, `exit_code`. Failed commands still report (the shared `action()` wrapper sets `process.exitCode` instead of rethrowing, so `postAction` runs).
- **Identity**: `SAPIOM_API_KEY` / stored session credential is passed as the emitter's `apiKey` — analytics-core sends it as the `x-sapiom-api-key` header only; it never enters payloads. No `user_id` is synthesized.
- **Ships dark**: no endpoint → `createAnalytics` returns a no-op — zero network calls, zero disk writes, no first-run notice (verified e2e).
- **Version reporting** reads the package.json next to the running `dist/bin.js` (name-checked, falls back to `0.0.0`) — no `import.meta`, so the module stays loadable under the CJS test runner.
- README gains a short usage-analytics disclosure; changeset: `@sapiom/cli` minor.

## Zero-regression gates

- Existing 19-test suite passes unchanged; full cli suite now 37 tests (10 in-process unit + 8 e2e added).
- e2e runs the **built CLI** against `startMockCollector()` (`SAPIOM_ANALYTICS_ENDPOINT`), with a fresh temp `HOME` per run:
  - envelope assertions (event/source/sdk fields, exact data keys, schema `1`)
  - first-run notice fires once per machine, marker stamped in `~/.sapiom/analytics.json`, silent on the second run
  - `SAPIOM_TELEMETRY_DISABLED=1` and `DO_NOT_TRACK=1` → zero requests, byte-identical stdout
  - `login` (against a local RFC 8628 stub) and `logout`: access token, device code, user code, org identifier, env/stored API keys **never appear in any request body** (explicit assertions); credential appears only as the delivery header
  - fault injection — collector down, connection refused, HTTP 500 — commands exit 0 with byte-identical stdout
- Dark-mode manual check: `--help`, `config set-target`, unknown-command output and exit codes identical; no `~/.sapiom` created.
- New `jest.global-setup.cjs` builds the package (and missing workspace deps) before tests so the e2e always runs the current `dist/bin.js`.

## Verification (local)

```
packages/cli:  build ✓  typecheck ✓  lint ✓
Test Suites: 4 passed, 4 total
Tests:       37 passed, 37 total

repo:  pnpm build ✓  pnpm typecheck ✓  pnpm lint ✓  pnpm test ✓ (exit 0, all packages)
leak grep (quito|conductor|plans/|SAP-[0-9]|heroku|bigquery) on packages/cli: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
