### PR TITLE
feat(harness): chat-first session view — conversation replaces the terminal (SAP-1477)

### DIFF
--- a/packages/harness/src/core/collector/claude-transcript-tailer.test.ts
+++ b/packages/harness/src/core/collector/claude-transcript-tailer.test.ts
@@ -1,0 +1,569 @@
+import { mkdir, mkdtemp, rm, writeFile, appendFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  tailClaudeTranscript,
+  findClaudeTranscript,
+  transcriptPathForSession,
+  encodeProjectPath,
+  agentSessionIdFromTranscriptPath,
+  type ClaudeTranscriptTailerHandle,
+} from "./claude-transcript-tailer.js";
+import type { ChatTurn, ChatToolCall } from "../../shared/types.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const POLL_MS = 20;
+
+// ---------------------------------------------------------------------------
+// JSONL line helpers — mirrors Claude Code's transcript format
+// ---------------------------------------------------------------------------
+
+function userLine(text: string): string {
+  return JSON.stringify({ type: "user", message: { role: "user", content: text } }) + "\n";
+}
+
+function userLineWithBlocks(blocks: unknown[]): string {
+  return JSON.stringify({ type: "user", message: { role: "user", content: blocks } }) + "\n";
+}
+
+function assistantLine(textOrBlocks: string | unknown[]): string {
+  const content =
+    typeof textOrBlocks === "string"
+      ? [{ type: "text", text: textOrBlocks }]
+      : textOrBlocks;
+  return JSON.stringify({ type: "assistant", message: { role: "assistant", content } }) + "\n";
+}
+
+function summaryLine(summary: string): string {
+  return JSON.stringify({ type: "summary", summary }) + "\n";
+}
+
+function toolUseLine(id: string, name: string, input: unknown = {}): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", id, name, input }],
+    },
+  }) + "\n";
+}
+
+function toolResultLine(toolUseId: string, output: string): string {
+  return JSON.stringify({
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: output }],
+    },
+  }) + "\n";
+}
+
+function assistantWithTextAndTool(text: string, id: string, name: string): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text },
+        { type: "tool_use", id, name, input: {} },
+      ],
+    },
+  }) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// tailClaudeTranscript — incremental tailer
+// ---------------------------------------------------------------------------
+
+describe("tailClaudeTranscript", () => {
+  let dir: string;
+  let transcriptPath: string;
+  let handle: ClaudeTranscriptTailerHandle | undefined;
+  let onTurn: ReturnType<typeof vi.fn<(turn: ChatTurn) => void>>;
+  let onToolCall: ReturnType<typeof vi.fn<(call: ChatToolCall) => void>>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-claude-tailer-"));
+    transcriptPath = join(dir, "session.jsonl");
+    onTurn = vi.fn();
+    onToolCall = vi.fn();
+    onError = vi.fn();
+  });
+
+  afterEach(async () => {
+    handle?.stop();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function start(overrides: { startFromBeginning?: boolean } = {}): ClaudeTranscriptTailerHandle {
+    handle = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      onError,
+      pollIntervalMs: POLL_MS,
+      ...overrides,
+    });
+    return handle;
+  }
+
+  // ── basic emission ──────────────────────────────────────────────────────
+
+  it("waits for the file to appear before emitting anything", async () => {
+    start();
+    await sleep(POLL_MS * 4);
+    expect(onTurn).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    await writeFile(transcriptPath, userLine("hello agent"));
+    await sleep(POLL_MS * 4);
+    expect(onTurn).toHaveBeenCalledWith(expect.objectContaining({ role: "user", content: "hello agent" }));
+  });
+
+  it("emits a user turn for a plain-text user message", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, userLine("build me a leasing workflow"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "user", content: "build me a leasing workflow" }),
+    );
+  });
+
+  it("emits an assistant turn for a text-block assistant message", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, assistantLine("I'll get started on that now."));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "assistant", content: "I'll get started on that now." }),
+    );
+  });
+
+  it("skips summary lines — they are not conversation turns", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, summaryLine("Condensed session history"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).not.toHaveBeenCalled();
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+
+  // ── tool_use / tool_result pairing ──────────────────────────────────────
+
+  it("emits a tool call start when a tool_use block appears in an assistant turn", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, toolUseLine("tu-1", "Read"));
+    await sleep(POLL_MS * 4);
+
+    expect(onToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "Read", status: "start" }),
+    );
+    expect(onTurn).not.toHaveBeenCalled(); // no text block, no turn
+  });
+
+  it("emits a tool call ok when the matching tool_result arrives in a user turn", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, toolUseLine("tu-2", "Write"));
+    await sleep(POLL_MS * 4);
+
+    const startCall = onToolCall.mock.calls[0][0] as ChatToolCall;
+    expect(startCall.status).toBe("start");
+
+    await appendFile(transcriptPath, toolResultLine("tu-2", "ok"));
+    await sleep(POLL_MS * 4);
+
+    expect(onToolCall).toHaveBeenCalledTimes(2);
+    const okCall = onToolCall.mock.calls[1][0] as ChatToolCall;
+    expect(okCall.callId).toBe(startCall.callId); // same callId
+    expect(okCall.status).toBe("ok");
+    expect(okCall.toolName).toBe("Write");
+  });
+
+  it("emits text turn separately from tool_use in a mixed assistant message", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, assistantWithTextAndTool("Looking at the file…", "tu-3", "Read"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "assistant", content: "Looking at the file…" }),
+    );
+    expect(onToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "Read", status: "start" }),
+    );
+  });
+
+  it("does not emit a user turn for a tool_result-only user message", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, toolUseLine("tu-4", "Bash"));
+    await sleep(POLL_MS * 4);
+
+    onTurn.mockClear();
+    await appendFile(transcriptPath, toolResultLine("tu-4", "output here"));
+    await sleep(POLL_MS * 4);
+
+    // onToolCall ok fired, but NO user turn for the result message
+    expect(onTurn).not.toHaveBeenCalled();
+  });
+
+  // ── baseline offset (resume vs startFromBeginning) ───────────────────────
+
+  it("does not backfill content that existed before the tailer started", async () => {
+    await writeFile(
+      transcriptPath,
+      userLine("old turn before start") + assistantLine("old reply"),
+    );
+    start();
+    await sleep(POLL_MS * 6);
+
+    expect(onTurn).not.toHaveBeenCalled();
+
+    await appendFile(transcriptPath, userLine("new turn after start"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledTimes(1);
+    expect(onTurn).toHaveBeenCalledWith(expect.objectContaining({ content: "new turn after start" }));
+  });
+
+  it("with startFromBeginning, emits content that already existed when the tailer started", async () => {
+    await writeFile(transcriptPath, userLine("already there") + assistantLine("already replied"));
+    start({ startFromBeginning: true });
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledTimes(2);
+    const contents = onTurn.mock.calls.map(([t]: [ChatTurn]) => t.content);
+    expect(contents).toContain("already there");
+    expect(contents).toContain("already replied");
+  });
+
+  // ── incremental polling ──────────────────────────────────────────────────
+
+  it("processes lines in file order across multiple poll cycles", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, userLine("first message"));
+    await sleep(POLL_MS * 4);
+    await appendFile(transcriptPath, userLine("second message"));
+    await sleep(POLL_MS * 4);
+
+    const contents = onTurn.mock.calls.map(([t]: [ChatTurn]) => t.content);
+    expect(contents).toEqual(["first message", "second message"]);
+  });
+
+  it("handles a line split across two poll cycles (partial trailing write)", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    const full = userLine("split across polls");
+    const mid = Math.floor(full.length / 2);
+    await appendFile(transcriptPath, full.slice(0, mid));
+    await sleep(POLL_MS * 4);
+    expect(onTurn).not.toHaveBeenCalled();
+
+    await appendFile(transcriptPath, full.slice(mid));
+    await sleep(POLL_MS * 4);
+    expect(onTurn).toHaveBeenCalledWith(expect.objectContaining({ content: "split across polls" }));
+  });
+
+  // ── error handling ───────────────────────────────────────────────────────
+
+  it("reports malformed JSON via onError and keeps tailing valid lines", async () => {
+    await writeFile(transcriptPath, "");
+    start();
+    await sleep(POLL_MS * 4);
+
+    await appendFile(transcriptPath, "not valid json\n");
+    await appendFile(transcriptPath, userLine("still works after garbage"));
+    await sleep(POLL_MS * 4);
+
+    expect(onError).toHaveBeenCalled();
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "still works after garbage" }),
+    );
+  });
+
+  // ── stop() ──────────────────────────────────────────────────────────────
+
+  it("stop() halts polling without throwing", async () => {
+    await writeFile(transcriptPath, "");
+    const h = start();
+    await sleep(POLL_MS * 4);
+    onTurn.mockClear();
+
+    h.stop();
+    await appendFile(transcriptPath, userLine("after stop"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).not.toHaveBeenCalled();
+  });
+
+  // ── readHistory() ────────────────────────────────────────────────────────
+
+  it("readHistory() returns an empty array when the file does not exist", async () => {
+    const h = tailClaudeTranscript({
+      transcriptPath: join(dir, "nonexistent.jsonl"),
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+    expect(hist).toEqual([]);
+  });
+
+  it("readHistory() returns user and assistant turns from an existing transcript", async () => {
+    await writeFile(
+      transcriptPath,
+      userLine("first user turn") +
+        assistantLine("first assistant reply") +
+        userLine("second user turn"),
+    );
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    expect(hist).toHaveLength(3);
+    expect(hist[0]).toMatchObject({ role: "user", content: "first user turn" });
+    expect(hist[1]).toMatchObject({ role: "assistant", content: "first assistant reply" });
+    expect(hist[2]).toMatchObject({ role: "user", content: "second user turn" });
+  });
+
+  it("readHistory() skips summary lines and tool-result-only user messages", async () => {
+    await writeFile(
+      transcriptPath,
+      summaryLine("Condensed history") +
+        userLine("real turn") +
+        toolUseLine("tu-5", "Bash") +
+        toolResultLine("tu-5", "result"),
+    );
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    // Only the plain user turn — summary and tool_result-only user messages filtered
+    const turns = hist.filter((t) => t.role === "user");
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({ content: "real turn" });
+  });
+
+  it("readHistory() preserves ordering of multiple turns", async () => {
+    const lines = [
+      userLine("turn 1"),
+      assistantLine("turn 2"),
+      userLine("turn 3"),
+      assistantLine("turn 4"),
+    ].join("");
+    await writeFile(transcriptPath, lines);
+
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    expect(hist.map((t) => t.content)).toEqual(["turn 1", "turn 2", "turn 3", "turn 4"]);
+  });
+
+  it("readHistory() returns unique turnIds for each turn", async () => {
+    await writeFile(
+      transcriptPath,
+      userLine("msg a") + userLine("msg b") + assistantLine("reply"),
+    );
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    const ids = hist.map((t) => t.turnId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("readHistory() handles a multi-block assistant message (only text blocks returned)", async () => {
+    const line = assistantWithTextAndTool("Let me check that for you.", "tu-6", "Read");
+    await writeFile(transcriptPath, line);
+
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    expect(hist).toHaveLength(1);
+    expect(hist[0]).toMatchObject({ role: "assistant", content: "Let me check that for you." });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encodeProjectPath
+// ---------------------------------------------------------------------------
+
+describe("encodeProjectPath", () => {
+  it("strips leading slash and replaces slashes with dashes", () => {
+    expect(encodeProjectPath("/Users/demo/acme-app")).toBe("-Users-demo-acme-app");
+  });
+
+  it("replaces dots with dashes", () => {
+    expect(encodeProjectPath("/home/user/.config/project")).toBe("-home-user--config-project");
+  });
+
+  it("handles a path without a leading slash", () => {
+    // Unusual, but the function should not crash
+    const result = encodeProjectPath("relative/path");
+    expect(result).toBe("relative-path");
+  });
+
+  it("handles a Windows-style path (backslashes normalized)", () => {
+    // Backslashes should be normalized to forward slashes first
+    const result = encodeProjectPath("C:\\Users\\demo\\project");
+    // colon stripped, then / and . → -
+    expect(result).toMatch(/C-Users-demo-project|C-Users-demo-project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transcriptPathForSession
+// ---------------------------------------------------------------------------
+
+describe("transcriptPathForSession", () => {
+  it("returns the expected path for a given cwd and agentSessionId", () => {
+    const path = transcriptPathForSession("/Users/demo/acme-app", "abc-123", "/home/user");
+    expect(path).toBe("/home/user/.claude/projects/-Users-demo-acme-app/abc-123.jsonl");
+  });
+
+  it("uses the real homedir when homeDir is not provided (smoke check)", () => {
+    const path = transcriptPathForSession("/tmp/test", "sess-1");
+    expect(path).toContain(".claude");
+    expect(path).toContain("sess-1.jsonl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agentSessionIdFromTranscriptPath
+// ---------------------------------------------------------------------------
+
+describe("agentSessionIdFromTranscriptPath", () => {
+  it("extracts the UUID from a transcript path", () => {
+    const uuid = "4b3c2a1d-5e6f-4071-8b9a-0c1d2e3f4a50";
+    const path = `/home/user/.claude/projects/-Users-demo-project/${uuid}.jsonl`;
+    expect(agentSessionIdFromTranscriptPath(path)).toBe(uuid);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaudeTranscript
+// ---------------------------------------------------------------------------
+
+describe("findClaudeTranscript", () => {
+  let homeDir: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "harness-claude-find-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  function projectDir(cwd: string): string {
+    const encoded = encodeProjectPath(cwd);
+    return join(homeDir, ".claude", "projects", encoded);
+  }
+
+  it("returns null when the projects directory does not exist", async () => {
+    const result = await findClaudeTranscript({ cwd: "/tmp/proj", homeDir });
+    expect(result).toBeNull();
+  });
+
+  it("returns the transcript for a specific agentSessionId", async () => {
+    const dir = projectDir("/tmp/proj");
+    await mkdir(dir, { recursive: true });
+    const uuid = "9a1b2c3d-4e5f-4a61-8b7c-6d5e4f3a2b1a";
+    await writeFile(join(dir, `${uuid}.jsonl`), userLine("hi"));
+
+    const found = await findClaudeTranscript({ cwd: "/tmp/proj", homeDir, agentSessionId: uuid });
+    expect(found).toBe(join(dir, `${uuid}.jsonl`));
+  });
+
+  it("returns a constructed path for agentSessionId even when the file does not yet exist", async () => {
+    // findClaudeTranscript with agentSessionId returns the expected path
+    // unconditionally — the tailer's startFromBeginning + poll handles the
+    // file-not-yet-exists case without needing null here.
+    const dir = projectDir("/tmp/proj");
+    await mkdir(dir, { recursive: true });
+
+    const found = await findClaudeTranscript({
+      cwd: "/tmp/proj",
+      homeDir,
+      agentSessionId: "my-session-id",
+    });
+    expect(found).toBe(join(dir, "my-session-id.jsonl"));
+  });
+
+  it("returns the most recently modified transcript when no agentSessionId is given", async () => {
+    const dir = projectDir("/tmp/proj");
+    await mkdir(dir, { recursive: true });
+
+    await writeFile(join(dir, "older.jsonl"), userLine("older"));
+    await sleep(20);
+    await writeFile(join(dir, "newer.jsonl"), userLine("newer"));
+
+    const found = await findClaudeTranscript({ cwd: "/tmp/proj", homeDir });
+    expect(found).toBe(join(dir, "newer.jsonl"));
+  });
+
+  it("ignores non-.jsonl files in the project directory", async () => {
+    const dir = projectDir("/tmp/proj");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "metadata.json"), "{}");
+
+    const found = await findClaudeTranscript({ cwd: "/tmp/proj", homeDir });
+    expect(found).toBeNull();
+  });
+});

--- a/packages/harness/src/core/collector/claude-transcript-tailer.test.ts
+++ b/packages/harness/src/core/collector/claude-transcript-tailer.test.ts
@@ -438,6 +438,168 @@ describe("tailClaudeTranscript", () => {
     expect(hist).toHaveLength(1);
     expect(hist[0]).toMatchObject({ role: "assistant", content: "Let me check that for you." });
   });
+
+  // ── readHistory() — newest-content window ────────────────────────────────
+
+  it("readHistory() returns the NEWEST turns when the transcript exceeds HISTORY_MAX_BYTES", async () => {
+    // Build a transcript that is 3× the 128 KB cap so the oldest turns are
+    // evicted from the window. Each line is padded to a fixed size so we know
+    // exactly which turns end up in the tail window.
+    //
+    // Strategy: write (cap / lineSize) "old" turns then twice that many "new"
+    // turns so the history window contains only the newer half.
+    const HISTORY_MAX_BYTES = 128 * 1024;
+
+    // Each padded user line is approximately 150 bytes; 1000 of them ~= 150 KB.
+    const pad = "x".repeat(100);
+    const makeLine = (label: string) =>
+      JSON.stringify({ type: "user", message: { role: "user", content: `${label} ${pad}` } }) + "\n";
+
+    // Write enough "old" turns to fill >1× cap, then "new" turns to fill another ~2× cap.
+    const LINES_PER_BATCH = Math.ceil(HISTORY_MAX_BYTES / makeLine("old-0000").length) + 10;
+    let content = "";
+    for (let i = 0; i < LINES_PER_BATCH; i++) {
+      content += makeLine(`old-${String(i).padStart(4, "0")}`);
+    }
+    // Marker: last "old" turn that should NOT appear in history window
+    const lastOldTurn = `old-${String(LINES_PER_BATCH - 1).padStart(4, "0")} ${pad}`;
+
+    // Write enough new turns so the combined file is well over 3× cap
+    const newTurnLabel = "newest-turn";
+    for (let i = 0; i < LINES_PER_BATCH * 2; i++) {
+      content += makeLine(`${newTurnLabel}-${String(i).padStart(4, "0")}`);
+    }
+    const lastNewTurn = `${newTurnLabel}-${String(LINES_PER_BATCH * 2 - 1).padStart(4, "0")} ${pad}`;
+
+    await writeFile(transcriptPath, content);
+
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    // The history window should contain the newest turns
+    const contents = hist.map((t) => t.content);
+    expect(contents.some((c) => c.includes(newTurnLabel))).toBe(true);
+    // The very last new turn must be present (it's within the window)
+    expect(contents.some((c) => c.includes(lastNewTurn))).toBe(true);
+    // The old turns that fell before the window should be absent
+    expect(contents.some((c) => c.includes(lastOldTurn))).toBe(false);
+  });
+
+  it("readHistory() drops the first partial line when seeking mid-file", async () => {
+    // Write a file that is just over HISTORY_MAX_BYTES so the seek lands
+    // partway through the second line. The first "line" in the read buffer
+    // will be a fragment and must be dropped.
+    const HISTORY_MAX_BYTES = 128 * 1024;
+    const pad = "y".repeat(100);
+    const makeLine = (label: string) =>
+      JSON.stringify({ type: "user", message: { role: "user", content: `${label} ${pad}` } }) + "\n";
+    const lineSize = makeLine("probe").length;
+
+    // Fill to just beyond the cap so startAt > 0 but small
+    const linesNeeded = Math.ceil(HISTORY_MAX_BYTES / lineSize) + 1;
+    let content = "";
+    for (let i = 0; i < linesNeeded; i++) {
+      content += makeLine(`line-${i}`);
+    }
+    await writeFile(transcriptPath, content);
+
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      onTurn,
+      onToolCall,
+      pollIntervalMs: POLL_MS,
+    });
+    const hist = await h.readHistory();
+    h.stop();
+
+    // All returned turns should be fully-parsed (no JSON errors, clean content)
+    for (const turn of hist) {
+      expect(turn.content).toMatch(/^line-\d+/);
+    }
+    // The very first historical turn (line-0) is outside the window
+    expect(hist.map((t) => t.content).some((c) => c.startsWith("line-0 "))).toBe(false);
+  });
+
+  // ── resume regression — no duplicate turns ────────────────────────────────
+
+  it("resume: readHistory() delivers past turns; fresh new turn arrives exactly once via onTurn", async () => {
+    // Seed a transcript with two historical turns already written
+    const histTurn1 = userLine("historical turn 1");
+    const histTurn2 = assistantLine("historical reply");
+    await writeFile(transcriptPath, histTurn1 + histTurn2);
+
+    // Resume semantics: startFromBeginning = false → tailer starts at EOF,
+    // so the live stream only emits content appended AFTER start.
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      startFromBeginning: false,
+      onTurn,
+      onToolCall,
+      onError,
+      pollIntervalMs: POLL_MS,
+    });
+
+    // Read history synchronously first (as the server does)
+    const hist = await h.readHistory();
+
+    // History path: both seeded turns should appear exactly once
+    expect(hist).toHaveLength(2);
+    expect(hist[0]).toMatchObject({ role: "user", content: "historical turn 1" });
+    expect(hist[1]).toMatchObject({ role: "assistant", content: "historical reply" });
+
+    // Wait for the tailer to resolve its baseline (EOF)
+    await sleep(POLL_MS * 3);
+    // The live stream must NOT have fired for the historical content
+    expect(onTurn).not.toHaveBeenCalled();
+
+    // Append a truly new turn — must arrive exactly once via onTurn
+    await appendFile(transcriptPath, userLine("brand new turn"));
+    await sleep(POLL_MS * 4);
+
+    expect(onTurn).toHaveBeenCalledTimes(1);
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "user", content: "brand new turn" }),
+    );
+
+    h.stop();
+  });
+
+  it("fresh launch (startFromBeginning=true): turns arrive via onTurn, NOT via readHistory duplication", async () => {
+    // A fresh session file — tailer tails from offset 0
+    const h = tailClaudeTranscript({
+      transcriptPath,
+      startFromBeginning: true,
+      onTurn,
+      onToolCall,
+      onError,
+      pollIntervalMs: POLL_MS,
+    });
+
+    // File doesn't exist yet — create it with one turn
+    await writeFile(transcriptPath, userLine("first ever turn"));
+    await sleep(POLL_MS * 4);
+
+    // Live stream delivers the turn
+    expect(onTurn).toHaveBeenCalledTimes(1);
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "first ever turn" }),
+    );
+
+    // readHistory() on a fresh session also sees the same turn — but the
+    // caller (server) only invokes one or the other, not both.
+    // Verify readHistory still returns it correctly.
+    const hist = await h.readHistory();
+    expect(hist).toHaveLength(1);
+    expect(hist[0]).toMatchObject({ content: "first ever turn" });
+
+    h.stop();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/src/core/collector/claude-transcript-tailer.ts
+++ b/packages/harness/src/core/collector/claude-transcript-tailer.ts
@@ -320,15 +320,18 @@ export function tailClaudeTranscript(options: ClaudeTranscriptTailerOptions): Cl
     },
 
     async readHistory(): Promise<ChatTurn[]> {
-      // Read up to HISTORY_MAX_BYTES from the beginning of the transcript
+      // Read up to HISTORY_MAX_BYTES from the END of the transcript so that
+      // long sessions surface the most-recent turns rather than ancient history.
       let content: string;
+      let startAt = 0;
       try {
         const fileStat = await stat(options.transcriptPath);
-        const length = Math.min(fileStat.size, HISTORY_MAX_BYTES);
+        startAt = Math.max(0, fileStat.size - HISTORY_MAX_BYTES);
+        const length = fileStat.size - startAt;
         const handle = await open(options.transcriptPath, "r");
         try {
           const buffer = Buffer.allocUnsafe(length);
-          await handle.read(buffer, 0, length, 0);
+          await handle.read(buffer, 0, length, startAt);
           content = buffer.toString("utf8");
         } finally {
           await handle.close();
@@ -338,8 +341,10 @@ export function tailClaudeTranscript(options: ClaudeTranscriptTailerOptions): Cl
       }
 
       const lines = content.split("\n");
-      // Drop the last line if we hit the byte cap (may be truncated)
-      if (content.length >= HISTORY_MAX_BYTES) lines.pop();
+      // When we started mid-file (startAt > 0) the first bytes may be a
+      // partial JSONL line — drop it so we never feed a truncated record to
+      // the parser.
+      if (startAt > 0) lines.shift();
 
       const { turns } = parseTranscriptLines(lines);
       return turns;

--- a/packages/harness/src/core/collector/claude-transcript-tailer.ts
+++ b/packages/harness/src/core/collector/claude-transcript-tailer.ts
@@ -1,0 +1,420 @@
+/**
+ * Claude Code session transcript tailer — produces chat events (ChatTurn,
+ * ChatToolCall) from Claude Code's session JSONL files.
+ *
+ * Claude Code stores session transcripts at:
+ *   ~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl
+ *
+ * where <encoded-cwd> strips the leading "/" and replaces "/" and "." with "-"
+ * (see ClaudeCodeAdapter.encodeProjectPath / listPastSessions).
+ *
+ * Each line is a JSON object with a `type` field:
+ *   - "user" — user message (content: string | ContentBlock[])
+ *   - "assistant" — assistant turn (message.content: ContentBlock[])
+ *   - "summary" — compact session summary (not a conversation turn)
+ *   - "tool_use" — not directly present; tool_use blocks are inside assistant content
+ *   - "tool_result" — not directly present; follow as user turns with tool_result blocks
+ *
+ * Actual Claude Code JSONL line shapes (observed):
+ *   { "type": "user", "message": { "role": "user", "content": "..." } }
+ *   { "type": "assistant", "message": { "role": "assistant", "content": [...] } }
+ *   { "type": "summary", "summary": "..." }
+ *
+ * The assistant's content array can include:
+ *   { "type": "text", "text": "..." }
+ *   { "type": "tool_use", "id": "...", "name": "...", "input": {...} }
+ *
+ * A following user message may contain:
+ *   { "type": "tool_result", "tool_use_id": "...", "content": "..." }
+ *
+ * This tailer:
+ *   1. Reads history from the transcript on open (modest head + tail to cap I/O)
+ *   2. Polls for new content at the same 300ms cadence as the codex tailer
+ *   3. Translates each new line into chat.turn / chat.tool bus events
+ *
+ * Privacy: outputs only chat UI events — nothing here writes to the analytics
+ * store. The hook pipeline already captures prompts via UserPromptSubmit.
+ */
+
+import { open, stat, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import * as crypto from "node:crypto";
+
+import type { ChatTurn, ChatToolCall } from "../../shared/types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 300;
+
+/** Maximum bytes read for the history snapshot on session open. */
+const HISTORY_MAX_BYTES = 128 * 1024;
+
+export type ChatTurnListener = (turn: ChatTurn) => void;
+export type ChatToolListener = (call: ChatToolCall) => void;
+
+export interface ClaudeTranscriptTailerOptions {
+  transcriptPath: string;
+  onTurn: ChatTurnListener;
+  onToolCall: ChatToolListener;
+  onError?: (err: unknown) => void;
+  pollIntervalMs?: number;
+  /** If true, emit from byte 0 (fresh launch). Default: start after current size. */
+  startFromBeginning?: boolean;
+}
+
+export interface ClaudeTranscriptTailerHandle {
+  stop(): void;
+  /** Read and return history turns (already-written lines) for the open snapshot. */
+  readHistory(): Promise<ChatTurn[]>;
+}
+
+interface TranscriptLine {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+  };
+  summary?: string;
+}
+
+interface ContentBlock {
+  type?: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return (content as ContentBlock[])
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text as string)
+      .join("\n");
+  }
+  return "";
+}
+
+function extractToolUseBlocks(content: unknown): ContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  return (content as ContentBlock[]).filter((b) => b.type === "tool_use" && typeof b.id === "string");
+}
+
+function extractToolResultBlocks(content: unknown): ContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  return (content as ContentBlock[]).filter(
+    (b) => b.type === "tool_result" && typeof b.tool_use_id === "string",
+  );
+}
+
+function makeId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Parse JSONL content into chat turns and tool calls.
+ * Returns them in order as they appear in the transcript.
+ */
+function parseTranscriptLines(lines: string[]): { turns: ChatTurn[]; toolCalls: ChatToolCall[] } {
+  const turns: ChatTurn[] = [];
+  const toolCalls: ChatToolCall[] = [];
+
+  // Track pending tool_use ids so we can emit ok when tool_result arrives
+  const pendingToolUses = new Map<string, { name: string; callId: string }>();
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    let entry: TranscriptLine;
+    try {
+      entry = JSON.parse(line) as TranscriptLine;
+    } catch {
+      continue;
+    }
+
+    const ts = new Date().toISOString();
+
+    if (entry.type === "user") {
+      const content = entry.message?.content;
+      // Check for tool_result blocks first — these are not user messages to show
+      const toolResults = extractToolResultBlocks(content);
+      if (toolResults.length > 0) {
+        for (const block of toolResults) {
+          const pending = pendingToolUses.get(block.tool_use_id ?? "");
+          if (pending) {
+            pendingToolUses.delete(block.tool_use_id ?? "");
+            toolCalls.push({ callId: pending.callId, toolName: pending.name, status: "ok", ts });
+          }
+        }
+        // A user message can be ONLY tool_results (no text turn) or mixed
+        const text = extractText(
+          Array.isArray(content) ? content.filter((b: ContentBlock) => b.type !== "tool_result") : content,
+        );
+        if (text.trim()) {
+          turns.push({ turnId: makeId(), role: "user", content: text.trim(), ts });
+        }
+      } else {
+        const text = extractText(content);
+        if (text.trim()) {
+          turns.push({ turnId: makeId(), role: "user", content: text.trim(), ts });
+        }
+      }
+    } else if (entry.type === "assistant") {
+      const content = entry.message?.content;
+
+      // Emit tool_use starts before the text turn
+      const toolUseBlocks = extractToolUseBlocks(content);
+      for (const block of toolUseBlocks) {
+        const callId = makeId();
+        const name = typeof block.name === "string" ? block.name : "unknown";
+        const id = typeof block.id === "string" ? block.id : "";
+        if (id) pendingToolUses.set(id, { name, callId });
+        toolCalls.push({ callId, toolName: name, status: "start", ts });
+      }
+
+      const text = extractText(
+        Array.isArray(content) ? content.filter((b: ContentBlock) => b.type !== "tool_use") : content,
+      );
+      if (text.trim()) {
+        turns.push({ turnId: makeId(), role: "assistant", content: text.trim(), ts });
+      }
+    }
+    // "summary" lines are not conversation turns — skip
+  }
+
+  return { turns, toolCalls };
+}
+
+/**
+ * Tail a Claude Code session transcript JSONL, emitting chat events for new
+ * content. The handle's `readHistory()` provides the already-written portion.
+ */
+export function tailClaudeTranscript(options: ClaudeTranscriptTailerOptions): ClaudeTranscriptTailerHandle {
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let offset = 0;
+  let carry = "";
+  let stopped = false;
+  let polling = false;
+
+  // Track pending tool_use ids across incremental polls
+  const pendingToolUses = new Map<string, { name: string; callId: string }>();
+
+  // Resolve the baseline offset exactly once before polling starts
+  let baselineResolved = false;
+  if (options.startFromBeginning) {
+    baselineResolved = true;
+  } else {
+    void stat(options.transcriptPath).then(
+      (s) => {
+        offset = s.size;
+        baselineResolved = true;
+      },
+      () => {
+        baselineResolved = true;
+      },
+    );
+  }
+
+  const timer = setInterval(() => {
+    void poll();
+  }, pollIntervalMs);
+  timer.unref?.();
+
+  async function poll(): Promise<void> {
+    if (stopped || polling || !baselineResolved) return;
+    polling = true;
+    try {
+      const fileStat = await stat(options.transcriptPath);
+      if (fileStat.size <= offset) return;
+
+      const handle = await open(options.transcriptPath, "r");
+      try {
+        const length = fileStat.size - offset;
+        const buffer = Buffer.allocUnsafe(length);
+        await handle.read(buffer, 0, length, offset);
+        offset = fileStat.size;
+
+        const chunk = carry + buffer.toString("utf8");
+        const lines = chunk.split("\n");
+        carry = lines.pop() ?? "";
+        for (const line of lines) processLine(line, new Date().toISOString());
+      } finally {
+        await handle.close();
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        options.onError?.(err);
+      }
+    } finally {
+      polling = false;
+    }
+  }
+
+  function processLine(raw: string, ts: string): void {
+    const line = raw.trim();
+    if (!line) return;
+    let entry: TranscriptLine;
+    try {
+      entry = JSON.parse(line) as TranscriptLine;
+    } catch (err) {
+      options.onError?.(err);
+      return;
+    }
+    translateLine(entry, ts);
+  }
+
+  function translateLine(entry: TranscriptLine, ts: string): void {
+    if (entry.type === "user") {
+      const content = entry.message?.content;
+      const toolResults = extractToolResultBlocks(content);
+      if (toolResults.length > 0) {
+        for (const block of toolResults) {
+          const pending = pendingToolUses.get(block.tool_use_id ?? "");
+          if (pending) {
+            pendingToolUses.delete(block.tool_use_id ?? "");
+            options.onToolCall({ callId: pending.callId, toolName: pending.name, status: "ok", ts });
+          }
+        }
+        const textContent = Array.isArray(content)
+          ? content.filter((b: ContentBlock) => b.type !== "tool_result")
+          : content;
+        const text = extractText(textContent);
+        if (text.trim()) {
+          options.onTurn({ turnId: makeId(), role: "user", content: text.trim(), ts });
+        }
+      } else {
+        const text = extractText(content);
+        if (text.trim()) {
+          options.onTurn({ turnId: makeId(), role: "user", content: text.trim(), ts });
+        }
+      }
+    } else if (entry.type === "assistant") {
+      const content = entry.message?.content;
+
+      const toolUseBlocks = extractToolUseBlocks(content);
+      for (const block of toolUseBlocks) {
+        const callId = makeId();
+        const name = typeof block.name === "string" ? block.name : "unknown";
+        const id = typeof block.id === "string" ? block.id : "";
+        if (id) pendingToolUses.set(id, { name, callId });
+        options.onToolCall({ callId, toolName: name, status: "start", ts });
+      }
+
+      const textContent = Array.isArray(content)
+        ? content.filter((b: ContentBlock) => b.type !== "tool_use")
+        : content;
+      const text = extractText(textContent);
+      if (text.trim()) {
+        options.onTurn({ turnId: makeId(), role: "assistant", content: text.trim(), ts });
+      }
+    }
+    // "summary" lines are not conversation turns — skip
+  }
+
+  return {
+    stop(): void {
+      stopped = true;
+      clearInterval(timer);
+    },
+
+    async readHistory(): Promise<ChatTurn[]> {
+      // Read up to HISTORY_MAX_BYTES from the beginning of the transcript
+      let content: string;
+      try {
+        const fileStat = await stat(options.transcriptPath);
+        const length = Math.min(fileStat.size, HISTORY_MAX_BYTES);
+        const handle = await open(options.transcriptPath, "r");
+        try {
+          const buffer = Buffer.allocUnsafe(length);
+          await handle.read(buffer, 0, length, 0);
+          content = buffer.toString("utf8");
+        } finally {
+          await handle.close();
+        }
+      } catch {
+        return [];
+      }
+
+      const lines = content.split("\n");
+      // Drop the last line if we hit the byte cap (may be truncated)
+      if (content.length >= HISTORY_MAX_BYTES) lines.pop();
+
+      const { turns } = parseTranscriptLines(lines);
+      return turns;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery: find the transcript file for a Claude Code session
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a project cwd the same way Claude Code does for its transcript
+ * directory names: strip leading "/" and replace "/" and "." with "-".
+ */
+export function encodeProjectPath(cwd: string): string {
+  const normalized = cwd.replace(/\\/g, "/");
+  return normalized.replace(/:/g, "").replace(/[/.]/g, "-");
+}
+
+export interface FindTranscriptOptions {
+  cwd: string;
+  /** Match a specific agent session id (UUID = transcript basename). */
+  agentSessionId?: string;
+  /** Override for tests. */
+  homeDir?: string;
+}
+
+/**
+ * Find the transcript file for a Claude Code session.
+ * With `agentSessionId`: returns `<projects-dir>/<encoded-cwd>/<id>.jsonl`.
+ * Without: returns the most-recently-modified transcript in the cwd directory.
+ */
+export async function findClaudeTranscript(options: FindTranscriptOptions): Promise<string | null> {
+  const homeDir = options.homeDir ?? homedir();
+  const projectDir = join(homeDir, ".claude", "projects", encodeProjectPath(options.cwd));
+
+  if (options.agentSessionId) {
+    return join(projectDir, `${options.agentSessionId}.jsonl`);
+  }
+
+  // Find most-recently-modified .jsonl in the project directory
+  let entries: string[];
+  try {
+    entries = await readdir(projectDir);
+  } catch {
+    return null;
+  }
+
+  let best: { path: string; mtimeMs: number } | null = null;
+  for (const entry of entries) {
+    if (!entry.endsWith(".jsonl")) continue;
+    const filePath = join(projectDir, entry);
+    try {
+      const s = await stat(filePath);
+      if (!best || s.mtimeMs > best.mtimeMs) {
+        best = { path: filePath, mtimeMs: s.mtimeMs };
+      }
+    } catch {
+      // Skip unreadable files
+    }
+  }
+  return best?.path ?? null;
+}
+
+/**
+ * Return a transcript path given a session's agentSessionId and cwd.
+ * Called from server/index.ts when a session becomes running (hooks adapter).
+ */
+export function transcriptPathForSession(cwd: string, agentSessionId: string, homeDir?: string): string {
+  const home = homeDir ?? homedir();
+  return join(home, ".claude", "projects", encodeProjectPath(cwd), `${agentSessionId}.jsonl`);
+}
+
+/** Extract just the session id (UUID) from a transcript file path. */
+export function agentSessionIdFromTranscriptPath(transcriptPath: string): string {
+  return basename(transcriptPath, ".jsonl");
+}

--- a/packages/harness/src/core/inject/claude-settings.test.ts
+++ b/packages/harness/src/core/inject/claude-settings.test.ts
@@ -17,7 +17,7 @@ describe("generateClaudeSettings", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("writes settings.json registering all six hooks pointed at emit.cjs", async () => {
+  it("writes settings.json registering all hooks pointed at emit.cjs", async () => {
     const { settingsPath, emitScriptPath } = await generateClaudeSettings({
       harnessSessionId: "session-abc",
       generatedRoot: tmpDir,
@@ -27,7 +27,8 @@ describe("generateClaudeSettings", () => {
     expect(emitScriptPath).toBe(path.join(tmpDir, "session-abc", "emit.cjs"));
 
     const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
-    const events = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SessionEnd"];
+    // Notification added so the chat attention banner can fire on permission prompts.
+    const events = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SessionEnd", "Notification"];
     expect(Object.keys(settings.hooks).sort()).toEqual([...events].sort());
 
     for (const event of events) {
@@ -63,6 +64,7 @@ describe("generateClaudeSettings", () => {
     });
     expect(second.settingsPath).toBe(first.settingsPath);
     const settings = JSON.parse(await fs.readFile(second.settingsPath, "utf8"));
-    expect(Object.keys(settings.hooks)).toHaveLength(6);
+    // 7 hooks: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd, Notification.
+    expect(Object.keys(settings.hooks)).toHaveLength(7);
   });
 });

--- a/packages/harness/src/core/inject/claude-settings.ts
+++ b/packages/harness/src/core/inject/claude-settings.ts
@@ -13,7 +13,11 @@ import * as path from "node:path";
 import { HARNESS_PATHS } from "../../shared/types.js";
 import { expandHome } from "../paths.js";
 
-/** The six Claude Code hook events the harness listens for. */
+/**
+ * The Claude Code hook events the harness listens for.
+ * `Notification` fires when Claude Code needs user attention (e.g. a tool
+ * permission prompt in auto mode) — used to show the chat attention banner.
+ */
 const HOOK_EVENTS = [
   "SessionStart",
   "UserPromptSubmit",
@@ -21,6 +25,7 @@ const HOOK_EVENTS = [
   "PostToolUse",
   "Stop",
   "SessionEnd",
+  "Notification",
 ] as const;
 
 export type ClaudeHookEvent = (typeof HOOK_EVENTS)[number];

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -699,12 +699,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     normalize: normalizeHookEvent,
     resolveSession: resolveIngestSession,
     onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
+      // Capture whether this harness session had a prior agent session before
+      // updating — used by startClaudeChatTailerFor to distinguish a fresh
+      // launch (tail from offset 0) from a resume (tail from EOF, history
+      // provides the past turns).
+      const priorSession = sessionManager.get(harnessSessionId);
+      const isResume = priorSession?.agentSessionId != null && priorSession.agentSessionId !== agentSessionId;
       sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
       // For claude-code sessions, start the chat transcript tailer now that
       // we know the transcript file path (it's keyed by agentSessionId).
       const session = sessionManager.get(harnessSessionId);
       if (session && adapters[session.harness]?.eventSource === "hooks") {
-        startClaudeChatTailerFor(harnessSessionId, agentSessionId).catch((err: unknown) => {
+        startClaudeChatTailerFor(harnessSessionId, agentSessionId, isResume).catch((err: unknown) => {
           console.error("[harness] claude chat tailer startup failed:", err);
         });
       }
@@ -780,7 +786,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const claudeChatTailers = new Map<string, ClaudeTranscriptTailerHandle>();
 
   /** Start tailing the Claude Code transcript for chat events. */
-  async function startClaudeChatTailerFor(harnessSessionId: string, agentSessionId: string): Promise<void> {
+  async function startClaudeChatTailerFor(harnessSessionId: string, agentSessionId: string, isResume: boolean): Promise<void> {
     if (claudeChatTailers.has(harnessSessionId)) return;
     const session = sessionManager.get(harnessSessionId);
     if (!session) return;
@@ -788,10 +794,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     const transcriptPath = transcriptPathForSession(session.cwd, agentSessionId, options.claudeHomeDir);
     const tailer = tailClaudeTranscript({
       transcriptPath,
-      // A fresh launch: start from beginning so we capture the first user prompt.
-      // A resume: also start from beginning to deliver the full history snapshot,
-      // but the historical turns go through readHistory() not the live stream.
-      startFromBeginning: true,
+      // Fresh session: tail from offset 0 to capture the first user prompt as
+      // it arrives. Resume: tail from EOF so the live stream only delivers NEW
+      // content; readHistory() supplies the past turns (sent via chat.history).
+      // Tailing from 0 on a resume would duplicate every historical turn — once
+      // via the live stream and once via the history snapshot.
+      startFromBeginning: !isResume,
       onTurn: (turn) => {
         bus.publish({ type: "chat.turn", harnessSessionId, turn });
       },

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -38,6 +38,11 @@ import { normalizeHookEvent } from "../core/collector/normalizer.js";
 import { enrichTurnCompleted } from "../core/collector/transcript.js";
 import { createSeqCounter } from "../core/collector/seq.js";
 import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "../core/collector/codex-tailer.js";
+import {
+  tailClaudeTranscript,
+  transcriptPathForSession,
+  type ClaudeTranscriptTailerHandle,
+} from "../core/collector/claude-transcript-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
 import { pruneDeadRecentDirs } from "../cli/settings.js";
 import type { HarnessIdentity } from "../cli/auth.js";
@@ -133,6 +138,10 @@ export interface HarnessServerOptions {
    * (`<home>/.codex/sessions/...`). Defaults to the real OS home dir; tests
    * point this at a fixture tree instead of touching `~/.codex` for real. */
   codexHomeDir?: string;
+  /** Overrides the home directory Claude Code transcript discovery scans
+   * (`<home>/.claude/projects/...`). Defaults to the real OS home dir; tests
+   * point this at a fixture tree instead of touching `~/.claude` for real. */
+  claudeHomeDir?: string;
   /** Directory the built SPA lives in. Defaults to dist/web next to this module. */
   webDir?: string;
   /** The directory the CLI was launched against — scanned for workflows at
@@ -691,6 +700,14 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     resolveSession: resolveIngestSession,
     onAgentSessionResolved: (harnessSessionId, agentSessionId) => {
       sessionManager.setAgentSessionId(harnessSessionId, agentSessionId);
+      // For claude-code sessions, start the chat transcript tailer now that
+      // we know the transcript file path (it's keyed by agentSessionId).
+      const session = sessionManager.get(harnessSessionId);
+      if (session && adapters[session.harness]?.eventSource === "hooks") {
+        startClaudeChatTailerFor(harnessSessionId, agentSessionId).catch((err: unknown) => {
+          console.error("[harness] claude chat tailer startup failed:", err);
+        });
+      }
     },
     onSessionReady: (harnessSessionId) => {
       sessionManager.setReady(harnessSessionId);
@@ -717,6 +734,28 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         portDetector.flush(event.harnessSessionId);
       }
     },
+    onRawHookEvent: (hookEvent, harnessSessionId, payload) => {
+      if (hookEvent === "Notification") {
+        // The Notification hook fires when Claude Code needs user attention —
+        // e.g. a tool-permission prompt in auto mode. Show the attention banner
+        // in the chat view. The `message` field carries the prompt text (when
+        // present); fall back to a generic message.
+        const message =
+          typeof payload.message === "string" && payload.message.trim()
+            ? payload.message.trim()
+            : "Claude is asking permission to run a command";
+        bus.publish({ type: "chat.attention", harnessSessionId, message });
+      } else if (
+        hookEvent === "PreToolUse" ||
+        hookEvent === "PostToolUse" ||
+        hookEvent === "Stop" ||
+        hookEvent === "UserPromptSubmit"
+      ) {
+        // Any subsequent hook activity means the permission prompt was answered
+        // or the session moved on — clear the attention banner.
+        bus.publish({ type: "chat.attention", harnessSessionId, message: "" });
+      }
+    },
     onError: (err) => console.error("[harness] ingest processing error:", err),
     seqCounter,
   };
@@ -733,6 +772,47 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // same seqCounter. On "exited", synthesize the SessionEnd the rollout
   // format has no line of its own for, and stop.
   const codexTailers = new Map<string, CodexTailerHandle>();
+
+  // Claude Code transcript tailers for chat events: keyed by harnessSessionId,
+  // started when the session's agentSessionId becomes known (the SessionStart
+  // hook fires and onAgentSessionResolved is called). Produces chat.turn and
+  // chat.tool bus events — UI-transport only, not written to analytics.
+  const claudeChatTailers = new Map<string, ClaudeTranscriptTailerHandle>();
+
+  /** Start tailing the Claude Code transcript for chat events. */
+  async function startClaudeChatTailerFor(harnessSessionId: string, agentSessionId: string): Promise<void> {
+    if (claudeChatTailers.has(harnessSessionId)) return;
+    const session = sessionManager.get(harnessSessionId);
+    if (!session) return;
+
+    const transcriptPath = transcriptPathForSession(session.cwd, agentSessionId, options.claudeHomeDir);
+    const tailer = tailClaudeTranscript({
+      transcriptPath,
+      // A fresh launch: start from beginning so we capture the first user prompt.
+      // A resume: also start from beginning to deliver the full history snapshot,
+      // but the historical turns go through readHistory() not the live stream.
+      startFromBeginning: true,
+      onTurn: (turn) => {
+        bus.publish({ type: "chat.turn", harnessSessionId, turn });
+      },
+      onToolCall: (call) => {
+        bus.publish({ type: "chat.tool", harnessSessionId, call });
+      },
+      onError: (err) => {
+        console.error(`[harness] claude chat tailer error for session ${harnessSessionId}:`, err);
+      },
+    });
+    claudeChatTailers.set(harnessSessionId, tailer);
+
+    // Deliver history snapshot immediately (fire-and-forget, non-blocking)
+    void tailer.readHistory().then((turns) => {
+      if (turns.length > 0) {
+        bus.publish({ type: "chat.history", history: { harnessSessionId, turns } });
+      }
+    }).catch((err: unknown) => {
+      console.error(`[harness] claude chat tailer history read failed for session ${harnessSessionId}:`, err);
+    });
+  }
 
   async function discoverCodexRolloutPath(session: HarnessSession): Promise<string | null> {
     const deadline = Date.now() + CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS;
@@ -784,6 +864,32 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         void processIngest(body, ingestDeps, seqCounter).catch((err: unknown) => {
           console.error("[harness] codex tailer ingest error:", err);
         });
+        // Also publish chat events for the conversation view — UI-transport
+        // only, not written to analytics. Map codex hook events to chat shapes.
+        const ts = new Date().toISOString();
+        if (hookEvent === "UserPromptSubmit" && typeof payload.prompt === "string" && payload.prompt.trim()) {
+          bus.publish({
+            type: "chat.turn",
+            harnessSessionId,
+            turn: {
+              turnId: `codex-user-${Date.now()}`,
+              role: "user",
+              content: payload.prompt.trim() as string,
+              ts,
+            },
+          });
+        } else if (hookEvent === "PostToolUse" && typeof payload.tool_name === "string") {
+          bus.publish({
+            type: "chat.tool",
+            harnessSessionId,
+            call: {
+              callId: `codex-tool-${Date.now()}`,
+              toolName: payload.tool_name as string,
+              status: "ok",
+              ts,
+            },
+          });
+        }
       },
       onError: (err) => console.error("[harness] codex tailer parse error:", err),
     });
@@ -808,6 +914,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         tailer.emitSessionEnd(session.exitCode != null ? `pty exited (code ${session.exitCode})` : undefined);
         codexTailers.delete(session.id);
       }
+    }
+  });
+
+  // Stop claude chat tailers when sessions exit (the analytics tailer for
+  // codex is handled above; this covers the hooks-sourced claude-code tailer).
+  sessionManager.onStatusChange((session) => {
+    if (session.status !== "exited") return;
+    const tailer = claudeChatTailers.get(session.id);
+    if (tailer) {
+      tailer.stop();
+      claudeChatTailers.delete(session.id);
     }
   });
 
@@ -893,6 +1010,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       workspaceWatcher.stopAll();
       for (const tailer of codexTailers.values()) tailer.stop();
       codexTailers.clear();
+      for (const tailer of claudeChatTailers.values()) tailer.stop();
+      claudeChatTailers.clear();
       // Closing the HTTP/WS server doesn't touch unrelated child processes
       // on its own — without this, every live claude/codex pty outlives
       // the harness server itself (e.g. after Ctrl+C or in a script that

--- a/packages/harness/src/server/ingest.ts
+++ b/packages/harness/src/server/ingest.ts
@@ -56,6 +56,13 @@ export interface IngestDeps {
    *  enrichment), before it's persisted — e.g. to feed a tool.call event's
    *  command/output text to dev-server port detection. */
   onNormalizedEvent?: (event: AnalyticsEvent) => void;
+  /**
+   * Called for every raw hook event BEFORE normalization — fired even for
+   * hook events that don't produce analytics events (e.g. `Notification`).
+   * Used to drive UI-transport-only signals such as the chat attention banner
+   * without going through the analytics normalize/store pipeline.
+   */
+  onRawHookEvent?: (hookEvent: string, harnessSessionId: string, payload: Record<string, unknown>) => void;
   onError?: (err: unknown) => void;
   /** Injectable for tests; defaults to a fresh per-router counter. */
   seqCounter?: SeqCounter;
@@ -96,6 +103,12 @@ export async function processIngest(
   if (!session) return;
 
   const hookPayload = body.payload ?? {};
+
+  // Fire before normalization so callers can observe hook events that don't
+  // produce analytics events (e.g. Notification — no analytics, but the chat
+  // attention banner needs to know it fired).
+  deps.onRawHookEvent?.(hookEvent, harnessSessionId, hookPayload);
+
   const event = deps.normalize(hookEvent, hookPayload, {
     userId: session.userId,
     tenantId: session.tenantId,

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -294,6 +294,43 @@ export type TerminalControlMessage = TerminalResizeMessage;
 // Event-bus WebSocket  (/ws/events?token=<boot token>)  — server → client
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Chat events (UI-transport only — never written to the analytics store)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single conversation turn delivered to the chat view. `streaming: true`
+ * means the turn is still in progress (content may grow); `streaming: false`
+ * (or absent) marks the final, settled version. The SPA merges by `turnId`.
+ */
+export interface ChatTurn {
+  /** Stable id for this turn — used to merge streaming updates. */
+  turnId: string;
+  role: "user" | "assistant";
+  /** Markdown text — rendered safely (no dangerouslySetInnerHTML). */
+  content: string;
+  /** True while the turn is still being streamed; omitted on final delivery. */
+  streaming?: boolean;
+  ts: string;
+}
+
+/**
+ * A tool invocation inline in the conversation. One event per status
+ * transition: start → ok | error. The SPA merges by `callId`.
+ */
+export interface ChatToolCall {
+  callId: string;
+  toolName: string;
+  status: "start" | "ok" | "error";
+  ts: string;
+}
+
+/** History snapshot delivered once when a chat session opens/resumes. */
+export interface ChatHistory {
+  harnessSessionId: string;
+  turns: ChatTurn[];
+}
+
 export type BusMessage =
   | { type: "session.status"; session: HarnessSession }
   | { type: "canvas.reload"; harnessSessionId: string }
@@ -313,7 +350,44 @@ export type BusMessage =
    * on /ws/events, which only the session with an open /ws/terminal socket
    * receives. Drives the SPA's per-tab busy pulse for background sessions.
    */
-  | { type: "session.activity"; harnessSessionId: string; at: string };
+  | { type: "session.activity"; harnessSessionId: string; at: string }
+  /**
+   * A single chat turn (user prompt or assistant response). UI-transport only —
+   * never written to the analytics store. The SPA upserts by turnId.
+   */
+  | { type: "chat.turn"; harnessSessionId: string; turn: ChatTurn }
+  /**
+   * A tool call inline in the conversation. UI-transport only. The SPA
+   * merges by callId.
+   */
+  | { type: "chat.tool"; harnessSessionId: string; call: ChatToolCall }
+  /**
+   * Delivered once per session open/resume: the current transcript history so
+   * the chat view isn't empty on reconnect.
+   */
+  | { type: "chat.history"; history: ChatHistory }
+  /**
+   * Emitted when Claude Code's `Notification` hook fires — the agent is
+   * blocked on a TUI permission prompt and the chat surface should show a
+   * banner prompting the user to review in the Terminal. Cleared by the next
+   * hook activity (PreToolUse / PostToolUse / Stop) or a session status change.
+   * UI-transport only — never written to the analytics store.
+   */
+  | { type: "chat.attention"; harnessSessionId: string; message: string };
+
+// ---------------------------------------------------------------------------
+// Adapter registry (GET /api/harnesses — SAP-1435 consumer)
+// ---------------------------------------------------------------------------
+
+/** One entry in the adapter registry, as the SPA sees it. */
+export interface HarnessEntry {
+  id: HarnessKind;
+  label: string;
+  /** False when the adapter can be spawned (spawn gated by POST /sessions). */
+  disabled: boolean;
+  /** Human-readable reason why the adapter is disabled, for a tooltip. */
+  disabledReason?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Analytics events

--- a/packages/harness/web/e2e/chat.spec.ts
+++ b/packages/harness/web/e2e/chat.spec.ts
@@ -477,3 +477,75 @@ test("when Terminal tab is active, the chat panel is hidden and the terminal pan
   await expect(page.getByTestId("center-panel-terminal")).toBeAttached();
   await expect(page.getByTestId("center-panel-terminal")).not.toHaveAttribute("hidden");
 });
+
+// ---------------------------------------------------------------------------
+// Directive: no machinery terms leak to the user surface
+// ---------------------------------------------------------------------------
+
+test("banned machinery terms never appear in the chat surface innerText", async ({ page }) => {
+  // Build a "busy" mock session: historical turns, a tool chip, an attention
+  // banner, and a slash-command system note — everything the UI can show.
+  // Then assert that no internal implementation term leaks to the visible text.
+
+  // 1. Seed history turns (via chat.history)
+  await publishHistory(page, {
+    sessionId: "sess-boot",
+    turns: [
+      { role: "user", content: "Show me the project structure" },
+      { role: "assistant", content: "I will explore the directory tree." },
+    ],
+  });
+  await expect(page.getByTestId("chat-turns")).toBeVisible();
+
+  // 2. Add a live assistant turn (via chat.turn)
+  await publishTurn(page, {
+    sessionId: "sess-boot",
+    role: "assistant",
+    content: "Running a scan of your workspace now.",
+    turnId: "banned-live-1",
+  });
+  await expect(page.locator("[data-turn-id=banned-live-1]")).toBeVisible();
+
+  // 3. Publish a tool chip (chat.tool)
+  await publish(page, {
+    type: "chat.tool",
+    harnessSessionId: "sess-boot",
+    call: {
+      callId: "tool-banned-1",
+      name: "Bash",
+      state: "running",
+      input: "ls -la",
+    },
+  });
+
+  // 4. Show the attention banner (chat.attention)
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-boot",
+    message: "Claude is asking permission to run a command",
+  });
+  await expect(page.getByTestId("chat-attention-banner")).toBeVisible();
+
+  // 5. Send a slash command so the system note appears in the chat
+  const textarea = page.locator(".prompt-bar-textarea");
+  await textarea.click();
+  await textarea.fill("/model claude-opus-4-5");
+  await textarea.press("Enter");
+  await page.waitForFunction(
+    () =>
+      (window as unknown as TestHarness).__HARNESS_TEST__?.lastInjectInput?.req.text ===
+      "/model claude-opus-4-5",
+  );
+  await expect(page.getByTestId("chat-system-note")).toBeVisible();
+
+  // Grab the full visible text of the chat pane
+  const chatView = page.getByTestId("chat-view");
+  const visibleText = (await chatView.innerText()).toLowerCase();
+
+  // Assert no internal machinery terms appear to the user.
+  // These words belong to the implementation layer, not the user-facing layer.
+  const banned = ["hook", "analytics", "telemetry", "ingest", "collector"];
+  for (const term of banned) {
+    expect(visibleText, `"${term}" must not appear in the chat surface`).not.toContain(term);
+  }
+});

--- a/packages/harness/web/e2e/chat.spec.ts
+++ b/packages/harness/web/e2e/chat.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * Chat view smoke tests — exercises the chat-first center pane against the
+ * mock tier (VITE_MOCK=1), no harness server required.
+ *
+ * Tests cover:
+ *  - Chat view renders as the default center pane for a running session
+ *  - Chat turns appear from bus-driven chat events via __HARNESS_TEST__.publish
+ *  - Terminal tab reachable + xterm mount stays in the DOM across tab flips
+ *  - Slash command → verbatim submit + system note with Terminal link
+ *  - Non-slash submit → no system note
+ *  - Harness label shows the right text per session kind (claude-code / codex)
+ *  - Per-session chat state isolation: sessions don't bleed into each other
+ *  - Switching sessions resets the center pane to "chat"
+ *  - Empty-state renders when no turns have arrived yet
+ *  - chat.history bus event populates history turns
+ */
+import { expect, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+type TestHarness = {
+  __HARNESS_TEST__: {
+    publish: (message: unknown) => void;
+    lastInjectInput?: { id: string; req: { text: string; submit?: boolean } };
+  };
+};
+
+const publish = (page: import("@playwright/test").Page, message: unknown): Promise<void> =>
+  page.evaluate((m) => {
+    (window as unknown as TestHarness).__HARNESS_TEST__.publish(m);
+  }, message);
+
+/** Publish a chat.turn bus event for the given session. */
+const publishTurn = (
+  page: import("@playwright/test").Page,
+  opts: { sessionId: string; role: "user" | "assistant"; content: string; turnId?: string },
+): Promise<void> =>
+  publish(page, {
+    type: "chat.turn",
+    harnessSessionId: opts.sessionId,
+    turn: {
+      turnId: opts.turnId ?? `turn-${Date.now()}-${Math.random()}`,
+      role: opts.role,
+      content: opts.content,
+      ts: new Date().toISOString(),
+    },
+  });
+
+/** Publish a chat.history bus event for the given session. */
+const publishHistory = (
+  page: import("@playwright/test").Page,
+  opts: { sessionId: string; turns: Array<{ role: "user" | "assistant"; content: string }> },
+): Promise<void> =>
+  publish(page, {
+    type: "chat.history",
+    history: {
+      harnessSessionId: opts.sessionId,
+      turns: opts.turns.map((t, i) => ({
+        turnId: `hist-${i}`,
+        role: t.role,
+        content: t.content,
+        ts: new Date().toISOString(),
+      })),
+    },
+  });
+
+/** Inject a codex-harness session into state via session.status. */
+const injectCodexSession = (
+  page: import("@playwright/test").Page,
+  id = "sess-codex-chat-test",
+): Promise<void> =>
+  publish(page, {
+    type: "session.status",
+    session: {
+      id,
+      agentSessionId: null,
+      boundWorkflowPath: null,
+      harness: "codex",
+      cwd: "/home/user/projects/rfq",
+      title: "rfq",
+      status: "running",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+      ready: true,
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Default view: chat pane
+// ---------------------------------------------------------------------------
+
+test("chat view is the default center pane for a running session", async ({ page }) => {
+  // The boot session (sess-boot) is running — chat view should be visible.
+  await expect(page.getByTestId("chat-view")).toBeVisible();
+  await expect(page.getByTestId("center-tab-chat")).toHaveAttribute("aria-selected", "true");
+  await page.screenshot({ path: "web/e2e/screenshots/chat-default.png" });
+});
+
+test("chat view shows the empty state when no turns have arrived yet", async ({ page }) => {
+  await expect(page.getByTestId("chat-empty")).toBeVisible();
+  await expect(page.locator(".chat-empty-heading")).toContainText("New conversation");
+  await page.screenshot({ path: "web/e2e/screenshots/chat-empty.png" });
+});
+
+// ---------------------------------------------------------------------------
+// Bus-driven turn rendering
+// ---------------------------------------------------------------------------
+
+test("user turn appears when a chat.turn bus event is published for the active session", async ({
+  page,
+}) => {
+  await publishTurn(page, {
+    sessionId: "sess-boot",
+    role: "user",
+    content: "Build me a leasing workflow",
+  });
+
+  await expect(page.getByTestId("chat-turn-user")).toBeVisible();
+  await expect(page.getByTestId("chat-turn-user")).toContainText("Build me a leasing workflow");
+  await page.screenshot({ path: "web/e2e/screenshots/chat-user-turn.png" });
+});
+
+test("assistant turn appears with markdown rendered (no dangerouslySetInnerHTML)", async ({
+  page,
+}) => {
+  await publishTurn(page, {
+    sessionId: "sess-boot",
+    role: "assistant",
+    content: "I'll **start** on that now. Here's the plan:\n- Step 1\n- Step 2",
+  });
+
+  await expect(page.getByTestId("chat-turn-assistant")).toBeVisible();
+  // Bold rendered as <strong>
+  await expect(page.locator(".chat-turn-markdown strong")).toContainText("start");
+  // List items rendered
+  await expect(page.locator(".chat-turn-markdown li")).toHaveCount(2);
+});
+
+test("multiple turns render in order (user, assistant, user)", async ({ page }) => {
+  await publishTurn(page, { sessionId: "sess-boot", role: "user", content: "First message", turnId: "t1" });
+  await publishTurn(page, { sessionId: "sess-boot", role: "assistant", content: "Reply here", turnId: "t2" });
+  await publishTurn(page, { sessionId: "sess-boot", role: "user", content: "Follow-up", turnId: "t3" });
+
+  const turns = page.getByTestId("chat-turns");
+  await expect(turns).toBeVisible();
+
+  await expect(page.locator("[data-turn-id=t1]")).toBeVisible();
+  await expect(page.locator("[data-turn-id=t2]")).toBeVisible();
+  await expect(page.locator("[data-turn-id=t3]")).toBeVisible();
+});
+
+test("bus events for a different session do not appear in the active session's chat", async ({
+  page,
+}) => {
+  // Publish a turn for a different session (sess-bg, not the active sess-boot).
+  await publishTurn(page, {
+    sessionId: "sess-bg",
+    role: "user",
+    content: "This belongs to sess-bg only",
+  });
+
+  // The active session (sess-boot) should still show the empty state.
+  await expect(page.getByTestId("chat-empty")).toBeVisible();
+  await expect(page.locator(".chat-turn")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// chat.history snapshot
+// ---------------------------------------------------------------------------
+
+test("chat.history bus event populates the turn list for the active session", async ({ page }) => {
+  await publishHistory(page, {
+    sessionId: "sess-boot",
+    turns: [
+      { role: "user", content: "History message one" },
+      { role: "assistant", content: "History reply one" },
+    ],
+  });
+
+  await expect(page.getByTestId("chat-turns")).toBeVisible();
+  await expect(page.getByTestId("chat-turn-user")).toContainText("History message one");
+  await expect(page.getByTestId("chat-turn-assistant")).toContainText("History reply one");
+});
+
+test("chat.history is ignored when the session already has live turns", async ({ page }) => {
+  // First publish a live turn.
+  await publishTurn(page, {
+    sessionId: "sess-boot",
+    role: "user",
+    content: "Live turn already here",
+    turnId: "live-1",
+  });
+  await expect(page.getByTestId("chat-turn-user")).toContainText("Live turn already here");
+
+  // Now publish history — should NOT overwrite the live turn.
+  await publishHistory(page, {
+    sessionId: "sess-boot",
+    turns: [{ role: "user", content: "History that should be ignored" }],
+  });
+
+  // Still shows the live turn, not the history.
+  await expect(page.locator("[data-turn-id=live-1]")).toBeVisible();
+  await expect(page.locator(".chat-turn")).toHaveCount(1);
+});
+
+// ---------------------------------------------------------------------------
+// Terminal tab
+// ---------------------------------------------------------------------------
+
+test("Terminal tab button is visible in the center tab bar", async ({ page }) => {
+  await expect(page.getByTestId("center-tab-terminal")).toBeVisible();
+  await expect(page.getByTestId("center-tab-bar")).toBeVisible();
+});
+
+test("clicking Terminal tab switches to the terminal panel", async ({ page }) => {
+  // Start on chat.
+  await expect(page.getByTestId("center-tab-chat")).toHaveAttribute("aria-selected", "true");
+
+  // Switch to terminal.
+  await page.getByTestId("center-tab-terminal").click();
+  await expect(page.getByTestId("center-tab-terminal")).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByTestId("center-tab-chat")).toHaveAttribute("aria-selected", "false");
+
+  await page.screenshot({ path: "web/e2e/screenshots/chat-terminal-tab.png" });
+});
+
+test("terminal panel stays mounted in the DOM across tab flips (CSS keep-alive)", async ({
+  page,
+}) => {
+  // Verify the terminal panel exists in the DOM regardless of active tab.
+  // The panel is CSS-hidden (not unmounted) so xterm connection survives.
+  await expect(page.getByTestId("center-panel-terminal")).toBeAttached();
+
+  // Switch to terminal and back.
+  await page.getByTestId("center-tab-terminal").click();
+  await expect(page.getByTestId("center-panel-terminal")).toBeAttached();
+
+  await page.getByTestId("center-tab-chat").click();
+  await expect(page.getByTestId("center-panel-terminal")).toBeAttached();
+});
+
+// ---------------------------------------------------------------------------
+// Slash commands
+// ---------------------------------------------------------------------------
+
+test("a slash command is submitted verbatim AND a system note appears in the chat", async ({
+  page,
+}) => {
+  const textarea = page.locator(".prompt-bar-textarea");
+  await textarea.click();
+  await textarea.fill("/model claude-4");
+  await textarea.press("Enter");
+
+  // Wait for the injectInput call to be recorded.
+  await page.waitForFunction(
+    () =>
+      (window as unknown as TestHarness).__HARNESS_TEST__?.lastInjectInput?.req.text === "/model claude-4",
+  );
+
+  // Verify verbatim forward (not trimmed, not wrapped).
+  const captured = await page.evaluate(
+    () => (window as unknown as TestHarness).__HARNESS_TEST__.lastInjectInput,
+  );
+  expect(captured?.req.text).toBe("/model claude-4");
+
+  // System note must appear in the chat.
+  await expect(page.getByTestId("chat-system-note")).toBeVisible();
+  await expect(page.getByTestId("chat-system-note")).toContainText("/model claude-4");
+});
+
+test("slash command system note includes a Terminal tab link that switches to the terminal", async ({
+  page,
+}) => {
+  const textarea = page.locator(".prompt-bar-textarea");
+  await textarea.click();
+  await textarea.fill("/init");
+  await textarea.press("Enter");
+
+  // Wait for the submission.
+  await page.waitForFunction(
+    () => (window as unknown as TestHarness).__HARNESS_TEST__?.lastInjectInput?.req.text === "/init",
+  );
+
+  // The system note has a "Terminal tab" link.
+  const terminalLink = page.getByTestId("chat-terminal-link");
+  await expect(terminalLink).toBeVisible();
+
+  // Clicking the link switches to the terminal tab.
+  await terminalLink.click();
+  await expect(page.getByTestId("center-tab-terminal")).toHaveAttribute("aria-selected", "true");
+});
+
+test("a non-slash submit does NOT produce a system note", async ({ page }) => {
+  const textarea = page.locator(".prompt-bar-textarea");
+  await textarea.click();
+  await textarea.fill("Tell me what files are in the repo");
+  await textarea.press("Enter");
+
+  await page.waitForFunction(
+    () =>
+      (window as unknown as TestHarness).__HARNESS_TEST__?.lastInjectInput?.req.text ===
+      "Tell me what files are in the repo",
+  );
+
+  // No system note for a plain message.
+  await expect(page.getByTestId("chat-system-note")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// Harness label in the composer footer
+// ---------------------------------------------------------------------------
+
+test("claude-code session shows 'Claude Code' as the harness label", async ({ page }) => {
+  // Default boot session is claude-code.
+  const label = page.getByTestId("chat-harness-label");
+  await expect(label).toBeVisible();
+  await expect(label).toHaveText("Claude Code");
+});
+
+test("codex session shows 'Codex' as the harness label", async ({ page }) => {
+  // Inject a codex session and switch to it.
+  await injectCodexSession(page, "sess-codex-label-test");
+  const codexTab = page.getByTestId("session-tab-sess-codex-label-test");
+  await expect(codexTab).toBeVisible({ timeout: 3_000 });
+  await codexTab.click();
+  await expect(codexTab).toHaveClass(/is-active/);
+
+  const label = page.getByTestId("chat-harness-label");
+  await expect(label).toBeVisible();
+  await expect(label).toHaveText("Codex");
+});
+
+// ---------------------------------------------------------------------------
+// Per-session state isolation and session switching
+// ---------------------------------------------------------------------------
+
+test("switching sessions resets the center pane to 'chat'", async ({ page }) => {
+  // Switch to terminal first.
+  await page.getByTestId("center-tab-terminal").click();
+  await expect(page.getByTestId("center-tab-terminal")).toHaveAttribute("aria-selected", "true");
+
+  // Switch sessions — the chat tab should become active again.
+  await page.getByTestId("session-tab-sess-bg").click();
+  await expect(page.getByTestId("center-tab-chat")).toHaveAttribute("aria-selected", "true");
+});
+
+test("each session maintains its own chat state — turns don't bleed across sessions", async ({
+  page,
+}) => {
+  // Add a turn to sess-boot.
+  await publishTurn(page, {
+    sessionId: "sess-boot",
+    role: "user",
+    content: "Boot session turn",
+    turnId: "boot-turn-1",
+  });
+  await expect(page.getByTestId("chat-turn-user")).toContainText("Boot session turn");
+
+  // Switch to sess-bg — it should have an empty state.
+  await page.getByTestId("session-tab-sess-bg").click();
+  await expect(page.getByTestId("chat-empty")).toBeVisible();
+
+  // Add a turn to sess-bg.
+  await publishTurn(page, {
+    sessionId: "sess-bg",
+    role: "user",
+    content: "Background session turn",
+    turnId: "bg-turn-1",
+  });
+  await expect(page.getByTestId("chat-turn-user")).toContainText("Background session turn");
+
+  // Switch back to sess-boot — should still have its own turn only.
+  await page.getByTestId("session-tab-sess-boot").click();
+  await expect(page.getByTestId("chat-turn-user")).toContainText("Boot session turn");
+  await expect(page.locator(".chat-turn")).toHaveCount(1);
+});
+
+// ---------------------------------------------------------------------------
+// Permission-pending attention banner (chat.attention bus event)
+// ---------------------------------------------------------------------------
+
+test("chat.attention event with a non-empty message shows the attention banner", async ({ page }) => {
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-boot",
+    message: "Claude is asking permission to run a command",
+  });
+
+  const banner = page.getByTestId("chat-attention-banner");
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("Claude is asking permission to run a command");
+  await page.screenshot({ path: "web/e2e/screenshots/chat-attention-banner.png" });
+});
+
+test("attention banner includes a 'Review in Terminal' link that switches to the Terminal tab", async ({
+  page,
+}) => {
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-boot",
+    message: "Claude is asking permission to use Bash",
+  });
+
+  const link = page.getByTestId("chat-attention-terminal-link");
+  await expect(link).toBeVisible();
+  await expect(link).toContainText("Review in Terminal");
+
+  await link.click();
+  await expect(page.getByTestId("center-tab-terminal")).toHaveAttribute("aria-selected", "true");
+});
+
+test("chat.attention with an empty message clears the attention banner", async ({ page }) => {
+  // Show the banner first.
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-boot",
+    message: "Awaiting permission",
+  });
+  await expect(page.getByTestId("chat-attention-banner")).toBeVisible();
+
+  // Clearing: publish with empty message (the server sends this on next activity).
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-boot",
+    message: "",
+  });
+  await expect(page.getByTestId("chat-attention-banner")).toHaveCount(0);
+});
+
+test("attention banner for a different session does not appear on the active session", async ({
+  page,
+}) => {
+  await publish(page, {
+    type: "chat.attention",
+    harnessSessionId: "sess-bg", // not the active sess-boot
+    message: "Permission needed in background session",
+  });
+
+  // Banner should NOT appear for the active session (sess-boot).
+  await expect(page.getByTestId("chat-attention-banner")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// Composer
+// ---------------------------------------------------------------------------
+
+test("the composer PromptBar is inside the chat view (not standalone under the terminal)", async ({
+  page,
+}) => {
+  // The prompt bar must be a descendant of [data-testid="chat-view"].
+  const promptBarInChat = page.locator('[data-testid="chat-view"] .prompt-bar');
+  await expect(promptBarInChat).toBeVisible();
+});
+
+test("when Terminal tab is active, the chat panel is hidden and the terminal panel is in the DOM", async ({
+  page,
+}) => {
+  // Switch to terminal.
+  await page.getByTestId("center-tab-terminal").click();
+  await expect(page.getByTestId("center-tab-terminal")).toHaveAttribute("aria-selected", "true");
+
+  // Chat panel has the HTML `hidden` attribute (CSS keep-alive pattern).
+  await expect(page.getByTestId("center-panel-chat")).toHaveAttribute("hidden", "");
+
+  // Terminal panel is attached to the DOM and does NOT have `hidden`.
+  await expect(page.getByTestId("center-panel-terminal")).toBeAttached();
+  await expect(page.getByTestId("center-panel-terminal")).not.toHaveAttribute("hidden");
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1,12 +1,12 @@
 /**
- * Harness SPA shell (workstream W2).
+ * Harness SPA shell (workstream W2 + SAP-1477 chat-first center pane).
  *
  * Layout: workflows rail (left) | docked action strip (anchored to the
- * selected workflow's row) | session tab strip + terminal (center) |
- * canvas/skills right pane. The strip carries the selected workflow's
- * full action set; the right pane has a segmented switch (Canvas | Skills)
- * at the top — canvas stays mounted behind CSS when Skills is active so a
- * running Visualize enrichment is never disturbed by a tab flip.
+ * selected workflow's row) | session tab strip + chat/terminal (center) |
+ * canvas/skills right pane. The center pane defaults to ChatView (conversation
+ * surface); the Terminal is a tab. The right pane has Canvas | Skills tabs —
+ * canvas stays mounted via CSS so a running Visualize enrichment is never
+ * disturbed by a tab flip.
  */
 import { useEffect, useMemo, useState } from "react";
 import type { JSX } from "react";
@@ -14,9 +14,9 @@ import type { HarnessKind, MacroDef, WorkflowInfo } from "@shared/types";
 
 import { BrandHeader } from "./components/BrandHeader";
 import { CanvasPane } from "./components/CanvasPane";
+import { ChatView } from "./components/ChatView";
 import { CommandPalette } from "./components/CommandPalette";
 import { DeadSessionPane } from "./components/DeadSessionPane";
-import { PromptBar } from "./components/PromptBar";
 import { SessionBar } from "./components/SessionBar";
 import { SkillsPanel } from "./components/SkillsPanel";
 import { TelemetryNotice } from "./components/TelemetryNotice";
@@ -32,6 +32,7 @@ import { CANVAS_MIN, RAIL_MIN, usePaneWidths } from "./lib/use-pane-widths";
 import { useHarnessState } from "./lib/use-harness-state";
 
 type RightTab = "canvas" | "skills";
+type CenterTab = "chat" | "terminal";
 
 export const App = (): JSX.Element => {
   const harness = useHarnessState();
@@ -57,6 +58,11 @@ export const App = (): JSX.Element => {
   const getSkill = useMemo(() => harness.api.getSkill.bind(harness.api), [harness.api]);
   const listHarnesses = useMemo(() => harness.api.listHarnesses.bind(harness.api), [harness.api]);
   const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
+  // Per-session center-pane tab (chat | terminal). Defaults to "chat".
+  const [centerTab, setCenterTab] = useState<CenterTab>("chat");
+  // When switching sessions, stay on "chat" unless already on terminal for this session.
+  const prevSessionIdRef = { current: harness.activeSessionId };
+  void prevSessionIdRef; // used below in effect
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
@@ -211,7 +217,11 @@ export const App = (): JSX.Element => {
           <SessionBar
             sessions={state.sessions}
             activeSessionId={harness.activeSessionId}
-            onSelectSession={harness.setActiveSessionId}
+            onSelectSession={(id) => {
+              harness.setActiveSessionId(id);
+              // Default to chat view when switching sessions.
+              setCenterTab("chat");
+            }}
             onResumeHistory={(summary) => void harness.resumeFromHistory(summary)}
             history={harness.history}
             historyLoading={harness.historyLoading}
@@ -240,11 +250,59 @@ export const App = (): JSX.Element => {
               />
             ) : harness.activeSessionId ? (
               <>
-                <Terminal sessionId={harness.activeSessionId} token={harness.bootToken} />
-                <PromptBar
-                  session={activeSession ?? null}
-                  onSubmit={harness.injectInput}
-                />
+                {/* Chat / Terminal tab switcher */}
+                <div className="center-tab-bar" data-testid="center-tab-bar" role="tablist" aria-label="Center pane view">
+                  <button
+                    className={`center-tab${centerTab === "chat" ? " is-active" : ""}`}
+                    data-testid="center-tab-chat"
+                    role="tab"
+                    aria-selected={centerTab === "chat"}
+                    onClick={() => setCenterTab("chat")}
+                  >
+                    Chat
+                  </button>
+                  <button
+                    className={`center-tab${centerTab === "terminal" ? " is-active" : ""}`}
+                    data-testid="center-tab-terminal"
+                    role="tab"
+                    aria-selected={centerTab === "terminal"}
+                    onClick={() => setCenterTab("terminal")}
+                  >
+                    Terminal
+                  </button>
+                </div>
+
+                {/* Chat view — default */}
+                <div
+                  className={`center-panel center-panel-chat${centerTab === "chat" ? " is-visible" : ""}`}
+                  hidden={centerTab !== "chat"}
+                  data-testid="center-panel-chat"
+                >
+                  {(() => {
+                    const chatState = harness.getChatState(harness.activeSessionId);
+                    return (
+                      <ChatView
+                        sessionId={harness.activeSessionId}
+                        session={activeSession ?? null}
+                        turns={chatState.turns}
+                        toolCalls={chatState.toolCalls}
+                        agentWorking={chatState.agentWorking}
+                        attentionMessage={chatState.attentionMessage}
+                        onSubmit={harness.injectInput}
+                        onSwitchToTerminal={() => setCenterTab("terminal")}
+                      />
+                    );
+                  })()}
+                </div>
+
+                {/* Terminal — kept MOUNTED (CSS-hidden) so xterm connection survives tab flips */}
+                <div
+                  className={`center-panel center-panel-terminal${centerTab === "terminal" ? " is-visible" : ""}`}
+                  hidden={centerTab !== "terminal"}
+                  data-testid="center-panel-terminal"
+                >
+                  <Terminal sessionId={harness.activeSessionId} token={harness.bootToken} />
+                </div>
               </>
             ) : showWelcome ? (
               <WelcomePanel

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -60,9 +60,6 @@ export const App = (): JSX.Element => {
   const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
   // Per-session center-pane tab (chat | terminal). Defaults to "chat".
   const [centerTab, setCenterTab] = useState<CenterTab>("chat");
-  // When switching sessions, stay on "chat" unless already on terminal for this session.
-  const prevSessionIdRef = { current: harness.activeSessionId };
-  void prevSessionIdRef; // used below in effect
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.

--- a/packages/harness/web/src/components/ChatView.tsx
+++ b/packages/harness/web/src/components/ChatView.tsx
@@ -1,0 +1,420 @@
+/**
+ * ChatView — the chat-first center-pane conversation surface.
+ *
+ * Renders a scrollable turn list (user bubbles, assistant markdown, tool-call
+ * chips inline) with the PromptBar composer at the bottom. Designed to feel
+ * like a considered conversation window in the style of Conductor/Lovable:
+ * calm rhythm, streamed states, tool activity that doesn't crowd the text.
+ *
+ * Chat events arrive via the EventBus (chat.turn / chat.tool / chat.history).
+ * State is per-session — the parent passes a sessionId and the hook handles
+ * its own per-session turn list.
+ *
+ * Scroll behavior:
+ *   - Auto-scrolls to the bottom as new turns arrive.
+ *   - Locks when the user scrolls up (doesn't hijack their reading position).
+ *   - Re-locks (follows) when the user scrolls back to within 60px of the bottom.
+ */
+import { useCallback, useEffect, useRef, useState, type JSX, type UIEvent } from "react";
+
+import type { ChatToolCall, ChatTurn, HarnessSession } from "@shared/types";
+
+import { PromptBar } from "./PromptBar";
+
+/** A synthetic system-note row (e.g. "Sent /model to the agent"). */
+interface SystemNote {
+  id: string;
+  text: string;
+  /** Cue to switch to the terminal tab, shown as a link in the note. */
+  showTerminalLink: boolean;
+}
+
+export interface ChatViewProps {
+  sessionId: string;
+  /** The full HarnessSession object — forwarded to PromptBar for readiness gating. */
+  session: HarnessSession | null;
+  /** All chat turns for this session, in order. */
+  turns: ChatTurn[];
+  /** All tool calls for this session, keyed by callId (last status wins). */
+  toolCalls: Map<string, ChatToolCall>;
+  /** Whether the agent is currently active (no final "stop" event yet). */
+  agentWorking: boolean;
+  /**
+   * Non-empty when the agent is blocked on a permission prompt (Notification
+   * hook). Shows a prominent banner with a Terminal tab link. Cleared by
+   * subsequent hook activity (PostToolUse / Stop / UserPromptSubmit).
+   */
+  attentionMessage?: string;
+  /** Empty-state: no turns yet for this session. */
+  onSubmit: (sessionId: string, text: string) => Promise<void>;
+  /** Called when the user clicks the "Terminal tab" link in a slash-command note. */
+  onSwitchToTerminal?: () => void;
+}
+
+/** Heuristic SCROLL_LOCK_THRESHOLD: user is "reading up" if more than 60px from bottom. */
+const SCROLL_LOCK_THRESHOLD = 60;
+
+/**
+ * Safe subset markdown renderer. Supports:
+ *   **bold**, *italic*, `code`, ```code blocks```, # headings, - lists, > blockquotes
+ *
+ * Implemented without dangerouslySetInnerHTML — builds a React element tree
+ * from the markdown string instead.
+ */
+function renderMarkdown(text: string): JSX.Element {
+  const lines = text.split("\n");
+  const elements: JSX.Element[] = [];
+  let i = 0;
+  let key = 0;
+
+  function nextKey(): number {
+    return key++;
+  }
+
+  function renderInline(line: string): (string | JSX.Element)[] {
+    // Handle inline code, bold, italic in sequence
+    const parts: (string | JSX.Element)[] = [];
+    // Regex: code (`...`), bold (**...**), italic (*...*)
+    const pattern = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g;
+    let last = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(line)) !== null) {
+      if (match.index > last) {
+        parts.push(line.slice(last, match.index));
+      }
+      const token = match[0];
+      if (token.startsWith("`") && token.endsWith("`")) {
+        parts.push(<code key={nextKey()} className="chat-inline-code">{token.slice(1, -1)}</code>);
+      } else if (token.startsWith("**") && token.endsWith("**")) {
+        parts.push(<strong key={nextKey()}>{token.slice(2, -2)}</strong>);
+      } else if (token.startsWith("*") && token.endsWith("*")) {
+        parts.push(<em key={nextKey()}>{token.slice(1, -1)}</em>);
+      } else {
+        parts.push(token);
+      }
+      last = match.index + token.length;
+    }
+    if (last < line.length) {
+      parts.push(line.slice(last));
+    }
+    return parts;
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block
+    if (line.startsWith("```")) {
+      const lang = line.slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // consume closing ```
+      elements.push(
+        <pre key={nextKey()} className="chat-code-block" data-lang={lang || undefined}>
+          <code>{codeLines.join("\n")}</code>
+        </pre>,
+      );
+      continue;
+    }
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,3})\s+(.+)/);
+    if (headingMatch) {
+      const level = headingMatch[1].length as 1 | 2 | 3;
+      const Tag = (`h${level}`) as "h1" | "h2" | "h3";
+      elements.push(
+        <Tag key={nextKey()} className="chat-heading">
+          {renderInline(headingMatch[2])}
+        </Tag>,
+      );
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith("> ")) {
+      elements.push(
+        <blockquote key={nextKey()} className="chat-blockquote">
+          {renderInline(line.slice(2))}
+        </blockquote>,
+      );
+      i++;
+      continue;
+    }
+
+    // List items
+    if (line.match(/^[-*+]\s+/)) {
+      const listItems: JSX.Element[] = [];
+      while (i < lines.length && lines[i].match(/^[-*+]\s+/)) {
+        const itemText = lines[i].replace(/^[-*+]\s+/, "");
+        listItems.push(<li key={nextKey()}>{renderInline(itemText)}</li>);
+        i++;
+      }
+      elements.push(<ul key={nextKey()} className="chat-list">{listItems}</ul>);
+      continue;
+    }
+
+    // Empty line
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+
+    // Paragraph
+    elements.push(
+      <p key={nextKey()} className="chat-paragraph">
+        {renderInline(line)}
+      </p>,
+    );
+    i++;
+  }
+
+  return <>{elements}</>;
+}
+
+function ToolChip({ call }: { call: ChatToolCall }): JSX.Element {
+  const statusClass =
+    call.status === "start"
+      ? "chat-tool-chip--running"
+      : call.status === "error"
+        ? "chat-tool-chip--error"
+        : "chat-tool-chip--ok";
+
+  return (
+    <span className={`chat-tool-chip ${statusClass}`} data-testid={`tool-chip-${call.callId}`}>
+      {call.status === "start" && <span className="chat-tool-spinner" aria-hidden="true" />}
+      {call.status === "ok" && (
+        <svg className="chat-tool-ok-icon" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      )}
+      {call.status === "error" && (
+        <svg className="chat-tool-err-icon" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      )}
+      <span className="chat-tool-name">{call.toolName}</span>
+    </span>
+  );
+}
+
+/** Compact label showing the active session's harness kind — passive, non-interactive. */
+function HarnessLabel({ harness }: { harness: string }): JSX.Element {
+  const label =
+    harness === "claude-code" ? "Claude Code"
+    : harness === "codex" ? "Codex"
+    : harness;
+  return (
+    <span className="chat-harness-label" data-testid="chat-harness-label" aria-label={`Active harness: ${label}`}>
+      {label}
+    </span>
+  );
+}
+
+let systemNoteCounter = 0;
+
+export function ChatView({
+  sessionId,
+  session,
+  turns,
+  toolCalls,
+  agentWorking,
+  attentionMessage,
+  onSubmit,
+  onSwitchToTerminal,
+}: ChatViewProps): JSX.Element {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollLocked, setScrollLocked] = useState(false);
+  const [systemNotes, setSystemNotes] = useState<SystemNote[]>([]);
+
+  const handleSlashCommand = useCallback((command: string): void => {
+    setSystemNotes((prev) => [
+      ...prev,
+      {
+        id: `sn-${++systemNoteCounter}`,
+        text: `Sent ${command} to the agent`,
+        showTerminalLink: true,
+      },
+    ]);
+  }, []);
+
+  // Auto-scroll: follow the bottom unless the user has scrolled up.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || scrollLocked) return;
+    el.scrollTop = el.scrollHeight;
+  }, [turns, toolCalls, agentWorking, scrollLocked]);
+
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>): void => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setScrollLocked(distanceFromBottom > SCROLL_LOCK_THRESHOLD);
+  }, []);
+
+  const isEmpty = turns.length === 0;
+
+  return (
+    <div className="chat-view" data-testid="chat-view">
+      <div
+        className="chat-scroll"
+        ref={scrollRef}
+        onScroll={handleScroll}
+        data-testid="chat-scroll"
+        aria-live="polite"
+        aria-label="Conversation"
+      >
+        {isEmpty ? (
+          <div className="chat-empty" data-testid="chat-empty">
+            <div className="chat-empty-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />
+              </svg>
+            </div>
+            <p className="chat-empty-heading">New conversation</p>
+            <p className="chat-empty-hint">Send a message to start working with the agent.</p>
+          </div>
+        ) : (
+          <div className="chat-turns" data-testid="chat-turns">
+            {turns.map((turn) => {
+              const isUser = turn.role === "user";
+
+              // Collect tool calls that appear "after" this turn and before the next one
+              // (in practice: tool calls interleaved between assistant turns).
+              // We render all tool calls associated with the session inline in order
+              // between turns — tracked by the parent via toolCalls Map.
+
+              return (
+                <div
+                  key={turn.turnId}
+                  className={`chat-turn chat-turn--${turn.role}${turn.streaming ? " chat-turn--streaming" : ""}`}
+                  data-testid={`chat-turn-${turn.role}`}
+                  data-turn-id={turn.turnId}
+                >
+                  {!isUser && (
+                    <div className="chat-turn-avatar" aria-hidden="true">
+                      <svg viewBox="0 0 16 16" fill="none">
+                        <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+                        <path d="M5 8h6M8 5v6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                      </svg>
+                    </div>
+                  )}
+                  <div className="chat-turn-bubble">
+                    {isUser ? (
+                      <p className="chat-turn-text">{turn.content}</p>
+                    ) : (
+                      <div className="chat-turn-markdown">
+                        {turn.streaming ? (
+                          <>
+                            {renderMarkdown(turn.content)}
+                            <span className="chat-streaming-cursor" aria-hidden="true" />
+                          </>
+                        ) : (
+                          renderMarkdown(turn.content)
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Tool chips at the bottom — latest activity */}
+            {toolCalls.size > 0 && (
+              <div className="chat-tool-row" data-testid="chat-tool-row">
+                {Array.from(toolCalls.values()).map((call) => (
+                  <ToolChip key={call.callId} call={call} />
+                ))}
+              </div>
+            )}
+
+            {/* System notes (slash commands, status events) */}
+            {systemNotes.map((note) => (
+              <div key={note.id} className="chat-system-note" data-testid="chat-system-note" role="status">
+                <span className="chat-system-note-text">{note.text}</span>
+                {note.showTerminalLink && onSwitchToTerminal && (
+                  <>
+                    {" — "}
+                    <button
+                      className="chat-system-note-link"
+                      data-testid="chat-terminal-link"
+                      onClick={onSwitchToTerminal}
+                    >
+                      Terminal tab
+                    </button>
+                  </>
+                )}
+              </div>
+            ))}
+
+            {/* Working indicator */}
+            {agentWorking && (
+              <div className="chat-working" data-testid="chat-working" aria-live="polite">
+                <span className="chat-working-dots" aria-label="Agent is working">
+                  <span /><span /><span />
+                </span>
+                <span className="chat-working-label">working…</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Jump-to-bottom pill when scroll is locked */}
+      {scrollLocked && (
+        <button
+          className="chat-scroll-to-bottom"
+          data-testid="chat-scroll-to-bottom"
+          onClick={() => {
+            setScrollLocked(false);
+            const el = scrollRef.current;
+            if (el) el.scrollTop = el.scrollHeight;
+          }}
+          aria-label="Jump to latest message"
+        >
+          ↓ Latest
+        </button>
+      )}
+
+      {/* Permission-pending attention banner */}
+      {attentionMessage && (
+        <div className="chat-attention-banner" data-testid="chat-attention-banner" role="status" aria-live="polite">
+          <span className="chat-attention-icon" aria-hidden="true">⚠</span>
+          <span className="chat-attention-message">{attentionMessage}</span>
+          {onSwitchToTerminal && (
+            <>
+              {" — "}
+              <button
+                className="chat-attention-link"
+                data-testid="chat-attention-terminal-link"
+                onClick={onSwitchToTerminal}
+              >
+                Review in Terminal
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Composer (evolved PromptBar) */}
+      <div className="chat-composer" data-testid="chat-composer">
+        <PromptBar
+          session={session}
+          onSubmit={onSubmit}
+          sessionId={sessionId}
+          onSlashCommand={handleSlashCommand}
+        />
+        <div className="chat-composer-footer">
+          {session?.harness ? (
+            <HarnessLabel harness={session.harness} />
+          ) : (
+            <span className="chat-harness-label chat-harness-label--none" aria-hidden="true" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/PromptBar.tsx
+++ b/packages/harness/web/src/components/PromptBar.tsx
@@ -39,6 +39,18 @@ export interface PromptBarProps {
   session: HarnessSession | null;
   /** Calls POST /api/sessions/:id/input. Must throw ApiError on 409/other errors. */
   onSubmit: (sessionId: string, text: string) => Promise<void>;
+  /**
+   * When set, overrides the session id used for submit (useful when PromptBar
+   * is embedded inside ChatView and the session object might transiently lag).
+   * Defaults to session.id when omitted.
+   */
+  sessionId?: string;
+  /**
+   * Called when the submitted text starts with "/" — signals that a slash
+   * command was sent to the agent and the caller should show a system note.
+   * The text is the full raw command string (e.g. "/model claude-4").
+   */
+  onSlashCommand?: (command: string) => void;
 }
 
 interface StatusReason {
@@ -61,7 +73,7 @@ function readinessReason(session: HarnessSession | null): StatusReason | null {
 
 const MAX_ROWS = 6;
 
-export const PromptBar = ({ session, onSubmit }: PromptBarProps): JSX.Element => {
+export const PromptBar = ({ session, onSubmit, sessionId: sessionIdProp, onSlashCommand }: PromptBarProps): JSX.Element => {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Per-session draft storage: switching tabs preserves each session's own
@@ -143,13 +155,18 @@ export const PromptBar = ({ session, onSubmit }: PromptBarProps): JSX.Element =>
   const handleSubmit = useCallback(async () => {
     if (!canSubmit || !session) return;
     const text = draft;
+    const effectiveSessionId = sessionIdProp ?? session.id;
     setSubmitting(true);
     try {
-      await onSubmit(session.id, text);
+      await onSubmit(effectiveSessionId, text);
       setDraft("");
       setReactiveReason(null);
       // Emit prompt.submitted — length only, never the text itself.
       track("prompt.submitted", { length: text.length }, session.id);
+      // Notify caller about slash commands (verbatim forwarding, system note).
+      if (text.trimStart().startsWith("/")) {
+        onSlashCommand?.(text.trimStart());
+      }
       // Focus back in the bar for rapid follow-ups.
       textareaRef.current?.focus();
     } catch (err) {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -33,17 +33,6 @@ export interface SkillDetail extends SkillMeta {
   body: string;
 }
 
-/** Shape of a single entry returned by GET /api/harnesses. */
-export interface HarnessEntry {
-  id: string;
-  label: string;
-  mode: "embedded" | "external";
-  experimental: boolean;
-  installed: boolean;
-  /** Per-harness MCP install instructions from the adapter registry. */
-  installMcpPrompt: string;
-}
-
 import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SAMPLE_PROJECT_ROOT, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_SKILLS, MOCK_SKILL_BODIES, MOCK_WORKFLOWS } from "./mock-data";
 
 export type { FsDirEntry, FsListResponse };
@@ -118,7 +107,7 @@ export interface HarnessApi {
   listSkills(): Promise<SkillMeta[]>;
   /** Fetch the full detail (including markdown body) for a single skill. */
   getSkill(id: string): Promise<SkillDetail>;
-  /** List all harness adapters with their MCP install prompts. */
+  /** Returns the full harness adapter registry (GET /api/harnesses). */
   listHarnesses(): Promise<HarnessEntry[]>;
 }
 

--- a/packages/harness/web/src/lib/events.ts
+++ b/packages/harness/web/src/lib/events.ts
@@ -6,7 +6,7 @@
 import type { BusMessage } from "@shared/types";
 
 import { getBootToken, isMockMode } from "./api";
-import { MOCK_ACTIVITY_SESSION_ID } from "./mock-data";
+import { MOCK_ACTIVITY_SESSION_ID, MOCK_CHAT_HISTORY } from "./mock-data";
 
 export type BusListener = (message: BusMessage) => void;
 
@@ -15,6 +15,8 @@ const RECONNECT_DELAY_MS = 2000;
  *  see `subscribeEvents`'s mock branch. Long enough that the tab strip has
  *  already rendered idle before the pulse appears. */
 const MOCK_ACTIVITY_DELAY_MS = 1200;
+/** Delay before the mock chat history is delivered to the session. */
+const MOCK_CHAT_DELAY_MS = 600;
 
 const mockListeners = new Set<BusListener>();
 let mockActivitySimulated = false;
@@ -55,6 +57,21 @@ export function subscribeEvents(onMessage: BusListener): () => void {
           }),
         );
       }, MOCK_ACTIVITY_DELAY_MS);
+
+      // Deliver mock chat history for the boot session so ChatView isn't empty
+      // in mock mode. This matches the real server's behavior (chat.history on
+      // open) — tests drive their own turns via __HARNESS_TEST__.publish.
+      setTimeout(() => {
+        mockListeners.forEach((listener) =>
+          listener({
+            type: "chat.history",
+            history: {
+              harnessSessionId: "sess-boot",
+              turns: MOCK_CHAT_HISTORY,
+            },
+          }),
+        );
+      }, MOCK_CHAT_DELAY_MS);
     }
     return () => mockListeners.delete(onMessage);
   }

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -2,7 +2,7 @@
  * Fixture data for `VITE_MOCK=1` — lets the SPA render fully without a
  * running harness server (see MockApi in ./api).
  */
-import type { HarnessSession, HarnessSettings, MacroDef, SessionSummary, WorkflowInfo } from "@shared/types";
+import type { ChatTurn, HarnessSession, HarnessSettings, MacroDef, SessionSummary, WorkflowInfo } from "@shared/types";
 import type { HarnessEntry, SkillMeta } from "./api";
 
 const now = Date.now();
@@ -318,3 +318,33 @@ Systematic review of code changes for correctness, style, and security.
 - [ ] Tests cover the happy path and key error cases
 `,
 };
+
+/** Pre-seeded chat turns for the boot session — shown in mock mode. */
+export const MOCK_CHAT_HISTORY: ChatTurn[] = [
+  {
+    turnId: "turn-1",
+    role: "user",
+    content: "Set up the leasing workflow with the intake and approval steps",
+    ts: new Date(Date.now() - 5 * 60_000).toISOString(),
+  },
+  {
+    turnId: "turn-2",
+    role: "assistant",
+    content:
+      "I'll set up the leasing workflow for you. Let me start by reading the existing workflow definition and then adding the intake and approval steps.\n\nThe workflow will have:\n- **Intake**: Collects applicant details and runs initial screening\n- **Approval**: Routes to underwriting and generates a decision",
+    ts: new Date(Date.now() - 4 * 60_000).toISOString(),
+  },
+  {
+    turnId: "turn-3",
+    role: "user",
+    content: "Make sure the approval step sends a notification email",
+    ts: new Date(Date.now() - 2 * 60_000).toISOString(),
+  },
+  {
+    turnId: "turn-4",
+    role: "assistant",
+    content:
+      "Done. I've added an `email_notification` action to the approval step that fires when a decision is made. The notification includes the applicant name, decision, and a link to the full report in the dashboard.",
+    ts: new Date(Date.now() - 1 * 60_000).toISOString(),
+  },
+];

--- a/packages/harness/web/src/lib/use-chat-state.ts
+++ b/packages/harness/web/src/lib/use-chat-state.ts
@@ -1,0 +1,120 @@
+/**
+ * Per-session chat state: accumulates chat.turn, chat.tool, and chat.history
+ * bus events from subscribeEvents into per-session maps that ChatView renders.
+ *
+ * Responsibilities:
+ *   - Receives chat events from the bus (via use-harness-state's lastMessage)
+ *   - Maintains per-session turn lists and tool-call maps
+ *   - Determines whether the agent is "working" (tool running or no Stop event yet)
+ *
+ * Privacy: chat events are UI-transport only — they never touch the analytics
+ * store. This hook only reads from the bus; it never writes.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { BusMessage, ChatToolCall, ChatTurn } from "@shared/types";
+
+export interface SessionChatState {
+  turns: ChatTurn[];
+  /** Most-recent tool calls, keyed by callId. Last status for each id wins. */
+  toolCalls: Map<string, ChatToolCall>;
+  /** True when any tool call is in "start" state (agent actively running a tool). */
+  agentWorking: boolean;
+  /**
+   * Non-empty string when the agent is blocked on a permission prompt (the
+   * `Notification` hook fired and no subsequent activity has cleared it).
+   * Empty string = no banner. UI-transport only.
+   */
+  attentionMessage: string;
+}
+
+export interface UseChatStateReturn {
+  /** Get the chat state for a specific session, or a default empty state. */
+  getChatState(sessionId: string): SessionChatState;
+  /** Called by useHarnessState when a new bus message arrives. */
+  handleBusMessage(message: BusMessage): void;
+}
+
+const EMPTY_STATE: SessionChatState = {
+  turns: [],
+  toolCalls: new Map(),
+  agentWorking: false,
+  attentionMessage: "",
+};
+
+export function useChatState(): UseChatStateReturn {
+  // Per-session state maps, kept in a ref to avoid triggering re-renders from
+  // the bus-message handler; only the per-session state objects are in React
+  // state so ChatView re-renders when its own data changes.
+  const stateRef = useRef<Map<string, SessionChatState>>(new Map());
+  // React state version counter: incrementing this causes useHarnessState
+  // consumers to pick up the new chat state on next render.
+  const [, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  const getOrCreate = useCallback((sessionId: string): SessionChatState => {
+    const existing = stateRef.current.get(sessionId);
+    if (existing) return existing;
+    const fresh: SessionChatState = {
+      turns: [],
+      toolCalls: new Map(),
+      agentWorking: false,
+      attentionMessage: "",
+    };
+    stateRef.current.set(sessionId, fresh);
+    return fresh;
+  }, []);
+
+  const handleBusMessage = useCallback((message: BusMessage): void => {
+    if (message.type === "chat.turn") {
+      const state = getOrCreate(message.harnessSessionId);
+      const idx = state.turns.findIndex((t) => t.turnId === message.turn.turnId);
+      const newTurns =
+        idx >= 0
+          ? state.turns.map((t, i) => (i === idx ? message.turn : t))
+          : [...state.turns, message.turn];
+      stateRef.current.set(message.harnessSessionId, {
+        ...state,
+        turns: newTurns,
+      });
+      bump();
+    } else if (message.type === "chat.tool") {
+      const state = getOrCreate(message.harnessSessionId);
+      const newToolCalls = new Map(state.toolCalls);
+      newToolCalls.set(message.call.callId, message.call);
+      const agentWorking = Array.from(newToolCalls.values()).some((c) => c.status === "start");
+      stateRef.current.set(message.harnessSessionId, {
+        ...state,
+        toolCalls: newToolCalls,
+        agentWorking,
+      });
+      bump();
+    } else if (message.type === "chat.history") {
+      const sessionId = message.history.harnessSessionId;
+      const state = getOrCreate(sessionId);
+      // History snapshot only applied when the session has no live turns yet
+      // (a mid-session reconnect has already been receiving live turns and
+      // shouldn't be overwritten with a potentially stale snapshot).
+      if (state.turns.length === 0) {
+        stateRef.current.set(sessionId, {
+          ...state,
+          turns: message.history.turns,
+        });
+        bump();
+      }
+    } else if (message.type === "chat.attention") {
+      const state = getOrCreate(message.harnessSessionId);
+      stateRef.current.set(message.harnessSessionId, {
+        ...state,
+        attentionMessage: message.message,
+      });
+      bump();
+    }
+  }, [getOrCreate, bump]);
+
+  const getChatState = useCallback((sessionId: string): SessionChatState => {
+    return stateRef.current.get(sessionId) ?? EMPTY_STATE;
+  }, []);
+
+  return { getChatState, handleBusMessage };
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -13,6 +13,7 @@ import type {
 
 import { ApiError, boundWorkflowPathOf, createApi, getBootToken, type FsListResponse, type HarnessApi } from "./api";
 import { subscribeEvents } from "./events";
+import { useChatState, type SessionChatState } from "./use-chat-state";
 
 const api = createApi();
 
@@ -74,6 +75,8 @@ export interface HarnessStateHook {
   /** The underlying API client — exposed so consumers (e.g. SkillsPanel) can
    *  call methods (listSkills, getSkill) not surfaced as dedicated hook fns. */
   api: HarnessApi;
+  /** Get the chat state (turns, tool calls, working indicator) for a session. */
+  getChatState: (sessionId: string) => SessionChatState;
 }
 
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
@@ -91,6 +94,7 @@ export function useHarnessState(): HarnessStateHook {
   const [busySessionIds, setBusySessionIds] = useState<Set<string>>(new Set());
   const [tasks, setTasks] = useState<BackgroundTask[]>([]);
   const busyTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const { getChatState, handleBusMessage: handleChatMessage } = useChatState();
 
   // Timers are keyed per-session and outlive individual renders — clear them
   // all on unmount so a pending "clear busy" timeout never fires against a
@@ -140,6 +144,17 @@ export function useHarnessState(): HarnessStateHook {
   useEffect(() => {
     return subscribeEvents((message) => {
       setLastMessage(message);
+      // Route chat events to the chat state hook — these are not stored in
+      // analytics, just accumulated for the ChatView.
+      if (
+        message.type === "chat.turn" ||
+        message.type === "chat.tool" ||
+        message.type === "chat.history" ||
+        message.type === "chat.attention"
+      ) {
+        handleChatMessage(message);
+        return;
+      }
       if (message.type === "session.status") {
         setState((prev) => {
           if (!prev) return prev;
@@ -364,5 +379,6 @@ export function useHarnessState(): HarnessStateHook {
     busySessionIds,
     tasks,
     api,
+    getChatState,
   };
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2740,3 +2740,511 @@ input {
   scrollbar-width: thin;
   scrollbar-color: rgba(161, 161, 170, 0.75) transparent;
 }
+
+/* Center pane: Chat | Terminal tab switcher -------------------------------- */
+
+.center-tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.center-tab {
+  padding: 3px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-dim);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  cursor: pointer;
+}
+
+.center-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.center-tab.is-active {
+  background: var(--bg-2);
+  border-color: var(--border-strong);
+  color: var(--text);
+  box-shadow: var(--shadow-xs);
+}
+
+.center-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Center pane panels — both mounted in the DOM; CSS-hide the inactive one
+   so the xterm WebSocket survives tab flips (same pattern as canvas keep-alive). */
+.center-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.center-panel:not(.is-visible) {
+  /* Visually hidden but still mounted — the xterm connection must not die
+     when the user switches to the Chat tab. */
+  visibility: hidden;
+  position: absolute;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+/* ChatView ----------------------------------------------------------------- */
+
+.chat-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-0);
+  position: relative;
+}
+
+/* Scrollable turn list */
+.chat-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 0 8px;
+}
+
+/* Empty state */
+.chat-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 8px;
+  color: var(--text-faint);
+  text-align: center;
+  padding: 32px;
+}
+
+.chat-empty-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--border-strong);
+  margin-bottom: 4px;
+}
+
+.chat-empty-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.chat-empty-heading {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-dim);
+  margin: 0;
+}
+
+.chat-empty-hint {
+  font-size: 12px;
+  margin: 0;
+}
+
+/* Turn list */
+.chat-turns {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding-bottom: 8px;
+}
+
+/* Individual turn */
+.chat-turn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 16px;
+}
+
+/* User turns: right-aligned, no avatar */
+.chat-turn--user {
+  flex-direction: row-reverse;
+}
+
+.chat-turn--user .chat-turn-bubble {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border-radius: var(--radius-xl) var(--radius-sm) var(--radius-xl) var(--radius-xl);
+  max-width: 72%;
+}
+
+/* Assistant turns: left-aligned, with avatar */
+.chat-turn--assistant .chat-turn-bubble {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm) var(--radius-xl) var(--radius-xl) var(--radius-xl);
+  max-width: 86%;
+}
+
+.chat-turn-avatar {
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent-dim);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.chat-turn-avatar svg {
+  width: 12px;
+  height: 12px;
+}
+
+.chat-turn-bubble {
+  padding: 8px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.chat-turn-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Markdown in assistant turns */
+.chat-turn-markdown {
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.chat-turn-markdown .chat-paragraph {
+  margin: 0 0 6px;
+}
+
+.chat-turn-markdown .chat-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.chat-turn-markdown .chat-heading {
+  margin: 8px 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.chat-turn-markdown h1.chat-heading { font-size: 14px; }
+
+.chat-turn-markdown .chat-list {
+  margin: 4px 0 6px;
+  padding-left: 18px;
+}
+
+.chat-turn-markdown .chat-list li {
+  margin-bottom: 2px;
+}
+
+.chat-turn-markdown .chat-blockquote {
+  margin: 4px 0;
+  padding: 4px 10px;
+  border-left: 2px solid var(--border-strong);
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.chat-inline-code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 3px;
+}
+
+.chat-code-block {
+  margin: 6px 0;
+  padding: 8px 10px;
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+/* Streaming cursor blink */
+.chat-streaming-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: chat-cursor-blink 1s step-end infinite;
+}
+
+@keyframes chat-cursor-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* Tool call chips */
+.chat-tool-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 16px 4px 46px; /* indented to align with assistant turn content */
+}
+
+.chat-tool-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text-dim);
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.chat-tool-chip--running {
+  border-color: var(--accent-border);
+  color: var(--accent);
+}
+
+.chat-tool-chip--ok {
+  color: var(--green);
+  border-color: rgba(5, 169, 188, 0.2);
+}
+
+[data-theme="dark"] .chat-tool-chip--ok {
+  border-color: rgba(107, 225, 149, 0.2);
+}
+
+.chat-tool-chip--error {
+  color: var(--red);
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.chat-tool-spinner {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: chat-tool-spin 0.7s linear infinite;
+}
+
+@keyframes chat-tool-spin {
+  to { transform: rotate(360deg); }
+}
+
+.chat-tool-ok-icon,
+.chat-tool-err-icon {
+  width: 10px;
+  height: 10px;
+}
+
+/* Working indicator */
+.chat-working {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px 6px 46px;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.chat-working-dots {
+  display: flex;
+  gap: 3px;
+}
+
+.chat-working-dots span {
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  animation: chat-working-bounce 1.2s ease-in-out infinite;
+}
+
+.chat-working-dots span:nth-child(2) { animation-delay: 0.2s; }
+.chat-working-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes chat-working-bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-4px); }
+}
+
+/* System notes (slash commands, status events) */
+.chat-system-note {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 16px;
+  font-size: 11px;
+  color: var(--text-faint);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-1);
+  margin: 4px 0;
+}
+
+.chat-system-note-text {
+  font-family: var(--font-mono);
+}
+
+.chat-system-note-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.chat-system-note-link:hover {
+  color: var(--accent-hover);
+}
+
+.chat-system-note-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring);
+  border-radius: 2px;
+}
+
+/* Jump-to-bottom pill */
+.chat-scroll-to-bottom {
+  position: absolute;
+  bottom: 84px; /* above the composer */
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 5px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  color: var(--text-dim);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  z-index: 10;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-scroll-to-bottom:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+/* Permission-pending attention banner */
+.chat-attention-banner {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-warning, #fff8e6);
+  border-top: 1px solid var(--border-warning, #f5d06a);
+  border-bottom: 1px solid var(--border-warning, #f5d06a);
+  font-size: 12.5px;
+  color: var(--text, #1a1a1a);
+}
+
+[data-theme="dark"] .chat-attention-banner {
+  background: #2a2200;
+  border-color: #5a4500;
+}
+
+.chat-attention-icon {
+  flex: 0 0 auto;
+  font-size: 13px;
+  color: var(--text-warning, #a07000);
+}
+
+[data-theme="dark"] .chat-attention-icon {
+  color: #e0a800;
+}
+
+.chat-attention-message {
+  flex: 1 1 auto;
+}
+
+.chat-attention-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent, #0060d0);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: inherit;
+}
+
+.chat-attention-link:hover {
+  color: var(--accent-hover, #0050b0);
+}
+
+.chat-attention-link:focus-visible {
+  outline: 2px solid var(--accent, #0060d0);
+  border-radius: 2px;
+}
+
+/* Composer */
+.chat-composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--border);
+  background: var(--bg-1);
+}
+
+/* PromptBar inside ChatView inherits its own styles but loses its outer border
+   (the chat-composer provides the top border). */
+.chat-composer .prompt-bar {
+  border-top: none;
+  background: transparent;
+}
+
+.chat-composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 2px 12px 6px;
+  min-height: 20px;
+}
+
+/* Passive harness label in the composer footer */
+.chat-harness-label {
+  font-size: 10.5px;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+}
+
+.chat-harness-label--none {
+  display: none;
+}


### PR DESCRIPTION
Unit PR into the v0 integration branch (umbrella: #266). **The owner's headline UX pivot.**

## What

The center pane is now a Lovable/Conductor-style conversation — identical for every embedded harness. Markdown agent turns, quiet tool-activity chips, working indicator, auto-scroll with scroll-lock, per-session history. The terminal is demoted to a `Chat | Terminal` tab (xterm stays mounted across flips, refit verified) for TUI-required moments. Branding untouched.

- **Turn sources, no pty parsing**: claude-code via a session-transcript tailer (path-encoding validated against Claude Code's real convention; partial-line buffering; resume tails from EOF while history supplies the past — duplicate-turn regression test); codex mapped from its existing tailer into the same `chat.turn`/`chat.tool` shapes. History-on-open reads the NEWEST 128KB window.
- **Composer = the evolved prompt bar**: two-tier readiness, per-session drafts, IME guard, and the `prompt.submitted` tracking all survive relocation (spec coverage verified intact).
- **Owner directives, each implemented + tested**: slash commands pass through byte-verbatim with a quiet system note linking to the Terminal tab; NO harness switcher (selection stays in the New-session modal) with a passive harness label in the composer; permission prompts surface as a chat banner (driven by the Notification hook, cleared on next activity); and a banned-words guard spec proves the rendered chat never mentions the machinery (hook/analytics/telemetry/ingest/collector).
- **Privacy boundary verified in review**: chat events are UI-transport only — the Notification hook and transcript text never touch the analytics store or emitter.

## Review rounds

Round 1: compliance checklist 3/4 pass + caught duplicate-turns-on-resume, oldest-window history, and the missing guard test — all fixed in round 2 along with the rebase over SAP-1423/1424 (kept 1423's real `track()` call; deduped `listHarnesses` to 1424's registry-backed shape).

Tests: 789 unit + 139 Playwright on the rebased tree. Minor changeset.

Closes SAP-1477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)