### PR TITLE
update / fix URL bases

### DIFF
--- a/.changeset/nest-agent-schedule-routes.md
+++ b/.changeset/nest-agent-schedule-routes.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/tools": patch
+"@sapiom/agent-core": patch
+---
+
+Align agent run and schedule requests with the current API endpoints. This also fixes `@sapiom/tools` `schedules` operations (create/list/get/cancel), which were targeting an outdated endpoint. Public function signatures are unchanged.

--- a/packages/agent-core/src/schedule.spec.ts
+++ b/packages/agent-core/src/schedule.spec.ts
@@ -31,7 +31,7 @@ function fakeClient(): { client: GatewayClient; calls: Call[] } {
 }
 
 describe('schedule core fns', () => {
-  it('createSchedule POSTs /:slug/triggers with the body (definition stripped)', async () => {
+  it('createSchedule POSTs /definitions/:slug/triggers with the body (definition stripped)', async () => {
     const { client, calls } = fakeClient();
     await createSchedule(
       { definition: 'enrich-lead', kind: 'schedule_cron', cron: '0 9 * * *', timezone: 'UTC' },
@@ -39,21 +39,21 @@ describe('schedule core fns', () => {
     );
     expect(calls[0]).toEqual({
       method: 'POST',
-      path: '/enrich-lead/triggers',
+      path: '/definitions/enrich-lead/triggers',
       body: { kind: 'schedule_cron', cron: '0 9 * * *', timezone: 'UTC' },
     });
   });
 
-  it('listSchedules GETs /:slug/triggers with a query string', async () => {
+  it('listSchedules GETs /definitions/:slug/triggers with a query string', async () => {
     const { client, calls } = fakeClient();
     await listSchedules({ definition: 'enrich-lead', status: 'active', limit: 10 }, client);
-    expect(calls[0]).toEqual({ method: 'GET', path: '/enrich-lead/triggers?status=active&limit=10' });
+    expect(calls[0]).toEqual({ method: 'GET', path: '/definitions/enrich-lead/triggers?status=active&limit=10' });
   });
 
   it('listSchedules omits an empty query', async () => {
     const { client, calls } = fakeClient();
     await listSchedules({ definition: 'enrich-lead' }, client);
-    expect(calls[0].path).toBe('/enrich-lead/triggers');
+    expect(calls[0].path).toBe('/definitions/enrich-lead/triggers');
   });
 
   it('getSchedule GETs /triggers/:id', async () => {

--- a/packages/agent-core/src/schedule.ts
+++ b/packages/agent-core/src/schedule.ts
@@ -2,9 +2,10 @@
  * schedule — manage scheduled triggers for a server-side agent definition.
  *
  * Networked operations: each takes a GatewayClient. The backend routes sit under the
- * `/v1/workflows` base the client already targets: create/list nest under the definition slug
- * (`/:slug/triggers`); detail/cancel are top-level (`/triggers/:id`); cron preview is stateless
- * (`/triggers/preview-cron`). "Schedule" is the SDK word for the engine's "trigger".
+ * `/v1/workflows` base the client already targets: create/list nest under the definition
+ * (`/definitions/:slug/triggers`) so the slug is never a leading path segment; detail/cancel are
+ * top-level (`/triggers/:id`); cron preview is stateless (`/triggers/preview-cron`). "Schedule" is
+ * the SDK word for the engine's "trigger".
  */
 import { GatewayClient } from './client.js';
 
@@ -84,13 +85,13 @@ export interface CronPreview {
 /** Create a schedule (cron or one-off) for the agent. Returns the schedule detail. */
 export async function createSchedule(opts: CreateScheduleOptions, client: GatewayClient): Promise<ScheduleDetail> {
   const { definition, ...body } = opts;
-  return client.post<ScheduleDetail>(`/${encodeURIComponent(definition)}/triggers`, body);
+  return client.post<ScheduleDetail>(`/definitions/${encodeURIComponent(definition)}/triggers`, body);
 }
 
 /** List an agent's schedules (newest first), optionally filtered by status. */
 export async function listSchedules(opts: ListSchedulesOptions, client: GatewayClient): Promise<ScheduleSummary[]> {
   const { definition, ...filters } = opts;
-  return client.get<ScheduleSummary[]>(`/${encodeURIComponent(definition)}/triggers${toQuery(filters)}`);
+  return client.get<ScheduleSummary[]>(`/definitions/${encodeURIComponent(definition)}/triggers${toQuery(filters)}`);
 }
 
 /** Get one schedule: config + next fire + recent fire ledger. */

--- a/packages/tools/src/agents/index.spec.ts
+++ b/packages/tools/src/agents/index.spec.ts
@@ -35,11 +35,11 @@ describe("orchestrations.launch — dispatch handle", () => {
     });
   });
 
-  it("POSTs to /agents/v1/:slug/executions (by slug)", async () => {
+  it("POSTs to /agents/v1/definitions/:slug/executions (by slug)", async () => {
     const capture: { url?: string } = {};
     const sapiom = createClient({ apiKey: "k", fetch: fakeFetch(capture) });
     await sapiom.agents.launch({ definition: "enrich-lead" });
-    expect(capture.url).toContain("/agents/v1/enrich-lead/executions");
+    expect(capture.url).toContain("/agents/v1/definitions/enrich-lead/executions");
   });
 
   it("AGENTS_RESULT_SIGNAL is the capability-stable terminal signal", () => {

--- a/packages/tools/src/agents/index.ts
+++ b/packages/tools/src/agents/index.ts
@@ -183,7 +183,7 @@ interface ExecutionDoc {
  */
 async function launchScheduled(spec: AgentRunSpec, transport: Transport, baseUrl: string): Promise<RunHandle> {
   const res = await transport.request<{ id: string }>(
-    `${baseUrl}/agents/v1/${encodeURIComponent(spec.definition)}/triggers`,
+    `${baseUrl}/agents/v1/definitions/${encodeURIComponent(spec.definition)}/triggers`,
     {
       method: "POST",
       body: JSON.stringify({ kind: "schedule_once", at: spec.at, input: spec.input ?? {} }),
@@ -212,7 +212,7 @@ export async function launch(
     return launchScheduled(spec, transport, baseUrl);
   }
   const res = await transport.request<StartResponse>(
-    `${baseUrl}/agents/v1/${encodeURIComponent(spec.definition)}/executions`,
+    `${baseUrl}/agents/v1/definitions/${encodeURIComponent(spec.definition)}/executions`,
     {
       method: "POST",
       body: JSON.stringify({

--- a/packages/tools/src/agents/schedule-launch.spec.ts
+++ b/packages/tools/src/agents/schedule-launch.spec.ts
@@ -39,7 +39,7 @@ describe("orchestrations.launch — delayed (scheduled) dispatch", () => {
     });
 
     // Hits the schedule (trigger) create route, not the execution route.
-    expect(cap.url).toMatch(/\/agents\/v1\/B\/triggers$/);
+    expect(cap.url).toMatch(/\/agents\/v1\/definitions\/B\/triggers$/);
     expect(cap.init?.method).toBe("POST");
     expect(JSON.parse(cap.init?.body as string)).toEqual({
       kind: "schedule_once",

--- a/packages/tools/src/schedules/index.ts
+++ b/packages/tools/src/schedules/index.ts
@@ -5,16 +5,17 @@
  *   import { schedules } from "@sapiom/tools";
  *   await schedules.create({ definition: "enrich-lead", kind: "schedule_cron", cron: "0 9 * * 1-5" });
  *
- * "Schedule" is the SDK word for the engine's "trigger". Routes sit under `/v1/workflows`:
- * create/list nest under the definition slug; detail/cancel are top-level under `/triggers`.
+ * "Schedule" is the SDK word for the engine's "trigger". Routes sit under the agents gateway
+ * (`/agents/v1`, same front door as {@link ../agents/index.js}): create/list nest under
+ * `definitions/:slug/triggers` (slug never a leading segment); detail/cancel are top-level under
+ * `/agents/v1/triggers`.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
-import { resolveServiceUrl } from "../_client/service-url.js";
 
-const DEFAULT_BASE_URL = resolveServiceUrl(
-  "workflows",
-  process.env.SAPIOM_WORKFLOWS_URL,
-);
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_AGENTS_URL ??
+  process.env.SAPIOM_TOOLS_BASE ??
+  "https://tools.sapiom.ai";
 
 export type ScheduleKind = "schedule_cron" | "schedule_once";
 export type ScheduleStatus = "active" | "paused" | "completed" | "disabled";
@@ -81,7 +82,7 @@ export async function create(
 ): Promise<ScheduleDetail> {
   const { definition, ...body } = spec;
   return transport.request<ScheduleDetail>(
-    `${baseUrl}/v1/workflows/${encodeURIComponent(definition)}/triggers`,
+    `${baseUrl}/agents/v1/definitions/${encodeURIComponent(definition)}/triggers`,
     { method: "POST", body: JSON.stringify(body) },
   );
 }
@@ -94,7 +95,7 @@ export async function list(
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<ScheduleSummary[]> {
   return transport.request<ScheduleSummary[]>(
-    `${baseUrl}/v1/workflows/${encodeURIComponent(definition)}/triggers${toQuery(opts)}`,
+    `${baseUrl}/agents/v1/definitions/${encodeURIComponent(definition)}/triggers${toQuery(opts)}`,
   );
 }
 
@@ -105,7 +106,7 @@ export async function get(
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<ScheduleDetail> {
   return transport.request<ScheduleDetail>(
-    `${baseUrl}/v1/workflows/triggers/${encodeURIComponent(scheduleId)}`,
+    `${baseUrl}/agents/v1/triggers/${encodeURIComponent(scheduleId)}`,
   );
 }
 
@@ -116,7 +117,7 @@ export async function cancel(
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<{ id: string; status: ScheduleStatus }> {
   return transport.request<{ id: string; status: ScheduleStatus }>(
-    `${baseUrl}/v1/workflows/triggers/${encodeURIComponent(scheduleId)}`,
+    `${baseUrl}/agents/v1/triggers/${encodeURIComponent(scheduleId)}`,
     { method: "DELETE" },
   );
 }


### PR DESCRIPTION
This pull request updates the API routes for schedule and execution management in both the core agent and tools packages to use the new `/agents/v1/definitions/:slug/...` and `/agents/v1/triggers/...` paths instead of the previous `/v1/workflows/:slug/...` format. This ensures consistency with the backend API changes and clarifies the route structure for agent definitions and triggers. The tests and documentation are also updated to reflect these new routes.

**API Route Updates:**

* Updated all schedule-related routes in `agent-core` and `tools` packages to use `/agents/v1/definitions/:slug/triggers` for schedule creation and listing, and `/agents/v1/triggers/:id` for schedule detail and cancellation. (`packages/agent-core/src/schedule.ts`, `packages/tools/src/schedules/index.ts`, [[1]](diffhunk://#diff-a72428a0732171492df11b1466974065667e2aa1652cf731693cd594570ff135L87-R94) [[2]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L84-R85) [[3]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L97-R98) [[4]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L108-R109) [[5]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L119-R120)
* Changed execution launch routes to `/agents/v1/definitions/:slug/executions` and scheduled trigger routes to `/agents/v1/definitions/:slug/triggers` in agent launch logic. (`packages/tools/src/agents/index.ts`, [[1]](diffhunk://#diff-f53866b0bb763b65189e4801a87e59af287fe9d3d6335591f4cdee5a67f0081fL186-R186) [[2]](diffhunk://#diff-f53866b0bb763b65189e4801a87e59af287fe9d3d6335591f4cdee5a67f0081fL215-R215)

**Test and Documentation Updates:**

* Updated all relevant tests to check for the new route structure, ensuring correct API usage. (`packages/agent-core/src/schedule.spec.ts`, `packages/tools/src/agents/index.spec.ts`, `packages/tools/src/agents/schedule-launch.spec.ts`, [[1]](diffhunk://#diff-08593fa521a06d86804ba4a84326a3ca27f2eb7a771466de75fd21bd5e1037a4L34-R56) [[2]](diffhunk://#diff-348b4e63ade1a5c5b5c20dad0ee0bacc679a3fe6c1c7bb0b90703418b6a266b4L38-R42) [[3]](diffhunk://#diff-6d2805ad6ed1fa0aa17272984c585803dc810f5025961478bcf001027b96d100L42-R42)
* Revised documentation comments to reflect the new API path conventions and clarify usage. (`packages/agent-core/src/schedule.ts`, `packages/tools/src/schedules/index.ts`, [[1]](diffhunk://#diff-a72428a0732171492df11b1466974065667e2aa1652cf731693cd594570ff135L5-R8) [[2]](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L8-R18)

**Configuration Update:**

* Changed the default base URL in `tools/schedules` to use `SAPIOM_AGENTS_URL` or `SAPIOM_TOOLS_BASE` environment variables, aligning with the new agents gateway. (`packages/tools/src/schedules/index.ts`, [packages/tools/src/schedules/index.tsL8-R18](diffhunk://#diff-5f8785f718eedc6cef6f5d975fd03bd5a3da068c64130bbff700d4a4b0dccd12L8-R18))