### PR TITLE
feat(tools): llm capability — /v2 routed LLM calls (run direct + submit/redeem deferred) [SAP-1200]

### DIFF
--- a/.changeset/llm-v2-capability.md
+++ b/.changeset/llm-v2-capability.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": minor
+---
+
+New `llm` capability — routed LLM calls through the gateway's `/v2` routing front-end: `llm.run` (synchronous `POST /v2/anthropic/v1/messages`; `model` names a Sapiom routing label (omit for the account's `default_label`), capacity-aware with per-label never-fail fallback, billed against the caller's Sapiom API key at the edge), `llm.submit` (deferred-start `POST /v2/route/async`; returns a pausable `DispatchHandle` that grants a single-use link when capacity frees), and `llm.redeem` (spend the granted link). Exported on the client (`ctx.sapiom.llm`), the barrel, a `./llm` subpath, and the stub client.
+
+Sessions (Surface B, `/v2/sessions`) — the REST resource replacing the async+grant lane: `llm.createSession` (reserve deferred capacity from a plain JSON body: `label`|`model`, `deadlineMinutes`, `budget{maxTokens, ttlMinutes}`, optional webhook; returns a pausable `LlmSessionHandle` firing `LLM_SESSION_READY_SIGNAL`), `llm.getSession` (poll `pending → ready → active → expired|exhausted|failed`), `llm.callSession` (REPEATABLE drop-in calls against the session-scoped Anthropic/OpenAI paths with the normal Sapiom credential — no single-use token; ends with clean `session_expired`/`session_exhausted` terminals), and `llm.releaseSession` (early release). `submit`/`redeem` keep working until the migration completes. Stubbed in the stub client.

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.5",
-  tools: "0.20.1",
+  agent: "0.6.6",
+  tools: "0.21.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -1104,4 +1104,29 @@ describe("skills router — real server mount proof", () => {
       true,
     );
   });
