### PR TITLE
fix(harness): registry write serialization, background-macro dedupe, async watcher poll (SAP-1453)

### DIFF
--- a/.changeset/harness-registry-dedupe-async-poll.md
+++ b/.changeset/harness-registry-dedupe-async-poll.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/harness": patch
+---
+
+Internal robustness fixes (no behavior change for users):
+
+- Serialize WorkflowRegistry writes through a promise queue so concurrent prune/scan/connectPath calls can't interleave and drop entries from workflows.json.
+- Thread the resolved workflow path from the macros router into background task requests so TaskManager can dedupe per-workflow across sessions, not just per-session.
+- Make the workspace-watcher polling fallback walk async (fs/promises) to avoid blocking the event loop on wide directories; lengthen the poll interval to 2 s.

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -159,4 +159,59 @@ describe("WorkflowRegistry", () => {
       await expect(fs.access(registryPath)).rejects.toThrow();
     });
   });
+
+  describe("write serialization", () => {
+    it("concurrent scan/prune calls serialize so no entry is lost from the persisted file", async () => {
+      // Seed N workflow directories and fire scan + prune concurrently.
+      // Without the write queue, a prune that starts reading this.workflows
+      // before a concurrent scan finishes writing it can overwrite the just-
+      // merged entries. With serialization, the persisted file must contain
+      // all discovered paths.
+      const N = 5;
+      for (let i = 0; i < N; i++) {
+        await writeMarker(path.join(tmpRoot, `proj-${i}`), i);
+      }
+
+      // Fire N scans and N prunes all at once.
+      const ops: Promise<unknown>[] = [];
+      for (let i = 0; i < N; i++) {
+        ops.push(registry.scan(tmpRoot));
+        ops.push(registry.prune());
+      }
+      await Promise.all(ops);
+
+      // All N workflow paths must survive in the persisted file.
+      const reloaded = new WorkflowRegistry(registryPath);
+      const list = await reloaded.list();
+      const paths = new Set(list.map((w) => w.path));
+      for (let i = 0; i < N; i++) {
+        expect(paths.has(path.join(tmpRoot, `proj-${i}`))).toBe(true);
+      }
+    });
+
+    it("a failed persist does not poison the queue — subsequent writes succeed", async () => {
+      // Seed one workflow so there's something to scan.
+      await writeMarker(path.join(tmpRoot, "proj-ok"), 1);
+
+      // Make the registry path a DIRECTORY so writeFile throws EISDIR
+      // (mkdir({ recursive: true }) on the parent won't help because the
+      // path itself is already a directory, not a file destination).
+      const badPath = path.join(tmpRoot, "workflows-dir");
+      await fs.mkdir(badPath, { recursive: true }); // now badPath is a dir, not a file
+
+      const brokenRegistry = new WorkflowRegistry(badPath);
+
+      // Scan — persist will throw (EISDIR: illegal operation on a directory).
+      // The write queue must swallow the error so the next op can proceed.
+      await expect(brokenRegistry.scan(tmpRoot)).rejects.toThrow();
+
+      // Clear the obstruction and scan again on the SAME instance — the
+      // queue must not be poisoned by the earlier rejection.
+      await fs.rmdir(badPath);
+      await brokenRegistry.scan(tmpRoot);
+      const list = await brokenRegistry.list();
+      expect(list).toHaveLength(1);
+      expect(list[0].path).toBe(path.join(tmpRoot, "proj-ok"));
+    });
+  });
 });

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -100,6 +100,10 @@ async function scanDir(root: string, dir: string, depth: number, found: Workflow
 export class WorkflowRegistry {
   private workflows: WorkflowInfo[] = [];
   private loaded = false;
+  /** Serializes mutations so concurrent prune/scan/connectPath calls can't
+   *  interleave and drop entries from the persisted file. Mirrors the pattern
+   *  used by SessionManager.persist() (session-manager.ts:278,851-853). */
+  private writeQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly registryPath: string = expandHome(HARNESS_PATHS.workflows)) {}
 
@@ -119,6 +123,17 @@ export class WorkflowRegistry {
     await fs.writeFile(this.registryPath, JSON.stringify(this.workflows, null, 2));
   }
 
+  /** Chains `run` onto the write queue so concurrent mutations never
+   *  interleave — a failed run never poisons later ones. */
+  private enqueue<T>(run: () => Promise<T>): Promise<T> {
+    const next = this.writeQueue.catch(() => {}).then(run);
+    this.writeQueue = next.then(
+      () => {},
+      () => {},
+    );
+    return next;
+  }
+
   async list(): Promise<WorkflowInfo[]> {
     await this.ensureLoaded();
     return this.workflows;
@@ -133,60 +148,66 @@ export class WorkflowRegistry {
    * stays registered. Returns what was pruned so the caller can log it.
    */
   async prune(): Promise<WorkflowInfo[]> {
-    await this.ensureLoaded();
-    const kept: WorkflowInfo[] = [];
-    const pruned: WorkflowInfo[] = [];
-    for (const workflow of this.workflows) {
-      try {
-        await fs.stat(workflow.path);
-        kept.push(workflow);
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT" || code === "ENOTDIR") pruned.push(workflow);
-        else kept.push(workflow);
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const kept: WorkflowInfo[] = [];
+      const pruned: WorkflowInfo[] = [];
+      for (const workflow of this.workflows) {
+        try {
+          await fs.stat(workflow.path);
+          kept.push(workflow);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === "ENOENT" || code === "ENOTDIR") pruned.push(workflow);
+          else kept.push(workflow);
+        }
       }
-    }
-    if (pruned.length > 0) {
-      this.workflows = kept;
-      await this.persist();
-    }
-    return pruned;
+      if (pruned.length > 0) {
+        this.workflows = kept;
+        await this.persist();
+      }
+      return pruned;
+    });
   }
 
   /** Scans `root` and merges discovered projects into the persisted registry. */
   async scan(root: string): Promise<WorkflowInfo[]> {
-    await this.ensureLoaded();
-    const absoluteRoot = path.resolve(expandHome(root));
-    const found: WorkflowInfo[] = [];
-    await scanDir(absoluteRoot, absoluteRoot, 0, found);
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const absoluteRoot = path.resolve(expandHome(root));
+      const found: WorkflowInfo[] = [];
+      await scanDir(absoluteRoot, absoluteRoot, 0, found);
 
-    const byPath = new Map(this.workflows.map((workflow) => [workflow.path, workflow]));
-    for (const workflow of found) {
-      const existing = byPath.get(workflow.path);
-      // A manually-connected entry keeps its `source`; a scan only refreshes name/definitionId.
-      byPath.set(workflow.path, existing ? { ...existing, ...workflow, source: existing.source } : workflow);
-    }
-    this.workflows = Array.from(byPath.values());
-    await this.persist();
-    return found;
+      const byPath = new Map(this.workflows.map((workflow) => [workflow.path, workflow]));
+      for (const workflow of found) {
+        const existing = byPath.get(workflow.path);
+        // A manually-connected entry keeps its `source`; a scan only refreshes name/definitionId.
+        byPath.set(workflow.path, existing ? { ...existing, ...workflow, source: existing.source } : workflow);
+      }
+      this.workflows = Array.from(byPath.values());
+      await this.persist();
+      return found;
+    });
   }
 
   /** Registers an arbitrary path (the "+ Connect" flow); marker is optional at connect time. */
   async connectPath(inputPath: string): Promise<WorkflowInfo> {
-    await this.ensureLoaded();
-    const absolutePath = path.resolve(expandHome(inputPath));
-    const marker = await readMarker(absolutePath);
-    const info: WorkflowInfo = {
-      name: await nameFor(absolutePath),
-      path: absolutePath,
-      definitionId: marker?.definitionId ?? null,
-      source: "connect",
-    };
-    const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);
-    if (idx >= 0) this.workflows[idx] = info;
-    else this.workflows.push(info);
-    await this.persist();
-    return info;
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const absolutePath = path.resolve(expandHome(inputPath));
+      const marker = await readMarker(absolutePath);
+      const info: WorkflowInfo = {
+        name: await nameFor(absolutePath),
+        path: absolutePath,
+        definitionId: marker?.definitionId ?? null,
+        source: "connect",
+      };
+      const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);
+      if (idx >= 0) this.workflows[idx] = info;
+      else this.workflows.push(info);
+      await this.persist();
+      return info;
+    });
   }
 }
 

