### PR TITLE
test(harness): transcript-fixture fake-agent for e2e/sim replay (SAP-1436)

### DIFF
--- a/packages/harness/e2e/fixtures/fake-agent/README.md
+++ b/packages/harness/e2e/fixtures/fake-agent/README.md
@@ -1,0 +1,65 @@
+# fake-agent
+
+A tiny transcript-driven terminal app used as a stand-in for a real coding
+agent in harness tests. It is designed to run inside a pty (spawned by the
+session manager) and behaves like an agent TUI: raw-mode input, a boot
+banner, an idle prompt, keystroke echo, and busy/idle output cycles.
+
+## Usage
+
+```bash
+node fake-agent.cjs [path/to/transcript.json]
+```
+
+Defaults to `transcripts/basic-echo.json`.
+
+The `.cjs` extension is required because the harness package declares `"type": "module"`, which would cause Node to treat a `.js` file as an ES module. The fake-agent uses CommonJS `require()` so it must be `.cjs`.
+
+## Transcript format
+
+Transcripts are JSON files:
+
+```jsonc
+{
+  "name": "basic-echo",
+  "synthetic": true,          // true = hand-written; false = recorded from a real agent
+  "description": "…",
+  "echoKeystrokes": true,     // echo bytes as they are typed (default true)
+  "announceResize": false,    // print "[resize] COLSxROWS" on terminal resize
+  "ignoreSigterm": false,     // ignore SIGTERM (lets tests exercise forced kill)
+  "boot": [ /* steps played once on startup */ ],
+  "onLine": [ /* steps played for each line typed on stdin */ ]
+}
+```
+
+Step types (unknown types are ignored, so transcripts can evolve):
+
+| Step | Effect |
+| --- | --- |
+| `{ "type": "print", "data": "…" }` | Write raw data to stdout. In `onLine` steps, `{{line}}` is replaced with the input line. |
+| `{ "type": "wait", "ms": 100 }` | Pause playback. |
+| `{ "type": "busy", "frames": ["⠋"], "intervalMs": 40, "cycles": 4, "label": "…", "doneData": "…" }` | Spinner-style busy cycle, then optional done output. |
+| `{ "type": "print-size" }` | Print `[size] COLSxROWS` (verifies pty size plumbing). |
+| `{ "type": "print-cwd" }` | Print `[cwd] <cwd>` (verifies cwd plumbing). |
+| `{ "type": "print-env", "name": "VAR" }` | Print `[env] VAR=<value>` (verifies env plumbing). |
+
+Control input: Ctrl+C exits with code 130, Ctrl+D on an empty line exits
+with code 0, backspace edits the current line.
+
+## Transcript provenance
+
+| File | Type | Notes |
+| --- | --- | --- |
+| `basic-echo.json` | Synthetic (hand-written) | Minimal deterministic agent with spinner |
+| `diagnostics.json` | Synthetic (hand-written) | Verifies env/cwd/cols/rows plumbing |
+| `stubborn.json` | Synthetic (hand-written) | Ignores SIGTERM — exercises kill escalation |
+| `claude-code-boot.json` | Hand-modeled | Hand-modeled on Claude Code v2.x boot output under a 100x30 pty; all identifiers (user, org, path) replaced with fictional values. Not a verbatim recording. |
+
+## Adding recordings
+
+New transcripts can be recorded from real agents (capture pty output chunks
+with timing, convert to `print`/`wait` steps). Before committing a
+recording, sanitize it: no usernames, no real filesystem paths, no account
+information. Mark hand-written transcripts with `"synthetic": true` and
+recorded ones with `"synthetic": false`, and include a `"recordedFrom"`
+field describing the tool and version the recording came from.

--- a/packages/harness/e2e/fixtures/fake-agent/README.md
+++ b/packages/harness/e2e/fixtures/fake-agent/README.md
@@ -22,7 +22,8 @@ Transcripts are JSON files:
 ```jsonc
 {
   "name": "basic-echo",
-  "synthetic": true,          // true = hand-written; false = recorded from a real agent
+  "synthetic": true,          // true = hand-written; false = verbatim recording from a real agent
+  "modeledOn": "…",           // optional; what a hand-written transcript imitates (omit for pure inventions)
   "description": "…",
   "echoKeystrokes": true,     // echo bytes as they are typed (default true)
   "announceResize": false,    // print "[resize] COLSxROWS" on terminal resize
@@ -31,6 +32,14 @@ Transcripts are JSON files:
   "onLine": [ /* steps played for each line typed on stdin */ ]
 }
 ```
+
+Key provenance fields:
+
+| Field | Meaning |
+| --- | --- |
+| `"synthetic": true` | Hand-written — every byte was authored manually |
+| `"synthetic": false` | Verbatim recording from a real agent session |
+| `"modeledOn"` | Optional (only on hand-written transcripts); describes what real output the transcript imitates |
 
 Step types (unknown types are ignored, so transcripts can evolve):
 
@@ -53,13 +62,30 @@ with code 0, backspace edits the current line.
 | `basic-echo.json` | Synthetic (hand-written) | Minimal deterministic agent with spinner |
 | `diagnostics.json` | Synthetic (hand-written) | Verifies env/cwd/cols/rows plumbing |
 | `stubborn.json` | Synthetic (hand-written) | Ignores SIGTERM — exercises kill escalation |