+
+  it("hides user skills from the list by default (showUserSkills off)", async () => {
+    const skillDir = path.join(skillsRoot, "my-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: My Skill\ndescription: Test skill\n---\n\nBody here.",
+    );
+
+    // Separate mount WITHOUT the opt-in flag — the default the real server uses.
+    const app = express();
+    app.use("/api", createBootTokenMiddleware(BOOT_TOKEN));
+    app.use(createSkillsRouter({ userSkillsRoot: skillsRoot }));
+    const defaultServer = app.listen(0, "127.0.0.1");
+    await new Promise<void>((resolve) => defaultServer.once("listening", resolve));
+    const { port } = defaultServer.address() as AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/skills`, { headers: TOKEN_HEADER });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ id: string; source: string }>;
+      expect(body.some((s) => s.source === "user")).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => defaultServer.close(() => resolve()));
+    }
+  });
 });

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -33,6 +33,11 @@
       "import": "./dist/esm/models/index.js",
       "require": "./dist/cjs/models/index.js"
     },
+    "./llm": {
+      "types": "./dist/cjs/llm/index.d.ts",
+      "import": "./dist/esm/llm/index.js",
+      "require": "./dist/cjs/llm/index.js"
+    },
     "./file-storage": {
       "types": "./dist/cjs/file-storage/index.d.ts",
       "import": "./dist/esm/file-storage/index.js",

--- a/packages/tools/src/_client/capability-call.spec.ts
+++ b/packages/tools/src/_client/capability-call.spec.ts
@@ -112,6 +112,9 @@ describe("capabilityCall()", () => {
     expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // Every request carries the SDK client marker so the gateway can tell SDK
+    // traffic from raw HTTP (bins to client:sdk on its /v2 metrics).
+    expect(headerOf(calls[0]!, "x-sapiom-client")).toMatch(/^sapiom-tools\//);
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       url: "https://example.com",
     });

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -28,6 +28,15 @@ import {
   capabilityCallData,
   type AnalyticsHolder,
 } from "./analytics.js";
+import { VERSION } from "../_generated/version.js";
+
+/**
+ * Client marker stamped on EVERY request so the gateway can tell SDK traffic
+ * from raw HTTP (drop-in provider SDK / curl). The gateway bins this to
+ * `client:sdk` on its /v2 routing metrics; the exact value carries the version
+ * for logs. Survives the edge→gateway hop (not in the edge strip-list).
+ */
+const CLIENT_MARKER = `sapiom-tools/${VERSION}`;
 
 /**
  * Per-request attribution recorded with the gateway transaction. Every field is
@@ -235,6 +244,7 @@ export class Transport {
         ...init,
         headers: {
           [options.authHeader ?? DEFAULT_AUTH_HEADER]: this.apiKey,
+          "x-sapiom-client": CLIENT_MARKER,
           ...attributionToHeaders(this.attribution),
           ...(init.headers ?? {}),
         },

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -37,15 +37,30 @@ import type {
   ModelRunResult,
   ModelRunHandle,
 } from "./models/index.js";
-import {
-  run as agentsRun,
-  launch as agentsLaunch,
-} from "./agents/index.js";
+import { run as agentsRun, launch as agentsLaunch } from "./agents/index.js";
 import type {
   AgentRunSpec,
   AgentRunResult,
   RunHandle as AgentRunHandle,
 } from "./agents/index.js";
+import {
+  run as llmRun,
+  submit as llmSubmit,
+  redeem as llmRedeem,
+  createSession as llmCreateSession,
+  getSession as llmGetSession,
+  callSession as llmCallSession,
+  releaseSession as llmReleaseSession,
+} from "./llm/index.js";
+import type {
+  LlmRunSpec,
+  LlmSubmitSpec,
+  LlmRouteHandle,
+  LlmGrantLink,
+  LlmSessionCreateSpec,
+  LlmSession,
+  LlmSessionHandle,
+} from "./llm/index.js";
 import * as fileStorage from "./file-storage/index.js";
 import type {
   UploadInput,
@@ -169,6 +184,38 @@ export interface Sapiom {
     run(spec: AgentRunSpec): Promise<AgentRunResult>;
     /** Launch a deployed agent; pass the handle to `pauseUntilSignal` to suspend on it. */
     launch(spec: AgentRunSpec): Promise<AgentRunHandle>;
+  };
+  /**
+   * Routed LLM calls through the gateway's `/v2` routing front-end. `run` is the
+   * synchronous paid call (`/v2/route/direct` — selector + capacity-aware LB,
+   * executed inline); `submit` is the deferred-start seam (`/v2/route/async` —
+   * the gateway grants a single-use link when a model has room, escalating
+   * toward run-now as the deadline nears); `redeem` spends the link.
+   */
+  readonly llm: {
+    /** One routed LLM call, executed immediately and returned inline. */
+    run<T = Record<string, unknown>>(spec: LlmRunSpec): Promise<T>;
+    /** Submit a routed call; pass the handle to `pauseUntilSignal` to suspend on it. */
+    submit(spec: LlmSubmitSpec): Promise<LlmRouteHandle>;
+    /** Spend a granted link: POST the (re-sent) request to /v1/messages with it. */
+    redeem<T = Record<string, unknown>>(
+      link: LlmGrantLink,
+      request: Record<string, unknown>,
+    ): Promise<T>;
+    /** Create a session (Surface B): reserve deferred capacity; poll or pause until ready. */
+    createSession(spec?: LlmSessionCreateSpec): Promise<LlmSessionHandle>;
+    /** Fetch a session by id (tenant-scoped). */
+    getSession(sessionId: string): Promise<LlmSession>;
+    /** Call a ready session — REPEATABLE until its TTL/budget terminal (410). */
+    callSession<T = Record<string, unknown>>(
+      session: LlmSessionHandle | LlmSession | string,
+      request: Record<string, unknown>,
+      opts?: { shape?: "anthropic" | "openai" },
+    ): Promise<T>;
+    /** Release a session early (idempotent) — frees the reserved capacity. */
+    releaseSession(
+      session: LlmSessionHandle | LlmSession | string,
+    ): Promise<LlmSession>;
   };
   readonly fileStorage: {
     upload(input: UploadInput): Promise<UploadResponse>;
@@ -426,6 +473,16 @@ function bind(transport: Transport): Sapiom {
     agents: {
       run: (spec) => agentsRun(spec, transport),
       launch: (spec) => agentsLaunch(spec, transport),
+    },
+    llm: {
+      run: (spec) => llmRun(spec, transport),
+      submit: (spec) => llmSubmit(spec, transport),
+      redeem: (link, request) => llmRedeem(link, request, transport),
+      createSession: (spec) => llmCreateSession(spec, transport),
+      getSession: (sessionId) => llmGetSession(sessionId, transport),
+      callSession: (session, request, opts) =>
+        llmCallSession(session, request, opts, transport),
+      releaseSession: (session) => llmReleaseSession(session, transport),
     },
     fileStorage: {
       upload: (input) => fileStorage.upload(input, transport),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -71,10 +71,23 @@ export * as schedules from "./schedules/index.js";
 // as input — annotate the resumed step with it instead of hand-rolling the shape.
 export type { AgentRunResultPayload } from "./agents/index.js";
 // Validate an AgentRunResultPayload at the resume boundary.
+export { agentResultSchema, AgentResultSchemaError } from "./agents/index.js";
+
+// llm — routed LLM calls through the gateway's /v2 routing front-end: `run`
+// (synchronous direct), `submit` (deferred-start; pausable handle), `redeem`,
+// and the sessions resource (`createSession`/`getSession`/`callSession`/
+// `releaseSession` — deferred capacity, repeatable calls).
+export * as llm from "./llm/index.js";
+// Surfaced top-level for the static `pause: { signal }` decl on an llm step.
+export { LLM_ROUTE_RESULT_SIGNAL, LLM_SESSION_READY_SIGNAL } from "./llm/index.js";
+// The shape a step resumed from `pauseUntilSignal(llmHandle, …)` receives as
+// input — annotate the resumed step with it instead of hand-rolling the shape.
+export type { LlmRouteResultPayload } from "./llm/index.js";
+// Validate an LlmRouteResultPayload at the resume boundary.
 export {
-  agentResultSchema,
-  AgentResultSchemaError,
-} from "./agents/index.js";
+  llmRouteResultSchema,
+  LlmRouteResultSchemaError,
+} from "./llm/index.js";
 
 export * as fileStorage from "./file-storage/index.js";
 export { FileStorageHttpError } from "./file-storage/index.js";

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -1,0 +1,654 @@
+/**
+ * `llm` capability — routed LLM calls through the gateway's `/v2` routing
+ * front-end (SAP-792), on the x402 unified edge (`llm.services.sapiom.ai`).
+ *
+ * Two verbs, mirroring the gateway's two entry points:
+ *
+ * `run` — SYNCHRONOUS (`POST /v2/anthropic/v1/messages`): one LLM call, routed through the
+ * model selector (a label via `model`, else the gateway's default label) and the
+ * capacity-aware load balancer, executed immediately and returned inline. Direct
+ * calls are run-now class and never queue. The edge settles billing against the
+ * caller's Sapiom API key (identity mode — no x402 payment handshake needed).
+ *
+ *   const reply = await ctx.sapiom.llm.run({
+ *     request: { messages: [{ role: "user", content: "…" }], max_tokens: 512 },
+ *     model: "m2.7", // a label (m2.7 | minimax-m3 | sonnet | …); omit → default label
+ *   });
+ *
+ * `submit` — DEFERRED (`POST /v2/route/async`): unlike `agents.run` (a full
+ * in-server loop), this routes ONE LLM call through the gateway's capacity-aware
+ * admission: `submit` asks for the call and returns a handle immediately; the
+ * gateway holds the job ordered by deadline and — when a model has room, or the
+ * deadline is close enough to escalate toward run-now — mints a single-use link
+ * and reports back. The request body itself is NEVER stored by the gateway: the
+ * caller re-sends it at redemption (`redeem`). Submit is the unpaid control
+ * plane; payment happens at redemption.
+ *
+ *   const handle = await ctx.sapiom.llm.submit({
+ *     request: { messages: [{ role: "user", content: "…" }], max_tokens: 512 },
+ *     model: "m2.7", // a label; omit → default label
+ *     deadlineMinutes: 30,
+ *   });
+ *   return pauseUntilSignal(handle, { resumeStep: "use-answer" });
+ *
+ *   // …and in the resumed step (input: LlmRouteResultPayload):
+ *   const reply = await ctx.sapiom.llm.redeem(input.link!, savedRequestBody);
+ *
+ * Inside a workflow the engine's resume token (ambient on the transport) rides the
+ * `x-sapiom-workflow-token` header; the gateway echoes it in its webhook so the
+ * engine's forwarder can resume the paused step. Standalone callers can instead
+ * poll `handle.wait()` — same admission, no pause.
+ *
+ * `createSession` / `getSession` / `callSession` / `releaseSession` — SESSIONS
+ * (`/v2/sessions`, Surface B): the REST resource replacing the async+grant lane.
+ * Create reserves future capacity for a label; once READY the session accepts
+ * REPEATED drop-in calls (both wire shapes) with the normal Sapiom credential
+ * until its TTL/token budget ends it — no single-use token. `submit`/`redeem`
+ * keep working until the migration completes.
+ *
+ *   const s = await ctx.sapiom.llm.createSession({
+ *     label: "sonnet", deadlineMinutes: 60,
+ *     budget: { maxTokens: 2_000_000, ttlMinutes: 120 },
+ *   });
+ *   const ready = await s.wait();                       // or pauseUntilSignal(s, …)
+ *   const reply = await ctx.sapiom.llm.callSession(s, { max_tokens: 512, messages: […] });
+ *   await ctx.sapiom.llm.releaseSession(s);             // or let TTL/budget end it
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import type { DispatchHandle } from "../dispatch.js";
+
+const DEFAULT_BASE_URL = resolveServiceUrl("llm", process.env.SAPIOM_LLM_URL);
+
+/**
+ * Capability-stable signal a routed job fires when it reaches a terminal state
+ * (granted OR failed — it carries the result either way, the resumed step
+ * branches). A workflow step paused on a submit handle resumes on this; it is the
+ * value carried in the handle's `dispatch.resultSignal`.
+ */
+export const LLM_ROUTE_RESULT_SIGNAL = "llm.route.result";
+
+/** Job lifecycle, mirrored from the gateway's async status endpoint. */
+export type LlmRouteStatus =
+  | "queued"
+  | "granted"
+  | "consumed"
+  | "failed"
+  | "expired"
+  | "lost"
+  | "not_found";
+const TERMINAL = new Set<LlmRouteStatus>([
+  "granted",
+  "consumed",
+  "failed",
+  "expired",
+  "lost",
+]);
+
+export interface LlmRunSpec {
+  /**
+   * The verbatim LLM request (Anthropic messages shape) — forwarded as-is and
+   * executed immediately on the routed deployment. Any `model` inside the body
+   * is superseded by the routing decision (set the route label via `model` below).
+   */
+  request: Record<string, unknown>;
+  /** Route label (e.g. `"m2.7"`, `"minimax-m3"`, `"sonnet"`). Omit → the gateway's default label. */
+  model?: string;
+  /**
+   * Guarantee an answer by spilling to the label's declared fallback when the
+   * preferred capacity is saturated (never-429). DEFAULTS TO TRUE here: the
+   * gateway's own direct default is OFF (drop-in callers get plain 429 +
+   * backoff), but a workflow step usually can't retry-with-backoff cheaply, so
+   * the SDK opts workflows in. Set `false` to take 429s and handle them.
+   * Note: spilling can serve a costlier deployment (usually Anthropic).
+   */
+  neverFail?: boolean;
+  /** Explicit complexity/capacity weight override (gateway clamps to its bounds). */
+  complexity?: number;
+}
+
+export interface LlmSubmitSpec {
+  /**
+   * The verbatim LLM request (Anthropic messages shape). Used only to estimate
+   * routing weight at submit — the gateway does NOT store it; keep it (e.g. in
+   * `ctx.shared`) and re-send it to `redeem` when the grant arrives.
+   */
+  request: Record<string, unknown>;
+  /** Route label (e.g. `"m2.7"`, `"minimax-m3"`, `"sonnet"`). Omit → the gateway's default label. */
+  model?: string;
+  /**
+   * How long the caller will wait, in minutes. Omitted or <= 0 → run-now (top
+   * priority, immediate escalation). The gateway orders jobs earliest-deadline-
+   * first and escalates toward run-now as the deadline nears.
+   */
+  deadlineMinutes?: number;
+  /**
+   * Never-429 override for the deferred route. Omit → the gateway's async
+   * default (ON — deferred work guarantees an answer). Set `false` to let a
+   * saturated cascade fail instead of spilling to the fallback.
+   */
+  neverFail?: boolean;
+  /** Explicit complexity/capacity weight override (gateway clamps to its bounds). */
+  complexity?: number;
+  /**
+   * Where the gateway reports the grant (or failure). Inside a workflow leave it
+   * unset — the engine injects `SAPIOM_LLM_WEBHOOK_URL` (its resume forwarder).
+   * Standalone callers must pass one, or rely purely on `handle.wait()` polling
+   * via a URL of their own.
+   */
+  webhookUrl?: string;
+  /** HMAC secret: the gateway signs the webhook body as `X-Sapiom-Signature`. */
+  webhookSecret?: string;
+}
+
+/**
+ * The single-use link a granted job carries: call `POST {anthropicBaseUrl}/v1/messages`
+ * with `apiKey` (or hand both to `redeem`). Spent on first use; expires at
+ * `expiresAtMs` if never redeemed.
+ */
+export interface LlmGrantLink {
+  anthropicBaseUrl: string;
+  apiKey: string;
+  /** USER-FACING model label (e.g. `"m2.7"`, `"minimax-m3"`) — the provider is never disclosed. */
+  model: string;
+  expiresAtMs: number;
+  usage: string;
+}
+
+/**
+ * The routed job's terminal result as it arrives at a step **resumed** from
+ * `pauseUntilSignal(handle, { resumeStep })` — the signal payload delivered as
+ * that step's `input`. `link` is present iff `status === "granted"`; on
+ * `"failed"`, `error` says why (e.g. `deadline_exhausted`, `grant_mint_failed`,
+ * `expired`, `lost`). Annotate the resumed step's input with this.
+ */
+export interface LlmRouteResultPayload {
+  executionId: string;
+  status: "granted" | "failed";
+  link: LlmGrantLink | null;
+  error: string | null;
+}
+
+/** Thrown by {@link llmRouteResultSchema}.parse on a malformed resume payload. */
+export class LlmRouteResultSchemaError extends Error {}
+
+/** Runtime validator for {@link LlmRouteResultPayload}. */
+export const llmRouteResultSchema = {
+  parse(value: unknown): LlmRouteResultPayload {
+    const fail = (msg: string): never => {
+      throw new LlmRouteResultSchemaError(
+        `invalid llm route result payload: ${msg}`,
+      );
+    };
+    if (!value || typeof value !== "object") fail("not an object");
+    const v = value as Record<string, unknown>;
+    if (typeof v.executionId !== "string") fail("executionId must be a string");
+    if (v.status !== "granted" && v.status !== "failed")
+      fail('status must be "granted" or "failed"');
+    if (v.error !== null && typeof v.error !== "string")
+      fail("error must be a string or null");
+    if (!("link" in v)) fail("link is required (use null on failure)");
+    if (v.link !== null) {
+      const l = v.link as Record<string, unknown>;
+      if (!l || typeof l !== "object") fail("link must be an object or null");
+      if (typeof l.anthropicBaseUrl !== "string")
+        fail("link.anthropicBaseUrl must be a string");
+      if (typeof l.apiKey !== "string") fail("link.apiKey must be a string");
+      if (typeof l.model !== "string") fail("link.model must be a string");
+      if (typeof l.expiresAtMs !== "number")
+        fail("link.expiresAtMs must be a number");
+    }
+    return value as LlmRouteResultPayload;
+  },
+};
+
+/**
+ * A submitted-but-not-awaited routed job. Satisfies {@link DispatchHandle}, so it
+ * can be handed straight to `pauseUntilSignal(handle, { resumeStep })` to suspend
+ * a workflow step until the gateway grants (or fails) it — or `wait()`-ed inline
+ * for standalone use (polls the gateway's status endpoint).
+ */
+export interface LlmRouteHandle extends DispatchHandle {
+  executionId: string;
+  /** Fetch the current lifecycle status without blocking. */
+  status(): Promise<LlmRouteStatus>;
+  /** Poll to a terminal state and resolve the result payload. */
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<LlmRouteResultPayload>;
+}
+
+/** Same header the engine resume token rides on coding/agent launches. */
+function workflowResumeHeaders(
+  token: string | undefined,
+): Record<string, string> {
+  return token ? { "x-sapiom-workflow-token": token } : {};
+}
+
+// --- wire shapes (snake_case, as served by the gateway) ---
+
+interface SubmitDoc {
+  execution_id: string;
+  status: string;
+  poll?: string;
+}
+
+interface WireLink {
+  anthropic_base_url: string;
+  api_key: string;
+  model: string;
+  expires_at_ms: number;
+  usage?: string;
+}
+
+interface StatusDoc {
+  execution_id: string;
+  status: LlmRouteStatus;
+  link?: WireLink | null;
+  error?: string | null;
+}
+
+function mapLink(l: WireLink | null | undefined): LlmGrantLink | null {
+  if (!l) return null;
+  return {
+    anthropicBaseUrl: l.anthropic_base_url,
+    apiKey: l.api_key,
+    model: l.model,
+    expiresAtMs: l.expires_at_ms,
+    usage: l.usage ?? "single_request",
+  };
+}
+
+function toPayload(executionId: string, d: StatusDoc): LlmRouteResultPayload {
+  // consumed = granted-and-already-redeemed; the link is spent, so surface it as a
+  // failure rather than handing back a dead credential. expired/lost carry their
+  // wire status as the error.
+  if (d.status === "granted") {
+    return {
+      executionId,
+      status: "granted",
+      link: mapLink(d.link),
+      error: null,
+    };
+  }
+  return {
+    executionId,
+    status: "failed",
+    link: null,
+    error: d.error ?? d.status,
+  };
+}
+
+function submitHeaders(spec: LlmSubmitSpec, resumeToken: string | undefined) {
+  const webhookUrl = spec.webhookUrl ?? process.env.SAPIOM_LLM_WEBHOOK_URL;
+  if (!webhookUrl) {
+    throw new Error(
+      "llm.submit: no webhook URL. Inside a workflow the engine injects " +
+        "SAPIOM_LLM_WEBHOOK_URL; standalone callers must pass { webhookUrl }.",
+    );
+  }
+  const h: Record<string, string> = {
+    "x-sapiom-webhook-url": webhookUrl,
+    ...workflowResumeHeaders(resumeToken),
+  };
+  if (spec.webhookSecret) h["x-sapiom-webhook-secret"] = spec.webhookSecret;
+  if (spec.model) h["x-sapiom-model"] = spec.model;
+  if (spec.neverFail !== undefined)
+    h["x-sapiom-never-fail"] = String(spec.neverFail);
+  if (spec.deadlineMinutes !== undefined)
+    h["x-sapiom-deadline"] = String(spec.deadlineMinutes);
+  if (spec.complexity !== undefined)
+    h["x-sapiom-complexity"] = String(spec.complexity);
+  return h;
+}
+
+/**
+ * Synchronous routed call: `POST /v2/anthropic/v1/messages` on the x402 edge (Surface A —
+ * the PATH is the wire shape; this client speaks Anthropic Messages). The gateway
+ * selects the deployment (the label via `spec.model`, else the default label), admits it
+ * against the shared capacity ledger (run-now class — never queued), executes,
+ * and returns the completion inline. Billing settles against the caller's
+ * Sapiom API key at the edge (identity mode; the default `x-sapiom-api-key`
+ * header is exactly what the edge's identity guard reads).
+ */
+export async function run<T = Record<string, unknown>>(
+  spec: LlmRunSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (spec.model) headers["x-sapiom-model"] = spec.model;
+  // Workflow surface defaults to never-fail ON (see LlmRunSpec.neverFail) —
+  // sent explicitly either way so the behavior never rides a gateway default.
+  headers["x-sapiom-never-fail"] = String(spec.neverFail ?? true);
+  if (spec.complexity !== undefined)
+    headers["x-sapiom-complexity"] = String(spec.complexity);
+  return transport.request<T>(`${baseUrl}/v2/anthropic/v1/messages`, {
+    method: "POST",
+    body: JSON.stringify(spec.request),
+    headers,
+  });
+}
+
+export async function submit(
+  spec: LlmSubmitSpec,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<LlmRouteHandle> {
+  // 202 + {execution_id, status: "queued", poll}. The `/v2` control plane sits on
+  // the x402 edge, whose identity guard reads the default `x-sapiom-api-key`
+  // header (SAP-1496: a Sapiom API key is required on every /v2 route).
+  const doc = await transport.request<SubmitDoc>(`${baseUrl}/v2/route/async`, {
+    method: "POST",
+    body: JSON.stringify(spec.request),
+    headers: submitHeaders(spec, transport.resumeToken),
+  });
+  const executionId = doc.execution_id;
+
+  const fetchDoc = () =>
+    transport.request<StatusDoc>(
+      `${baseUrl}/v2/route/async/${encodeURIComponent(executionId)}`,
+    );
+
+  return {
+    executionId,
+    // Framework plumbing for `pauseUntilSignal` — see DispatchHandle. correlationId
+    // is the gateway execution id (echoed back with the webhook's callback_token).
+    dispatch: {
+      correlationId: executionId,
+      resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+    },
+    async status() {
+      return (await fetchDoc()).status;
+    },
+    async wait({ timeoutMs = 30 * 60_000, pollMs = 2_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (TERMINAL.has(d.status)) return toPayload(executionId, d);
+        if (Date.now() > deadline) {
+          throw new Error(
+            `llm route ${executionId} timed out after ${timeoutMs}ms (last status: ${d.status})`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+/**
+ * Spend a granted link: `POST {link.anthropicBaseUrl}/v2/anthropic/v1/messages` with the
+ * single-use grant in the `x-sapiom-grant-token` header, the caller's Sapiom API
+ * key as identity, and the (re-sent) request body. This is the PAID call — the
+ * edge settles it against the caller's account ("payment at redemption",
+ * SAP-1496), and the gateway routes it to the exact deployment the grant
+ * reserved (single-use, consumed atomically; the response `model` carries the
+ * user-facing label). `request.model` may be anything — the reserved deployment
+ * wins. Returns the parsed LLM response.
+ */
+export async function redeem<T = Record<string, unknown>>(
+  link: LlmGrantLink,
+  request: Record<string, unknown>,
+  transport: Transport = defaultTransport(),
+): Promise<T> {
+  const url = `${link.anthropicBaseUrl.replace(/\/$/, "")}/v2/anthropic/v1/messages`;
+  return transport.request<T>(url, {
+    method: "POST",
+    headers: { "x-sapiom-grant-token": link.apiKey },
+    body: JSON.stringify(request),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sessions (Surface B) — `/v2/sessions`, the REST resource replacing the
+// async+grant lane: create a session (deferred capacity), poll or resume until
+// READY, then call it REPEATEDLY with the normal Sapiom credential until its
+// TTL/token budget ends it. No single-use token, no body re-send ceremony.
+// `submit`/`redeem` above keep working until the migration completes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Capability-stable signal a session fires when it leaves `pending` (ready OR
+ * failed — the payload carries the session either way; the resumed step
+ * branches on `state`). Delivered by the gateway's ready-webhook through the
+ * engine's resume forwarder, correlated by the session id.
+ */
+export const LLM_SESSION_READY_SIGNAL = "llm.session.ready";
+
+/** Session lifecycle, mirrored from `GET /v2/sessions/{id}`. */
+export type LlmSessionState =
+  | "pending"
+  | "ready"
+  | "active"
+  | "expired"
+  | "exhausted"
+  | "failed"
+  | "not_found";
+const SESSION_SETTLED = new Set<LlmSessionState>([
+  "ready",
+  "active",
+  "expired",
+  "exhausted",
+  "failed",
+]);
+
+export interface LlmSessionCreateSpec {
+  /** Route label (e.g. `"sonnet"`, `"haiku"`). Mutually exclusive with `model`; omit both → the gateway's default label. */
+  label?: string;
+  /** Pin an exact Sapiom-supported alias. Mutually exclusive with `label`. */
+  model?: string;
+  /** How long you'll wait for capacity, in minutes. Omitted or <= 0 → run-now. */
+  deadlineMinutes?: number;
+  /**
+   * The session's envelope. `ttlMinutes` starts counting at READY (default:
+   * gateway-configured, 60); `maxTokens` caps total usage (input + output)
+   * across ALL calls — omit for time-boxed only.
+   */
+  budget?: { maxTokens?: number; ttlMinutes?: number };
+  /**
+   * Never-429 override for the capacity request. Omit → the gateway's async
+   * default (ON — a queued session is guaranteed to become ready, possibly on
+   * the label's costlier fallback).
+   */
+  neverFail?: boolean;
+  /**
+   * Where the gateway reports readiness. Inside a workflow leave it unset —
+   * the engine's `SAPIOM_LLM_WEBHOOK_URL` (resume forwarder) is used when
+   * present. Unlike `submit`, a webhook is OPTIONAL: standalone callers may
+   * rely purely on `handle.wait()` polling.
+   */
+  webhookUrl?: string;
+  /** HMAC secret: the gateway signs the webhook body as `X-Sapiom-Signature`. */
+  webhookSecret?: string;
+}
+
+/** A session as the gateway reports it (camelCase view of the wire doc). */
+export interface LlmSession {
+  sessionId: string;
+  state: LlmSessionState;
+  /** USER-FACING label (e.g. `"sonnet"`) — the serving provider is never disclosed. */
+  model?: string;
+  /** Present from READY on: the drop-in base URLs scoped under the session. */
+  baseUrls?: { anthropic: string; openai: string };
+  expiresAtMs?: number;
+  budget?: { maxTokens: number | null; usedTokens?: number; ttlMinutes?: number | null };
+  /** Set when `state === "failed"` (e.g. `deadline_exhausted`, `released_by_client`). */
+  error?: string;
+}
+
+/**
+ * A created-but-possibly-not-ready session. Satisfies {@link DispatchHandle}
+ * (hand it to `pauseUntilSignal(handle, { resumeStep })`), or `wait()` inline.
+ */
+export interface LlmSessionHandle extends DispatchHandle {
+  sessionId: string;
+  /** Fetch the current session doc without blocking. */
+  get(): Promise<LlmSession>;
+  /** Poll until the session leaves `pending`; resolves the session (check `state`). */
+  wait(opts?: { timeoutMs?: number; pollMs?: number }): Promise<LlmSession>;
+}
+
+// --- wire shapes (snake_case, as served by the gateway) ---
+
+interface SessionDoc {
+  session_id: string;
+  state: LlmSessionState;
+  model?: string;
+  base_urls?: { anthropic: string; openai: string };
+  expires_at_ms?: number;
+  budget?: {
+    max_tokens?: number | null;
+    used_tokens?: number;
+    ttl_minutes?: number | null;
+  };
+  error?: string | null;
+}
+
+function mapSession(d: SessionDoc): LlmSession {
+  const out: LlmSession = { sessionId: d.session_id, state: d.state };
+  if (d.model) out.model = d.model;
+  if (d.base_urls) out.baseUrls = d.base_urls;
+  if (d.expires_at_ms !== undefined) out.expiresAtMs = d.expires_at_ms;
+  if (d.budget)
+    out.budget = {
+      maxTokens: d.budget.max_tokens ?? null,
+      usedTokens: d.budget.used_tokens,
+      ttlMinutes: d.budget.ttl_minutes ?? null,
+    };
+  if (d.error) out.error = d.error;
+  return out;
+}
+
+/**
+ * Create a session: `POST /v2/sessions` — a plain JSON resource create (NOT an
+ * LLM payload; nothing about your prompts is sent or stored). Returns a handle
+ * immediately (`202 pending`); the gateway reserves capacity within
+ * `deadlineMinutes` and reports READY via webhook and/or the pollable GET.
+ */
+export async function createSession(
+  spec: LlmSessionCreateSpec = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<LlmSessionHandle> {
+  if (spec.label !== undefined && spec.model !== undefined) {
+    throw new Error("llm.createSession: `label` and `model` are mutually exclusive");
+  }
+  const body: Record<string, unknown> = {};
+  if (spec.label) body.label = spec.label;
+  if (spec.model) body.model = spec.model;
+  if (spec.deadlineMinutes !== undefined)
+    body.deadline_minutes = spec.deadlineMinutes;
+  if (spec.budget) {
+    const budget: Record<string, unknown> = {};
+    if (spec.budget.maxTokens !== undefined) budget.max_tokens = spec.budget.maxTokens;
+    if (spec.budget.ttlMinutes !== undefined) budget.ttl_minutes = spec.budget.ttlMinutes;
+    body.budget = budget;
+  }
+  if (spec.neverFail !== undefined) body.never_fail = spec.neverFail;
+  // Webhook is optional (poll-only is a legitimate mode). Inside a workflow the
+  // engine's forwarder URL + the ambient resume token wire up pause/resume.
+  const webhookUrl = spec.webhookUrl ?? process.env.SAPIOM_LLM_WEBHOOK_URL;
+  if (webhookUrl) {
+    const webhook: Record<string, unknown> = { url: webhookUrl };
+    if (spec.webhookSecret) webhook.secret = spec.webhookSecret;
+    if (transport.resumeToken) webhook.token = transport.resumeToken;
+    body.webhook = webhook;
+  }
+
+  const doc = await transport.request<SessionDoc>(`${baseUrl}/v2/sessions`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  const sessionId = doc.session_id;
+
+  const fetchDoc = () =>
+    transport.request<SessionDoc>(
+      `${baseUrl}/v2/sessions/${encodeURIComponent(sessionId)}`,
+    );
+
+  return {
+    sessionId,
+    dispatch: {
+      correlationId: sessionId,
+      resultSignal: LLM_SESSION_READY_SIGNAL,
+    },
+    async get() {
+      return mapSession(await fetchDoc());
+    },
+    async wait({ timeoutMs = 30 * 60_000, pollMs = 2_000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const d = await fetchDoc();
+        if (SESSION_SETTLED.has(d.state)) return mapSession(d);
+        if (Date.now() > deadline) {
+          throw new Error(
+            `llm session ${sessionId} timed out after ${timeoutMs}ms (last state: ${d.state})`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+      }
+    },
+  };
+}
+
+/** Fetch a session by id (tenant-scoped: other accounts' ids read as `not_found`). */
+export async function getSession(
+  sessionId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<LlmSession> {
+  return mapSession(
+    await transport.request<SessionDoc>(
+      `${baseUrl}/v2/sessions/${encodeURIComponent(sessionId)}`,
+    ),
+  );
+}
+
+/**
+ * Call a ready session — `POST /v2/sessions/{id}/anthropic/v1/messages` (the
+ * default Anthropic shape; pass `shape: "openai"` for Chat Completions).
+ * REPEATABLE: keep calling until the server ends the session — TTL/budget
+ * terminals return 410 (`session_expired` / `session_exhausted`); each call is
+ * billed individually against the caller's Sapiom key, exactly like `run`.
+ * `request.model` may be anything — the session's reserved deployment wins,
+ * and the response `model` carries the user-facing label.
+ */
+export async function callSession<T = Record<string, unknown>>(
+  session: LlmSessionHandle | LlmSession | string,
+  request: Record<string, unknown>,
+  opts: { shape?: "anthropic" | "openai" } = {},
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<T> {
+  const sessionId = typeof session === "string" ? session : session.sessionId;
+  const suffix =
+    opts.shape === "openai"
+      ? "openai/v1/chat/completions"
+      : "anthropic/v1/messages";
+  return transport.request<T>(
+    `${baseUrl}/v2/sessions/${encodeURIComponent(sessionId)}/${suffix}`,
+    { method: "POST", body: JSON.stringify(request) },
+  );
+}
+
+/**
+ * Release a session early: `DELETE /v2/sessions/{id}` — frees the reserved
+ * capacity; idempotent (a session already at a terminal returns its state).
+ */
+export async function releaseSession(
+  session: LlmSessionHandle | LlmSession | string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<LlmSession> {
+  const sessionId = typeof session === "string" ? session : session.sessionId;
+  return mapSession(
+    await transport.request<SessionDoc>(
+      `${baseUrl}/v2/sessions/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
+    ),
+  );
+}

