### PR TITLE
feat(analytics-core): deliver to the hosted collector by default (ship-dark flip)

### DIFF
--- a/.changeset/hot-poets-shine.md
+++ b/.changeset/hot-poets-shine.md
@@ -2,4 +2,4 @@
 "@sapiom/analytics-core": minor
 ---
 
-Analytics delivery is now on by default to the hosted collector (the ship-dark default flipped live): with no `endpoint` configured, `createAnalytics` delivers to `SAPIOM_COLLECTOR_ENDPOINT`. Opt-outs unchanged (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, programmatic `disabled: true`) — any of them still makes the emitter a complete no-op: zero network calls, zero disk writes.
+Analytics delivery is now on by default to the hosted collector (the ship-dark default flipped live): with no `endpoint` configured, `createAnalytics` delivers to `SAPIOM_COLLECTOR_ENDPOINT`. Opt-outs unchanged (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, programmatic `disabled: true`) — any of them still makes the emitter a complete no-op: zero network calls, zero disk writes. Consent providers returning `undefined` deliver by default; return `false` to stay off.

--- a/.changeset/hot-poets-shine.md
+++ b/.changeset/hot-poets-shine.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/analytics-core": minor
+---
+
+Analytics delivery is now on by default to the hosted collector (the ship-dark default flipped live): with no `endpoint` configured, `createAnalytics` delivers to `SAPIOM_COLLECTOR_ENDPOINT`. Opt-outs unchanged (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, programmatic `disabled: true`) — any of them still makes the emitter a complete no-op: zero network calls, zero disk writes.

--- a/packages/agent-core/jest.config.js
+++ b/packages/agent-core/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   testEnvironment: 'node',
   passWithNoTests: true,
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.js'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/agent-core/jest.telemetry-guard.js
+++ b/packages/agent-core/jest.telemetry-guard.js
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/agent-core/jest.telemetry-guard.js
+++ b/packages/agent-core/jest.telemetry-guard.js
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/agent-core/src/__tests__/analytics-events.test.ts
+++ b/packages/agent-core/src/__tests__/analytics-events.test.ts
@@ -394,7 +394,7 @@ describe("local run step events", () => {
   });
 });
 
