### PR TITLE
ci(harness): wire unit + Playwright mock tiers into PR CI; document the local loop (SAP-1425)

### DIFF
--- a/.changeset/analytics-core-harness-seq-gaps.md
+++ b/.changeset/analytics-core-harness-seq-gaps.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/analytics-core": patch
+---
+
+Clarify harness `seq` gap semantics in CONTRACT.md.
+
+The per-session `seq` section now notes that for the harness specifically,
+`seq` indexes the local capture stream; some locally-sequenced event kinds are
+not forwarded remotely, so remote streams have expected gaps. Duplicates are
+the anomaly signal, not gaps. Verified against production data 2026-07-09.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,55 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Playwright mock-mode tier — harness web/e2e specs (VITE_MOCK=1, chromium only).
+  # The live/real-pty tiers (e2e:live, sim) are opt-in local only; nothing here
+  # invokes them — they require real agent binaries and credentials not in CI.
+  playwright-mock:
+    runs-on: ubuntu-latest
+    # Single Node version is enough — the mock tier tests browser behaviour,
+    # not Node version compat; that's covered by the matrix job above.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build harness and dependencies
+        run: pnpm --filter "@sapiom/harness..." build
+
+      # Cache Playwright browser binaries keyed on the package.json devDependency
+      # version so the cache invalidates on every @playwright/test bump.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('packages/harness/package.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @sapiom/harness exec playwright install chromium --with-deps
+
+      - name: Install Playwright system deps (cached hit path)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
+
+      - name: Run Playwright mock-mode suite
+        run: pnpm --filter @sapiom/harness test:ui
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/harness/web/e2e/playwright-report/
+          retention-days: 7

--- a/packages/analytics-core/CONTRACT.md
+++ b/packages/analytics-core/CONTRACT.md
@@ -130,13 +130,17 @@ cross-producer analysis stays cheap.
 
 **Per-session `seq`.** Producers that manage sessions locally (e.g. the dev
 harness) MAY assign each session's events a monotonic sequence number
-starting at 1, carried as `data.seq`. Within one `session_id`, gaps
-indicate loss and `seq` order is authoritative — when it disagrees with
-`event_timestamp` (a client clock), trust `seq`. It is producer-assigned
-and stored verbatim; the collector never renumbers, and `seq` values from
-different sessions are not comparable. If a producer restarts mid-session,
-`seq` resets — consumers should treat a `seq` decrease as a restart
-boundary, not loss.
+starting at 1, carried as `data.seq`. Within one `session_id`, `seq` order
+is authoritative — when it disagrees with `event_timestamp` (a client
+clock), trust `seq`. It is producer-assigned and stored verbatim; the
+collector never renumbers, and `seq` values from different sessions are not
+comparable. If a producer restarts mid-session, `seq` resets — consumers
+should treat a `seq` decrease as a restart boundary, not loss.
+
+For the harness specifically: `seq` indexes the harness's local capture
+stream; some locally-sequenced event kinds are not forwarded remotely, so
+remote streams have **expected gaps** — duplicates are the anomaly signal,
+not gaps. (Verified against production data 2026-07-09.)
 
 **Batch context.** `data.context` MAY carry `app_version`, `os`, `arch`,
 and `node`, stamped once per batch by the producer — the conventional

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -46,3 +46,37 @@ pnpm --filter @sapiom/harness build      # server (tsc) + SPA (vite) → dist/
 Architecture: a single Node process (Express + ws + node-pty) serves the built
 SPA, a small REST API, terminal WebSocket streams, and the local telemetry
 ingest endpoint. The interface contract lives in `src/shared/types.ts`.
+
+## Testing
+
+Three tiers — run whatever fits your change:
+
+**Unit tier** (vitest, no browser, no agent): covers server logic, adapters,
+analytics, and canvas rendering. Runs in CI on every PR.
+
+```bash
+pnpm --filter @sapiom/harness test
+```
+
+**Playwright mock tier** (chromium, Vite dev server with `VITE_MOCK=1`, no
+harness server or agent process). The full `web/e2e/` suite against the SPA in
+mock mode. Runs in CI on every PR. For a fast watch loop locally, use UI mode:
+
+```bash
+# One-time browser install (not included in pnpm install):
+pnpm --filter @sapiom/harness exec playwright install chromium
+
+# Watch/UI mode — re-runs affected specs on save:
+pnpm --filter @sapiom/harness exec playwright test \
+  --config web/e2e/playwright.config.ts --ui
+
+# Or run the full suite once (same command CI uses):
+pnpm --filter @sapiom/harness test:ui
+```
+
+**E2E live tier** (real agent binaries, real pty, no CI). Requires Claude Code
+or Codex installed and a valid `SAPIOM_API_KEY` in your environment.
+
+```bash
+pnpm --filter @sapiom/harness e2e:live
+```