--- a/packages/tools/src/llm/sessions.spec.ts
+++ b/packages/tools/src/llm/sessions.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * llm.createSession() / getSession() / callSession() / releaseSession() —
+ * Surface B wire shape: the REST create body (snake_case, config in the BODY
+ * not headers), the dispatch-handle shape, optional-webhook semantics (poll-only
+ * is legitimate; the resume token rides webhook.token only when both a URL and
+ * a token exist), wait() polling to a settled state, the repeatable call paths,
+ * and the camelCase mapping of the session doc.
+ *
+ * Injects a fake fetch (no real network), mirroring submit.spec.ts.
+ */
+import { createClient } from "../index.js";
+import { LLM_SESSION_READY_SIGNAL } from "./index.js";
+
+interface Captured {
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+const READY_DOC = {
+  session_id: "sess-1",
+  state: "ready",
+  model: "sonnet",
+  base_urls: {
+    anthropic: "https://llm.services.sapiom.ai/v2/sessions/sess-1/anthropic",
+    openai: "https://llm.services.sapiom.ai/v2/sessions/sess-1/openai/v1",
+  },
+  expires_at_ms: 1_726_574_400_000,
+  budget: { max_tokens: 2_000_000, used_tokens: 0, ttl_minutes: 120 },
+};
+
+/** 202 on POST /v2/sessions, then the given docs on successive GETs (poll). */
+function fakeSessionFetch(
+  capture: Captured,
+  getDocs: Array<Record<string, unknown>> = [READY_DOC],
+): typeof globalThis.fetch {
+  const polls = [...getDocs];
+  return (async (url: string, init: RequestInit = {}) => {
+    const method = init.method ?? "GET";
+    if (method === "POST" && url.endsWith("/v2/sessions")) {
+      capture.url = url;
+      capture.method = method;
+      capture.headers = init.headers as Record<string, string>;
+      capture.body = init.body as string;
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({
+          session_id: "sess-1",
+          state: "pending",
+          model: "sonnet",
+          poll: "/v2/sessions/sess-1",
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    }
+    if (method === "DELETE") {
+      capture.url = url;
+      capture.method = method;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ session_id: "sess-1", state: "expired", released: true }),
+        text: async () => "",
+      } as unknown as Response;
+    }
+    if (method === "POST") {
+      // session-scoped LLM call
+      capture.url = url;
+      capture.method = method;
+      capture.headers = init.headers as Record<string, string>;
+      capture.body = init.body as string;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ type: "message", model: "sonnet", content: [] }),
+        text: async () => "",
+      } as unknown as Response;
+    }
+    const doc = polls.length > 1 ? polls.shift() : polls[0];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => doc,
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("llm.createSession — REST create + dispatch handle", () => {
+  it("POSTs a plain JSON body (config in the body, never headers) and returns a handle", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    const handle = await sapiom.llm.createSession({
+      label: "sonnet",
+      deadlineMinutes: 60,
+      budget: { maxTokens: 2_000_000, ttlMinutes: 120 },
+      neverFail: true,
+    });
+    expect(cap.url).toMatch(/\/v2\/sessions$/);
+    expect(JSON.parse(cap.body!)).toEqual({
+      label: "sonnet",
+      deadline_minutes: 60,
+      budget: { max_tokens: 2_000_000, ttl_minutes: 120 },
+      never_fail: true,
+    });
+    // Routing config must NOT leak into headers on the sessions surface.
+    const headerNames = Object.keys(cap.headers ?? {}).map((h) => h.toLowerCase());
+    // Routing config must NOT leak into headers (sessions are body-driven); the
+    // api-key + client marker are legitimate transport headers, not routing.
+    expect(
+      headerNames.filter(
+        (h) => h.startsWith("x-sapiom-") && h !== "x-sapiom-api-key" && h !== "x-sapiom-client",
+      ),
+    ).toEqual([]);
+    expect(handle.sessionId).toBe("sess-1");
+    expect(handle.dispatch).toEqual({
+      correlationId: "sess-1",
+      resultSignal: LLM_SESSION_READY_SIGNAL,
+    });
+  });
+
+  it("LLM_SESSION_READY_SIGNAL is the capability-stable settled signal", () => {
+    expect(LLM_SESSION_READY_SIGNAL).toBe("llm.session.ready");
+  });
+
+  it("label and model are mutually exclusive", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch({}) });
+    await expect(
+      sapiom.llm.createSession({ label: "sonnet", model: "x" }),
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it("webhook is OPTIONAL (poll-only mode sends none)", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    await sapiom.llm.createSession({ label: "sonnet" });
+    expect(JSON.parse(cap.body!)).toEqual({ label: "sonnet" });
+  });
+
+  it("webhook carries url/secret and the ambient resume token as webhook.token", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      resumeToken: "resume-tok",
+      fetch: fakeSessionFetch(cap),
+    });
+    await sapiom.llm.createSession({
+      label: "sonnet",
+      webhookUrl: "https://engine.example/llm-callback",
+      webhookSecret: "s3cret",
+    });
+    expect(JSON.parse(cap.body!).webhook).toEqual({
+      url: "https://engine.example/llm-callback",
+      secret: "s3cret",
+      token: "resume-tok",
+    });
+  });
+
+  it("wait() polls past pending and resolves the mapped session", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeSessionFetch({}, [
+        { session_id: "sess-1", state: "pending" },
+        READY_DOC,
+      ]),
+    });
+    const handle = await sapiom.llm.createSession({ label: "sonnet" });
+    const session = await handle.wait({ pollMs: 1 });
+    expect(session).toEqual({
+      sessionId: "sess-1",
+      state: "ready",
+      model: "sonnet",
+      baseUrls: READY_DOC.base_urls,
+      expiresAtMs: READY_DOC.expires_at_ms,
+      budget: { maxTokens: 2_000_000, usedTokens: 0, ttlMinutes: 120 },
+    });
+  });
+
+  it("wait() resolves failed sessions too (caller branches on state)", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeSessionFetch({}, [
+        { session_id: "sess-1", state: "failed", error: "deadline_exhausted" },
+      ]),
+    });
+    const handle = await sapiom.llm.createSession({ label: "sonnet" });
+    const session = await handle.wait({ pollMs: 1 });
+    expect(session.state).toBe("failed");
+    expect(session.error).toBe("deadline_exhausted");
+  });
+});
+
+describe("llm.callSession / releaseSession — the repeatable surface", () => {
+  it("POSTs the verbatim request to the session-scoped anthropic path by default", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    const req = { max_tokens: 64, messages: [{ role: "user", content: "hi" }] };
+    await sapiom.llm.callSession("sess-1", req);
+    expect(cap.url).toMatch(/\/v2\/sessions\/sess-1\/anthropic\/v1\/messages$/);
+    expect(JSON.parse(cap.body!)).toEqual(req);
+    // No grant token — the caller's normal identity is the only credential.
+    const headerNames = Object.keys(cap.headers ?? {}).map((h) => h.toLowerCase());
+    expect(headerNames).not.toContain("x-sapiom-grant-token");
+  });
+
+  it('shape: "openai" targets the chat-completions path', async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    await sapiom.llm.callSession("sess-1", {}, { shape: "openai" });
+    expect(cap.url).toMatch(/\/v2\/sessions\/sess-1\/openai\/v1\/chat\/completions$/);
+  });
+
+  it("accepts a handle or session object in place of the id", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    const handle = await sapiom.llm.createSession({ label: "sonnet" });
+    await sapiom.llm.callSession(handle, {});
+    expect(cap.url).toMatch(/\/v2\/sessions\/sess-1\/anthropic\/v1\/messages$/);
+  });
+
+  it("releaseSession DELETEs the resource and maps the terminal doc", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeSessionFetch(cap) });
+    const out = await sapiom.llm.releaseSession("sess-1");
+    expect(cap.method).toBe("DELETE");
+    expect(cap.url).toMatch(/\/v2\/sessions\/sess-1$/);
+    expect(out.state).toBe("expired");
+  });
+});