-describe("consent and ship-dark", () => {
+describe("consent and live-default", () => {
   it.each(["SAPIOM_TELEMETRY_DISABLED", "DO_NOT_TRACK"])(
     "%s=1 → zero collector requests, identical results",
     async (envVar) => {
@@ -423,18 +423,20 @@ describe("consent and ship-dark", () => {
     },
   );
 
-  it("no endpoint configured (ships dark) → zero requests, identical results", async () => {
-    delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
-    resetOrchestrationAnalyticsForTesting();
-
+  it("live by default: with no explicit endpoint config, emitter is enabled and events reach the collector", async () => {
+    // No explicit `endpoint` on the analytics config, but the env override
+    // (SAPIOM_ANALYTICS_ENDPOINT) set by beforeEach points at the mock so
+    // nothing hits the production URL. This exercises the live-default
+    // fall-through path: resolveEndpoint() returns the hosted collector when no
+    // config is set, and the env override redirects that to the mock.
     const gateway = await startFakeGateway(HAPPY_ROUTES);
     try {
       const { started } = await runHappyFlow(gateway.host);
       expect(started.executionId).toBe("exec_1");
-      expect(getOrchestrationAnalytics().enabled).toBe(false);
+      expect(getOrchestrationAnalytics().enabled).toBe(true);
 
       await getOrchestrationAnalytics().flush();
-      expect(collector.requests).toHaveLength(0);
+      expect(collector.requests.length).toBeGreaterThan(0);
     } finally {
       await gateway.close();
     }

--- a/packages/agent-core/src/analytics.ts
+++ b/packages/agent-core/src/analytics.ts
@@ -1,9 +1,8 @@
 /**
  * Usage-analytics plumbing for the orchestration operations (deploy / run /
  * link / run-local). Events are emitted through `@sapiom/analytics-core`,
- * which ships dark by default: unless a collector endpoint is explicitly
- * configured (the `SAPIOM_ANALYTICS_ENDPOINT` environment variable), every
- * `track` call is a silent no-op — zero network calls, zero disk writes.
+ * which is live by default: an unconfigured emitter delivers to the hosted
+ * Sapiom collector. Use `SAPIOM_ANALYTICS_ENDPOINT` to redirect (test use).
  * Opt out any time with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
  *
  * This module is the package's ONLY exception to the "no process.env reads /

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -52,7 +52,7 @@ export interface DeployResult {
  * Throws `AgentOperationError` on git, network, or build failures.
  *
  * Emits one `workflow.deploy` usage-analytics event (metadata only: ids,
- * status, duration). Ships dark — see ./analytics.ts; telemetry never
+ * status, duration). Live by default — see ./analytics.ts; telemetry never
  * changes the operation's behavior.
  */
 export async function deploy(opts: DeployOptions, client: GatewayClient): Promise<DeployResult> {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -11,9 +11,9 @@
  * Sole exception to the env/global rules: anonymous usage analytics
  * (src/analytics.ts) — a lazy, process-shared @sapiom/analytics-core emitter
  * constructed at the operation call boundary (never inside GatewayClient).
- * It honors SAPIOM_TELEMETRY_DISABLED / DO_NOT_TRACK, is a silent no-op
- * unless a collector endpoint is configured (ships dark), and never affects
- * an operation's behavior or results.
+ * It is live by default (delivers to the hosted collector); opt out with
+ * SAPIOM_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1. It never affects an
+ * operation's behavior or results.
  *
  * Consumers: @sapiom/cli (thin arg-parse + render shell), @sapiom/mcp (SAP-930).
  */

--- a/packages/agent-core/src/link.ts
+++ b/packages/agent-core/src/link.ts
@@ -34,7 +34,7 @@ export interface LinkResult {
  * failures.
  *
  * Emits one `workflow.link` usage-analytics event (metadata only: name, id,
- * status, duration). Ships dark — see ./analytics.ts; telemetry never
+ * status, duration). Live by default — see ./analytics.ts; telemetry never
  * changes the operation's behavior.
  */
 export async function link(opts: LinkOptions, client: GatewayClient): Promise<LinkResult> {

--- a/packages/agent-core/src/local/run-local.ts
+++ b/packages/agent-core/src/local/run-local.ts
@@ -99,7 +99,7 @@ export async function runLocal(opts: RunLocalOptions): Promise<LocalRunResult> {
   dispatcher.setSignals(signals);
   // Step lifecycle usage analytics (`step.start` / `step.complete` /
   // `step.error`), flagged `local: true` so local runs are distinguishable
-  // from server executions. Ships dark — see ../analytics.ts; `track` is
+  // from server executions. Live by default — see ../analytics.ts; `track` is
   // enqueue-only and never throws, so the run itself is unaffected.
   const analytics = getOrchestrationAnalytics();
   const core = new AgentRunnerCore({

--- a/packages/agent-core/src/run.ts
+++ b/packages/agent-core/src/run.ts
@@ -33,7 +33,7 @@ export interface RunResult {
  * Throws `AgentOperationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
  *
  * Emits one `workflow.run` usage-analytics event (metadata only: ids,
- * status, duration — never the execution input). Ships dark — see
+ * status, duration — never the execution input). Live by default — see
  * ./analytics.ts; telemetry never changes the operation's behavior.
  */
 export async function run(opts: RunOptions, client: GatewayClient): Promise<RunResult> {

--- a/packages/agent-runtime/jest.config.js
+++ b/packages/agent-runtime/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   testEnvironment: 'node',
   passWithNoTests: true,
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.js'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/agent-runtime/jest.telemetry-guard.js
+++ b/packages/agent-runtime/jest.telemetry-guard.js
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/agent-runtime/jest.telemetry-guard.js
+++ b/packages/agent-runtime/jest.telemetry-guard.js
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/analytics-core/CONTRACT.md
+++ b/packages/analytics-core/CONTRACT.md
@@ -22,9 +22,9 @@ to the events (see [Server-stamped fields](#server-stamped-fields-never-client-t
 An invalid or missing key never causes a rejection.
 
 This URL is exported by `@sapiom/analytics-core` as the constant
-`SAPIOM_COLLECTOR_ENDPOINT`. Note that the emitter **ships dark by default**:
-it sends nothing unless an endpoint is configured explicitly (see the README's
-telemetry section).
+`SAPIOM_COLLECTOR_ENDPOINT` and is the emitter's **default endpoint**: an
+emitter with no explicit `endpoint` configured delivers here, unless the
+user has opted out (see the README's telemetry section).
 
 ## Request envelope
 

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -12,8 +12,9 @@ be invisible to the host application:
   best-effort on process exit. A failed batch is retried at most once, then
   dropped. Oversized fields are truncated (flagged with `data._truncated`).
 - **Zero runtime dependencies.** Node built-ins only.
-- **Ships dark by default.** Unless an endpoint is explicitly configured,
-  nothing is sent anywhere — see below.
+- **On by default, off with one switch.** Events go to the hosted Sapiom
+  collector unless you opt out — every opt-out is documented below and makes
+  the emitter a complete no-op.
 
 ## Telemetry: what, where, and how to turn it off
 
@@ -65,16 +66,17 @@ one-line notice to stderr, so collection is never silent.
 A single file, `~/.sapiom/analytics.json` (permissions `0600`), holding a
 random anonymous machine id and the first-run-notice marker. It contains no
 personal information. Delete it at any time to reset the identity; it is
-never created while analytics is disabled or unconfigured.
+never created while analytics is disabled.
 
-### Current status: ships dark
+### Current status: live by default
 
-The emitter has **no default endpoint**. Unless an endpoint is explicitly
-configured — `endpoint` in the config, or the `SAPIOM_ANALYTICS_ENDPOINT`
-environment variable (used by tests) — `createAnalytics` returns a no-op
-instance: zero network calls, zero disk writes, no first-run notice. The
-hosted collector URL is exported as the constant `SAPIOM_COLLECTOR_ENDPOINT`
-for when you (or a future release of this package) want to send there.
+The emitter delivers to the hosted Sapiom collector by default — the URL is
+exported as the constant `SAPIOM_COLLECTOR_ENDPOINT`, and an explicit
+`endpoint` in the config sends somewhere else (for example, the mock
+collector in tests). Everything in [Opting out](#opting-out) above applies
+unchanged: `disabled: true` in the config, `SAPIOM_TELEMETRY_DISABLED=1`, or
+`DO_NOT_TRACK=1` disables analytics entirely — nothing is sent, nothing is
+written to disk, zero network calls are made, and no notice is printed.
 
 ## Usage
 
@@ -85,8 +87,8 @@ const analytics = createAnalytics({
   source: "cli",
   sdkName: "@sapiom/cli",
   sdkVersion: "1.0.0",
-  // No endpoint → a silent no-op. To actually deliver:
-  // endpoint: SAPIOM_COLLECTOR_ENDPOINT,
+  // Delivers to the hosted Sapiom collector (SAPIOM_COLLECTOR_ENDPOINT)
+  // by default; pass `endpoint` to send somewhere else.
 });
 
 analytics.track("command.run", { command: "dev" });

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -55,6 +55,9 @@ Any of these disables analytics entirely (highest precedence first):
 2. `SAPIOM_TELEMETRY_DISABLED=1` in the environment.
 3. `DO_NOT_TRACK=1` in the environment (the ecosystem-wide convention).
 
+For packages wiring a custom `consentProvider`: returning `undefined` defers
+to the default, which is enabled — return `false` to keep analytics off.
+
 When opted out, nothing is sent, nothing is written to disk, zero network
 calls are made — and no notice is printed.
 

--- a/packages/analytics-core/src/__tests__/fault-injection.test.ts
+++ b/packages/analytics-core/src/__tests__/fault-injection.test.ts
@@ -132,30 +132,62 @@ describe("fault injection", () => {
     expect(capture.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("treats an explicit empty-string endpoint as absent (ship-dark no-op)", async () => {
+  it("treats an explicit empty-string endpoint as absent → hosted default", async () => {
     delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
     const capture = createCapturingFetch();
     const analytics = tracker.register(
-      createAnalytics(baseConfig({ endpoint: "", fetchImpl: capture.fetchImpl })),
+      createAnalytics(
+        baseConfig({ endpoint: "", fetchImpl: capture.fetchImpl }),
+      ),
     );
 
-    expect(analytics.enabled).toBe(false);
+    expect(analytics.enabled).toBe(true);
     analytics.track("event", { n: 1 });
     await analytics.flush();
-    expect(capture.calls).toHaveLength(0);
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.calls[0].url).toBe(SAPIOM_COLLECTOR_ENDPOINT);
   });
 
-  it("ships dark: no endpoint configured → no-op, zero fetches, zero disk writes", async () => {
+  it("no endpoint configured → delivers to the hosted collector by default", async () => {
     delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
     const capture = createCapturingFetch();
     const analytics = tracker.register(
       createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
     );
 
-    expect(analytics.enabled).toBe(false);
+    expect(analytics.enabled).toBe(true);
     expect(() => analytics.track("event", { n: 1 })).not.toThrow();
     await expect(analytics.flush()).resolves.toBeUndefined();
     await expect(analytics.shutdown()).resolves.toBeUndefined();
+
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.calls[0].url).toBe(SAPIOM_COLLECTOR_ENDPOINT);
+  });
+
+  it("opt-out keeps the true no-op path: zero fetches, zero disk writes", async () => {
+    // The live default makes consent the only dark switch — verify it still
+    // guarantees a full no-op even when the default endpoint would apply.
+    delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
+    process.env.SAPIOM_TELEMETRY_DISABLED = "1";
+    const capture = createCapturingFetch();
+
+    const optedOutByEnv = tracker.register(
+      createAnalytics(baseConfig({ fetchImpl: capture.fetchImpl })),
+    );
+    expect(optedOutByEnv.enabled).toBe(false);
+    expect(() => optedOutByEnv.track("event", { n: 1 })).not.toThrow();
+    await expect(optedOutByEnv.flush()).resolves.toBeUndefined();
+    await expect(optedOutByEnv.shutdown()).resolves.toBeUndefined();
+
+    delete process.env.SAPIOM_TELEMETRY_DISABLED;
+    const optedOutByConfig = tracker.register(
+      createAnalytics(
+        baseConfig({ disabled: true, fetchImpl: capture.fetchImpl }),
+      ),
+    );
+    expect(optedOutByConfig.enabled).toBe(false);
+    optedOutByConfig.track("event", { n: 1 });
+    await optedOutByConfig.flush();
 
     expect(capture.calls).toHaveLength(0);
     expect(fs.existsSync(home.identityPath)).toBe(false);

--- a/packages/analytics-core/src/__tests__/fault-injection.test.ts
+++ b/packages/analytics-core/src/__tests__/fault-injection.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 
 import { createAnalytics } from "../analytics.js";
 import { SAPIOM_COLLECTOR_ENDPOINT } from "../http-sender.js";
-import type { AnalyticsConfig } from "../types.js";
+import type { AnalyticsConfig, FetchLike } from "../types.js";
 import {
   cleanAnalyticsEnv,
   createCapturingFetch,
@@ -55,15 +55,40 @@ describe("fault injection", () => {
 
   it("collector down (real ECONNREFUSED on a closed port, env endpoint override): never rejects", async () => {
     const port = await getClosedPort();
+    // DO NOT REMOVE this override: without it the live default is the
+    // production collector, and this test — which uses the real global
+    // fetch — would dial real network.
     process.env.SAPIOM_ANALYTICS_ENDPOINT = `http://127.0.0.1:${port}/collector`;
 
-    // Real global fetch, real connection failure.
-    const analytics = tracker.register(createAnalytics(baseConfig()));
-    expect(analytics.enabled).toBe(true);
+    // Real global fetch, real connection failure. The wrapper records every
+    // dialed URL and refuses the production collector outright, so a lost
+    // override fails the assertions below instead of leaking real traffic.
+    const dialed: string[] = [];
+    const globalWithFetch = globalThis as { fetch: FetchLike };
+    const realFetch = globalWithFetch.fetch;
+    globalWithFetch.fetch = (url, init) => {
+      dialed.push(String(url));
+      if (String(url) === SAPIOM_COLLECTOR_ENDPOINT) {
+        return Promise.reject(
+          new Error("test attempted to dial the production collector"),
+        );
+      }
+      return realFetch(url, init);
+    };
 
-    expect(() => analytics.track("event", { n: 1 })).not.toThrow();
-    await expect(analytics.flush()).resolves.toBeUndefined();
-    await expect(analytics.shutdown()).resolves.toBeUndefined();
+    try {
+      const analytics = tracker.register(createAnalytics(baseConfig()));
+      expect(analytics.enabled).toBe(true);
+
+      expect(() => analytics.track("event", { n: 1 })).not.toThrow();
+      await expect(analytics.flush()).resolves.toBeUndefined();
+      await expect(analytics.shutdown()).resolves.toBeUndefined();
+    } finally {
+      globalWithFetch.fetch = realFetch;
+    }
+
+    expect(dialed.length).toBeGreaterThanOrEqual(1);
+    expect(dialed).not.toContain(SAPIOM_COLLECTOR_ENDPOINT);
   });
 
   it("HTTP 500: no throw, at most one retry, then silent drop", async () => {
@@ -133,6 +158,7 @@ describe("fault injection", () => {
   });
 
   it("treats an explicit empty-string endpoint as absent → hosted default", async () => {
+    // Unpinned to prove default fall-through; fetchImpl is the egress guard.
     delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
     const capture = createCapturingFetch();
     const analytics = tracker.register(
@@ -149,6 +175,7 @@ describe("fault injection", () => {
   });
 
   it("no endpoint configured → delivers to the hosted collector by default", async () => {
+    // Unpinned to prove default fall-through; fetchImpl is the egress guard.
     delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
     const capture = createCapturingFetch();
     const analytics = tracker.register(
@@ -167,6 +194,7 @@ describe("fault injection", () => {
   it("opt-out keeps the true no-op path: zero fetches, zero disk writes", async () => {
     // The live default makes consent the only dark switch — verify it still
     // guarantees a full no-op even when the default endpoint would apply.
+    // Unpinned so consent beats the live default; fetchImpl guards egress.
     delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
     process.env.SAPIOM_TELEMETRY_DISABLED = "1";
     const capture = createCapturingFetch();
@@ -194,7 +222,8 @@ describe("fault injection", () => {
   });
 
   it("explicitly passing SAPIOM_COLLECTOR_ENDPOINT targets the hosted collector", async () => {
-    delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
+    // The beforeEach pin stays: a config endpoint beats the env override
+    // (proven separately below), so no unpinning is needed here.
     const capture = createCapturingFetch();
     const analytics = tracker.register(
       createAnalytics(

--- a/packages/analytics-core/src/__tests__/helpers.ts
+++ b/packages/analytics-core/src/__tests__/helpers.ts
@@ -75,9 +75,9 @@ export const TEST_ENDPOINT = "http://127.0.0.1:9/test-collector";
 /**
  * Give the test a deterministic analytics environment: clear the consent
  * opt-outs and pin `SAPIOM_ANALYTICS_ENDPOINT` to {@link TEST_ENDPOINT}.
- * The emitter ships dark (no endpoint → no-op), so tests exercising delivery
- * must configure an endpoint — the env override is how these suites do it.
- * Returns a restore fn.
+ * The emitter delivers to the hosted collector by default, so the pin is
+ * mandatory: it guarantees no test can ever target the production URL, even
+ * if one forgets to inject a `fetchImpl`. Returns a restore fn.
  */
 export function cleanAnalyticsEnv(): () => void {
   const keys = [

--- a/packages/analytics-core/src/__tests__/identity.test.ts
+++ b/packages/analytics-core/src/__tests__/identity.test.ts
@@ -123,7 +123,7 @@ describe("identity store + first-run notice", () => {
     expect(fs.existsSync(home.identityPath)).toBe(false);
   });
 
-  it("keeps emitting (anonymous_id null, no notice) when HOME is unwritable", async () => {
+  it("keeps emitting (anonymous_id null, notice still prints) when HOME is unwritable", async () => {
     // Point HOME below a regular file so mkdir must fail.
     const blocker = path.join(home.dir, "blocker");
     fs.writeFileSync(blocker, "i am a file");
@@ -138,10 +138,30 @@ describe("identity store + first-run notice", () => {
     expect(() => analytics.track("event")).not.toThrow();
     await analytics.flush();
 
-    expect(noticeCount()).toBe(0);
+    // Delivery happens, so the notice must too ("never silent") — even
+    // though the shown-marker cannot persist without identity storage.
+    expect(noticeCount()).toBe(1);
     expect(capture.calls).toHaveLength(1);
     expect(capture.batch()[0].anonymous_id).toBeNull();
     expect(analytics.anonymousId).toBeNull();
+  });
+
+  it("unwritable HOME + enabled → first-run notice fires on first track", () => {
+    // Same blocked-HOME technique as above: the marker cannot persist, so
+    // the notice prints unconditionally instead of being suppressed.
+    const blocker = path.join(home.dir, "blocker");
+    fs.writeFileSync(blocker, "i am a file");
+    process.env.HOME = path.join(blocker, "nested");
+    process.env.USERPROFILE = process.env.HOME;
+
+    const analytics = tracker.register(createAnalytics(baseConfig()));
+    expect(noticeCount()).toBe(0); // tied to track(), not instance creation
+
+    analytics.track("event");
+    expect(noticeCount()).toBe(1);
+
+    analytics.track("event_two");
+    expect(noticeCount()).toBe(1); // once per instance, not per event
   });
 
   it("shares one session id per process and exposes it as uuid4", () => {

--- a/packages/analytics-core/src/__tests__/internals.test.ts
+++ b/packages/analytics-core/src/__tests__/internals.test.ts
@@ -16,6 +16,7 @@ import { buildEnvelope } from "../envelope.js";
 import {
   HttpSender,
   resolveEndpoint,
+  SAPIOM_COLLECTOR_ENDPOINT,
   type SendOutcome,
 } from "../http-sender.js";
 import type { AnalyticsConfig, Envelope, EnvelopeFields } from "../types.js";
@@ -226,17 +227,23 @@ describe("resolveEndpoint (unit)", () => {
     restoreEnv();
   });
 
-  it("stays dark (null, no throw) when nothing is configured", () => {
-    expect(resolveEndpoint()).toBeNull();
-    expect(resolveEndpoint(undefined)).toBeNull();
+  it("defaults to the hosted collector when nothing is configured", () => {
+    expect(resolveEndpoint()).toBe(SAPIOM_COLLECTOR_ENDPOINT);
+    expect(resolveEndpoint(undefined)).toBe(SAPIOM_COLLECTOR_ENDPOINT);
   });
 
-  it("does not treat empty strings as endpoints", () => {
-    expect(resolveEndpoint("")).toBeNull();
+  it("treats empty strings as absent, falling through to the next source", () => {
+    // Empty config endpoint falls through to the environment override…
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = "http://127.0.0.1:9/env";
+    expect(resolveEndpoint("")).toBe("http://127.0.0.1:9/env");
 
+    // …and when that is empty or absent too, to the hosted default.
     process.env.SAPIOM_ANALYTICS_ENDPOINT = "";
-    expect(resolveEndpoint()).toBeNull();
-    expect(resolveEndpoint("")).toBeNull();
+    expect(resolveEndpoint()).toBe(SAPIOM_COLLECTOR_ENDPOINT);
+    expect(resolveEndpoint("")).toBe(SAPIOM_COLLECTOR_ENDPOINT);
+
+    delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
+    expect(resolveEndpoint("")).toBe(SAPIOM_COLLECTOR_ENDPOINT);
   });
 
   it("prefers the config endpoint over the environment override", () => {

--- a/packages/analytics-core/src/analytics.ts
+++ b/packages/analytics-core/src/analytics.ts
@@ -31,10 +31,12 @@ function getProcessSessionId(): string {
  * Guarantees, regardless of configuration or environment:
  * - `createAnalytics` and `track` never throw
  * - `flush`/`shutdown` never reject
- * - nothing is written or sent unless consent resolves to enabled AND a
- *   collector endpoint is explicitly configured (`endpoint` in the config or
- *   the `SAPIOM_ANALYTICS_ENDPOINT` environment variable) — the default
- *   build ships dark
+ * - nothing is written or sent unless consent resolves to enabled —
+ *   `disabled: true`, `SAPIOM_TELEMETRY_DISABLED=1`, and `DO_NOT_TRACK=1`
+ *   each force a full no-op (zero fetches, zero disk writes)
+ *
+ * Events deliver to the hosted Sapiom collector by default
+ * (`SAPIOM_COLLECTOR_ENDPOINT`); a configured `endpoint` overrides it.
  */
 export function createAnalytics(config: AnalyticsConfig): SapiomAnalytics {
   try {
@@ -61,14 +63,9 @@ function buildAnalytics(config: AnalyticsConfig): SapiomAnalytics {
   const sessionId = getProcessSessionId();
   if (!resolveConsent(config)) return createDisabledInstance(sessionId);
 
-  // Ship-dark: with no explicitly configured endpoint there is nowhere to
-  // send, so the instance is a full no-op — events are dropped at enqueue,
-  // nothing is written to disk, and no first-run notice is printed.
+  // Resolution always yields an endpoint — the hosted collector when nothing
+  // is configured. Consent (checked above) is the only off switch.
   const endpoint = resolveEndpoint(config.endpoint);
-  if (endpoint === null) {
-    debug("no collector endpoint configured; analytics is a no-op");
-    return createDisabledInstance(sessionId);
-  }
 
   const identityStore = new IdentityStore(debug);
   const sender = new HttpSender({

--- a/packages/analytics-core/src/analytics.ts
+++ b/packages/analytics-core/src/analytics.ts
@@ -91,9 +91,13 @@ function buildAnalytics(config: AnalyticsConfig): SapiomAnalytics {
 
         // First-ever tracked event across all packages on this machine
         // prints a one-line notice (marker lives in the identity file).
+        // When identity storage is unavailable the marker cannot persist:
+        // print unconditionally rather than collect silently — repeating
+        // the notice every process start in that edge case is acceptable,
+        // silent delivery is not.
         if (!noticeAttempted) {
           noticeAttempted = true;
-          if (identityStore.markFirstRunNoticeShown()) {
+          if (identity === null || identityStore.markFirstRunNoticeShown()) {
             try {
               process.stderr.write(FIRST_RUN_NOTICE + "\n");
             } catch {

--- a/packages/analytics-core/src/http-sender.ts
+++ b/packages/analytics-core/src/http-sender.ts
@@ -42,7 +42,7 @@ export function resolveEndpoint(configEndpoint?: string): string {
   const fromEnv = process.env[ENDPOINT_ENV_VAR];
   if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
   // LIVE DEFAULT: the hosted collector is deployed, so an unconfigured
-  // emitter delivers there. (This is the pre-planned ship-dark flip.)
+  // emitter delivers there.
   return SAPIOM_COLLECTOR_ENDPOINT;
 }
 

--- a/packages/analytics-core/src/http-sender.ts
+++ b/packages/analytics-core/src/http-sender.ts
@@ -3,11 +3,10 @@ import type { DebugHook, Envelope, FetchLike } from "./types.js";
 /**
  * The hosted Sapiom collector URL (see CONTRACT.md).
  *
- * The emitter does NOT send here by default — it ships dark (see
- * {@link resolveEndpoint}). Pass this constant as `endpoint` to deliver to
- * the hosted collector:
- *
- *   createAnalytics({ ..., endpoint: SAPIOM_COLLECTOR_ENDPOINT })
+ * This is the emitter's DEFAULT endpoint: an emitter with no explicit
+ * `endpoint` configured delivers here (see {@link resolveEndpoint}).
+ * Turning analytics off is a consent decision (`disabled: true`,
+ * `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`), not an endpoint one.
  */
 export const SAPIOM_COLLECTOR_ENDPOINT =
   "https://api.sapiom.ai/v1/analytics/collector";
@@ -27,21 +26,24 @@ const REQUEST_TIMEOUT_MS = 5_000;
 export type SendOutcome = "ok" | "retry" | "drop";
 
 /**
- * Endpoint resolution: explicit config → environment override → dark.
+ * Endpoint resolution: explicit config → environment override → hosted
+ * default ({@link SAPIOM_COLLECTOR_ENDPOINT}).
  *
- * `null` means "no endpoint configured": the emitter becomes a silent no-op
- * (zero fetches, zero retries, nothing written to disk).
+ * Empty strings are treated as absent rather than as endpoints, so an
+ * explicit `endpoint: ""` falls through to the environment override and
+ * then to the hosted default. Resolution always yields an endpoint;
+ * disabling delivery is consent's job (see `consent.ts`), never this
+ * function's.
  */
-export function resolveEndpoint(configEndpoint?: string): string | null {
+export function resolveEndpoint(configEndpoint?: string): string {
   if (typeof configEndpoint === "string" && configEndpoint.length > 0) {
     return configEndpoint;
   }
   const fromEnv = process.env[ENDPOINT_ENV_VAR];
   if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
-  // SHIP-DARK DEFAULT: the hosted collector is not deployed yet, so an
-  // unconfigured emitter must send nothing. Once the collector is live,
-  // flip the next line to `return SAPIOM_COLLECTOR_ENDPOINT;`.
-  return null;
+  // LIVE DEFAULT: the hosted collector is deployed, so an unconfigured
+  // emitter delivers there. (This is the pre-planned ship-dark flip.)
+  return SAPIOM_COLLECTOR_ENDPOINT;
 }
 
 export interface HttpSenderOptions {

--- a/packages/analytics-core/src/index.ts
+++ b/packages/analytics-core/src/index.ts
@@ -12,13 +12,13 @@
  *   analytics.track("command.run", { command: "dev" });
  *   await analytics.shutdown();
  *
- * The emitter ships dark: unless an endpoint is explicitly configured
- * (`endpoint` in the config, or the `SAPIOM_ANALYTICS_ENDPOINT` environment
- * variable), it is a silent no-op — zero network calls, zero disk writes.
- * Pass `SAPIOM_COLLECTOR_ENDPOINT` to deliver to the hosted collector.
+ * The emitter delivers to the hosted Sapiom collector
+ * (`SAPIOM_COLLECTOR_ENDPOINT`) by default; a configured `endpoint`
+ * overrides it.
  *
  * Opt out with `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or
- * `disabled: true`. Analytics never throws and never blocks the host.
+ * `disabled: true` — an opted-out emitter is a silent no-op: zero network
+ * calls, zero disk writes. Analytics never throws and never blocks the host.
  *
  * Test utilities (an in-process mock collector) live in the
  * `@sapiom/analytics-core/testing` subpath export.

--- a/packages/analytics-core/src/types.ts
+++ b/packages/analytics-core/src/types.ts
@@ -49,11 +49,11 @@ export interface AnalyticsConfig {
   /** Emitting package version. */
   sdkVersion: string;
   /**
-   * Collector URL. There is no default: when neither this nor the
-   * `SAPIOM_ANALYTICS_ENDPOINT` environment variable is set, the emitter is
-   * a silent no-op (nothing is sent anywhere, nothing is written to disk).
-   * Pass the exported `SAPIOM_COLLECTOR_ENDPOINT` constant to deliver to the
-   * hosted Sapiom collector. An empty string is treated as absent.
+   * Collector URL. Defaults to the hosted Sapiom collector (the exported
+   * `SAPIOM_COLLECTOR_ENDPOINT` constant). An empty string is treated as
+   * absent and falls through to the default. To turn analytics off, use an
+   * opt-out (`disabled`, `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`)
+   * rather than the endpoint.
    */
   endpoint?: string;
   /** Optional API key, sent as `x-sapiom-api-key` for server-side enrichment. */
@@ -117,10 +117,9 @@ export interface SapiomAnalytics {
   shutdown(): Promise<void>;
   /**
    * `true` only when events can actually be emitted: consent resolved to
-   * enabled AND a collector endpoint is configured. The two `false` causes
-   * (consent denied vs no endpoint) are intentionally merged; callers that
-   * need to distinguish them should inspect `SAPIOM_TELEMETRY_DISABLED` /
-   * `DO_NOT_TRACK` themselves.
+   * enabled (and initialization succeeded). The `false` causes are
+   * intentionally merged; callers that need to distinguish the opt-outs
+   * should inspect `SAPIOM_TELEMETRY_DISABLED` / `DO_NOT_TRACK` themselves.
    */
   readonly enabled: boolean;
   /** Persisted anonymous machine id, or `null` when disabled/unavailable. */

--- a/packages/analytics-core/src/types.ts
+++ b/packages/analytics-core/src/types.ts
@@ -63,9 +63,10 @@ export interface AnalyticsConfig {
   /** Programmatic opt-out. Highest-precedence consent signal. */
   disabled?: boolean;
   /**
-   * Optional consent hook, consulted after the environment opt-outs.
-   * Return `true` or `false` to decide; return `undefined` (or throw) to
-   * fall through to the default (enabled).
+   * Optional consent hook, consulted after `disabled` and the environment
+   * opt-outs. Return `true` or `false` to decide. Returning `undefined`
+   * (or throwing) defers to the default, which is ENABLED — return `false`
+   * to disable; do not use `undefined` as a "not decided yet" sentinel.
    */
   consentProvider?: () => boolean | undefined;
   /** Custom fetch implementation (dependency injection, primarily for tests). */

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -4,6 +4,10 @@ module.exports = {
   // Builds this package (and missing workspace deps) so the analytics e2e
   // suite always runs the current dist/bin.js.
   globalSetup: '<rootDir>/jest.global-setup.cjs',
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.cjs'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/cli/jest.telemetry-guard.cjs
+++ b/packages/cli/jest.telemetry-guard.cjs
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/cli/jest.telemetry-guard.cjs
+++ b/packages/cli/jest.telemetry-guard.cjs
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/cli/src/__tests__/command-analytics.e2e.test.ts
+++ b/packages/cli/src/__tests__/command-analytics.e2e.test.ts
@@ -263,17 +263,21 @@ describe('command.run analytics (built CLI against a mock collector)', () => {
     expect(optedOut.stderr).toBe('');
   }, 30_000);
 
-  it('ships dark: without an endpoint nothing is sent, written, or printed', async () => {
+  it('live by default: with no opt-outs configured, the first-run notice prints and events reach the collector', async () => {
+    // No SAPIOM_TELEMETRY_DISABLED or DO_NOT_TRACK — the emitter is live by
+    // default and routes to the hosted collector. SAPIOM_ANALYTICS_ENDPOINT
+    // redirects that to the mock so nothing hits the production URL.
     const home = freshHome();
-    const result = await runCli(['logout', '--json'], cliEnv(home));
-    await settle(250);
+    const result = await runCli(['logout', '--json'], cliEnv(home, { SAPIOM_ANALYTICS_ENDPOINT: collector.url }));
 
     expect(result.code).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({ ok: true, cleared: false });
-    expect(result.stderr).toBe('');
-    expect(collector.requests).toHaveLength(0);
-    // No identity file, no first-run marker — zero disk writes.
-    expect(existsSync(path.join(home, '.sapiom', 'analytics.json'))).toBe(false);
+    // The first-run notice prints because no opt-out silences it.
+    expect(result.stderr).toContain(FIRST_RUN_NOTICE);
+    await collector.waitForRequests(1);
+    expect(collector.requests.length).toBeGreaterThan(0);
+    // Identity file is created (first run on a fresh HOME).
+    expect(existsSync(path.join(home, '.sapiom', 'analytics.json'))).toBe(true);
   }, 20_000);
 
   it('prints the first-run notice exactly once per machine and stamps the marker', async () => {

--- a/packages/cli/src/lib/analytics.ts
+++ b/packages/cli/src/lib/analytics.ts
@@ -2,10 +2,11 @@
  * Usage analytics for the CLI: one `command.run` event per executed command,
  * emitted through @sapiom/analytics-core via commander lifecycle hooks.
  *
- * Ships dark: unless a collector endpoint is explicitly configured (the
- * `SAPIOM_ANALYTICS_ENDPOINT` environment variable), the emitter is a silent
- * no-op — zero network calls, zero disk writes, no notice. Opt out any time
- * with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
+ * Live by default: the emitter delivers to the hosted Sapiom collector unless
+ * opted out. `SAPIOM_ANALYTICS_ENDPOINT` overrides the destination (useful in
+ * tests). Opt out with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` —
+ * either makes the emitter a complete no-op (zero network calls, zero disk
+ * writes, no notice).
  *
  * Privacy: an event carries the command path (canonical command names only),
  * the NAMES of the flags that were passed, the duration, and the exit status.

--- a/packages/langchain-classic/jest.config.js
+++ b/packages/langchain-classic/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   testEnvironment: 'node',
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.js'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/langchain-classic/jest.telemetry-guard.js
+++ b/packages/langchain-classic/jest.telemetry-guard.js
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/langchain-classic/jest.telemetry-guard.js
+++ b/packages/langchain-classic/jest.telemetry-guard.js
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/langchain-classic/src/analytics.test.ts
+++ b/packages/langchain-classic/src/analytics.test.ts
@@ -456,7 +456,7 @@ describe("langchain-classic usage analytics", () => {
     });
   });
 
-  describe("opt-out and ship-dark", () => {
+  describe("opt-out and live-default", () => {
     it.each(["SAPIOM_TELEMETRY_DISABLED", "DO_NOT_TRACK"])(
       "%s=1 results in zero collector requests",
       async (envKey) => {
@@ -481,10 +481,12 @@ describe("langchain-classic usage analytics", () => {
       },
     );
 
-    it("ships dark (no requests) when no endpoint is configured", async () => {
-      delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
-      await __resetAnalyticsForTests();
-
+    it("live by default: with no explicit endpoint config, emitter is enabled and events reach the collector", async () => {
+      // No explicit `endpoint` on the analytics config, but the env override
+      // (SAPIOM_ANALYTICS_ENDPOINT) set by beforeEach points at the mock so
+      // nothing hits the production URL. This exercises the live-default
+      // fall-through path: resolveEndpoint() returns the hosted collector when
+      // no config is set, and the env override redirects that to the mock.
       mockOpenAIGenerate("Hi", {
         input_tokens: 1,
         output_tokens: 1,
@@ -496,9 +498,9 @@ describe("langchain-classic usage analytics", () => {
       );
       await model.invoke("Hello");
 
-      expect(getAnalytics().enabled).toBe(false);
+      expect(getAnalytics().enabled).toBe(true);
       await getAnalytics().flush();
-      expect(collector.requests).toHaveLength(0);
+      expect(collector.requests.length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/langchain-classic/src/internal/analytics.ts
+++ b/packages/langchain-classic/src/internal/analytics.ts
@@ -25,8 +25,8 @@
  *   content.
  *
  * Emission is enqueue-only (`track()` is synchronous and never throws) and
- * ships dark by default: without the `SAPIOM_ANALYTICS_ENDPOINT` environment
- * variable (or an explicit endpoint) `@sapiom/analytics-core` is a no-op.
+ * live by default: an unconfigured emitter delivers to the hosted Sapiom
+ * collector. Use `SAPIOM_ANALYTICS_ENDPOINT` to redirect (test use).
  * Opt-outs: `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
  */
 import type { LLMResult } from "@langchain/core/outputs";

--- a/packages/langchain/jest.config.js
+++ b/packages/langchain/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   testEnvironment: 'node',
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.js'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/langchain/jest.telemetry-guard.js
+++ b/packages/langchain/jest.telemetry-guard.js
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/langchain/jest.telemetry-guard.js
+++ b/packages/langchain/jest.telemetry-guard.js
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/langchain/src/analytics.test.ts
+++ b/packages/langchain/src/analytics.test.ts
@@ -404,7 +404,7 @@ describe("langchain middleware usage analytics", () => {
     });
   });
 
-  describe("opt-out and ship-dark", () => {
+  describe("opt-out and live-default", () => {
     it.each(["SAPIOM_TELEMETRY_DISABLED", "DO_NOT_TRACK"])(
       "%s=1 results in zero collector requests",
       async (envKey) => {
@@ -429,10 +429,12 @@ describe("langchain middleware usage analytics", () => {
       },
     );
 
-    it("ships dark (no requests) when no endpoint is configured", async () => {
-      delete process.env.SAPIOM_ANALYTICS_ENDPOINT;
-      await __resetAnalyticsForTests();
-
+    it("live by default: with no explicit endpoint config, emitter is enabled and events reach the collector", async () => {
+      // No explicit `endpoint` on the analytics config, but the env override
+      // (SAPIOM_ANALYTICS_ENDPOINT) set by beforeEach points at the mock so
+      // nothing hits the production URL. This exercises the live-default
+      // fall-through path: resolveEndpoint() returns the hosted collector when
+      // no config is set, and the env override redirects that to the mock.
       const middleware = createSapiomMiddleware();
       const response = modelResponse();
       const result = await middleware.wrapModelCall!(
@@ -441,9 +443,9 @@ describe("langchain middleware usage analytics", () => {
       );
 
       expect(result).toBe(response);
-      expect(getAnalytics().enabled).toBe(false);
+      expect(getAnalytics().enabled).toBe(true);
       await getAnalytics().flush();
-      expect(collector.requests).toHaveLength(0);
+      expect(collector.requests.length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/langchain/src/internal/analytics.ts
+++ b/packages/langchain/src/internal/analytics.ts
@@ -22,8 +22,8 @@
  *   content.
  *
  * Emission is enqueue-only (`track()` is synchronous and never throws) and
- * ships dark by default: without the `SAPIOM_ANALYTICS_ENDPOINT` environment
- * variable (or an explicit endpoint) `@sapiom/analytics-core` is a no-op.
+ * live by default: an unconfigured emitter delivers to the hosted Sapiom
+ * collector. Use `SAPIOM_ANALYTICS_ENDPOINT` to redirect (test use).
  * Opt-outs: `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
  */
 import { createAnalytics, type SapiomAnalytics } from "@sapiom/analytics-core";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -105,15 +105,14 @@ never grows a per-capability tool of its own — capabilities live in
 
 ## Usage analytics
 
-The server can emit anonymous usage analytics (one `tool.call` event per tool
+The server emits anonymous usage analytics (one `tool.call` event per tool
 invocation: tool name, arguments, duration, ok/error class) via
-[`@sapiom/analytics-core`](../analytics-core). It currently ships dark: unless
-a collector endpoint is explicitly configured through the
-`SAPIOM_ANALYTICS_ENDPOINT` environment variable, nothing is sent anywhere and
-nothing is written to disk. Opt out at any time with
-`SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`. Telemetry is a synchronous
-in-memory enqueue that never throws, never blocks a tool call, and can never
-change a tool result.
+[`@sapiom/analytics-core`](../analytics-core) to the hosted Sapiom collector
+by default. Opt out at any time with `SAPIOM_TELEMETRY_DISABLED=1` or
+`DO_NOT_TRACK=1` — either makes the emitter a complete no-op (nothing is sent,
+nothing is written to disk). `SAPIOM_ANALYTICS_ENDPOINT` overrides the
+destination. Telemetry is a synchronous in-memory enqueue that never throws,
+never blocks a tool call, and can never change a tool result.
 
 ## License
 

--- a/packages/mcp/src/analytics.e2e.test.ts
+++ b/packages/mcp/src/analytics.e2e.test.ts
@@ -246,7 +246,7 @@ describe("analytics e2e (real stdio server)", () => {
   );
 
   it(
-    "tool results are identical across collector down/500/slow, telemetry disabled, and no endpoint",
+    "tool results are identical across collector down/500/slow, telemetry disabled, and analytics unreachable",
     { timeout: 60_000 },
     async () => {
       // A fixed path (not under the per-server temp HOME) so error payloads
@@ -265,7 +265,12 @@ describe("analytics e2e (real stdio server)", () => {
         SAPIOM_ANALYTICS_ENDPOINT: collector.url,
         SAPIOM_TELEMETRY_DISABLED: "1",
       });
-      const dark = await spawnServer({}); // ships dark: no endpoint at all
+      // Live-default with a permanently-refused endpoint (port 9 = discard).
+      // Telemetry is enabled (no opt-out), delivery fails silently — tool
+      // results must be identical whether analytics succeeds or fails.
+      const refused = await spawnServer({
+        SAPIOM_ANALYTICS_ENDPOINT: "http://127.0.0.1:9/v1/analytics/collector",
+      });
       try {
         const snapshot = async (client: Client) => ({
           status: await callTool(client, "sapiom_status"),
@@ -290,13 +295,13 @@ describe("analytics e2e (real stdio server)", () => {
         collector.setMode({ kind: "slow", delayMs: 300 });
         expect(await snapshot(healthy.client)).toEqual(baseline);
 
-        // Telemetry disabled and never-configured servers behave identically.
+        // Telemetry disabled and analytics-unreachable servers behave identically.
         expect(await snapshot(disabled.client)).toEqual(baseline);
-        expect(await snapshot(dark.client)).toEqual(baseline);
+        expect(await snapshot(refused.client)).toEqual(baseline);
       } finally {
         await closeServer(healthy);
         await closeServer(disabled);
-        await closeServer(dark);
+        await closeServer(refused);
         await collector.close();
       }
     },

--- a/packages/mcp/src/analytics.ts
+++ b/packages/mcp/src/analytics.ts
@@ -6,12 +6,12 @@
  * environment's cached credentials when one exists (server-side enrichment);
  * everything else reaches the same instance through {@link getAnalytics}.
  *
- * The emitter ships dark: unless a collector endpoint is explicitly
- * configured (the `SAPIOM_ANALYTICS_ENDPOINT` environment variable), it is a
- * silent no-op — zero network calls, zero disk writes. The standard opt-outs
- * (`SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`) are honored by
- * `@sapiom/analytics-core`, and `track()` is a synchronous enqueue that
- * never throws and never blocks a tool call.
+ * The emitter is live by default: it delivers to the hosted Sapiom collector
+ * unless opted out. `SAPIOM_ANALYTICS_ENDPOINT` overrides the destination
+ * (useful in tests). The standard opt-outs (`SAPIOM_TELEMETRY_DISABLED=1`,
+ * `DO_NOT_TRACK=1`) are honored by `@sapiom/analytics-core` and produce a
+ * complete no-op (zero network calls, zero disk writes). `track()` is a
+ * synchronous enqueue that never throws and never blocks a tool call.
  */
 import { createRequire } from "node:module";
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,8 +20,8 @@ async function main(): Promise<void> {
   }
 
   // Construct the process-wide usage-analytics emitter once, keyed with the
-  // cached credential when one exists. Ships dark (a no-op unless a collector
-  // endpoint is configured) and honors the standard telemetry opt-outs.
+  // cached credential when one exists. Live by default; honors the standard
+  // telemetry opt-outs (SAPIOM_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1).
   configureAnalytics({ apiKey: env.credentials?.apiKey });
 
   // Pull the latest authoring instructions from the backend (falls back to the

--- a/packages/mcp/src/register-tool.ts
+++ b/packages/mcp/src/register-tool.ts
@@ -13,7 +13,8 @@
  * unchanged, and a thrown error is rethrown unchanged. Emission is a
  * synchronous enqueue — no awaits on the hot path — and can never throw, so
  * telemetry cannot alter a tool result or take the server down. The emitter
- * ships dark: with no collector endpoint configured it is a no-op.
+ * is live by default; `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`
+ * make it a no-op.
  */
 import type {
   McpServer,

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    // Telemetry defaults live; disable it globally so no test emits to the real
+    // production collector. Tests that assert events ARE sent must opt in by
+    // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+    env: { SAPIOM_TELEMETRY_DISABLED: "1" },
     coverage: {
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/index.ts"],

--- a/packages/tools/jest.config.js
+++ b/packages/tools/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   testEnvironment: 'node',
   passWithNoTests: true,
+  // Telemetry defaults live; disable it globally so no test emits to the real
+  // production collector. Tests that assert events ARE sent must opt in by
+  // setting SAPIOM_ANALYTICS_ENDPOINT to the mock collector.
+  setupFiles: ['<rootDir>/jest.telemetry-guard.js'],
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/packages/tools/jest.telemetry-guard.js
+++ b/packages/tools/jest.telemetry-guard.js
@@ -1,0 +1,4 @@
+// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
+// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
+// test suite can accidentally emit to the real production collector.
+process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/tools/jest.telemetry-guard.js
+++ b/packages/tools/jest.telemetry-guard.js
@@ -1,4 +1,4 @@
-// Telemetry defaults live after the ship-dark flip; tests must opt in explicitly
-// via the mock collector (SAPIOM_ANALYTICS_ENDPOINT). This guard ensures no
-// test suite can accidentally emit to the real production collector.
+// Telemetry is live by default: an unconfigured emitter delivers to the real
+// production collector. Disable it globally here; tests that assert delivery
+// opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
 process.env.SAPIOM_TELEMETRY_DISABLED = "1";

--- a/packages/tools/src/_client/analytics.e2e.spec.ts
+++ b/packages/tools/src/_client/analytics.e2e.spec.ts
@@ -346,7 +346,7 @@ describe("capability.call analytics (e2e, mock collector)", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Consent + ship-dark
+  // Consent + live-default
   // -------------------------------------------------------------------------
 
   it("SAPIOM_TELEMETRY_DISABLED=1 → zero collector requests, identical result", async () => {

--- a/packages/tools/src/_client/analytics.e2e.spec.ts
+++ b/packages/tools/src/_client/analytics.e2e.spec.ts
@@ -375,18 +375,22 @@ describe("capability.call analytics (e2e, mock collector)", () => {
     expect(collector.requests).toHaveLength(0);
   });
 
-  it("ships dark: with no endpoint configured, nothing is sent and nothing is written", async () => {
-    // No SAPIOM_ANALYTICS_ENDPOINT. Remove the seeded identity file so any
-    // (forbidden) disk write would be visible.
-    fs.rmSync(path.join(tempHome, ".sapiom"), { recursive: true, force: true });
+  it("live by default: with no explicit endpoint config, emitter is enabled and requests reach the collector", async () => {
+    // No explicit `endpoint` on the analytics config, but the env override
+    // (SAPIOM_ANALYTICS_ENDPOINT) points at the mock so nothing hits the
+    // production URL. This exercises the live-default fall-through path:
+    // resolveEndpoint() returns the hosted collector when no config/env is set,
+    // and here the env override redirects that to the mock.
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = collector.url;
 
     const { result, transport } = await scrapeOnce();
     expect(result.markdown).toBe("# Example");
     await analyticsOf(transport)?.flush();
 
-    expect(collector.requests).toHaveLength(0);
-    expect(analyticsOf(transport)?.enabled).toBe(false);
-    expect(fs.existsSync(path.join(tempHome, ".sapiom"))).toBe(false);
+    expect(analyticsOf(transport)?.enabled).toBe(true);
+    expect(collector.requests.length).toBeGreaterThan(0);
+    // The identity file is written (first-run on a fresh HOME).
+    expect(fs.existsSync(path.join(tempHome, ".sapiom", "analytics.json"))).toBe(true);
   });
 
   // -------------------------------------------------------------------------
@@ -401,10 +405,13 @@ describe("capability.call analytics (e2e, mock collector)", () => {
 
   for (const [label, applyMode] of failureModes) {
     it(`collector ${label} → capability result identical, nothing thrown`, async () => {
-      // Baseline: telemetry fully dark.
-      const { result: baseline } = await scrapeOnce();
-
+      // Baseline: telemetry on with a healthy mock collector.
       enableTelemetry();
+      const { result: baseline } = await scrapeOnce();
+      // Reset before applying the fault mode so the assertions below only
+      // reflect the fault-mode scrape's delivery attempts.
+      collector.reset();
+
       applyMode();
       const { result, transport } = await scrapeOnce();
       expect(result).toEqual(baseline);
@@ -424,7 +431,7 @@ describe("capability.call analytics (e2e, mock collector)", () => {
     });
   }
 
-  it("a failing capability call throws identically whether telemetry is on, dark, or disabled", async () => {
+  it("a failing capability call throws identically whether telemetry is on (default-live) or disabled", async () => {
     const failingScrape = async (): Promise<SearchHttpError> => {
       const { transport } = makeTransport(
         () => new Response("upstream exploded", { status: 502 }),
@@ -437,19 +444,25 @@ describe("capability.call analytics (e2e, mock collector)", () => {
       throw new Error("scrape unexpectedly succeeded");
     };
 
-    const dark = await failingScrape();
+    // Default-live: no explicit endpoint override — the emitter resolves to the
+    // hosted collector, but here the env override redirects to the mock so
+    // nothing hits production. The throw behavior is the baseline.
+    process.env.SAPIOM_ANALYTICS_ENDPOINT = collector.url;
+    const defaultLive = await failingScrape();
 
+    // Explicit enableTelemetry (same endpoint, same behavior).
     enableTelemetry();
     const withTelemetry = await failingScrape();
 
+    // Disabled: no sends at all, but the throw must be identical.
     process.env.SAPIOM_TELEMETRY_DISABLED = "1";
     const disabled = await failingScrape();
 
     for (const thrown of [withTelemetry, disabled]) {
-      expect(thrown.name).toBe(dark.name);
-      expect(thrown.message).toBe(dark.message);
-      expect(thrown.status).toBe(dark.status);
-      expect(thrown.body).toEqual(dark.body);
+      expect(thrown.name).toBe(defaultLive.name);
+      expect(thrown.message).toBe(defaultLive.message);
+      expect(thrown.status).toBe(defaultLive.status);
+      expect(thrown.body).toEqual(defaultLive.body);
     }
   });
 });

--- a/packages/tools/src/_client/analytics.ts
+++ b/packages/tools/src/_client/analytics.ts
@@ -4,11 +4,13 @@
  * call through `@sapiom/analytics-core`.
  *
  * Non-negotiables, guaranteed regardless of configuration:
- * - Ships dark: without a collector endpoint (`SAPIOM_ANALYTICS_ENDPOINT`) the
- *   emitter is a silent no-op — zero network calls, zero disk writes.
+ * - Live by default: the emitter delivers to the hosted Sapiom collector unless
+ *   opted out. Opt out with `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`,
+ *   or `disabled: true` in the config — any of these makes the emitter a
+ *   complete no-op (zero network calls, zero disk writes, no notice).
+ *   `SAPIOM_ANALYTICS_ENDPOINT` overrides the destination (useful in tests).
  * - Enqueue-only on the call path: `track()` is synchronous, delivery is
  *   batched off the call path, and no failure here can surface to a caller.
- * - Opt out with `SAPIOM_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -20,7 +20,7 @@
  *
  * Being the single HTTP choke point also makes this the (one) instrumentation
  * seam: every call enqueues a `capability.call` usage event — synchronously,
- * never awaited, dark by default. See `./analytics.ts`.
+ * never awaited, live by default. See `./analytics.ts`.
  */
 import {
   CAPABILITY_CALL_EVENT,
@@ -160,7 +160,7 @@ export class Transport {
    * Flush and shut down this client's usage-analytics emitter: buffered events
    * are delivered best-effort and the emitter's `beforeExit` hook is detached.
    * Resolves immediately when no emitter was ever created (no calls made, or
-   * analytics dark/disabled); idempotent; never rejects. One call covers every
+   * analytics disabled); idempotent; never rejects. One call covers every
    * transport derived via {@link withAttribution} (they share the emitter).
    *
    * Call this once per client in hosts that construct MANY clients in one


### PR DESCRIPTION
## Why now

The hosted analytics collector is now **live in production**, so this executes the pre-planned ship-dark flip in `@sapiom/analytics-core`: the emitter's default endpoint turns on. This was designed for from day one — the flip line was marked in code.

## The flip

`resolveEndpoint()` in `src/http-sender.ts` carried the marked flip:

```ts
// SHIP-DARK DEFAULT: the hosted collector is not deployed yet, so an
// unconfigured emitter must send nothing. Once the collector is live,
// flip the next line to `return SAPIOM_COLLECTOR_ENDPOINT;`.
return null;
```

That line now returns `SAPIOM_COLLECTOR_ENDPOINT`. Precedence is unchanged: `config.endpoint` → env override → **(new) hosted default**. Empty strings are still treated as absent, so `endpoint: ""` falls through to the env override and then to the hosted default (documented on `resolveEndpoint` and `AnalyticsConfig.endpoint`).

Because resolution can no longer yield `null`, the return type narrows `string | null` → `string`, and the now-unreachable "no endpoint → disabled instance" branch in `createAnalytics` is removed (it would be a TS2367 strict-mode error left in place). Consent is the only off switch, exactly as before: `disabled: true`, `SAPIOM_TELEMETRY_DISABLED=1`, or `DO_NOT_TRACK=1` still yields a full no-op — zero fetches, zero disk writes, no first-run notice.

## Tests

- `fault-injection.test.ts` — the two ship-dark tests flipped:
  - "no endpoint configured → no-op" is now "no endpoint configured → delivers to the hosted collector by default", asserting the delivered URL is `SAPIOM_COLLECTOR_ENDPOINT` (via injected capturing fetch — nothing real is dialed).
  - the `endpoint: ""` test now asserts empty string = absent → hosted default.
  - a new test keeps the **true no-op path** pinned with no endpoint configured: `SAPIOM_TELEMETRY_DISABLED=1` and `disabled: true` each produce zero fetches and zero disk writes.
- `internals.test.ts` — `resolveEndpoint` unit tests updated for the live default; the empty-string test now also pins that an empty config endpoint yields to the env override before the hosted default.
- `helpers.ts` — `cleanAnalyticsEnv` docs now state why the loopback endpoint pin is mandatory post-flip: no suite may ever target the production URL, even if a test forgets to inject `fetchImpl`.

## Cross-package test audit (dark-default → live-default)

Audited every other package for tests constructing an emitter with no endpoint and no opt-out, which would now attempt real network calls to the production URL from CI:

- **No package in this repo depends on `@sapiom/analytics-core` yet** — verified via every `packages/*/package.json` and a repo-wide source grep for `createAnalytics` / `SAPIOM_ANALYTICS_ENDPOINT` / `@sapiom/analytics-core`. The harness's consent/machine-id modules reference analytics-core only in comments (they have their own standalone implementation), and its "analytics pipeline" e2e scripts are the session-transcript collector, unrelated to this emitter.
- **Result: zero cross-package test adjustments were required.** Confirmed empirically by the full-repo suite below.
- Within analytics-core itself, every delivery suite already pins `SAPIOM_ANALYTICS_ENDPOINT` to a loopback URL via `cleanAnalyticsEnv()` **and** injects `fetchImpl`, so no test can reach the real endpoint.

## Docs

- **README**: "Current status: ships dark" → "Current status: live by default", restating all opt-outs with the same wording as the telemetry disclosure section; the intro bullet, the usage example, and the identity-file note ("never created while analytics is disabled" — the "or unconfigured" clause no longer applies) updated to match.
- **CONTRACT.md**: the endpoint section now states `SAPIOM_COLLECTOR_ENDPOINT` is the emitter's default endpoint.
- **Changeset** (minor): delivery on by default to the hosted collector; opt-outs unchanged. Note: the programmatic opt-out is written as `disabled: true` — this package's actual config option — since `analytics: false` is not an option of `@sapiom/analytics-core` itself (it is the switch host packages are expected to expose).

## Verification

- analytics-core: 8 suites, **151 tests passed**
- Full repo `pnpm test` (with `SAPIOM_API_URL` unset): **all 13 in-scope packages green**, exit 0 (`langchain`/`langchain-classic` are quarantined from the workspace on `main` per `pnpm-workspace.yaml`, pre-existing and unrelated)
- `pnpm build`, `pnpm typecheck`, `pnpm lint`: green
- dist smoke (opt-out envs unset, endpoint unset, temp HOME, injected fetch): `createAnalytics({source:'cli',sdkName:'x',sdkVersion:'1'}).enabled === true` and the batch delivered to `https://api.sapiom.ai/v1/analytics/collector`; with `SAPIOM_TELEMETRY_DISABLED=1`, `enabled === false`

Refs SAP-1415 / SAP-1442
https://linear.app/sapiom/issue/SAP-1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Consumer packages: CI guards + honest tests (added after the instrumentation PRs merged)

The flip changes what an *unconfigured* emitter does, so every instrumented package's test environment needed hardening before this could merge:

- **Global test guards** — all six jest packages (tools, cli, agent-core, agent-runtime, langchain, langchain-classic) get a `setupFiles` guard setting `SAPIOM_TELEMETRY_DISABLED=1`; mcp gets the same via vitest `test.env`. No test can dial the production collector; suites that assert delivery opt back in explicitly against the in-process mock via `SAPIOM_ANALYTICS_ENDPOINT`.
- **"Ships dark" tests rewritten to the live-default invariant** — the old "no endpoint → nothing sent" tests now assert delivery-by-default (against the mock) and that consent opt-outs are the gate producing zero requests. The tools tri-state identical-throw property now covers on / default-live / disabled. Fault-injection baselines that would have dialed production were repointed at the mock.
- **Docstring/README sweep** — every "ships dark" claim across the seven consumer packages updated to the live-by-default truth (opt-outs: `SAPIOM_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, programmatic).
- **No consumer changesets** — their diffs are tests/docs/config only; the behavior change ships via the `@sapiom/analytics-core` minor bump.

Suites at final state: analytics-core 152, tools 360, cli 39, mcp 70, agent-core 115, agent-runtime 26, langchain 34, langchain-classic 180 — all green. Internal review round documented in the comments.