### PR TITLE
add sandbox previews

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@sapiom/agent": "workspace:^",
     "@sapiom/agent-core": "workspace:^",
     "@sapiom/analytics-core": "workspace:^",
+    "@sapiom/sandbox-preview": "workspace:^",
     "commander": "^14.0.2",
     "zod": "^3.25.76"
   },

--- a/packages/cli/src/commands/sandbox/index.ts
+++ b/packages/cli/src/commands/sandbox/index.ts
@@ -1,0 +1,19 @@
+import { Command } from 'commander';
+
+import { action, json } from '../shared.js';
+import { runPreview } from './preview.js';
+
+/**
+ * Mount the `sapiom sandbox …` command group. `preview` deploys local web-app code
+ * to a sandbox and exposes a live URL. Distinct from `agents` (the composition
+ * product) and from the future production `applications` product.
+ */
+export function registerSandboxCommands(program: Command): void {
+  const group = program.command('sandbox').alias('sbx').description('Run and preview code on Sapiom sandboxes.');
+
+  json(group.command('preview [name]').description('Provision, upload, build, start, and expose a live preview URL.'))
+    // Sandboxes run on the compute host, not the API host — so this is a precise
+    // services-base override, not the agents' --host/--target (API host).
+    .option('--services-url <url>', 'override the compute/sandbox service base URL')
+    .action(action(runPreview));
+}

