### PR TITLE
chore(harness): packaging polish — LICENSE, exports map, tarball verification (SAP-1439)

### DIFF
--- a/.changeset/harness-packaging-polish.md
+++ b/.changeset/harness-packaging-polish.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+---
+
+Packaging polish: LICENSE file, explicit exports map, and pack-contents audit.
+
+Adds a per-package LICENSE file (MIT, matching repo root) so published tarballs include it. Adds an explicit `exports` map with a main entry (`"."`) and `"./package.json"` sub-path — the latter is required by `@sapiom/cli`'s `createRequire().resolve('@sapiom/harness/package.json')` resolution path; without it a conditional-exports package would fire `ERR_PACKAGE_PATH_NOT_EXPORTED` and break `sapiom dev`. Updates `files` to include `LICENSE`, `CHANGELOG.md`, and `README.md` alongside `dist`. Excludes `src/test-setup.ts` from the build tsconfig so `dist/test-setup.*` no longer appears in the published tarball. Stays ESM-only (`"type": "module"`) — the harness is an app-style bin package, not a library; a dual CJS+ESM build would introduce the dual-package hazard for the typed error hierarchy (`instanceof` dispatch) with no user benefit.

--- a/packages/harness/LICENSE
+++ b/packages/harness/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -22,13 +22,23 @@
   "license": "MIT",
   "author": "Sapiom",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "sapiom-harness": "./dist/cli/bin.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json && vite build --config web/vite.config.ts",

--- a/packages/harness/tsconfig.build.json
+++ b/packages/harness/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "web", "src/**/*.test.ts", "src/**/__fixtures__/**"]
+  "exclude": ["node_modules", "dist", "web", "src/**/*.test.ts", "src/test-setup.ts", "src/**/__fixtures__/**"]
 }


### PR DESCRIPTION
Unit PR into the v0 integration branch (umbrella: #266).

## Decision: ESM-only (justified deviation from the ticket's dual-build title)

The harness is an app-style bin package (`npx`/`sapiom dev` spawn) — no consumer `require()`s it. Adding CJS output would reintroduce the dual-package hazard for the publicly-exported typed error hierarchy (`instanceof` dispatch verified safe precisely because there is one build format). No user benefit offsets that risk. Rationale recorded in the changeset.

## What shipped

- **LICENSE** (MIT, matching the repo/per-package convention exactly)
- **exports map**: `"."` (types-first order) + `"./package.json"` — the latter explicitly protects `sapiom dev`'s `createRequire` resolution (verified working)
- **files/pack audit**: CHANGELOG now packed; `dist/test-setup.*` excluded from the build (257→255 files); `dist/web` (the served UI) confirmed present and the server's `packageRoot()` resolution verified against the packed layout
- No deep-subpath imports anywhere in the repo get blocked by the map (grepped)

## Proof

Tarball installed into a temp prefix boots cleanly: doctor detects node/claude/codex/git, server comes up with boot token (401 on unauthenticated /api/health = live + guarded). Suite 654/654; typecheck clean.

Internal review round: APPROVE, no findings.

Closes SAP-1439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)