### PR TITLE
changesets for sandbox previews

### DIFF
--- a/.changeset/cli-sandbox-preview.md
+++ b/.changeset/cli-sandbox-preview.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/cli": patch
+---
+
+Add `sapiom sandbox preview [name]` (alias `sbx`): deploy a web-app preview from the current project to a Sapiom sandbox and print the live URL. Reads the sandbox's declared intent from `sapiom.json` (`type: "sandbox"`, singular-default when the project defines exactly one, or pass a name). A `failed` status prints the build/start logs so you can fix and re-run; `--json` emits the structured result.

--- a/.changeset/mcp-sandbox-preview.md
+++ b/.changeset/mcp-sandbox-preview.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/mcp": patch
+---
+
+Add sandbox preview tools to the `sapiom-dev` MCP so a coding agent can build and ship a web app from a local checkout:
+
+- `sapiom_dev_sandbox_configure` — write a validated `type: "sandbox"` resource into `sapiom.json` from typed arguments (the agent fills a schema instead of hand-writing JSON, which it tends to get wrong).
+- `sapiom_dev_sandbox_check` — validate the project's sandbox resources without deploying; returns actionable issues.
+- `sapiom_dev_sandbox_preview` — provision the sandbox if needed, upload the local code, build, start, and expose a live URL. Returns `{ name, url, status, logs }`.

--- a/.changeset/sandbox-preview-capability.md
+++ b/.changeset/sandbox-preview-capability.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/sandbox-preview": patch
+---
+
+New package: the client flow for deploying a web-app preview to a Sapiom sandbox and getting a live URL.
+
+Reads the project's `sapiom.json` (`type: "sandbox"` resource), provisions the sandbox if needed, ships the code — either a local directory upload or a Sapiom git repository — and calls the server-side deploy op to build, start, and expose a public preview URL. Returns `{ name, url, status, logs }`; a non-`deployed` status carries the build/start log tail so a crash-on-boot is visible to fix and retry.
+
+Includes a zod-validated `sapiom.json` schema carrying a config version, so a malformed or hand-edited file fails with an actionable message rather than a confusing downstream error. Exposes `configureSandbox` (validate typed input and write the resource) and `checkSandboxes` (validate a project's sandbox resources without deploying) for building tooling on top.

--- a/.changeset/tools-sandbox-preview.md
+++ b/.changeset/tools-sandbox-preview.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": patch
+---
+
+Add sandbox preview primitives to the `sandbox` capability.
+
+- `deployPreview({ source, build, start, port, env })` triggers the server-side deploy op and returns the live preview URL. `source` is either a local upload or a Sapiom git repository (`{ kind: 'git', repo, ref? }`), so an in-process caller with an existing repo can deploy in one call.
+- `uploadDir(localDir, { ignore })` ships a local directory to the sandbox (ignore-aware walk), the companion to the upload source.
+- Renames `createPreview` to `createPublicUrl` — the method exposes a sandbox port at a public URL and is not a 1:1 wrapper of any single provider's naming.


### PR DESCRIPTION
This pull request introduces a new sandbox preview workflow across several packages, allowing users and coding agents to deploy web-app previews to Sapiom sandboxes and obtain live URLs. It includes a new package for the client flow, CLI and MCP commands for previewing and validating sandboxes, and new primitives in the tools package for deploying and exposing previews. The changes also add schema validation to prevent misconfiguration and provide actionable error messages.

**New sandbox preview capability:**

* Introduced the `@sapiom/sandbox-preview` package, which handles deploying a web-app preview to a Sapiom sandbox, provisioning as needed, uploading code, and exposing a public URL. It validates `sapiom.json` with zod, provides actionable errors, and exposes helper methods for configuration and validation (`configureSandbox`, `checkSandboxes`).

**CLI and MCP enhancements:**

* Added the `sapiom sandbox preview [name]` (alias `sbx`) command to the `@sapiom/cli` package, enabling users to deploy a web-app preview from the current project and print the live URL, with support for logs and structured output.
* Added sandbox preview tools to the `@sapiom/mcp` package, including commands to configure, validate, and preview sandboxes (`sapiom_dev_sandbox_configure`, `sapiom_dev_sandbox_check`, `sapiom_dev_sandbox_preview`), returning structured results and actionable issues.

**Tooling primitives:**

* Enhanced the `@sapiom/tools` package with new sandbox preview primitives: `deployPreview` for deploying and exposing a live preview URL, `uploadDir` for uploading local directories, and renamed `createPreview` to `createPublicUrl` for clarity.