### PR TITLE
feat(harness): awaitable kill with liveness-fallback resolution (SAP-1438)

### DIFF
--- a/.changeset/harness-awaitable-kill.md
+++ b/.changeset/harness-awaitable-kill.md
@@ -1,0 +1,26 @@
+---
+"@sapiom/harness": patch
+---
+
+Awaitable kill for harness sessions and tasks with liveness-fallback resolution.
+
+`SessionManager.kill()` now returns `Promise<boolean>` that resolves once the
+process is **actually gone** — not fire-and-forget. Existing callers that do not
+await the return value keep working unchanged.
+
+Resolution is driven by whichever path fires first: node-pty's real `onExit`
+event, or a synthesized exit from `kill()`'s own SIGTERM→SIGKILL escalation
+fallback (which performs an OS-level pid liveness check after the escalation
+window). The promise never hangs: worst-case resolution is
+`KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS` (2500 ms), after which the
+process is declared dead via the OS probe regardless of whether node-pty's event
+arrived.
+
+`SessionManager.killAll()` is now `async` and resolves when all concurrent kills
+have confirmed death. `TaskManager.killAll()` gains the same awaitable treatment
+with SIGTERM→SIGKILL escalation and per-task exit promises wired through the
+existing `finish()` convergence point.
+
+Server shutdown (`close()` in server/index.ts) now awaits both `killAll()` calls
+with a 5-second outer timeout, so the process actually exits cleanly instead of
+leaving orphaned agent children.

--- a/.changeset/harness-awaitable-kill.md
+++ b/.changeset/harness-awaitable-kill.md
@@ -9,17 +9,28 @@ process is **actually gone** — not fire-and-forget. Existing callers that do n
 await the return value keep working unchanged.
 
 Resolution is driven by whichever path fires first: node-pty's real `onExit`
-event, or a synthesized exit from `kill()`'s own SIGTERM→SIGKILL escalation
-fallback (which performs an OS-level pid liveness check after the escalation
-window). The promise never hangs: worst-case resolution is
-`KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS` (2500 ms), after which the
-process is declared dead via the OS probe regardless of whether node-pty's event
-arrived.
+event, or a synthesized exit from `kill()`'s own escalation path. The escalation
+path is genuinely bounded:
+
+1. SIGTERM sent immediately.
+2. After `KILL_ESCALATION_MS` (2000 ms): if still alive, send SIGKILL.
+3. After a further `KILL_ESCALATION_CONFIRM_MS` (500 ms): `markExited()` is
+   called **unconditionally** — SIGKILL has been sent and the window has
+   elapsed, so the session is over regardless of any liveness probe. This
+   prevents an EPERM zombie (a process that `isPidAlive` still reports as alive
+   after SIGKILL) from leaving the promise pending forever.
 
 `SessionManager.killAll()` is now `async` and resolves when all concurrent kills
-have confirmed death. `TaskManager.killAll()` gains the same awaitable treatment
-with SIGTERM→SIGKILL escalation and per-task exit promises wired through the
-existing `finish()` convergence point.
+have confirmed death via `markExited()` — the single convergence point for real
+and synthesized exits alike.
+
+`TaskManager.killAll()` gains the same awaitable treatment with SIGTERM→SIGKILL
+escalation and per-task exit promises wired through the existing `finish()`
+convergence point. After the SIGKILL confirm window, `finish(id, null)` is
+synthesized for any still-registered process — a zombie that never emits an exit
+event is declared dead rather than leaving `killAll()` pending forever.
+`finish()`'s idempotence guard prevents a double-fire if the real exit event
+arrives concurrently.
 
 Server shutdown (`close()` in server/index.ts) now awaits both `killAll()` calls
 with a 5-second outer timeout, so the process actually exits cleanly instead of

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -1158,5 +1158,35 @@ describe("SessionManager", () => {
       await killAllPromise;
       expect(resolved).toBe(true);
     });
+
+    it("REGRESSION: kill() resolves unconditionally in the confirm window even when isPidAlive stays true (EPERM zombie after SIGKILL)", async () => {
+      // An EPERM zombie: process.kill(pid, 0) still returns true (EPERM means
+      // "exists but can't be signalled") even after SIGKILL. The old confirm-
+      // timer guarded on `!isPidAlive(pid)` — that would leave handle.exited
+      // pending forever. The fixed confirm callback synthesizes markExited()
+      // unconditionally (SIGKILL was already sent; the session is over).
+      const { manager, spawns } = makeManager({
+        fakePid: 4444,
+        // Always "alive" — simulates an EPERM zombie that survives all probes.
+        isPidAlive: () => true,
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const killPromise = manager.kill(session.id);
+      // Initial signal sent.
+      expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(1);
+
+      // Advance past KILL_ESCALATION_MS: isPidAlive returns true → SIGKILL sent.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(2);
+      expect(spawns[0]?.pty.kill).toHaveBeenLastCalledWith("SIGKILL");
+
+      // Advance past KILL_ESCALATION_CONFIRM_MS: the confirm callback fires.
+      // isPidAlive is still true (zombie) but the fix synthesizes unconditionally.
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(await killPromise).toBe(true);
+      expect(manager.get(session.id)?.status).toBe("exited");
+    });
   });
 });

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -487,22 +487,34 @@ describe("SessionManager", () => {
     expect(statuses).toEqual(["exited"]);
   });
 
