### PR TITLE
feat(tools): read-only vault namespace — ctx.sapiom.vault (SAP-1471)

### DIFF
--- a/.changeset/vault-read-namespace.md
+++ b/.changeset/vault-read-namespace.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add a READ-ONLY `vault` namespace (`vault.list/get/getMany/getAll` + `ctx.sapiom.vault`) against the vault gateway's v2 API. List returns key names only; get maps a 404 to `null`. No set/delete by decision (SAP-1471) — writing secrets stays in the dashboard / `@sapiom/core` `VaultAPI`.

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -129,6 +129,7 @@ import type {
   Memory,
   MemoryCallOptions,
 } from "./memory/index.js";
+import * as vault from "./vault/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -344,6 +345,18 @@ export interface Sapiom {
     forget(id: string, options?: MemoryCallOptions): Promise<void>;
   };
   /**
+   * READ-ONLY tenant vault secrets (SAP-1471): `list` returns key names, `get`
+   * one value (or null when absent), `getMany`/`getAll` a key→value map. No
+   * set/delete by decision — write secrets from the dashboard or `@sapiom/core`'s
+   * `VaultAPI`. Values are credentials: use them, don't persist or echo them.
+   */
+  readonly vault: {
+    list(ref: string): Promise<string[]>;
+    get(ref: string, key: string): Promise<string | null>;
+    getMany(ref: string, keys: string[]): Promise<Record<string, string>>;
+    getAll(ref: string): Promise<Record<string, string>>;
+  };
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
@@ -480,6 +493,12 @@ function bind(transport: Transport): Sapiom {
       sweep: (input) => memory.sweep(input, transport),
       get: (id, options) => memory.get(id, transport, undefined, options),
       forget: (id, options) => memory.forget(id, transport, undefined, options),
+    },
+    vault: {
+      list: (ref) => vault.list(ref, transport),
+      get: (ref, key) => vault.get(ref, key, transport),
+      getMany: (ref, keys) => vault.getMany(ref, keys, transport),
+      getAll: (ref) => vault.getAll(ref, transport),
     },
     withAttribution: (attribution) =>
       bind(transport.withAttribution(attribution)),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -103,3 +103,6 @@ export { DomainsHttpError } from "./domains/index.js";
 
 export * as memory from "./memory/index.js";
 export { MemoryHttpError } from "./memory/index.js";
+
+export * as vault from "./vault/index.js";
+export { VaultHttpError } from "./vault/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -1255,6 +1255,22 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           r("memory.forget", [id, options], () => undefined) as void,
         ),
     },
+    // Read-only vault (SAP-1471). Stubs return empty/absent — a local run must
+    // never surface real credentials, and "no secret found" is the safe default.
+    vault: {
+      list: (ref: string) =>
+        Promise.resolve(r("vault.list", [ref], () => []) as string[]),
+      get: (ref: string, key: string) =>
+        Promise.resolve(r("vault.get", [ref, key], () => null) as string | null),
+      getMany: (ref: string, keys: string[]) =>
+        Promise.resolve(
+          r("vault.getMany", [ref, keys], () => ({})) as Record<string, string>,
+        ),
+      getAll: (ref: string) =>
+        Promise.resolve(
+          r("vault.getAll", [ref], () => ({})) as Record<string, string>,
+        ),
+    },
     withAttribution: () => client,
     // The stub makes no HTTP calls and creates no analytics emitter — nothing
     // to release, so shutdown matches the real client's "resolve immediately".