-| `claude-code-boot.json` | Hand-modeled | Hand-modeled on Claude Code v2.x boot output under a 100x30 pty; all identifiers (user, org, path) replaced with fictional values. Not a verbatim recording. |
+| `claude-code-boot.json` | Hand-modeled | Hand-modeled on Claude Code v2.x boot output under a 100x30 pty; all identifiers (user, org, path) replaced with fictional values. `"synthetic": true` (not a verbatim recording); `"modeledOn"` field names the source. |
+
+## Test consumer
+
+The vitest suite `src/core/transcript-replay.test.ts` is the primary consumer
+of these fixtures. It exercises the fake-agent directly via real node-pty
+(six tests) and via the SessionManager integration path (one test).
+
+`scripts/e2e-live.ts` keeps its own capture-oriented `scripts/fixtures/fake-claude.mjs`
+fixture because that script's session lifecycle requires the spawned process to
+fire real hook events (SessionStart etc.) so `session.ready` flips before any
+input injection. `fake-agent.cjs` is a pure pty app with no hook-firing logic;
+wiring it into `e2e-live.ts` would require either adding hook-firing to
+`fake-agent.cjs` (scope creep) or calling `setReady` directly from the script
+(which breaks the invariant the ready-gate exists to test). The transcript-replay
+vitest tests cover the same SessionManager pty path end-to-end without
+those constraints.
 
 ## Adding recordings
 
 New transcripts can be recorded from real agents (capture pty output chunks
 with timing, convert to `print`/`wait` steps). Before committing a
 recording, sanitize it: no usernames, no real filesystem paths, no account
-information. Mark hand-written transcripts with `"synthetic": true` and
-recorded ones with `"synthetic": false`, and include a `"recordedFrom"`
-field describing the tool and version the recording came from.
+information. Mark verbatim recordings with `"synthetic": false` and include
+a `"recordedFrom"` field naming the tool and version. Mark hand-written or
+hand-modeled transcripts with `"synthetic": true` and, if they imitate real
+output, a `"modeledOn"` field describing the source.

--- a/packages/harness/e2e/fixtures/fake-agent/fake-agent.cjs
+++ b/packages/harness/e2e/fixtures/fake-agent/fake-agent.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * fake-agent — a tiny transcript-driven terminal app that stands in for a
+ * real coding agent in harness tests. It is meant to run INSIDE a pty.
+ *
+ * Usage:
+ *   node fake-agent.js [path/to/transcript.json]
+ *
+ * Defaults to transcripts/basic-echo.json. See README.md in this directory
+ * for the transcript format.
+ *
+ * Provenance: hand-modeled synthetic fixtures (synthetic: true) and one
+ * hand-modeled rendition of a real Claude Code boot sequence (claude-code-boot).
+ * Transcripts marked synthetic: true are fully hand-written. The claude-code-boot
+ * transcript is hand-modeled on Claude Code v2.x boot output — not a verbatim
+ * recording — with all identifiers (user, org, path) replaced with fictional values.
+ */
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const transcriptPath = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(__dirname, "transcripts", "basic-echo.json");
+const transcript = JSON.parse(fs.readFileSync(transcriptPath, "utf8"));
+
+const echoKeystrokes = transcript.echoKeystrokes !== false;
+
+const out = (data) => process.stdout.write(data);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Replace the `{{line}}` placeholder with the last input line, if any. */
+function substitute(text, line) {
+  return line === undefined ? text : text.split("{{line}}").join(line);
+}
+
+async function playStep(step, line) {
+  switch (step.type) {
+    case "print":
+      out(substitute(step.data ?? "", line));
+      break;
+    case "wait":
+      await sleep(step.ms ?? 0);
+      break;
+    case "busy": {
+      // Simulates a busy/idle cycle: spinner frames, then a done line.
+      const frames =
+        Array.isArray(step.frames) && step.frames.length > 0
+          ? step.frames
+          : ["-", "\\", "|", "/"];
+      const cycles = step.cycles ?? frames.length;
+      const label = step.label ?? "working";
+      for (let i = 0; i < cycles; i += 1) {
+        out(`\r${frames[i % frames.length]} ${label}`);
+        await sleep(step.intervalMs ?? 40);
+      }
+      out(`\r[K`); // carriage return + clear the spinner line
+      if (step.doneData) out(substitute(step.doneData, line));
+      break;
+    }
+    case "print-size":
+      out(`[size] ${process.stdout.columns}x${process.stdout.rows}\r\n`);
+      break;
+    case "print-cwd":
+      out(`[cwd] ${process.cwd()}\r\n`);
+      break;
+    case "print-env":
+      out(`[env] ${step.name}=${process.env[step.name] ?? ""}\r\n`);
+      break;
+    default:
+      // Unknown step types are ignored so transcripts can evolve.
+      break;
+  }
+}
+
+async function playSteps(steps, line) {
+  for (const step of steps ?? []) {
+    await playStep(step, line);
+  }
+}
+
+let exiting = false;
+function shutdown(code) {
+  if (exiting) return;
+  exiting = true;
+  process.exit(code);
+}
+
+// ---------------------------------------------------------------------------
+// Input handling: raw-mode byte stream, manual line assembly (like a real
+// agent TUI). Each completed line replays the transcript's `onLine` steps.
+// ---------------------------------------------------------------------------
+
+let inputBuffer = "";
+let lineQueue = Promise.resolve();
+
+function handleInput(chunk) {
+  const text = chunk.toString("utf8");
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    if (code === 0x03) {
+      // Ctrl+C
+      out("^C\r\n");
+      shutdown(130);
+      return;
+    }
+    if (code === 0x04 && inputBuffer.length === 0) {
+      // Ctrl+D on an empty line
+      shutdown(0);
+      return;
+    }
+    if (ch === "\r" || ch === "\n") {
+      const line = inputBuffer;
+      inputBuffer = "";
+      if (echoKeystrokes) out("\r\n");
+      lineQueue = lineQueue.then(() => playSteps(transcript.onLine, line));
+    } else if (code === 0x7f || code === 0x08) {
+      // Backspace
+      if (inputBuffer.length > 0) {
+        inputBuffer = inputBuffer.slice(0, -1);
+        if (echoKeystrokes) out("\b \b");
+      }
+    } else {
+      inputBuffer += ch;
+      if (echoKeystrokes) out(ch);
+    }
+  }
+}
+
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
+process.stdin.on("data", handleInput);
+process.stdin.on("end", () => shutdown(0));
+process.stdin.on("error", () => shutdown(0));
+
+process.on("SIGTERM", () => {
+  if (transcript.ignoreSigterm) {
+    out("\r\n[fake-agent] SIGTERM ignored (transcript.ignoreSigterm)\r\n");
+    return;
+  }
+  shutdown(143);
+});
+
+if (transcript.announceResize) {
+  process.stdout.on("resize", () => {
+    out(`\r\n[resize] ${process.stdout.columns}x${process.stdout.rows}\r\n`);
+  });
+}
+
+playSteps(transcript.boot).catch((error) => {
+  out(`\r\n[fake-agent] transcript error: ${error && error.message}\r\n`);
+  shutdown(1);
+});