--- a/packages/harness/src/core/workspace-watcher.test.ts
+++ b/packages/harness/src/core/workspace-watcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { WorkspaceWatcherManager, snapshotWorkspaceWorkflows } from "./workspace-watcher.js";
+import { WorkspaceWatcherManager, snapshotWorkspaceWorkflows, snapshotWorkspaceWorkflowsAsync } from "./workspace-watcher.js";
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -137,5 +137,59 @@ describe("snapshotWorkspaceWorkflows", () => {
     await scaffoldWorkflow(path.join(dir, "flow-a"), "nested");
     const snapshot = snapshotWorkspaceWorkflows(dir);
     expect(snapshot).not.toContain("nested");
+  });
+});
+
+describe("snapshotWorkspaceWorkflowsAsync", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-workspace-snapshot-async-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("produces the same fingerprint as the sync version for a populated workspace", async () => {
+    await scaffoldWorkflow(dir, "flow-a");
+    await scaffoldWorkflow(dir, "flow-b");
+    await fs.mkdir(path.join(dir, "node_modules", "pkg"), { recursive: true });
+
+    const sync = snapshotWorkspaceWorkflows(dir);
+    const async_ = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(async_).toBe(sync);
+    expect(async_).toContain("flow-a");
+    expect(async_).toContain("flow-b");
+  });
+
+  it("returns an empty string for an empty root, matching the sync version", async () => {
+    const sync = snapshotWorkspaceWorkflows(dir);
+    const async_ = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(async_).toBe(sync);
+    expect(async_).toBe("");
+  });
+
+  it("changes when a workflow appears and again when it's removed — same as the sync version", async () => {
+    const emptySync = snapshotWorkspaceWorkflows(dir);
+    const emptyAsync = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(emptyAsync).toBe(emptySync);
+
+    const wfDir = await scaffoldWorkflow(dir, "flow-c");
+    const withOneSync = snapshotWorkspaceWorkflows(dir);
+    const withOneAsync = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(withOneAsync).toBe(withOneSync);
+    expect(withOneAsync).not.toBe(emptyAsync);
+
+    await fs.rm(wfDir, { recursive: true, force: true });
+    const afterRemoveAsync = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(afterRemoveAsync).toBe(emptyAsync);
+  });
+
+  it("does not descend into a marker directory — same stop-at-first-marker semantics as sync", async () => {
+    await scaffoldWorkflow(dir, "flow-d");
+    await scaffoldWorkflow(path.join(dir, "flow-d"), "nested-should-not-appear");
+    const async_ = await snapshotWorkspaceWorkflowsAsync(dir);
+    expect(async_).not.toContain("nested-should-not-appear");
   });
 });

