### PR TITLE
[SAP-1486] sapiom-sandbox-preview skill + instructions fallback sync

### DIFF
--- a/.changeset/sapiom-sandbox-preview-guidance.md
+++ b/.changeset/sapiom-sandbox-preview-guidance.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/mcp": patch
+---
+
+Instructions now cover the sandbox-preview lifecycle: sapiom-dev drives agent
+authoring **and sandbox app previews** — `sapiom_dev_sandbox_configure` →
+`sapiom_dev_sandbox_check` → `sapiom_dev_sandbox_preview` (live URL; a `failed`
+status carries build/start logs). A new `sapiom-sandbox-preview` skill ships in
+the plugin so agents route "preview this app" asks correctly.

--- a/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
+++ b/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
@@ -22,7 +22,8 @@ directory.
 ## Prerequisite
 
 Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
-The sandbox tools return a structured not-authenticated error otherwise. Check with
+`sapiom_dev_sandbox_preview` returns a structured not-authenticated error otherwise;
+`configure` and `check` only touch local files and work signed-out. Check with
 `sapiom_status`.
 
 ## The lifecycle
@@ -82,11 +83,13 @@ Defaults to the single resource when the project defines exactly one.
 
 ## From inside a Sapiom agent step
 
-Steps can deploy previews through the typed client: `ctx.sapiom.sandboxes.uploadDir(localDir)`
-to stage the code, then `sandbox.deployPreview({ start, port, build?, env? })` →
+Steps can deploy previews through the typed client. Get a `Sandbox` instance first —
+`await ctx.sapiom.sandboxes.create({...})` or `.attach(name)` — then call
+`sandbox.uploadDir(localDir)` to stage the code and
+`sandbox.deployPreview({ start, port, build?, env? })` →
 `{ url, status: "deployed" | "unverified" | "failed", logs }` (failures return `status:
-"failed"` with logs, not a throw). `createPublicUrl({ port })` is the low-level primitive —
-the port must have been declared when the sandbox was created.
+"failed"` with logs, not a throw). `sandbox.createPublicUrl({ port })` is the low-level
+primitive — the port must have been declared when the sandbox was created.
 
 ## Reference
 

--- a/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
+++ b/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sapiom-sandbox-preview
+description: Deploy a live preview of a web app from the current project to a
+  Sapiom sandbox. Use when the user wants to preview, host, or deploy a web
+  app, dev server, API, or static site to a live URL ("preview this app",
+  "give me a live link", "host this server"), or mentions sapiom.json sandbox
+  resources. Do NOT use for deploying Sapiom agents (that's
+  sapiom_dev_agents_deploy) or for one-off capability calls.
+---
+
+# Sandbox Previews
+
+Deploy the web app in the current project directory to a Sapiom **sandbox** and get a
+**live public URL** — provisioned, uploaded, built, and started in one tool call. Driven
+by the sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
+if it isn't connected).
+
+**This is not agent deployment.** Sapiom *agents* deploy with `sapiom_dev_agents_deploy`;
+sandbox previews host an ordinary app (Node server, static site, API) from your working
+directory.
+
+## Prerequisite
+
+Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
+The sandbox tools return a structured not-authenticated error otherwise. Check with
+`sapiom_status`.
+
+## The lifecycle
+
+1. **`sapiom_dev_sandbox_configure`** — creates or updates a preview resource in the
+   project's `sapiom.json`. Fill the typed arguments instead of hand-writing JSON — the
+   config is validated and written under `resources.<name>` (`type: "sandbox"`). Returns
+   the stored config.
+2. **`sapiom_dev_sandbox_check`** *(optional)* — statically validates the resources without
+   deploying. Returns `{ ok, sandboxes, issues }`; fix any `issues` before previewing.
+3. **`sapiom_dev_sandbox_preview`** — reads `sapiom.json`, provisions the sandbox if
+   needed, uploads the local code, builds, starts, and exposes a public URL. Returns
+   `{ name, url, status, logs }`. Pass `name` only when the project defines more than one
+   resource.
+
+**A `failed` status is not an error** — it carries the build/start logs so you can fix the
+app or the config and run `sapiom_dev_sandbox_preview` again. `unverified` means the app
+started but didn't answer 2xx yet.
+
+## The `sapiom.json` resource
+
+```json
+{
+  "version": 1,
+  "resources": {
+    "web": {
+      "type": "sandbox",
+      "source": { "kind": "upload" },
+      "start": "node server.js",
+      "port": 3000,
+      "ttl": "1h"
+    }
+  }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `source` | yes | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
+| `start` | yes | The server command (e.g. `node server.js`) |
+| `port` | yes | 1–65535 — the port your app listens on |
+| `build` | no | Build command run before start (e.g. `npm run build`) |
+| `tier` | no | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl` |
+| `ttl` | no | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` |
+| `env` | no | Environment variables (string map) |
+
+Uploads skip `node_modules`, `.git`, and dotfiles — dependencies install in the sandbox at
+build time; never upload them.
+
+## CLI alternative
+
+```bash
+sapiom sandbox preview [name]   # alias: sapiom sbx preview; add --json for machine output
+```
+
+Defaults to the single resource when the project defines exactly one.
+
+## From inside a Sapiom agent step
+
+Steps can deploy previews through the typed client: `ctx.sapiom.sandboxes.uploadDir(localDir)`
+to stage the code, then `sandbox.deployPreview({ start, port, build?, env? })` →
+`{ url, status: "deployed" | "unverified" | "failed", logs }` (failures return `status:
+"failed"` with logs, not a throw). `createPublicUrl({ port })` is the low-level primitive —
+the port must have been declared when the sandbox was created.
+
+## Reference
+
+Full details: [Compute — Sandbox previews](https://docs.sapiom.ai/capabilities/compute#sandbox-previews).

--- a/packages/agent-core/src/__tests__/skill-sync.test.ts
+++ b/packages/agent-core/src/__tests__/skill-sync.test.ts
@@ -66,3 +66,37 @@ describe("plugin skill copy (when present)", () => {
     expect(readFileSync(pluginCopy, "utf8")).toBe(canonical);
   });
 });