--- a/packages/tools/src/llm/submit.spec.ts
+++ b/packages/tools/src/llm/submit.spec.ts
@@ -1,0 +1,431 @@
+/**
+ * llm.run() / llm.submit() — direct-route wire shape, dispatch-handle shape,
+ * routing headers, resume-token forwarding, wait() polling, and redeem().
+ *
+ * Injects a fake fetch (no real network) to assert the handle satisfies
+ * DispatchHandle, the routing controls ride as x-sapiom-* headers (the body stays
+ * a verbatim LLM request), and the engine-injected resume token is forwarded as a
+ * header only when present — so standalone use is unaffected.
+ */
+import { createClient } from "../index.js";
+import {
+  LLM_ROUTE_RESULT_SIGNAL,
+  llmRouteResultSchema,
+  LlmRouteResultSchemaError,
+  redeem,
+  type LlmGrantLink,
+} from "./index.js";
+
+const WIRE_LINK = {
+  anthropic_base_url: "https://llm.services.sapiom.ai",
+  api_key: "sapiom-grant-xyz",
+  model: "smart",
+  expires_at_ms: 1_726_574_400_000,
+  usage: "single_request",
+};
+
+interface Captured {
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/** 202 on POST (submit), then the given status docs on successive GETs (poll). */
+function fakeGatewayFetch(
+  capture: Captured,
+  statusDocs: Array<Record<string, unknown>> = [],
+): typeof globalThis.fetch {
+  const polls = [...statusDocs];
+  return (async (url: string, init: RequestInit = {}) => {
+    if ((init.method ?? "GET") === "POST") {
+      capture.url = url;
+      capture.headers = init.headers as Record<string, string>;
+      capture.body = init.body as string;
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({
+          execution_id: "exec-1",
+          status: "queued",
+          poll: "/v2/route/async/exec-1",
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    }
+    const doc = polls.length > 1 ? polls.shift() : polls[0];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => doc,
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const SPEC = {
+  request: { messages: [{ role: "user", content: "hi" }], max_tokens: 64 },
+  model: "smart",
+  deadlineMinutes: 30,
+  complexity: 2,
+  webhookUrl: "https://engine.example/llm-callback",
+};
+
+describe("llm.submit — dispatch handle", () => {
+  it("returns a handle that satisfies DispatchHandle", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    expect(handle.executionId).toBe("exec-1");
+    expect(handle.dispatch).toEqual({
+      correlationId: "exec-1",
+      resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+    });
+  });
+
+  it("LLM_ROUTE_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(LLM_ROUTE_RESULT_SIGNAL).toBe("llm.route.result");
+  });
+});
+
+describe("llm.run — direct routed call", () => {
+  function fakeDirectFetch(
+    cap: Captured,
+    response: Record<string, unknown>,
+  ): typeof globalThis.fetch {
+    return (async (url: string, init: RequestInit = {}) => {
+      cap.url = url;
+      cap.headers = init.headers as Record<string, string>;
+      cap.body = init.body as string;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => response,
+        text: async () => "",
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  it("POSTs the verbatim request to /v2/anthropic/v1/messages with routing + identity headers", async () => {
+    const cap: Captured = {};
+    const completion = {
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "m2.7",
+      content: [{ type: "text", text: "hi" }],
+    };
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeDirectFetch(cap, completion),
+    });
+    const res = await sapiom.llm.run({
+      request: SPEC.request,
+      model: "m2.7",
+      complexity: 3,
+    });
+    expect(cap.url).toContain("/v2/anthropic/v1/messages");
+    expect(cap.headers?.["x-sapiom-model"]).toBe("m2.7");
+    expect(cap.headers?.["x-sapiom-complexity"]).toBe("3");
+    expect(cap.headers?.["x-sapiom-api-key"]).toBe("k");
+    // Workflow surface: never-fail defaults ON and is sent EXPLICITLY (the gateway's
+    // own direct default is OFF for drop-in callers — 07-15 contract, per-mode).
+    expect(cap.headers?.["x-sapiom-never-fail"]).toBe("true");
+    // direct is synchronous — no async control headers
+    expect(cap.headers?.["x-sapiom-webhook-url"]).toBeUndefined();
+    expect(cap.headers?.["x-sapiom-deadline"]).toBeUndefined();
+    expect(JSON.parse(cap.body ?? "{}")).toEqual(SPEC.request);
+    expect(res).toEqual(completion);
+  });
+
+  it("run(): neverFail: false opts into plain 429s (header sent as false)", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeDirectFetch(cap, { ok: true }) });
+    await sapiom.llm.run({ request: SPEC.request, model: "m2.7", neverFail: false });
+    expect(cap.headers?.["x-sapiom-never-fail"]).toBe("false");
+  });
+
+  it("submit(): neverFail is passed through only when specified (gateway async default is ON)", async () => {
+    const cap: Captured = {};
+    let sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit({ ...SPEC });
+    expect(cap.headers?.["x-sapiom-never-fail"]).toBeUndefined();
+
+    const cap2: Captured = {};
+    sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap2) });
+    await sapiom.llm.submit({ ...SPEC, neverFail: false });
+    expect(cap2.headers?.["x-sapiom-never-fail"]).toBe("false");
+  });
+
+  it("omits routing headers when unset (gateway falls back to its default label)", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeDirectFetch(cap, { ok: true }),
+    });
+    await sapiom.llm.run({ request: SPEC.request });
+    expect(cap.headers?.["x-sapiom-model"]).toBeUndefined();
+    expect(cap.headers?.["x-sapiom-complexity"]).toBeUndefined();
+  });
+
+  it("surfaces a non-2xx gateway answer as an error with the status", async () => {
+    const failFetch = (async () =>
+      ({
+        ok: false,
+        status: 429,
+        text: async () => "no capacity",
+        json: async () => ({}),
+      }) as unknown as Response) as unknown as typeof globalThis.fetch;
+    const sapiom = createClient({ apiKey: "k", fetch: failFetch });
+    await expect(sapiom.llm.run({ request: SPEC.request })).rejects.toThrow(
+      /429/,
+    );
+  });
+});
+
+describe("llm.submit — routing headers + body", () => {
+  it("sends routing controls as x-sapiom-* headers and the request verbatim as the body", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.url).toContain("/v2/route/async");
+    expect(cap.headers?.["x-sapiom-webhook-url"]).toBe(SPEC.webhookUrl);
+    expect(cap.headers?.["x-sapiom-model"]).toBe("smart");
+    expect(cap.headers?.["x-sapiom-deadline"]).toBe("30");
+    expect(cap.headers?.["x-sapiom-complexity"]).toBe("2");
+    // tenant credential rides the edge identity header (SAP-1496: the x402
+    // edge's IdentityVerificationGuard reads x-sapiom-api-key)
+    expect(cap.headers?.["x-sapiom-api-key"]).toBe("k");
+    expect(JSON.parse(cap.body ?? "{}")).toEqual(SPEC.request);
+  });
+
+  it("throws without a webhook URL (no spec field, no env)", async () => {
+    delete process.env.SAPIOM_LLM_WEBHOOK_URL;
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch({}) });
+    await expect(sapiom.llm.submit({ request: SPEC.request })).rejects.toThrow(
+      /webhook URL/,
+    );
+  });
+
+  it("falls back to SAPIOM_LLM_WEBHOOK_URL from the env", async () => {
+    process.env.SAPIOM_LLM_WEBHOOK_URL = "https://engine.example/from-env";
+    try {
+      const cap: Captured = {};
+      const sapiom = createClient({
+        apiKey: "k",
+        fetch: fakeGatewayFetch(cap),
+      });
+      await sapiom.llm.submit({ request: SPEC.request });
+      expect(cap.headers?.["x-sapiom-webhook-url"]).toBe(
+        "https://engine.example/from-env",
+      );
+    } finally {
+      delete process.env.SAPIOM_LLM_WEBHOOK_URL;
+    }
+  });
+});
+
+describe("llm.submit — workflow resume token", () => {
+  const KEY = "SAPIOM_CAPABILITY_RESUME_TOKEN";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("forwards the env token as the x-sapiom-workflow-token header", async () => {
+    process.env[KEY] = "tok-abc";
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.headers?.["x-sapiom-workflow-token"]).toBe("tok-abc");
+    expect(cap.body).not.toContain("tok-abc"); // header, never the body
+  });
+
+  it("sends no token header when none is present (standalone)", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeGatewayFetch(cap) });
+    await sapiom.llm.submit(SPEC);
+    expect(cap.headers?.["x-sapiom-workflow-token"]).toBeUndefined();
+  });
+});
+
+describe("llm.submit — wait() polling", () => {
+  it("polls to granted and maps the link to camelCase", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}, [
+        { execution_id: "exec-1", status: "queued" },
+        { execution_id: "exec-1", status: "granted", link: WIRE_LINK },
+      ]),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    const result = await handle.wait({ pollMs: 1 });
+    expect(result).toEqual({
+      executionId: "exec-1",
+      status: "granted",
+      link: {
+        anthropicBaseUrl: "https://llm.services.sapiom.ai",
+        apiKey: "sapiom-grant-xyz",
+        model: "smart",
+        expiresAtMs: 1_726_574_400_000,
+        usage: "single_request",
+      },
+      error: null,
+    });
+  });
+
+  it("maps failure terminals (deadline_exhausted / expired / lost) to failed + error", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeGatewayFetch({}, [
+        {
+          execution_id: "exec-1",
+          status: "failed",
+          error: "deadline_exhausted",
+        },
+      ]),
+    });
+    const handle = await sapiom.llm.submit(SPEC);
+    const result = await handle.wait({ pollMs: 1 });
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("deadline_exhausted");
+    expect(result.link).toBeNull();
+  });
+
+  it("status polls (GET) carry the identity credential — SAP-1496 gates /v2 status before id validation", async () => {
+    // The edge 401s ANY /v2 call without a resolved Sapiom identity, status GETs
+    // included. Pin that polling sends x-sapiom-api-key on every GET, not just on
+    // the submit POST.
+    const getHeaders: Array<Record<string, string>> = [];
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if ((init.method ?? "GET") === "POST") {
+        return {
+          ok: true,
+          status: 202,
+          json: async () => ({ execution_id: "exec-1", status: "queued" }),
+          text: async () => "",
+        } as unknown as Response;
+      }
+      getHeaders.push(init.headers as Record<string, string>);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          execution_id: "exec-1",
+          status: "granted",
+          link: WIRE_LINK,
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    const sapiom = createClient({ apiKey: "k", fetch: fetchImpl });
+    const handle = await sapiom.llm.submit(SPEC);
+    await handle.status();
+    await handle.wait({ pollMs: 1 });
+    expect(getHeaders.length).toBeGreaterThanOrEqual(2);
+    for (const h of getHeaders) {
+      expect(h?.["x-sapiom-api-key"]).toBe("k");
+    }
+  });
+});
+
+describe("llm.redeem", () => {
+  const LINK: LlmGrantLink = {
+    anthropicBaseUrl: "https://llm.services.sapiom.ai",
+    apiKey: "sapiom-grant-xyz",
+    model: "smart",
+    expiresAtMs: 1,
+    usage: "single_request",
+  };
+
+  it("POSTs /v2/anthropic/v1/messages with the grant header + identity credential (payment at redemption)", async () => {
+    const cap: Captured = {};
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      cap.url = url;
+      cap.headers = init.headers as Record<string, string>;
+      cap.body = init.body as string;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ content: [{ type: "text", text: "hello" }] }),
+        text: async () => "",
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "k", fetch: fetchImpl });
+    const out = await sapiom.llm.redeem(LINK, {
+      messages: [],
+      model: "ignored",
+    });
+    expect(cap.url).toBe("https://llm.services.sapiom.ai/v2/anthropic/v1/messages");
+    // the grant rides its own header; the reserved deployment wins server-side
+    expect(cap.headers?.["x-sapiom-grant-token"]).toBe("sapiom-grant-xyz");
+    // the caller's API key settles billing at the edge (SAP-1496)
+    expect(cap.headers?.["x-sapiom-api-key"]).toBe("k");
+    // body is re-sent verbatim — no client-side model rewrite
+    expect(JSON.parse(cap.body ?? "{}").model).toBe("ignored");
+    expect(out).toEqual({ content: [{ type: "text", text: "hello" }] });
+  });
+
+  it("standalone redeem() uses the ambient transport credential", async () => {
+    const cap: Captured = {};
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      cap.headers = init.headers as Record<string, string>;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        text: async () => "",
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    const { Transport } = await import("../_client/index.js");
+    await redeem(
+      LINK,
+      { messages: [] },
+      new Transport({ apiKey: "k2", fetch: fetchImpl }),
+    );
+    expect(cap.headers?.["x-sapiom-grant-token"]).toBe("sapiom-grant-xyz");
+    expect(cap.headers?.["x-sapiom-api-key"]).toBe("k2");
+  });
+});
+
+describe("llmRouteResultSchema", () => {
+  it("accepts a granted payload", () => {
+    const payload = {
+      executionId: "exec-1",
+      status: "granted",
+      link: {
+        anthropicBaseUrl: "https://llm.services.sapiom.ai",
+        apiKey: "sapiom-grant-xyz",
+        model: "smart",
+        expiresAtMs: 1,
+        usage: "single_request",
+      },
+      error: null,
+    };
+    expect(llmRouteResultSchema.parse(payload)).toBe(payload);
+  });
+
+  it("accepts a failed payload with a null link", () => {
+    const payload = {
+      executionId: "exec-1",
+      status: "failed",
+      link: null,
+      error: "deadline_exhausted",
+    };
+    expect(llmRouteResultSchema.parse(payload)).toBe(payload);
+  });
+
+  it("rejects a malformed payload", () => {
+    expect(() => llmRouteResultSchema.parse({ status: "granted" })).toThrow(
+      LlmRouteResultSchemaError,
+    );
+    expect(() =>
+      llmRouteResultSchema.parse({
+        executionId: "e",
+        status: "granted",
+        error: null,
+      }),
+    ).toThrow(/link is required/);
+  });
+});

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -31,10 +31,21 @@ import type {
   RunStatus,
 } from "../models/index.js";
 import { AGENTS_RESULT_SIGNAL } from "../agents/index.js";