--- a/packages/harness/e2e/fixtures/fake-agent/transcripts/basic-echo.json
+++ b/packages/harness/e2e/fixtures/fake-agent/transcripts/basic-echo.json
@@ -1,0 +1,26 @@
+{
+  "name": "basic-echo",
+  "synthetic": true,
+  "description": "Minimal deterministic agent: boot banner, short wait, idle prompt, then echoes each input line back after a brief busy cycle.",
+  "echoKeystrokes": true,
+  "boot": [
+    {
+      "type": "print",
+      "data": "\u001b[1mfake-agent\u001b[0m v0.1.0 — transcript: basic-echo\r\n"
+    },
+    { "type": "wait", "ms": 40 },
+    { "type": "print", "data": "Ready. Type something and press Enter.\r\n" },
+    { "type": "print", "data": "> " }
+  ],
+  "onLine": [
+    {
+      "type": "busy",
+      "frames": ["⠋", "⠙", "⠹", "⠸"],
+      "intervalMs": 15,
+      "cycles": 4,
+      "label": "thinking"
+    },
+    { "type": "print", "data": "you said: {{line}}\r\n" },
+    { "type": "print", "data": "> " }
+  ]
+}

--- a/packages/harness/e2e/fixtures/fake-agent/transcripts/claude-code-boot.json
+++ b/packages/harness/e2e/fixtures/fake-agent/transcripts/claude-code-boot.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-boot",
   "synthetic": true,
-  "recordedFrom": "hand-modeled on Claude Code v2.x boot output under a 100x30 pty",
+  "modeledOn": "hand-modeled on Claude Code v2.x boot output under a 100x30 pty",
   "sanitized": true,
   "notes": "Hand-modeled rendition of a Claude Code boot sequence (trust prompt, trust acceptance, welcome box, promo notice, idle prompt/footer) — not a verbatim recording; every identifier (user, organization, path) is fictional. Waits capped at 800ms. Input handling (onLine) is synthetic. Re-model when the boot UI changes materially; see the fixture README for the sanitize-before-commit rule.",
   "echoKeystrokes": true,

