### PR TITLE
feat(harness): consent surfaces + UI-interaction analytics layer (SAP-1423)

### DIFF
--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -154,7 +154,8 @@ const main = async (): Promise<void> => {
   if (identity?.source === "cached") {
     console.log(`\nSigned in as ${identity.organizationName} (cached credential).`);
   }
-  const telemetryOptIn = await ensureConsent({ noTelemetry: options.noTelemetry });
+  const consentResult = await ensureConsent({ noTelemetry: options.noTelemetry });
+  const { telemetryOptIn } = consentResult;
   // First run = no recent directories recorded before this boot. Must be read
   // BEFORE recordRecentDir below stamps the launch dir in — after that the
   // signal is gone for good. Drives the SPA's welcome panel (AppState.firstRun)
@@ -172,6 +173,8 @@ const main = async (): Promise<void> => {
       port: options.port,
       bootToken,
       telemetryOptIn,
+      consentSource: consentResult.source,
+      consentEnvReason: consentResult.envReason,
       identity,
       machineId,
       launchDir: options.dir,
@@ -194,7 +197,7 @@ const main = async (): Promise<void> => {
     port: server?.port ?? options.port,
     bootToken,
     identity,
-    telemetryOptIn,
+    telemetryOptIn: consentResult.telemetryOptIn,
     serverStarted: server !== null,
   });
 

--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -49,8 +49,9 @@ describe("ensureConsent", () => {
   });
 
   it("--no-telemetry forces false without prompting or persisting", async () => {
-    const optIn = await ensureConsent({ noTelemetry: true });
-    expect(optIn).toBe(false);
+    const result = await ensureConsent({ noTelemetry: true });
+    expect(result.telemetryOptIn).toBe(false);
+    expect(result.source).toBe("env-forced-off");
 
     const settings = await loadSettings();
     expect(settings.telemetryOptIn).toBe(false);
@@ -61,8 +62,9 @@ describe("ensureConsent", () => {
     Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
     try {
-      const optIn = await ensureConsent({ noTelemetry: false });
-      expect(optIn).toBe(true);
+      const result = await ensureConsent({ noTelemetry: false });
+      expect(result.telemetryOptIn).toBe(true);
+      expect(result.source).toBe("default-silent");
 
       const settings = await loadSettings();
       expect(settings.telemetryOptIn).toBe(true);
@@ -85,8 +87,9 @@ describe("ensureConsent", () => {
         JSON.stringify({ ...settings, telemetryOptIn: false }),
       );
 
-      const optIn = await ensureConsent({ noTelemetry: false });
-      expect(optIn).toBe(false);
+      const result = await ensureConsent({ noTelemetry: false });
+      expect(result.telemetryOptIn).toBe(false);
+      expect(result.source).toBe("stored-explicit");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -98,7 +101,9 @@ describe("ensureConsent", () => {
     nextAnswer = "";
 
     try {
-      expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+      const result = await ensureConsent({ noTelemetry: false });
+      expect(result.telemetryOptIn).toBe(true);
+      expect(result.source).toBe("prompted");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -110,7 +115,9 @@ describe("ensureConsent", () => {
     nextAnswer = "n";
 
     try {
-      expect(await ensureConsent({ noTelemetry: false })).toBe(false);
+      const result = await ensureConsent({ noTelemetry: false });
+      expect(result.telemetryOptIn).toBe(false);
+      expect(result.source).toBe("prompted");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -122,7 +129,9 @@ describe("ensureConsent", () => {
     nextAnswer = "y";
 
     try {
-      expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+      const result = await ensureConsent({ noTelemetry: false });
+      expect(result.telemetryOptIn).toBe(true);
+      expect(result.source).toBe("prompted");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -155,9 +164,11 @@ describe("ensureConsent", () => {
     ])("%s=%s forces telemetry off without prompting, on a first run", async (envVar, value) => {
       process.env[envVar] = value;
 
-      const optIn = await ensureConsent({ noTelemetry: false });
+      const result = await ensureConsent({ noTelemetry: false });
 
-      expect(optIn).toBe(false);
+      expect(result.telemetryOptIn).toBe(false);
+      expect(result.source).toBe("env-forced-off");
+      expect(result.envReason).toBe(envVar);
       expect(questionCallCount).toBe(0);
       // Nothing persisted: hasStoredSettings() must still say "no" so a
       // later run without the env var gets a genuine first-run prompt,
@@ -170,16 +181,18 @@ describe("ensureConsent", () => {
       const wasTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
       try {
-        expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+        const firstResult = await ensureConsent({ noTelemetry: false });
+        expect(firstResult.telemetryOptIn).toBe(true);
       } finally {
         Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
       }
       expect((await loadSettings()).telemetryOptIn).toBe(true);
 
       process.env.DO_NOT_TRACK = "1";
-      const optIn = await ensureConsent({ noTelemetry: false });
+      const result = await ensureConsent({ noTelemetry: false });
 
-      expect(optIn).toBe(false);
+      expect(result.telemetryOptIn).toBe(false);
+      expect(result.source).toBe("env-forced-off");
       expect(questionCallCount).toBe(0);
       // The stored preference is untouched — a run without DO_NOT_TRACK set
       // still honors what the user actually answered.
@@ -197,14 +210,19 @@ describe("ensureConsent", () => {
       Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
       try {
-        expect(await ensureConsent({ noTelemetry: false })).toBe(true);
+        const result = await ensureConsent({ noTelemetry: false });
+        expect(result.telemetryOptIn).toBe(true);
+        // env var present but not an opt-out value → "default-silent" (non-TTY)
+        expect(result.source).toBe("default-silent");
       } finally {
         Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
       }
     });
 
     it("--no-telemetry still wins even without any env var set", async () => {
-      expect(await ensureConsent({ noTelemetry: true })).toBe(false);
+      const result = await ensureConsent({ noTelemetry: true });
+      expect(result.telemetryOptIn).toBe(false);
+      expect(result.source).toBe("env-forced-off");
       expect(questionCallCount).toBe(0);
     });
   });

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -4,6 +4,14 @@ import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 // Internal/friendlies phase: default to opted in (matches the on-by-default
 // prompt below and the non-TTY fallback) — flip this the other way for a
 // wider release.
+//
+// Pre-external-release checklist: revisit the non-TTY silent opt-in below.
+// The current default (true) is intentional for the internal/friendlies phase
+// where every user is a known collaborator; for a wider/public release the
+// conservative choice is false (opt-out by default) so users who never see
+// a TTY (CI, Docker, headless environments) are not silently opted in.
+// See also the first-run UI notice wiring in web/src/components/TelemetryNotice.tsx,
+// which surfaces this path to interactive users who did get the default.
 const DEFAULT_TELEMETRY_OPT_IN = true;
 
 const CONSENT_COPY = `
@@ -41,6 +49,32 @@ export interface EnsureConsentOptions {
 }
 
 /**
+ * How the telemetry consent state was determined for this boot.
+ * Exposed to the server so the UI can show a first-run notice when
+ * consent was implicitly set by the non-TTY default rather than explicitly
+ * answered by the user.
+ */
+export type ConsentSource =
+  /** `--no-telemetry` flag or SAPIOM_TELEMETRY_DISABLED/DO_NOT_TRACK env var. */
+  | "env-forced-off"
+  /** Stored consent from a previous first-run prompt — user answered explicitly. */
+  | "stored-explicit"
+  /** User answered the Y/n prompt just now (interactive TTY). */
+  | "prompted"
+  /** Non-TTY first run: the silent default was applied and persisted. */
+  | "default-silent";
+
+export interface ConsentResult {
+  telemetryOptIn: boolean;
+  /**
+   * Which env var (if any) is forcing telemetry off this run.
+   * Only set when source === "env-forced-off".
+   */
+  envReason: string | null;
+  source: ConsentSource;
+}
+
+/**
  * Environment opt-out, same precedence and value-parsing as
  * `@sapiom/analytics-core`'s `resolveConsent()`: `SAPIOM_TELEMETRY_DISABLED`
  * (Sapiom-specific) before `DO_NOT_TRACK` (the ecosystem-wide convention),
@@ -69,22 +103,33 @@ function envDisableReason(): string | null {
  * skipping the prompt entirely — without touching what's actually stored, so
  * a later run without the env var set sees whatever the user answered (or
  * will still be asked, if this env-vetoed run was their first).
+ *
+ * Returns a ConsentResult that includes the source of the decision — the UI
+ * uses this to show a first-run notice when the user never explicitly answered
+ * (source === "default-silent"), skipping it when they did.
  */
-export async function ensureConsent(options: EnsureConsentOptions): Promise<boolean> {
-  if (options.noTelemetry) return false;
+export async function ensureConsent(options: EnsureConsentOptions): Promise<ConsentResult> {
+  if (options.noTelemetry) {
+    return { telemetryOptIn: false, envReason: null, source: "env-forced-off" };
+  }
 
   const envReason = envDisableReason();
   if (envReason) {
     console.log(`Telemetry disabled via ${envReason} — skipping the consent prompt.\n`);
-    return false;
+    return { telemetryOptIn: false, envReason, source: "env-forced-off" };
   }
 
   const isFirstRun = !(await hasStoredSettings());
   const settings = await loadSettings();
 
-  if (!isFirstRun) return settings.telemetryOptIn;
+  if (!isFirstRun) {
+    return { telemetryOptIn: settings.telemetryOptIn, envReason: null, source: "stored-explicit" };
+  }
 
+  // First run: prompt the user (TTY) or apply the silent default (non-TTY).
+  const isTTY = process.stdin.isTTY;
   const telemetryOptIn = await promptConsent();
   await saveSettings({ ...settings, telemetryOptIn });
-  return telemetryOptIn;
+  const source: ConsentSource = isTTY ? "prompted" : "default-silent";
+  return { telemetryOptIn, envReason: null, source };
 }

--- a/packages/harness/src/core/collector/store-retention.test.ts
+++ b/packages/harness/src/core/collector/store-retention.test.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { sweepNdjson, DEFAULT_MAX_SIZE_BYTES, DEFAULT_MAX_AGE_MS } from "./store-retention.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeEvent(opts: {
+  eventId: string;
+  ts?: string;
+  payload?: Record<string, unknown>;
+}): string {
+  return JSON.stringify({
+    eventId: opts.eventId,
+    seq: 1,
+    ts: opts.ts ?? new Date().toISOString(),
+    userId: null,
+    tenantId: null,
+    machineId: "machine-1",
+    harnessSessionId: "session-1",
+    agentSessionId: null,
+    harness: "claude-code",
+    type: "session.start",
+    payload: opts.payload ?? {},
+  });
+}
+
+describe("sweepNdjson", () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-retention-test-"));
+    filePath = path.join(tmpDir, "events.ndjson");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeLines(lines: string[]): Promise<void> {
+    await fs.writeFile(filePath, lines.join("\n") + "\n", "utf8");
+  }
+
+  async function readLines(): Promise<string[]> {
+    const content = await fs.readFile(filePath, "utf8");
+    return content.trim().split("\n").filter(Boolean);
+  }
+
+  it("returns rewritten:false on ENOENT — file does not exist yet", async () => {
+    const result = await sweepNdjson(path.join(tmpDir, "nonexistent.ndjson"));
+    expect(result).toEqual({ linesBefore: 0, linesAfter: 0, rewritten: false });
+  });
+
+  it("does nothing when the file is within both caps", async () => {
+    const lines = [
+      makeEvent({ eventId: "a", ts: new Date().toISOString() }),
+      makeEvent({ eventId: "b", ts: new Date().toISOString() }),
+    ];
+    await writeLines(lines);
+
+    const result = await sweepNdjson(filePath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: DEFAULT_MAX_AGE_MS });
+    expect(result.rewritten).toBe(false);
+    expect(result.linesBefore).toBe(2);
+    expect(result.linesAfter).toBe(2);
+  });
+
+  it("age trigger: drops events older than maxAgeMs, retains newer ones", async () => {
+    const oldTs = new Date(Date.now() - 31 * DAY_MS).toISOString();
+    const newTs = new Date().toISOString();
+    await writeLines([
+      makeEvent({ eventId: "old-1", ts: oldTs }),
+      makeEvent({ eventId: "old-2", ts: oldTs }),
+      makeEvent({ eventId: "new-1", ts: newTs }),
+    ]);
+
+    const result = await sweepNdjson(filePath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: 30 * DAY_MS });
+    expect(result.rewritten).toBe(true);
+    expect(result.linesBefore).toBe(3);
+    expect(result.linesAfter).toBe(1);
+
+    const remaining = await readLines();
+    expect(remaining).toHaveLength(1);
+    expect(JSON.parse(remaining[0]).eventId).toBe("new-1");
+  });
+
+  it("size trigger: drops oldest lines until content fits within maxSizeBytes", async () => {
+    // Build lines where the oldest ones push us over the size cap.
+    const ts = new Date().toISOString();
+    const lines = Array.from({ length: 10 }, (_, i) =>
+      makeEvent({ eventId: `evt-${i}`, ts }),
+    );
+    await writeLines(lines);
+
+    // Cap that fits roughly 3 events — each line is ~227 bytes, so 700 bytes
+    // allows 3 but not all 10. Pick a value larger than one event but well
+    // below 10 events so we can assert some-but-not-all survive.
+    const singleLineBytes = Buffer.byteLength(lines[0] + "\n", "utf8"); // ~227
+    const tinyMaxBytes = singleLineBytes * 3; // fits exactly 3 events
+    const result = await sweepNdjson(filePath, { maxSizeBytes: tinyMaxBytes, maxAgeMs: DEFAULT_MAX_AGE_MS });
+
+    expect(result.rewritten).toBe(true);
+    expect(result.linesBefore).toBe(10);
+    expect(result.linesAfter).toBeLessThan(10);
+    expect(result.linesAfter).toBeGreaterThan(0);
+
+    // Verify the FILE content after sweep actually fits in the cap.
+    const fileContent = await fs.readFile(filePath, "utf8");
+    expect(Buffer.byteLength(fileContent, "utf8")).toBeLessThanOrEqual(tinyMaxBytes);
+  });
+
+  it("atomic rewrite: newest events are preserved — oldest dropped by size cap", async () => {
+    const ts = new Date().toISOString();
+    const lines = Array.from({ length: 10 }, (_, i) =>
+      makeEvent({ eventId: `evt-${i}`, ts }),
+    );
+    await writeLines(lines);
+
+    // Cap that keeps only the last ~3 events.
+    const singleLineBytes = Buffer.byteLength(lines[0] + "\n", "utf8");
+    const threeLines = singleLineBytes * 3;
+    await sweepNdjson(filePath, { maxSizeBytes: threeLines, maxAgeMs: DEFAULT_MAX_AGE_MS });
+
+    const remaining = await readLines();
+    // Last three events should be: evt-7, evt-8, evt-9.
+    const ids = remaining.map((l) => (JSON.parse(l) as { eventId: string }).eventId);
+    expect(ids[ids.length - 1]).toBe("evt-9");
+    expect(ids[0]).toBe(`evt-${10 - remaining.length}`);
+  });
+
+  it("corrupted-line tolerance: bad JSON is kept on age pass, size cap may drop it", async () => {
+    const ts = new Date().toISOString();
+    await writeLines([
+      makeEvent({ eventId: "good", ts }),
+      "this is not valid json {{{",
+    ]);
+
+    // No caps triggered — corrupted line should pass through.
+    const result = await sweepNdjson(filePath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: DEFAULT_MAX_AGE_MS });
+    expect(result.rewritten).toBe(false);
+    expect(result.linesAfter).toBe(2);
+
+    const remaining = await readLines();
+    expect(remaining).toContain("this is not valid json {{{");
+  });
+
+  it("drops all events when every line is older than the age cap", async () => {
+    const oldTs = new Date(Date.now() - 60 * DAY_MS).toISOString();
+    await writeLines([
+      makeEvent({ eventId: "very-old-1", ts: oldTs }),
+      makeEvent({ eventId: "very-old-2", ts: oldTs }),
+    ]);
+
+    const result = await sweepNdjson(filePath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: 30 * DAY_MS });
+    expect(result.rewritten).toBe(true);
+    expect(result.linesAfter).toBe(0);
+
+    const content = await fs.readFile(filePath, "utf8");
+    expect(content).toBe(""); // file is empty but exists
+  });
+
+  it("creates the parent directory if it does not exist before a rewrite", async () => {
+    const deepPath = path.join(tmpDir, "nested", "dir", "events.ndjson");
+    const oldTs = new Date(Date.now() - 60 * DAY_MS).toISOString();
+    await fs.mkdir(path.dirname(deepPath), { recursive: true });
+    await fs.writeFile(deepPath, makeEvent({ eventId: "old", ts: oldTs }) + "\n", "utf8");
+
+    // Should rewrite without throwing on missing parent.
+    const result = await sweepNdjson(deepPath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: 30 * DAY_MS });
+    expect(result.rewritten).toBe(true);
+  });
+});

--- a/packages/harness/src/core/collector/store-retention.test.ts
+++ b/packages/harness/src/core/collector/store-retention.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { createEventStore } from "./store.js";
 import { sweepNdjson, DEFAULT_MAX_SIZE_BYTES, DEFAULT_MAX_AGE_MS } from "./store-retention.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -171,5 +172,91 @@ describe("sweepNdjson", () => {
     // Should rewrite without throwing on missing parent.
     const result = await sweepNdjson(deepPath, { maxSizeBytes: DEFAULT_MAX_SIZE_BYTES, maxAgeMs: 30 * DAY_MS });
     expect(result.rewritten).toBe(true);
+  });
+});
+
+describe("EventStore.runExclusive — sweep/append concurrency safety", () => {
+  // Verifies that appends and sweeps run through EventStore.runExclusive() are
+  // strictly serialized — no append can sneak into the file between a sweep's
+  // readFile and its rename, which would cause the renamed file to be missing
+  // that line. The queue ensures: sweep reads file → sweep writes temp → rename
+  // is one uninterrupted slot; any append enqueued after the sweep waits until
+  // rename completes.
+
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-store-concurrency-"));
+    filePath = path.join(tmpDir, "events.ndjson");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("appends enqueued after a sweep contain exactly what the queue dictates — no lines lost to rename races", async () => {
+    const ts = new Date().toISOString();
+    const store = createEventStore(filePath);
+
+    // Write 10 seed events through the store's queue.
+    const seedLines = Array.from({ length: 10 }, (_, i) => makeEvent({ eventId: `seed-${i}`, ts }));
+    const seedEvents = seedLines.map((l) => JSON.parse(l) as Parameters<typeof store.append>[0]);
+    for (const event of seedEvents) {
+      await store.append(event);
+    }
+
+    // Each line is ~227 bytes; cap = 3 lines so the sweep will keep only the
+    // 3 newest seed events (seed-7, seed-8, seed-9) and drop seed-0..6.
+    const singleLineBytes = Buffer.byteLength(seedLines[0] + "\n", "utf8");
+    const cap = singleLineBytes * 3;
+
+    // Enqueue the sweep, then immediately enqueue 5 more appends.
+    // Queue order: sweep → post-0 → post-1 → ... → post-4 → final-read.
+    // The sweep sees exactly the 10 seed events; the 5 post-appends wait
+    // until after the rename. Crucially, none of the 5 post-appends can
+    // slip between the sweep's readFile and its rename — that window is
+    // an uninterrupted queue slot.
+    const sweepP = store.runExclusive(() =>
+      sweepNdjson(filePath, { maxSizeBytes: cap, maxAgeMs: DEFAULT_MAX_AGE_MS }),
+    );
+
+    const POST_IDS = ["post-0", "post-1", "post-2", "post-3", "post-4"];
+    const postEvents = POST_IDS.map((id) => JSON.parse(makeEvent({ eventId: id, ts })) as Parameters<typeof store.append>[0]);
+    const postAppends = postEvents.map((event) => store.append(event));
+
+    const [sweepResult] = await Promise.all([sweepP, ...postAppends]);
+
+    // Sweep ran first (cap of 3 seed events) — should have rewritten.
+    expect(sweepResult.rewritten).toBe(true);
+    expect(sweepResult.linesBefore).toBe(10);
+    expect(sweepResult.linesAfter).toBe(3);
+
+    // Read final file through the queue to see the complete post-sweep state.
+    const finalContent = await store.runExclusive(async () => fs.readFile(filePath, "utf8"));
+    const finalIds = finalContent
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => (JSON.parse(l) as { eventId: string }).eventId);
+
+    // The 3 kept seed events must be there (sweep result).
+    expect(finalIds).toContain("seed-7");
+    expect(finalIds).toContain("seed-8");
+    expect(finalIds).toContain("seed-9");
+
+    // All 5 post-sweep appends must be there — they ran AFTER the rename,
+    // so the rename could not have silently dropped them.
+    for (const id of POST_IDS) {
+      expect(finalIds, `"${id}" was appended after sweep but is missing`).toContain(id);
+    }
+
+    // Total: 3 kept seeds + 5 post-appends = 8 lines.
+    expect(finalIds).toHaveLength(8);
+
+    // Every line must parse cleanly — no corruption.
+    for (const line of finalContent.trim().split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(line), `line is corrupt: ${line}`).not.toThrow();
+    }
   });
 });

--- a/packages/harness/src/core/collector/store-retention.ts
+++ b/packages/harness/src/core/collector/store-retention.ts
@@ -1,0 +1,125 @@
+/**
+ * Retention cap enforcement for the local analytics sink (events.ndjson).
+ *
+ * Policy (enforced on server boot and periodically afterwards):
+ *   - Size cap: 50 MB — truncate to the newest events that fit.
+ *   - Age cap: 30 days — drop events older than this by their `ts` field.
+ *   The stricter of the two wins; oldest-first truncation always preserves
+ *   the newest events.
+ *
+ * Atomicity: rewrites happen via a temp-file rename so a crash mid-write
+ * never leaves a corrupt or empty events file. The write path must be in
+ * the same directory (same filesystem partition) as the target so rename()
+ * is atomic.
+ *
+ * Concurrency: store.ts serializes appends via a promise queue. Retention
+ * sweeps call sweepNdjson() between appends (never concurrently with one)
+ * — callers are responsible for not overlapping sweeps with each other or
+ * with active appends. In practice, sweeps run on boot (before the first
+ * append) and on a periodic timer (see server/index.ts's wiring).
+ *
+ * Corruption tolerance: lines that fail JSON.parse are silently dropped
+ * rather than aborting the sweep — a single bad line never blocks retention.
+ *
+ * Documented in CONTRIBUTING.md (not README) per the project owner's
+ * constraint that the README's --no-telemetry wording stays as shipped.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/** 50 MB default size cap. */
+export const DEFAULT_MAX_SIZE_BYTES = 50 * 1024 * 1024;
+/** 30 days default age cap. */
+export const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface SweepOptions {
+  maxSizeBytes?: number;
+  maxAgeMs?: number;
+}
+
+export interface SweepResult {
+  /** Number of lines in the file before the sweep. */
+  linesBefore: number;
+  /** Number of lines retained after the sweep. */
+  linesAfter: number;
+  /** True when the file was actually rewritten (something was trimmed). */
+  rewritten: boolean;
+}
+
+/**
+ * Enforces size and age caps on an ndjson file, retaining the newest events.
+ *
+ * Returns a SweepResult describing what happened. Never throws on ENOENT
+ * (the file doesn't exist yet — that's fine). Propagates other I/O errors
+ * to the caller.
+ */
+export async function sweepNdjson(
+  filePath: string,
+  options: SweepOptions = {},
+): Promise<SweepResult> {
+  const maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const cutoffMs = Date.now() - maxAgeMs;
+
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { linesBefore: 0, linesAfter: 0, rewritten: false };
+    }
+    throw err;
+  }
+
+  const rawLines = content.split("\n");
+  // Last line is often empty (trailing newline) — exclude it from the count.
+  const lines = rawLines[rawLines.length - 1] === "" ? rawLines.slice(0, -1) : rawLines;
+  const linesBefore = lines.length;
+
+  // Filter by age first — drop lines whose `ts` field is older than the cap.
+  // Lines that fail JSON.parse are kept (corrupted lines fall through the age
+  // filter; the size cap below may still drop them if needed).
+  const ageFiltered = lines.filter((line) => {
+    try {
+      const parsed = JSON.parse(line) as { ts?: unknown };
+      if (typeof parsed.ts !== "string") return true; // keep if no ts
+      const lineMs = Date.parse(parsed.ts);
+      return !Number.isNaN(lineMs) && lineMs >= cutoffMs;
+    } catch {
+      return true; // keep on parse failure
+    }
+  });
+
+  // Size cap: drop oldest lines (front) until the remaining content fits.
+  // Each line is measured with its trailing newline appended.
+  let kept = ageFiltered;
+  while (kept.length > 0) {
+    const byteLength = Buffer.byteLength(kept.join("\n") + "\n", "utf8");
+    if (byteLength <= maxSizeBytes) break;
+    kept = kept.slice(1); // drop oldest
+  }
+
+  const linesAfter = kept.length;
+  const nothingChanged = linesAfter === linesBefore;
+  if (nothingChanged) {
+    return { linesBefore, linesAfter, rewritten: false };
+  }
+
+  // Atomic rewrite via temp file + rename. Both must be on the same filesystem
+  // (same directory) for the rename to be atomic.
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = path.join(dir, `.events-retention-tmp-${process.pid}-${Date.now()}.ndjson`);
+  try {
+    const newContent = kept.length === 0 ? "" : kept.join("\n") + "\n";
+    await fs.writeFile(tmpPath, newContent, "utf8");
+    await fs.rename(tmpPath, filePath);
+  } catch (err) {
+    // Best-effort cleanup of the temp file; the rename failure is what matters.
+    await fs.unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+
+  return { linesBefore, linesAfter, rewritten: true };
+}

--- a/packages/harness/src/core/collector/store-retention.ts
+++ b/packages/harness/src/core/collector/store-retention.ts
@@ -12,17 +12,14 @@
  * the same directory (same filesystem partition) as the target so rename()
  * is atomic.
  *
- * Concurrency: store.ts serializes appends via a promise queue. Retention
- * sweeps call sweepNdjson() between appends (never concurrently with one)
- * — callers are responsible for not overlapping sweeps with each other or
- * with active appends. In practice, sweeps run on boot (before the first
- * append) and on a periodic timer (see server/index.ts's wiring).
+ * Concurrency: callers MUST run sweepNdjson() through EventStore.runExclusive()
+ * so the sweep's read→filter→rename window never races a concurrent append.
+ * The store serializes all appends through a promise queue; runExclusive()
+ * chains the sweep onto that same queue, guaranteeing mutual exclusion.
+ * See store.ts and server/index.ts for the wiring.
  *
- * Corruption tolerance: lines that fail JSON.parse are silently dropped
- * rather than aborting the sweep — a single bad line never blocks retention.
- *
- * Documented in CONTRIBUTING.md (not README) per the project owner's
- * constraint that the README's --no-telemetry wording stays as shipped.
+ * Corruption tolerance: lines that fail JSON.parse are silently kept rather
+ * than aborting the sweep — a single bad line never blocks retention.
  */
 
 import * as fs from "node:fs/promises";
@@ -53,6 +50,9 @@ export interface SweepResult {
  * Returns a SweepResult describing what happened. Never throws on ENOENT
  * (the file doesn't exist yet — that's fine). Propagates other I/O errors
  * to the caller.
+ *
+ * IMPORTANT: callers must run this through EventStore.runExclusive() to
+ * prevent races with concurrent appends (see module-level docstring).
  */
 export async function sweepNdjson(
   filePath: string,
@@ -91,14 +91,28 @@ export async function sweepNdjson(
     }
   });
 
-  // Size cap: drop oldest lines (front) until the remaining content fits.
-  // Each line is measured with its trailing newline appended.
-  let kept = ageFiltered;
-  while (kept.length > 0) {
-    const byteLength = Buffer.byteLength(kept.join("\n") + "\n", "utf8");
-    if (byteLength <= maxSizeBytes) break;
-    kept = kept.slice(1); // drop oldest
+  // Size cap: O(n) cumulative-bytes pass — compute the byte length of each
+  // line (with its trailing newline), accumulate from the BACK (newest first),
+  // and find the earliest index that still fits in maxSizeBytes. Avoids the
+  // O(n²) cost of re-joining the entire array on each iteration.
+  let dropCount = 0;
+  if (ageFiltered.length > 0) {
+    // Total byte count of all age-filtered lines.
+    const lineLengths = ageFiltered.map((line) => Buffer.byteLength(line + "\n", "utf8"));
+    const total = lineLengths.reduce((sum, n) => sum + n, 0);
+
+    if (total > maxSizeBytes) {
+      // Walk from the front, accumulating bytes to drop until the remaining
+      // content (total − dropped) fits within the cap.
+      let dropped = 0;
+      for (let i = 0; i < ageFiltered.length; i++) {
+        if (total - dropped <= maxSizeBytes) break;
+        dropped += lineLengths[i];
+        dropCount = i + 1;
+      }
+    }
   }
+  const kept = dropCount > 0 ? ageFiltered.slice(dropCount) : ageFiltered;
 
   const linesAfter = kept.length;
   const nothingChanged = linesAfter === linesBefore;

--- a/packages/harness/src/core/collector/store.ts
+++ b/packages/harness/src/core/collector/store.ts
@@ -2,6 +2,13 @@
  * Append-only local sink for analytics events. Always written, regardless
  * of telemetry opt-in — this is the "demo inspects this" local debug file,
  * independent of whether anything gets batched to a remote collector.
+ *
+ * Concurrency: every append is serialized through a promise queue (the same
+ * pattern as workflow-registry.ts and session-manager.ts). `runExclusive(fn)`
+ * chains `fn` onto the same queue so retention sweeps (read→filter→rename)
+ * never overlap with an in-flight append and no appended line can be lost
+ * in a sweep's read window. Overhead is negligible — appends are low-frequency
+ * (one per hook event), and the queue never holds more than O(sessions) entries.
  */
 
 import * as fs from "node:fs/promises";
@@ -11,8 +18,17 @@ import { HARNESS_PATHS, type AnalyticsEvent } from "../../shared/types.js";
 import { expandHome } from "../paths.js";
 
 export interface EventStore {
-  /** Append one event as a single ndjson line. Crash-safe (fs.appendFile). */
+  /** Append one event as a single ndjson line, serialized through the queue. */
   append(event: AnalyticsEvent): Promise<void>;
+  /**
+   * Run `fn` exclusively — after all pending appends complete and blocking
+   * any new appends until `fn` resolves. Use this to run a retention sweep
+   * without racing concurrent writes.
+   *
+   * A failed `fn` never poisons the queue (later appends proceed normally).
+   * The return value of `fn` is forwarded to the caller.
+   */
+  runExclusive<T>(fn: () => Promise<T>): Promise<T>;
 }
 
 /**
@@ -30,10 +46,30 @@ export function createEventStore(filePath: string = HARNESS_PATHS.events): Event
     return dirReady;
   }
 
+  // Promise queue — same pattern as workflow-registry.ts:106-135.
+  // Chains each operation so they execute strictly one-at-a-time.
+  // A failed run never poisons subsequent operations.
+  let queue: Promise<void> = Promise.resolve();
+
+  function enqueue<T>(run: () => Promise<T>): Promise<T> {
+    const next = queue.catch(() => {}).then(run);
+    queue = next.then(
+      () => {},
+      () => {},
+    );
+    return next;
+  }
+
   return {
-    async append(event: AnalyticsEvent): Promise<void> {
-      await ensureDir();
-      await fs.appendFile(resolvedPath, `${JSON.stringify(event)}\n`, "utf8");
+    append(event: AnalyticsEvent): Promise<void> {
+      return enqueue(async () => {
+        await ensureDir();
+        await fs.appendFile(resolvedPath, `${JSON.stringify(event)}\n`, "utf8");
+      });
+    },
+
+    runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+      return enqueue(fn);
     },
   };
 }

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -17,6 +17,7 @@ import open from "open";
 
 import type {
   AnalyticsEvent,
+  AppState,
   HarnessAdapter,
   HarnessKind,
   HarnessSession,
@@ -52,6 +53,7 @@ import { writeHarnessContext, harnessContextFileExists } from "../core/workspace
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
 import { renderCanvasForSession, renderWorkflowRenderFile } from "../core/canvas-render.js";
 import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
+import { sweepNdjson } from "../core/collector/store-retention.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
@@ -87,6 +89,10 @@ const WORKFLOWS_CACHE_REFRESH_MS = 3_000;
  * in the tab strip until the server restarts. The sweep is a cheap in-memory
  * walk plus a signal-0 probe per live pty. */
 const SESSION_LIVENESS_SWEEP_MS = 10_000;
+
+/** events.ndjson retention: sweeps once at boot and then periodically.
+ * Keeps the local sink from growing unbounded on long-lived installs. */
+const NDJSON_RETENTION_SWEEP_MS = 6 * 60 * 60 * 1_000; // every 6 hours
 
 export interface HarnessServerOptions {
   port: number;
@@ -149,6 +155,17 @@ export interface HarnessServerOptions {
    *  the CLI before it records the launch dir, surfaced verbatim in
    *  AppState.firstRun (see its doc comment). Omitted → absent there too. */
   firstRun?: boolean;
+  /**
+   * How telemetry consent was determined — passed through verbatim into
+   * AppState.consentSource. Omitted when the caller didn't run the consent
+   * flow (tests, mocks).
+   */
+  consentSource?: AppState["consentSource"];
+  /**
+   * Which env var forced telemetry off (when consentSource === "env-forced-off").
+   * Passed through into AppState.consentEnvReason.
+   */
+  consentEnvReason?: string | null;
   /** Where POST /api/sample-project seeds the bundled example. Defaults to
    *  `<stateRoot>/sample-project`. */
   sampleProjectRoot?: string;
@@ -505,7 +522,21 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     return [] as WorkflowInfo[];
   });
 
-  const eventStore = createEventStore(options.eventStorePath ?? statePaths.events);
+  const eventStorePath = options.eventStorePath ?? statePaths.events;
+  const eventStore = createEventStore(eventStorePath);
+
+  // Boot-time retention sweep: keeps events.ndjson within the 50 MB / 30-day
+  // caps even on long-lived installs. Runs fire-and-forget — a slow FS is no
+  // reason to delay the rest of server startup. Also scheduled periodically.
+  const runNdjsonSweep = (): void => {
+    void sweepNdjson(eventStorePath).catch((err: unknown) => {
+      console.error("[harness] events.ndjson retention sweep failed:", err);
+    });
+  };
+  runNdjsonSweep();
+  const ndjsonRetentionTimer = setInterval(runNdjsonSweep, NDJSON_RETENTION_SWEEP_MS);
+  ndjsonRetentionTimer.unref?.();
+
   const harnessVersion = readVersion();
   const batcher = createHarnessEmitter({
     telemetryOptIn: options.telemetryOptIn,
@@ -532,6 +563,13 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       agentSessionId: session.agentSessionId,
     };
   };
+
+  // Shared by the ingest pipeline, the Codex transcript tailer, and the UI
+  // track endpoint — all three sources feed the same seq namespace so a given
+  // harnessSessionId gets one consistent, gap-detectable seq space regardless
+  // of which source produced the event. Declared here (before createRestRouter
+  // and createIngestRouter) so the uiTrack closure can reference it lazily.
+  const seqCounter = createSeqCounter();
 
   const app: Express = express();
   app.disable("x-powered-by");
@@ -572,6 +610,16 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       availableHarnesses: options.availableHarnesses,
       listTasks: () => taskManager.list(),
       firstRun: options.firstRun,
+      consentSource: options.consentSource,
+      consentEnvReason: options.consentEnvReason,
+      uiTrack: {
+        store: eventStore,
+        batcher,
+        nextSeq: (sessionId) => seqCounter.next(sessionId),
+        machineId,
+        userId: identity?.userId ?? null,
+        tenantId: identity?.tenantId ?? null,
+      },
       seedSampleProject: async () => {
         const { root, projectDir, created } = await seedExampleProject({
           targetRoot: options.sampleProjectRoot ?? statePaths.sampleProject,
@@ -632,12 +680,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     }),
   );
 
-  // Shared by both event sources feeding the analytics pipeline: real hook
-  // POSTs (via the /ingest router below) and the Codex transcript tailer
-  // (in-process, no HTTP round-trip — see startCodexTailerFor). One
-  // seqCounter so a given harnessSessionId gets one consistent seq space
-  // regardless of which source produced the event.
-  const seqCounter = createSeqCounter();
+  // Feeds the same seqCounter declared above — both hook POSTs and the Codex
+  // transcript tailer run through processIngest(), which shares the counter.
   const ingestDeps: IngestDeps = {
     ingestToken: options.bootToken,
     normalize: normalizeHookEvent,
@@ -841,6 +885,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     close: async () => {
       clearInterval(workflowsCacheTimer);
       clearInterval(sessionSweepTimer);
+      clearInterval(ndjsonRetentionTimer);
       canvasWatcher.stopAll();
       workspaceWatcher.stopAll();
       for (const tailer of codexTailers.values()) tailer.stop();

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -526,10 +526,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const eventStore = createEventStore(eventStorePath);
 
   // Boot-time retention sweep: keeps events.ndjson within the 50 MB / 30-day
-  // caps even on long-lived installs. Runs fire-and-forget — a slow FS is no
-  // reason to delay the rest of server startup. Also scheduled periodically.
+  // caps even on long-lived installs. Runs through the store's exclusive queue
+  // so the sweep's read→filter→rename window never races a concurrent append.
+  // Fire-and-forget — a slow FS is no reason to delay server startup.
   const runNdjsonSweep = (): void => {
-    void sweepNdjson(eventStorePath).catch((err: unknown) => {
+    void eventStore.runExclusive(() => sweepNdjson(eventStorePath)).catch((err: unknown) => {
       console.error("[harness] events.ndjson retention sweep failed:", err);
     });
   };

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -7,7 +7,9 @@
 import express, { Router } from "express";
 import { z } from "zod";
 
+import { randomUUID } from "node:crypto";
 import type {
+  AnalyticsEvent,
   AppState,
   BackgroundTask,
   BindWorkflowRequest,
@@ -20,6 +22,8 @@ import type {
   MacroDef,
   SampleProjectSeedResponse,
   SessionSummary,
+  UiEventName,
+  UiTrackRequest,
   WorkflowInfo,
 } from "../shared/types.js";
 import { SPAWNABLE_HARNESS_KINDS } from "../shared/types.js";
@@ -51,6 +55,21 @@ const settingsPatchSchema = z.object({
   telemetryOptIn: z.boolean().optional(),
   recentDirs: z.array(z.string()).optional(),
 }) satisfies z.ZodType<Partial<HarnessSettings>>;
+
+const UI_EVENT_NAMES: readonly UiEventName[] = [
+  "prompt.submitted",
+  "session.switched",
+  "macro.invoked",
+  "visualize.triggered",
+  "consent.changed",
+  "session.created",
+];
+
+const uiTrackSchema = z.object({
+  event: z.enum(UI_EVENT_NAMES as [UiEventName, ...UiEventName[]]),
+  data: z.record(z.unknown()).optional(),
+  harnessSessionId: z.string().optional(),
+}) satisfies z.ZodType<UiTrackRequest>;
 
 export interface RestRouterOptions {
   sessionManager: SessionManager;
@@ -103,6 +122,13 @@ export interface RestRouterOptions {
    * mutated any state, surfaced verbatim in AppState.firstRun. Omitted when
    * the caller doesn't supply it (tests), leaving AppState.firstRun absent. */
   firstRun?: boolean;
+  /** How telemetry consent was determined at boot — surfaced in AppState so the
+   * UI can show the first-run notice when the user never explicitly answered.
+   * Omitted when the caller didn't run the consent flow (tests). */
+  consentSource?: AppState["consentSource"];
+  /** Which env var forced telemetry off — surfaced in AppState for the
+   * tracking indicator's "off (env)" label. Null/absent otherwise. */
+  consentEnvReason?: string | null;
   /** Seeds (or reuses) the bundled example project and returns where it
    * landed — backs POST /api/sample-project (the welcome panel's "Run the
    * sample project"). Optional so callers without the real seeder (tests)
@@ -113,6 +139,20 @@ export interface RestRouterOptions {
    * (server/index.ts) passes the path under its resolved state root so an
    * isolated boot never reads or writes the developer's real settings. */
   settingsPath?: string;
+  /**
+   * Dependencies for POST /api/track (UI-interaction analytics).
+   * Optional: when omitted, /api/track returns 501 (tests that don't care
+   * about UI analytics don't need to stub these).
+   */
+  uiTrack?: {
+    store: { append(event: import("../shared/types.js").AnalyticsEvent): Promise<void> };
+    batcher: { enqueue(event: import("../shared/types.js").AnalyticsEvent): void };
+    /** Per-boot seq counter shared with the ingest pipeline. */
+    nextSeq: (sessionId: string) => number;
+    machineId: string;
+    userId: string | null;
+    tenantId: string | null;
+  };
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
@@ -136,6 +176,8 @@ export function createRestRouter(options: RestRouterOptions): Router {
         ...(options.availableHarnesses ? { availableHarnesses: options.availableHarnesses } : {}),
         ...(options.listTasks ? { tasks: options.listTasks() } : {}),
         ...(options.firstRun !== undefined ? { firstRun: options.firstRun } : {}),
+        ...(options.consentSource !== undefined ? { consentSource: options.consentSource } : {}),
+        ...(options.consentEnvReason !== undefined ? { consentEnvReason: options.consentEnvReason } : {}),
       };
       res.json(state);
     } catch (err) {
@@ -362,6 +404,65 @@ export function createRestRouter(options: RestRouterOptions): Router {
       }
       next(err);
     }
+  });
+
+  /**
+   * POST /api/track — UI-interaction analytics.
+   *
+   * Feeds the same store + batcher pipeline as hook events from /ingest, so
+   * ui.* events get the same local ndjson write (always) and remote delivery
+   * (per consent) that agent hook events do.  The client fires fire-and-forget
+   * — we always respond 200 fast, then process.
+   *
+   * Consent semantics: store.append always; batcher.enqueue only when opted in
+   * (batcher.enqueue is gated by the HarnessEmitter's disabled flag, which
+   * mirrors the live consent state — same as hook events).
+   */
+  router.post("/track", (req, res) => {
+    if (!options.uiTrack) {
+      // Not wired in this server instance (tests without UI analytics deps).
+      res.status(501).json({ error: "ui tracking not available" });
+      return;
+    }
+
+    // Validate before responding — bad shape gets a 400 synchronously.
+    const parsed = uiTrackSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+
+    // Respond immediately — fire-and-forget from the client's perspective.
+    res.json({ ok: true });
+
+    const { store, batcher, nextSeq, machineId, userId, tenantId } = options.uiTrack;
+    const { event, data, harnessSessionId } = parsed.data;
+    // Use the provided session id for seq tracking; fall back to a synthetic
+    // one-use id so ui events without a session still get a valid seq.
+    const sessionId = harnessSessionId ?? `ui-${randomUUID()}`;
+
+    const analyticsEvent: AnalyticsEvent = {
+      eventId: randomUUID(),
+      seq: nextSeq(sessionId),
+      ts: new Date().toISOString(),
+      userId,
+      tenantId,
+      machineId,
+      harnessSessionId: sessionId,
+      agentSessionId: null,
+      harness: "claude-code", // ui events have no harness kind; use canonical placeholder
+      type: event as AnalyticsEvent["type"],
+      payload: {
+        ...(data ?? {}),
+        surface: "ui",
+      },
+    };
+
+    void store.append(analyticsEvent).catch((err: unknown) => {
+      // Non-fatal: local write failure should never surface to the user.
+      void err;
+    });
+    batcher.enqueue(analyticsEvent);
   });
 
   return router;

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -451,7 +451,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       harnessSessionId: sessionId,
       agentSessionId: null,
       harness: "claude-code", // ui events have no harness kind; use canonical placeholder
-      type: event as AnalyticsEvent["type"],
+      type: event,
       payload: {
         ...(data ?? {}),
         surface: "ui",

--- a/packages/harness/src/server/track.test.ts
+++ b/packages/harness/src/server/track.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for POST /api/track — the UI-interaction analytics endpoint.
+ *
+ * Verifies:
+ *   - Valid events are stored locally (always) and enqueued for remote (gated).
+ *   - store.append() is called for every valid event regardless of consent.
+ *   - batcher.enqueue() is called (remote delivery, consent assumed by batcher).
+ *   - Invalid event names are rejected with 400.
+ *   - Missing uiTrack deps yield 501.
+ *   - Response is 200 OK with no blocking on the async writes.
+ */
+import type { AddressInfo } from "node:net";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpHome: string;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return { ...actual, homedir: () => tmpHome };
+});
+
+import type { AnalyticsEvent } from "../shared/types.js";
+import { createRestRouter, type RestRouterOptions } from "./rest.js";
+
+const TOKEN_HEADER = { "Content-Type": "application/json", "X-Harness-Token": "unused-in-router-tests" };
+
+function makeBaseOptions(overrides: Partial<RestRouterOptions> = {}): RestRouterOptions {
+  return {
+    sessionManager: {
+      list: () => [],
+      get: () => undefined,
+      create: vi.fn(),
+      resume: vi.fn(),
+      kill: vi.fn(),
+      write: vi.fn(),
+      submitInput: vi.fn(),
+      setBoundWorkflowPath: vi.fn(),
+    } as unknown as RestRouterOptions["sessionManager"],
+    adapters: {},
+    version: "0.0.1-test",
+    identity: null,
+    listWorkflows: async () => [],
+    listMacros: () => [],
+    findWorkflow: () => null,
+    writeWorkspaceContext: vi.fn().mockResolvedValue(undefined),
+    onTelemetryOptInChange: vi.fn(),
+    launchDir: "/tmp/test-launch-dir",
+    ...overrides,
+  };
+}
+
+describe("POST /api/track", () => {
+  let server: ReturnType<express.Express["listen"]>;
+  let baseUrl: string;
+  let stored: AnalyticsEvent[];
+  let enqueued: AnalyticsEvent[];
+
+  function start(overrides: Partial<RestRouterOptions> = {}) {
+    stored = [];
+    enqueued = [];
+    const uiTrack: RestRouterOptions["uiTrack"] = {
+      store: {
+        append: vi.fn(async (event: AnalyticsEvent) => {
+          stored.push(event);
+        }),
+      },
+      batcher: {
+        enqueue: vi.fn((event: AnalyticsEvent) => {
+          enqueued.push(event);
+        }),
+      },
+      nextSeq: vi.fn(() => 1),
+      machineId: "machine-test",
+      userId: "user-test",
+      tenantId: "tenant-test",
+    };
+    const app = express();
+    app.use(createRestRouter(makeBaseOptions({ uiTrack, ...overrides })));
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "harness-track-test-"));
+    start();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 200 for a valid event", async () => {
+    const res = await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "prompt.submitted", data: { length: 42 } }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("stores the event locally (store.append) for every valid event", async () => {
+    await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "session.created" }),
+    });
+    // Give the async fire-and-forget a tick to settle.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(stored).toHaveLength(1);
+    expect(stored[0].type).toBe("session.created");
+    expect((stored[0].payload as Record<string, unknown>).surface).toBe("ui");
+  });
+
+  it("enqueues for remote delivery (batcher.enqueue)", async () => {
+    await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "consent.changed", data: { optIn: true } }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].type).toBe("consent.changed");
+  });
+
+  it("includes data fields in payload", async () => {
+    await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "macro.invoked", data: { macroId: "visualize" } }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(stored[0].payload).toMatchObject({ macroId: "visualize", surface: "ui" });
+  });
+
+  it("uses harnessSessionId from body in the event", async () => {
+    await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "session.switched", harnessSessionId: "sess-abc" }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(stored[0].harnessSessionId).toBe("sess-abc");
+  });
+
+  it("generates a synthetic session id when no harnessSessionId is provided", async () => {
+    await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "prompt.submitted", data: { length: 5 } }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(stored[0].harnessSessionId).toMatch(/^ui-/);
+  });
+
+  it("returns 400 for an unknown event name", async () => {
+    const res = await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ event: "unknown.event" }),
+    });
+    expect(res.status).toBe(400);
+    expect(stored).toHaveLength(0);
+  });
+
+  it("returns 400 for a missing event field", async () => {
+    const res = await fetch(`${baseUrl}/track`, {
+      method: "POST",
+      headers: TOKEN_HEADER,
+      body: JSON.stringify({ data: { foo: "bar" } }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 501 when uiTrack is not configured", async () => {
+    // Start a fresh server without uiTrack.
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    const app2 = express();
+    app2.use(createRestRouter(makeBaseOptions({ uiTrack: undefined })));
+    const server2 = app2.listen(0);
+    const address2 = server2.address() as AddressInfo;
+    const url2 = `http://127.0.0.1:${address2.port}`;
+
+    try {
+      const res = await fetch(`${url2}/track`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+        body: JSON.stringify({ event: "session.created" }),
+      });
+      expect(res.status).toBe(501);
+    } finally {
+      await new Promise<void>((resolve) => server2.close(() => resolve()));
+    }
+  });
+
+  it("all UiEventName values are accepted", async () => {
+    const events = [
+      "prompt.submitted",
+      "session.switched",
+      "macro.invoked",
+      "visualize.triggered",
+      "consent.changed",
+      "session.created",
+    ] as const;
+
+    for (const event of events) {
+      const res = await fetch(`${baseUrl}/track`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+        body: JSON.stringify({ event }),
+      });
+      expect(res.status, `expected 200 for event "${event}"`).toBe(200);
+    }
+  });
+});

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -319,6 +319,38 @@ export type BusMessage =
 // Analytics events
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// UI-interaction analytics  (POST /api/track)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical UI event names.  Dot-separated, source "harness", surface marker
+ * data.surface: "ui".  These ride the same collector pipeline as hook events
+ * (local ndjson always; remote only when opted in), so seq/session dimensions
+ * and the analytics-core envelope are added server-side, not client-side.
+ * See the collector README section in packages/harness/src/core/collector/
+ * for the full surface-"ui" contract.
+ */
+export type UiEventName =
+  | "prompt.submitted"
+  | "session.switched"
+  | "macro.invoked"
+  | "visualize.triggered"
+  | "consent.changed"
+  | "session.created";
+
+export interface UiTrackRequest {
+  /** Dot-canonical event name — one of the UiEventName literals. */
+  event: UiEventName;
+  /** Arbitrary data payload; server stamps data.surface: "ui" automatically.
+   *  Never include prompt text — this is UI-interaction metadata only. */
+  data?: Record<string, unknown>;
+  /** harnessSessionId to associate this event with (for seq/session dims).
+   *  Optional: when omitted, the event gets a synthetic single-use session id.
+   */
+  harnessSessionId?: string;
+}
+
 export const ANALYTICS_SCHEMA_VERSION = 1;
 
 export type AnalyticsEventType =
@@ -396,6 +428,7 @@ export interface CollectorBatch {
 // PATCH  /api/settings                  Partial<HarnessSettings> → HarnessSettings
 // POST   /api/sample-project            → SampleProjectSeedResponse (seed/reuse the bundled example)
 // GET    /api/fs/list?path=&hidden=     → FsListResponse (directory autocomplete)
+// POST   /api/track                     UiTrackRequest → { ok: true }  (UI-interaction analytics)
 // POST   /ingest                        (hook payloads; bearer = ingest token)
 
 export interface CreateSessionRequest {
@@ -451,6 +484,21 @@ export interface AppState {
   userId: string | null;
   organizationName: string | null;
   telemetryOptIn: boolean;
+  /**
+   * How telemetry consent was determined at CLI boot. The UI uses this to
+   * decide whether to show the first-run notice: "default-silent" means the
+   * user never explicitly answered the Y/n prompt (e.g. non-TTY / CI), so
+   * we surface a gentle one-time indicator. Optional: omitted by callers that
+   * don't run the consent flow (tests, mocks — treated as "stored-explicit"
+   * by the UI, i.e. no notice).
+   */
+  consentSource?: "env-forced-off" | "stored-explicit" | "prompted" | "default-silent";
+  /**
+   * When consentSource === "env-forced-off", which env var forced it off —
+   * rendered in the tracking indicator as "off (env)" with the var name.
+   * Null/absent otherwise.
+   */
+  consentEnvReason?: string | null;
   sessions: HarnessSession[];
   workflows: WorkflowInfo[];
   macros: MacroDef[];
@@ -492,6 +540,12 @@ export interface HarnessSettings {
   telemetryOptIn: boolean;
   /** Most-recently-used project directories, newest first. */
   recentDirs: string[];
+  /**
+   * True once the user has dismissed the first-run telemetry notice
+   * (shown when consent was determined silently in a non-TTY environment).
+   * Persisted so the notice never appears again after the first dismiss.
+   */
+  telemetryNoticeDismissed?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -358,7 +358,13 @@ export type AnalyticsEventType =
   | "prompt.submitted"
   | "tool.call"
   | "turn.completed"
-  | "session.end";
+  | "session.end"
+  // UI-interaction analytics (surface: "ui" in payload — see UiEventName):
+  | "session.switched"
+  | "macro.invoked"
+  | "visualize.triggered"
+  | "consent.changed"
+  | "session.created";
 
 /**
  * The normalized event — the shape that (with opt-in) is batched to the

--- a/packages/harness/web/e2e/consent.spec.ts
+++ b/packages/harness/web/e2e/consent.spec.ts
@@ -64,6 +64,16 @@ test.describe("telemetry chip in BrandHeader", () => {
     await expect(chip.locator(".telemetry-chip-label")).toHaveText("analytics off (env)");
   });
 
+  test("shows 'analytics on' chip when consentSource is prompted (user said yes)", async ({ page }) => {
+    // "prompted" sets telemetryOptIn:true in the mock — mirrors a user who answered yes at the CLI.
+    await page.goto("/?mockConsentSource=prompted");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const chip = page.getByTestId("telemetry-chip");
+    await expect(chip).toHaveAttribute("data-state", "on");
+    await expect(chip.locator(".telemetry-chip-label")).toHaveText("analytics on");
+  });
+
   test("chip click opens the settings popover", async ({ page }) => {
     await page.goto("/?mockConsentSource=stored-explicit");
     await expect(page.locator(".rail-workflows")).toBeVisible();

--- a/packages/harness/web/e2e/consent.spec.ts
+++ b/packages/harness/web/e2e/consent.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Playwright specs for consent-UI surfaces (Part 1b + 1c + 2f tracking assertions).
+ *
+ * Runs in mock mode (VITE_MOCK=1) — no harness server required.
+ * Uses mockConsentSource and mockEnvReason query params to exercise all
+ * chip states without a real server.
+ *
+ * Coverage:
+ *   - Telemetry chip in BrandHeader (on / off / env states)
+ *   - Chip click opens settings popover
+ *   - TelemetryNotice shown for "default-silent", dismissed permanently
+ *   - TelemetryNotice NOT shown for other consent sources
+ *   - track("prompt.submitted") fires on prompt-bar submit
+ *   - track("consent.changed") fires on toggle
+ *   - track("session.created") fires on new session creation
+ */
+import { expect, test } from "@playwright/test";
+
+type TestHarnessWindow = {
+  __HARNESS_TEST__: {
+    publish: (message: unknown) => void;
+    trackEvents?: Array<{ event: string; data?: Record<string, unknown>; harnessSessionId?: string }>;
+    lastInjectInput?: { id: string; req: { text: string; submit?: boolean } };
+  };
+};
+
+/** Wait for at least one track event matching the given event name. */
+async function waitForTrackEvent(page: import("@playwright/test").Page, eventName: string) {
+  await page.waitForFunction(
+    (name: string) => {
+      const win = window as unknown as TestHarnessWindow;
+      return (win.__HARNESS_TEST__?.trackEvents ?? []).some((e) => e.event === name);
+    },
+    eventName,
+    { timeout: 5_000 },
+  );
+}
+
+/** Read all captured track events. */
+async function getTrackEvents(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    return (window as unknown as TestHarnessWindow).__HARNESS_TEST__?.trackEvents ?? [];
+  });
+}
+
+test.describe("telemetry chip in BrandHeader", () => {
+  test("shows 'analytics off' chip when telemetryOptIn is false (stored-explicit)", async ({ page }) => {
+    // Default mock: telemetryOptIn=false, consentSource=stored-explicit.
+    await page.goto("/?mockConsentSource=stored-explicit");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const chip = page.getByTestId("telemetry-chip");
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute("data-state", "off");
+    await expect(chip.locator(".telemetry-chip-label")).toHaveText("analytics off");
+  });
+
+  test("shows 'analytics off (env)' chip when consentSource is env-forced-off", async ({ page }) => {
+    await page.goto("/?mockConsentSource=env-forced-off&mockEnvReason=SAPIOM_TELEMETRY_DISABLED");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const chip = page.getByTestId("telemetry-chip");
+    await expect(chip).toHaveAttribute("data-state", "env");
+    await expect(chip.locator(".telemetry-chip-label")).toHaveText("analytics off (env)");
+  });
+
+  test("chip click opens the settings popover", async ({ page }) => {
+    await page.goto("/?mockConsentSource=stored-explicit");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    // Settings popover should not be visible yet.
+    await expect(page.getByTestId("settings-popover")).toHaveCount(0);
+
+    // Click the chip.
+    await page.getByTestId("telemetry-chip").click();
+
+    // Settings popover should now be open.
+    await expect(page.getByTestId("settings-popover")).toBeVisible();
+  });
+
+  test("chip reflects live telemetryOptIn — toggles on when the toggle is switched on", async ({ page }) => {
+    await page.goto("/?mockConsentSource=stored-explicit");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const chip = page.getByTestId("telemetry-chip");
+    await expect(chip).toHaveAttribute("data-state", "off");
+
+    // Open settings and toggle telemetry on.
+    await page.getByTestId("settings-trigger").click();
+    await expect(page.getByTestId("settings-popover")).toBeVisible();
+    await page.getByTestId("telemetry-toggle").click();
+
+    // Wait for the chip to update (settings PATCH is async in mock).
+    await expect(chip).toHaveAttribute("data-state", "on", { timeout: 3_000 });
+    await expect(chip.locator(".telemetry-chip-label")).toHaveText("analytics on");
+  });
+});
+
+test.describe("TelemetryNotice — first-run notice", () => {
+  test("shows TelemetryNotice when consentSource is default-silent", async ({ page }) => {
+    await page.goto("/?mockConsentSource=default-silent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await expect(page.getByTestId("telemetry-notice")).toBeVisible();
+  });
+
+  test("does NOT show TelemetryNotice when consentSource is stored-explicit", async ({ page }) => {
+    await page.goto("/?mockConsentSource=stored-explicit");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await expect(page.getByTestId("telemetry-notice")).toHaveCount(0);
+  });
+
+  test("does NOT show TelemetryNotice when consentSource is env-forced-off", async ({ page }) => {
+    await page.goto("/?mockConsentSource=env-forced-off");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await expect(page.getByTestId("telemetry-notice")).toHaveCount(0);
+  });
+
+  test("does NOT show TelemetryNotice when consentSource is prompted", async ({ page }) => {
+    await page.goto("/?mockConsentSource=prompted");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await expect(page.getByTestId("telemetry-notice")).toHaveCount(0);
+  });
+
+  test("dismissing the notice hides it immediately", async ({ page }) => {
+    await page.goto("/?mockConsentSource=default-silent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const notice = page.getByTestId("telemetry-notice");
+    await expect(notice).toBeVisible();
+
+    await page.getByTestId("telemetry-notice-dismiss").click();
+    await expect(notice).toHaveCount(0);
+  });
+
+  test("notice 'Settings' link opens the settings popover and closes the notice", async ({ page }) => {
+    await page.goto("/?mockConsentSource=default-silent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await expect(page.getByTestId("telemetry-notice")).toBeVisible();
+    await expect(page.getByTestId("settings-popover")).toHaveCount(0);
+
+    // Click the "Settings" link inside the notice.
+    await page.locator(".telemetry-notice-settings-link").click();
+
+    // Popover opens, notice closes.
+    await expect(page.getByTestId("settings-popover")).toBeVisible();
+    await expect(page.getByTestId("telemetry-notice")).toHaveCount(0);
+  });
+});
+
+test.describe("UI event tracking (track() calls)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+  });
+
+  test("prompt bar submit emits track('prompt.submitted') with length", async ({ page }) => {
+    const textarea = page.locator(".prompt-bar-textarea");
+    await textarea.click();
+    await textarea.fill("Hello agent");
+    await textarea.press("Enter");
+
+    // Wait for the submit to record.
+    await page.waitForFunction(
+      () =>
+        (window as unknown as TestHarnessWindow).__HARNESS_TEST__?.lastInjectInput?.req.text === "Hello agent",
+    );
+
+    // Now wait for the track event.
+    await waitForTrackEvent(page, "prompt.submitted");
+    const events = await getTrackEvents(page);
+    const submitEvent = events.find((e) => e.event === "prompt.submitted");
+    expect(submitEvent).toBeDefined();
+    // Length should be the character count, never the text itself.
+    expect(submitEvent?.data?.length).toBe("Hello agent".length);
+    expect(submitEvent?.data?.text).toBeUndefined();
+  });
+
+  test("telemetry toggle emits track('consent.changed') with optIn value", async ({ page }) => {
+    await page.getByTestId("settings-trigger").click();
+    await expect(page.getByTestId("settings-popover")).toBeVisible();
+
+    // Toggle is off by default in mock mode; clicking turns it on.
+    await page.getByTestId("telemetry-toggle").click();
+
+    await waitForTrackEvent(page, "consent.changed");
+    const events = await getTrackEvents(page);
+    const toggleEvent = events.find((e) => e.event === "consent.changed");
+    expect(toggleEvent).toBeDefined();
+    expect(toggleEvent?.data?.optIn).toBe(true);
+  });
+
+  test("new session creation emits track('session.created')", async ({ page }) => {
+    // Open new session modal.
+    await page.getByTestId("new-session-btn").click();
+    await expect(page.locator(".modal-new-session")).toBeVisible();
+
+    // Use the existing MOCK_LAUNCH_DIR path from the picker.
+    // The directory field is prefilled — just click Start.
+    const startBtn = page.locator(".modal-new-session .btn-primary");
+    await expect(startBtn).toBeEnabled();
+    await startBtn.click();
+
+    // Wait for the modal to close (session created successfully in mock).
+    await expect(page.locator(".modal-new-session")).toHaveCount(0, { timeout: 3_000 });
+
+    await waitForTrackEvent(page, "session.created");
+    const events = await getTrackEvents(page);
+    expect(events.some((e) => e.event === "session.created")).toBe(true);
+  });
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -17,6 +17,7 @@ import { CommandPalette } from "./components/CommandPalette";
 import { DeadSessionPane } from "./components/DeadSessionPane";
 import { PromptBar } from "./components/PromptBar";
 import { SessionBar } from "./components/SessionBar";
+import { TelemetryNotice } from "./components/TelemetryNotice";
 import { Terminal } from "./components/Terminal";
 import { Toast } from "./components/Toast";
 import { WelcomePanel } from "./components/WelcomePanel";
@@ -32,6 +33,9 @@ export const App = (): JSX.Element => {
   const harness = useHarnessState();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [welcomeDismissed, setWelcomeDismissed] = useState(false);
+  // Lifted so the telemetry chip in BrandHeader can open the settings popover
+  // from outside SessionBar (which owns the popover's render).
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(null);
   const [stripColEl, setStripColEl] = useState<HTMLDivElement | null>(null);
   const rowAnchor = useElementTopOffset(selectedRowEl, stripColEl);
@@ -123,7 +127,20 @@ export const App = (): JSX.Element => {
         authenticated={state.authenticated}
         organizationName={state.organizationName}
         onOpenPalette={() => setPaletteOpen(true)}
+        telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+        consentSource={state.consentSource}
+        consentEnvReason={state.consentEnvReason}
+        onOpenSettings={() => setSettingsOpen(true)}
       />
+
+      {state.consentSource === "default-silent" && !harness.settings?.telemetryNoticeDismissed && (
+        <TelemetryNotice
+          onDismiss={() => {
+            void harness.updateSettings({ telemetryNoticeDismissed: true });
+          }}
+          onOpenSettings={() => setSettingsOpen(true)}
+        />
+      )}
 
       <div
         className="app"
@@ -194,6 +211,8 @@ export const App = (): JSX.Element => {
               await harness.updateSettings({ telemetryOptIn: next });
             }}
             busySessionIds={harness.busySessionIds}
+            settingsOpen={settingsOpen}
+            onSetSettingsOpen={setSettingsOpen}
           />
           <div className="terminal-slot">
             {activeSession?.status === "exited" ? (

--- a/packages/harness/web/src/components/BrandHeader.tsx
+++ b/packages/harness/web/src/components/BrandHeader.tsx
@@ -1,22 +1,64 @@
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
+import type { AppState } from "@shared/types";
 
 import sapiomMark from "../assets/sapiom-mark.svg";
 import { getTheme, subscribeTheme, toggleTheme } from "../lib/theme";
 import { Icon } from "./Icon";
 
+type ConsentSource = AppState["consentSource"];
+
 interface BrandHeaderProps {
   authenticated: boolean;
   organizationName: string | null;
   onOpenPalette: () => void;
+  /** Current telemetry opt-in state — drives the tracking indicator chip. */
+  telemetryOptIn: boolean;
+  /** How consent was determined — drives chip label and tooltip. */
+  consentSource?: ConsentSource;
+  /** Which env var forced telemetry off, when consentSource === "env-forced-off". */
+  consentEnvReason?: string | null;
+  /** Called when the tracking chip is clicked — should open the settings popover. */
+  onOpenSettings: () => void;
 }
 
 const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
 const SHORTCUT_HINT = IS_MAC ? "⌘K" : "Ctrl+K";
 
-export function BrandHeader({ authenticated, organizationName, onOpenPalette }: BrandHeaderProps): JSX.Element {
+function chipLabel(telemetryOptIn: boolean, consentSource: ConsentSource): string {
+  if (consentSource === "env-forced-off") return "analytics off (env)";
+  return telemetryOptIn ? "analytics on" : "analytics off";
+}
+
+function chipTooltip(telemetryOptIn: boolean, consentSource: ConsentSource, envReason: string | null | undefined): string {
+  if (consentSource === "env-forced-off") {
+    const reason = envReason ? `$${envReason}` : "environment variable";
+    return `Remote analytics disabled by ${reason}. Click to open settings.`;
+  }
+  if (telemetryOptIn) return "Remote analytics enabled. Click to open settings.";
+  return "Remote analytics disabled. Click to open settings.";
+}
+
+function chipState(telemetryOptIn: boolean, consentSource: ConsentSource): "on" | "off" | "env" {
+  if (consentSource === "env-forced-off") return "env";
+  return telemetryOptIn ? "on" : "off";
+}
+
+export function BrandHeader({
+  authenticated,
+  organizationName,
+  onOpenPalette,
+  telemetryOptIn,
+  consentSource,
+  consentEnvReason,
+  onOpenSettings,
+}: BrandHeaderProps): JSX.Element {
   const [theme, setTheme] = useState(getTheme());
   useEffect(() => subscribeTheme(setTheme), []);
+
+  const state = chipState(telemetryOptIn, consentSource);
+  const label = chipLabel(telemetryOptIn, consentSource);
+  const tooltip = chipTooltip(telemetryOptIn, consentSource, consentEnvReason);
 
   return (
     <header className="brand-header">
@@ -37,6 +79,18 @@ export function BrandHeader({ authenticated, organizationName, onOpenPalette }: 
           <Icon name="Search" size={13} />
           Jump
           <span className="palette-trigger-hint">{SHORTCUT_HINT}</span>
+        </button>
+
+        <button
+          className="telemetry-chip"
+          data-testid="telemetry-chip"
+          data-state={state}
+          aria-label={tooltip}
+          title={tooltip}
+          onClick={onOpenSettings}
+        >
+          <span className="telemetry-chip-dot" aria-hidden="true" />
+          <span className="telemetry-chip-label">{label}</span>
         </button>
 
         <button

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -5,6 +5,7 @@ import type { BackgroundTask, BusMessage, MacroDef, WorkflowInfo } from "@shared
 import { isMockMode } from "../lib/api";
 import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
 import { getTheme, subscribeTheme } from "../lib/theme";
+import { track } from "../lib/track";
 import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 
@@ -119,6 +120,7 @@ export function CanvasPane({
   const handleReVisualize = (): void => {
     if (!visualizeMacro) return;
     onRunMacro(visualizeMacro);
+    track("visualize.triggered");
   };
 
   return (
@@ -195,7 +197,10 @@ export function CanvasPane({
               data-testid="canvas-visualize-cta"
               data-tooltip={visualizeDisabledReason ?? visualizeMacro.label}
               disabled={Boolean(visualizeDisabledReason)}
-              onClick={() => onRunMacro(visualizeMacro)}
+              onClick={() => {
+                onRunMacro(visualizeMacro);
+                track("visualize.triggered");
+              }}
             >
               <Icon name="Sparkles" size={14} /> Visualize
             </button>

--- a/packages/harness/web/src/components/NewSessionModal.tsx
+++ b/packages/harness/web/src/components/NewSessionModal.tsx
@@ -3,6 +3,7 @@ import type { JSX, RefObject } from "react";
 import type { HarnessKind } from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
+import { track } from "../lib/track";
 import { useDismissable } from "../lib/use-dismissable";
 import { DirectoryPicker } from "./DirectoryPicker";
 
@@ -44,6 +45,7 @@ export function NewSessionModal({
     setError(null);
     try {
       await onCreate(trimmed, harness);
+      track("session.created");
       onClose();
     } catch (err) {
       setError((err as Error).message);

--- a/packages/harness/web/src/components/PromptBar.tsx
+++ b/packages/harness/web/src/components/PromptBar.tsx
@@ -26,15 +26,13 @@
  *
  * Draft text is per-session: switching tabs preserves each session's own
  * half-typed text; no cross-session leakage.
- *
- * Analytics seam: when a submit succeeds, emit a prompt.submitted event here.
- * TODO(SAP-analytics): hook the analytics layer at the `// ANALYTICS_SEAM` comment below.
  */
 import { useCallback, useEffect, useRef, useState, type JSX, type KeyboardEvent } from "react";
 
 import type { HarnessSession } from "@shared/types";
 
 import { ApiError } from "../lib/api";
+import { track } from "../lib/track";
 
 export interface PromptBarProps {
   /** The active session, or null when no session is selected. */
@@ -150,7 +148,8 @@ export const PromptBar = ({ session, onSubmit }: PromptBarProps): JSX.Element =>
       await onSubmit(session.id, text);
       setDraft("");
       setReactiveReason(null);
-      // ANALYTICS_SEAM: emit prompt.submitted event here (SAP-analytics).
+      // Emit prompt.submitted — length only, never the text itself.
+      track("prompt.submitted", { length: text.length }, session.id);
       // Focus back in the bar for rapid follow-ups.
       textareaRef.current?.focus();
     } catch (err) {

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "react";
 import type { HarnessKind, HarnessSession, SessionSummary } from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
+import { track } from "../lib/track";
 import { useDismissable } from "../lib/use-dismissable";
 import { Icon } from "./Icon";
 import { NewSessionModal } from "./NewSessionModal";
@@ -29,6 +30,10 @@ interface SessionBarProps {
   /** Session ids with terminal output in roughly the last ~3s — renders a
    *  busy pulse on that session's tab regardless of whether it's active. */
   busySessionIds: Set<string>;
+  /** Controlled open state for the settings popover — lifted to App so the
+   *  telemetry chip in BrandHeader can open it from outside SessionBar. */
+  settingsOpen: boolean;
+  onSetSettingsOpen: (open: boolean) => void;
 }
 
 export function SessionBar({
@@ -49,10 +54,11 @@ export function SessionBar({
   telemetryOptIn,
   onToggleTelemetry,
   busySessionIds,
+  settingsOpen,
+  onSetSettingsOpen,
 }: SessionBarProps): JSX.Element {
   const [historyOpen, setHistoryOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const historyWrapRef = useRef<HTMLDivElement>(null);
   const historyTriggerRef = useRef<HTMLButtonElement>(null);
@@ -61,7 +67,7 @@ export function SessionBar({
   const newSessionTriggerRef = useRef<HTMLButtonElement>(null);
 
   const closeHistory = useCallback(() => setHistoryOpen(false), []);
-  const closeSettings = useCallback(() => setSettingsOpen(false), []);
+  const closeSettings = useCallback(() => onSetSettingsOpen(false), [onSetSettingsOpen]);
   useDismissable(historyOpen, {
     onDismiss: closeHistory,
     containerRef: historyWrapRef,
@@ -109,7 +115,10 @@ export function SessionBar({
               aria-selected={isActive}
               className={"session-tab" + (isActive ? " is-active" : "")}
               data-testid={`session-tab-${session.id}`}
-              onClick={() => onSelectSession(session.id)}
+              onClick={() => {
+                onSelectSession(session.id);
+                track("session.switched", {}, session.id);
+              }}
             >
               <span className="session-dot" data-status={session.status} />
               <span className="session-tab-title">{session.title}</span>
@@ -210,7 +219,7 @@ export function SessionBar({
           className="gear-btn"
           aria-label="Settings"
           data-testid="settings-trigger"
-          onClick={() => setSettingsOpen((prev) => !prev)}
+          onClick={() => onSetSettingsOpen(!settingsOpen)}
         >
           <Icon name="Settings" size={16} />
         </button>
@@ -220,7 +229,7 @@ export function SessionBar({
             organizationName={organizationName}
             telemetryOptIn={telemetryOptIn}
             onToggleTelemetry={onToggleTelemetry}
-            onClose={() => setSettingsOpen(false)}
+            onClose={() => onSetSettingsOpen(false)}
           />
         )}
       </div>

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import type { JSX } from "react";
 import { HARNESS_PATHS } from "@shared/types";
 
+import { track } from "../lib/track";
+
 interface SettingsPopoverProps {
   authenticated: boolean;
   organizationName: string | null;
@@ -20,9 +22,11 @@ export function SettingsPopover({
   const [busy, setBusy] = useState(false);
 
   const handleToggle = async (): Promise<void> => {
+    const next = !telemetryOptIn;
     setBusy(true);
     try {
-      await onToggleTelemetry(!telemetryOptIn);
+      await onToggleTelemetry(next);
+      track("consent.changed", { optIn: next });
     } finally {
       setBusy(false);
     }

--- a/packages/harness/web/src/components/TelemetryNotice.tsx
+++ b/packages/harness/web/src/components/TelemetryNotice.tsx
@@ -1,0 +1,51 @@
+/**
+ * TelemetryNotice — non-blocking first-run notice shown when consent was
+ * determined silently in a non-TTY environment (consentSource === "default-silent").
+ *
+ * Rendered once; dismissed permanently via PATCH /api/settings
+ * (telemetryNoticeDismissed: true).  If the user answered the CLI prompt
+ * (consentSource === "prompted") or telemetry was forced off by the environment
+ * (consentSource === "env-forced-off"), this notice is never shown.
+ *
+ * Points the user at the tracking indicator chip in the top bar and the
+ * settings toggle to change the preference.
+ */
+import type { JSX } from "react";
+
+interface TelemetryNoticeProps {
+  /** Called when the user dismisses the notice. */
+  onDismiss: () => void;
+  /** Called when the user clicks "Settings" — should open the settings popover. */
+  onOpenSettings: () => void;
+}
+
+export function TelemetryNotice({ onDismiss, onOpenSettings }: TelemetryNoticeProps): JSX.Element {
+  return (
+    <div className="telemetry-notice" role="status" data-testid="telemetry-notice">
+      <div className="telemetry-notice-body">
+        <p className="telemetry-notice-text">
+          Analytics are <strong>on by default</strong> — usage events are sent to Sapiom to help improve
+          the product. Change this any time in{" "}
+          <button
+            className="telemetry-notice-settings-link"
+            onClick={() => {
+              onOpenSettings();
+              onDismiss();
+            }}
+          >
+            Settings
+          </button>
+          , or use the indicator in the top bar.
+        </p>
+      </div>
+      <button
+        className="telemetry-notice-dismiss"
+        aria-label="Dismiss analytics notice"
+        data-testid="telemetry-notice-dismiss"
+        onClick={onDismiss}
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowActionStrip.tsx
+++ b/packages/harness/web/src/components/WorkflowActionStrip.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, JSX } from "react";
 import type { MacroDef, WorkflowInfo } from "@shared/types";
 
 import { macroDisabledReason } from "../lib/macro-gating";
+import { track } from "../lib/track";
 import { Icon } from "./Icon";
 
 interface WorkflowActionStripProps {
@@ -51,7 +52,10 @@ export function WorkflowActionStrip({
               data-testid={`macro-${macro.id}`}
               aria-label={disabledReason ? `${macro.label}: ${disabledReason}` : macro.label}
               disabled={Boolean(disabledReason)}
-              onClick={() => onRunMacro(macro)}
+              onClick={() => {
+                onRunMacro(macro);
+                track("macro.invoked", { macroId: macro.id });
+              }}
             >
               <span className="strip-item-icon">
                 <Icon name={macro.icon} size={15} />

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -217,6 +217,17 @@ class MockApi implements HarnessApi {
 
   async getState(): Promise<AppState> {
     await delay();
+    // mockConsentSource query param lets Playwright exercise all chip states:
+    //   ?mockConsentSource=env-forced-off  → "analytics off (env)" chip
+    //   ?mockConsentSource=default-silent  → shows TelemetryNotice
+    //   ?mockConsentSource=stored-explicit → off chip (telemetryOptIn=false)
+    //   ?mockConsentSource=prompted        → on chip (telemetryOptIn=true in mock)
+    const mockConsentSource = typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("mockConsentSource") as AppState["consentSource"] ?? "stored-explicit"
+      : "stored-explicit";
+    const mockEnvReason = typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("mockEnvReason") ?? null
+      : null;
     return {
       version: "0.0.1-mock",
       authenticated: true,
@@ -227,6 +238,8 @@ class MockApi implements HarnessApi {
       workflows: this.workflows,
       macros: MOCK_MACROS,
       launchDir: MOCK_LAUNCH_DIR,
+      consentSource: mockConsentSource,
+      ...(mockEnvReason ? { consentEnvReason: mockEnvReason } : {}),
       ...(this.fresh ? { firstRun: true } : {}),
     };
   }
@@ -396,6 +409,32 @@ class MockApi implements HarnessApi {
     }
     return response;
   }
+}
+
+/**
+ * Intercepts fetch("/api/track") in mock mode so Playwright can assert that
+ * track() calls fire without a real server. Attach BEFORE the app mounts.
+ * Accumulated events are available on window.__HARNESS_TEST__.trackEvents.
+ */
+export function interceptMockTrack(): void {
+  if (!isMockMode()) return;
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url === "/api/track" && init?.method === "POST") {
+      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
+      let body: unknown;
+      try {
+        body = JSON.parse(typeof init.body === "string" ? init.body : "{}");
+      } catch {
+        body = {};
+      }
+      const prev = (win.__HARNESS_TEST__?.trackEvents as unknown[]) ?? [];
+      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), trackEvents: [...prev, body] };
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return originalFetch(input, init);
+  };
 }
 
 export function createApi(): HarnessApi {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -209,11 +209,20 @@ const delay = (ms = 180): Promise<void> => new Promise((resolve) => setTimeout(r
 class MockApi implements HarnessApi {
   // `?mockState=fresh` = brand-new install: nothing yet, firstRun set — see isFreshMockState().
   private readonly fresh = isFreshMockState();
+  // `?mockConsentSource=prompted` mirrors a user who answered yes at the TTY prompt:
+  // telemetryOptIn starts true so the chip shows "analytics on" from the first render.
+  private readonly promptedConsent =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("mockConsentSource") === "prompted";
   private sessions = this.fresh ? [] : MOCK_SESSIONS.map((session) => ({ ...session }));
   private workflows = this.fresh ? [] : MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
   private settings: HarnessSettings = this.fresh
     ? { ...MOCK_SETTINGS, recentDirs: [] }
-    : { ...MOCK_SETTINGS, recentDirs: [...MOCK_SETTINGS.recentDirs] };
+    : {
+        ...MOCK_SETTINGS,
+        recentDirs: [...MOCK_SETTINGS.recentDirs],
+        ...(this.promptedConsent ? { telemetryOptIn: true } : {}),
+      };
 
   async getState(): Promise<AppState> {
     await delay();
@@ -228,12 +237,16 @@ class MockApi implements HarnessApi {
     const mockEnvReason = typeof window !== "undefined"
       ? new URLSearchParams(window.location.search).get("mockEnvReason") ?? null
       : null;
+    // When consent was answered via a TTY prompt ("prompted"), the user
+    // necessarily said yes — mirror that in the mock so the chip shows "on".
+    const telemetryOptIn =
+      mockConsentSource === "prompted" ? true : this.settings.telemetryOptIn;
     return {
       version: "0.0.1-mock",
       authenticated: true,
       userId: "user_mock",
       organizationName: "Acme (mock)",
-      telemetryOptIn: this.settings.telemetryOptIn,
+      telemetryOptIn,
       sessions: this.sessions,
       workflows: this.workflows,
       macros: MOCK_MACROS,

--- a/packages/harness/web/src/lib/track.ts
+++ b/packages/harness/web/src/lib/track.ts
@@ -1,0 +1,53 @@
+/**
+ * UI-interaction analytics — fire-and-forget client capture.
+ *
+ * Posts to POST /api/track (the server's UI analytics endpoint) with the
+ * current boot token.  Never blocks the UI, never retries, silently drops
+ * failures — the server deduplicates via eventId and the local ndjson sink
+ * is the ground truth.  Consent semantics are enforced server-side (same
+ * store-always / remote-per-consent rule as hook events).
+ *
+ * Event names are dot-canonical (e.g. "prompt.submitted"), data is
+ * UI-interaction metadata only — NEVER include prompt text or user content.
+ *
+ * See packages/harness/src/shared/types.ts UiEventName for the full
+ * canonical list and packages/harness/src/core/collector/ for how the
+ * surface:"ui" marker propagates through the pipeline.
+ */
+import type { UiEventName, UiTrackRequest } from "@shared/types";
+
+import { getBootToken } from "./api";
+
+/**
+ * Fire-and-forget UI event capture.
+ *
+ * @param event  Canonical event name (see UiEventName).
+ * @param data   Optional metadata — never include prompt text or PII.
+ * @param harnessSessionId  Associate with this session for seq/session dims.
+ */
+export function track(
+  event: UiEventName,
+  data?: Record<string, unknown>,
+  harnessSessionId?: string,
+): void {
+  const body: UiTrackRequest = {
+    event,
+    ...(data ? { data } : {}),
+    ...(harnessSessionId ? { harnessSessionId } : {}),
+  };
+
+  // Fire-and-forget: never await, never surface errors to the caller.
+  fetch("/api/track", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Harness-Token": getBootToken(),
+    },
+    body: JSON.stringify(body),
+    // keepalive so the request survives a page unload (e.g. session.created
+    // fires right before navigation in some flows).
+    keepalive: true,
+  }).catch(() => {
+    // Intentionally silent — tracking failures must never affect the UI.
+  });
+}

--- a/packages/harness/web/src/main.tsx
+++ b/packages/harness/web/src/main.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.js";
+import { interceptMockTrack } from "./lib/api.js";
 import "./styles.css";
+
+// In mock mode, intercept /api/track calls so Playwright tests can assert
+// that track() events fire without a real server. No-op in real mode.
+interceptMockTrack();
 
 // The shell is viewport-locked (html/body overflow:hidden) — page scroll is
 // never legitimate. overflow:hidden stops user scrolling but NOT the

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -288,6 +288,124 @@ input {
   background: var(--green);
 }
 
+/* Tracking indicator chip — persistent status display left of the org badge.
+   Click opens the settings popover. Three states: on / off / env (forced-off). */
+.telemetry-chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-faint);
+  font-size: 11px;
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.telemetry-chip:hover {
+  background: var(--bg-2);
+  border-color: var(--border);
+  color: var(--text-dim);
+}
+
+.telemetry-chip:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.telemetry-chip-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-faint);
+  transition: background-color var(--transition-fast);
+}
+
+/* on: accent-colored dot — remote analytics active */
+.telemetry-chip[data-state="on"] .telemetry-chip-dot {
+  background: var(--accent);
+}
+
+.telemetry-chip[data-state="on"] {
+  color: var(--text-dim);
+}
+
+/* off / env: muted dot — remote analytics inactive */
+.telemetry-chip[data-state="off"] .telemetry-chip-dot,
+.telemetry-chip[data-state="env"] .telemetry-chip-dot {
+  background: var(--text-faint);
+}
+
+.telemetry-chip-label {
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+}
+
+/* First-run telemetry notice — non-blocking banner shown when consent was
+   determined silently (non-TTY default). Dismissed permanently via settings. */
+.telemetry-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--accent-dim);
+  border-bottom: 1px solid var(--accent-border);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.telemetry-notice-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.telemetry-notice-text {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.telemetry-notice-settings-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.telemetry-notice-settings-link:hover {
+  color: var(--accent-hover);
+}
+
+.telemetry-notice-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-faint);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  transition: color var(--transition-fast);
+}
+
+.telemetry-notice-dismiss:hover {
+  color: var(--text);
+}
+
+.telemetry-notice-dismiss:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
 .app {
   position: relative;
   display: grid;


### PR DESCRIPTION
Unit PR into the v0 integration branch (umbrella: #266).

## Part 1 — bound and surface the adopted consent model

- **Retention cap on `events.ndjson`** (was an unbounded plaintext prompt log): 50 MB / 30 days, age-then-size in O(n), atomic temp+rename, corruption-tolerant — serialized against appends through a new promise queue on the store (`runExclusive`), with a concurrency test proving a sweep can never lose a concurrent append. Boot + 6h periodic.
- **Telemetry chip** in the top bar: `on` / `off` / `off (env)` states (tooltip names the forcing env var), click opens the settings popover. Live-updates with consent changes.
- **First-run notice**: one-time dismissible banner shown ONLY when consent came from the silent non-TTY default (never after an answered CLI prompt); dismissal persists, fail-safe re-show if the persist fails.
- Pre-release checklist note near `DEFAULT_TELEMETRY_OPT_IN`. **README untouched** (owner constraint — verified empty diff).

## Part 2 — ui.* analytics layer

- `POST /api/track` (boot-token guarded, UiEventName-validated, 100KB-bounded): rides the existing collector pipeline — ndjson always, remote per consent, shared per-session `seq`, `surface:"ui"`.
- Fire-and-forget `track()` client wired to six surfaces: `prompt.submitted` (length only — never text), `session.switched`, `macro.invoked` (id only), `visualize.triggered`, `consent.changed` (boolean), `session.created` (no path). **Privacy review: every payload metadata-only, zero user content or paths.**

## Review rounds

Round 1 passed all privacy checks and caught 3 real bugs — UI event names missing from the type union behind an `as` cast, a sweep/append race behind a docstring claiming a queue that didn't exist, and an O(n²) trim loop — all fixed in round 2 with the store queue as the structural fix.

Tests: 726 unit (known pre-existing workspace-rescan flake excepted, passes in isolation) + 91 Playwright (13 new consent/chip/notice specs). Minor changeset.

Closes SAP-1423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)