### PR TITLE
feat(mcp): registerTool seam + tool.call usage analytics

### DIFF
--- a/.changeset/mcp-tool-call-analytics.md
+++ b/.changeset/mcp-tool-call-analytics.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/mcp": minor
+---
+
+Emit anonymous `tool.call` usage analytics from the MCP server via `@sapiom/analytics-core`: every tool invocation records the tool name, its arguments (size-capped), duration, and ok/error class. The emitter ships dark — with no collector endpoint configured (`SAPIOM_ANALYTICS_ENDPOINT`), nothing is sent anywhere and nothing is written to disk — and honors the standard opt-outs (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`). Emission is a synchronous in-memory enqueue off the tool hot path and can never change a tool result: a collector that is down, slow, or erroring is invisible to tool callers.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -98,6 +98,18 @@ never grows a per-capability tool of its own — capabilities live in
 `@sapiom/tools` and the remote `sapiom` MCP. See
 [the positioning doc](../../docs/mcp-servers.md) for the full policy.
 
+## Usage analytics
+
+The server can emit anonymous usage analytics (one `tool.call` event per tool
+invocation: tool name, arguments, duration, ok/error class) via
+[`@sapiom/analytics-core`](../analytics-core). It currently ships dark: unless
+a collector endpoint is explicitly configured through the
+`SAPIOM_ANALYTICS_ENDPOINT` environment variable, nothing is sent anywhere and
+nothing is written to disk. Opt out at any time with
+`SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`. Telemetry is a synchronous
+in-memory enqueue that never throws, never blocks a tool call, and can never
+change a tool result.
+
 ## License
 
 MIT

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -80,10 +80,15 @@ authentication — they run entirely offline.
 | `sapiom_dev_agents_check` | — | Bundle + validate the step graph offline |
 | `sapiom_dev_agents_run_local` | — | Run the workflow locally, resolving capability calls from stubs (no cost) |
 | `sapiom_dev_agents_link` | ✓ | Resolve/create the hosted orchestration and cache its id |
+| `sapiom_dev_agents_clone` | ✓ | Fork a gallery template (or re-clone a fork) into a local project |
 | `sapiom_dev_agents_deploy` | ✓ | Push the current commit, build, and wait for it |
 | `sapiom_dev_agents_run` | ✓ | Start a real cloud execution |
 | `sapiom_dev_agents_inspect` | ✓ | Inspect an execution or build (optionally waiting for it) |
 | `sapiom_dev_agents_signal` | ✓ | Resume a paused execution by delivering a signal |
+| `sapiom_dev_agents_schedule` | ✓ | Create a recurring (cron) or one-off schedule for a deployed agent |
+| `sapiom_dev_agents_schedule_inspect` | ✓ | Inspect one schedule (with fire history) or list an agent's schedules |
+| `sapiom_dev_agents_schedule_cancel` | ✓ | Cancel a schedule (stops all future fires) |
+| `sapiom_dev_agents_cron_preview` | ✓ | Validate a cron expression and preview its next occurrences |
 
 A typical loop: `scaffold` → write step code → `run_local` until green → `link`
 → `deploy` → `run` → `inspect`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@sapiom/agent-core": "workspace:^",
+    "@sapiom/analytics-core": "workspace:^",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/analytics.e2e.test.ts
+++ b/packages/mcp/src/analytics.e2e.test.ts
@@ -1,0 +1,304 @@
+/**
+ * End-to-end analytics tests: spawn the BUILT stdio server (`dist/index.js`,
+ * the `sapiom-mcp` bin) as a real child process, drive it with a real MCP
+ * client over stdio, and assert on the envelopes an in-process mock collector
+ * receives — the full path a published install exercises.
+ *
+ * Requires `dist/` to exist (`pnpm --filter @sapiom/mcp build`); CI builds
+ * before testing. Each server gets a throwaway HOME with a credentials file
+ * whose apiURL points at a closed local port, so nothing here touches the
+ * network beyond 127.0.0.1.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  startMockCollector,
+  type MockCollector,
+} from "@sapiom/analytics-core/testing";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const serverEntry = path.resolve(here, "..", "dist", "index.js");
+
+const E2E_API_KEY = "sk-e2e-analytics";
+
+/** Every tool the server registers, sorted — an over-the-wire registration guard. */
+const ALL_TOOL_NAMES = [
+  "sapiom_authenticate",
+  "sapiom_dev_agents_check",
+  "sapiom_dev_agents_clone",
+  "sapiom_dev_agents_cron_preview",
+  "sapiom_dev_agents_deploy",
+  "sapiom_dev_agents_inspect",
+  "sapiom_dev_agents_link",
+  "sapiom_dev_agents_run",
+  "sapiom_dev_agents_run_local",
+  "sapiom_dev_agents_scaffold",
+  "sapiom_dev_agents_schedule",
+  "sapiom_dev_agents_schedule_cancel",
+  "sapiom_dev_agents_schedule_inspect",
+  "sapiom_dev_agents_signal",
+  "sapiom_logout",
+  "sapiom_status",
+];
+
+/**
+ * A throwaway HOME containing a credentials file for a hermetic "e2e"
+ * environment: the apiURL is a closed local port (the instructions fetch
+ * fails instantly and falls back to the bundled copy), and the cached
+ * credential's API key should surface as the collector's x-sapiom-api-key.
+ */
+function writeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "sapiom-mcp-e2e-"));
+  fs.mkdirSync(path.join(home, ".sapiom"), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, ".sapiom", "credentials.json"),
+    JSON.stringify(
+      {
+        currentEnvironment: "e2e",
+        environments: {
+          e2e: {
+            appURL: "http://127.0.0.1:9999",
+            apiURL: "http://127.0.0.1:9",
+            credentials: {
+              apiKey: E2E_API_KEY,
+              tenantId: "t-e2e",
+              organizationName: "E2E Org",
+              apiKeyId: "k-e2e",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return home;
+}
+
+interface SpawnedServer {
+  client: Client;
+  home: string;
+}
+
+/** Spawn `dist/index.js` over stdio with an explicit (minimal) environment. */
+async function spawnServer(
+  extraEnv: Record<string, string>,
+): Promise<SpawnedServer> {
+  const home = writeTempHome();
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverEntry],
+    env: {
+      HOME: home,
+      USERPROFILE: home,
+      SAPIOM_ENVIRONMENT: "e2e",
+      ...extraEnv,
+    },
+    stderr: "ignore",
+  });
+  const client = new Client({ name: "analytics-e2e", version: "0.0.0" });
+  await client.connect(transport);
+  return { client, home };
+}
+
+async function closeServer(server: SpawnedServer): Promise<void> {
+  try {
+    await server.client.close();
+  } finally {
+    fs.rmSync(server.home, { recursive: true, force: true });
+  }
+}
+
+type ToolResult = {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<ToolResult> {
+  return (await client.callTool({
+    name,
+    arguments: args,
+  })) as unknown as ToolResult;
+}
+
+/** Poll until `count` tool.call events have arrived (batches may split). */
+async function waitForToolCallEvents(
+  collector: MockCollector,
+  count: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const arrived = () =>
+    collector.events().filter((e) => e.event_type === "tool.call").length;
+  while (arrived() < count && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+describe("analytics e2e (real stdio server)", () => {
+  it(
+    "emits tool.call envelopes for real tool invocations",
+    { timeout: 30_000 },
+    async () => {
+      const collector = await startMockCollector();
+      const server = await spawnServer({
+        SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+      });
+      try {
+        const { tools } = await server.client.listTools();
+        expect(tools.map((t) => t.name).sort()).toEqual(ALL_TOOL_NAMES);
+
+        const statusResult = await callTool(server.client, "sapiom_status");
+        expect(statusResult.content[0].text).toContain(
+          "Authenticated as E2E Org",
+        );
+
+        const missingDir = path.join(server.home, "does-not-exist");
+        const checkResult = await callTool(
+          server.client,
+          "sapiom_dev_agents_check",
+          { dir: missingDir },
+        );
+        expect(checkResult.isError).toBe(true);
+
+        await waitForToolCallEvents(collector, 2, 15_000);
+        const events = collector
+          .events()
+          .filter((e) => e.event_type === "tool.call");
+        expect(events).toHaveLength(2);
+
+        const statusEvent = events.find((e) => e.data.tool === "sapiom_status");
+        expect(statusEvent).toBeDefined();
+        expect(statusEvent!.source).toBe("mcp");
+        expect(statusEvent!.sdk_name).toBe("@sapiom/mcp");
+        expect(statusEvent!.sdk_version).toMatch(/^\d+\.\d+\.\d+/);
+        expect(statusEvent!.data.ok).toBe(true);
+        expect(statusEvent!.data.args).toEqual({});
+        expect(typeof statusEvent!.data.duration_ms).toBe("number");
+        expect(statusEvent!.event_id).toBeTruthy();
+        expect(statusEvent!.anonymous_id).toBeTruthy();
+
+        const checkEvent = events.find(
+          (e) => e.data.tool === "sapiom_dev_agents_check",
+        );
+        expect(checkEvent).toBeDefined();
+        expect(checkEvent!.data.ok).toBe(false);
+        expect(typeof checkEvent!.data.error_class).toBe("string");
+        expect((checkEvent!.data.error_class as string).length).toBeGreaterThan(
+          0,
+        );
+        // Sapiom-bound tools capture arguments in full.
+        expect((checkEvent!.data.args as { dir?: string }).dir).toBe(missingDir);
+
+        // Both events share the server process's session.
+        expect(checkEvent!.session_id).toBe(statusEvent!.session_id);
+
+        // The cached credential's API key rode along for enrichment.
+        const request = collector.requests[0];
+        expect(request.path).toBe("/v1/analytics/collector");
+        expect(request.headers["x-sapiom-api-key"]).toBe(E2E_API_KEY);
+      } finally {
+        await closeServer(server);
+        await collector.close();
+      }
+    },
+  );
+
+  it(
+    "opt-out env vars produce zero collector requests while tools still work",
+    { timeout: 30_000 },
+    async () => {
+      const collector = await startMockCollector();
+      const servers = await Promise.all([
+        spawnServer({
+          SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+          SAPIOM_TELEMETRY_DISABLED: "1",
+        }),
+        spawnServer({
+          SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+          DO_NOT_TRACK: "1",
+        }),
+      ]);
+      try {
+        for (const server of servers) {
+          const result = await callTool(server.client, "sapiom_status");
+          expect(result.content[0].text).toContain("Authenticated as E2E Org");
+        }
+
+        // One shared negative window comfortably past the 3s flush interval.
+        await expect(collector.waitForRequests(1, 4_500)).rejects.toThrow();
+        expect(collector.requests).toHaveLength(0);
+      } finally {
+        for (const server of servers) await closeServer(server);
+        await collector.close();
+      }
+    },
+  );
+
+  it(
+    "tool results are identical across collector down/500/slow, telemetry disabled, and no endpoint",
+    { timeout: 60_000 },
+    async () => {
+      // A fixed path (not under the per-server temp HOME) so error payloads
+      // are comparable across servers.
+      const missingDir = path.join(
+        os.tmpdir(),
+        "sapiom-mcp-e2e-never-created",
+        "project",
+      );
+
+      const collector = await startMockCollector();
+      const healthy = await spawnServer({
+        SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+      });
+      const disabled = await spawnServer({
+        SAPIOM_ANALYTICS_ENDPOINT: collector.url,
+        SAPIOM_TELEMETRY_DISABLED: "1",
+      });
+      const dark = await spawnServer({}); // ships dark: no endpoint at all
+      try {
+        const snapshot = async (client: Client) => ({
+          status: await callTool(client, "sapiom_status"),
+          check: await callTool(client, "sapiom_dev_agents_check", {
+            dir: missingDir,
+          }),
+        });
+
+        const baseline = await snapshot(healthy.client);
+        expect(baseline.status.content[0].text).toContain(
+          "Authenticated as E2E Org",
+        );
+        expect(baseline.check.isError).toBe(true);
+
+        // Fault injection: the collector misbehaves, tool results do not move.
+        collector.setMode({ kind: "down" });
+        expect(await snapshot(healthy.client)).toEqual(baseline);
+
+        collector.setMode({ kind: "status", status: 500 });
+        expect(await snapshot(healthy.client)).toEqual(baseline);
+
+        collector.setMode({ kind: "slow", delayMs: 300 });
+        expect(await snapshot(healthy.client)).toEqual(baseline);
+
+        // Telemetry disabled and never-configured servers behave identically.
+        expect(await snapshot(disabled.client)).toEqual(baseline);
+        expect(await snapshot(dark.client)).toEqual(baseline);
+      } finally {
+        await closeServer(healthy);
+        await closeServer(disabled);
+        await closeServer(dark);
+        await collector.close();
+      }
+    },
+  );
+});

--- a/packages/mcp/src/analytics.ts
+++ b/packages/mcp/src/analytics.ts
@@ -1,0 +1,63 @@
+/**
+ * Process-wide usage-analytics emitter for the MCP server.
+ *
+ * One instance per process: `main()` constructs it at startup via
+ * {@link configureAnalytics}, passing the API key from the resolved
+ * environment's cached credentials when one exists (server-side enrichment);
+ * everything else reaches the same instance through {@link getAnalytics}.
+ *
+ * The emitter ships dark: unless a collector endpoint is explicitly
+ * configured (the `SAPIOM_ANALYTICS_ENDPOINT` environment variable), it is a
+ * silent no-op — zero network calls, zero disk writes. The standard opt-outs
+ * (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`) are honored by
+ * `@sapiom/analytics-core`, and `track()` is a synchronous enqueue that
+ * never throws and never blocks a tool call.
+ */
+import { createRequire } from "node:module";
+
+import { createAnalytics, type SapiomAnalytics } from "@sapiom/analytics-core";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/** This package's own version, for the envelope's `sdk_version` field. */
+function packageVersion(): string {
+  try {
+    const pkg = nodeRequire("../package.json") as { version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0
+      ? pkg.version
+      : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+let instance: SapiomAnalytics | null = null;
+
+/**
+ * Construct the process-wide emitter once. Later calls return the existing
+ * instance unchanged, so the API key must be supplied by the first caller
+ * (in practice `main()`, right after the environment is resolved).
+ */
+export function configureAnalytics(
+  options: { apiKey?: string } = {},
+): SapiomAnalytics {
+  if (instance === null) {
+    instance = createAnalytics({
+      source: "mcp",
+      sdkName: "@sapiom/mcp",
+      sdkVersion: packageVersion(),
+      apiKey: options.apiKey,
+    });
+  }
+  return instance;
+}
+
+/** The emitter, lazily constructed (keyless) if `configureAnalytics` hasn't run. */
+export function getAnalytics(): SapiomAnalytics {
+  return instance ?? configureAnalytics();
+}
+
+/** Test seam: replace (or, with `null`, reset) the process-wide instance. */
+export function setAnalyticsForTesting(next: SapiomAnalytics | null): void {
+  instance = next;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { configureAnalytics } from "./analytics.js";
 import { resolveEnvironment } from "./credentials.js";
 import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
@@ -17,6 +18,11 @@ async function main(): Promise<void> {
       `\u26a0 Using environment "${env.name}": app=${env.appURL} api=${env.apiURL}`,
     );
   }
+
+  // Construct the process-wide usage-analytics emitter once, keyed with the
+  // cached credential when one exists. Ships dark (a no-op unless a collector
+  // endpoint is configured) and honors the standard telemetry opt-outs.
+  configureAnalytics({ apiKey: env.credentials?.apiKey });
 
   // Pull the latest authoring instructions from the backend (falls back to the
   // bundled copy offline / on error), so guidance can change without a release.

--- a/packages/mcp/src/register-tool.test.ts
+++ b/packages/mcp/src/register-tool.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SapiomAnalytics } from "@sapiom/analytics-core";
 import { z } from "zod";
 
-import { registerTool } from "./register-tool.js";
+import { setAnalyticsForTesting } from "./analytics.js";
+import { registerTool, TOOL_CALL_EVENT } from "./register-tool.js";
 
 type CapturedRegistration = {
   name: string;
@@ -110,5 +112,153 @@ describe("registerTool pass-through", () => {
     registerTool(server, "second", "2", {}, handler);
 
     expect(registrations.map((r) => r.name)).toEqual(["first", "second"]);
+  });
+});
+
+type TrackedEvent = { eventType: string; data: Record<string, unknown> };
+
+function fakeAnalytics(
+  trackImpl?: (eventType: string, data?: Record<string, unknown>) => void,
+): { analytics: SapiomAnalytics; events: TrackedEvent[] } {
+  const events: TrackedEvent[] = [];
+  const analytics: SapiomAnalytics = {
+    track(eventType, data) {
+      if (trackImpl) trackImpl(eventType, data);
+      events.push({ eventType, data: data ?? {} });
+    },
+    flush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+    enabled: true,
+    anonymousId: null,
+    sessionId: "session-under-test",
+  };
+  return { analytics, events };
+}
+
+describe("registerTool tool.call emission", () => {
+  let events: TrackedEvent[];
+
+  beforeEach(() => {
+    const fake = fakeAnalytics();
+    events = fake.events;
+    setAnalyticsForTesting(fake.analytics);
+  });
+
+  afterEach(() => {
+    setAnalyticsForTesting(null);
+  });
+
+  it("emits one tool.call per successful invocation with name, args, duration, ok", async () => {
+    const { server, registrations } = createMockServer();
+    registerTool(
+      server,
+      "tool_ok",
+      "succeeds",
+      { dir: z.string() },
+      async () => ({ content: [{ type: "text" as const, text: "done" }] }),
+    );
+
+    await registrations[0].handler({ dir: "/tmp/project" }, {});
+
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe(TOOL_CALL_EVENT);
+    expect(events[0].data.tool).toBe("tool_ok");
+    expect(events[0].data.args).toEqual({ dir: "/tmp/project" });
+    expect(typeof events[0].data.duration_ms).toBe("number");
+    expect(events[0].data.duration_ms as number).toBeGreaterThanOrEqual(0);
+    expect(events[0].data.ok).toBe(true);
+    expect(events[0].data).not.toHaveProperty("error_class");
+  });
+
+  it("enqueues synchronously: the event is tracked by the time the handler's promise settles", async () => {
+    const { server, registrations } = createMockServer();
+    registerTool(server, "tool_sync", "succeeds", {}, async () => ({
+      content: [{ type: "text" as const, text: "done" }],
+    }));
+
+    // No extra ticks after the await: a fire-and-forget (awaited or deferred)
+    // emission would not have landed yet.
+    await registrations[0].handler({}, {});
+    expect(events).toHaveLength(1);
+  });
+
+  it("classifies a structured isError result by its error.code", async () => {
+    const { server, registrations } = createMockServer();
+    registerTool(server, "tool_structured_err", "fails", {}, async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            error: { code: "NOT_AUTHENTICATED", message: "Not authenticated." },
+          }),
+        },
+      ],
+      isError: true,
+    }));
+
+    await registrations[0].handler({}, {});
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data.ok).toBe(false);
+    expect(events[0].data.error_class).toBe("NOT_AUTHENTICATED");
+  });
+
+  it("classifies an unstructured isError result as tool_error", async () => {
+    const { server, registrations } = createMockServer();
+    registerTool(server, "tool_plain_err", "fails", {}, async () => ({
+      content: [{ type: "text" as const, text: "Authentication failed: boom" }],
+      isError: true,
+    }));
+
+    await registrations[0].handler({}, {});
+
+    expect(events[0].data.ok).toBe(false);
+    expect(events[0].data.error_class).toBe("tool_error");
+  });
+
+  it("classifies a thrown error by constructor name and rethrows it unchanged", async () => {
+    const { server, registrations } = createMockServer();
+    const boom = new RangeError("out of range");
+    registerTool(server, "tool_throws", "throws", {}, async () => {
+      throw boom;
+    });
+
+    await expect(registrations[0].handler({}, {})).rejects.toBe(boom);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].data.ok).toBe(false);
+    expect(events[0].data.error_class).toBe("RangeError");
+  });
+
+  it("returns the tool result unchanged even when track() itself throws", async () => {
+    const throwing = fakeAnalytics(() => {
+      throw new Error("collector exploded");
+    });
+    setAnalyticsForTesting(throwing.analytics);
+
+    const { server, registrations } = createMockServer();
+    const result = { content: [{ type: "text" as const, text: "safe" }] };
+    registerTool(server, "tool_faulty_emitter", "succeeds", {}, async () => result);
+
+    const returned = await registrations[0].handler({}, {});
+    expect(returned).toBe(result);
+  });
+
+  it("does not mutate the args object it captures", async () => {
+    const { server, registrations } = createMockServer();
+    registerTool(
+      server,
+      "tool_args",
+      "succeeds",
+      { input: z.unknown().optional() },
+      async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    );
+
+    const args = { input: { nested: [1, 2, 3] } };
+    const snapshot = JSON.stringify(args);
+    await registrations[0].handler(args, {});
+
+    expect(JSON.stringify(args)).toBe(snapshot);
+    expect(events[0].data.args).toBe(args);
   });
 });