+
+// Second skill: sapiom-sandbox-preview — canonical + plugin copy only (NOT in the
+// scaffold templates: agent projects are not web apps).
+describe("sapiom-sandbox-preview skill sync", () => {
+  const canonicalPreview = path.join(
+    PKG_ROOT,
+    "skills",
+    "sapiom-sandbox-preview",
+    "SKILL.md",
+  );
+
+  it("has a canonical source with the preview trigger frontmatter", () => {
+    const content = readFileSync(canonicalPreview, "utf8");
+    expect(content.startsWith("---\nname: sapiom-sandbox-preview")).toBe(true);
+    expect(content).toContain("description:");
+  });
+
+  it("plugin copy matches the canonical (when present)", () => {
+    const pluginCopy = path.resolve(
+      PKG_ROOT,
+      "..",
+      "..",
+      "plugins",
+      "sapiom",
+      "skills",
+      "sapiom-sandbox-preview",
+      "SKILL.md",
+    );
+    if (!existsSync(pluginCopy)) return;
+    expect(readFileSync(pluginCopy, "utf8")).toBe(
+      readFileSync(canonicalPreview, "utf8"),
+    );
+  });
+});

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -29,6 +29,7 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_scaffold");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_clone");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_agents_run_local");
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_sandbox_preview");
     // Canonical naming (and the stale names it must steer away from)
     expect(AUTHORING_INSTRUCTIONS).toContain("@sapiom/agent");
     expect(AUTHORING_INSTRUCTIONS).toContain("defineAgent");

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -48,9 +48,9 @@ remote MCP or the SDK for a single action.
 
 ## Preview a web app
 From inside the project: \`sapiom_dev_sandbox_configure\` (writes the validated \`sapiom.json\`
-resource — start command, port, optional build/tier/ttl/env) → optionally
-\`sapiom_dev_sandbox_check\` → \`sapiom_dev_sandbox_preview\` (uploads, builds, starts, and
-returns a live URL; a \`failed\` status carries the build/start logs — fix and retry).
+resource — source, start command, port, optional build/tier/ttl/env) →
+\`sapiom_dev_sandbox_check\` (optional) → \`sapiom_dev_sandbox_preview\` (uploads, builds, starts,
+and returns a live URL; a \`failed\` status carries the build/start logs — fix and retry).
 
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -17,10 +17,11 @@
 export const AUTHORING_INSTRUCTIONS = `# Sapiom dev MCP (sapiom-dev)
 
 \`sapiom-dev\` is Sapiom's local developer MCP — the terminal surface for building and managing
-your Sapiom projects. Today it drives **agent authoring** (more dev/management tools will land
-here over time): build, test, and deploy a Sapiom agent — a \`defineAgent({ name, entry, steps })\`
-(from \`@sapiom/agent\`) where each step's \`run(input, ctx)\` does work and returns a directive.
-All from the terminal; no dashboard required.
+your Sapiom projects. Today it drives **agent authoring and sandbox app previews** (more
+dev/management tools will land here over time). Agent authoring: build, test, and deploy a
+Sapiom agent — a \`defineAgent({ name, entry, steps })\` (from \`@sapiom/agent\`) where each
+step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no
+dashboard required.
 
 ## Two ways to use Sapiom
 This server (\`sapiom-dev\`) is where you **author agents** — the \`sapiom_dev_agents_*\` tools
@@ -44,6 +45,12 @@ remote MCP or the SDK for a single action.
 3. Test for free: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (validates the step graph,
    offline) → \`sapiom_dev_agents_run_local\` (capabilities are stubbed; zero spend).
 4. Ship: \`sapiom_dev_agents_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.
+
+## Preview a web app
+From inside the project: \`sapiom_dev_sandbox_configure\` (writes the validated \`sapiom.json\`
+resource — start command, port, optional build/tier/ttl/env) → optionally
+\`sapiom_dev_sandbox_check\` → \`sapiom_dev_sandbox_preview\` (uploads, builds, starts, and
+returns a live URL; a \`failed\` status carries the build/start logs — fix and retry).
 
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives

--- a/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
@@ -22,7 +22,8 @@ directory.
 ## Prerequisite
 
 Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
-The sandbox tools return a structured not-authenticated error otherwise. Check with
+`sapiom_dev_sandbox_preview` returns a structured not-authenticated error otherwise;
+`configure` and `check` only touch local files and work signed-out. Check with
 `sapiom_status`.
 
 ## The lifecycle
@@ -82,11 +83,13 @@ Defaults to the single resource when the project defines exactly one.
 
 ## From inside a Sapiom agent step
 
-Steps can deploy previews through the typed client: `ctx.sapiom.sandboxes.uploadDir(localDir)`
-to stage the code, then `sandbox.deployPreview({ start, port, build?, env? })` →
+Steps can deploy previews through the typed client. Get a `Sandbox` instance first —
+`await ctx.sapiom.sandboxes.create({...})` or `.attach(name)` — then call
+`sandbox.uploadDir(localDir)` to stage the code and
+`sandbox.deployPreview({ start, port, build?, env? })` →
 `{ url, status: "deployed" | "unverified" | "failed", logs }` (failures return `status:
