### PR TITLE
refactor(harness): typed error hierarchy for session/spawn failures (SAP-1437)

### DIFF
--- a/.changeset/harness-typed-error-hierarchy.md
+++ b/.changeset/harness-typed-error-hierarchy.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+---
+
+Typed error codes on session and spawn failures; HTTP status mappings unchanged.
+
+Adds a `HarnessError` base class and five typed subclasses — `UnknownSessionError`, `SessionNotReadyError`, `SessionNotResumeableError`, `SessionAlreadyLiveError`, `AdapterNotFoundError` — each carrying a stable machine-readable `code` property. Server routes now dispatch on `instanceof` rather than parsing `error.message` text, so future message rewordings cannot silently alter the HTTP status they produce. Wire responses and response body shapes are unchanged.

--- a/packages/harness/src/core/errors.test.ts
+++ b/packages/harness/src/core/errors.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the typed error hierarchy. Each class must:
+ *   1. carry the correct stable code
+ *   2. pass instanceof for both its own class and HarnessError
+ *   3. map to the correct HTTP status via rest.ts / macros.ts
+ *
+ * The "wrong text, same class still maps correctly" tests prove the
+ * point of the port: server routes dispatch on class identity, not
+ * message strings, so any human-readable message change is safe.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  HarnessError,
+  UnknownSessionError,
+  SessionNotReadyError,
+  SessionNotResumeableError,
+  SessionAlreadyLiveError,
+  AdapterNotFoundError,
+} from "./errors.js";
+
+describe("HarnessError (base)", () => {
+  it("carries the supplied code and message", () => {
+    const err = new HarnessError("TEST_CODE", "some message");
+    expect(err.code).toBe("TEST_CODE");
+    expect(err.message).toBe("some message");
+    expect(err.name).toBe("HarnessError");
+  });
+
+  it("instanceof Error", () => {
+    expect(new HarnessError("C", "m") instanceof Error).toBe(true);
+  });
+
+  it("stores an optional cause", () => {
+    const cause = new Error("root");
+    const err = new HarnessError("C", "m", cause);
+    expect(err.cause).toBe(cause);
+  });
+});
+
+describe("UnknownSessionError", () => {
+  it("code is UNKNOWN_SESSION", () => {
+    expect(new UnknownSessionError("abc").code).toBe("UNKNOWN_SESSION");
+  });
+
+  it("instanceof HarnessError and Error", () => {
+    const err = new UnknownSessionError("abc");
+    expect(err instanceof HarnessError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it("message mentions the session id", () => {
+    expect(new UnknownSessionError("sess-42").message).toMatch(/sess-42/);
+  });
+
+  it("wrong-text-same-class: a subclass with an altered message is still instanceof UnknownSessionError", () => {
+    // Point of the port: server routes check instanceof, so a future
+    // rewording of the message never silently changes the HTTP status.
+    class AltUnknownSessionError extends UnknownSessionError {
+      constructor(id: string) {
+        super(id);
+        // Override message to simulate a future rewording.
+        Object.defineProperty(this, "message", {
+          value: "completely different wording for session " + id,
+        });
+      }
+    }
+    const err = new AltUnknownSessionError("x");
+    expect(err instanceof UnknownSessionError).toBe(true);
+    // Message no longer starts with "Unknown session" — yet the class identity is preserved.
+    expect(err.message).not.toMatch(/^Unknown session/);
+    expect(err instanceof HarnessError).toBe(true);
+  });
+});
+
+describe("SessionNotReadyError", () => {
+  it("code is SESSION_NOT_READY", () => {
+    expect(new SessionNotReadyError("s1").code).toBe("SESSION_NOT_READY");
+  });
+
+  it("instanceof HarnessError", () => {
+    expect(new SessionNotReadyError("s1") instanceof HarnessError).toBe(true);
+  });
+
+  it("message mentions trust-the-folder guidance", () => {
+    expect(new SessionNotReadyError("s1").message).toMatch(/trust the folder/i);
+  });
+
+  it("wrong-text-same-class: altered message still has correct code", () => {
+    const err = new SessionNotReadyError("s1");
+    // Simulate a future rephrasing:
+    (err as { message: string }).message = "session s1 blocked on onboarding";
+    // Code is unchanged — routes dispatch on code, not message text.
+    expect(err.code).toBe("SESSION_NOT_READY");
+    expect(err instanceof SessionNotReadyError).toBe(true);
+  });
+});
+
+describe("SessionNotResumeableError", () => {
+  it("code is SESSION_NOT_RESUMEABLE", () => {
+    expect(new SessionNotResumeableError("s2").code).toBe("SESSION_NOT_RESUMEABLE");
+  });
+
+  it("instanceof HarnessError", () => {
+    expect(new SessionNotResumeableError("s2") instanceof HarnessError).toBe(true);
+  });
+
+  it("message mentions agentSessionId", () => {
+    expect(new SessionNotResumeableError("s2").message).toMatch(/agentSessionId/);
+  });
+});
+
+describe("SessionAlreadyLiveError", () => {
+  it("code is SESSION_ALREADY_LIVE", () => {
+    expect(new SessionAlreadyLiveError("s3").code).toBe("SESSION_ALREADY_LIVE");
+  });
+
+  it("instanceof HarnessError", () => {
+    expect(new SessionAlreadyLiveError("s3") instanceof HarnessError).toBe(true);
+  });
+
+  it("message mentions live pty", () => {
+    expect(new SessionAlreadyLiveError("s3").message).toMatch(/live pty/i);
+  });
+});
+
+describe("AdapterNotFoundError", () => {
+  it("code is ADAPTER_NOT_FOUND", () => {
+    expect(new AdapterNotFoundError("codex").code).toBe("ADAPTER_NOT_FOUND");
+  });
+
+  it("instanceof HarnessError", () => {
+    expect(new AdapterNotFoundError("codex") instanceof HarnessError).toBe(true);
+  });
+
+  it("message mentions the harness kind", () => {
+    expect(new AdapterNotFoundError("codex").message).toMatch(/codex/);
+  });
+});
+
+describe("HTTP mapping contract (class → status)", () => {
+  /**
+   * These tests simulate the route handler dispatch table that replaced the
+   * old string-match. Each assertion proves that the class identity alone —
+   * independent of message text — routes to the correct status.
+   *
+   * Mapping table:
+   *   UnknownSessionError       → 404
+   *   SessionNotReadyError      → 409
+   *   SessionAlreadyLiveError   → 409
+   *   SessionNotResumeableError → 409
+   *   AdapterNotFoundError      → 400
+   */
+  function classToStatus(err: unknown): number {
+    if (err instanceof UnknownSessionError) return 404;
+    if (err instanceof SessionNotReadyError) return 409;
+    if (err instanceof SessionAlreadyLiveError) return 409;
+    if (err instanceof SessionNotResumeableError) return 409;
+    if (err instanceof AdapterNotFoundError) return 400;
+    return 500;
+  }
+
+  it("UnknownSessionError → 404", () => {
+    expect(classToStatus(new UnknownSessionError("x"))).toBe(404);
+  });
+
+  it("SessionNotReadyError → 409", () => {
+    expect(classToStatus(new SessionNotReadyError("x"))).toBe(409);
+  });
+
+  it("SessionAlreadyLiveError → 409", () => {
+    expect(classToStatus(new SessionAlreadyLiveError("x"))).toBe(409);
+  });
+
+  it("SessionNotResumeableError → 409", () => {
+    expect(classToStatus(new SessionNotResumeableError("x"))).toBe(409);
+  });
+
+  it("AdapterNotFoundError → 400", () => {
+    expect(classToStatus(new AdapterNotFoundError("codex"))).toBe(400);
+  });
+
+  it("plain Error → 500 (falls through — only typed harness errors are handled)", () => {
+    expect(classToStatus(new Error("unexpected"))).toBe(500);
+  });
+
+  it("wrong-text-same-class still maps correctly: UnknownSessionError with reworded message → 404", () => {
+    const err = new UnknownSessionError("abc");
+    // Reword the message — the old string-match 'startsWith("Unknown session")' would fail here.
+    Object.defineProperty(err, "message", { value: "session abc could not be located" });
+    expect(err.message).not.toMatch(/^Unknown session/);
+    // But instanceof still works → still 404.
+    expect(classToStatus(err)).toBe(404);
+  });
+});

--- a/packages/harness/src/core/errors.ts
+++ b/packages/harness/src/core/errors.ts
@@ -1,0 +1,84 @@
+/**
+ * Typed errors for session and spawn failures. Each carries a stable `code`
+ * so callers can react programmatically to specific failure modes instead of
+ * parsing error message strings.
+ *
+ * HTTP mappings (server/rest.ts, server/macros.ts):
+ *   UnknownSessionError       → 404
+ *   SessionNotReadyError      → 409
+ *   SessionAlreadyLiveError   → 409
+ *   SessionNotResumeableError → 409
+ *   AdapterNotFoundError      → 400
+ */
+
+/** Base class for all typed harness errors. */
+export class HarnessError extends Error {
+  /** Stable machine-readable code callers can branch on without parsing messages. */
+  readonly code: string;
+  /** Underlying error, when this error wraps another. */
+  readonly cause?: unknown;
+
+  constructor(code: string, message: string, cause?: unknown) {
+    super(message);
+    this.code = code;
+    this.cause = cause;
+    // Ensure instanceof checks survive transpilation to ES5-style output.
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when an operation references a session id that does not exist in the
+ * registry. Maps to HTTP 404.
+ */
+export class UnknownSessionError extends HarnessError {
+  constructor(id: string) {
+    super("UNKNOWN_SESSION", `Unknown session "${id}"`);
+  }
+}
+
+/**
+ * Thrown by `submitInput()` when a session's pty is alive but never became
+ * interactive within the grace period — the trust-dialog race this readiness
+ * mechanism exists to catch. Maps to HTTP 409.
+ */
+export class SessionNotReadyError extends HarnessError {
+  constructor(id: string) {
+    super(
+      "SESSION_NOT_READY",
+      `Session "${id}" is not ready yet — check the terminal, it may be asking to trust the folder.`,
+    );
+  }
+}
+
+/**
+ * Thrown by `resume()` when the session record has no `agentSessionId` to
+ * resume from (it was never fully started, or is history-only with no
+ * recorded session). Maps to HTTP 409.
+ */
+export class SessionNotResumeableError extends HarnessError {
+  constructor(id: string) {
+    super("SESSION_NOT_RESUMEABLE", `Session "${id}" has no agentSessionId to resume from`);
+  }
+}
+
+/**
+ * Thrown by `resume()` when the session already has a live pty — double-resume
+ * is a no-op caller error. Maps to HTTP 409.
+ */
+export class SessionAlreadyLiveError extends HarnessError {
+  constructor(id: string) {
+    super("SESSION_ALREADY_LIVE", `Session "${id}" already has a live pty`);
+  }
+}
+
+/**
+ * Thrown when an operation requires a harness adapter that has not been
+ * registered. Maps to HTTP 400.
+ */
+export class AdapterNotFoundError extends HarnessError {
+  constructor(harness: string) {
+    super("ADAPTER_NOT_FOUND", `No adapter registered for harness "${harness}"`);
+  }
+}

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -22,6 +22,21 @@ import {
   type SpawnSpec,
 } from "../shared/types.js";
 import { expandHome } from "./paths.js";
+import {
+  AdapterNotFoundError,
+  SessionAlreadyLiveError,
+  SessionNotReadyError,
+  SessionNotResumeableError,
+  UnknownSessionError,
+} from "./errors.js";
+
+export {
+  AdapterNotFoundError,
+  SessionAlreadyLiveError,
+  SessionNotReadyError,
+  SessionNotResumeableError,
+  UnknownSessionError,
+} from "./errors.js";
 
 // node-pty is a native module. Load it lazily so a missing/broken prebuild on
 // an unsupported platform surfaces as a spawn-time error instead of crashing
@@ -147,23 +162,6 @@ const defaultIsPidAlive = (pid: number): boolean => {
     return (err as NodeJS.ErrnoException).code === "EPERM";
   }
 };
-
-/**
- * Thrown by `submitInput()` when a session's pty is alive but never became
- * ready (see `HarnessSession.ready`) within `READY_GRACE_MS` — the trust-
- * dialog race this whole readiness mechanism exists to catch. Callers
- * (rest.ts, macros.ts) catch this specifically and surface it as a 409 with
- * a UI-visible reason, rather than letting it fall into a generic 500 or
- * (worse, the bug this fixes) silently writing into a non-interactive TUI.
- */
-export class SessionNotReadyError extends Error {
-  constructor(id: string) {
-    super(
-      `Session "${id}" is not ready yet — check the terminal, it may be asking to trust the folder.`,
-    );
-    this.name = "SessionNotReadyError";
-  }
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -334,7 +332,7 @@ export class SessionManager {
 
   private getAdapter(harness: HarnessKind): HarnessAdapter {
     const adapter = this.adapters[harness];
-    if (!adapter) throw new Error(`No adapter registered for harness "${harness}"`);
+    if (!adapter) throw new AdapterNotFoundError(harness);
     return adapter;
   }
 
@@ -415,12 +413,12 @@ export class SessionManager {
 
   async resume(id: string): Promise<HarnessSession> {
     const session = this.sessions.get(id);
-    if (!session) throw new Error(`Unknown session "${id}"`);
+    if (!session) throw new UnknownSessionError(id);
     if (!session.agentSessionId) {
-      throw new Error(`Session "${id}" has no agentSessionId to resume from`);
+      throw new SessionNotResumeableError(id);
     }
     if (this.ptys.has(id)) {
-      throw new Error(`Session "${id}" already has a live pty`);
+      throw new SessionAlreadyLiveError(id);
     }
     const adapter = this.getAdapter(session.harness);
     const opts: LaunchOpts = {

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -33,6 +33,7 @@ import {
 } from "../shared/types.js";
 import type { LaunchOptsBuilder } from "./session-manager.js";
 import { parseTaskStreamLine } from "./task-stream.js";
+import { AdapterNotFoundError } from "./errors.js";
 
 /** Rolling status-line window kept per task — enough for the activity view's
  *  recent-history list without unbounded growth on a chatty run. */
@@ -190,7 +191,7 @@ export class TaskManager {
    */
   async run(req: RunTaskRequest): Promise<BackgroundTask> {
     const adapter = this.adapters[req.harness];
-    if (!adapter) throw new Error(`No adapter registered for harness "${req.harness}"`);
+    if (!adapter) throw new AdapterNotFoundError(req.harness);
     if (!adapter.launchTask) throw new TaskNotSupportedError(req.harness, req.label);
 
     const reqWorkflowPath = req.workflowPath ?? null;

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -4,3 +4,11 @@
  */
 
 export * from "./shared/types.js";
+export {
+  HarnessError,
+  UnknownSessionError,
+  SessionNotReadyError,
+  SessionNotResumeableError,
+  SessionAlreadyLiveError,
+  AdapterNotFoundError,
+} from "./core/errors.js";

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -13,7 +13,7 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 import type { HarnessSession, MacroDef, WorkflowInfo } from "../shared/types.js";
-import { SessionNotReadyError } from "../core/session-manager.js";
+import { SessionNotReadyError, UnknownSessionError } from "../core/session-manager.js";
 import { createRestRouter, type RestRouterOptions } from "./rest.js";
 
 const TOKEN_HEADER = { "X-Harness-Token": "unused-in-router-tests" };
@@ -478,5 +478,40 @@ describe("createRestRouter", () => {
       expect(res.status).toBe(400);
     });
 
+  });
+
+  describe("POST /sessions/:id/resume — error class → HTTP status mapping", () => {
+    it("404s when resume() throws UnknownSessionError (class-based dispatch, not string match)", async () => {
+      const sessionManager = fakeSessionManager();
+      (sessionManager.resume as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new UnknownSessionError("does-not-exist"),
+      );
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/does-not-exist/resume`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("404s even when UnknownSessionError carries a reworded message — proves class dispatch, not string-match", async () => {
+      // This is the point of the port: the old code did
+      //   err.message.startsWith("Unknown session")
+      // so any rewording would silently fall to a 500. Now that the route
+      // checks instanceof, the message can say anything.
+      const sessionManager = fakeSessionManager();
+      const err = new UnknownSessionError("xyz");
+      Object.defineProperty(err, "message", { value: "session xyz could not be located" });
+      (sessionManager.resume as ReturnType<typeof vi.fn>).mockRejectedValue(err);
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/xyz/resume`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
+      // Old string-match would give 500 here; class dispatch gives 404.
+      expect(res.status).toBe(404);
+    });
   });
 });

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -22,7 +22,7 @@ import type {
   SessionSummary,
   WorkflowInfo,
 } from "../shared/types.js";
-import { SessionNotReadyError, type SessionManager } from "../core/session-manager.js";
+import { SessionNotReadyError, UnknownSessionError, type SessionManager } from "../core/session-manager.js";
 import { loadSettings, saveSettings } from "../cli/settings.js";
 
 const createSessionSchema = z.object({
@@ -281,7 +281,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       const session = await sessionManager.resume(req.params.id);
       res.json(session);
     } catch (err) {
-      if (err instanceof Error && err.message.startsWith("Unknown session")) {
+      if (err instanceof UnknownSessionError) {
         res.status(404).json({ error: err.message });
         return;
       }


### PR DESCRIPTION
## What

Ports the typed error hierarchy from the closed scaffold PR #177 into the shipped harness: `src/core/errors.ts` defines `HarnessError` + five subclasses, each carrying a machine-readable `code`, and the session-manager/task-manager/server paths throw them instead of text-matched generic `Error`s.

| Class | code | HTTP |
|---|---|---|
| `UnknownSessionError` | `UNKNOWN_SESSION` | 404 |
| `SessionNotReadyError` | `SESSION_NOT_READY` | 409 |
| `SessionAlreadyLiveError` | `SESSION_ALREADY_LIVE` | 409 |
| `SessionNotResumeableError` | `SESSION_NOT_RESUMEABLE` | 409 |
| `AdapterNotFoundError` | `ADAPTER_NOT_FOUND` | 400 |

The resume route's `err.message.startsWith("Unknown session")` dispatch becomes `instanceof` — the last string-matched error dispatch in the server. Classes are exported from the public entry (additive).

## Wire compatibility

**Byte-identical**, verified template-string-by-template-string against main: every replaced throw site produces the exact same message text, and routes serialize `err.message` unchanged. Statuses and body shapes untouched — only the dispatch mechanism changed. (Single-ESM build, so no dual-package `instanceof` hazard; `SessionNotReadyError` moved files but is re-exported from its old import path, preserving class identity for every consumer.)

## Tests

29 new (27 class-level + 2 route-level integration tests that boot the real server and prove a mutated error message still maps to 404 via class dispatch — the exact fragility the old string match had). Full suite 640/640 green; all 15 packages build + typecheck clean.

Internal review round: MERGE-READY, zero findings.

Closes SAP-1437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)