--- a/packages/mcp/src/register-tool.test.ts
+++ b/packages/mcp/src/register-tool.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { registerTool } from "./register-tool.js";
+
+type CapturedRegistration = {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (args: unknown, extra: unknown) => unknown;
+};
+
+function createMockServer(): {
+  server: McpServer;
+  registrations: CapturedRegistration[];
+} {
+  const registrations: CapturedRegistration[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        description: string,
+        schema: unknown,
+        handler: CapturedRegistration["handler"],
+      ) => {
+        registrations.push({ name, description, schema, handler });
+      },
+    ),
+  } as unknown as McpServer;
+  return { server, registrations };
+}
+
+describe("registerTool pass-through", () => {
+  it("forwards name, description, and schema to server.tool verbatim", () => {
+    const { server, registrations } = createMockServer();
+    const schema = { dir: z.string() };
+
+    registerTool(server, "tool_a", "does a thing", schema, async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0].name).toBe("tool_a");
+    expect(registrations[0].description).toBe("does a thing");
+    expect(registrations[0].schema).toBe(schema);
+  });
+
+  it("invokes the handler with the same args and extra, and returns its result unchanged", async () => {
+    const { server, registrations } = createMockServer();
+    const result = { content: [{ type: "text" as const, text: "hello" }] };
+    const seen: unknown[] = [];
+
+    registerTool(
+      server,
+      "tool_b",
+      "echo",
+      { value: z.string() },
+      async (args, extra) => {
+        seen.push(args, extra);
+        return result;
+      },
+    );
+
+    const args = { value: "hi" };
+    const extra = { signal: new AbortController().signal };
+    const returned = await registrations[0].handler(args, extra);
+
+    expect(seen[0]).toBe(args);
+    expect(seen[1]).toBe(extra);
+    expect(returned).toBe(result);
+  });
+
+  it("passes isError results through unchanged", async () => {
+    const { server, registrations } = createMockServer();
+    const errorResult = {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ error: { code: "NOT_AUTHENTICATED" } }),
+        },
+      ],
+      isError: true,
+    };
+
+    registerTool(server, "tool_c", "fails", {}, async () => errorResult);
+
+    const returned = await registrations[0].handler({}, {});
+    expect(returned).toBe(errorResult);
+  });
+
+  it("propagates a thrown error to the caller unchanged", async () => {
+    const { server, registrations } = createMockServer();
+    const boom = new TypeError("exploded");
+
+    registerTool(server, "tool_d", "throws", {}, async () => {
+      throw boom;
+    });
+
+    await expect(registrations[0].handler({}, {})).rejects.toBe(boom);
+  });
+
+  it("registers each tool exactly once, in call order", () => {
+    const { server, registrations } = createMockServer();
+    const handler = async () => ({
+      content: [{ type: "text" as const, text: "x" }],
+    });
+
+    registerTool(server, "first", "1", {}, handler);
+    registerTool(server, "second", "2", {}, handler);
+
+    expect(registrations.map((r) => r.name)).toEqual(["first", "second"]);
+  });
+});