--- a/packages/harness/e2e/fixtures/fake-agent/transcripts/claude-code-boot.json
+++ b/packages/harness/e2e/fixtures/fake-agent/transcripts/claude-code-boot.json
@@ -1,0 +1,59 @@
+{
+  "name": "claude-code-boot",
+  "synthetic": true,
+  "recordedFrom": "hand-modeled on Claude Code v2.x boot output under a 100x30 pty",
+  "sanitized": true,
+  "notes": "Hand-modeled rendition of a Claude Code boot sequence (trust prompt, trust acceptance, welcome box, promo notice, idle prompt/footer) — not a verbatim recording; every identifier (user, organization, path) is fictional. Waits capped at 800ms. Input handling (onLine) is synthetic. Re-model when the boot UI changes materially; see the fixture README for the sanitize-before-commit rule.",
+  "echoKeystrokes": true,
+  "boot": [
+    {
+      "type": "wait",
+      "ms": 480
+    },
+    {
+      "type": "print",
+      "data": "\u001b7\u001b[r\u001b8\u001b[?25h\u001b[?25l\u001b[?2004h\u001b[?1004h\u001b[?2031h\r\r\n\u001b[38;5;220m────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[39m\r\r\n\u001b[2G\u001b[38;5;220m\u001b[1mAccessing\u001b[12Gworkspace:\u001b[22m\u001b[39m\r\r\n\r\r\n\u001b[2G\u001b[1m/home/user/projects/workspace\u001b[22m\r\r\n\r\r\n\u001b[2GQuick\u001b[8Gsafety\u001b[15Gcheck:\u001b[22GIs\u001b[25Gthis\u001b[30Ga\u001b[32Gproject\u001b[40Gyou\u001b[44Gcreated\u001b[52Gor\u001b[55Gone\u001b[59Gyou\u001b[63Gtrust?\u001b[70G(Like\u001b[76Gyour\u001b[81Gown\u001b[85Gcode,\u001b[91Ga\r\r\n\u001b[2Gwell-known\u001b[13Gopen\u001b[18Gsource\u001b[25Gproject,\u001b[34Gor\u001b[37Gwork\u001b[42Gfrom\u001b[47Gyour\u001b[52Gteam).\u001b[59GIf\u001b[62Gnot,\u001b[67Gtake\u001b[72Ga\u001b[74Gmoment\u001b[81Gto\u001b[84Greview\u001b[91Gwhat's\u001b[98Gin\r\r\n\u001b[2Gthis\u001b[7Gfolder\u001b[14Gfirst.\r\r\n\r\r\n\u001b[2GClaude\u001b[9GCode'll\u001b[17Gbe\u001b[20Gable\u001b[25Gto\u001b[28Gread,\u001b[34Gedit,\u001b[40Gand\u001b[44Gexecute\u001b[52Gfiles\u001b[58Ghere.\r\r\n\r\r\n\u001b[2G\u001b[38;5;246mSecurity\u001b[11Gguide\u001b[39m\r\r\n\r\r\n\u001b[2G\u001b[38;5;153m❯\u001b[4G\u001b[38;5;246m1.\u001b[7G\u001b[38;5;153mYes,\u001b[12GI\u001b[14Gtrust\u001b[20Gthis\u001b[25Gfolder\u001b[39m\r\r\n\u001b[4G\u001b[38;5;246m2.\u001b[7G\u001b[39mNo,\u001b[11Gexit\r\r\n\r\r\n\u001b[2G\u001b[38;5;246mEnter\u001b[8Gto\u001b[11Gconfirm\u001b[19G·\u001b[21GEsc\u001b[25Gto\u001b[28Gcancel\u001b[39m\r\r\n\u001b[1C\u001b[4A\u001b[>0q\u001b[c"
+    },
+    {
+      "type": "wait",
+      "ms": 800
+    },
+    {
+      "type": "print",
+      "data": "\u001b[1D\u001b[4B\r\u001b[6C\u001b[4A\u001b[38;5;75mYes, I trust this folder\u001b[32G✔\u001b[39m\r\r\n\r\n\r\n\r\n\u001b[1C\u001b[4A"
+    },
+    {
+      "type": "wait",
+      "ms": 60
+    },
+    {
+      "type": "print",
+      "data": "\u001b[?1049h\u001b[2J\u001b[H\u001b[?1000h\u001b[?1002h\u001b[?1003h\u001b[?1006h\u001b]0;✳ Claude Code\u0007\u001b[H\r\u001b[1B\u001b[38;5;215m╭───\u001b[6GClaude Code\u001b[18G\u001b[38;5;246mv2.1.204\u001b[27G\u001b[38;5;215m─────────────────────────────────────────────────────────────────────────╮\r\u001b[1B│\u001b[52G\u001b[2m│\u001b[54G\u001b[22m\u001b[1mTips for getting started\u001b[100G\u001b[22m│\r\u001b[1B│\u001b[17G\u001b[39m\u001b[1mWelcome back friend!\u001b[52G\u001b[22m\u001b[2m\u001b[38;5;215m│\u001b[54G\u001b[39m\u001b[22mAsk\u001b[58GClaude\u001b[65Gto\u001b[68Gcreate\u001b[75Ga\u001b[77Gnew\u001b[81Gapp\u001b[85Gor\u001b[88Gclone\u001b[94Ga\u001b[96Gre…\u001b[100G\u001b[38;5;215m│\r\u001b[1B│\u001b[52G\u001b[2m│\u001b[54G\u001b[22m─────────────────────────────────────────────\u001b[100G│\r\u001b[1B│\u001b[23G\u001b[38;5;174m ▐\u001b[48;5;16m▛███▜\u001b[49m▌\u001b[52G\u001b[2m\u001b[38;5;215m│\u001b[54G\u001b[22m\u001b[1mWhat's new\u001b[100G\u001b[22m│\r\u001b[1B│\u001b[23G\u001b[38;5;174m▝▜\u001b[48;5;16m█████\u001b[49m▛▘\u001b[52G\u001b[2m\u001b[38;5;215m│\u001b[54G\u001b[39m\u001b[22mFixed\u001b[60Ghook\u001b[65Gevents\u001b[72Gnot\u001b[76Gstreaming\u001b[86Gduring\u001b[93GSessi…\u001b[100G\u001b[38;5;215m│\r\u001b[1B│\u001b[23G\u001b[38;5;174m  ▘▘ ▝▝  \u001b[52G\u001b[2m\u001b[38;5;215m│\u001b[54G\u001b[39m\u001b[22mAdded\u001b[60Ga\u001b[62Gwarning\u001b[70Gwhen\u001b[75Gyour\u001b[80Glogin\u001b[86Gis\u001b[89Gabout\u001b[95Gto\u001b[98G…\u001b[100G\u001b[38;5;215m│\r\u001b[1B│\u001b[52G\u001b[2m│\u001b[54G\u001b[39m\u001b[22mAdded\u001b[60Ga\u001b[62Ggrey\u001b[67G⏸\u001b[69Gbadge\u001b[75Gto\u001b[78Gthe\u001b[82Gfooter\u001b[89Gwhen\u001b[94Gin\u001b[97Gm…\u001b[100G\u001b[38;5;215m│\r\u001b[1B│\u001b[5G\u001b[38;5;246mOpus 4.8 (1M context) · Claude Team · Acme Robotics\u001b[52G\u001b[2m\u001b[38;5;215m│\u001b[54G\u001b[22m\u001b[38;5;246m\u001b[3m/release-notes for more\u001b[100G\u001b[23m\u001b[38;5;215m│\r\u001b[1B│\u001b[12G\u001b[38;5;246m/home/user/projects/workspace\u001b[52G\u001b[2m\u001b[38;5;215m│\u001b[100G\u001b[22m│\r\u001b[1B╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\r\u001b[1C\u001b[2B▎\u001b[4GExtended: Fable 5 is included in your weekly limit\r\u001b[1C\u001b[1B▎\u001b[4G\u001b[39mThrough\u001b[12GJuly\u001b[17G12,\u001b[21Gyou\u001b[25Gcan\u001b[29Guse\u001b[33Gup\u001b[36Gto\u001b[39G50%\u001b[43Gof\u001b[46Gyour\u001b[51Gweekly\u001b[58Gusage\u001b[64Glimit\u001b[70Gon\u001b[73GFable\u001b[79G5.\u001b[82GIf\u001b[85Gyou\u001b[89Ghit\u001b[93Gyour\r\u001b[1C\u001b[1B\u001b[38;5;215m▎\u001b[4G\u001b[39mlimit,\u001b[11Gyou\u001b[15Gcan\u001b[19Gcontinue\u001b[28Gon\u001b[31GFable\u001b[37G5\u001b[39Gwith\u001b[44Gusage\u001b[50Gcredits.\u001b[59GFable\u001b[65G5\u001b[67Gdraws\u001b[73Gdown\u001b[78Gusage\u001b[84Gfaster\u001b[91Gthan\u001b[96GOpus\r\u001b[1C\u001b[1B\u001b[38;5;215m▎\u001b[4G\u001b[39m4.8.\u001b[9GRun\u001b[13G/model\u001b[20Gand\u001b[24Gselect\u001b[31GFable\u001b[37Gto\u001b[40Guse\u001b[44Git.\u001b[48GLearn\u001b[54Gmore\r\u001b[1C\u001b[1B\u001b[38;5;215m▎\u001b[4G\u001b[39m(https://support.claude.com/en/articles/15424964-claude-fable-5-promotional-access)\r\u001b[83C\u001b[8B\u001b[38;5;246m● high · /effort\r\u001b[1B\u001b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\r\u001b[1B\u001b[39m❯ \u001b[2mTry \"edit <filepath> to...\"\r\u001b[1B\u001b[22m\u001b[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────\r\u001b[2C\u001b[1B\u001b[38;5;246m⏸ manual mode on · ? for shortcuts · ← for agents\u001b[39m\u001b[30;1H\u001b[28;3H\u001b[?25h"
+    },
+    {
+      "type": "wait",
+      "ms": 800
+    },
+    {
+      "type": "print",
+      "data": "\u001b[?25l\u001b[H\r\u001b[1C\u001b[13B\u001b[38;5;220m⚠\u001b[4G1 MCP server needs authentication\u001b[38;5;246m · run /mcp\u001b[39m\u001b[K\r\u001b[1C\u001b[1B\u001b[K\r\u001b[3C\u001b[1B\u001b[38;5;215mExtended: Fable 5 is included in your weekly limit\u001b[39m\u001b[K\r\u001b[3C\u001b[1BThrough July 12, you can use up to 50% of your weekly usage\u001b[64Glimit\u001b[70Gon\u001b[73GFable\u001b[79G5.\u001b[82GIf\u001b[85Gyou\u001b[89Ghit\u001b[93Gyour\r\u001b[3C\u001b[1Blimit, you can continu\u001b[27G on Fable 5 with usage credits. Fable 5 draws dow\u001b[77G us\u001b[81Gge faster\u001b[91Gthan\u001b[96GOpus\r\u001b[1C\u001b[1B\u001b[38;5;215m▎\u001b[4G\u001b[39m4.8.\u001b[9GRun\u001b[13G/model\u001b[20Gand\u001b[24Gselect\u001b[31GFable\u001b[37Gto\u001b[40Guse\u001b[44Git.\u001b[48GLearn\u001b[54Gmore\r\u001b[1C\u001b[1B\u001b[38;5;215m▎\u001b[4G\u001b[39m(https://support.claude.com/en/articles/15424964-claude-fable-5-promotional-access)\u001b[30;1H\u001b[28;3H\u001b[?25h"
+    }
+  ],
+  "onLine": [
+    {
+      "type": "busy",
+      "frames": ["·", "✢", "✳", "✶", "✻", "✽"],
+      "intervalMs": 50,
+      "cycles": 8,
+      "label": "Thinking…"
+    },
+    {
+      "type": "print",
+      "data": "● You typed: {{line}}\r\n\r\n"
+    },
+    {
+      "type": "print",
+      "data": "❯ "
+    }
+  ]
+}