+import {
+  LLM_ROUTE_RESULT_SIGNAL,
+  LLM_SESSION_READY_SIGNAL,
+} from "../llm/index.js";
 import type {
   AgentRunResult,
   RunHandle as AgentRunHandle,
 } from "../agents/index.js";
+import type {
+  LlmGrantLink,
+  LlmRouteHandle,
+  LlmRouteResultPayload,
+  LlmSession,
+  LlmSessionHandle,
+} from "../llm/index.js";
 import type { Sapiom } from "../client.js";
 import { Repository } from "../repositories/index.js";
 import { Sandbox } from "../sandboxes/index.js";
@@ -764,6 +775,131 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         }));
       },
     },
+    llm: {
+      run: <T = Record<string, unknown>>(spec: {
+        request: Record<string, unknown>;
+        model?: string;
+        complexity?: number;
+      }) =>
+        Promise.resolve(
+          r("llm.run", [spec], () => ({
+            id: "stub-msg",
+            type: "message",
+            role: "assistant",
+            model: spec.model ?? "smart",
+            content: [{ type: "text", text: "(stub) llm reply" }],
+            stop_reason: "end_turn",
+          })) as T,
+        ),
+      submit: (spec) => {
+        const executionId = `stub-exec-${++launchSeq}`;
+        const stubLink: LlmGrantLink = {
+          anthropicBaseUrl: "https://llm.local",
+          apiKey: "sapiom-grant-stub",
+          model: spec.model ?? "smart",
+          expiresAtMs: 4102444800000,
+          usage: "single_request",
+        };
+        const payload = r("llm.submit", [spec], () => ({
+          executionId,
+          status: "granted" as const,
+          link: stubLink,
+          error: null,
+        })) as LlmRouteResultPayload;
+        const handle: LlmRouteHandle = {
+          executionId,
+          dispatch: {
+            correlationId: executionId,
+            resultSignal: LLM_ROUTE_RESULT_SIGNAL,
+          },
+          status: () =>
+            Promise.resolve(
+              payload.status === "granted"
+                ? ("granted" as const)
+                : ("failed" as const),
+            ),
+          wait: () => Promise.resolve(payload),
+        };
+        // Register the resume payload so a local `pauseUntilSignal` on this handle
+        // resolves with an LlmRouteResultPayload.
+        return dispatchable(handle, opts.signals);
+      },
+      redeem: <T = Record<string, unknown>>(
+        link: LlmGrantLink,
+        request: Record<string, unknown>,
+      ) =>
+        Promise.resolve(
+          r("llm.redeem", [link, request], () => ({
+            id: "stub-msg",
+            type: "message",
+            role: "assistant",
+            model: link.model,
+            content: [{ type: "text", text: "(stub) llm reply" }],
+            stop_reason: "end_turn",
+          })) as T,
+        ),
+      createSession: (spec = {}) => {
+        const sessionId = `stub-sess-${++launchSeq}`;
+        const session = (): LlmSession =>
+          r("llm.createSession", [spec], () => ({
+            sessionId,
+            state: "ready" as const,
+            model: spec.label ?? spec.model ?? "smart",
+            baseUrls: {
+              anthropic: `https://llm.local/v2/sessions/${sessionId}/anthropic`,
+              openai: `https://llm.local/v2/sessions/${sessionId}/openai/v1`,
+            },
+            expiresAtMs: 4102444800000,
+            budget: {
+              maxTokens: spec.budget?.maxTokens ?? null,
+              usedTokens: 0,
+              ttlMinutes: spec.budget?.ttlMinutes ?? null,
+            },
+          })) as LlmSession;
+        const handle: LlmSessionHandle = {
+          sessionId,
+          dispatch: {
+            correlationId: sessionId,
+            resultSignal: LLM_SESSION_READY_SIGNAL,
+          },
+          get: () => Promise.resolve(session()),
+          wait: () => Promise.resolve(session()),
+        };
+        // Register the resume payload so a local `pauseUntilSignal` on this
+        // handle resolves with the ready session.
+        return dispatchable(handle, opts.signals, session);
+      },
+      getSession: (sessionId) =>
+        Promise.resolve(
+          r("llm.getSession", [sessionId], () => ({
+            sessionId,
+            state: "ready" as const,
+            model: "smart",
+          })) as LlmSession,
+        ),
+      callSession: <T = Record<string, unknown>>(
+        session: LlmSessionHandle | LlmSession | string,
+        request: Record<string, unknown>,
+        callOpts: { shape?: "anthropic" | "openai" } = {},
+      ) =>
+        Promise.resolve(
+          r("llm.callSession", [session, request, callOpts], () => ({
+            id: "stub-msg",
+            type: "message",
+            role: "assistant",
+            model: "smart",
+            content: [{ type: "text", text: "(stub) llm reply" }],
+            stop_reason: "end_turn",
+          })) as T,
+        ),
+      releaseSession: (session) =>
+        Promise.resolve(
+          r("llm.releaseSession", [session], () => ({
+            sessionId: typeof session === "string" ? session : session.sessionId,
+            state: "expired" as const,
+          })) as LlmSession,
+        ),
+    },
     fileStorage: {
       upload: (input) =>
         Promise.resolve(
@@ -839,12 +975,12 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 contentType: "video/mp4",
                 // mirror the real behavior: a fileId only when storage was requested.
                 ...(input.storage
-                    ? {
-                        fileId: "stub-file",
-                        downloadUrl: "https://content.local/stub-download",
-                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                      }
-                    : {}),
+                  ? {
+                      fileId: "stub-file",
+                      downloadUrl: "https://content.local/stub-download",
+                      downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                    }
+                  : {}),
               },
             })) as VideoGenerationResult,
           ),
