### PR TITLE
fix(ci): pin publish npm to 11.x (npm 12 breaks provenance sigstore)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,12 @@ jobs:
           cache: pnpm
 
       - name: Ensure npm >= 11.5 (OIDC trusted publishing)
-        run: npm install -g npm@latest && npm --version
+        # Pinned to the 11.x line rather than `npm@latest`: npm 12.0.0's
+        # publish path fails to resolve its bundled `sigstore` module when
+        # generating provenance attestations under trusted publishing
+        # ("Cannot find module 'sigstore'"), which aborts `changeset publish`
+        # for every package. 11.x (>= the 11.5 OIDC minimum) publishes cleanly.
+        run: npm install -g 'npm@^11.5' && npm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

The `publish.yml` run triggered by merging #251 failed for **every** package with `Cannot find module 'sigstore'`. The workflow does `npm install -g npm@latest`, which currently resolves to **npm 12.0.0**, whose provenance-attestation path (used by OIDC trusted publishing) can't resolve its bundled `sigstore` module — so `changeset publish` aborts before publishing anything (harness is still the `0.0.0` placeholder; agent/agent-core/mcp unchanged).

This is a CI-tooling regression, not a package problem.

## Fix

Pin the global npm to the `11.x` line (`npm@^11.5`, still ≥ the 11.5 OIDC minimum the step name calls out). 11.x generates provenance cleanly.

## After merge

Merging re-triggers `publish.yml` on main, which should publish the pending versions (`@sapiom/harness 0.1.0`, `@sapiom/agent 0.6.1`, `@sapiom/agent-core 0.8.0`, `@sapiom/mcp 0.10.0`, and the other bumped packages) via OIDC, superseding the placeholder.