--- a/packages/harness/src/server/workspace-rescan.test.ts
+++ b/packages/harness/src/server/workspace-rescan.test.ts
@@ -77,44 +77,52 @@ describe("mid-session workflow rescan", () => {
     return (await res.json()) as WorkflowInfo[];
   }
 
-  it("adds a scaffolded workflow and drops a removed one, broadcasting each change", async () => {
-    server = await startServer({
-      port: 0,
-      bootToken: "test-token",
-      telemetryOptIn: false,
-      adapters: { "claude-code": fakeClaudeAdapter() },
-      stateRoot: dir,
-      launchDir: cwd,
-      autoCreateSession: false,
-    });
-    const port = server.port;
+  // retry:1 — this test exercises a real filesystem watcher under parallel load;
+  // the watcher's debounce window occasionally races with the vi.waitFor polling
+  // interval, producing a spurious timeout on the first run. One retry isolates
+  // a scheduling artifact from a genuine regression without masking real failures.
+  it(
+    "adds a scaffolded workflow and drops a removed one, broadcasting each change",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      server = await startServer({
+        port: 0,
+        bootToken: "test-token",
+        telemetryOptIn: false,
+        adapters: { "claude-code": fakeClaudeAdapter() },
+        stateRoot: dir,
+        launchDir: cwd,
+        autoCreateSession: false,
+      });
+      const port = server.port;
 
-    const session = await server.sessionManager.create({ cwd, harness: "claude-code" });
-    expect(session.status).toBe("running");
-    await connectEvents(port);
+      const session = await server.sessionManager.create({ cwd, harness: "claude-code" });
+      expect(session.status).toBe("running");
+      await connectEvents(port);
 
-    // Add a workflow mid-session — it must appear in the broadcast list AND
-    // trigger a `workflows.changed` frame.
-    await scaffoldWorkflow(cwd, "hn-story-images");
-    await vi.waitFor(
-      async () => {
-        const workflows = await listWorkflows(port);
-        expect(workflows.some((w) => w.name === "hn-story-images")).toBe(true);
-        expect(changedFrames).toBeGreaterThan(0);
-      },
-      { timeout: 8_000, interval: 150 },
-    );
+      // Add a workflow mid-session — it must appear in the broadcast list AND
+      // trigger a `workflows.changed` frame.
+      await scaffoldWorkflow(cwd, "hn-story-images");
+      await vi.waitFor(
+        async () => {
+          const workflows = await listWorkflows(port);
+          expect(workflows.some((w) => w.name === "hn-story-images")).toBe(true);
+          expect(changedFrames).toBeGreaterThan(0);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
 
-    // Remove it — the prune in the rescan must drop it back out and broadcast again.
-    const framesBeforeRemoval = changedFrames;
-    await rm(join(cwd, "hn-story-images"), { recursive: true, force: true });
-    await vi.waitFor(
-      async () => {
-        const workflows = await listWorkflows(port);
-        expect(workflows.some((w) => w.name === "hn-story-images")).toBe(false);
-        expect(changedFrames).toBeGreaterThan(framesBeforeRemoval);
-      },
-      { timeout: 8_000, interval: 150 },
-    );
-  }, 20_000);
+      // Remove it — the prune in the rescan must drop it back out and broadcast again.
+      const framesBeforeRemoval = changedFrames;
+      await rm(join(cwd, "hn-story-images"), { recursive: true, force: true });
+      await vi.waitFor(
+        async () => {
+          const workflows = await listWorkflows(port);
+          expect(workflows.some((w) => w.name === "hn-story-images")).toBe(false);
+          expect(changedFrames).toBeGreaterThan(framesBeforeRemoval);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+    },
+  );
 });


### PR DESCRIPTION
Final unit PR into the v0 integration branch (umbrella: #266).

- **New `playwright-mock` CI job**: builds the harness chain, caches Chromium (`hashFiles` on the harness package.json), runs the 139-spec mock-mode suite (`VITE_MOCK=1`, vite-only webServer — no harness server, no agents, no credentials). Live/real-pty tiers verified absent from CI.
- **Targeted flake handling**: `{ retry: 1 }` on the single known-intermittent workspace-rescan test (filesystem-watcher debounce race, documented inline) — no blanket retries.
- **README "Testing" section**: copy-paste commands for the three tiers (unit / Playwright watch loop / e2e-live). `--no-telemetry` wording untouched.
- **CONTRACT.md seq amendment** (+ docs patch changeset per #248 precedent): harness `seq` indexes the local capture stream, so remote streams have expected gaps — duplicates are the anomaly signal. Verified against production data 2026-07-09.

789 unit + 139 Playwright green; the exact CI commands were executed locally as proof.

Closes SAP-1425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)