@@ -858,12 +994,12 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 url: "https://content.local/stub-video.mp4",
                 contentType: "video/mp4",
                 ...(input.storage
-                    ? {
-                        fileId: "stub-file",
-                        downloadUrl: "https://content.local/stub-download",
-                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                      }
-                    : {}),
+                  ? {
+                      fileId: "stub-file",
+                      downloadUrl: "https://content.local/stub-download",
+                      downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                    }
+                  : {}),
               },
             }),
           ) as VideoGenerationResult;


### PR DESCRIPTION
## What

New `llm` namespace on the Sapiom client (`ctx.sapiom.llm`), wiring workflows into the
LLM gateway's `/v2` routing front-end (SAP-792) via the x402 unified edge
(`llm.services.sapiom.ai`, SAP-1496). Direct-first, per the integration roadmap:

- **`llm.run(spec)` — NEW, synchronous.** `POST /v2/route/direct`: one LLM call routed
  through the model selector (pin via `spec.model`, else smart cascade) and the
  capacity-aware load balancer, executed inline and returned as the parsed completion.
  Run-now class — never queued. Billing settles against the caller's Sapiom API key at
  the edge (identity mode — **live-verified HTTP 200 on prod** with `x-sapiom-api-key`
  only; no x402 payment handshake, so no new dependency).