--- a/packages/harness/e2e/fixtures/fake-agent/transcripts/diagnostics.json
+++ b/packages/harness/e2e/fixtures/fake-agent/transcripts/diagnostics.json
@@ -1,0 +1,15 @@
+{
+  "name": "diagnostics",
+  "synthetic": true,
+  "description": "Prints the terminal size, cwd and a marker env var on boot, and announces resizes — used to verify create() plumbs env/cwd/cols/rows and that resize reaches the child.",
+  "echoKeystrokes": true,
+  "announceResize": true,
+  "boot": [
+    { "type": "print", "data": "diagnostics online\r\n" },
+    { "type": "print-size" },
+    { "type": "print-cwd" },
+    { "type": "print-env", "name": "FAKE_AGENT_MARKER" },
+    { "type": "print", "data": "> " }
+  ],
+  "onLine": [{ "type": "print", "data": "{{line}}\r\n> " }]
+}

--- a/packages/harness/e2e/fixtures/fake-agent/transcripts/stubborn.json
+++ b/packages/harness/e2e/fixtures/fake-agent/transcripts/stubborn.json
@@ -1,0 +1,14 @@
+{
+  "name": "stubborn",
+  "synthetic": true,
+  "description": "Ignores SIGTERM so tests can exercise the runtime's SIGTERM→SIGKILL escalation.",
+  "ignoreSigterm": true,
+  "echoKeystrokes": true,
+  "boot": [
+    {
+      "type": "print",
+      "data": "fake-agent (stubborn) — SIGTERM will be ignored\r\n> "
+    }
+  ],
+  "onLine": [{ "type": "print", "data": "{{line}}\r\n> " }]
+}