-"failed"` with logs, not a throw). `createPublicUrl({ port })` is the low-level primitive —
-the port must have been declared when the sandbox was created.
+"failed"` with logs, not a throw). `sandbox.createPublicUrl({ port })` is the low-level
+primitive — the port must have been declared when the sandbox was created.
 
 ## Reference
 

--- a/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sapiom-sandbox-preview
+description: Deploy a live preview of a web app from the current project to a
+  Sapiom sandbox. Use when the user wants to preview, host, or deploy a web
+  app, dev server, API, or static site to a live URL ("preview this app",
+  "give me a live link", "host this server"), or mentions sapiom.json sandbox
+  resources. Do NOT use for deploying Sapiom agents (that's
+  sapiom_dev_agents_deploy) or for one-off capability calls.
+---
+
+# Sandbox Previews
+
+Deploy the web app in the current project directory to a Sapiom **sandbox** and get a
+**live public URL** — provisioned, uploaded, built, and started in one tool call. Driven
+by the sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
+if it isn't connected).
+
+**This is not agent deployment.** Sapiom *agents* deploy with `sapiom_dev_agents_deploy`;
+sandbox previews host an ordinary app (Node server, static site, API) from your working
+directory.
+
+## Prerequisite
+
+Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
+The sandbox tools return a structured not-authenticated error otherwise. Check with
+`sapiom_status`.
+
+## The lifecycle
+
+1. **`sapiom_dev_sandbox_configure`** — creates or updates a preview resource in the
+   project's `sapiom.json`. Fill the typed arguments instead of hand-writing JSON — the
+   config is validated and written under `resources.<name>` (`type: "sandbox"`). Returns
+   the stored config.
+2. **`sapiom_dev_sandbox_check`** *(optional)* — statically validates the resources without
+   deploying. Returns `{ ok, sandboxes, issues }`; fix any `issues` before previewing.
+3. **`sapiom_dev_sandbox_preview`** — reads `sapiom.json`, provisions the sandbox if
+   needed, uploads the local code, builds, starts, and exposes a public URL. Returns
+   `{ name, url, status, logs }`. Pass `name` only when the project defines more than one
+   resource.
+
+**A `failed` status is not an error** — it carries the build/start logs so you can fix the
+app or the config and run `sapiom_dev_sandbox_preview` again. `unverified` means the app
+started but didn't answer 2xx yet.
+
+## The `sapiom.json` resource
+
+```json
+{
+  "version": 1,
+  "resources": {
+    "web": {
+      "type": "sandbox",
+      "source": { "kind": "upload" },
+      "start": "node server.js",
+      "port": 3000,
+      "ttl": "1h"
+    }
+  }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `source` | yes | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
+| `start` | yes | The server command (e.g. `node server.js`) |
+| `port` | yes | 1–65535 — the port your app listens on |
+| `build` | no | Build command run before start (e.g. `npm run build`) |
+| `tier` | no | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl` |
+| `ttl` | no | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` |
+| `env` | no | Environment variables (string map) |
+
+Uploads skip `node_modules`, `.git`, and dotfiles — dependencies install in the sandbox at
+build time; never upload them.
+
+## CLI alternative
+
+```bash
+sapiom sandbox preview [name]   # alias: sapiom sbx preview; add --json for machine output
+```
+
+Defaults to the single resource when the project defines exactly one.
+
+## From inside a Sapiom agent step
+
+Steps can deploy previews through the typed client: `ctx.sapiom.sandboxes.uploadDir(localDir)`
+to stage the code, then `sandbox.deployPreview({ start, port, build?, env? })` →
+`{ url, status: "deployed" | "unverified" | "failed", logs }` (failures return `status:
+"failed"` with logs, not a throw). `createPublicUrl({ port })` is the low-level primitive —
+the port must have been declared when the sandbox was created.
+
+## Reference
+
+Full details: [Compute — Sandbox previews](https://docs.sapiom.ai/capabilities/compute#sandbox-previews).


### PR DESCRIPTION
## What

1. **New `sapiom-sandbox-preview` skill** (canonical at `packages/agent-core/skills/`, copy in `plugins/sapiom/skills/`) — the "when" trigger for preview-shaped asks ("preview this app", "give me a live link", "host this server"), explicitly disambiguated from `sapiom_dev_agents_deploy`. Body covers: auth prereq, the configure→check→preview lifecycle with the failed-carries-logs retry semantics, the `sapiom.json` schema table (all fields cited from `packages/sandbox-preview/src/schema.ts`), the CLI, and the in-agent `uploadDir`/`deployPreview`/`createPublicUrl` path. **Not** shipped in scaffold templates by design (agent projects ≠ web apps) — plugin users get it on marketplace refresh (git-SHA versioning), zero republish.
2. **Instructions fallback** (`packages/mcp/src/instructions.ts`) — same two edits as the backend constant PR (Sapiom #3073), **byte-identical** (verified programmatically).
3. **Tests**: `instructions.test.ts` asserts `sapiom_dev_sandbox_preview`; `skill-sync.test.ts` gains the second canonical/plugin pair (existence-gated).
4. Changeset: `@sapiom/mcp` patch.

## Verification

- `pnpm --filter @sapiom/mcp test` → 70/70 (10 files) after `pnpm install` (new `@sapiom/analytics-core` workspace dep needed installing — pre-existing, unrelated to this diff)
- `pnpm --filter @sapiom/agent-core test` → 75/75 incl. both skill-sync suites
- Byte-identity with Sapiom #3073: IDENTICAL

Ticket: SAP-1486 (citations on the ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)