--- a/packages/tools/src/vault/errors.ts
+++ b/packages/tools/src/vault/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * Error thrown by the vault capability when the gateway returns a non-2xx
+ * response. Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
+ * raw text when the body isn't JSON) for programmatic inspection.
+ *
+ * Useful statuses to branch on: `401` (missing identity), `403` (ownership
+ * failure), `404` (unknown ref/key — `get` maps this to `null` for you).
+ */
+export class VaultHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "VaultHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link VaultHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new VaultHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/vault/index.spec.ts
+++ b/packages/tools/src/vault/index.spec.ts
@@ -1,0 +1,178 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as vault from "./index.js";
+import { VaultHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — capability fns are tested directly with a real Transport wired to a
+// scripted fetch mock (so URL/method/header assertions are exact, and we verify
+// the Transport itself injects the tenant credential). Mirrors memory/index.spec.
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://vault.test";
+
+// ---------------------------------------------------------------------------
+// Base URL resolution
+// ---------------------------------------------------------------------------
+
+describe("vault — base URL resolution", () => {
+  it("defaults to the production vault service origin (v2 path appended)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ API_KEY: "sk-1" }),
+    ]);
+    await vault.getAll("my-creds", transport);
+    expect(calls[0]!.url).toBe(
+      "https://vault.services.sapiom.ai/v2/secrets/my-creds",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAll / getMany / list
+// ---------------------------------------------------------------------------
+
+describe("vault.getAll", () => {
+  it("GETs /v2/secrets/:ref (ref URL-encoded) and returns the flat map", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ API_KEY: "sk-1", DB_URL: "postgres://x" }),
+    ]);
+    const all = await vault.getAll("team/creds", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v2/secrets/team%2Fcreds`);
+    expect(calls[0]!.init.method ?? "GET").toBe("GET");
+    expect(all).toEqual({ API_KEY: "sk-1", DB_URL: "postgres://x" });
+  });
+
+  it("throws VaultHttpError with status/body on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ error: "forbidden" }, { status: 403 }),
+    ]);
+    await expect(vault.getAll("my-creds", transport, BASE)).rejects.toMatchObject({
+      name: "VaultHttpError",
+      status: 403,
+    });
+  });
+});
+
+describe("vault.getMany", () => {
+  it("passes the keys subset as a comma-joined query param", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ A: "1", B: "2" }),
+    ]);
+    const subset = await vault.getMany("my-creds", ["A", "B"], transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v2/secrets/my-creds?keys=A%2CB`);
+    expect(subset).toEqual({ A: "1", B: "2" });
+  });
+
+  it("sends keys= for an empty subset (API returns the empty map)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+    await expect(vault.getMany("my-creds", [], transport, BASE)).resolves.toEqual({});
+    expect(calls[0]!.url).toBe(`${BASE}/v2/secrets/my-creds?keys=`);
+  });
+});
+
+describe("vault.list", () => {
+  it("returns only the sorted key names, never the values", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ ZEBRA: "z", API_KEY: "sk-1" }),
+    ]);
+    await expect(vault.list("my-creds", transport, BASE)).resolves.toEqual([
+      "API_KEY",
+      "ZEBRA",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get (single value; 404 → null)
+// ---------------------------------------------------------------------------
+
+describe("vault.get", () => {
+  it("GETs /v2/secrets/:ref/:key (both segments URL-encoded) and unwraps value", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ value: "sk-live-123" }),
+    ]);
+    const value = await vault.get("my creds", "API/KEY", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v2/secrets/my%20creds/API%2FKEY`);
+    expect(value).toBe("sk-live-123");
+  });
+
+  it("returns null on a 404 (missing key is an expected lookup outcome)", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ error: "not found" }, { status: 404 }),
+    ]);
+    await expect(vault.get("my-creds", "MISSING", transport, BASE)).resolves.toBeNull();
+  });
+
+  it("rethrows non-404 failures as VaultHttpError", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ error: "nope" }, { status: 403 }),
+    ]);
+    await expect(vault.get("my-creds", "API_KEY", transport, BASE)).rejects.toBeInstanceOf(
+      VaultHttpError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// client binding (ctx.sapiom.vault)
+// ---------------------------------------------------------------------------
+
+describe("createClient().vault", () => {
+  it("binds the read-only surface and injects the client credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push({ url, init });
+      return jsonResponse({ value: "sk-1" });
+    }) as typeof globalThis.fetch;
+
+    const client = createClient({ apiKey: "client-key", fetch: fetchMock });
+    await expect(client.vault.get("my-creds", "API_KEY")).resolves.toBe("sk-1");
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    const headerNames = Object.keys(headers).map((h) => h.toLowerCase());
+    expect(headerNames.some((h) => h.includes("key") || h.includes("authorization"))).toBe(true);
+  });
+});

--- a/packages/tools/src/vault/index.ts
+++ b/packages/tools/src/vault/index.ts
@@ -1,0 +1,123 @@
+/**
+ * READ-ONLY access to tenant vault secrets (SAP-1471).
+ *
+ *   import { vault } from "@sapiom/tools";              // ambient auth
+ *   const keys = await vault.list("my-service-creds");  // key names only
+ *   const value = await vault.get("my-service-creds", "API_KEY"); // string | null
+ *   const all = await vault.getAll("my-service-creds"); // full key→value map
+ *
+ * Or via an explicit client: `createClient({ apiKey }).vault.get(...)`.
+ *
+ * Read/list only BY DECISION — no set/delete: giving an LLM agent write access to a
+ * secret store is a separate, deliberate risk decision. Write secrets from the
+ * dashboard or the low-level `@sapiom/core` `VaultAPI`.
+ *
+ * Wire: the vault gateway's v2 API ONLY (`/v2/secrets/:ref[/:key]`, GSM-backed).
+ * v1 is a separate legacy store that silently returns `{}` with HTTP 200 — never
+ * call it. Values are credentials: use them, don't persist or echo them.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, VaultHttpError } from "./errors.js";
+
+export { VaultHttpError };
+
+/**
+ * Vault service ORIGIN. Resolves like every other @sapiom/tools capability: an
+ * explicit `SAPIOM_VAULT_URL` override wins, else the `SAPIOM_SERVICES_BASE` knob
+ * re-homes it (subdomain preserved), else the production
+ * `https://vault.services.sapiom.ai`. This is the bare origin; the `/v2/secrets`
+ * path prefix is appended per-method below.
+ */
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "vault",
+  process.env.SAPIOM_VAULT_URL,
+);
+
+/** The gateway's single-secret response shape (`GET /v2/secrets/:ref/:key`). */
+interface VaultSecretResponse {
+  value: string | null;
+}
+
+/** Build the `/v2/secrets/:ref` URL, optionally narrowed to a `keys=` subset. */
+function secretsUrl(baseUrl: string, ref: string, keys?: string[]): string {
+  const path = `${baseUrl}/v2/secrets/${encodeURIComponent(ref)}`;
+  if (keys === undefined) return path;
+  const params = new URLSearchParams();
+  params.set("keys", keys.join(","));
+  return `${path}?${params.toString()}`;
+}
+
+// ----- capability operations (read-only) -----
+
+/**
+ * Get all secrets stored under a ref as a flat key→value map. Handle the values
+ * as credentials — use them, never persist or echo them.
+ */
+export async function getAll(
+  ref: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Record<string, string>> {
+  const res = await ensureOk(
+    await transport.fetch(secretsUrl(baseUrl, ref)),
+    `Failed to get vault secrets for ref '${ref}'`,
+  );
+  return (await res.json()) as Record<string, string>;
+}
+
+/**
+ * Get a subset of secrets stored under a ref. Passing an empty keys array sends
+ * `keys=` and returns the API's empty subset.
+ */
+export async function getMany(
+  ref: string,
+  keys: string[],
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Record<string, string>> {
+  const res = await ensureOk(
+    await transport.fetch(secretsUrl(baseUrl, ref, keys)),
+    `Failed to get vault secrets for ref '${ref}'`,
+  );
+  return (await res.json()) as Record<string, string>;
+}
+
+/**
+ * Get one secret value by ref and key. Returns `null` when the key (or ref) is
+ * absent — a missing credential is an expected lookup outcome, not an error.
+ */
+export async function get(
+  ref: string,
+  key: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<string | null> {
+  const url = `${baseUrl}/v2/secrets/${encodeURIComponent(ref)}/${encodeURIComponent(key)}`;
+  try {
+    const res = await ensureOk(
+      await transport.fetch(url),
+      `Failed to get vault secret '${key}' for ref '${ref}'`,
+    );
+    const body = (await res.json()) as VaultSecretResponse;
+    return body.value;
+  } catch (error) {
+    if (error instanceof VaultHttpError && error.status === 404) return null;
+    throw error;
+  }
+}
+
+/**
+ * List the secret KEY NAMES stored under a ref (sorted). The gateway's v2 API has
+ * no names-only endpoint, so this fetches the map and returns only its keys — use
+ * it when you need to discover what exists without spreading values through your
+ * code.
+ */
+export async function list(
+  ref: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<string[]> {
+  const all = await getAll(ref, transport, baseUrl);
+  return Object.keys(all).sort();
+}


### PR DESCRIPTION
## Summary
Adds the READ-ONLY `vault` namespace to `@sapiom/tools` per the recorded SAP-1471 decision: `vault.list` (key names only), `vault.get` (one value; 404 → `null`), `vault.getMany`/`vault.getAll` (key→value maps), bound as `ctx.sapiom.vault`. **No set/delete** — write access to a secret store is a separate, deliberate risk decision; writes stay in the dashboard / `@sapiom/core`'s `VaultAPI`.

Sibling backend PR (sapiom/Sapiom#3050) adds the matching read-only MCP tools (`sapiom_vault_list`/`sapiom_vault_get`).

## Changes
- New self-contained `packages/tools/src/vault/` (own `errors.ts` + `resolveServiceUrl("vault", SAPIOM_VAULT_URL)`, no `@sapiom/core` cross-import) — the `memory` namespace recipe.
- **v2 endpoints only** (`/v2/secrets/:ref[/:key]`) — v1 is the separate legacy store that silently returns `{}` with HTTP 200 (the engine-#2413 bug class); documented in the module header.
- `client.ts`: `readonly vault` on the `Sapiom` interface + transport binding.
- `stub/index.ts`: vault stubs return empty/absent — local runs never surface real credentials.
- Barrel exports + changeset (`@sapiom/tools` minor).

## Testing
- [x] New `vault/index.spec.ts` — 10 cases (URL/encoding/method assertions via scripted Transport, 404→null, error mapping, empty-subset `keys=`, client binding + credential injection)
- [x] `pnpm --filter @sapiom/tools test` — 370 passed (20 suites, incl. the stub-completeness path)
- [x] typecheck + lint clean

## Related
- Refs: SAP-1471 (Capability Consistency project; read-only decision recorded in the ticket 2026-07-09)

🤖 Generated with [Claude Code](https://claude.com/claude-code)