--- a/packages/harness/src/core/transcript-replay.test.ts
+++ b/packages/harness/src/core/transcript-replay.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Transcript-fixture replay tests — verifies that the fake-agent pty fixture
+ * (e2e/fixtures/fake-agent/) behaves correctly under the real node-pty spawn.
+ *
+ * These tests are hermetic: they spawn only `node` (the current executable)
+ * with a minimal environment — no external agents, credentials, or network.
+ * Each test drives a specific transcript JSON and asserts the expected output.
+ *
+ * A final test wires one transcript through SessionManager itself (with the
+ * real node-pty spawn injected), proving the full create→attach→write→kill
+ * path works end-to-end with the fake-agent.
+ *
+ * Fixture provenance:
+ *   basic-echo.json    — synthetic (hand-written)
+ *   diagnostics.json   — synthetic (hand-written)
+ *   stubborn.json      — synthetic (hand-written)
+ *   claude-code-boot.json — hand-modeled on Claude Code v2.x boot output
+ *                         under a 100x30 pty; all identifiers (user, org,
+ *                         path) are fictional. Not a verbatim recording.
+ *   See e2e/fixtures/fake-agent/README.md for the full provenance table.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SessionManager } from "./session-manager.js";
+import type { HarnessAdapter, SpawnSpec } from "../shared/types.js";
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Absolute path to the fake-agent entry point. Uses .cjs extension because
+ * the harness package.json declares "type": "module", which would cause Node to
+ * treat a .js file as an ES module — but fake-agent is CommonJS (require-based)
+ * so it needs the .cjs extension to opt out of that treatment.
+ */
+const FAKE_AGENT = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "e2e",
+  "fixtures",
+  "fake-agent",
+  "fake-agent.cjs",
+);
+
+/** Absolute path to the transcript directory. */
+const TRANSCRIPTS = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "e2e",
+  "fixtures",
+  "fake-agent",
+  "transcripts",
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal env for spawning the fake-agent: only the inherited PATH, a
+ * sensible TERM, and HOME pointing to a temp dir so nothing leaks to the real
+ * home directory. Tests add FAKE_AGENT_MARKER via the `extra` parameter.
+ */
+function minimalEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    TERM: "xterm-256color",
+    HOME: os.tmpdir(),
+    ...extra,
+  };
+}
+
+/**
+ * Collects output from a node-pty data listener and supports async waiting
+ * for a specific string to appear. Falls back to a poll every 50ms so tests
+ * don't spin-wait.
+ */
+class OutputCollector {
+  private buffer = "";
+  private waiters: Array<() => void> = [];
+
+  readonly listener = (chunk: string): void => {
+    this.buffer += chunk;
+    const waiters = this.waiters.splice(0);
+    for (const notify of waiters) notify();
+  };
+
+  get text(): string {
+    return this.buffer;
+  }
+
+  async waitFor(needle: string, timeoutMs = 10_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (!this.buffer.includes(needle)) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(
+          `Timed out waiting for ${JSON.stringify(needle)}.\nOutput so far:\n${this.buffer}`,
+        );
+      }
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, Math.min(remaining, 50));
+        this.waiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    }
+    return this.buffer;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level fake-agent pty tests (bypass SessionManager)
+// ---------------------------------------------------------------------------
+
+describe("fake-agent fixture (real pty, direct spawn)", () => {
+  // We use node-pty directly — import lazily to avoid crashing the test
+  // suite on a platform without the prebuilt native module.
+  let nodePty: typeof import("node-pty") | undefined;
+
+  interface SpawnedAgent {
+    pty: import("node-pty").IPty;
+    output: OutputCollector;
+  }
+
+  async function spawnAgent(
+    transcript: string,
+    opts: {
+      cols?: number;
+      rows?: number;
+      env?: Record<string, string>;
+      cwd?: string;
+    } = {},
+  ): Promise<SpawnedAgent> {
+    if (!nodePty) {
+      nodePty = await import("node-pty");
+    }
+    const output = new OutputCollector();
+    const pty = nodePty.spawn(process.execPath, [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)], {
+      name: "xterm-256color",
+      cols: opts.cols ?? 80,
+      rows: opts.rows ?? 24,
+      cwd: opts.cwd ?? path.dirname(FAKE_AGENT),
+      env: opts.env ?? minimalEnv(),
+    });
+    pty.onData(output.listener);
+    return { pty, output };
+  }
+
+  it("streams the boot banner from the basic-echo transcript", async () => {
+    const { pty, output } = await spawnAgent("basic-echo");
+    try {
+      await output.waitFor("fake-agent");
+      expect(output.text).toContain("v0.1.0");
+      await output.waitFor("> ");
+    } finally {
+      pty.kill();
+    }
+  }, 20_000);
+
+  it("echoes typed input back after the busy spinner", async () => {
+    const { pty, output } = await spawnAgent("basic-echo");
+    try {
+      await output.waitFor("> ");
+      pty.write("hello world\r");
+      await output.waitFor("you said: hello world");
+      // The spinner label from the transcript must have appeared before the echo.
+      expect(output.text).toContain("thinking");
+    } finally {
+      pty.kill();
+    }
+  }, 20_000);
+
+  it("diagnostics transcript prints terminal size, cwd and env marker", async () => {
+    const cwd = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "fake-agent-cwd-")),
+    );
+    try {
+      const { pty, output } = await spawnAgent("diagnostics", {
+        cols: 100,
+        rows: 40,
+        env: minimalEnv({ FAKE_AGENT_MARKER: "plumbing-ok" }),
+        cwd,
+      });
+      try {
+        await output.waitFor("[size] 100x40");
+        await output.waitFor(`[cwd] ${cwd}`);
+        await output.waitFor("[env] FAKE_AGENT_MARKER=plumbing-ok");
+      } finally {
+        pty.kill();
+      }
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("diagnostics transcript announces terminal resize", async () => {
+    const { pty, output } = await spawnAgent("diagnostics");
+    try {
+      await output.waitFor("> ");
+      pty.resize(120, 30);
+      await output.waitFor("[resize] 120x30");
+    } finally {
+      pty.kill();
+    }
+  }, 20_000);
+
+  it("stubborn transcript acknowledges SIGTERM but does not exit", async () => {
+    const { pty, output } = await spawnAgent("stubborn");
+    try {
+      await output.waitFor("> ");
+      // SIGTERM must not kill the process — the transcript sets ignoreSigterm.
+      pty.kill("SIGTERM");
+      await output.waitFor("SIGTERM ignored");
+    } finally {
+      pty.kill("SIGKILL");
+    }
+  }, 20_000);
+
+  it("replays the claude-code-boot transcript and reaches the idle footer", async () => {
+    // Hand-modeled at 100x30; replay at the same size so box drawing is faithful.
+    const { pty, output } = await spawnAgent("claude-code-boot", {
+      cols: 100,
+      rows: 30,
+    });
+    try {
+      await output.waitFor("Claude Code");
+      await output.waitFor("? for shortcuts");
+    } finally {
+      pty.kill();
+    }
+  }, 20_000);
+});
+
+// ---------------------------------------------------------------------------
+// SessionManager integration — wires basic-echo through the full
+// create→attach→write→kill path using the real node-pty spawn.
+// ---------------------------------------------------------------------------
+
+describe("transcript-fixture replay via SessionManager (real pty)", () => {
+  let tmpDir: string;
+  let sessionsPath: string;
+  let manager: SessionManager;
+
+  /** Adapter that spawns the fake-agent instead of a real coding agent. */
+  function makeFakeAgentAdapter(transcript: string): HarnessAdapter {
+    return {
+      id: "claude-code",
+      eventSource: "hooks",
+      doctor: async () => [],
+      launch: (): SpawnSpec => ({
+        command: process.execPath,
+        args: [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)],
+        env: minimalEnv(),
+        cwd: path.dirname(FAKE_AGENT),
+      }),
+      resume: (agentSessionId): SpawnSpec => ({
+        command: process.execPath,
+        args: [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)],
+        env: minimalEnv(),
+        cwd: path.dirname(FAKE_AGENT),
+      }),
+      listPastSessions: async () => [],
+    };
+  }
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-transcript-replay-"));
+    sessionsPath = path.join(tmpDir, "sessions.json");
+    manager = new SessionManager({
+      adapters: { "claude-code": makeFakeAgentAdapter("basic-echo") },
+      ingestUrl: "http://127.0.0.1:0",
+      ingestToken: "test-token",
+      sessionsPath,
+      // No spawnPty override — uses the real node-pty.
+    });
+    await manager.init();
+  });
+
+  afterEach(async () => {
+    manager.killAll();
+    await manager.flush();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates a session against the basic-echo transcript, streams boot output, echoes a line, then kills cleanly", async () => {
+    // This test uses the real node-pty so it needs more time than the default.
+    const session = await manager.create({ harness: "claude-code", cwd: tmpDir });
+
+    expect(session.status).toBe("running");
+
+    // Attach and collect output.
+    const output = new OutputCollector();
+    const detach = manager.attach(session.id, output.listener);
+    expect(detach).toBeDefined();
+
+    try {
+      // The scrollback buffer replays immediately on attach — wait for the prompt.
+      await output.waitFor("> ");
+      expect(output.text).toContain("fake-agent");
+      expect(output.text).toContain("v0.1.0");
+
+      // Write a line and verify the echo.
+      manager.write(session.id, "integration-test\r");
+      await output.waitFor("you said: integration-test");
+    } finally {
+      detach?.();
+      manager.kill(session.id);
+    }
+
+    // After kill, the session should be exited.
+    await new Promise<void>((resolve) => {
+      const unsubscribe = manager.onStatusChange((s) => {
+        if (s.id === session.id && s.status === "exited") {
+          unsubscribe();
+          resolve();
+        }
+      });
+      // Already exited (if kill resolved synchronously via markExited)?
+      const current = manager.get(session.id);
+      if (current?.status === "exited") {
+        unsubscribe();
+        resolve();
+      }
+    });
+
+    expect(manager.get(session.id)?.status).toBe("exited");
+  }, 30_000);
+});