--- a/packages/harness/src/core/workspace-watcher.ts
+++ b/packages/harness/src/core/workspace-watcher.ts
@@ -24,12 +24,18 @@
  *
  * The polling fallback (Linux, or a watcher runtime error) diffs the same
  * fingerprint on an interval, so both paths share one notion of "changed".
+ * The fallback walk is async (fs/promises) to avoid blocking the event loop
+ * on a wide cwd — the poll interval is longer than the watch debounce,
+ * so a filesystem event via the watcher is still the fast path.
  */
 import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 
 const DEBOUNCE_MS = 250;
-const POLL_INTERVAL_MS = 1_000;
+/** Longer than the watch debounce — the watcher path is the fast signal;
+ *  the poll is just a backstop for platforms without recursive fs.watch. */
+const POLL_INTERVAL_MS = 2_000;
 
 /** Kept in sync with core/workflow-registry.ts's scan: the marker file that
  *  makes a directory a workflow, and how deep the scan looks for it. */
@@ -52,7 +58,12 @@ function firstSegmentIgnored(relPath: string): boolean {
  * Fingerprint of the set of workflow-marker directories under `root` (sorted,
  * bounded depth, ignored subtrees skipped). Changes exactly when a workflow is
  * added, removed, or renamed — not when unrelated files are edited. Exported
- * for the polling fallback and for direct testing.
+ * for direct testing.
+ *
+ * The synchronous form is retained for callers that need an immediate
+ * baseline at construction time (before async I/O is possible). The
+ * polling fallback uses the async form to avoid blocking the event loop on
+ * a wide directory tree.
  */
 export function snapshotWorkspaceWorkflows(root: string): string {
   const markerDirs: string[] = [];
@@ -81,6 +92,37 @@ export function snapshotWorkspaceWorkflows(root: string): string {
   return markerDirs.sort().join("|");
 }
 
+/**
+ * Async variant used by the polling fallback — yields between directories so
+ * a wide workspace can't stutter the event loop on platforms without recursive
+ * fs.watch. Produces the same fingerprint as the sync version. Exported for
+ * direct testing.
+ */
+export async function snapshotWorkspaceWorkflowsAsync(root: string): Promise<string> {
+  const markerDirs: string[] = [];
+
+  const walk = async (dir: string, depth: number): Promise<void> => {
+    if (depth > MAX_SCAN_DEPTH) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    if (entries.some((entry) => entry.isFile() && entry.name === WORKFLOW_MARKER)) {
+      markerDirs.push(dir);
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || IGNORED_DIR_NAMES.has(entry.name)) continue;
+      await walk(path.join(dir, entry.name), depth + 1);
+    }
+  };
+
+  await walk(root, 0);
+  return markerDirs.sort().join("|");
+}
+
 /** One session's workspace watcher. */
 class SessionWorkspaceWatcher {
   private watcher: fs.FSWatcher | null = null;
@@ -98,7 +140,9 @@ class SessionWorkspaceWatcher {
     this.arm();
   }
 
-  /** Debounced check: recompute the fingerprint and fire only on a real change. */
+  /** Debounced check: recompute the fingerprint and fire only on a real change.
+   *  The watcher path uses the sync snapshot (fast, on a single event-loop
+   *  tick); the polling path uses the async variant (yields between dirs). */
   private scheduleCheck(): void {
     if (this.closed) return;
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
@@ -108,6 +152,17 @@ class SessionWorkspaceWatcher {
   private checkNow(): void {
     if (this.closed) return;
     const snapshot = snapshotWorkspaceWorkflows(this.cwd);
+    if (snapshot === this.lastSnapshot) return;
+    this.lastSnapshot = snapshot;
+    this.onChange(this.harnessSessionId);
+  }
+
+  /** Async variant of the fingerprint check — used by the polling fallback
+   *  so the walk doesn't block the event loop on a wide directory tree. */
+  private async checkNowAsync(): Promise<void> {
+    if (this.closed) return;
+    const snapshot = await snapshotWorkspaceWorkflowsAsync(this.cwd);
+    if (this.closed) return; // session may have closed during the await
     if (snapshot === this.lastSnapshot) return;
     this.lastSnapshot = snapshot;
     this.onChange(this.harnessSessionId);
@@ -137,7 +192,12 @@ class SessionWorkspaceWatcher {
     if (this.closed || this.pollTimer) return;
     this.watcher?.close();
     this.watcher = null;
-    this.pollTimer = setInterval(() => this.checkNow(), POLL_INTERVAL_MS);
+    this.pollTimer = setInterval(() => {
+      this.checkNowAsync().catch(() => {
+        // Snapshot errors (permission denied, etc.) are benign — the next
+        // tick will retry, same as the sync path silently swallowing them.
+      });
+    }, POLL_INTERVAL_MS);
   }
 
   close(): void {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -601,7 +601,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         // bracketed paste and never submits.
         await sessionManager.submitInput(harnessSessionId, text, submit);
       },
-      runBackgroundTask: async (harnessSessionId, macro, prompt) => {
+      runBackgroundTask: async (harnessSessionId, macro, prompt, workflowPath) => {
         // The router already 404'd on an unknown session (getSessionCwd),
         // so the session is present here; its harness kind decides whether
         // a headless run is even possible (TaskNotSupportedError → 400).
@@ -614,6 +614,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
           harness: session.harness,
           cwd: session.cwd,
           prompt,
+          workflowPath,
         });
       },
       openUrl: async (url) => {

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -230,15 +230,44 @@ describe("macros router", () => {
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
     });
     expect(res.status).toBe(200);
-    const [sessionId, macro, prompt] = (deps.runBackgroundTask as ReturnType<typeof vi.fn>).mock.calls[0] as [
-      string,
-      { id: string },
-      string,
-    ];
+    const [sessionId, macro, prompt, passedWorkflowPath] = (
+      deps.runBackgroundTask as ReturnType<typeof vi.fn>
+    ).mock.calls[0] as [string, { id: string }, string, string | null];
     expect(sessionId).toBe("sess-1");
     expect(macro.id).toBe("bg-macro");
     expect(prompt).toBe("do something in /Users/demo/acme-app"); // {{session.cwd}} substituted
+    // No workflowPath on the request and no bound workflow — must be null (not omitted)
+    // so TaskManager can apply its per-session dedupe key (not per-workflow).
+    expect(passedWorkflowPath).toBeNull();
     expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("passes the resolved workflowPath into runBackgroundTask so TaskManager can dedupe per-workflow", async () => {
+    const backgroundMacro = {
+      id: "bg-wf-macro",
+      label: "Background workflow macro",
+      icon: "Wand2",
+      execution: "background" as const,
+      action: { kind: "inject" as const, text: "enrich {{workflow.path}}", submit: true },
+    };
+    const deps = makeDeps({ listMacros: () => [...DEFAULT_MACROS, backgroundMacro] });
+    await start(deps);
+
+    const res = await fetch(`${baseUrl}/api/macros/bg-wf-macro/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+    expect(res.status).toBe(200);
+    const [, , , passedWorkflowPath] = (deps.runBackgroundTask as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { id: string },
+      string,
+      string | null,
+    ];
+    // workflowPath must be threaded through so TaskManager can reject a
+    // second session running the same macro against the same workflow.
+    expect(passedWorkflowPath).toBe(workflow.path);
   });
 
   it("400s visualize on a harness with no headless mode (TaskNotSupportedError from the enrichment spawn)", async () => {

--- a/packages/harness/src/server/macros.ts
+++ b/packages/harness/src/server/macros.ts
@@ -30,10 +30,13 @@ export interface MacrosRouterDeps {
   injectInput(harnessSessionId: string, text: string, submit: boolean): Promise<void>;
   /** Runs an "inject" macro marked `execution: "background"` as a headless
    *  one-shot task (the TaskManager) instead of touching the session's pty.
+   *  `workflowPath` is the resolved workflow the macro was invoked against —
+   *  passed through to TaskManager so two sessions running the same macro
+   *  against the same workflow dedupe per-workflow rather than per-session.
    *  May throw TaskNotSupportedError (session's harness has no headless
    *  mode → 400) or TaskAlreadyRunningError (same macro already in flight
-   *  for this session → 409). */
-  runBackgroundTask(harnessSessionId: string, macro: MacroDef, prompt: string): Promise<void>;
+   *  for this target → 409). */
+  runBackgroundTask(harnessSessionId: string, macro: MacroDef, prompt: string, workflowPath: string | null): Promise<void>;
   /** Opens a URL in the user's default browser (the `open` package). */
   openUrl(url: string): Promise<void>;
   /** The "visualize" macro's `render-canvas` action: force refresh of the
@@ -88,7 +91,7 @@ export function createMacrosRouter(deps: MacrosRouterDeps): ExpressRouter {
       } else if (resolved.kind === "render-canvas") {
         await deps.renderCanvas(body.harnessSessionId);
       } else if (macro.execution === "background") {
-        await deps.runBackgroundTask(body.harnessSessionId, macro, resolved.text);
+        await deps.runBackgroundTask(body.harnessSessionId, macro, resolved.text, workflowPath ?? null);
       } else {
         await deps.injectInput(body.harnessSessionId, resolved.text, resolved.submit);
       }


### PR DESCRIPTION
## What — three v0 hygiene fixes from the post-merge delta review

1. **WorkflowRegistry write serialization** — `prune()`/`scan()`/`connectPath()` now chain through a promise queue (mirroring the sessions.json idiom), so concurrent per-session watcher rescans can't interleave and drop a just-scanned entry from `workflows.json`. Callers still receive real results/rejections; a failed persist can't poison the queue (pinned by a same-instance recovery test).
2. **Background macros dedupe per workflow** — `runBackgroundTask` now threads `workflowPath` into the `RunTaskRequest`, so `execution:"background"` macros dedupe cross-session per workflow instead of per-session only. (No default macro uses the channel yet — plumbing + tests.)
3. **Watcher polling fallback off the event loop** — the fallback's 1s synchronous FS walk is now async (`fs/promises`) with the interval at 2s; the primary `fs.watch` path keeps its synchronous low-latency check. Overlapping slow walks are benign (idempotent rescan + snapshot comparison).

## Review round

APPROVE with one nit (the poison-queue test proved a fresh instance recovers rather than the same instance) — fixed: the test now clears the obstruction and rescans on the same registry.

## Tests

Suite 618/618 green (+7 new: serialization interleave, async-snapshot parity, workflowPath plumbing); build green. Patch changeset (interval change called out).

Closes SAP-1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)