-  it("kill() signals the pty for a running session and is a no-op otherwise", async () => {
+  it("kill() signals the pty for a running session and returns a Promise resolving true; returns Promise<false> otherwise", async () => {
     const { manager, spawns } = makeManager();
     const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
 
-    expect(manager.kill(session.id)).toBe(true);
+    // kill() now returns Promise<boolean> — fire-and-forget still works via void,
+    // but here we confirm the resolved value and that the signal was sent.
+    const killResult = manager.kill(session.id);
+    expect(killResult).toBeInstanceOf(Promise);
     expect(spawns[0]?.pty.kill).toHaveBeenCalled();
-    expect(manager.kill("unknown-id")).toBe(false);
+
+    // Let the exit propagate so the promise resolves.
+    spawns[0]?.emitExit(0);
+    expect(await killResult).toBe(true);
+
+    // Unknown session: resolves false immediately.
+    expect(await manager.kill("unknown-id")).toBe(false);
   });
 
-  it("killAll() signals every currently-live pty", async () => {
+  it("killAll() signals every currently-live pty and resolves when all exit", async () => {
     const { manager, spawns } = makeManager();
     const a = await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
     const b = await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
     spawns[0]?.emitExit(0); // a exits on its own before killAll() runs
 
-    manager.killAll();
+    // Drive the exit event on b so killAll() can resolve.
+    const killAllPromise = manager.killAll();
+    spawns[1]?.emitExit(0);
+    await killAllPromise;
 
     expect(spawns[0]?.pty.kill).not.toHaveBeenCalled(); // already gone — nothing to signal
     expect(spawns[1]?.pty.kill).toHaveBeenCalled();
@@ -510,9 +522,9 @@ describe("SessionManager", () => {
     void b;
   });
 
-  it("killAll() is a harmless no-op with no live sessions", () => {
+  it("killAll() is a harmless no-op with no live sessions", async () => {
     const { manager } = makeManager();
-    expect(() => manager.killAll()).not.toThrow();
+    await expect(manager.killAll()).resolves.toBeUndefined();
   });
 
   it("resume() requires a known agentSessionId and respawns via adapter.resume", async () => {
@@ -828,13 +840,14 @@ describe("SessionManager", () => {
 
       const statuses: string[] = [];
       manager.onStatusChange((s) => statuses.push(s.status));
-      expect(manager.kill(session.id)).toBe(true);
+      // kill() now returns Promise<boolean>; the ghost path resolves immediately.
+      expect(await manager.kill(session.id)).toBe(true);
       expect(manager.get(session.id)?.status).toBe("exited");
       expect(statuses).toEqual(["exited"]);
 
       // A genuinely exited record is still a no-op false, as before.
-      expect(manager.kill(session.id)).toBe(false);
-      expect(manager.kill("unknown-id")).toBe(false);
+      expect(await manager.kill(session.id)).toBe(false);
+      expect(await manager.kill("unknown-id")).toBe(false);
     });
 
     describe("sweepDeadSessions", () => {
@@ -1005,5 +1018,145 @@ describe("SessionManager", () => {
 
     expect(capturedEnvs[0]?.["HARNESS_TEST_UNSET_ME"]).toBeUndefined();
     delete process.env["HARNESS_TEST_UNSET_ME"];
+  });
+
+  describe("awaitable kill — liveness-fallback resolution", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("REGRESSION: kill() resolves via the synthesis/liveness path when node-pty's onExit never fires (missed-exit bug)", async () => {
+      // Simulate the node-pty missed-exit bug: the pty's kill() is called
+      // but its onExit listeners are never invoked — the OS process is gone
+      // (isPidAlive returns false) but the event never arrives. kill() must
+      // still resolve within the escalation window via the synthesized exit.
+      let pidAlive = true;
+      const { manager, spawns } = makeManager({
+        fakePid: 9999,
+        isPidAlive: () => pidAlive,
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      expect(session.status).toBe("running");
+
+      // Confirm the pty exists and won't emit onExit on its own — the exit
+      // listeners on the fake pty exist, but we never call emitExit().
+      expect(spawns[0]?.pty.kill).not.toHaveBeenCalled();
+
+      const killPromise = manager.kill(session.id);
+      // kill() sent SIGTERM (the initial pty.kill() with no signal arg).
+      expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(1);
+
+      // The process is now "dead" at the OS level but node-pty hasn't fired.
+      pidAlive = false;
+
+      // Advance past KILL_ESCALATION_MS (2000ms): the escalation fires and
+      // checks isPidAlive. Since the process is already dead, it skips SIGKILL
+      // and schedules the KILL_ESCALATION_CONFIRM_MS (500ms) confirm window.
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      // Advance past KILL_ESCALATION_CONFIRM_MS: the confirm fires, sees
+      // isPidAlive=false, and calls markExited() → resolves handle.exited.
+      await vi.advanceTimersByTimeAsync(500);
+
+      // The promise must now be resolved — await it to confirm.
+      expect(await killPromise).toBe(true);
+      expect(manager.get(session.id)?.status).toBe("exited");
+    });
+
+    it("kill() resolves immediately via real onExit when node-pty fires before the escalation window", async () => {
+      const { manager, spawns } = makeManager({ fakePid: 8888, isPidAlive: () => false });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const killPromise = manager.kill(session.id);
+      // Drive the real onExit — this fires before the escalation timer.
+      spawns[0]?.emitExit(0);
+
+      // Promise should resolve immediately (the real path, not the synthesis path).
+      expect(await killPromise).toBe(true);
+      expect(manager.get(session.id)?.status).toBe("exited");
+      expect(manager.get(session.id)?.exitCode).toBe(0);
+    });
+
+    it("kill() escalates to SIGKILL when the process survives SIGTERM, then resolves once it dies", async () => {
+      // Process ignores SIGTERM (stubborn process), but dies after SIGKILL.
+      let pidAlive = true;
+      const { manager, spawns } = makeManager({
+        fakePid: 7777,
+        isPidAlive: () => pidAlive,
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      const killPromise = manager.kill(session.id);
+      expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(1); // initial SIGTERM (no arg)
+
+      // Advance to KILL_ESCALATION_MS: process is still alive → SIGKILL sent.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(2); // SIGKILL
+      expect(spawns[0]?.pty.kill).toHaveBeenLastCalledWith("SIGKILL");
+
+      // Now the process dies (SIGKILL lands) — simulate via emitExit.
+      pidAlive = false;
+      spawns[0]?.emitExit(137); // SIGKILL exit code
+
+      expect(await killPromise).toBe(true);
+      expect(manager.get(session.id)?.exitCode).toBe(137);
+    });
+
+    it("killAll() resolves once all sessions are confirmed dead, even when exits come at different times", async () => {
+      const { manager, spawns } = makeManager({ fakePid: 6666, isPidAlive: () => false });
+      const a = await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
+      const b = await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
+
+      const killAllPromise = manager.killAll();
+      let resolved = false;
+      void killAllPromise.then(() => {
+        resolved = true;
+      });
+
+      // Neither has exited yet — killAll() should not be resolved.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resolved).toBe(false);
+
+      // First session exits.
+      spawns[0]?.emitExit(0);
+      await vi.advanceTimersByTimeAsync(0);
+      // Second session still alive — not resolved yet.
+      expect(resolved).toBe(false);
+
+      // Second session exits.
+      spawns[1]?.emitExit(0);
+      await killAllPromise;
+      expect(resolved).toBe(true);
+      expect(manager.get(a.id)?.status).toBe("exited");
+      expect(manager.get(b.id)?.status).toBe("exited");
+    });
+
+    it("killAll() resolves via liveness synthesis when node-pty misses exits for all sessions", async () => {
+      // Both ptys swallow their onExit events — killAll() must still resolve
+      // via the missed-exit synthesis path within the escalation window.
+      let pidAlive = true;
+      const { manager } = makeManager({ fakePid: 5555, isPidAlive: () => pidAlive });
+      await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
+      await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
+
+      const killAllPromise = manager.killAll();
+      let resolved = false;
+      void killAllPromise.then(() => {
+        resolved = true;
+      });
+
+      // Mark the OS processes as gone — liveness check will confirm this.
+      pidAlive = false;
+
+      // Advance past the full escalation window.
+      await vi.advanceTimersByTimeAsync(2_000 + 500);
+
+      await killAllPromise;
+      expect(resolved).toBe(true);
+    });
   });
 });

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -526,7 +526,11 @@ export class SessionManager {
       const pid = handle.pty.pid;
       if (this.isPidAlive(pid)) handle.pty.kill("SIGKILL");
       setTimeout(() => {
-        if (this.ptys.get(id) === handle && !this.isPidAlive(pid)) this.markExited(id, handle, null);
+        // Synthesize unconditionally: SIGKILL was already sent; after the
+        // confirm window the session is over regardless of isPidAlive. An
+        // EPERM-alive zombie (a process that exists but can't be signalled)
+        // would leave handle.exited pending forever if we gated on liveness.
+        if (this.ptys.get(id) === handle) this.markExited(id, handle, null);
       }, KILL_ESCALATION_CONFIRM_MS).unref?.();
     }, KILL_ESCALATION_MS);
     escalate.unref?.();
@@ -864,9 +868,8 @@ export class SessionManager {
     if (this.ptys.get(id) !== handle) return;
     this.ptys.delete(id);
     this.lastActivityBroadcast.delete(id);
-    // Resolve the handle's `exited` promise so any awaiting kill() caller
-    // (and any caller of killAll()) unblocks. Must happen before the session
-    // status broadcast so subscribers see "exited" before the promise resolves.
+    // Resolve after the pty map is cleaned up. transitionExited runs
+    // synchronously to set status before any awaiting continuation resumes.
     handle.resolveExited();
     const session = this.sessions.get(id);
     if (!session) return;

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -250,6 +250,21 @@ interface PtyHandle {
   emitter: EventEmitter;
   /** Epoch ms this pty was spawned — see `isReadyEnough`'s settle window. */
   spawnedAt: number;
+  /**
+   * Resolves when this specific pty handle's session has fully exited —
+   * either via node-pty's real `onExit` event OR a synthesized exit (kill()'s
+   * escalation fallback, sweepDeadSessions, or pre-pty failure reconciliation).
+   * `markExited()` is the single convergence point for all three paths, so
+   * awaiting `exited` never hangs regardless of which path fires first.
+   *
+   * Always tied to THIS handle instance: markExited() is idempotent on the
+   * handle identity, so a stale duplicate call (e.g. from a late liveness
+   * sweep after kill()'s own fallback already ran) is a silent no-op and
+   * never resolves a DIFFERENT session's promise.
+   */
+  exited: Promise<void>;
+  /** Internal resolver — called exactly once by markExited(). */
+  resolveExited: () => void;
 }
 
 export class SessionManager {
@@ -455,7 +470,31 @@ export class SessionManager {
     return session;
   }
 
-  kill(id: string): boolean {
+  /**
+   * Signals the session's pty to exit and returns a Promise that resolves
+   * once the process is **actually gone** — not fire-and-forget.
+   *
+   * Resolution source (either one unblocks the promise):
+   *   1. node-pty's own `onExit` event → markExited() → `handle.exited` resolves.
+   *   2. Synthesized exit: kill()'s escalation fallback (SIGTERM → SIGKILL →
+   *      pid liveness check) → markExited() → `handle.exited` resolves.
+   *   3. Synthesized exit from an external `sweepDeadSessions()` call that
+   *      happens to run during the escalation window → same path.
+   *
+   * The promise is bounded: after `KILL_ESCALATION_MS` the escalation sends
+   * SIGKILL; after a further `KILL_ESCALATION_CONFIRM_MS` it synthesizes the
+   * exit from an OS-level pid check regardless of node-pty's event. So the
+   * worst-case resolution time is `KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS`
+   * (2500 ms at current constants), never infinite.
+   *
+   * Existing fire-and-forget callers keep working: an unawaited Promise is
+   * fine and produces no floating-promise lint warnings when suppressed with
+   * `void`.
+   *
+   * Returns false (resolved immediately) when the session has no live pty.
+   * Returns true (resolved on actual death) when a pty was signalled.
+   */
+  kill(id: string): Promise<boolean> {
     const handle = this.ptys.get(id);
     if (!handle) {
       // A non-exited record with no pty behind it has nothing left to kill —
@@ -465,9 +504,9 @@ export class SessionManager {
       const session = this.sessions.get(id);
       if (session && session.status !== "exited") {
         void this.transitionExited(session, null);
-        return true;
+        return Promise.resolve(true);
       }
-      return false;
+      return Promise.resolve(false);
     }
     handle.pty.kill();
     // Root-caused via instrumented real-process runs: node-pty's `onExit`
@@ -491,15 +530,26 @@ export class SessionManager {
       }, KILL_ESCALATION_CONFIRM_MS).unref?.();
     }, KILL_ESCALATION_MS);
     escalate.unref?.();
-    return true;
+    // Return a promise that resolves on actual death — either the real onExit
+    // event or a synthesized exit from the escalation above or sweepDeadSessions.
+    // `handle.exited` is resolved by markExited(), which is the single
+    // convergence point for all three paths — it never hangs.
+    return handle.exited.then(() => true);
   }
 
-  /** Kills every currently-live pty. Call this on server shutdown — without
-   *  it, spawned agent processes (claude/codex) outlive the harness server
-   *  itself, e.g. after Ctrl+C, since closing the HTTP/WS server doesn't
-   *  touch unrelated child processes on its own. */
-  killAll(): void {
-    for (const id of [...this.ptys.keys()]) this.kill(id);
+  /**
+   * Kills every currently-live pty and returns a Promise that resolves when
+   * all of them have actually exited (real or synthesized). Bounded by the
+   * same escalation window as `kill()` — never hangs.
+   *
+   * Call this on server shutdown so the process actually exits instead of
+   * waiting on orphaned claude/codex children. A bounded timeout can be layered
+   * on top via `Promise.race` when callers need a hard deadline:
+   *   `await Promise.race([sessionManager.killAll(), sleep(5_000)])`
+   */
+  async killAll(): Promise<void> {
+    const kills = [...this.ptys.keys()].map((id) => this.kill(id));
+    await Promise.all(kills);
   }
 
   /**
@@ -776,7 +826,11 @@ export class SessionManager {
 
     const emitter = new EventEmitter();
     emitter.setMaxListeners(0);
-    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now() };
+    let resolveExited!: () => void;
+    const exited = new Promise<void>((resolve) => {
+      resolveExited = resolve;
+    });
+    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now(), exited, resolveExited };
     this.ptys.set(session.id, handle);
 
     session.status = "running";
@@ -810,6 +864,10 @@ export class SessionManager {
     if (this.ptys.get(id) !== handle) return;
     this.ptys.delete(id);
     this.lastActivityBroadcast.delete(id);
+    // Resolve the handle's `exited` promise so any awaiting kill() caller
+    // (and any caller of killAll()) unblocks. Must happen before the session
+    // status broadcast so subscribers see "exited" before the promise resolves.
+    handle.resolveExited();
     const session = this.sessions.get(id);
     if (!session) return;
     void this.transitionExited(session, exitCode);

--- a/packages/harness/src/core/task-manager.test.ts
+++ b/packages/harness/src/core/task-manager.test.ts
@@ -405,5 +405,43 @@ describe("TaskManager", () => {
       // No running tasks — should resolve immediately.
       await expect(manager.killAll()).resolves.toBeUndefined();
     });
+
+    it("REGRESSION: killAll() resolves and finalizes a zombie that never emits exit even after SIGKILL (synthesizes finish)", async () => {
+      // A process that swallows both SIGTERM and SIGKILL — its "exit" event
+      // never fires. Without the synthesis path in killAll(), allExited would
+      // hang forever. This test confirms killAll() resolves within the bounded
+      // window and that the task record is finalized (not left "running").
+      vi.useFakeTimers();
+      try {
+        const { manager, spawned, statuses } = makeManager();
+        const task = await manager.run(runRequest);
+        expect(task.status).toBe("running");
+
+        const killAllPromise = manager.killAll();
+
+        // Phase 1: SIGTERM sent, but the process ignores it — no exit event.
+        expect(spawned[0].proc.killed).toBe("SIGTERM");
+
+        // Advance past TASK_KILL_ESCALATION_MS — killAll escalates to SIGKILL.
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(spawned[0].proc.killed).toBe("SIGKILL");
+
+        // The zombie never emits exit even after SIGKILL. Advance past
+        // TASK_KILL_CONFIRM_MS — killAll must synthesize finish() and resolve.
+        await vi.advanceTimersByTimeAsync(500);
+        // Drain any microtask ticks from the finish() synchronous chain.
+        await vi.advanceTimersByTimeAsync(0);
+
+        await killAllPromise;
+
+        // The task must be finalized — never left "running" — even without a
+        // real exit event.
+        const finished = manager.get(task.id);
+        expect(finished?.status).not.toBe("running");
+        expect(statuses.at(-1)?.status).not.toBe("running");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/harness/src/core/task-manager.test.ts
+++ b/packages/harness/src/core/task-manager.test.ts
@@ -327,14 +327,83 @@ describe("TaskManager", () => {
     expect(manager.list()).toHaveLength(0);
   });
 
-  it("killAll signals every still-running task process", async () => {
+  it("killAll signals every still-running task process with SIGTERM", async () => {
     const { manager, spawned } = makeManager();
     await manager.run(runRequest);
     await manager.run({ ...runRequest, harnessSessionId: "sess-2" });
     spawned[1].proc.emit("exit", 0); // finished — no longer tracked
 
-    manager.killAll();
+    // killAll() is now async — drive the remaining task's exit so it resolves.
+    const killAllPromise = manager.killAll();
+    spawned[0].proc.emit("exit", 0);
+    await killAllPromise;
+
     expect(spawned[0].proc.killed).toBe("SIGTERM");
-    expect(spawned[1].proc.killed).toBeUndefined();
+    expect(spawned[1].proc.killed).toBeUndefined(); // already finished before killAll
+  });
+
+  describe("awaitable killAll — TaskManager", () => {
+    it("killAll() is a no-op and resolves immediately when no tasks are running", async () => {
+      const { manager } = makeManager();
+      await expect(manager.killAll()).resolves.toBeUndefined();
+    });
+
+    it("killAll() resolves when all running tasks exit after SIGTERM (real timers)", async () => {
+      const { manager, spawned } = makeManager();
+      await manager.run(runRequest);
+      await manager.run({ ...runRequest, harnessSessionId: "sess-2" });
+
+      // Drive both exits concurrently: killAll() awaits both, so emit
+      // both exits before awaiting the promise.
+      const killAllPromise = manager.killAll();
+      spawned[0].proc.emit("exit", 0);
+      spawned[1].proc.emit("exit", 0);
+      await tick();
+      await killAllPromise;
+
+      expect(spawned[0].proc.killed).toBe("SIGTERM");
+      expect(spawned[1].proc.killed).toBe("SIGTERM");
+    });
+
+    it("killAll() escalates to SIGKILL for stubborn tasks that ignore SIGTERM, then resolves", async () => {
+      // A task process that ignores SIGTERM — killAll() must escalate to
+      // SIGKILL after TASK_KILL_ESCALATION_MS and then resolve once dead.
+      // Use fake timers to control the escalation delay.
+      vi.useFakeTimers();
+      try {
+        const { manager, spawned } = makeManager();
+        await manager.run(runRequest);
+
+        const killAllPromise = manager.killAll();
+        expect(spawned[0].proc.killed).toBe("SIGTERM");
+
+        // Advance past TASK_KILL_ESCALATION_MS (2000ms): the process hasn't
+        // exited yet, so killAll() escalates to SIGKILL.
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(spawned[0].proc.killed).toBe("SIGKILL");
+
+        // Now the process dies (SIGKILL takes effect) — simulate via exit event.
+        spawned[0].proc.emit("exit", 137);
+        // Let the Promise chain drain.
+        await vi.advanceTimersByTimeAsync(0);
+        await killAllPromise;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("killAll() resolves without blocking on already-finished tasks", async () => {
+      const { manager, spawned } = makeManager();
+      await manager.run(runRequest);
+      await manager.run({ ...runRequest, harnessSessionId: "sess-2" });
+
+      // Finish both before calling killAll.
+      spawned[0].proc.emit("exit", 0);
+      spawned[1].proc.emit("exit", 0);
+      await tick();
+
+      // No running tasks — should resolve immediately.
+      await expect(manager.killAll()).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -50,6 +50,14 @@ const MAX_FINISHED_TASKS = 20;
  * interactive ptys, but the same bounded escalation semantics apply.
  */
 const TASK_KILL_ESCALATION_MS = 2_000;
+/**
+ * How long killAll() waits after sending SIGKILL before synthesizing finish()
+ * for any still-registered process. Mirrors SessionManager's
+ * KILL_ESCALATION_CONFIRM_MS. After this window the task is declared dead
+ * regardless — a zombie that never emits "exit" would otherwise leave
+ * allExited pending forever.
+ */
+const TASK_KILL_CONFIRM_MS = 500;
 
 /**
  * The slice of node's ChildProcess a task actually uses — injectable so
@@ -335,14 +343,16 @@ export class TaskManager {
 
   /**
    * Kills every still-running task process and returns a Promise that resolves
-   * when all of them have actually exited (or when the escalation window
-   * expires). Call on server shutdown so headless agent processes (claude -p)
-   * don't outlive the harness server.
+   * when all of them have actually exited. Bounded and never hangs:
    *
-   * Escalation: sends SIGTERM to all running tasks, then waits
-   * `TASK_KILL_ESCALATION_MS`. Any still-alive task gets SIGKILL. The returned
-   * promise resolves once all tasks' `finish()` has run (real exit event or
-   * after SIGKILL), so it is bounded and never hangs.
+   * 1. SIGTERM all running tasks.
+   * 2. Wait up to `TASK_KILL_ESCALATION_MS` for graceful exits.
+   * 3. SIGKILL any survivors.
+   * 4. Wait up to `TASK_KILL_CONFIRM_MS` for SIGKILL exits.
+   * 5. Synthesize `finish(id, null)` for any still-registered processes —
+   *    a zombie that never emits "exit" would otherwise leave allExited
+   *    pending forever. finish()'s idempotence guard (status !== "running")
+   *    makes a double-call harmless if the exit event arrives concurrently.
    */
   async killAll(): Promise<void> {
     const runningIds = [...this.processes.keys()];
@@ -363,7 +373,7 @@ export class TaskManager {
       }
     }
 
-    // Wait for all to die gracefully or escalate.
+    // Wait for graceful exits or escalation window.
     const allExited = Promise.all(exitWaiters);
     const escalationTimer = new Promise<void>((resolve) => setTimeout(resolve, TASK_KILL_ESCALATION_MS));
     await Promise.race([allExited, escalationTimer]);
@@ -377,8 +387,19 @@ export class TaskManager {
       }
     }
 
-    // Final wait: after SIGKILL the processes should exit almost immediately.
-    await allExited;
+    // Wait for SIGKILL exits or the confirm window, then synthesize for zombies.
+    // Using a separate timer (not reusing escalationTimer which already fired)
+    // so the SIGKILL phase gets its own full window.
+    const confirmTimer = new Promise<void>((resolve) => setTimeout(resolve, TASK_KILL_CONFIRM_MS));
+    await Promise.race([allExited, confirmTimer]);
+
+    // Synthesize finish() for any process that still hasn't emitted an exit
+    // event — a zombie or a process whose exit event was lost. finish()'s
+    // idempotence guard (task.status !== "running") prevents a double-fire if
+    // the real exit event arrives concurrently or slightly later.
+    for (const id of [...this.processes.keys()]) {
+      this.finish(id, null);
+    }
   }
 
   private handleStdoutLine(id: string, line: string): void {

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -43,6 +43,13 @@ const MAX_STDERR_CHARS = 2_000;
 /** Finished tasks retained (per whole manager) for late-mounting clients;
  *  running tasks are always retained regardless. */
 const MAX_FINISHED_TASKS = 20;
+/**
+ * How long killAll() waits for a graceful SIGTERM to take effect before
+ * escalating to SIGKILL. Mirrors SessionManager's KILL_ESCALATION_MS — tasks
+ * are headless child processes (claude -p) so they typically die faster than
+ * interactive ptys, but the same bounded escalation semantics apply.
+ */
+const TASK_KILL_ESCALATION_MS = 2_000;
 
 /**
  * The slice of node's ChildProcess a task actually uses — injectable so
@@ -153,6 +160,13 @@ export class TaskManager {
    *  as `resultText`, so a structured task's caller can parse the answer. */
   private readonly resultTexts = new Map<string, string>();
   private readonly statusEmitter = new EventEmitter();
+  /**
+   * Per-task exit promises: each resolves when `finish()` runs for that task
+   * (whether via a normal exit, an error event, or a killAll() escalation).
+   * `killAll()` awaits these to confirm actual death before resolving.
+   */
+  private readonly exitedPromises = new Map<string, Promise<void>>();
+  private readonly resolveExited = new Map<string, () => void>();
 
   constructor(options: TaskManagerOptions) {
     this.adapters = options.adapters;
@@ -289,6 +303,11 @@ export class TaskManager {
     // Registered — the running-task check owns dedupe from here.
     releasePending();
     this.processes.set(id, child);
+    // Set up the per-task exit promise so killAll() can await actual death.
+    const exited = new Promise<void>((resolve) => {
+      this.resolveExited.set(id, resolve);
+    });
+    this.exitedPromises.set(id, exited);
     this.trimFinished();
     this.emitStatus(task);
 
@@ -314,17 +333,52 @@ export class TaskManager {
     return task;
   }
 
-  /** Kills every still-running task process. Call on server shutdown, same
-   *  reason as SessionManager.killAll — child processes aren't torn down by
-   *  the HTTP server closing. */
-  killAll(): void {
+  /**
+   * Kills every still-running task process and returns a Promise that resolves
+   * when all of them have actually exited (or when the escalation window
+   * expires). Call on server shutdown so headless agent processes (claude -p)
+   * don't outlive the harness server.
+   *
+   * Escalation: sends SIGTERM to all running tasks, then waits
+   * `TASK_KILL_ESCALATION_MS`. Any still-alive task gets SIGKILL. The returned
+   * promise resolves once all tasks' `finish()` has run (real exit event or
+   * after SIGKILL), so it is bounded and never hangs.
+   */
+  async killAll(): Promise<void> {
+    const runningIds = [...this.processes.keys()];
+    if (runningIds.length === 0) return;
+
+    // Snapshot the exit promises before sending signals — `finish()` deletes
+    // them from the map, so we must capture them now while all are present.
+    const exitWaiters = runningIds
+      .map((id) => this.exitedPromises.get(id))
+      .filter((p): p is Promise<void> => p !== undefined);
+
+    // Phase 1: SIGTERM all running tasks.
     for (const child of this.processes.values()) {
       try {
         child.kill("SIGTERM");
       } catch {
+        // Already gone — finish() will handle it when the exit event arrives.
+      }
+    }
+
+    // Wait for all to die gracefully or escalate.
+    const allExited = Promise.all(exitWaiters);
+    const escalationTimer = new Promise<void>((resolve) => setTimeout(resolve, TASK_KILL_ESCALATION_MS));
+    await Promise.race([allExited, escalationTimer]);
+
+    // Phase 2: SIGKILL any still-alive processes after the grace window.
+    for (const child of this.processes.values()) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
         // Already gone.
       }
     }
+
+    // Final wait: after SIGKILL the processes should exit almost immediately.
+    await allExited;
   }
 
   private handleStdoutLine(id: string, line: string): void {
@@ -362,6 +416,13 @@ export class TaskManager {
     this.stderrTails.delete(id);
     this.resultErrors.delete(id);
     this.resultTexts.delete(id);
+    // Resolve the per-task exit promise so killAll() waiters unblock.
+    const resolve = this.resolveExited.get(id);
+    if (resolve) {
+      resolve();
+      this.resolveExited.delete(id);
+      this.exitedPromises.delete(id);
+    }
     this.emitStatus(task);
     this.onCleanup(id);
   }

--- a/packages/harness/src/core/transcript-replay.test.ts
+++ b/packages/harness/src/core/transcript-replay.test.ts
@@ -303,7 +303,7 @@ describe.skipIf(!nodePty)("transcript-fixture replay via SessionManager (real pt
   });
 
   afterEach(async () => {
-    manager.killAll();
+    void manager.killAll();
     await manager.flush();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -329,7 +329,7 @@ describe.skipIf(!nodePty)("transcript-fixture replay via SessionManager (real pt
       await output.waitFor("you said: integration-test");
     } finally {
       detach?.();
-      manager.kill(session.id);
+      void manager.kill(session.id);
     }
 
     // After kill, the session should be exited.

--- a/packages/harness/src/server/codex-session-lifecycle.test.ts
+++ b/packages/harness/src/server/codex-session-lifecycle.test.ts
@@ -157,7 +157,7 @@ describe("codex session lifecycle (real files, no mocking)", () => {
     });
 
     // --- session end: killing the pty should synthesize a SessionEnd ---
-    server.sessionManager.kill(session.id);
+    void server.sessionManager.kill(session.id);
     await vi.waitFor(
       async () => {
         const finalEvents = await readEvents(eventStorePath);

--- a/packages/harness/src/server/codex-tailer-wiring.test.ts
+++ b/packages/harness/src/server/codex-tailer-wiring.test.ts
@@ -130,7 +130,7 @@ describe("codex tailer lifecycle wiring", () => {
     // resolves once the HTTP server stops listening, independent of whether
     // this session's exit-triggered persist() has landed yet, which can
     // still be mid-write when the test's temp dir gets removed.
-    server.sessionManager.kill(session.id);
+    void server.sessionManager.kill(session.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
     }, PTY_EXIT_WAIT_OPTIONS);
@@ -168,7 +168,7 @@ describe("codex tailer lifecycle wiring", () => {
 
     // See the first test's comment: wait for the real spawned process to
     // actually exit rather than leaving that race to afterEach's close().
-    server.sessionManager.kill(resumed.id);
+    void server.sessionManager.kill(resumed.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(resumed.id)?.status).toBe("exited");
     }, PTY_EXIT_WAIT_OPTIONS);
@@ -209,7 +209,7 @@ describe("codex tailer lifecycle wiring", () => {
 
     // See the first test's comment: wait for the real spawned process to
     // actually exit rather than leaving that race to afterEach's close().
-    server.sessionManager.kill(session.id);
+    void server.sessionManager.kill(session.id);
     await vi.waitFor(() => {
       expect(server!.sessionManager.get(session.id)?.status).toBe("exited");
     }, PTY_EXIT_WAIT_OPTIONS);
@@ -230,7 +230,7 @@ describe("codex tailer lifecycle wiring", () => {
     const session = await server.sessionManager.create({ cwd, harness: "codex" });
     await vi.waitFor(() => expect(tailCodexRollout).toHaveBeenCalled());
 
-    server.sessionManager.kill(session.id);
+    void server.sessionManager.kill(session.id);
 
     // emitSessionEnd() only fires from the onStatusChange("exited") handler
     // — it's downstream of the same real pty-exit transition as the other

--- a/packages/harness/src/server/generated-retention.test.ts
+++ b/packages/harness/src/server/generated-retention.test.ts
@@ -103,7 +103,7 @@ describe("generated-dir retention wiring", () => {
     expect(await exists(join(sessionDir, "settings.json"))).toBe(true);
     expect(await exists(join(sessionDir, "emit.cjs"))).toBe(true);
 
-    server.sessionManager.kill(session.id);
+    void server.sessionManager.kill(session.id);
     await vi.waitFor(
       async () => {
         expect(server!.sessionManager.get(session.id)?.status).toBe("exited");

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -832,27 +832,36 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   return {
     port: actualPort,
     sessionManager,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        clearInterval(workflowsCacheTimer);
-        clearInterval(sessionSweepTimer);
-        canvasWatcher.stopAll();
-        workspaceWatcher.stopAll();
-        for (const tailer of codexTailers.values()) tailer.stop();
-        codexTailers.clear();
-        // Closing the HTTP/WS server doesn't touch unrelated child processes
-        // on its own — without this, every live claude/codex pty outlives
-        // the harness server itself (e.g. after Ctrl+C or in a script that
-        // expects the process to actually exit once close() resolves).
-        sessionManager.killAll();
-        taskManager.killAll();
-        void batcher.close();
-        terminalWss.close();
-        eventsWss.close();
+    close: async () => {
+      clearInterval(workflowsCacheTimer);
+      clearInterval(sessionSweepTimer);
+      canvasWatcher.stopAll();
+      workspaceWatcher.stopAll();
+      for (const tailer of codexTailers.values()) tailer.stop();
+      codexTailers.clear();
+      // Closing the HTTP/WS server doesn't touch unrelated child processes
+      // on its own — without this, every live claude/codex pty outlives
+      // the harness server itself (e.g. after Ctrl+C or in a script that
+      // expects the process to actually exit once close() resolves).
+      // Await kills with a bounded timeout so shutdown never hangs: if a
+      // process somehow survives both SIGTERM and SIGKILL within the
+      // escalation window (shouldn't happen), we still resolve and let the
+      // HTTP server close proceed. The SIGKILL escalation inside each kill()
+      // itself is bounded (KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS
+      // = 2500ms); the outer timeout here is a final safety net above that.
+      const SHUTDOWN_KILL_TIMEOUT_MS = 5_000;
+      const killsSettled = Promise.all([sessionManager.killAll(), taskManager.killAll()]);
+      const shutdownTimeout = new Promise<void>((resolve) => setTimeout(resolve, SHUTDOWN_KILL_TIMEOUT_MS));
+      await Promise.race([killsSettled, shutdownTimeout]);
+      void batcher.close();
+      terminalWss.close();
+      eventsWss.close();
+      await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => {
           if (err) reject(err);
           else resolve();
         });
-      }),
+      });
+    },
   };
 };

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -295,7 +295,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       res.status(404).json({ error: "session not found" });
       return;
     }
-    sessionManager.kill(req.params.id);
+    void sessionManager.kill(req.params.id);
     res.json({ ok: true });
   });
 


### PR DESCRIPTION
Unit PR into the v0 integration branch (umbrella: #266).

## What

`kill()` now returns a promise that resolves when the process is ACTUALLY gone; `SessionManager.killAll()` / `TaskManager.killAll()` await all deaths; server `close()` awaits both under a 5s outer race so shutdown actually waits without ever hanging.

## The hard requirement, honored

node-pty's exit event sometimes never fires (the known missed-exit bug) — resolution therefore rides `markExited()`, the single convergence point where the real exit, the kill-escalation synthesis, and the pid-liveness sweep all race. Whichever lands first resolves the awaiter.

## Bounds are genuine, not just the server-layer race (review round)

The internal round found two hang paths in the first cut — a SIGKILL-surviving zombie hung `TaskManager.killAll()` (unconditional `await allExited`), and the session confirm-timer only synthesized when the pid read dead, so an EPERM-alive zombie never resolved. Both fixed with unconditional synthesis after the confirm window (SIGTERM → 2000ms → SIGKILL → 500ms → declared dead), each pinned by a regression test (fake pty that never emits exit; `isPidAlive` pinned true). Floating-promise callers exposed by the return-type change were `void`-prefixed; `kill()` isn't public API surface (SessionManager unexported), so patch semver holds.

## Tests

665/665 (11 new: missed-exit regression, EPERM-zombie confirm, SIGKILL escalation, concurrent killAll, task-zombie finalization, exit-code propagation). Patch changeset with honest bounded-ness wording.

Closes SAP-1438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)