--- a/packages/mcp/src/register-tool.ts
+++ b/packages/mcp/src/register-tool.ts
@@ -1,0 +1,27 @@
+/**
+ * The single seam every tool registration goes through.
+ *
+ * `registerTool` forwards to `server.tool(name, description, schema, handler)`
+ * verbatim. Having one choke point (instead of a direct `server.tool` call per
+ * tool) lets cross-cutting concerns wrap every tool handler in one place
+ * without touching the tool modules themselves.
+ */
+import type {
+  McpServer,
+  ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShape } from "zod";
+
+/**
+ * Register one MCP tool. Behaviorally identical to calling
+ * `server.tool(name, description, schema, handler)` directly.
+ */
+export function registerTool<Args extends ZodRawShape>(
+  server: McpServer,
+  name: string,
+  description: string,
+  schema: Args,
+  handler: ToolCallback<Args>,
+): void {
+  server.tool(name, description, schema, handler);
+}

--- a/packages/mcp/src/register-tool.ts
+++ b/packages/mcp/src/register-tool.ts
@@ -36,6 +36,11 @@ type AnyToolHandler = (
  * Register one MCP tool. Wire-identical to calling
  * `server.tool(name, description, schema, handler)` directly, plus one
  * `tool.call` analytics event per invocation.
+ *
+ * A zero-argument tool passes `{}` as `schema`: the SDK accepts it as an
+ * empty ZodRawShape, and the handler just ignores its (empty) `args`. This is
+ * the pre-existing convention of the direct `server.tool` call sites this
+ * seam replaced, preserved as-is; no schema-less overload is needed.
  */
 export function registerTool<Args extends ZodRawShape>(
   server: McpServer,

--- a/packages/mcp/src/register-tool.ts
+++ b/packages/mcp/src/register-tool.ts
@@ -1,20 +1,41 @@
 /**
  * The single seam every tool registration goes through.
  *
- * `registerTool` forwards to `server.tool(name, description, schema, handler)`
- * verbatim. Having one choke point (instead of a direct `server.tool` call per
- * tool) lets cross-cutting concerns wrap every tool handler in one place
- * without touching the tool modules themselves.
+ * `registerTool` forwards the registration to
+ * `server.tool(name, description, schema, handler)` and wraps the handler to
+ * emit one `tool.call` usage-analytics event per invocation — tool name,
+ * arguments, duration, ok/error class — via the process-wide emitter in
+ * `./analytics.ts` (the envelope's `source: "mcp"` disambiguates same-named
+ * events from other producers).
+ *
+ * The wrapper is transparent: the handler receives the exact `args`/`extra`
+ * the MCP SDK produced, its result (success or `isError`) is returned
+ * unchanged, and a thrown error is rethrown unchanged. Emission is a
+ * synchronous enqueue — no awaits on the hot path — and can never throw, so
+ * telemetry cannot alter a tool result or take the server down. The emitter
+ * ships dark: with no collector endpoint configured it is a no-op.
  */
 import type {
   McpServer,
   ToolCallback,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape } from "zod";
 
+import { getAnalytics } from "./analytics.js";
+
+/** Event type emitted once per tool invocation. */
+export const TOOL_CALL_EVENT = "tool.call";
+
+type AnyToolHandler = (
+  args: unknown,
+  extra: unknown,
+) => CallToolResult | Promise<CallToolResult>;
+
 /**
- * Register one MCP tool. Behaviorally identical to calling
- * `server.tool(name, description, schema, handler)` directly.
+ * Register one MCP tool. Wire-identical to calling
+ * `server.tool(name, description, schema, handler)` directly, plus one
+ * `tool.call` analytics event per invocation.
  */
 export function registerTool<Args extends ZodRawShape>(
   server: McpServer,
@@ -23,5 +44,90 @@ export function registerTool<Args extends ZodRawShape>(
   schema: Args,
   handler: ToolCallback<Args>,
 ): void {
-  server.tool(name, description, schema, handler);
+  const wrapped = (async (args: unknown, extra: unknown) => {
+    const startedAt = performance.now();
+    try {
+      const result = await (handler as AnyToolHandler)(args, extra);
+      emitToolCall(name, args, startedAt, resultOutcome(result));
+      return result;
+    } catch (error) {
+      emitToolCall(name, args, startedAt, {
+        ok: false,
+        errorClass: classifyThrown(error),
+      });
+      throw error;
+    }
+  }) as unknown as ToolCallback<Args>;
+
+  server.tool(name, description, schema, wrapped);
+}
+
+interface CallOutcome {
+  ok: boolean;
+  errorClass?: string;
+}
+
+/**
+ * Synchronous, never throws. These are Sapiom's own developer tools
+ * (Sapiom-bound calls), so arguments are captured in full per the
+ * analytics contract; the emitter size-caps each `data` field (~16 KB)
+ * and flags truncation.
+ */
+function emitToolCall(
+  tool: string,
+  args: unknown,
+  startedAt: number,
+  outcome: CallOutcome,
+): void {
+  try {
+    const data: Record<string, unknown> = {
+      tool,
+      args: args ?? {},
+      duration_ms: Math.max(0, Math.round(performance.now() - startedAt)),
+      ok: outcome.ok,
+    };
+    if (outcome.errorClass !== undefined) {
+      data.error_class = outcome.errorClass;
+    }
+    getAnalytics().track(TOOL_CALL_EVENT, data);
+  } catch {
+    // Telemetry must never affect the tool result.
+  }
+}
+
+function resultOutcome(result: CallToolResult): CallOutcome {
+  if (result?.isError !== true) return { ok: true };
+  return { ok: false, errorClass: classifyErrorResult(result) };
+}
+
+/**
+ * Error class for an `isError` result: the structured `error.code` the tool
+ * modules put in their JSON payloads when present, else `"tool_error"`.
+ */
+function classifyErrorResult(result: CallToolResult): string {
+  try {
+    const first = Array.isArray(result.content) ? result.content[0] : undefined;
+    if (
+      first &&
+      first.type === "text" &&
+      typeof (first as { text?: unknown }).text === "string"
+    ) {
+      const parsed = JSON.parse((first as { text: string }).text) as {
+        error?: { code?: unknown };
+      };
+      const code = parsed?.error?.code;
+      if (typeof code === "string" && code.length > 0) return code;
+    }
+  } catch {
+    // Not a structured error payload.
+  }
+  return "tool_error";
+}
+
+/** Error class for a thrown value: the error's constructor name. */
+function classifyThrown(error: unknown): string {
+  if (error instanceof Error) {
+    return error.constructor?.name || error.name || "Error";
+  }
+  return "non_error_throw";
 }

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -43,6 +43,7 @@ import {
   type StubFile,
 } from "@sapiom/agent-core";
 import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
+import { registerTool } from "../register-tool.js";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -177,7 +178,8 @@ function scheduleHint(schedule: ScheduleDetail): string | undefined {
 export function register(server: McpServer, env: ResolvedEnvironment): void {
   // ── Local tools (no network) ──────────────────────────────────────────────
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_scaffold",
     "Scaffold a new Sapiom agent project into <dir>. Produces an npm-install-ready TypeScript project with a starter agent in index.ts. After scaffolding, the author writes step definitions and uses sapiom_dev_agents_run_local to test them.",
     {
@@ -209,7 +211,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_check",
     "Validate an agent locally: bundle index.ts, derive the manifest, and check the step graph. Offline and instant. Returns the agent name, step count, the manifest (which contains the full step graph for visualization), and any graph warnings.",
     {
@@ -229,7 +232,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_run_local",
     [
       "Execute an agent entirely on the local machine, running the author's actual step code with every ctx.sapiom.* capability call resolved from stubs (no real capability calls, no cost, instant).",
@@ -281,7 +285,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
 
   // ── Networked tools (require authentication) ───────────────────────────────
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_link",
     "Resolve a hosted agent by name (or create it with create:true) and cache its id in the project's sapiom.json. Run this before deploy.",
     {
@@ -339,7 +344,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_clone",
     [
       "Materialize a Sapiom workflow template as a local project — the 'use this template' handoff. Given a template id (from the gallery) it forks the template into a repo you own; given an existing fork id it re-clones that fork. Either way it mints a short-lived, repo-scoped clone credential, git-clones the repo into <dir>, and writes sapiom.json recording the fork.",
@@ -384,7 +390,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_deploy",
     "Deploy the linked agent: push the current git commit, trigger a build, and wait for it to finish. The project must be linked (sapiom.json) and a git repo with at least one commit.",
     {
@@ -417,7 +424,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_run",
     "Start a real (cloud) execution of the linked agent. Use sapiom_dev_agents_inspect to follow it.",
     {
@@ -453,7 +461,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_inspect",
     "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
     {
@@ -530,7 +539,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_signal",
     "Resume a paused cloud execution by delivering a named signal (matched by name + correlationId).",
     {
@@ -557,7 +567,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
 
   // ── Schedules (triggers) ──────────────────────────────────────────────────
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_schedule",
     "Create a schedule for a deployed agent: a recurring cron schedule (kind 'schedule_cron' + cron + timezone) or a one-off delayed run (kind 'schedule_once' + at). Returns the schedule with its next fire time. Tip: validate a cron with sapiom_dev_agents_cron_preview first.",
     {
@@ -613,7 +624,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_schedule_inspect",
     "Inspect schedules. With scheduleId: returns one schedule's config, next fire time, and recent fire history (each with the run's executionId) — use this to debug a misbehaving schedule, then inspect a failed run's executionId with sapiom_dev_agents_inspect. With definition (slug) and no scheduleId: lists that agent's schedules.",
     {
@@ -651,7 +663,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_schedule_cancel",
     "Cancel a schedule by id. Stops all future fires (a recurring schedule won't re-arm; a pending one-off won't run). Irreversible — recreate to reschedule.",
     {
@@ -668,7 +681,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_dev_agents_cron_preview",
     "Validate a cron expression and preview its next occurrences, creating nothing. Use before sapiom_dev_agents_schedule to confirm a cron + timezone fire when you expect (cron syntax is easy to get subtly wrong).",
     {

--- a/packages/mcp/src/tools/authenticate.ts
+++ b/packages/mcp/src/tools/authenticate.ts
@@ -5,9 +5,11 @@ import {
   type ResolvedEnvironment,
 } from "../credentials.js";
 import { performBrowserAuth } from "../auth.js";
+import { registerTool } from "../register-tool.js";
 
 export function register(server: McpServer, env: ResolvedEnvironment): void {
-  server.tool(
+  registerTool(
+    server,
     "sapiom_authenticate",
     "Authenticate this local Sapiom developer MCP (sapiom-dev) by opening a browser login flow. Run this when a networked agent tool (link/deploy/run/inspect/signal) reports that authentication is required.",
     {},

--- a/packages/mcp/src/tools/status.ts
+++ b/packages/mcp/src/tools/status.ts
@@ -4,9 +4,11 @@ import {
   clearCredentials,
   type ResolvedEnvironment,
 } from "../credentials.js";
+import { registerTool } from "../register-tool.js";
 
 export function register(server: McpServer, env: ResolvedEnvironment): void {
-  server.tool(
+  registerTool(
+    server,
     "sapiom_status",
     "Check authentication status for this local Sapiom developer MCP (sapiom-dev). Returns whether you're authenticated and which organization.",
     {},
@@ -35,7 +37,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
   );
 
-  server.tool(
+  registerTool(
+    server,
     "sapiom_logout",
     "Log out of Sapiom by removing cached credentials for the current environment.",
     {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@sapiom/agent-core':
         specifier: workspace:^
         version: link:../agent-core
+      '@sapiom/analytics-core':
+        specifier: workspace:^
+        version: link:../analytics-core
       zod:
         specifier: ^3.25.0
         version: 3.25.76


### PR DESCRIPTION
## Summary

Instruments `@sapiom/mcp` with usage analytics, in two strictly-ordered commits (Tidy First):

**Commit 1 — structure only (zero behavior change).** Introduces `registerTool(server, name, description, schema, handler)` and routes all 16 existing `server.tool(...)` registrations through it (`sapiom_authenticate`, `sapiom_status`, `sapiom_logout`, and the 13 `sapiom_dev_agents_*` tools). The seam forwards to `server.tool` verbatim; the pre-existing suite passes unchanged, and a live stdio `listTools` smoke check shows the identical 16-tool surface.

**Commit 2 — emission.** `registerTool` wraps handlers to emit one **`tool.call`** event per invocation (dot-canon event name; the envelope's `source: "mcp"` disambiguates) via `@sapiom/analytics-core`, with `sdkName: "@sapiom/mcp"`:

- `data`: tool name, args (Sapiom-bound developer tools → full capture per the analytics contract; the emitter size-caps each field at ~16 KB with `_truncated` flagging), `duration_ms`, `ok`, and `error_class` (the structured `error.code` from `isError` payloads, the constructor name for thrown errors).
- Synchronous enqueue — no awaits on the hot path; emission can never throw or alter a tool result.
- The emitter is constructed once at server startup, keyed with the cached credential's API key when one exists (surfaces as `x-sapiom-api-key`). Ships dark: no collector endpoint (`SAPIOM_ANALYTICS_ENDPOINT`) → full no-op; `SAPIOM_TELEMETRY_DISABLED=1` / `DO_NOT_TRACK=1` opt out.

Also adds a "Usage analytics" section to the package README and a `minor` changeset.

## Zero-regression gates

- Commit 1 is provably structure-only: `registerTool` forwards verbatim; existing suite green before commit 2.
- Pre-existing `@sapiom/mcp` test files are byte-identical to `main` and pass unchanged at the final state.
- The #187 `./auth` subpath export is untouched (`auth-api.ts` byte-identical) and still resolves with the same exports, verified by an ESM import from `@sapiom/harness`.
- No public API changes; no new required config; no hot-path awaits.

## Tests

- Unit: `registerTool` pass-through (commit 1) + emission behavior, including fault injection at the emitter boundary (`track()` throwing does not affect tool results).
- e2e (real stdio lifecycle): spawns the built `sapiom-mcp` bin as a child process, drives it with a real MCP client, and asserts envelopes at `startMockCollector()` via `SAPIOM_ANALYTICS_ENDPOINT`; opt-out env vars produce zero collector requests; tool results are identical across collector down/500/slow, telemetry disabled, and no-endpoint.
- Full repo build / typecheck / lint / test green (`@sapiom/mcp`: 10 files, 70 tests).

Fixes SAP-1417
https://linear.app/sapiom/issue/SAP-1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