- **`llm.submit(spec)` — deferred-start.** `POST /v2/route/async`: returns an
  `LlmRouteHandle` satisfying `DispatchHandle`, ready for
  `pauseUntilSignal(handle, { resumeStep })` (or `handle.wait()` polling standalone).
  Routing controls ride `x-sapiom-*` headers; the engine resume token rides
  `x-sapiom-workflow-token`; fires the capability-stable `llm.route.result` signal.
- **`llm.redeem(link, request)`.** Spends the granted single-use link against
  `/v1/messages` (the gateway stores no body — the caller re-sends it).

## Why not a rebase

This re-lands the SAP-1200 branch commit `450b8e5` fresh on current `main`: the old
branch sat 132 commits behind and predates the `agent→agents` rename, so a port beats
a conflict-heavy rebase. Two deliberate changes beyond the port:

1. **`llm.run` added** — the missing synchronous verb (the old branch was async-only).
2. **Auth header switched `x-api-key` → default `x-sapiom-api-key`** — `/v2` now
   enters through the x402 edge, whose `IdentityVerificationGuard` reads
   `x-sapiom-api-key` (SAP-1496 requires a Sapiom API key on every `/v2` route). The
   old header targeted the internal gateway's vkey auth, which no longer fronts `/v2`.

## Surface