--- a/packages/cli/src/commands/sandbox/preview.ts
+++ b/packages/cli/src/commands/sandbox/preview.ts
@@ -1,0 +1,38 @@
+import { previewSandbox, PreviewOperationError } from '@sapiom/sandbox-preview';
+
+import { resolveApiKey } from '../../lib/client.js';
+import { CliError, isJsonMode, ok } from '../../lib/output.js';
+
+/**
+ * `sapiom sandbox preview [name]` — provision a sandbox (if needed), upload the
+ * local code, build it, start it, and expose a live preview URL. Reads the
+ * sandbox's declared intent from `sapiom.json` (`type: "sandbox"`, singular-default
+ * when there's exactly one).
+ */
+export async function runPreview(name: string | undefined, opts: { servicesUrl?: string }): Promise<void> {
+  try {
+    const apiKey = resolveApiKey();
+    const result = await previewSandbox({
+      dir: process.cwd(),
+      name,
+      apiKey,
+      servicesBaseUrl: opts.servicesUrl,
+      // Progress goes to stderr so it never pollutes --json stdout.
+      log: (msg) => {
+        if (!isJsonMode()) process.stderr.write(`  ${msg}\n`);
+      },
+    });
+
+    if (isJsonMode()) {
+      ok({ name: result.name, url: result.url, status: result.status });
+    } else if (result.status === 'failed') {
+      ok({}, [`✗ ${result.name} build/start failed:`, result.logs]);
+    } else {
+      const verified = result.status === 'deployed' ? 'live' : 'started (unverified)';
+      ok({}, [`✓ ${result.name} ${verified}: ${result.url}`]);
+    }
+  } catch (err) {
+    if (err instanceof PreviewOperationError) throw new CliError(err.toStructured());
+    throw err;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { registerAuthCommands } from './commands/auth/index.js';
 import { registerConfigCommands } from './commands/config/index.js';
 import { registerAgentsCommands } from './commands/agents/index.js';
 import { registerCommandAnalytics } from './lib/analytics.js';
+import { registerSandboxCommands } from './commands/sandbox/index.js';
 
 /**
  * Build the root `sapiom` program. Account-level commands (login/logout) sit at
@@ -20,6 +21,7 @@ export function buildProgram(): Command {
   registerAuthCommands(program);
   registerConfigCommands(program);
   registerAgentsCommands(program);
+  registerSandboxCommands(program);
 
   return program;
 }

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -20,7 +20,7 @@ export type { CliTarget };
  * agents), then the stored session from `sapiom login`. Stateful by default,
  * but every stateful path has a stateless override.
  */
-function resolveApiKey(): string {
+export function resolveApiKey(): string {
   const env = process.env.SAPIOM_API_KEY;
   if (env) return env;
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -56,6 +56,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@sapiom/agent-core": "workspace:^",
     "@sapiom/analytics-core": "workspace:^",
+    "@sapiom/sandbox-preview": "workspace:^",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/analytics.e2e.test.ts
+++ b/packages/mcp/src/analytics.e2e.test.ts
@@ -43,6 +43,9 @@ const ALL_TOOL_NAMES = [
   "sapiom_dev_agents_schedule_cancel",
   "sapiom_dev_agents_schedule_inspect",
   "sapiom_dev_agents_signal",
+  "sapiom_dev_sandbox_check",
+  "sapiom_dev_sandbox_configure",
+  "sapiom_dev_sandbox_preview",
   "sapiom_logout",
   "sapiom_status",
 ];

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ import { resolveEnvironment } from "./credentials.js";
 import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerAgents } from "./tools/agents.js";
+import { register as registerSandbox } from "./tools/sandbox.js";
 import { fetchInstructions } from "./instructions-fetch.js";
 
 async function main(): Promise<void> {
@@ -55,6 +56,7 @@ async function main(): Promise<void> {
   registerAuthenticate(server, env);
   registerStatus(server, env);
   registerAgents(server, env);
+  registerSandbox(server, env);
 
   // Connect via stdio transport
   const transport = new StdioServerTransport();

--- a/packages/mcp/src/tools/sandbox.ts
+++ b/packages/mcp/src/tools/sandbox.ts
@@ -1,0 +1,64 @@
+/**
+ * Sandbox preview tools. Thin wrappers over @sapiom/sandbox-preview.
+ *
+ * `sapiom_dev_sandbox_preview` reads the project's `sapiom.json` (`type: "sandbox"`),
+ * provisions the sandbox if needed, uploads the local code, and calls the
+ * server-side deploy op for a live URL. Results are returned as JSON text so the
+ * calling agent can parse them.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { previewSandbox, PreviewOperationError } from "@sapiom/sandbox-preview";
+
+import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function fail(err: unknown): ToolResult {
+  const structured =
+    err instanceof PreviewOperationError
+      ? err.toStructured()
+      : { code: "UNEXPECTED", message: err instanceof Error ? err.message : String(err) };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: structured }, null, 2) }],
+    isError: true,
+  };
+}
+
+const NOT_AUTHED = fail(
+  new PreviewOperationError({
+    code: "NOT_AUTHENTICATED",
+    message: "Not authenticated. Run sapiom_authenticate first.",
+  }),
+);
+
+export function register(server: McpServer, env: ResolvedEnvironment): void {
+  server.tool(
+    "sapiom_dev_sandbox_preview",
+    "Deploy a web-app preview from the current project to a Sapiom sandbox and get a live URL. " +
+      "Reads sapiom.json (a `type: \"sandbox\"` resource), provisions the sandbox if needed, uploads " +
+      "the local code, builds, starts, and exposes a public URL. Returns { name, url, status, logs }. " +
+      "A `failed` status carries build/start logs (not an error) so you can fix and retry.",
+    {
+      dir: z.string().optional().describe("Project directory (defaults to the current working directory)."),
+      name: z.string().optional().describe("Which sandbox to deploy, when the project defines more than one."),
+    },
+    async ({ dir, name }) => {
+      const creds = await readCredentials(env.name);
+      if (!creds) return NOT_AUTHED;
+      try {
+        const result = await previewSandbox({ dir: dir ?? process.cwd(), name, apiKey: creds.apiKey });
+        return ok(result);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/sandbox.ts
+++ b/packages/mcp/src/tools/sandbox.ts
@@ -1,14 +1,25 @@
 /**
  * Sandbox preview tools. Thin wrappers over @sapiom/sandbox-preview.
  *
- * `sapiom_dev_sandbox_preview` reads the project's `sapiom.json` (`type: "sandbox"`),
- * provisions the sandbox if needed, uploads the local code, and calls the
- * server-side deploy op for a live URL. Results are returned as JSON text so the
- * calling agent can parse them.
+ * - `sapiom_dev_sandbox_configure` writes a validated `type: "sandbox"` resource
+ *   into `sapiom.json` from typed args (config-as-tool-args — the agent fills a
+ *   typed schema instead of hand-writing JSON, which it tends to get wrong).
+ * - `sapiom_dev_sandbox_check` validates those resources without deploying.
+ * - `sapiom_dev_sandbox_preview` reads the project's `sapiom.json` (`type: "sandbox"`),
+ *   provisions the sandbox if needed, uploads the local code, and calls the
+ *   server-side deploy op for a live URL.
+ *
+ * Results are returned as JSON text so the calling agent can parse them.
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { previewSandbox, PreviewOperationError } from "@sapiom/sandbox-preview";
+import {
+  previewSandbox,
+  configureSandbox,
+  checkSandboxes,
+  sandboxConfigBodySchema,
+  PreviewOperationError,
+} from "@sapiom/sandbox-preview";
 
 import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
 
@@ -40,6 +51,47 @@ const NOT_AUTHED = fail(
 );
 
 export function register(server: McpServer, env: ResolvedEnvironment): void {
+  server.tool(
+    "sapiom_dev_sandbox_configure",
+    "Create or update a sandbox preview resource in the project's sapiom.json. Fill the typed " +
+      "arguments instead of hand-writing JSON — the config is validated and written under " +
+      "resources.<name> (type: \"sandbox\"). Returns the stored config. Use sapiom_dev_sandbox_preview " +
+      "afterwards to deploy it.",
+    {
+      dir: z.string().optional().describe("Project directory (defaults to the current working directory)."),
+      name: z
+        .string()
+        .describe("Resource name — the sapiom.json `resources` key and the sandbox name (e.g. `web`)."),
+      ...sandboxConfigBodySchema.shape,
+    },
+    async ({ dir, name, ...body }) => {
+      try {
+        const result = configureSandbox(dir ?? process.cwd(), name, body);
+        return ok(result);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
+  server.tool(
+    "sapiom_dev_sandbox_check",
+    "Validate the sandbox preview resources in the project's sapiom.json without deploying. " +
+      "Returns { ok, sandboxes, issues }; `issues` lists actionable validation problems to fix " +
+      "before previewing.",
+    {
+      dir: z.string().optional().describe("Project directory (defaults to the current working directory)."),
+    },
+    async ({ dir }) => {
+      try {
+        const result = checkSandboxes(dir ?? process.cwd());
+        return ok(result);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
   server.tool(
     "sapiom_dev_sandbox_preview",
     "Deploy a web-app preview from the current project to a Sapiom sandbox and get a live URL. " +

--- a/packages/sandbox-preview/.eslintrc.js
+++ b/packages/sandbox-preview/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
+  },
+};

--- a/packages/sandbox-preview/e2e/fixture/package.json
+++ b/packages/sandbox-preview/e2e/fixture/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sapiom-e2e-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/packages/sandbox-preview/e2e/fixture/sapiom.json
+++ b/packages/sandbox-preview/e2e/fixture/sapiom.json
@@ -1,0 +1,11 @@
+{
+  "resources": {
+    "sapiom-e2e-app": {
+      "type": "sandbox",
+      "source": { "kind": "upload" },
+      "start": "node server.js",
+      "port": 3000,
+      "ttl": "1h"
+    }
+  }
+}

--- a/packages/sandbox-preview/e2e/fixture/server.js
+++ b/packages/sandbox-preview/e2e/fixture/server.js
@@ -1,0 +1,20 @@
+// Minimal zero-dependency web app used by the e2e. Binds the port injected by
+// the deploy recipe (PORT) — deploy sets it to the app's declared port, which
+// overrides the sandbox runtime's injected PORT=80. Serves /health for readiness.
+const http = require('node:http');
+
+const port = Number(process.env.PORT) || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end('<!doctype html><title>sapiom e2e</title><h1>deployed via applications-core</h1>');
+});
+
+server.listen(port, () => {
+  console.log(`listening on ${port}`);
+});

--- a/packages/sandbox-preview/e2e/upload-deploy.e2e.spec.ts
+++ b/packages/sandbox-preview/e2e/upload-deploy.e2e.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * End-to-end: deploy the fixture app to a REAL Sapiom sandbox on prod and assert
+ * the preview URL serves 2xx. This provisions a real, TTL-bounded sandbox +
+ * preview (real spend), so it is gated:
+ *
+ *   RUN_E2E=1 SAPIOM_API_KEY=<prod key> pnpm --filter @sapiom/sandbox-preview test:e2e
+ *
+ * Optional: SAPIOM_SERVICES_BASE / SAPIOM_SANDBOX_URL to target a non-prod gateway.
+ * Without the gate it is skipped, so the default `jest` run stays offline.
+ */
+import path from 'node:path';
+
+import { createClient } from '@sapiom/tools';
+
+import { previewSandbox } from '../src/index.js';
+
+const ENABLED = process.env.RUN_E2E === '1' && Boolean(process.env.SAPIOM_API_KEY);
+const d = ENABLED ? describe : describe.skip;
+
+const FIXTURE_DIR = path.join(__dirname, 'fixture');
+const APP_NAME = 'sapiom-e2e-app';
+
+d('sandbox preview upload deploy (prod)', () => {
+  const apiKey = process.env.SAPIOM_API_KEY;
+  const servicesBaseUrl = process.env.SAPIOM_SERVICES_BASE ?? process.env.SAPIOM_SANDBOX_URL;
+
+  afterAll(async () => {
+    try {
+      const sapiom = createClient({ apiKey });
+      const box = sapiom.sandboxes.attach(APP_NAME, servicesBaseUrl ? { baseUrl: servicesBaseUrl } : {});
+      await box.destroy();
+    } catch {
+      /* best-effort teardown */
+    }
+  });
+
+  it('provisions, uploads, starts, and serves a live preview URL', async () => {
+    const result = await previewSandbox({
+      dir: FIXTURE_DIR,
+      apiKey,
+      servicesBaseUrl,
+      // eslint-disable-next-line no-console
+      log: (msg) => console.error(`  ${msg}`),
+    });
+
+    expect(result.name).toBe(APP_NAME);
+    expect(result.url).toMatch(/^https:\/\//);
+    expect(result.status).toBe('deployed');
+
+    const res = await fetch(`${result.url}/health`, { signal: AbortSignal.timeout(15_000) });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+  }, 300_000);
+});

--- a/packages/sandbox-preview/jest.config.js
+++ b/packages/sandbox-preview/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testEnvironment: 'node',
+  passWithNoTests: true,
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/packages/sandbox-preview/jest.e2e.config.js
+++ b/packages/sandbox-preview/jest.e2e.config.js
@@ -1,0 +1,17 @@
+// E2E config — runs the real, prod-hitting deploy test in ./e2e.
+// Kept separate from the default `jest` run (which only covers ./src) so
+// unit tests stay offline. Gated at runtime on SAPIOM_API_KEY + RUN_E2E.
+module.exports = {
+  testEnvironment: 'node',
+  passWithNoTests: true,
+  roots: ['<rootDir>/e2e'],
+  testMatch: ['**/*.e2e.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { module: 'commonjs' } }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testTimeout: 300_000,
+};

--- a/packages/sandbox-preview/package.json
+++ b/packages/sandbox-preview/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@sapiom/sandbox-preview",
+  "version": "0.1.1",
+  "description": "Client-side flow for deploying a web-app preview to a Sapiom sandbox — provision, upload, deploy to a live URL. Shared by the CLI and MCP packages.",
+  "license": "MIT",
+  "author": "Sapiom",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/sandbox-preview"
+  },
+  "keywords": [
+    "sapiom",
+    "sandbox",
+    "preview",
+    "deploy",
+    "sdk"
+  ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run build:esm-pkg",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build:esm-pkg": "echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc --watch --project tsconfig.cjs.json",
+    "test": "jest",
+    "test:e2e": "jest --config jest.e2e.config.js",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@sapiom/tools": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sandbox-preview/package.json
+++ b/packages/sandbox-preview/package.json
@@ -50,7 +50,8 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@sapiom/tools": "workspace:^"
+    "@sapiom/tools": "workspace:^",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/sandbox-preview/src/config.spec.ts
+++ b/packages/sandbox-preview/src/config.spec.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { getSandbox, readSandboxes, writeSandbox } from './config.js';
+
+function tmpProject(contents?: unknown): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sbxprev-'));
+  if (contents !== undefined) {
+    writeFileSync(path.join(dir, 'sapiom.json'), JSON.stringify(contents));
+  }
+  return dir;
+}
+
+const webSandbox = {
+  type: 'sandbox',
+  source: { kind: 'upload' },
+  start: 'node server.js',
+  port: 3000,
+};
+
+describe('config — getSandbox', () => {
+  it('returns the sole sandbox when no name is given (singular-default)', () => {
+    const dir = tmpProject({ resources: { web: webSandbox } });
+    try {
+      const sb = getSandbox(dir);
+      expect(sb.name).toBe('web');
+      expect(sb.port).toBe(3000);
+      expect(sb.source).toEqual({ kind: 'upload' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws AMBIGUOUS when multiple sandboxes and no name', () => {
+    const dir = tmpProject({ resources: { web: webSandbox, api: { ...webSandbox, port: 4000 } } });
+    try {
+      expect(() => getSandbox(dir)).toThrow(/Multiple sandboxes/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('selects by name and throws NO_SANDBOX for an unknown name', () => {
+    const dir = tmpProject({ resources: { web: webSandbox, api: { ...webSandbox, port: 4000 } } });
+    try {
+      expect(getSandbox(dir, 'api').port).toBe(4000);
+      expect(() => getSandbox(dir, 'nope')).toThrow(/No sandbox named 'nope'/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores non-sandbox resources', () => {
+    const dir = tmpProject({
+      definitionId: 'orch_1',
+      resources: { flow: { type: 'agent', definitionId: 'orch_1' }, web: webSandbox },
+    });
+    try {
+      expect(Object.keys(readSandboxes(dir))).toEqual(['web']);
+      expect(getSandbox(dir).name).toBe('web');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws NO_SANDBOX when the file or map is missing/empty', () => {
+    const dir = tmpProject();
+    try {
+      expect(() => getSandbox(dir)).toThrow(/No sandbox resources/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('config — writeSandbox', () => {
+  it('merges into resources without clobbering siblings or top-level keys', () => {
+    const dir = tmpProject({ definitionId: 'orch_1', resources: { flow: { type: 'agent' } } });
+    try {
+      writeSandbox(dir, {
+        name: 'web',
+        source: { kind: 'upload' },
+        start: 'node server.js',
+        port: 3000,
+        ttl: '7d',
+      });
+      const raw = JSON.parse(readFileSync(path.join(dir, 'sapiom.json'), 'utf8'));
+      expect(raw.definitionId).toBe('orch_1');
+      expect(raw.resources.flow).toEqual({ type: 'agent' });
+      expect(raw.resources.web).toEqual({
+        type: 'sandbox',
+        source: { kind: 'upload' },
+        start: 'node server.js',
+        port: 3000,
+        ttl: '7d',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sandbox-preview/src/config.spec.ts
+++ b/packages/sandbox-preview/src/config.spec.ts
@@ -2,7 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { getSandbox, readSandboxes, writeSandbox } from './config.js';
+import { getSandbox, readSandboxes, writeSandbox, configureSandbox, checkSandboxes } from './config.js';
+import { PreviewOperationError } from './errors.js';
+import { CONFIG_VERSION } from './schema.js';
 
 function tmpProject(contents?: unknown): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'sbxprev-'));
@@ -74,8 +76,8 @@ describe('config — getSandbox', () => {
   });
 });
 
-describe('config — writeSandbox', () => {
-  it('merges into resources without clobbering siblings or top-level keys', () => {
+describe('config — writeSandbox / configureSandbox', () => {
+  it('merges into resources without clobbering siblings or top-level keys, and stamps version', () => {
     const dir = tmpProject({ definitionId: 'orch_1', resources: { flow: { type: 'agent' } } });
     try {
       writeSandbox(dir, {
@@ -86,6 +88,7 @@ describe('config — writeSandbox', () => {
         ttl: '7d',
       });
       const raw = JSON.parse(readFileSync(path.join(dir, 'sapiom.json'), 'utf8'));
+      expect(raw.version).toBe(CONFIG_VERSION);
       expect(raw.definitionId).toBe('orch_1');
       expect(raw.resources.flow).toEqual({ type: 'agent' });
       expect(raw.resources.web).toEqual({
@@ -95,6 +98,81 @@ describe('config — writeSandbox', () => {
         port: 3000,
         ttl: '7d',
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid body with an actionable hint (no file written)', () => {
+    const dir = tmpProject();
+    try {
+      let caught: unknown;
+      try {
+        // @ts-expect-error — deliberately invalid (missing start, bad port) to exercise validation
+        configureSandbox(dir, 'web', { source: { kind: 'upload' }, port: 0 });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(PreviewOperationError);
+      expect((caught as PreviewOperationError).message).toMatch(/Invalid sandbox configuration/);
+      expect((caught as PreviewOperationError).hint).toMatch(/start.*required|port/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('config — validation on read', () => {
+  it('throws an actionable error for a malformed sandbox entry', () => {
+    const dir = tmpProject({ resources: { web: { type: 'sandbox', source: { kind: 'upload' }, port: 3000 } } });
+    try {
+      // missing `start`
+      expect(() => getSandbox(dir)).toThrow(/Invalid sandbox resource "web"/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a config from a newer tool version', () => {
+    const dir = tmpProject({ version: CONFIG_VERSION + 1, resources: { web: webSandbox } });
+    try {
+      expect(() => getSandbox(dir)).toThrow(/version .*supports up to/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on non-JSON', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sbxprev-'));
+    writeFileSync(path.join(dir, 'sapiom.json'), '{ not json');
+    try {
+      expect(() => getSandbox(dir)).toThrow(/not valid JSON/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('config — checkSandboxes', () => {
+  it('reports ok with the sandbox names when all valid', () => {
+    const dir = tmpProject({ resources: { web: webSandbox, api: { ...webSandbox, port: 4000 } } });
+    try {
+      const result = checkSandboxes(dir);
+      expect(result.ok).toBe(true);
+      expect(result.sandboxes.sort()).toEqual(['api', 'web']);
+      expect(result.issues).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('collects issues (does not throw) for an invalid entry', () => {
+    const dir = tmpProject({ resources: { web: { type: 'sandbox', source: { kind: 'upload' }, port: 3000 } } });
+    try {
+      const result = checkSandboxes(dir);
+      expect(result.ok).toBe(false);
+      expect(result.sandboxes).toEqual(['web']);
+      expect(result.issues.join(' ')).toMatch(/start/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/sandbox-preview/src/config.ts
+++ b/packages/sandbox-preview/src/config.ts
@@ -2,24 +2,29 @@
  * `sapiom.json` — the project's committed declared intent. Sandbox previews live
  * under a name-keyed `resources` map, discriminated by `type`:
  *
- *   { "resources": { "web": { "type": "sandbox", "source": {...}, "start": "...", "port": 3000 } } }
+ *   { "version": 1, "resources": { "web": { "type": "sandbox", "source": {...}, "start": "...", "port": 3000 } } }
  *
- * The map coexists with other capabilities' top-level keys (e.g. an agent's
- * `definitionId`) — each capability owns only its own entries and never rewrites
- * a sibling's. This module reads/writes ONLY `type: "sandbox"` entries.
+ * The map coexists with other capabilities' entries (e.g. an agent's `definitionId`)
+ * — each capability owns only its own entries and never rewrites a sibling's. This
+ * module reads/writes ONLY `type: "sandbox"` entries and validates them against the
+ * capability-owned zod schema, so a malformed/hallucinated file fails with an
+ * actionable message rather than a confusing downstream error.
+ *
+ * ENVELOPE vs RESOURCE: the `version` + `resources` envelope is the shared,
+ * multi-surface part (see schema.ts) and is a candidate to extract into a shared
+ * `@sapiom/project-config` once a second resources-map surface exists.
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { PreviewOperationError } from './errors.js';
+import { CONFIG_VERSION, storedSandboxSchema, type SandboxConfigBody } from './schema.js';
 import type { SandboxConfig } from './types.js';
 
 export const CONFIG_FILE = 'sapiom.json';
 
-/** Stored sandbox entry — the on-disk shape (name is the map key, not a field). */
-type StoredSandbox = Omit<SandboxConfig, 'name'> & { type: 'sandbox' };
-
 interface SapiomFile {
+  version?: number;
   host?: string;
   resources?: Record<string, { type?: string } & Record<string, unknown>>;
   [key: string]: unknown;
@@ -28,33 +33,56 @@ interface SapiomFile {
 function readFile(dir: string): SapiomFile | null {
   const file = path.join(dir, CONFIG_FILE);
   if (!existsSync(file)) return null;
+  let parsed: SapiomFile;
   try {
-    return JSON.parse(readFileSync(file, 'utf8')) as SapiomFile;
+    parsed = JSON.parse(readFileSync(file, 'utf8')) as SapiomFile;
   } catch {
+    throw new PreviewOperationError({ code: 'BAD_CONFIG', message: `${CONFIG_FILE} is not valid JSON.` });
+  }
+  // Envelope version gate: an unversioned file is assumed current; a higher version
+  // means the file was written by a newer tool than this one understands.
+  if (typeof parsed.version === 'number' && parsed.version > CONFIG_VERSION) {
     throw new PreviewOperationError({
-      code: 'BAD_CONFIG',
-      message: `${CONFIG_FILE} is not valid JSON.`,
+      code: 'UNSUPPORTED_CONFIG_VERSION',
+      message: `${CONFIG_FILE} is version ${parsed.version}, but this tool supports up to ${CONFIG_VERSION}.`,
+      hint: 'Upgrade the Sapiom SDK/CLI.',
     });
   }
+  return parsed;
 }
 
-/** All sandbox resources in the project, keyed by name (empty object if none). */
+/** Parse + validate one stored `type:"sandbox"` entry into a SandboxConfig (throws actionable on invalid). */
+function parseSandboxEntry(name: string, entry: Record<string, unknown>): SandboxConfig {
+  const result = storedSandboxSchema.safeParse(entry);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${['resources', name, ...i.path].join('.')}: ${i.message}`)
+      .join('; ');
+    throw new PreviewOperationError({
+      code: 'INVALID_SANDBOX',
+      message: `Invalid sandbox resource "${name}" in ${CONFIG_FILE}.`,
+      hint: detail,
+    });
+  }
+  const { type: _type, ...body } = result.data;
+  return { name, ...(body as SandboxConfigBody) };
+}
+
+/** All sandbox resources in the project, keyed by name (validated; empty object if none). */
 export function readSandboxes(dir: string): Record<string, SandboxConfig> {
   const cfg = readFile(dir);
   const resources = cfg?.resources ?? {};
   const out: Record<string, SandboxConfig> = {};
   for (const [name, entry] of Object.entries(resources)) {
     if (entry?.type !== 'sandbox') continue;
-    const { type: _type, ...rest } = entry as StoredSandbox;
-    out[name] = { name, ...(rest as Omit<SandboxConfig, 'name'>) };
+    out[name] = parseSandboxEntry(name, entry);
   }
   return out;
 }
 
 /**
  * Resolve a single sandbox to deploy. With a `name`, returns that one. Without,
- * returns the sole sandbox (singular-default) or throws if there are zero or many
- * — so the common one-app project needs no `--name`.
+ * returns the sole sandbox (singular-default) or throws if there are zero or many.
  */
 export function getSandbox(dir: string, name?: string): SandboxConfig {
   const sandboxes = readSandboxes(dir);
@@ -76,7 +104,7 @@ export function getSandbox(dir: string, name?: string): SandboxConfig {
     throw new PreviewOperationError({
       code: 'NO_SANDBOX',
       message: `No sandbox resources defined in ${CONFIG_FILE}.`,
-      hint: 'Add a resource with "type": "sandbox" (source, start, port).',
+      hint: 'Add one with sapiom_dev_sandbox_configure (or a "type":"sandbox" resource).',
     });
   }
   if (names.length > 1) {
@@ -90,16 +118,50 @@ export function getSandbox(dir: string, name?: string): SandboxConfig {
 }
 
 /**
- * Persist a sandbox resource into `sapiom.json`, merging into the `resources` map
- * without clobbering sibling entries or other top-level keys.
+ * Validate + persist a sandbox resource into `sapiom.json` (the `configure` core).
+ * Validates the body against the schema (actionable errors), stamps the envelope
+ * `version`, and merges into `resources` without clobbering siblings/top-level keys.
  */
-export function writeSandbox(dir: string, cfg: SandboxConfig): void {
+export function configureSandbox(dir: string, name: string, body: SandboxConfigBody): SandboxConfig {
+  const parsed = storedSandboxSchema.safeParse({ type: 'sandbox', ...body });
+  if (!parsed.success) {
+    const detail = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new PreviewOperationError({
+      code: 'INVALID_SANDBOX',
+      message: `Invalid sandbox configuration for "${name}".`,
+      hint: detail,
+    });
+  }
   const existing = readFile(dir) ?? {};
-  const { name, ...rest } = cfg;
-  const entry: StoredSandbox = { type: 'sandbox', ...rest };
   const next: SapiomFile = {
+    version: CONFIG_VERSION,
     ...existing,
-    resources: { ...(existing.resources ?? {}), [name]: entry },
+    resources: { ...(existing.resources ?? {}), [name]: parsed.data },
   };
+  next.version = CONFIG_VERSION; // ensure current even if `existing` had an older/absent one
   writeFileSync(path.join(dir, CONFIG_FILE), JSON.stringify(next, null, 2) + '\n');
+  return { name, ...body };
+}
+
+/** Back-compat alias — `configureSandbox` is the validated writer. */
+export const writeSandbox = (dir: string, cfg: SandboxConfig): SandboxConfig => {
+  const { name, ...body } = cfg;
+  return configureSandbox(dir, name, body);
+};
+
+/** Validate every sandbox resource without deploying (the `check` core). */
+export function checkSandboxes(dir: string): { ok: boolean; sandboxes: string[]; issues: string[] } {
+  const issues: string[] = [];
+  const cfg = readFile(dir); // throws on bad JSON / unsupported version
+  const resources = cfg?.resources ?? {};
+  const found: string[] = [];
+  for (const [name, entry] of Object.entries(resources)) {
+    if (entry?.type !== 'sandbox') continue;
+    found.push(name);
+    const r = storedSandboxSchema.safeParse(entry);
+    if (!r.success) {
+      for (const i of r.error.issues) issues.push(`resources.${name}.${i.path.join('.')}: ${i.message}`);
+    }
+  }
+  return { ok: issues.length === 0, sandboxes: found, issues };
 }

--- a/packages/sandbox-preview/src/config.ts
+++ b/packages/sandbox-preview/src/config.ts
@@ -1,0 +1,105 @@
+/**
+ * `sapiom.json` — the project's committed declared intent. Sandbox previews live
+ * under a name-keyed `resources` map, discriminated by `type`:
+ *
+ *   { "resources": { "web": { "type": "sandbox", "source": {...}, "start": "...", "port": 3000 } } }
+ *
+ * The map coexists with other capabilities' top-level keys (e.g. an agent's
+ * `definitionId`) — each capability owns only its own entries and never rewrites
+ * a sibling's. This module reads/writes ONLY `type: "sandbox"` entries.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { PreviewOperationError } from './errors.js';
+import type { SandboxConfig } from './types.js';
+
+export const CONFIG_FILE = 'sapiom.json';
+
+/** Stored sandbox entry — the on-disk shape (name is the map key, not a field). */
+type StoredSandbox = Omit<SandboxConfig, 'name'> & { type: 'sandbox' };
+
+interface SapiomFile {
+  host?: string;
+  resources?: Record<string, { type?: string } & Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+function readFile(dir: string): SapiomFile | null {
+  const file = path.join(dir, CONFIG_FILE);
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as SapiomFile;
+  } catch {
+    throw new PreviewOperationError({
+      code: 'BAD_CONFIG',
+      message: `${CONFIG_FILE} is not valid JSON.`,
+    });
+  }
+}
+
+/** All sandbox resources in the project, keyed by name (empty object if none). */
+export function readSandboxes(dir: string): Record<string, SandboxConfig> {
+  const cfg = readFile(dir);
+  const resources = cfg?.resources ?? {};
+  const out: Record<string, SandboxConfig> = {};
+  for (const [name, entry] of Object.entries(resources)) {
+    if (entry?.type !== 'sandbox') continue;
+    const { type: _type, ...rest } = entry as StoredSandbox;
+    out[name] = { name, ...(rest as Omit<SandboxConfig, 'name'>) };
+  }
+  return out;
+}
+
+/**
+ * Resolve a single sandbox to deploy. With a `name`, returns that one. Without,
+ * returns the sole sandbox (singular-default) or throws if there are zero or many
+ * — so the common one-app project needs no `--name`.
+ */
+export function getSandbox(dir: string, name?: string): SandboxConfig {
+  const sandboxes = readSandboxes(dir);
+  const names = Object.keys(sandboxes);
+
+  if (name) {
+    const found = sandboxes[name];
+    if (!found) {
+      throw new PreviewOperationError({
+        code: 'NO_SANDBOX',
+        message: `No sandbox named '${name}' in ${CONFIG_FILE}.`,
+        hint: names.length ? `Known sandboxes: ${names.join(', ')}.` : undefined,
+      });
+    }
+    return found;
+  }
+
+  if (names.length === 0) {
+    throw new PreviewOperationError({
+      code: 'NO_SANDBOX',
+      message: `No sandbox resources defined in ${CONFIG_FILE}.`,
+      hint: 'Add a resource with "type": "sandbox" (source, start, port).',
+    });
+  }
+  if (names.length > 1) {
+    throw new PreviewOperationError({
+      code: 'AMBIGUOUS_SANDBOX',
+      message: `Multiple sandboxes defined (${names.join(', ')}); specify which one.`,
+      hint: 'Pass a name, e.g. `sapiom sandbox preview <name>`.',
+    });
+  }
+  return sandboxes[names[0]];
+}
+
+/**
+ * Persist a sandbox resource into `sapiom.json`, merging into the `resources` map
+ * without clobbering sibling entries or other top-level keys.
+ */
+export function writeSandbox(dir: string, cfg: SandboxConfig): void {
+  const existing = readFile(dir) ?? {};
+  const { name, ...rest } = cfg;
+  const entry: StoredSandbox = { type: 'sandbox', ...rest };
+  const next: SapiomFile = {
+    ...existing,
+    resources: { ...(existing.resources ?? {}), [name]: entry },
+  };
+  writeFileSync(path.join(dir, CONFIG_FILE), JSON.stringify(next, null, 2) + '\n');
+}

--- a/packages/sandbox-preview/src/errors.ts
+++ b/packages/sandbox-preview/src/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Structured error type shared across sandbox-preview operations. Kept
+ * separate from CLI rendering (no process.stderr, no process.exitCode) so it
+ * can be caught and re-shaped by any consumer (CLI, MCP, programmatic).
+ */
+
+export interface StructuredError {
+  code: string;
+  message: string;
+  step?: string;
+  hint?: string;
+  docsUrl?: string;
+}
+
+/** A typed, machine-readable failure from any core operation. */
+export class PreviewOperationError extends Error {
+  readonly code: string;
+  readonly step?: string;
+  readonly hint?: string;
+  readonly docsUrl?: string;
+
+  constructor(err: StructuredError) {
+    super(err.message);
+    this.name = 'PreviewOperationError';
+    this.code = err.code;
+    this.step = err.step;
+    this.hint = err.hint;
+    this.docsUrl = err.docsUrl;
+  }
+
+  toStructured(): StructuredError {
+    return {
+      code: this.code,
+      message: this.message,
+      ...(this.step ? { step: this.step } : {}),
+      ...(this.hint ? { hint: this.hint } : {}),
+      ...(this.docsUrl ? { docsUrl: this.docsUrl } : {}),
+    };
+  }
+}

--- a/packages/sandbox-preview/src/git-push.ts
+++ b/packages/sandbox-preview/src/git-push.ts
@@ -1,0 +1,47 @@
+/**
+ * Push a local directory's current contents to a Sapiom git repo — without
+ * touching the user's directory (no `.git` created there).
+ *
+ * Uses a throwaway git-dir in the OS temp area with the source as the work-tree,
+ * so `git add -A` snapshots the current files (respecting an exclude for
+ * node_modules/.git), commits, and force-pushes to the repo's clone URL. Auth is
+ * the caller's credential sent as the `x-sapiom-git-token` header (the git
+ * smart-HTTP data plane accepts it). Force-push because a freshly-created repo is
+ * auto-initialized, so a plain push is non-fast-forward — the local working tree
+ * is the source of truth for a preview.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { PreviewOperationError } from './errors.js';
+
+export function pushLocalDir(sourceDir: string, cloneUrl: string, token: string, branch = 'main'): void {
+  const gitDir = mkdtempSync(path.join(tmpdir(), 'sbxprev-git-'));
+  const git = (args: string[]): void => {
+    try {
+      execFileSync('git', ['--git-dir', gitDir, '--work-tree', sourceDir, ...args], { stdio: 'pipe' });
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer }).stderr?.toString().trim();
+      throw new PreviewOperationError({
+        code: 'GIT_PUSH_FAILED',
+        message: `git ${args[0]} failed while pushing to the Sapiom repo.`,
+        hint: stderr || (err instanceof Error ? err.message : String(err)),
+      });
+    }
+  };
+
+  try {
+    git(['init', '-q', '-b', branch]);
+    // Never upload deps / vcs metadata — the sandbox build installs deps.
+    mkdirSync(path.join(gitDir, 'info'), { recursive: true });
+    writeFileSync(path.join(gitDir, 'info', 'exclude'), 'node_modules/\n.git/\n');
+    git(['add', '-A']);
+    git(['-c', 'user.email=preview@sapiom.ai', '-c', 'user.name=sapiom-preview', 'commit', '-q', '-m', 'preview']);
+    // Token via -c http.extraHeader (scoped to this command). Force-push HEAD.
+    git(['-c', `http.extraHeader=x-sapiom-git-token: ${token}`, 'push', '--force', cloneUrl, `HEAD:${branch}`]);
+  } finally {
+    rmSync(gitDir, { recursive: true, force: true });
+  }
+}

--- a/packages/sandbox-preview/src/index.ts
+++ b/packages/sandbox-preview/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @sapiom/sandbox-preview — client-side flow for deploying a web-app preview to a
+ * Sapiom sandbox: read `sapiom.json`, provision the sandbox, upload the source,
+ * and call the server-side `previews` deploy op for a live URL.
+ *
+ * The deploy recipe itself lives server-side; this package only reads intent,
+ * provisions, uploads, and triggers. Consumed by `@sapiom/cli` and the
+ * `sapiom-dev` MCP.
+ */
+export { previewSandbox } from './preview.js';
+export type { PreviewSandboxOptions } from './preview.js';
+
+export { getSandbox, readSandboxes, writeSandbox, CONFIG_FILE } from './config.js';
+
+export { PreviewOperationError } from './errors.js';
+export type { StructuredError } from './errors.js';
+
+export type { SandboxConfig, SandboxSourceSpec, PreviewResult } from './types.js';

--- a/packages/sandbox-preview/src/index.ts
+++ b/packages/sandbox-preview/src/index.ts
@@ -10,7 +10,12 @@
 export { previewSandbox } from './preview.js';
 export type { PreviewSandboxOptions } from './preview.js';
 
-export { getSandbox, readSandboxes, writeSandbox, CONFIG_FILE } from './config.js';
+export { getSandbox, readSandboxes, writeSandbox, configureSandbox, checkSandboxes, CONFIG_FILE } from './config.js';
+
+// Validation schema (single source of truth) — reused by the config reader, the
+// `check` pass, and the MCP `configure` tool's typed arg schema (config-as-tool-args).
+export { sandboxConfigBodySchema, storedSandboxSchema, CONFIG_VERSION } from './schema.js';
+export type { SandboxConfigBody } from './schema.js';
 
 export { PreviewOperationError } from './errors.js';
 export type { StructuredError } from './errors.js';

--- a/packages/sandbox-preview/src/preview.spec.ts
+++ b/packages/sandbox-preview/src/preview.spec.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { previewSandbox } from './preview.js';
+
+// jest hoists jest.mock above imports; factory-referenced vars must be `mock`-prefixed.
+const mockGet = jest.fn();
+const mockCreate = jest.fn().mockResolvedValue({});
+const mockUploadDir = jest.fn().mockResolvedValue(undefined);
+const mockDeployPreview = jest.fn();
+const mockAttach = jest.fn(() => ({ uploadDir: mockUploadDir, deployPreview: mockDeployPreview }));
+
+jest.mock('@sapiom/tools', () => ({
+  createClient: () => ({ sandboxes: { get: mockGet, create: mockCreate, attach: mockAttach } }),
+}));
+
+function tmpProject(sandbox: Record<string, unknown>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sbxprev-'));
+  writeFileSync(path.join(dir, 'sapiom.json'), JSON.stringify({ resources: { web: sandbox } }));
+  return dir;
+}
+
+const UPLOAD_SANDBOX = { type: 'sandbox', source: { kind: 'upload' }, build: 'npm install', start: 'node server.js', port: 3000 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue({ status: 'running', url: 'https://rt' });
+  mockDeployPreview.mockResolvedValue({ url: 'https://x.preview.bl.run', status: 'deployed', logs: '' });
+});
+
+describe('previewSandbox', () => {
+  it('reuses a running sandbox: uploads then deploys, returns the result', async () => {
+    const dir = tmpProject(UPLOAD_SANDBOX);
+    try {
+      const result = await previewSandbox({ dir, apiKey: 'sk_test' });
+
+      expect(mockCreate).not.toHaveBeenCalled(); // sandbox already exists
+      expect(mockUploadDir).toHaveBeenCalledWith(path.resolve(dir, '.'));
+      expect(mockDeployPreview).toHaveBeenCalledWith({
+        build: 'npm install',
+        start: 'node server.js',
+        port: 3000,
+        env: undefined,
+      });
+      expect(result).toEqual({ name: 'web', url: 'https://x.preview.bl.run', status: 'deployed', logs: '' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('provisions the sandbox when absent, then deploys', async () => {
+    mockGet.mockRejectedValueOnce(new Error('404 not found')); // existence check
+    mockGet.mockResolvedValue({ status: 'running', url: 'https://rt' }); // readiness poll
+    const dir = tmpProject(UPLOAD_SANDBOX);
+    try {
+      await previewSandbox({ dir, apiKey: 'sk_test' });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'web', port: 3000 }));
+      expect(mockDeployPreview).toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unsupported (git) source kind before any client call', async () => {
+    const dir = tmpProject({ ...UPLOAD_SANDBOX, source: { kind: 'git', slug: 'x' } });
+    try {
+      await expect(previewSandbox({ dir })).rejects.toThrow(/not supported yet/);
+      expect(mockAttach).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sandbox-preview/src/preview.spec.ts
+++ b/packages/sandbox-preview/src/preview.spec.ts
@@ -10,10 +10,17 @@ const mockCreate = jest.fn().mockResolvedValue({});
 const mockUploadDir = jest.fn().mockResolvedValue(undefined);
 const mockDeployPreview = jest.fn();
 const mockAttach = jest.fn(() => ({ uploadDir: mockUploadDir, deployPreview: mockDeployPreview }));
+const mockRepoGet = jest.fn();
+const mockRepoCreate = jest.fn();
+const mockPushLocalDir = jest.fn();
 
 jest.mock('@sapiom/tools', () => ({
-  createClient: () => ({ sandboxes: { get: mockGet, create: mockCreate, attach: mockAttach } }),
+  createClient: () => ({
+    sandboxes: { get: mockGet, create: mockCreate, attach: mockAttach },
+    repositories: { get: mockRepoGet, create: mockRepoCreate },
+  }),
 }));
+jest.mock('./git-push.js', () => ({ pushLocalDir: (...args: unknown[]) => mockPushLocalDir(...args) }));
 
 function tmpProject(sandbox: Record<string, unknown>): string {
   const dir = mkdtempSync(path.join(tmpdir(), 'sbxprev-'));
@@ -62,11 +69,34 @@ describe('previewSandbox', () => {
     }
   });
 
-  it('rejects an unsupported (git) source kind before any client call', async () => {
-    const dir = tmpProject({ ...UPLOAD_SANDBOX, source: { kind: 'git', slug: 'x' } });
+  it('git source: ensures the repo (create-if-absent), pushes local, deploys from git', async () => {
+    mockRepoGet.mockRejectedValue(new Error('404')); // repo does not exist yet
+    mockRepoCreate.mockResolvedValue({ slug: 'my-app', cloneUrl: 'http://git.local/repositories/t/my-app' });
+    const dir = tmpProject({ ...UPLOAD_SANDBOX, source: { kind: 'git', slug: 'my-app' } });
     try {
-      await expect(previewSandbox({ dir })).rejects.toThrow(/not supported yet/);
-      expect(mockAttach).not.toHaveBeenCalled();
+      const result = await previewSandbox({ dir, apiKey: 'sk_test' });
+
+      expect(mockRepoCreate).toHaveBeenCalledWith('my-app');
+      expect(mockPushLocalDir).toHaveBeenCalledWith(
+        path.resolve(dir, '.'),
+        'http://git.local/repositories/t/my-app',
+        'sk_test',
+      );
+      expect(mockUploadDir).not.toHaveBeenCalled(); // git source doesn't upload
+      expect(mockDeployPreview).toHaveBeenCalledWith(expect.objectContaining({ source: { kind: 'git', repo: 'my-app' } }));
+      expect(result.status).toBe('deployed');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('git source: reuses an existing repo (no create)', async () => {
+    mockRepoGet.mockResolvedValue({ slug: 'my-app', cloneUrl: 'http://git.local/repositories/t/my-app' });
+    const dir = tmpProject({ ...UPLOAD_SANDBOX, source: { kind: 'git', slug: 'my-app' } });
+    try {
+      await previewSandbox({ dir, apiKey: 'sk_test' });
+      expect(mockRepoCreate).not.toHaveBeenCalled();
+      expect(mockPushLocalDir).toHaveBeenCalled();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/sandbox-preview/src/preview.ts
+++ b/packages/sandbox-preview/src/preview.ts
@@ -14,6 +14,7 @@ import type { Sapiom } from '@sapiom/tools';
 
 import { getSandbox } from './config.js';
 import { PreviewOperationError } from './errors.js';
+import { pushLocalDir } from './git-push.js';
 import type { PreviewResult, SandboxConfig } from './types.js';
 
 const RUNNING_TIMEOUT_MS = 120_000;
@@ -36,30 +37,41 @@ export interface PreviewSandboxOptions {
 
 export async function previewSandbox(opts: PreviewSandboxOptions): Promise<PreviewResult> {
   const cfg = getSandbox(opts.dir, opts.name);
-  if (cfg.source.kind !== 'upload') {
-    throw new PreviewOperationError({
-      code: 'UNSUPPORTED_SOURCE',
-      message: `Source kind '${cfg.source.kind}' is not supported yet.`,
-      hint: "Use source.kind 'upload' for now.",
-    });
-  }
   const log = opts.log ?? (() => {});
   const sapiom = createClient({ apiKey: opts.apiKey });
   const baseUrl = opts.servicesBaseUrl;
+  const sub = cfg.source.path ?? '.';
+  const sourceDir = path.resolve(opts.dir, sub);
 
-  // 1. Ensure a running sandbox (provision-if-absent, then wait).
+  // 1. `git` source: get the code into a Sapiom repo BEFORE the sandbox — ensure
+  //    the repo (create-if-absent) and push the local working tree. The server
+  //    deploy op then checks that repo out into the sandbox.
+  let deploySource: { kind: 'git'; repo: string } | undefined;
+  if (cfg.source.kind === 'git') {
+    const slug = cfg.source.slug;
+    log(`ensuring repo "${slug}" …`);
+    const repo = await sapiom.repositories.get(slug).catch(() => null);
+    const cloneUrl = repo?.cloneUrl ?? (await sapiom.repositories.create(slug)).cloneUrl;
+    log(`pushing ${sub} → repo "${slug}" …`);
+    pushLocalDir(sourceDir, cloneUrl, opts.apiKey ?? '');
+    deploySource = { kind: 'git', repo: slug };
+  }
+
+  // 2. Ensure a running sandbox (provision-if-absent, then wait).
   log(`ensuring sandbox "${cfg.name}" …`);
   await ensureRunning(sapiom, cfg, baseUrl, log);
-
-  // 2. Upload the local source tree.
-  const sub = cfg.source.path ?? '.';
   const box = sapiom.sandboxes.attach(cfg.name, baseUrl ? { baseUrl } : {});
-  log(`uploading ${sub} …`);
-  await box.uploadDir(path.resolve(opts.dir, sub));
 
-  // 3. Trigger the server-side deploy op (build → start → expose → poll).
+  // 3. `upload` source: push the local tree straight into the sandbox.
+  if (cfg.source.kind === 'upload') {
+    log(`uploading ${sub} …`);
+    await box.uploadDir(sourceDir);
+  }
+
+  // 4. Trigger the server-side deploy op (checkout-if-git → build → start → expose → poll).
   log('deploying …');
   const res = await box.deployPreview({
+    ...(deploySource ? { source: deploySource } : {}),
     build: cfg.build,
     start: cfg.start,
     port: cfg.port,

--- a/packages/sandbox-preview/src/preview.ts
+++ b/packages/sandbox-preview/src/preview.ts
@@ -1,0 +1,113 @@
+/**
+ * previewSandbox — the client-side sandbox-preview flow.
+ *
+ * Reads the `sapiom.json` `type: "sandbox"` resource, ensures a running sandbox,
+ * uploads the local source, and calls the server-side `previews` deploy op. The
+ * deploy recipe (build/start/expose/poll) lives server-side; this layer only
+ * provisions + uploads + triggers. Pure of process.env — the caller (CLI/MCP)
+ * supplies `dir`, `apiKey`, and any host override.
+ */
+import path from 'node:path';
+
+import { createClient } from '@sapiom/tools';
+import type { Sapiom } from '@sapiom/tools';
+
+import { getSandbox } from './config.js';
+import { PreviewOperationError } from './errors.js';
+import type { PreviewResult, SandboxConfig } from './types.js';
+
+const RUNNING_TIMEOUT_MS = 120_000;
+const RUNNING_POLL_MS = 2000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface PreviewSandboxOptions {
+  /** Project directory containing `sapiom.json`. */
+  dir: string;
+  /** Which sandbox to deploy (omit when the project has exactly one). */
+  name?: string;
+  /** Explicit API key; falls back to ambient `SAPIOM_API_KEY` if omitted. */
+  apiKey?: string;
+  /** Override the compute/sandbox service base URL. */
+  servicesBaseUrl?: string;
+  /** Progress sink. */
+  log?: (message: string) => void;
+}
+
+export async function previewSandbox(opts: PreviewSandboxOptions): Promise<PreviewResult> {
+  const cfg = getSandbox(opts.dir, opts.name);
+  if (cfg.source.kind !== 'upload') {
+    throw new PreviewOperationError({
+      code: 'UNSUPPORTED_SOURCE',
+      message: `Source kind '${cfg.source.kind}' is not supported yet.`,
+      hint: "Use source.kind 'upload' for now.",
+    });
+  }
+  const log = opts.log ?? (() => {});
+  const sapiom = createClient({ apiKey: opts.apiKey });
+  const baseUrl = opts.servicesBaseUrl;
+
+  // 1. Ensure a running sandbox (provision-if-absent, then wait).
+  log(`ensuring sandbox "${cfg.name}" …`);
+  await ensureRunning(sapiom, cfg, baseUrl, log);
+
+  // 2. Upload the local source tree.
+  const sub = cfg.source.path ?? '.';
+  const box = sapiom.sandboxes.attach(cfg.name, baseUrl ? { baseUrl } : {});
+  log(`uploading ${sub} …`);
+  await box.uploadDir(path.resolve(opts.dir, sub));
+
+  // 3. Trigger the server-side deploy op (build → start → expose → poll).
+  log('deploying …');
+  const res = await box.deployPreview({
+    build: cfg.build,
+    start: cfg.start,
+    port: cfg.port,
+    env: cfg.env,
+  });
+
+  return { name: cfg.name, url: res.url, status: res.status, logs: res.logs };
+}
+
+/** Create the sandbox if absent, then poll until it reports `running`. */
+async function ensureRunning(
+  sapiom: Sapiom,
+  cfg: SandboxConfig,
+  baseUrl: string | undefined,
+  log: (m: string) => void,
+): Promise<void> {
+  const getOpts = baseUrl ? { baseUrl } : {};
+  const existing = await sapiom.sandboxes.get(cfg.name, getOpts).catch(() => null);
+
+  if (!existing) {
+    log(`creating sandbox "${cfg.name}" …`);
+    const createArgs = {
+      name: cfg.name,
+      port: cfg.port,
+      ...(cfg.tier ? { tier: cfg.tier } : {}),
+      ...(cfg.ttl ? { ttl: cfg.ttl } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+    };
+    await sapiom.sandboxes.create(createArgs as Parameters<typeof sapiom.sandboxes.create>[0]);
+  }
+
+  const deadline = Date.now() + RUNNING_TIMEOUT_MS;
+  for (;;) {
+    const info = await sapiom.sandboxes.get(cfg.name, getOpts);
+    if (info.status === 'running') return;
+    if (info.status === 'failed') {
+      throw new PreviewOperationError({
+        code: 'SANDBOX_FAILED',
+        message: `Sandbox '${cfg.name}' failed to start.`,
+        hint: info.error,
+      });
+    }
+    if (Date.now() > deadline) {
+      throw new PreviewOperationError({
+        code: 'SANDBOX_NOT_READY',
+        message: `Sandbox '${cfg.name}' did not reach 'running' in time (status: ${info.status}).`,
+      });
+    }
+    await sleep(RUNNING_POLL_MS);
+  }
+}

--- a/packages/sandbox-preview/src/schema.ts
+++ b/packages/sandbox-preview/src/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Validation schema for the sandbox-preview parts of `sapiom.json`.
+ *
+ * Two concerns, deliberately split (see the note below) so the shared "envelope"
+ * can later move to a `@sapiom/project-config` package while the sandbox resource
+ * schema stays capability-owned:
+ *
+ *   - ENVELOPE (shared, versioned): the file's `version` + `resources` map. The
+ *     format WILL evolve and be co-owned by several Sapiom-dev surfaces (agents,
+ *     sandbox, later database/domain), so it carries a version the reader checks.
+ *   - RESOURCE SCHEMA (capability-owned): the `type: "sandbox"` entry shape. Each
+ *     capability owns/validates its own resource type; this file owns only sandbox.
+ *
+ * The zod schema is the single source of truth reused by: the config reader
+ * (actionable read-time errors), a validate/check pass, and the MCP `configure`
+ * tool's arg schema (config-as-tool-args — the agent fills typed args, never
+ * hand-writes JSON).
+ */
+import { z } from 'zod';
+
+/** Bump when the file envelope changes incompatibly. Readers reject a higher version. */
+export const CONFIG_VERSION = 1;
+
+const sourceSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('upload'), path: z.string().optional() }),
+  z.object({ kind: z.literal('git'), slug: z.string().min(1), path: z.string().optional() }),
+]);
+
+/**
+ * The sandbox resource body (without the `name`, which is the map key). This is
+ * also the shape the MCP `configure` tool accepts as typed args.
+ */
+export const sandboxConfigBodySchema = z.object({
+  source: sourceSchema,
+  build: z.string().optional(),
+  start: z.string().min(1, 'start (the server command) is required'),
+  port: z.number().int().min(1).max(65535),
+  tier: z.enum(['xs', 's', 'm', 'l', 'xl']).optional(),
+  ttl: z.string().optional(),
+  env: z.record(z.string()).optional(),
+});
+
+export type SandboxConfigBody = z.infer<typeof sandboxConfigBodySchema>;
+
+/** The stored on-disk sandbox entry (adds the `type` discriminant). */
+export const storedSandboxSchema = sandboxConfigBodySchema.extend({ type: z.literal('sandbox') });

--- a/packages/sandbox-preview/src/types.ts
+++ b/packages/sandbox-preview/src/types.ts
@@ -2,32 +2,21 @@
  * Public contract for the sandbox-preview client flow. Provider-neutral: the
  * deploy recipe itself lives server-side (the `previews` capability); this layer
  * only reads intent, provisions the sandbox, uploads, and calls the server op.
+ *
+ * The declared-intent shapes below are derived from the zod schema (schema.ts) —
+ * the single source of truth — so the config validator and these types never drift.
  */
+import type { SandboxConfigBody } from './schema.js';
 
 /** Where the app's code comes from. `upload` (local fs) is supported now; `git` is a later phase. */
-export type SandboxSourceSpec =
-  | { kind: 'upload'; path?: string }
-  | { kind: 'git'; slug: string; path?: string };
+export type SandboxSourceSpec = SandboxConfigBody['source'];
 
-/** Declared intent for one sandbox-preview resource (`sapiom.json`, `type: "sandbox"`). */
-export interface SandboxConfig {
-  /** Local resource handle (the `resources` map key) — also the sandbox name. */
-  name: string;
-  /** Where the code comes from. */
-  source: SandboxSourceSpec;
-  /** Build command (e.g. `npm install`). Skipped if omitted. */
-  build?: string;
-  /** Command that starts the long-running server. */
-  start: string;
-  /** Port the app listens on — exposed publicly. */
-  port: number;
-  /** Memory tier for the sandbox (xs|s|m|l|xl). */
-  tier?: string;
-  /** Time-to-live (e.g. `24h`, `7d`). */
-  ttl?: string;
-  /** Extra environment variables injected into the app process. */
-  env?: Record<string, string>;
-}
+/**
+ * Declared intent for one sandbox-preview resource (`sapiom.json`, `type: "sandbox"`).
+ * The `name` is the `resources` map key (also the sandbox name); the rest is the
+ * validated resource body (source, build?, start, port, tier?, ttl?, env?).
+ */
+export type SandboxConfig = { name: string } & SandboxConfigBody;
 
 /** Result of a preview deploy. */
 export interface PreviewResult {

--- a/packages/sandbox-preview/src/types.ts
+++ b/packages/sandbox-preview/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Public contract for the sandbox-preview client flow. Provider-neutral: the
+ * deploy recipe itself lives server-side (the `previews` capability); this layer
+ * only reads intent, provisions the sandbox, uploads, and calls the server op.
+ */
+
+/** Where the app's code comes from. `upload` (local fs) is supported now; `git` is a later phase. */
+export type SandboxSourceSpec =
+  | { kind: 'upload'; path?: string }
+  | { kind: 'git'; slug: string; path?: string };
+
+/** Declared intent for one sandbox-preview resource (`sapiom.json`, `type: "sandbox"`). */
+export interface SandboxConfig {
+  /** Local resource handle (the `resources` map key) — also the sandbox name. */
+  name: string;
+  /** Where the code comes from. */
+  source: SandboxSourceSpec;
+  /** Build command (e.g. `npm install`). Skipped if omitted. */
+  build?: string;
+  /** Command that starts the long-running server. */
+  start: string;
+  /** Port the app listens on — exposed publicly. */
+  port: number;
+  /** Memory tier for the sandbox (xs|s|m|l|xl). */
+  tier?: string;
+  /** Time-to-live (e.g. `24h`, `7d`). */
+  ttl?: string;
+  /** Extra environment variables injected into the app process. */
+  env?: Record<string, string>;
+}
+
+/** Result of a preview deploy. */
+export interface PreviewResult {
+  /** The sandbox / resource name. */
+  name: string;
+  /** The public URL serving the app. Null when the deploy failed before exposure. */
+  url: string | null;
+  /** Deploy outcome: `deployed`, `unverified`, or `failed`. */
+  status: string;
+  /** Build/start log output (tail); populated especially on failure. */
+  logs: string;
+}

--- a/packages/sandbox-preview/tsconfig.cjs.json
+++ b/packages/sandbox-preview/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts", "e2e"]
+}

--- a/packages/sandbox-preview/tsconfig.esm.json
+++ b/packages/sandbox-preview/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./dist/esm",
+    "composite": true
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts", "e2e"]
+}

--- a/packages/sandbox-preview/tsconfig.json
+++ b/packages/sandbox-preview/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node", "jest"],
+    "removeComments": true,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tools/src/sandboxes/README.md
+++ b/packages/tools/src/sandboxes/README.md
@@ -29,6 +29,6 @@ await box.destroy();
 
 ## Reference
 
-`create` · `attach` · `get` · `list` · `exec` · `execStream` · `readFile` · `writeFile` · `uploadFile` · `getProcess` · `waitForProcess` · `destroy`
+`create` · `attach` · `get` · `list` · `exec` · `execStream` · `readFile` · `writeFile` · `uploadFile` · `uploadDir` · `createPublicUrl` · `deployPreview` · `getProcess` · `waitForProcess` · `destroy`
 
 See the exported types for full signatures and options.

--- a/packages/tools/src/sandboxes/index.spec.ts
+++ b/packages/tools/src/sandboxes/index.spec.ts
@@ -227,3 +227,82 @@ describe("Sandbox.get / Sandbox.list — read-only metadata", () => {
     expect(result.map((s) => s.name)).toEqual(["box-1", "box-2"]);
   });
 });
+
+describe("Sandbox.createPublicUrl", () => {
+  it("POSTs the metadata/spec body and maps spec.url to url", async () => {
+    let seenUrl = "";
+    let seenBody: unknown;
+    const box = sandboxWith((url, init) => {
+      seenUrl = url;
+      seenBody = JSON.parse((init.body as string) ?? "{}");
+      return ok({
+        metadata: { name: "web" },
+        spec: { url: "https://abc123.us.preview.bl.run", port: 3000 },
+      });
+    });
+    const preview = await box.createPublicUrl({ port: 3000, name: "web" });
+    expect(seenUrl.endsWith("/v1/sandboxes/box/previews")).toBe(true);
+    expect(seenBody).toEqual({
+      metadata: { name: "web" },
+      spec: { port: 3000, public: true },
+    });
+    expect(preview).toEqual({
+      url: "https://abc123.us.preview.bl.run",
+      name: "web",
+    });
+  });
+
+  it("includes prefixUrl when a prefix is given and honors public:false", async () => {
+    let seenBody: Record<string, unknown> = {};
+    const box = sandboxWith((_url, init) => {
+      seenBody = JSON.parse((init.body as string) ?? "{}");
+      return ok({ spec: { url: "https://my-prefix.preview.bl.run" } });
+    });
+    await box.createPublicUrl({ port: 8080, public: false, prefix: "my-prefix" });
+    expect(seenBody.spec).toEqual({
+      port: 8080,
+      public: false,
+      prefixUrl: "my-prefix",
+    });
+  });
+
+  it("throws on a non-2xx response", async () => {
+    const box = sandboxWith(() => err(400, "port 3000 does not exist"));
+    await expect(box.createPublicUrl({ port: 3000 })).rejects.toThrow(
+      /Failed to create public URL: 400/,
+    );
+  });
+});
+
+describe("Sandbox.deployPreview", () => {
+  it("POSTs to /preview/deploy with build/start/port and returns { url, status, logs }", async () => {
+    let seenUrl = "";
+    let seenBody: unknown;
+    const box = sandboxWith((url, init) => {
+      seenUrl = url;
+      seenBody = JSON.parse((init.body as string) ?? "{}");
+      return ok({ url: "https://xyz.preview.bl.run", status: "deployed", logs: "" });
+    });
+    const result = await box.deployPreview({
+      build: "npm install",
+      start: "node server.js",
+      port: 3000,
+      env: { NODE_ENV: "production" },
+    });
+    expect(seenUrl.endsWith("/v1/sandboxes/box/preview/deploy")).toBe(true);
+    expect(seenBody).toEqual({
+      build: "npm install",
+      start: "node server.js",
+      port: 3000,
+      env: { NODE_ENV: "production" },
+    });
+    expect(result).toEqual({ url: "https://xyz.preview.bl.run", status: "deployed", logs: "" });
+  });
+
+  it("passes through a failed status + logs without throwing", async () => {
+    const box = sandboxWith(() => ok({ url: null, status: "failed", logs: "npm ERR! boom" }));
+    const result = await box.deployPreview({ start: "node server.js", port: 3000 });
+    expect(result.status).toBe("failed");
+    expect(result.logs).toContain("boom");
+  });
+});

--- a/packages/tools/src/sandboxes/index.spec.ts
+++ b/packages/tools/src/sandboxes/index.spec.ts
@@ -305,4 +305,14 @@ describe("Sandbox.deployPreview", () => {
     expect(result.status).toBe("failed");
     expect(result.logs).toContain("boom");
   });
+
+  it("forwards a git source verbatim in the body", async () => {
+    let seenBody: Record<string, unknown> = {};
+    const box = sandboxWith((_url, init) => {
+      seenBody = JSON.parse((init.body as string) ?? "{}");
+      return ok({ url: "https://g.preview.bl.run", status: "deployed", logs: "" });
+    });
+    await box.deployPreview({ source: { kind: "git", repo: "my-app", ref: "main" }, start: "node server.js", port: 3000 });
+    expect(seenBody.source).toEqual({ kind: "git", repo: "my-app", ref: "main" });
+  });
 });

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -32,19 +32,27 @@ import type {
   ExecStreamOptions,
   MultipartInitiateResponse,
   MultipartPartInfo,
+  DeployPreviewOptions,
+  DeployPreviewResult,
   MultipartUploadedPart,
   OutputLine,
   ProcessCreateResponse,
   ProcessStatus,
+  PublicUrlInfo,
+  PublicUrlOptions,
   SandboxCreateOptions,
   SandboxInfo,
   StreamingExecResult,
+  UploadDirOptions,
   UploadFileOptions,
 } from "./types.js";
+import { collectDirFiles } from "./upload-dir.js";
 
 export { SandboxHttpError } from "./multipart.js";
 
 export type {
+  DeployPreviewOptions,
+  DeployPreviewResult,
   ExecOptions,
   ExecResult,
   ExecStreamOptions,
@@ -54,10 +62,13 @@ export type {
   OutputLine,
   PortSpec,
   ProcessStatus,
+  PublicUrlInfo,
+  PublicUrlOptions,
   SandboxCreateOptions,
   SandboxInfo,
   SandboxTier,
   StreamingExecResult,
+  UploadDirOptions,
   UploadFileOptions,
   UploadProgress,
 } from "./types.js";
@@ -579,6 +590,77 @@ export class Sandbox {
     opts?: { pollInterval?: number; timeout?: number; signal?: AbortSignal },
   ): Promise<ExecResult> {
     return this.pollProcess(pid, opts);
+  }
+
+  /**
+   * Expose a sandbox port at a public URL (the low-level primitive). The port
+   * must have been declared when the sandbox was created (via `port`/`ports`).
+   * For a full "build + run + expose" flow, use {@link deployPreview}.
+   */
+  async createPublicUrl(opts: PublicUrlOptions): Promise<PublicUrlInfo> {
+    const url = `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/previews`;
+    const body = {
+      metadata: { name: opts.name ?? "default" },
+      spec: {
+        port: opts.port,
+        public: opts.public ?? true,
+        ...(opts.prefix ? { prefixUrl: opts.prefix } : {}),
+      },
+    };
+    const res = await this.transport.fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok)
+      throw new Error(
+        `Failed to create public URL: ${res.status} ${await res.text()}`,
+      );
+    const raw = (await res.json()) as {
+      spec?: { url?: string };
+      metadata?: { name?: string };
+    };
+    return { url: raw.spec?.url ?? "", name: raw.metadata?.name };
+  }
+
+  /**
+   * Deploy a preview of a web app: build and (re)start the app already present in
+   * the sandbox, then expose it at a stable public URL. Returns `{ url, status,
+   * logs }`; build/start failures come back as `status: "failed"` with `logs`
+   * (not a thrown error), so callers can inspect and retry. Upload the source
+   * first with {@link uploadDir} (or `writeFile`).
+   */
+  async deployPreview(opts: DeployPreviewOptions): Promise<DeployPreviewResult> {
+    const url = `${this.baseUrl}/v1/sandboxes/${encodeURIComponent(this.name)}/preview/deploy`;
+    const res = await this.transport.fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...(opts.source ? { source: opts.source } : {}),
+        ...(opts.build ? { build: opts.build } : {}),
+        start: opts.start,
+        port: opts.port,
+        ...(opts.env ? { env: opts.env } : {}),
+      }),
+    });
+    if (!res.ok)
+      throw new Error(
+        `Failed to deploy preview: ${res.status} ${await res.text()}`,
+      );
+    return (await res.json()) as DeployPreviewResult;
+  }
+
+  /**
+   * Upload a local directory into the sandbox (files relative to the workspace
+   * root), skipping `node_modules`, `.git`, and dotfiles. Dependencies install in
+   * the sandbox at build time — never uploaded. fs-only (no-op target for
+   * in-process callers without a local filesystem).
+   */
+  async uploadDir(localDir: string, opts?: UploadDirOptions): Promise<void> {
+    const files = collectDirFiles(localDir, opts?.ignore);
+    for (const f of files) {
+      await this.writeFile(f.path, f.content);
+    }
   }
 
   /** Destroy the sandbox and release its resources. */

--- a/packages/tools/src/sandboxes/types.ts
+++ b/packages/tools/src/sandboxes/types.ts
@@ -69,8 +69,12 @@ export interface PublicUrlInfo {
  * sandbox (e.g. via {@link Sandbox.uploadDir}); `source` defaults to those files.
  */
 export interface DeployPreviewOptions {
-  /** Where the app code comes from. Defaults to already-uploaded files. */
-  source?: { kind: "fs" };
+  /**
+   * Where the app code comes from. `fs` (default) = files already uploaded to the
+   * sandbox. `git` = the server checks the Sapiom repo `repo` out into the sandbox
+   * first (no local upload needed — the in-process/agent path).
+   */
+  source?: { kind: "fs" } | { kind: "git"; repo: string; ref?: string };
   /** Build command run before start (e.g. `npm install`). Skipped if omitted. */
   build?: string;
   /** Command that starts the long-running server. */

--- a/packages/tools/src/sandboxes/types.ts
+++ b/packages/tools/src/sandboxes/types.ts
@@ -43,6 +43,60 @@ export interface SandboxCreateOptions {
   baseUrl?: string;
 }
 
+/** Options for exposing a sandbox port at a public URL (the low-level primitive). */
+export interface PublicUrlOptions {
+  /** Sandbox port to expose. Must have been declared when the sandbox was created. */
+  port: number;
+  /** Public (no auth) or private (token-gated). @default true */
+  public?: boolean;
+  /** Name for the exposed URL. @default "default" */
+  name?: string;
+  /** Optional custom subdomain prefix. */
+  prefix?: string;
+}
+
+/** A created public URL exposing a sandbox port. */
+export interface PublicUrlInfo {
+  /** The public URL serving the exposed port. */
+  url: string;
+  /** The name of the exposed URL. */
+  name?: string;
+}
+
+/**
+ * Options for {@link Sandbox.deployPreview}. Builds and (re)starts the app in the
+ * sandbox and exposes it at a stable public URL. Source must already be in the
+ * sandbox (e.g. via {@link Sandbox.uploadDir}); `source` defaults to those files.
+ */
+export interface DeployPreviewOptions {
+  /** Where the app code comes from. Defaults to already-uploaded files. */
+  source?: { kind: "fs" };
+  /** Build command run before start (e.g. `npm install`). Skipped if omitted. */
+  build?: string;
+  /** Command that starts the long-running server. */
+  start: string;
+  /** Port the app listens on — exposed publicly (declared at sandbox create). */
+  port: number;
+  /** Extra environment variables injected into the app process. */
+  env?: Record<string, string>;
+}
+
+/** Result of {@link Sandbox.deployPreview}. */
+export interface DeployPreviewResult {
+  /** The public URL serving the app. Null when the deploy failed before exposure. */
+  url: string | null;
+  /** Deploy outcome: `deployed` (served 2xx), `unverified`, or `failed`. */
+  status: string;
+  /** Build/start log output (tail); populated especially on failure. */
+  logs: string;
+}
+
+/** Options for {@link Sandbox.uploadDir}. */
+export interface UploadDirOptions {
+  /** Extra path patterns to skip (in addition to node_modules, .git, dotfiles). */
+  ignore?: string[];
+}
+
 /** Options for executing a command (non-streaming). */
 export interface ExecOptions {
   /** Working directory, resolved relative to the sandbox workspace root. */

--- a/packages/tools/src/sandboxes/upload-dir.ts
+++ b/packages/tools/src/sandboxes/upload-dir.ts
@@ -1,0 +1,53 @@
+/**
+ * Collect the files to upload from a local directory for a preview deploy.
+ *
+ * Walks `dir` and returns `{ path, content }[]` with POSIX-relative paths. Always
+ * skips `node_modules`, `.git`, and dotfiles/dot-dirs (dependencies install in the
+ * sandbox — never uploaded). Extra `ignore` patterns match by exact path, path
+ * prefix (`dir/`), name segment, or suffix (`*.log`).
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import path from "node:path";
+
+export interface CollectedFile {
+  /** POSIX path relative to the walked directory. */
+  path: string;
+  /** UTF-8 file contents. */
+  content: string;
+}
+
+const ALWAYS_SKIP = new Set(["node_modules", ".git"]);
+
+function isIgnored(relPath: string, patterns: string[]): boolean {
+  return patterns.some((p) => {
+    if (p.endsWith("/")) return relPath.startsWith(p) || relPath.includes(`/${p}`);
+    if (p.startsWith("*")) return relPath.endsWith(p.slice(1));
+    return relPath === p || relPath.startsWith(`${p}/`) || relPath.split("/").includes(p);
+  });
+}
+
+/** Collect deployable files under `dir` (UTF-8 text; binary assets out of scope). */
+export function collectDirFiles(dir: string, ignore: string[] = []): CollectedFile[] {
+  const root = path.resolve(dir);
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new Error(`Directory not found: ${root}`);
+  }
+  const files: CollectedFile[] = [];
+
+  const walk = (abs: string): void => {
+    for (const entry of readdirSync(abs)) {
+      if (ALWAYS_SKIP.has(entry) || entry.startsWith(".")) continue;
+      const childAbs = path.join(abs, entry);
+      const rel = path.relative(root, childAbs).split(path.sep).join("/");
+      if (isIgnored(rel, ignore)) continue;
+      if (statSync(childAbs).isDirectory()) {
+        walk(childAbs);
+      } else {
+        files.push({ path: rel, content: readFileSync(childAbs, "utf8") });
+      }
+    }
+  };
+
+  walk(root);
+  return files;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@sapiom/analytics-core':
         specifier: workspace:^
         version: link:../analytics-core
+      '@sapiom/sandbox-preview':
+        specifier: workspace:^
+        version: link:../sandbox-preview
       commander:
         specifier: ^14.0.2
         version: 14.0.3
@@ -533,6 +536,9 @@ importers:
       '@sapiom/analytics-core':
         specifier: workspace:^
         version: link:../analytics-core
+      '@sapiom/sandbox-preview':
+        specifier: workspace:^
+        version: link:../sandbox-preview
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -638,6 +644,9 @@ importers:
       '@sapiom/tools':
         specifier: workspace:^
         version: link:../tools
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,40 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/sandbox-preview:
+    dependencies:
+      '@sapiom/tools':
+        specifier: workspace:^
+        version: link:../tools
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.43)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.8.4
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.43))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+
   packages/tools:
     dependencies:
       '@sapiom/analytics-core':

--- a/scripts/publish-local.mjs
+++ b/scripts/publish-local.mjs
@@ -161,12 +161,16 @@ try {
     }
   }
 } finally {
-  // 3. Revert source version bumps so the working tree stays clean.
-  run("git", [
-    "checkout",
-    "--",
-    ...PACKAGES.map((d) => path.join("packages", d, "package.json")),
-  ]);
+  // 3. Revert source version bumps so the working tree stays clean. Restore ONLY the
+  //    `version` field (from the pre-bump originals) — a `git checkout` of the whole
+  //    file would also clobber legitimate uncommitted edits (e.g. a new dependency).
+  for (const dir of PACKAGES) {
+    const pkg = readPkg(dir);
+    if (pkg.version !== originals[dir]) {
+      pkg.version = originals[dir];
+      writeFileSync(pkgJsonPath(dir), JSON.stringify(pkg, null, 2) + "\n");
+    }
+  }
 }
 
 if (failed.length) {

--- a/scripts/publish-local.mjs
+++ b/scripts/publish-local.mjs
@@ -37,6 +37,7 @@ const PACKAGES = [
   "agent-runtime",
   "agent-core",
   "sandbox",
+  "sandbox-preview",
   "cli",
   "mcp",
 ];


### PR DESCRIPTION
This pull request introduces the new `@sapiom/sandbox-preview` package and integrates sandbox preview functionality into both the CLI and MCP. It enables users to provision, upload, and deploy local web-app code to a live Sapiom sandbox URL, with new commands and tools for configuration, validation, and deployment. The changes also add comprehensive end-to-end tests for the deployment flow and set up the necessary configuration and linting for the new package.

**Sandbox preview feature integration:**

* Added the `@sapiom/sandbox-preview` package, which provides client-side flows for provisioning, uploading, and deploying web-app previews to Sapiom sandboxes, including project setup, build, and test configuration. [[1]](diffhunk://#diff-b1b86ecfad2dc9b03c80062ef4c8fbad646c2480a34fcf0383d64c72be25c9b4R1-R73) [[2]](diffhunk://#diff-105eec86bd82e007f95f68c62e158d7ffcb781bbe20396cc5dfa2e81da231caeR1-R23) [[3]](diffhunk://#diff-353937842724fe070b85babe4ebe53392d8bf570dfce9bf2bc3c4fb18400a3faR1-R13) [[4]](diffhunk://#diff-7abf297fef82c89262cd765688ca76fd8314e4d1b644f1dbdffadafe1a2e2fbbR1-R17)
* Integrated the new sandbox preview feature into the CLI by adding a `sandbox` command group with a `preview` subcommand (`sapiom sandbox preview`) that provisions, uploads, builds, and exposes a live preview URL. [[1]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758R43) [[2]](diffhunk://#diff-851182cafc84fa25bb51924774a050df7390b176c7814f3cce2d06807c589147R1-R19) [[3]](diffhunk://#diff-dd1a548ff4e56910aecd650e3c2b77cae8233b4a7bd311f0de863f59550d295cR1-R38) [[4]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR6) [[5]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR20) [[6]](diffhunk://#diff-08ca6272dae27b9243cfeec389aa083393e17b9d24bdf9a59e2fc563f34c3eceL23-R23)
* Added the `@sapiom/sandbox-preview` dependency to the MCP and exposed three new MCP tools: `sapiom_dev_sandbox_configure`, `sapiom_dev_sandbox_check`, and `sapiom_dev_sandbox_preview` for configuring, validating, and deploying sandbox previews, respectively. [[1]](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbR48) [[2]](diffhunk://#diff-5deaef31cdabad1ece972ee94992e5673fe61df357c789cc48e29685367bbf2fR9) [[3]](diffhunk://#diff-5deaef31cdabad1ece972ee94992e5673fe61df357c789cc48e29685367bbf2fR53) [[4]](diffhunk://#diff-31c26d0f06ff40a142465959718274bdfc4bd409bad2e38698c8f2adc7a1265dR1-R116)

**End-to-end testing and fixtures:**

* Added a full end-to-end test that provisions, uploads, and deploys a real web-app fixture to a Sapiom sandbox, then verifies the preview URL serves traffic. Includes a minimal fixture app and configuration for realistic testing. [[1]](diffhunk://#diff-51a978cde16bfd99a77e55916efbeff2466d1c2d2c37c2e4227a82d277661f7cR1-R8) [[2]](diffhunk://#diff-852a11ade47850af8571dcfa0c9d4e2e934db16f31d539f8ebda57fa1dc42c8aR1-R11) [[3]](diffhunk://#diff-d9c7b6ca8aa092a264fb586ad274fafd7442bc5397df29791658239e69d09662R1-R20) [[4]](diffhunk://#diff-976234ebf2b73fc8adb005b8ed314c0cc331f5c1f763572024a251183345a2c7R1-R55)

**Configuration and linting:**

* Added ESLint configuration for the new package to ensure code quality and consistency.