### PR TITLE
fix(harness): canvas keeps the instant render during enrichment + true no-op on deduped Visualize (SAP-1451, SAP-1452)

### DIFF
--- a/.changeset/canvas-v0-bugs.md
+++ b/.changeset/canvas-v0-bugs.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/harness": patch
+---
+
+Fix two canvas v0 bugs:
+
+**UI (CanvasPane)**: While an enrichment task runs, the activity strip now overlays the iframe instead of replacing it. The deterministic SVG render is visible immediately after binding; the spinner appears on top during the LLM annotation pass and disappears on completion. Failure state (Retry/Dismiss) remains full-screen and is unchanged.
+
+**Server (forceRefresh)**: The already-running check for a workflow's enrichment task is now performed before any cache invalidation or re-render. A double-clicked Visualize correctly rejects with a 409 and leaves the enrichment cache and render files exactly as the still-running task will need them.

--- a/packages/harness/src/core/canvas-enrich.test.ts
+++ b/packages/harness/src/core/canvas-enrich.test.ts
@@ -78,6 +78,7 @@ interface FakeRunner extends EnrichmentTaskRunner {
 function makeRunner(): FakeRunner {
   const listeners = new Set<(task: BackgroundTask) => void>();
   const requests: RunTaskRequest[] = [];
+  const running = new Map<string, BackgroundTask>(); // keyed by task id
   let n = 0;
   let last: BackgroundTask | undefined;
   return {
@@ -99,13 +100,28 @@ function makeRunner(): FakeRunner {
         resultText: null,
         errorTail: null,
       };
+      running.set(last.id, last);
       return last;
     },
     onStatusChange(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
+    isRunning(macroId: string, workflowPath: string): boolean {
+      for (const task of running.values()) {
+        if (task.status === "running" && task.macroId === macroId && task.workflowPath === workflowPath) {
+          return true;
+        }
+      }
+      return false;
+    },
     emit(task) {
+      // Mirror real TaskManager: update status in running map when emitting
+      const existing = running.get(task.id);
+      if (existing) {
+        existing.status = task.status;
+        if (task.status !== "running") running.delete(task.id);
+      }
       for (const listener of [...listeners]) listener(task);
     },
     lastTask() {
@@ -310,6 +326,48 @@ describe("CanvasEnrichmentCoordinator.forceRefresh", () => {
     const { coordinator, session } = makeCoordinator(refusing as unknown as FakeRunner, cwd);
 
     await expect(coordinator.forceRefresh(session, [WORKFLOW])).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+  });
+
+  it("double-click guard: second forceRefresh while a task is running rejects BEFORE touching the cache or re-rendering", async () => {
+    const runner = makeRunner();
+    const cwd = await tmpCwd();
+    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
+
+    // Write an enrichment cache file that should survive the second call.
+    const cacheFile = enrichmentCacheFileFor(cwd, WORKFLOW.path);
+    await writeEnrichmentCacheFile(cacheFile, {
+      graph: GRAPH,
+      enrichment: { summary: "cached annotations" },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    // First forceRefresh: starts the task (cache is cleared, rerender called once).
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+    expect(runner.requests).toHaveLength(1);
+    // The running task is still in flight (never emitted a terminal status).
+
+    // Write the cache back, simulating the state mid-run where the cache has
+    // been partially repopulated (or was never cleared yet by the second call).
+    await writeEnrichmentCacheFile(cacheFile, {
+      graph: GRAPH,
+      enrichment: { summary: "mid-run annotations" },
+      sourceFingerprint: "fp-1",
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    // Second forceRefresh while the task is still running: must reject with
+    // TaskAlreadyRunningError and be a true no-op — cache untouched, no
+    // additional rerender, no additional spawn.
+    const rerenderCallsBefore = rerender.mock.calls.length;
+    await expect(coordinator.forceRefresh(session, [WORKFLOW])).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+
+    // Cache survives the second call (the running enrichment still needs it).
+    expect(await readEnrichmentCacheFile(cacheFile)).not.toBeNull();
+    // No additional rerender was triggered.
+    expect(rerender.mock.calls.length).toBe(rerenderCallsBefore);
+    // No additional task was spawned.
+    expect(runner.requests).toHaveLength(1);
   });
 
   it("is a no-op for an unbound session — matching the deterministic render's unbound contract", async () => {

--- a/packages/harness/src/core/canvas-enrich.ts
+++ b/packages/harness/src/core/canvas-enrich.ts
@@ -113,6 +113,10 @@ export function extractEnrichmentJson(text: string): unknown | null {
 export interface EnrichmentTaskRunner {
   run(req: RunTaskRequest): Promise<BackgroundTask>;
   onStatusChange(listener: (task: BackgroundTask) => void): () => void;
+  /** Returns true when an enrichment task for this workflow is currently
+   *  running — checked before cache destruction in forceRefresh so a
+   *  double-click Visualize is a true no-op, not a half-destroyed cache. */
+  isRunning(macroId: string, workflowPath: string): boolean;
 }
 
 /** The session shape the coordinator needs — satisfied by HarnessSession. */
@@ -184,10 +188,18 @@ export class CanvasEnrichmentCoordinator {
    * to the macros router (TaskAlreadyRunningError → 409,
    * TaskNotSupportedError → 400). Unbound session: just a no-op, matching
    * the deterministic render's own unbound contract.
+   *
+   * The already-running check happens BEFORE any cache destruction so that a
+   * double-click Visualize is a true no-op: the second call rejects with
+   * TaskAlreadyRunningError and the caches and render are left exactly as
+   * the still-running enrichment will need them.
    */
   async forceRefresh(session: EnrichmentSession, workflows: readonly RenderableWorkflow[]): Promise<void> {
     const bound = this.resolveBound(session, workflows);
     if (!bound) return;
+    if (this.tasks.isRunning(ENRICHMENT_MACRO_ID, bound.path)) {
+      throw new TaskAlreadyRunningError(ENRICHMENT_TASK_LABEL);
+    }
     invalidateExtractionCache(bound.path);
     await removeEnrichmentCacheFile(enrichmentCacheFileFor(session.cwd, bound.path));
     await this.rerender(session.cwd, bound);

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -174,6 +174,18 @@ export class TaskManager {
     return this.tasks.get(id);
   }
 
+  /** Returns true when any registered task with the given macroId is currently
+   *  running against the given workflowPath — used by forceRefresh to check
+   *  before destroying caches so a second Visualize click is a true no-op. */
+  isRunning(macroId: string, workflowPath: string): boolean {
+    for (const task of this.tasks.values()) {
+      if (task.status === "running" && task.macroId === macroId && task.workflowPath === workflowPath) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   onStatusChange(listener: TaskStatusListener): () => void {
     this.statusEmitter.on("status", listener);
     return () => {

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -813,6 +813,80 @@ test.describe("background-task canvas states", () => {
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
   });
 
+  test("enrichment running after content exists: iframe stays visible with the activity strip overlaid", async ({
+    page,
+  }) => {
+    // Bring up the canvas iframe first — simulates the deterministic render
+    // that fires immediately when the user clicks Visualize.
+    await page.route("**/canvas/sess-boot/**", async (route) => {
+      await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+    });
+    await page.evaluate(() => {
+      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+        type: "canvas.reload",
+        harnessSessionId: "sess-boot",
+      });
+    });
+    await expect(page.locator(".canvas-iframe")).toBeVisible();
+
+    // Now the enrichment task starts (LLM annotating the diagram in the
+    // background). The iframe must stay in the DOM — the activity strip
+    // overlays it, not replaces it.
+    await publish(page, { ...baseTask, status: "running" });
+
+    const activity = page.getByTestId("canvas-task-activity");
+    await expect(activity).toBeVisible();
+    await expect(activity).toContainText("Visualize is running");
+    // Headline feature: the iframe is NOT hidden while enrichment runs.
+    await expect(page.locator(".canvas-iframe")).toBeVisible();
+    // The overlay class is applied so the strip sits on top of the iframe.
+    await expect(activity).toHaveClass(/canvas-task-activity--overlay/);
+
+    await page.screenshot({ path: "web/e2e/screenshots/canvas-enrichment-overlay.png" });
+
+    // Status lines stream through normally.
+    await publish(page, {
+      ...baseTask,
+      status: "running",
+      statusLines: ["Reading steps/intake.ts"],
+    });
+    await expect(page.getByTestId("canvas-task-lines")).toContainText("Reading steps/intake.ts");
+    await expect(page.locator(".canvas-iframe")).toBeVisible();
+
+    // Task completes: activity strip disappears, iframe stays.
+    await publish(page, { ...baseTask, status: "completed", endedAt: new Date().toISOString(), exitCode: 0 });
+    await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
+    await expect(page.locator(".canvas-iframe")).toBeVisible();
+  });
+
+  test("failure view is full-screen (no iframe behind it) — unchanged from before", async ({ page }) => {
+    // Get an iframe up first, then trigger a failure.
+    await page.route("**/canvas/sess-boot/**", async (route) => {
+      await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+    });
+    await page.evaluate(() => {
+      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+        type: "canvas.reload",
+        harnessSessionId: "sess-boot",
+      });
+    });
+    await expect(page.locator(".canvas-iframe")).toBeVisible();
+
+    await publish(page, {
+      ...baseTask,
+      status: "failed",
+      endedAt: new Date().toISOString(),
+      exitCode: 1,
+      errorTail: "Connection lost",
+    });
+
+    // Failure state replaces everything — iframe gone, failure panel shown.
+    await expect(page.getByTestId("canvas-task-failed")).toBeVisible();
+    await expect(page.locator(".canvas-iframe")).toHaveCount(0);
+
+    await page.screenshot({ path: "web/e2e/screenshots/canvas-failure-fullscreen.png" });
+  });
+
   test("a failed task shows the error tail with retry and dismiss affordances", async ({ page }) => {
     await publish(page, {
       ...baseTask,

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -133,23 +133,6 @@ export function CanvasPane({
 
       {!sessionId ? (
         <div className="canvas-empty">Start a session to see its canvas here.</div>
-      ) : runningTask ? (
-        <div className="canvas-task-activity" data-testid="canvas-task-activity">
-          <div className="canvas-task-title">
-            <span className="canvas-task-spinner" aria-hidden="true" />
-            <span>{runningTask.label} is running…</span>
-          </div>
-          {runningTask.statusLines.length > 0 && (
-            <ul className="canvas-task-lines" data-testid="canvas-task-lines">
-              {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
-                <li key={`${index}-${line}`}>{line}</li>
-              ))}
-            </ul>
-          )}
-          <p className="canvas-empty-hint">
-            Running as a background task — your session stays free. The canvas reloads here when it finishes.
-          </p>
-        </div>
       ) : failedTask ? (
         <div className="canvas-task-failed" data-testid="canvas-task-failed">
           <p className="canvas-task-title">
@@ -181,6 +164,23 @@ export function CanvasPane({
             </button>
           </div>
         </div>
+      ) : runningTask && !hasGeneratedContent ? (
+        <div className="canvas-task-activity" data-testid="canvas-task-activity">
+          <div className="canvas-task-title">
+            <span className="canvas-task-spinner" aria-hidden="true" />
+            <span>{runningTask.label} is running…</span>
+          </div>
+          {runningTask.statusLines.length > 0 && (
+            <ul className="canvas-task-lines" data-testid="canvas-task-lines">
+              {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
+                <li key={`${index}-${line}`}>{line}</li>
+              ))}
+            </ul>
+          )}
+          <p className="canvas-empty-hint">
+            Running as a background task — your session stays free. The canvas reloads here when it finishes.
+          </p>
+        </div>
       ) : probing ? (
         <div className="canvas-loading" data-testid="canvas-loading">
           <span className="canvas-task-spinner" aria-hidden="true" />
@@ -211,6 +211,27 @@ export function CanvasPane({
             <div className="canvas-loading canvas-loading--overlay" data-testid="canvas-loading">
               <span className="canvas-task-spinner" aria-hidden="true" />
               <p className="canvas-empty-hint">Rendering diagram…</p>
+            </div>
+          )}
+          {runningTask && (
+            <div
+              className="canvas-task-activity canvas-task-activity--overlay"
+              data-testid="canvas-task-activity"
+            >
+              <div className="canvas-task-title">
+                <span className="canvas-task-spinner" aria-hidden="true" />
+                <span>{runningTask.label} is running…</span>
+              </div>
+              {runningTask.statusLines.length > 0 && (
+                <ul className="canvas-task-lines" data-testid="canvas-task-lines">
+                  {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
+                    <li key={`${index}-${line}`}>{line}</li>
+                  ))}
+                </ul>
+              )}
+              <p className="canvas-empty-hint">
+                Running as a background task — your session stays free. The canvas reloads here when it finishes.
+              </p>
             </div>
           )}
           <iframe

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1494,6 +1494,17 @@ input {
   line-height: 1.6;
 }
 
+/* Overlay variant: sits on top of the iframe so the deterministic render
+   remains visible while the enrichment task is in flight — only the
+   activity strip appears on top, not a full replacement of the canvas. */
+.canvas-task-activity--overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: color-mix(in srgb, var(--bg-1) 85%, transparent);
+  backdrop-filter: blur(2px);
+}
+
 .canvas-task-title {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Bug 1 — canvas hid the instant deterministic render while enrichment ran (SAP-1451)

`CanvasPane` rendered the task-activity view INSTEAD of the iframe during enrichment — hiding the just-written zero-LLM diagram for up to a minute, inverting the feature's headline benefit. Now the iframe never disappears once content exists: the activity strip overlays it (translucent + blur, reusing the existing overlay pattern); full-screen activity remains only for true first-runs (no prior content), and the failure view (Retry/Dismiss) is untouched.

No flicker on legitimate force-refreshes: the deterministic re-render lands (and `canvas.reload` fires) before the task's `running` status reaches the client, so `hasGeneratedContent` never dips mid-refresh — verified in review by tracing the bus.

## Bug 2 — Visualize force-refresh destroyed caches before the already-running check (SAP-1452)

`forceRefresh()` invalidated the extraction cache, deleted the enrichment cache file, and re-rendered BEFORE `spawn()` threw `TaskAlreadyRunningError` — a double-clicked Visualize 409'd correctly but had already stripped annotations. Now an `isRunning(macroId, workflowPath)` check runs FIRST, making a refused refresh a true no-op; `spawn()`'s own throw remains the concurrency backstop for the true-race case. Ordering pinned by test: second refresh rejects AND the cache file survives AND no second re-render.

## Tests

+1 unit (ordering guard), +2 Playwright specs (iframe + strip visible simultaneously during enrichment, strip gone on completion, failure view iframe-free). Suites: vitest 612/612, Playwright 65/65. Patch changeset.

Internal review round: APPROVE, no changes (interface widening internal-only; TOCTOU backstop preserved; assertions verified strong).

Closes SAP-1451, SAP-1452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)