`Sapiom.llm` on the client, `export * as llm` on the barrel, a `./llm` subpath export,
a shape-faithful stub (`run`/`submit`/`redeem`) so `run_local` works offline, and a
`minor` changeset for `@sapiom/tools`.

## Testing

- 16 llm spec tests (dispatch-handle shape, wire headers/body, resume-token
  forwarding, `wait()` polling + terminal mapping, redeem, schema validation, plus
  3 new `llm.run` tests: URL/headers/verbatim body, defaults, non-2xx surfacing).
- Package suite **382/382 green**; typecheck, eslint, prettier clean.
- **Live e2e through the built SDK on prod**: `createClient().llm.run({ model: "smart", … })`
  → real routed completion (billed, smart-cascaded), confirming URL resolution,
  identity auth, and response parsing end-to-end.

## Known follow-ups (out of scope here)

- Engine forwarder (`feat/SAP-1200-llm-route-resume-forwarder`) rebase to make
  `submit` + `pauseUntilSignal` resume on the gateway webhook (Phase 2).
- Gateway: `/v2` auth-gate deploy (`dbd715916`, SAP-1496) — anonymous async submit
  still 202s on prod today; this SDK already sends the key on every call, so it's
  gate-ready.
- Gateway: direct responses expose the internal deployment name in `model` (the
  user-label relabel currently covers grant redemption only).

Refs: SAP-1200, SAP-792, SAP-1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)