--- a/packages/harness/src/core/transcript-replay.test.ts
+++ b/packages/harness/src/core/transcript-replay.test.ts
@@ -18,6 +18,14 @@
  *                         under a 100x30 pty; all identifiers (user, org,
  *                         path) are fictional. Not a verbatim recording.
  *   See e2e/fixtures/fake-agent/README.md for the full provenance table.
+ *
+ * e2e-live.ts uses a separate capture-oriented fixture (fake-claude.mjs) rather
+ * than fake-agent.cjs. See e2e/fixtures/fake-agent/README.md § "Test consumer"
+ * for the rationale: fake-agent.cjs fires no hook events, so session.ready
+ * never flips and submitInput would throw SessionNotReadyError — wiring it into
+ * e2e-live.ts would require hook-firing logic (scope creep) or bypassing the
+ * ready-gate (breaks the invariant it tests). The vitest suite here covers the
+ * same SessionManager pty path without those constraints.
  */
 
 import * as fs from "node:fs";
@@ -28,6 +36,23 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { SessionManager } from "./session-manager.js";
 import type { HarnessAdapter, SpawnSpec } from "../shared/types.js";
+
+// ---------------------------------------------------------------------------
+// node-pty availability — resolve once at module load, skip all tests if
+// the native prebuilt is absent on this platform/arch.
+// ---------------------------------------------------------------------------
+
+const nodePty = await import("node-pty").then(
+  (m) => m,
+  () => {
+    console.log(
+      "[transcript-replay] node-pty native module unavailable on this platform — " +
+        "skipping all transcript-replay tests. " +
+        "If this is unexpected, try: pnpm rebuild node-pty",
+    );
+    return null;
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -124,17 +149,8 @@ class OutputCollector {
 // Low-level fake-agent pty tests (bypass SessionManager)
 // ---------------------------------------------------------------------------
 
-describe("fake-agent fixture (real pty, direct spawn)", () => {
-  // We use node-pty directly — import lazily to avoid crashing the test
-  // suite on a platform without the prebuilt native module.
-  let nodePty: typeof import("node-pty") | undefined;
-
-  interface SpawnedAgent {
-    pty: import("node-pty").IPty;
-    output: OutputCollector;
-  }
-
-  async function spawnAgent(
+describe.skipIf(!nodePty)("fake-agent fixture (real pty, direct spawn)", () => {
+  function spawnAgent(
     transcript: string,
     opts: {
       cols?: number;
@@ -142,12 +158,10 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
       env?: Record<string, string>;
       cwd?: string;
     } = {},
-  ): Promise<SpawnedAgent> {
-    if (!nodePty) {
-      nodePty = await import("node-pty");
-    }
+  ): { pty: import("node-pty").IPty; output: OutputCollector } {
+    // nodePty is non-null inside this describe block (skipIf guards it).
     const output = new OutputCollector();
-    const pty = nodePty.spawn(process.execPath, [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)], {
+    const pty = nodePty!.spawn(process.execPath, [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)], {
       name: "xterm-256color",
       cols: opts.cols ?? 80,
       rows: opts.rows ?? 24,
@@ -159,7 +173,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
   }
 
   it("streams the boot banner from the basic-echo transcript", async () => {
-    const { pty, output } = await spawnAgent("basic-echo");
+    const { pty, output } = spawnAgent("basic-echo");
     try {
       await output.waitFor("fake-agent");
       expect(output.text).toContain("v0.1.0");
@@ -170,7 +184,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
   }, 20_000);
 
   it("echoes typed input back after the busy spinner", async () => {
-    const { pty, output } = await spawnAgent("basic-echo");
+    const { pty, output } = spawnAgent("basic-echo");
     try {
       await output.waitFor("> ");
       pty.write("hello world\r");
@@ -187,7 +201,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
       fs.mkdtempSync(path.join(os.tmpdir(), "fake-agent-cwd-")),
     );
     try {
-      const { pty, output } = await spawnAgent("diagnostics", {
+      const { pty, output } = spawnAgent("diagnostics", {
         cols: 100,
         rows: 40,
         env: minimalEnv({ FAKE_AGENT_MARKER: "plumbing-ok" }),
@@ -206,7 +220,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
   }, 20_000);
 
   it("diagnostics transcript announces terminal resize", async () => {
-    const { pty, output } = await spawnAgent("diagnostics");
+    const { pty, output } = spawnAgent("diagnostics");
     try {
       await output.waitFor("> ");
       pty.resize(120, 30);
@@ -217,7 +231,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
   }, 20_000);
 
   it("stubborn transcript acknowledges SIGTERM but does not exit", async () => {
-    const { pty, output } = await spawnAgent("stubborn");
+    const { pty, output } = spawnAgent("stubborn");
     try {
       await output.waitFor("> ");
       // SIGTERM must not kill the process — the transcript sets ignoreSigterm.
@@ -230,7 +244,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
 
   it("replays the claude-code-boot transcript and reaches the idle footer", async () => {
     // Hand-modeled at 100x30; replay at the same size so box drawing is faithful.
-    const { pty, output } = await spawnAgent("claude-code-boot", {
+    const { pty, output } = spawnAgent("claude-code-boot", {
       cols: 100,
       rows: 30,
     });
@@ -248,7 +262,7 @@ describe("fake-agent fixture (real pty, direct spawn)", () => {
 // create→attach→write→kill path using the real node-pty spawn.
 // ---------------------------------------------------------------------------
 
-describe("transcript-fixture replay via SessionManager (real pty)", () => {
+describe.skipIf(!nodePty)("transcript-fixture replay via SessionManager (real pty)", () => {
   let tmpDir: string;
   let sessionsPath: string;
   let manager: SessionManager;
@@ -265,7 +279,7 @@ describe("transcript-fixture replay via SessionManager (real pty)", () => {
         env: minimalEnv(),
         cwd: path.dirname(FAKE_AGENT),
       }),
-      resume: (agentSessionId): SpawnSpec => ({
+      resume: (_agentSessionId): SpawnSpec => ({
         command: process.execPath,
         args: [FAKE_AGENT, path.join(TRANSCRIPTS, `${transcript}.json`)],
         env: minimalEnv(),
@@ -295,7 +309,6 @@ describe("transcript-fixture replay via SessionManager (real pty)", () => {
   });
 
   it("creates a session against the basic-echo transcript, streams boot output, echoes a line, then kills cleanly", async () => {
-    // This test uses the real node-pty so it needs more time than the default.
     const session = await manager.create({ harness: "claude-code", cwd: tmpDir });
 
     expect(session.status).toBe("running");


### PR DESCRIPTION
## What

Ports the transcript-driven fake-agent pty app + 4 transcript fixtures from the closed scaffold PR #177 into the shipped harness's test machinery, plus a 7-test vitest suite (`src/core/transcript-replay.test.ts`) exercising `SessionManager` against them with real node-pty: replay fidelity, cwd/env/size plumbing, resize handling, and SIGTERM-resistant kill escalation (`stubborn` transcript).

## Provenance honesty

The transcripts are **hand-written/hand-modeled, not recordings**: `claude-code-boot.json` is modeled on Claude Code v2.x boot output with fictional identifiers, and says so in its `modeledOn`/`notes` fields. The fixture README documents the schema (`synthetic` = hand-written vs verbatim recording; `modeledOn` = what a hand-written transcript imitates) and a provenance table. A genuinely recorded transcript is a good future upgrade.

## Deviation from the ticket AC, documented

The AC asked for an existing e2e phase to consume the fixtures. `e2e:live` phases depend on the agent firing real `SessionStart` hook POSTs to flip `session.ready`; `fake-agent.cjs` is deliberately a pure pty app with no HTTP client, and force-flipping readiness from the script would defeat the ready-gate invariant those phases protect. The vitest suite covers the same SessionManager pty surface end-to-end instead — rationale recorded in the fixture README (§ Test consumer) and the test-file header.

## Safety

- Tests/fixtures only — no runtime changes, no changeset (`files: ["dist"]` keeps `e2e/` and tests out of the npm tarball, verified via `npm pack --dry-run`)
- `describe.skipIf` guards the suite where node-pty's native module is unavailable (skips with an actionable message instead of erroring)
- 611 harness tests green; build green

Internal review round: 3 findings (e2e-phase scope gap, provenance-flag contradiction, missing pty guard) — all addressed in `182b5cb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)