### PR TITLE
feat(tools): align memory surface to v1 contract

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -80,7 +80,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 | `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks               | [src/email](./src/email/README.md)                           |
 | `domains`           | Register domain names and manage their DNS records                                                    | [src/domains](./src/domains/README.md)                       |
-| `memory`            | Tenant-scoped long-term memory (append-log; cosine recall, Neon keyword recall)                       | [src/memory](./src/memory/README.md)                         |
+| `memory`            | Tenant-scoped long-term memory (namespace-isolated append-log; semantic/keyword/hybrid recall)        | [src/memory](./src/memory/README.md)                         |
 
 ## Composing capabilities
 

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -124,10 +124,7 @@ import type {
   AppendResult,
   RecallInput,
   RecallResponse,
-  SweepInput,
-  MemorySweepResponse,
-  Memory,
-  MemoryCallOptions,
+  ForgetInput,
 } from "./memory/index.js";
 import * as vault from "./vault/index.js";
 
@@ -332,17 +329,20 @@ export interface Sapiom {
     };
   };
   /**
-   * Tenant-scoped long-term memory. `append` writes (or no-ops on a duplicate),
-   * `recall` searches by cosine vector similarity or Neon keyword strategy, `get`
-   * fetches one by id; prune with Neon `sweep` (LRU/oldest eviction) or `forget`
-   * (hard-delete a single id).
+   * Tenant-scoped long-term memory. `append` writes one memory into a
+   * `namespace`, `recall` searches one namespace by relevance (semantic, keyword,
+   * or hybrid), `forget` hard-deletes ids, and `drop` deletes a whole namespace.
+   *
+   * Partition with a namespace per agent / per user / per project by default;
+   * co-locate subsets in one namespace (via `metadata` + recall `filter`) only
+   * when a single recall must span them. Memory is not chat history — `recall`
+   * ranks by relevance, never recency.
    */
   readonly memory: {
     append(input: AppendInput): Promise<AppendResult>;
     recall(input: RecallInput): Promise<RecallResponse>;
-    sweep(input?: SweepInput): Promise<MemorySweepResponse>;
-    get(id: string, options?: MemoryCallOptions): Promise<Memory>;
-    forget(id: string, options?: MemoryCallOptions): Promise<void>;
+    forget(input: ForgetInput): Promise<void>;
+    drop(namespace: string): Promise<void>;
   };
   /**
    * READ-ONLY tenant vault secrets (SAP-1471): `list` returns key names, `get`
@@ -490,9 +490,8 @@ function bind(transport: Transport): Sapiom {
     memory: {
       append: (input) => memory.append(input, transport),
       recall: (input) => memory.recall(input, transport),
-      sweep: (input) => memory.sweep(input, transport),
-      get: (id, options) => memory.get(id, transport, undefined, options),
-      forget: (id, options) => memory.forget(id, transport, undefined, options),
+      forget: (input) => memory.forget(input, transport),
+      drop: (namespace) => memory.drop(namespace, transport),
     },
     vault: {
       list: (ref) => vault.list(ref, transport),

--- a/packages/tools/src/memory/README.md
+++ b/packages/tools/src/memory/README.md
@@ -1,70 +1,115 @@
 # memory
 
-Tenant-scoped long-term memory over the Sapiom memory gateway.
+Tenant-scoped long-term memory backed by the Sapiom memory service.
 
 ```typescript
 import { createClient } from "@sapiom/tools";
 
 const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
 
-const { id, decision } = await sapiom.memory.append({
+const { id } = await sapiom.memory.append({
   content: "User prefers dark mode.",
-  scope: "user",
-  metadata: { source: "preference-survey" },
+  namespace: "user-42",
+  metadata: { source: "preference-survey", user_theme: "dark" },
 });
 
 const { results } = await sapiom.memory.recall({
   query: "ui preferences",
-  scope: "user",
+  namespace: "user-42",
   topK: 5,
 });
 
-const record = await sapiom.memory.get(id);
-await sapiom.memory.forget(id);
+await sapiom.memory.forget({ ids: [id], namespace: "user-42" });
+await sapiom.memory.drop("user-42");
 ```
 
 Ambient import works too: `import { memory } from "@sapiom/tools"`.
 
 ## Operations
 
-| Method                 | Notes                                                                                                 |
-| ---------------------- | ----------------------------------------------------------------------------------------------------- |
-| `append(input)`        | Writes a memory or returns an existing near-duplicate. Success decisions are `"ADDED"` or `"NOOP"`.   |
-| `recall(input)`        | Searches memories by `query`; supports `strategy`, temporal `weight`, metadata `filter`, and `store`. |
-| `sweep(input?)`        | Neon-only compaction. `dryRun` defaults to `true`; pass `false` to delete selected rows.              |
-| `get(id, options?)`    | Fetches one memory. Pass `options.store` when the write used a non-default store.                     |
-| `forget(id, options?)` | Hard-deletes one memory. Idempotent: already-gone rows still resolve successfully.                    |
+| Method            | Notes                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `append(input)`   | Writes one memory into a namespace. Metered.                                                                |
+| `recall(input)`   | Searches one namespace by `query`; supports `strategy`, temporal `weight`, and metadata `filter`. Metered.  |
+| `forget(input)`   | Hard-deletes memories by id. Blind-idempotent: already-gone ids still resolve successfully. Free.           |
+| `drop(namespace)` | Deletes an entire namespace. Idempotent. Free.                                                              |
 
-## Store Identity
+## Namespaces
 
-`store` selects the physical store. Reads must pass the same selector used by the matching write.
+`namespace` is the isolation boundary: reads only ever see one namespace, and
+`drop` deletes one namespace wholesale.
+
+**Default to a namespace per agent, per user, or per project.** A namespace has
+bounded capacity, so prefer many small namespaces over one large one. Put
+subsets into a single shared namespace — distinguished by `metadata` and
+narrowed with a recall `filter` — only when a single recall must span those
+subsets. For better performance, use a namespace instead if you'd always
+filter to one value.
 
 ```typescript
-export interface MemoryStore {
-  backend?: "neon-pgvector" | "upstash-vector";
-  embedder?: {
-    provider: string;
-    model: string;
-  };
-  namespace?: string;
-}
+// Preferred: one namespace per user
+await sapiom.memory.append({ content, namespace: `user-${userId}` });
+
+// Only when one recall must span subsets: shared namespace + metadata + filter
+await sapiom.memory.append({
+  content,
+  namespace: "support-team",
+  metadata: { user_id: userId },
+});
+await sapiom.memory.recall({
+  query,
+  namespace: "support-team",
+  filter: { user_id: userId },
+});
 ```
 
-Pass the same `store` to reads/deletes that was used when writing. Omit `store` for the v0 default: Neon pgvector, your default namespace, and OpenRouter `openai/text-embedding-3-small`.
+## Metadata
+
+Metadata you WRITE is flat: a map of identifier keys to string, number, or
+boolean values (arrays and nulls are rejected with `invalid_metadata`). Express
+hierarchy through key naming conventions (e.g. `env_prod`, `user_theme`) rather
+than nesting. Keys start with a letter and must not contain `.`. Key count and
+sizes are bounded (enforced server-side).
+
+Every metadata leaf is a scalar. Filter values match exactly, or against a set
+with `{ in: [...] }`. For better performance, use `namespace` for a key you'd
+filter on every recall — metadata suits optionally-filtered dimensions.
+
+## Limits
+
+| Field                     | Limit                                         |
+| ------------------------- | --------------------------------------------- |
+| `content`                 | ≤ 32,000 characters                           |
+| `namespace`               | 1–100 characters; letters, digits, `-`, `_`   |
+| `query`                   | ≤ 4,096 characters                            |
+| `topK`                    | 1–50 (default 5)                              |
+| `metadata` keys           | ≤ 20 per memory                               |
+| `metadata` key            | ≤ 64 bytes; matches `^[a-zA-Z]\w*$`           |
+| `metadata` string value   | ≤ 512 characters                              |
+| `filter` keys             | ≤ 20                                          |
+| `filter` `{ in: [...] }`  | ≤ 64 values                                   |
+| `forget` ids              | ≤ 100 per call                                |
+| `weight.halfLifeDays`     | 1–365 (default 30)                            |
 
 ## Contract Notes
 
-- `append` is append-log only. It never mutates or supersedes existing rows.
-- Secret-like content or metadata is rejected before embedding with `MemoryHttpError` status `400` and body fields such as `error: "SecretDetected"` and `decision: "REJECTED"`.
-- `occurredAt` is optional event time. When omitted, the backend stores `null`; temporal recall falls back to `createdAt`.
-- `recall` defaults to `strategy: "cosine"`, `topK: 5`, and `minSimilarity: 0`.
-- `strategy: "keyword"` is Neon-only; requesting it on `upstash-vector` returns `400`.
-- `sweep` is Neon-only; for Upstash-backed stores, call `forget` on specific ids.
-- `upstash-vector` is experimental in v0. Append, cosine recall, get, and forget work; native Upstash embedding, keyword recall, and sweep are not part of this SDK contract yet.
-- The gateway is authoritative for embedder support. v0 currently supports OpenRouter-backed embedding providers/models and returns `400` for unsupported selectors.
-- `filter` is a hard metadata filter. Neon uses JSONB containment; Upstash supports scalar equality filters.
-- After the route gate succeeds, recall degrades child infra, billing, rate-limit, and timeout failures to `{ results: [], count: 0 }`. Bad requests, missing identity, and ownership failures still throw.
-- Every route has the near-zero x402 minimum gate. Embedding and store operations are child costs billed to the run.
+- Memory is durable knowledge, not chat history: `recall` ranks by relevance,
+  never by recency — it is not a way to page through recent turns. Keep last-N
+  context in your own store.
+- `append` is append-log only; it never mutates existing memories.
+- Secret-like content is rejected before anything is stored:
+  `MemoryHttpError` status `400`, body `code: "secret_detected"`.
+- `occurredAt` is optional event time, distinct from `createdAt` (ingestion
+  time); it drives `weight.temporal` recall decay.
+- `recall` defaults to `strategy: "semantic"` and `topK: 5`; `"keyword"` and
+  `"hybrid"` are also supported. Scores are a relevance ranking weight — higher
+  is more relevant; compare only within one result set.
+- Caller-safe validation failures surface as `400` with a stable `body.code`
+  (`invalid_metadata`, `invalid_filter`, `secret_detected`). Other request-shape
+  violations (e.g. oversized content) surface as a plain `400` without a stable
+  code. Infrastructure failures surface as generic `502`/`503`/`504` — details
+  are logged server-side, never returned to the caller.
 - Non-2xx responses throw `MemoryHttpError` with `status` and parsed `body`.
 
-The base URL follows the shared service resolver: `SAPIOM_MEMORY_URL`, then `SAPIOM_SERVICES_BASE`, then `https://memory.services.sapiom.ai`.
+The base URL follows the shared service resolver: `SAPIOM_MEMORY_URL`, then
+`SAPIOM_SERVICES_BASE`, then `https://memory.services.sapiom.ai`.

--- a/packages/tools/src/memory/errors.ts
+++ b/packages/tools/src/memory/errors.ts
@@ -1,11 +1,16 @@
 /**
- * Error thrown by the memory capability when the gateway returns a non-2xx
- * response. Exposes `status` (HTTP status code) and `body` (parsed JSON body, or
- * raw text when the body isn't JSON) for programmatic inspection.
+ * Error thrown by the memory capability when the memory service returns a
+ * non-2xx response. Exposes `status` (HTTP status code) and `body` (parsed
+ * JSON body, or raw text when the body isn't JSON) for programmatic inspection.
  *
- * Useful statuses to branch on: `400` (validation or `SecretDetected`), `401`
- * (missing identity), `402` (route gate balance), `403` (ownership failure),
- * `404` (`get` only), `422` (resource limit), and `507` (store full).
+ * Wrap semantics: caller-safe validation errors pass through as `400` with a
+ * stable `body.code` to branch on — `invalid_metadata`, `invalid_filter`, and
+ * `secret_detected`. Other request-shape violations (e.g. oversized content)
+ * surface as a plain `400` without a stable code. Infrastructure failures are
+ * wrapped and surface only as a generic `502` (service error), `503` (memory
+ * unavailable), or `504` (timeout) — details are logged server-side, never
+ * returned. `401`/`402`/`403` keep their usual identity/balance/ownership
+ * meanings.
  */
 export class MemoryHttpError extends Error {
   readonly status: number;

--- a/packages/tools/src/memory/index.spec.ts
+++ b/packages/tools/src/memory/index.spec.ts
@@ -1,5 +1,6 @@
 import { createClient } from "../index.js";
 import { Transport } from "../_client/index.js";
+import { createStubClient } from "../stub/index.js";
 import * as memory from "./index.js";
 import { MemoryHttpError } from "./errors.js";
 
@@ -52,19 +53,20 @@ function makeTransport(
 const BASE = "https://api.test";
 const headerOf = (c: FetchCall, k: string) =>
   (c.init.headers as Record<string, string>)[k];
+const bodyOf = (c: FetchCall) => JSON.parse(String(c.init.body)) as unknown;
 
-// ---------------------------------------------------------------------------
-// Public contract constants
-// ---------------------------------------------------------------------------
+const APPEND_OK = {
+  id: "mem-1",
+  content: "User prefers dark mode.",
+  createdAt: "2026-07-09T00:00:00Z",
+};
 
-describe("memory — public contract constants", () => {
-  it("exports the current backend allowlist", () => {
-    expect(memory.MEMORY_BACKENDS).toEqual([
-      "neon-pgvector",
-      "upstash-vector",
-    ]);
-  });
-});
+const RECALL_OK = {
+  results: [],
+  query: "ui preferences",
+  topK: 5,
+  count: 0,
+};
 
 // ---------------------------------------------------------------------------
 // Base URL resolution (resolveServiceUrl at module load)
@@ -75,961 +77,279 @@ describe("memory — base URL resolution", () => {
     // DEFAULT_BASE_URL is captured at module load from process.env; with no
     // SAPIOM_MEMORY_URL / SAPIOM_SERVICES_BASE set in this test run it must be
     // the production origin, and the /v1/memory path prefix is appended per-method.
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    // Call WITHOUT the baseUrl arg so the module-level default is exercised.
-    await memory.append({ content: "c" }, transport);
+    const { transport, calls } = makeTransport([() => jsonResponse(APPEND_OK)]);
+    await memory.append({ content: "x" }, transport);
     expect(calls[0]!.url).toBe(
       "https://memory.services.sapiom.ai/v1/memory/append",
     );
   });
-
-  it("honors an explicit per-call baseUrl override verbatim (path prefix appended)", async () => {
-    // An SAPIOM_MEMORY_URL override wins verbatim, but it is read at module load;
-    // the per-call baseUrl arg is the same bare-origin knob threaded per request,
-    // so we exercise the override shape through it.
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    await memory.append(
-      { content: "c" },
-      transport,
-      "http://memory.services.localhost:3100",
-    );
-    expect(calls[0]!.url).toBe(
-      "http://memory.services.localhost:3100/v1/memory/append",
-    );
-  });
 });
 
 // ---------------------------------------------------------------------------
-// append()
+// append
 // ---------------------------------------------------------------------------
 
-describe("memory.append()", () => {
-  it("POSTs /append with JSON body + credential and returns the camelCase payload as-is", async () => {
-    const raw = {
-      id: "m-123",
-      content: "User prefers dark mode.",
-      scope: "user",
-      decision: "ADDED",
-      createdAt: "2026-06-22T12:00:00Z",
-      occurredAt: null,
-      metadata: { source: "survey" },
-    };
-    const { transport, calls } = makeTransport([
-      () => jsonResponse(raw, { status: 201 }),
-    ]);
-
-    const result = await memory.append(
-      {
-        content: "User prefers dark mode.",
-        scope: "user",
-        metadata: { source: "survey" },
-      },
-      transport,
-      BASE,
-    );
-
-    expect(result).toEqual(raw);
-    expect(result.decision).toBe("ADDED");
+describe("memory.append", () => {
+  it("POSTs only { content } when every optional field is omitted", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(APPEND_OK)]);
+    const result = await memory.append({ content: "x" }, transport, BASE);
     expect(calls[0]!.url).toBe(`${BASE}/v1/memory/append`);
     expect(calls[0]!.init.method).toBe("POST");
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
     expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      content: "User prefers dark mode.",
-      scope: "user",
-      metadata: { source: "survey" },
-    });
-    // store omitted from the body when not supplied → gateway falls back to its
-    // neon-pgvector default store.
-    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
-      "store",
-    );
+    expect(bodyOf(calls[0]!)).toEqual({ content: "x" });
+    expect(result).toEqual(APPEND_OK);
   });
 
-  it("includes occurredAt in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: "2026-05-01T00:00:00Z",
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    const result = await memory.append(
-      { content: "c", occurredAt: "2026-05-01T00:00:00Z" },
-      transport,
-      BASE,
-    );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      content: "c",
-      occurredAt: "2026-05-01T00:00:00Z",
-    });
-    // occurredAt echoed back on the result.
-    expect(result.occurredAt).toBe("2026-05-01T00:00:00Z");
-  });
-
-  it("forwards the store selector (backend) in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    const store: memory.MemoryStore = { backend: "upstash-vector" };
-    await memory.append({ content: "c", store }, transport, BASE);
-
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      content: "c",
-      store: { backend: "upstash-vector" },
-    });
-  });
-
-  it("forwards the full store selector (namespace + embedder) verbatim in the body", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    const store: memory.MemoryStore = {
-      namespace: "tenant-7",
-      embedder: {
-        provider: "openrouter",
-        model: "openai/text-embedding-3-large",
-      },
+  it("passes namespace, flat metadata, and occurredAt through verbatim", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(APPEND_OK)]);
+    const metadata = {
+      team: "sales",
+      user_theme: "dark",
+      logged_in: true,
+      visits: 3,
     };
-    await memory.append({ content: "c", store }, transport, BASE);
-
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      content: "c",
-      store: {
-        namespace: "tenant-7",
-        embedder: {
-          provider: "openrouter",
-          model: "openai/text-embedding-3-large",
-        },
+    await memory.append(
+      {
+        content: "x",
+        namespace: "agent-42",
+        metadata,
+        occurredAt: "2026-07-01T00:00:00Z",
       },
-    });
-  });
-
-  it("surfaces a NOOP decision echoing the existing memory (nothing written)", async () => {
-    const { transport } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-existing",
-            content: "User prefers dark mode.",
-            scope: "user",
-            decision: "NOOP",
-            createdAt: "2026-06-01T00:00:00Z",
-            occurredAt: null,
-            metadata: { source: "survey" },
-          },
-          // NOOP may come back as 200 or 201; either is a success and parses the same.
-          { status: 200 },
-        ),
-    ]);
-
-    const result = await memory.append(
-      { content: "User prefers dark mode.", scope: "user" },
       transport,
       BASE,
     );
-    expect(result.decision).toBe("NOOP");
-    expect(result.id).toBe("m-existing"); // the existing memory's id, echoed
-  });
-
-  it("returns NOOP on byte-identical content (no idempotency key sent)", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-existing",
-            content: "c",
-            scope: "default",
-            decision: "NOOP",
-            createdAt: "2026-06-01T00:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 200 },
-        ),
-    ]);
-
-    // NOOP is decided purely on byte-identical content (or a near-exact semantic
-    // duplicate) in the same owner + scope — there is no idempotency key on the wire.
-    const result = await memory.append({ content: "c" }, transport, BASE);
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ content: "c" });
-    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
-      "idempotencyKey",
-    );
-    expect(result.decision).toBe("NOOP");
-    expect(result.id).toBe("m-existing");
-  });
-
-  it("omits optional fields from the body when not provided", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse(
-          {
-            id: "m-1",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        ),
-    ]);
-
-    await memory.append({ content: "c" }, transport, BASE);
-    const body = JSON.parse(calls[0]!.init.body as string);
-    expect(body).toEqual({ content: "c" });
-    expect(body).not.toHaveProperty("scope");
-    expect(body).not.toHaveProperty("metadata");
-    expect(body).not.toHaveProperty("idempotencyKey");
-    expect(body).not.toHaveProperty("occurredAt");
-    expect(body).not.toHaveProperty("store");
-  });
-
-  it("throws MemoryHttpError carrying the REJECTED body on a 400 SecretDetected", async () => {
-    const { transport } = makeTransport([
-      () =>
-        new Response(
-          JSON.stringify({
-            statusCode: 400,
-            error: "SecretDetected",
-            decision: "REJECTED",
-            message: "Potential secret detected in content or metadata.",
-          }),
-          { status: 400 },
-        ),
-    ]);
-
-    // REJECTED is not a success decision — it rides back on the 400 error body, so
-    // it must surface via MemoryHttpError.body, never as an AppendResult.decision.
-    await expect(
-      memory.append({ content: "sk-live-abc" }, transport, BASE),
-    ).rejects.toMatchObject({
-      status: 400,
-      body: { error: "SecretDetected", decision: "REJECTED" },
+    expect(bodyOf(calls[0]!)).toEqual({
+      content: "x",
+      namespace: "agent-42",
+      metadata,
+      occurredAt: "2026-07-01T00:00:00Z",
     });
   });
 
-  it("throws MemoryHttpError on a 507 (store full)", async () => {
-    const { transport } = makeTransport([
-      () =>
-        new Response(
-          JSON.stringify({ statusCode: 507, message: "Memory store full." }),
-          { status: 507 },
-        ),
-    ]);
+  it("returns the response as-is, including omitted optionals", async () => {
+    const wire = {
+      ...APPEND_OK,
+      occurredAt: "2026-07-01T00:00:00Z",
+    };
+    const { transport } = makeTransport([() => jsonResponse(wire)]);
+    const result = await memory.append({ content: "x" }, transport, BASE);
+    expect(result).toEqual(wire);
+    expect(result.metadata).toBeUndefined();
+  });
 
-    await expect(
-      memory.append({ content: "c" }, transport, BASE),
-    ).rejects.toMatchObject({ status: 507 });
-    await expect(
-      memory.append({ content: "c" }, transport, BASE),
-    ).rejects.toBeInstanceOf(MemoryHttpError);
+  it("throws MemoryHttpError with status and parsed body on a caller-safe 400", async () => {
+    const body = {
+      code: "secret_detected",
+      message: "content contains a secret",
+    };
+    const { transport } = makeTransport([
+      () => jsonResponse(body, { status: 400 }),
+    ]);
+    const err = await memory
+      .append({ content: "sk-..." }, transport, BASE)
+      .then(
+        () => null,
+        (e: unknown) => e as MemoryHttpError,
+      );
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err!.status).toBe(400);
+    expect(err!.body).toEqual(body);
   });
 });
 
 // ---------------------------------------------------------------------------
-// recall()
+// recall
 // ---------------------------------------------------------------------------
 
-describe("memory.recall()", () => {
-  const match = {
-    id: "m-1",
-    content: "The project deadline is end of Q3.",
-    scope: "project",
-    // Provider returns a single canonical [0,1] `score` plus an optional
-    // backend-specific `scoreBreakdown` map (some backends fill component scores;
-    // opaque/dense-only paths omit it).
-    score: 0.71,
-    scoreBreakdown: { vector: 0.82, text: 0.4, combined: 0.71 },
-    createdAt: "2026-06-01T00:00:00Z",
-    occurredAt: "2026-05-15T00:00:00Z",
-    lastAccessedAt: "2026-06-20T00:00:00Z",
-    metadata: {},
-  };
-
-  it("POSTs /recall with the query and returns results + echoed fields", async () => {
-    const { transport, calls } = makeTransport([
-      () =>
-        jsonResponse({
-          results: [match],
-          query: "deadline",
-          topK: 10,
-          count: 1,
-        }),
-    ]);
-
-    const result = await memory.recall({ query: "deadline" }, transport, BASE);
-
-    expect(result.count).toBe(1);
-    expect(result.topK).toBe(10);
-    expect(result.query).toBe("deadline");
-    expect(result.results[0]).toEqual(match);
-    // The match maps the score shape 1:1 — canonical `score` + optional
-    // `scoreBreakdown`, plus occurredAt / lastAccessedAt passthrough.
-    expect(result.results[0]!.score).toBe(0.71);
-    expect(result.results[0]!.scoreBreakdown).toEqual({
-      vector: 0.82,
-      text: 0.4,
-      combined: 0.71,
-    });
-    expect(result.results[0]!.occurredAt).toBe("2026-05-15T00:00:00Z");
-    expect(result.results[0]!.lastAccessedAt).toBe("2026-06-20T00:00:00Z");
+describe("memory.recall", () => {
+  it("POSTs only { query } when every optional field is omitted", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(RECALL_OK)]);
+    const result = await memory.recall({ query: "q" }, transport, BASE);
     expect(calls[0]!.url).toBe(`${BASE}/v1/memory/recall`);
     expect(calls[0]!.init.method).toBe("POST");
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "deadline",
-    });
-    expect(JSON.parse(calls[0]!.init.body as string)).not.toHaveProperty(
-      "store",
-    );
+    expect(bodyOf(calls[0]!)).toEqual({ query: "q" });
+    expect(result).toEqual(RECALL_OK);
   });
 
-  it("surfaces a match with null occurredAt/lastAccessedAt and no scoreBreakdown (opaque backend)", async () => {
-    const opaqueMatch = {
-      id: "m-opaque",
-      content: "Opaque-backend match.",
-      scope: "default",
-      score: 0.66,
-      createdAt: "2026-06-01T00:00:00Z",
-      occurredAt: null,
-      lastAccessedAt: null,
-      metadata: {},
+  it("passes namespace, topK, strategy, temporal weight, and filter through verbatim", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(RECALL_OK)]);
+    const filter = {
+      team: "sales",
+      "user.theme": "dark",
+      env: { in: ["prod", "staging"] },
     };
-    const { transport } = makeTransport([
-      () =>
-        jsonResponse({
-          results: [opaqueMatch],
-          query: "q",
-          topK: 10,
-          count: 1,
-        }),
-    ]);
-
-    const result = await memory.recall({ query: "q" }, transport, BASE);
-    expect(result.results[0]).toEqual(opaqueMatch);
-    expect(result.results[0]!.score).toBe(0.66);
-    expect(result.results[0]!.scoreBreakdown).toBeUndefined();
-    expect(result.results[0]!.occurredAt).toBeNull();
-    expect(result.results[0]!.lastAccessedAt).toBeNull();
-  });
-
-  it("includes scope, topK, minSimilarity, and strategy in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
-    ]);
-
     await memory.recall(
       {
         query: "q",
-        scope: "project",
-        topK: 5,
-        minSimilarity: 0.5,
-        strategy: "keyword",
+        namespace: "agent-42",
+        topK: 10,
+        strategy: "hybrid",
+        weight: { temporal: { halfLifeDays: 7 } },
+        filter,
       },
       transport,
       BASE,
     );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+    expect(bodyOf(calls[0]!)).toEqual({
       query: "q",
-      scope: "project",
+      namespace: "agent-42",
+      topK: 10,
+      strategy: "hybrid",
+      weight: { temporal: { halfLifeDays: 7 } },
+      filter,
+    });
+  });
+
+  it("returns matches as-is (nullable metadata/occurredAt)", async () => {
+    const wire = {
+      results: [
+        {
+          id: "mem-1",
+          content: "c",
+          score: 0.92,
+          createdAt: "2026-07-09T00:00:00Z",
+          occurredAt: null,
+          metadata: null,
+        },
+      ],
+      query: "q",
       topK: 5,
-      minSimilarity: 0.5,
-      strategy: "keyword",
-    });
-  });
-
-  it("includes weight and filter in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
-    ]);
-
-    await memory.recall(
-      {
-        query: "q",
-        weight: {
-          temporal: { center: "2026-06-01T00:00:00Z", halfLifeDays: 14 },
-        },
-        filter: { source: "survey" },
-      },
-      transport,
-      BASE,
-    );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "q",
-      weight: {
-        temporal: { center: "2026-06-01T00:00:00Z", halfLifeDays: 14 },
-      },
-      filter: { source: "survey" },
-    });
-  });
-
-  it("forwards the store selector (backend) in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
-    ]);
-
-    await memory.recall(
-      { query: "q", store: { backend: "upstash-vector" } },
-      transport,
-      BASE,
-    );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "q",
-      store: { backend: "upstash-vector" },
-    });
-  });
-
-  it("forwards the full store selector (namespace + embedder) verbatim in the body", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
-    ]);
-
-    await memory.recall(
-      {
-        query: "q",
-        store: {
-          namespace: "tenant-7",
-          embedder: {
-            provider: "openrouter",
-            model: "openai/text-embedding-3-large",
-          },
-        },
-      },
-      transport,
-      BASE,
-    );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      query: "q",
-      store: {
-        namespace: "tenant-7",
-        embedder: {
-          provider: "openrouter",
-          model: "openai/text-embedding-3-large",
-        },
-      },
-    });
-  });
-
-  it("omits optional fields from the body when not provided", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 5, count: 0 }),
-    ]);
-
-    await memory.recall({ query: "q" }, transport, BASE);
-    const body = JSON.parse(calls[0]!.init.body as string);
-    expect(body).toEqual({ query: "q" });
-    expect(body).not.toHaveProperty("scope");
-    expect(body).not.toHaveProperty("topK");
-    expect(body).not.toHaveProperty("minSimilarity");
-    expect(body).not.toHaveProperty("strategy");
-    expect(body).not.toHaveProperty("weight");
-    expect(body).not.toHaveProperty("filter");
-    expect(body).not.toHaveProperty("store");
-  });
-
-  it("returns an empty result set without error", async () => {
-    const { transport } = makeTransport([
-      () => jsonResponse({ results: [], query: "q", topK: 10, count: 0 }),
-    ]);
-
+      count: 1,
+    };
+    const { transport } = makeTransport([() => jsonResponse(wire)]);
     const result = await memory.recall({ query: "q" }, transport, BASE);
-    expect(result.results).toEqual([]);
-    expect(result.count).toBe(0);
+    expect(result).toEqual(wire);
   });
 
-  it("throws MemoryHttpError on non-2xx", async () => {
+  it("throws MemoryHttpError on invalid_filter", async () => {
+    const body = { code: "invalid_filter", message: "bad key '0key'" };
     const { transport } = makeTransport([
-      () => new Response("server error", { status: 503 }),
+      () => jsonResponse(body, { status: 400 }),
     ]);
-
-    await expect(
-      memory.recall({ query: "q" }, transport, BASE),
-    ).rejects.toMatchObject({ status: 503 });
+    const err = await memory
+      .recall({ query: "q", filter: { "0key": "x" } }, transport, BASE)
+      .then(
+        () => null,
+        (e: unknown) => e as MemoryHttpError,
+      );
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err!.status).toBe(400);
+    expect(err!.body).toEqual(body);
   });
 });
 
 // ---------------------------------------------------------------------------
-// sweep()
+// forget
 // ---------------------------------------------------------------------------
 
-describe("memory.sweep()", () => {
-  it("POSTs /sweep with an empty body by default (dryRun omitted, server defaults it true)", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ evicted: 0, candidates: [] }),
-    ]);
-
-    const result = await memory.sweep(undefined, transport, BASE);
-
-    expect(result.evicted).toBe(0);
-    expect(result.candidates).toEqual([]);
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/sweep`);
-    expect(calls[0]!.init.method).toBe("POST");
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-    // dryRun now defaults to true SERVER-side; the client only sends it when the
-    // caller provides it, so an unspecified sweep sends no dryRun at all.
-    const body = JSON.parse(calls[0]!.init.body as string);
-    expect(body).toEqual({});
-    expect(body).not.toHaveProperty("dryRun");
-  });
-
-  it("includes count, strategy, and the store selector in the body when provided", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ evicted: 2 }),
-    ]);
-
-    await memory.sweep(
-      {
-        count: 2,
-        strategy: "oldest",
-        store: {
-          backend: "upstash-vector",
-          namespace: "tenant-7",
-          embedder: {
-            provider: "openrouter",
-            model: "openai/text-embedding-3-large",
-          },
-        },
-      },
-      transport,
-      BASE,
-    );
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      count: 2,
-      strategy: "oldest",
-      store: {
-        backend: "upstash-vector",
-        namespace: "tenant-7",
-        embedder: {
-          provider: "openrouter",
-          model: "openai/text-embedding-3-large",
-        },
-      },
-    });
-  });
-
-  it("returns the candidates a dryRun would evict (evicted: 0)", async () => {
-    const candidate = {
-      id: "m-old",
-      content: "stale note",
-      scope: "default",
-      createdAt: "2026-01-01T00:00:00Z",
-      lastAccessedAt: null,
-    };
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ evicted: 0, candidates: [candidate] }),
-    ]);
-
-    // dryRun:true is the server default, but when the caller passes it explicitly
-    // the client forwards it in the body.
-    const result = await memory.sweep({ dryRun: true }, transport, BASE);
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ dryRun: true });
-    expect(result.evicted).toBe(0);
-    expect(result.candidates).toEqual([candidate]);
-    expect(result.candidates![0]!.lastAccessedAt).toBeNull();
-  });
-
-  it("sends dryRun:false in the body when the caller opts into a real eviction", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ evicted: 4 }),
-    ]);
-
-    const result = await memory.sweep({ dryRun: false }, transport, BASE);
-    // Only sent because the caller provided it; the client never injects a default.
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      dryRun: false,
-    });
-    expect(result.evicted).toBe(4);
-  });
-
-  it("throws MemoryHttpError on non-2xx", async () => {
-    const { transport } = makeTransport([
-      () => new Response("server error", { status: 500 }),
-    ]);
-
-    await expect(memory.sweep({}, transport, BASE)).rejects.toMatchObject({
-      status: 500,
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// get()
-// ---------------------------------------------------------------------------
-
-describe("memory.get()", () => {
-  const record = {
-    id: "m-1",
-    content: "c",
-    scope: "default",
-    createdAt: "2026-06-01T00:00:00Z",
-    occurredAt: "2026-05-15T00:00:00Z",
-    lastAccessedAt: "2026-06-20T00:00:00Z",
-    metadata: {},
-  };
-
-  it("GETs /:id and returns the record", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    const result = await memory.get("m-1", transport, BASE);
-
-    expect(result).toEqual(record);
-    expect(result.occurredAt).toBe("2026-05-15T00:00:00Z");
-    expect(result.lastAccessedAt).toBe("2026-06-20T00:00:00Z");
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
-    expect(calls[0]!.init.method).toBeUndefined(); // default GET
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
-  });
-
-  it("returns a record with null occurredAt/lastAccessedAt", async () => {
-    const bare = {
-      id: "m-2",
-      content: "c",
-      scope: "default",
-      createdAt: "2026-06-01T00:00:00Z",
-      occurredAt: null,
-      lastAccessedAt: null,
-      metadata: {},
-    };
-    const { transport } = makeTransport([() => jsonResponse(bare)]);
-
-    const result = await memory.get("m-2", transport, BASE);
-    expect(result).toEqual(bare);
-    expect(result.occurredAt).toBeNull();
-    expect(result.lastAccessedAt).toBeNull();
-  });
-
-  it("appends the flat storeBackend query param when the option is provided", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    await memory.get("m-1", transport, BASE, {
-      store: { backend: "upstash-vector" },
-    });
-    const expected = new URLSearchParams();
-    expected.set("storeBackend", "upstash-vector");
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1?${expected.toString()}`);
-  });
-
-  it("omits the store query params when the option is absent", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    await memory.get("m-1", transport, BASE, {});
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
-    expect(calls[0]!.url).not.toContain("store");
-  });
-
-  it("appends flat store query params (namespace + embedder)", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    await memory.get("m-1", transport, BASE, {
-      store: {
-        namespace: "tenant-7",
-        embedder: {
-          provider: "openrouter",
-          model: "openai/text-embedding-3-large",
-        },
-      },
-    });
-    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
-    expect(query.get("storeNamespace")).toBe("tenant-7");
-    expect(query.get("storeEmbedderProvider")).toBe("openrouter");
-    expect(query.get("storeEmbedderModel")).toBe(
-      "openai/text-embedding-3-large",
-    );
-  });
-
-  it("omits the flat store query params when the store option is absent", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    await memory.get("m-1", transport, BASE, {});
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-1`);
-    expect(calls[0]!.url).not.toContain("store");
-  });
-
-  it("encodes special characters in the id", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(record)]);
-
-    await memory.get("id/with slash", transport, BASE);
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
-  });
-
-  it("throws MemoryHttpError on 404", async () => {
-    const { transport } = makeTransport([
-      () => new Response("not found", { status: 404 }),
-    ]);
-
-    await expect(memory.get("bad-id", transport, BASE)).rejects.toMatchObject({
-      status: 404,
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// forget()
-// ---------------------------------------------------------------------------
-
-describe("memory.forget()", () => {
-  it("DELETEs /:id and resolves void on 204", async () => {
+describe("memory.forget", () => {
+  it("DELETEs /v1/memory with an { ids } body and resolves void on 204", async () => {
     const { transport, calls } = makeTransport([
       () => new Response(null, { status: 204 }),
     ]);
-
-    const result = await memory.forget("m-abc", transport, BASE);
-    expect(result).toBeUndefined();
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
+    await expect(
+      memory.forget({ ids: ["a", "b"] }, transport, BASE),
+    ).resolves.toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/memory`);
     expect(calls[0]!.init.method).toBe("DELETE");
     expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "b"] });
   });
 
-  it("appends the flat storeBackend query param when the option is provided", async () => {
+  it("includes namespace in the body when provided", async () => {
     const { transport, calls } = makeTransport([
       () => new Response(null, { status: 204 }),
     ]);
+    await memory.forget({ ids: ["a"], namespace: "agent-42" }, transport, BASE);
+    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a"], namespace: "agent-42" });
+  });
 
-    await memory.forget("m-abc", transport, BASE, {
-      store: { backend: "upstash-vector" },
-    });
-    const expected = new URLSearchParams();
-    expected.set("storeBackend", "upstash-vector");
+  it("throws MemoryHttpError with parsed body on failure", async () => {
+    const body = { code: "batch_too_large", message: "too many ids" };
+    const { transport } = makeTransport([
+      () => jsonResponse(body, { status: 400 }),
+    ]);
+    const err = await memory.forget({ ids: ["a"] }, transport, BASE).then(
+      () => null,
+      (e: unknown) => e as MemoryHttpError,
+    );
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err!.status).toBe(400);
+    expect(err!.body).toEqual(body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drop
+// ---------------------------------------------------------------------------
+
+describe("memory.drop", () => {
+  it("DELETEs /v1/memory/namespaces/:namespace (URL-encoded) and resolves void on 204", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await expect(
+      memory.drop("agent 42/beta", transport, BASE),
+    ).resolves.toBeUndefined();
     expect(calls[0]!.url).toBe(
-      `${BASE}/v1/memory/m-abc?${expected.toString()}`,
+      `${BASE}/v1/memory/namespaces/agent%2042%2Fbeta`,
     );
     expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
   });
 
-  it("omits the store query params when the option is absent", async () => {
-    const { transport, calls } = makeTransport([
-      () => new Response(null, { status: 204 }),
+  it("throws MemoryHttpError with raw-text body when the error body is not JSON", async () => {
+    const { transport } = makeTransport([
+      () => new Response("upstream exploded", { status: 502 }),
     ]);
-
-    await memory.forget("m-abc", transport, BASE, {});
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
-    expect(calls[0]!.url).not.toContain("store");
-  });
-
-  it("appends flat store query params (namespace + embedder)", async () => {
-    const { transport, calls } = makeTransport([
-      () => new Response(null, { status: 204 }),
-    ]);
-
-    await memory.forget("m-abc", transport, BASE, {
-      store: {
-        namespace: "tenant-7",
-        embedder: {
-          provider: "openrouter",
-          model: "openai/text-embedding-3-large",
-        },
-      },
-    });
-    const query = new URLSearchParams(calls[0]!.url.split("?")[1]);
-    expect(query.get("storeNamespace")).toBe("tenant-7");
-    expect(query.get("storeEmbedderProvider")).toBe("openrouter");
-    expect(query.get("storeEmbedderModel")).toBe(
-      "openai/text-embedding-3-large",
+    const err = await memory.drop("ns", transport, BASE).then(
+      () => null,
+      (e: unknown) => e as MemoryHttpError,
     );
-    expect(calls[0]!.init.method).toBe("DELETE");
-  });
-
-  it("omits the flat store query params when the store option is absent", async () => {
-    const { transport, calls } = makeTransport([
-      () => new Response(null, { status: 204 }),
-    ]);
-
-    await memory.forget("m-abc", transport, BASE, {});
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/m-abc`);
-    expect(calls[0]!.url).not.toContain("store");
-  });
-
-  it("encodes special characters in the id", async () => {
-    const { transport, calls } = makeTransport([
-      () => new Response(null, { status: 204 }),
-    ]);
-
-    await memory.forget("id/with slash", transport, BASE);
-    expect(calls[0]!.url).toBe(`${BASE}/v1/memory/id%2Fwith%20slash`);
-  });
-
-  it("is idempotent: a second forget of an already-gone id resolves (204, no throw)", async () => {
-    // forget is a hard DELETE but idempotent: the gateway always returns
-    // 204 No Content, whether or not the id existed. Deleting an already-gone
-    // (or never-existed / other-owner) id is success — NOT a 404. Mirror the
-    // gateway by returning 204 on every call.
-    const { transport, calls } = makeTransport([
-      () => new Response(null, { status: 204 }),
-      () => new Response(null, { status: 204 }),
-    ]);
-
-    await expect(
-      memory.forget("m-abc", transport, BASE),
-    ).resolves.toBeUndefined();
-    // Second forget of the now-gone id still succeeds (idempotent).
-    await expect(
-      memory.forget("m-abc", transport, BASE),
-    ).resolves.toBeUndefined();
-    expect(calls).toHaveLength(2);
-    expect(calls.every((c) => c.init.method === "DELETE")).toBe(true);
-  });
-
-  it("surfaces a real transport error as MemoryHttpError with status + parsed JSON body", async () => {
-    // Idempotency only covers gone-already ids (→ 204). Genuine failures must
-    // still throw, exercising forget()'s inline error parser (not ensureOk).
-    const { transport } = makeTransport([
-      () =>
-        new Response(JSON.stringify({ message: "boom", code: "internal" }), {
-          status: 500,
-        }),
-    ]);
-
-    await expect(
-      memory.forget("bad-id", transport, BASE),
-    ).rejects.toMatchObject({
-      status: 500,
-      body: { message: "boom", code: "internal" },
-    });
-  });
-
-  it("surfaces a real transport error as MemoryHttpError (non-JSON body)", async () => {
-    const { transport } = makeTransport([
-      () => new Response("upstream boom", { status: 500 }),
-    ]);
-
-    await expect(
-      memory.forget("bad-id", transport, BASE),
-    ).rejects.toMatchObject({ status: 500, body: "upstream boom" });
-    await expect(
-      memory.forget("bad-id", transport, BASE),
-    ).rejects.toBeInstanceOf(MemoryHttpError);
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err!.status).toBe(502);
+    expect(err!.body).toBe("upstream exploded");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Client wiring + auth
+// createClient wiring
 // ---------------------------------------------------------------------------
 
-describe("memory — client wiring + credential", () => {
-  it("createClient().memory routes all five methods with the credential", async () => {
+describe("createClient().memory", () => {
+  it("routes every verb through the client transport with the tenant credential", async () => {
     const calls: FetchCall[] = [];
     const fetchMock = (async (
       input: Parameters<typeof globalThis.fetch>[0],
       init: RequestInit = {},
     ): Promise<Response> => {
-      const url = typeof input === "string" ? input : (input as URL).toString();
+      const url = typeof input === "string" ? input : String(input);
       calls.push({ url, init });
-      const method = init.method ?? "GET";
-      if (method === "DELETE") return new Response(null, { status: 204 });
-      if (url.endsWith("/recall"))
-        return jsonResponse({ results: [], query: "q", topK: 10, count: 0 });
-      if (url.endsWith("/sweep")) return jsonResponse({ evicted: 0 });
-      if (url.endsWith("/append"))
-        return jsonResponse(
-          {
-            id: "m",
-            content: "c",
-            scope: "default",
-            decision: "ADDED",
-            createdAt: "2026-06-22T12:00:00Z",
-            occurredAt: null,
-            metadata: {},
-          },
-          { status: 201 },
-        );
-      // GET /:id
-      return jsonResponse({
-        id: "m",
-        content: "c",
-        scope: "default",
-        createdAt: "2026-06-22T12:00:00Z",
-        occurredAt: null,
-        lastAccessedAt: null,
-        metadata: {},
-      });
+      if (url.endsWith("/append")) return jsonResponse(APPEND_OK);
+      if (url.endsWith("/recall")) return jsonResponse(RECALL_OK);
+      return new Response(null, { status: 204 });
     }) as typeof globalThis.fetch;
 
     const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
-    await sapiom.memory.append({ content: "c" });
+    await sapiom.memory.append({ content: "x" });
     await sapiom.memory.recall({ query: "q" });
-    await sapiom.memory.sweep();
-    await sapiom.memory.get("m", { store: { namespace: "tenant-7" } });
-    await sapiom.memory.forget("m", { store: { namespace: "tenant-7" } });
+    await sapiom.memory.forget({ ids: ["a"] });
+    await sapiom.memory.drop("ns");
 
-    expect(calls).toHaveLength(5);
+    expect(calls).toHaveLength(4);
     for (const c of calls) {
       expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
     }
-    const expected = new URLSearchParams();
-    expected.set("storeNamespace", "tenant-7");
+    expect(calls.map((c) => c.init.method ?? "GET")).toEqual([
+      "POST",
+      "POST",
+      "DELETE",
+      "DELETE",
+    ]);
     expect(calls[3]!.url).toBe(
-      `https://memory.services.sapiom.ai/v1/memory/m?${expected.toString()}`,
-    );
-    expect(calls[4]!.url).toBe(
-      `https://memory.services.sapiom.ai/v1/memory/m?${expected.toString()}`,
+      "https://memory.services.sapiom.ai/v1/memory/namespaces/ns",
     );
   });
 
@@ -1050,18 +370,163 @@ describe("memory — client wiring + credential", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Stub client — semantic fidelity (see stub/index.ts for what is simulated)
+// ---------------------------------------------------------------------------
+
+describe("createStubClient().memory", () => {
+  it("append → recall round-trips a record within its namespace", async () => {
+    const stub = createStubClient();
+    const appended = await stub.memory.append({
+      content: "User prefers dark mode.",
+      namespace: "u1",
+      metadata: { source: "onboarding", user_theme: "dark" },
+      occurredAt: "2026-07-01T00:00:00Z",
+    });
+    expect(appended.metadata).toEqual({
+      source: "onboarding",
+      user_theme: "dark",
+    });
+    expect(appended.occurredAt).toBe("2026-07-01T00:00:00Z");
+
+    const hit = await stub.memory.recall({ query: "theme", namespace: "u1" });
+    expect(hit.count).toBe(1);
+    expect(hit.results[0]).toMatchObject({
+      id: appended.id,
+      content: "User prefers dark mode.",
+      metadata: { source: "onboarding", user_theme: "dark" },
+    });
+
+    const miss = await stub.memory.recall({ query: "theme" });
+    expect(miss.count).toBe(0); // different (default) namespace
+  });
+
+  it("matches filters on flat keys and `{in}` sets", async () => {
+    const stub = createStubClient();
+    await stub.memory.append({
+      content: "a",
+      metadata: { user_theme: "dark", env: "prod" },
+    });
+    await stub.memory.append({
+      content: "b",
+      metadata: { env: "dev" },
+    });
+
+    const byKey = await stub.memory.recall({
+      query: "q",
+      filter: { user_theme: "dark" },
+    });
+    expect(byKey.results.map((m) => m.content)).toEqual(["a"]);
+
+    const byIn = await stub.memory.recall({
+      query: "q",
+      filter: { env: { in: ["dev", "staging"] } },
+    });
+    expect(byIn.results.map((m) => m.content)).toEqual(["b"]);
+  });
+
+  it("accepts every valid strategy and defaults fine when omitted", async () => {
+    const stub = createStubClient();
+    await stub.memory.append({ content: "x" });
+    for (const strategy of ["semantic", "keyword", "hybrid"] as const) {
+      await expect(
+        stub.memory.recall({ query: "q", strategy }),
+      ).resolves.toMatchObject({ count: 1 });
+    }
+    await expect(stub.memory.recall({ query: "q" })).resolves.toMatchObject({
+      count: 1,
+    });
+  });
+
+  it("rejects an invalid recall strategy with the allowed-values message", async () => {
+    const stub = createStubClient();
+    const err = await stub.memory
+      .recall({ query: "q", strategy: "foobar" as never })
+      .then(
+        () => null,
+        (e: unknown) => e as MemoryHttpError,
+      );
+    expect(err).toBeInstanceOf(MemoryHttpError);
+    expect(err!.status).toBe(400);
+    expect(err!.message).toBe(
+      "strategy must be one of the following values: semantic, keyword, hybrid",
+    );
+  });
+
+  it("rejects array, null, nested-object values and dotted keys like the service", async () => {
+    const stub = createStubClient();
+    for (const metadata of [
+      { tags: ["a", "b"] },
+      { bad: null },
+      { nested: { not: "allowed" } },
+      { "dotted.key": "x" },
+    ] as unknown[]) {
+      const err = await stub.memory
+        .append({ content: "x", metadata: metadata as never })
+        .then(
+          () => null,
+          (e: unknown) => e as MemoryHttpError,
+        );
+      expect(err).toBeInstanceOf(MemoryHttpError);
+      expect(err!.status).toBe(400);
+      expect((err!.body as { code: string }).code).toBe("invalid_metadata");
+    }
+  });
+
+  it("rejects metadata with neutral, topology-free messages", async () => {
+    const stub = createStubClient();
+    const messageFor = (metadata: unknown) =>
+      stub.memory
+        .append({ content: "x", metadata: metadata as never })
+        .then(
+          () => "",
+          (e: unknown) => (e as MemoryHttpError).message,
+        );
+
+    // A dotted key is rejected with a pure constraint message (no internals).
+    const dotted = await messageFor({ "dotted.key": "x" });
+    expect(dotted).toContain("must not contain '.'");
+
+    // Any other non-identifier key gets the key-grammar message.
+    const badKey = await messageFor({ "bad-key": "x" });
+    expect(badKey).toContain("must start with a letter");
+
+    for (const message of [dotted, badKey]) {
+      expect(message).not.toMatch(/gateway|upstream|engine|backend|proxy/i);
+    }
+  });
+
+  it("forget is blind-idempotent and drop clears the namespace", async () => {
+    const stub = createStubClient();
+    const { id } = await stub.memory.append({ content: "x", namespace: "n" });
+    await expect(
+      stub.memory.forget({ ids: [id, "never-existed"], namespace: "n" }),
+    ).resolves.toBeUndefined();
+    expect(
+      (await stub.memory.recall({ query: "q", namespace: "n" })).count,
+    ).toBe(0);
+
+    await stub.memory.append({ content: "y", namespace: "n" });
+    await stub.memory.drop("n");
+    expect(
+      (await stub.memory.recall({ query: "q", namespace: "n" })).count,
+    ).toBe(0);
+    await expect(stub.memory.drop("n")).resolves.toBeUndefined(); // idempotent
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MemoryHttpError
 // ---------------------------------------------------------------------------
 
 describe("MemoryHttpError", () => {
   it("carries status and body and is instanceof Error", () => {
-    const err = new MemoryHttpError("something went wrong", 422, {
-      code: "authorization_denied",
+    const err = new MemoryHttpError("something went wrong", 400, {
+      code: "invalid_metadata",
     });
     expect(err).toBeInstanceOf(Error);
     expect(err).toBeInstanceOf(MemoryHttpError);
-    expect(err.status).toBe(422);
-    expect(err.body).toEqual({ code: "authorization_denied" });
+    expect(err.status).toBe(400);
+    expect(err.body).toEqual({ code: "invalid_metadata" });
     expect(err.name).toBe("MemoryHttpError");
   });
 });

--- a/packages/tools/src/memory/index.ts
+++ b/packages/tools/src/memory/index.ts
@@ -1,16 +1,19 @@
 /**
- * Tenant-scoped long-term memory on the Sapiom memory gateway.
+ * Tenant-scoped long-term memory backed by the Sapiom memory service.
  *
  *   import { memory } from "@sapiom/tools";                 // ambient auth
- *   const { id } = await memory.append({ content: "User prefers dark mode.", scope: "user" });
- *   const { results } = await memory.recall({ query: "ui preferences", topK: 5 });
- *   const record = await memory.get(id);
- *   await memory.forget(id);
+ *   const { id } = await memory.append({ content: "User prefers dark mode.", namespace: "user-42" });
+ *   const { results } = await memory.recall({ query: "ui preferences", namespace: "user-42", topK: 5 });
+ *   await memory.forget({ ids: [id], namespace: "user-42" });
+ *   await memory.drop("user-42");
  *
  * Or via an explicit client: `createClient({ apiKey }).memory.append(...)`.
  *
- * The gateway speaks camelCase JSON, so this client keeps request and response
- * objects 1:1 with the wire contract.
+ * Memory is durable knowledge, not chat history: `recall` ranks by relevance to
+ * the query, never by recency — keep last-N-turns context in your own store.
+ *
+ * The memory service speaks camelCase JSON, so this client keeps request and
+ * response objects 1:1 with the wire contract.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
 import { resolveServiceUrl } from "../_client/service-url.js";
@@ -23,7 +26,7 @@ export { MemoryHttpError };
  * explicit `SAPIOM_MEMORY_URL` override wins, else the `SAPIOM_SERVICES_BASE` knob
  * re-homes it (subdomain preserved), else the production
  * `https://memory.services.sapiom.ai`. This is the bare origin; the `/v1/memory`
- * path prefix is appended per-method below (a local override is just the gateway
+ * path prefix is appended per-method below (a local override is just the service
  * origin, e.g. `http://memory.services.localhost:3100`).
  */
 const DEFAULT_BASE_URL = resolveServiceUrl(
@@ -33,116 +36,85 @@ const DEFAULT_BASE_URL = resolveServiceUrl(
 
 // ----- SDK-facing types (identical to the wire; camelCase end to end) -----
 
-/** Storage backend selector. Omit for the v0 default `"neon-pgvector"`. */
-export const MEMORY_BACKENDS = ["neon-pgvector", "upstash-vector"] as const;
-export type MemoryBackend = (typeof MEMORY_BACKENDS)[number];
-
-/** Embedding model selector. Omit for the default OpenRouter text-embedding-3-small embedder. */
-export interface MemoryEmbedder {
-  /**
-   * Embedding provider. The gateway is authoritative for provider support and
-   * returns 400 for unknown providers; v0 currently supports `"openrouter"`.
-   */
-  provider: string;
-  /**
-   * Embedding model. A model is part of the store identity, so a write and all
-   * later reads must use the same model. The gateway is authoritative for model
-   * support and returns 400 for unknown models.
-   */
-  model: string;
-}
+/** A metadata leaf value. Strings, numbers, and booleans only — no arrays, no nulls. */
+export type MemoryMetadataValue = string | number | boolean;
 
 /**
- * Optional store selector. Omit for the default Neon store.
+ * Metadata stored alongside a memory: a FLAT map of identifier keys (letter
+ * first; `.` is reserved and rejected) to string/number/boolean values.
+ * No nesting, no arrays, no nulls — violations are a 400 `invalid_metadata`.
+ * Express hierarchy through key naming conventions (e.g. `env_prod`,
+ * `user_theme`). Bounds (enforced server-side): up to 20 keys per memory, each
+ * key at most 64 bytes, and string values at most 512 characters.
  *
- * A memory is only visible from the store it was written to. If you set any of
- * these fields on append, pass the same `store` to recall/get/forget/sweep.
+ * A key's value TYPE is pinned per namespace at its first write and is
+ * immutable after — a later write with a conflicting type is a 400
+ * `invalid_metadata` naming the key, so keep each key's type consistent
+ * within a namespace. Numbers are stored as floats (integers and fractional
+ * values mix freely on one key).
+ *
+ * Metadata keys are usable as hard {@link RecallInput.filter} keys. For
+ * better performance, use `namespace` for a key you'd filter on every
+ * recall — metadata suits optionally-filtered dimensions.
  */
-export interface MemoryStore {
-  /**
-   * Storage backend. Default: `"neon-pgvector"`. `"upstash-vector"` is experimental
-   * and does not support keyword recall or sweep.
-   */
-  backend?: MemoryBackend;
-  /**
-   * Embedding model. Default: OpenRouter `"openai/text-embedding-3-small"`.
-   */
-  embedder?: MemoryEmbedder;
-  /**
-   * Physical isolation namespace. Use to separate projects/tenants under one
-   * owner. 1-100 chars, `[a-zA-Z0-9_-]`.
-   */
-  namespace?: string;
-}
+export type MemoryMetadata = Record<string, MemoryMetadataValue>;
+
+/** Metadata as it comes back on reads — the same flat shape as {@link MemoryMetadata}. */
+export type StoredMemoryMetadata = MemoryMetadata;
 
 export interface AppendInput {
   /**
-   * Text to store as a memory (1–32,000 chars). Must not contain secrets — the
-   * gateway runs an admission gate and rejects API keys / tokens / passwords with
-   * a 400 (`error: "SecretDetected"`, `decision: "REJECTED"`) before anything is
-   * embedded or stored.
+   * Text to store as a memory. Must not contain secrets — API keys / tokens /
+   * passwords are rejected server-side with a 400 (`secret_detected`) before
+   * anything is embedded or stored. At most 32,000 characters; oversized
+   * content is rejected with a 400.
    */
   content: string;
   /**
-   * Scope label grouping related memories (e.g. "session", "user", "project").
-   * Alphanumeric plus hyphens/underscores, 1–100 chars. Defaults to "default".
+   * Isolation namespace this memory lives in. Reads only ever see one namespace,
+   * and {@link drop} deletes one namespace wholesale.
+   *
+   * Default to a namespace per agent, per user, or per project. A namespace has
+   * bounded capacity, so prefer many small namespaces over one large one; put
+   * subsets in a single namespace (distinguished by `metadata` + recall `filter`)
+   * only when one recall must span them. Omit for your owner's default namespace.
+   * 1–100 characters, limited to letters, digits, `-`, and `_`.
    */
-  scope?: string;
+  namespace?: string;
   /**
-   * Arbitrary JSON stored alongside the memory and returned on read. Opaque to
-   * ranking (not embedded), but usable as a hard `filter` on recall. Max 10 KB when
-   * JSON-serialized.
+   * Flat metadata stored with the memory and returned on recall — see
+   * {@link MemoryMetadata}. Opaque to ranking (not embedded); keys are usable
+   * as a hard `filter` on recall.
    */
-  metadata?: Record<string, unknown>;
+  metadata?: MemoryMetadata;
   /**
    * Event-time this memory is *about* (ISO-8601), distinct from `createdAt` (the
    * server ingestion time). Drives temporal recall weighting. When omitted, the
-   * gateway stores `null` and temporal recall falls back to `createdAt`.
+   * service stores `null` and temporal recall falls back to `createdAt`.
    */
   occurredAt?: string;
-  /** Optional store selector. Omit for the default store. See {@link MemoryStore}. */
-  store?: MemoryStore;
 }
 
 export interface AppendResult {
-  /**
-   * UUID of the memory. For `decision: "ADDED"` this is the newly created record;
-   * for `decision: "NOOP"` it is the existing memory that was echoed (nothing was
-   * written).
-   */
+  /** Id of the stored memory. Keep it to `forget` the memory later. */
   id: string;
   /** The stored content, echoed back. */
   content: string;
-  /** The resolved scope label ("default" when you omitted it). */
-  scope: string;
-  /**
-   * What the gateway did, made legible (never a silent write):
-   * - `"ADDED"` — a new memory was written to the append-log.
-   * - `"NOOP"`  — byte-identical content or a near-exact semantic duplicate in the
-   *   same owner + scope; the existing memory is echoed and nothing is written.
-   *
-   * A secret caught by the admission gate is *not* a decision here — it surfaces as
-   * a 400 {@link MemoryHttpError} whose body carries `decision: "REJECTED"`.
-   */
-  decision: "ADDED" | "NOOP";
-  /** ISO-8601 timestamp when the memory was created (server ingestion time). */
+  /** ISO-8601 acknowledgement timestamp (the authoritative record timestamps return on recall). */
   createdAt: string;
-  /**
-   * ISO-8601 event-time this memory is *about*, or `null` when none was supplied on
-   * append (the gateway does not backfill it with `createdAt`).
-   */
-  occurredAt: string | null;
-  /** The stored metadata (`{}` when none was provided). */
-  metadata: Record<string, unknown>;
+  /** The stored metadata. Omitted when none was provided (never `{}`). */
+  metadata?: StoredMemoryMetadata;
+  /** ISO-8601 event-time this memory is *about*. Omitted when none was supplied. */
+  occurredAt?: string;
 }
 
 /**
  * Retrieval strategy for {@link recall}:
- * - `"cosine"`  — dense vector similarity (default; supported on every backend).
- * - `"keyword"` — full-text / BM25 ranking. Neon-only; requesting it on a backend
- *   that doesn't support it is a 400 {@link MemoryHttpError} (never degraded).
+ * - `"semantic"` — ranks by meaning; the default.
+ * - `"keyword"`  — matches exact terms and identifiers.
+ * - `"hybrid"`   — fuses semantic and keyword ranking (opt-in).
  */
-export type RetrievalStrategy = "cosine" | "keyword";
+export type RetrievalStrategy = "semantic" | "keyword" | "hybrid";
 
 /** Time-decay weighting for {@link RecallInput.weight}. Optional; omit for pure relevance. */
 export interface TemporalWeight {
@@ -152,8 +124,9 @@ export interface TemporalWeight {
    */
   center?: string;
   /**
-   * Half-life in days (1–365, default 30): a memory whose `occurredAt` is this far
-   * from `center` keeps half its relevance. Smaller = sharper recency preference.
+   * Half-life in days: a memory whose `occurredAt` is this far from `center`
+   * keeps half its relevance. Smaller = sharper recency preference. Defaults to
+   * 30 when omitted (bounds: 1–365).
    */
   halfLifeDays?: number;
 }
@@ -164,17 +137,34 @@ export interface RecallWeight {
   temporal?: TemporalWeight;
 }
 
+/** A filter value: a scalar to match exactly, or `{ in: [...] }` to match any of a set. */
+export type MemoryFilterValue =
+  | MemoryMetadataValue
+  | { in: MemoryMetadataValue[] };
+
+/**
+ * Hard metadata filter for {@link recall}: keys are your metadata keys, values
+ * match exactly (scalar) or against a set (`{ in: [...] }`). Applied before
+ * ranking. A malformed key or value shape is a 400 (`invalid_filter`).
+ */
+export type MemoryFilter = Record<string, MemoryFilterValue>;
+
 export interface RecallInput {
-  /** Natural-language search text (1–4,096 chars). Embedded and compared against stored memories. */
-  query: string;
-  /** Restrict the search to this scope label. Omit to search every scope for your owner. */
-  scope?: string;
-  /** Maximum number of results to return (1–50). Defaults to 5. */
-  topK?: number;
-  /** Minimum score [0–1]; matches below it are dropped. Defaults to 0. */
-  minSimilarity?: number;
   /**
-   * Retrieval strategy — `"cosine"` (default) or `"keyword"` (Neon-only). See
+   * Natural-language search text. Embedded and compared against stored memories.
+   * At most 4,096 characters.
+   */
+  query: string;
+  /**
+   * Namespace to search. A recall never spans namespaces — see
+   * {@link AppendInput.namespace} for how to partition. Omit for your owner's
+   * default namespace.
+   */
+  namespace?: string;
+  /** Maximum number of results to return. Defaults to 5; at most 50. */
+  topK?: number;
+  /**
+   * Retrieval strategy — `"semantic"` (default), `"keyword"`, or `"hybrid"`. See
    * {@link RetrievalStrategy}.
    */
   strategy?: RetrievalStrategy;
@@ -184,141 +174,57 @@ export interface RecallInput {
    */
   weight?: RecallWeight;
   /**
-   * Hard metadata filter. Neon uses JSONB containment; Upstash supports scalar
-   * equality filters. Applied before ranking; max 4 KB serialized.
+   * Hard metadata filter — see {@link MemoryFilter}. For better performance,
+   * use `namespace` for a dimension you'd filter on every recall — `filter`
+   * suits optionally-filtered subsets. Up to 20 keys; an `{ in: [...] }` set
+   * holds at most 64 values.
    */
-  filter?: Record<string, unknown>;
-  /** Optional store selector. Pass the same store used at write time. See {@link MemoryStore}. */
-  store?: MemoryStore;
+  filter?: MemoryFilter;
 }
 
 export interface RecallMatch {
-  /** UUID of the memory. */
+  /** Id of the memory. */
   id: string;
   /** The stored content. */
   content: string;
-  /** The scope label. */
-  scope: string;
   /**
-   * Canonical [0–1] relevance the matches are ranked and thresholded on (highest
-   * first). Provider-neutral: an opaque backend reports only this single score.
+   * Relevance the matches are ranked on (highest first). Strategy-relative: scores
+   * are comparable within one response, not across strategies or queries.
    */
   score: number;
-  /**
-   * Optional backend-specific score legs. A backend may fill this with its own
-   * components; most dense-only paths omit it entirely. This is an open map —
-   * don't assume a fixed set of keys.
-   */
-  scoreBreakdown?: Record<string, number>;
   /** ISO-8601 timestamp when the memory was created. */
   createdAt: string;
   /** ISO-8601 event-time this memory is *about*, or `null` when none was supplied. */
   occurredAt: string | null;
-  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
-  lastAccessedAt: string | null;
-  /** The stored metadata. */
-  metadata: Record<string, unknown>;
+  /** The stored metadata, or `null` when the record carries none. */
+  metadata: StoredMemoryMetadata | null;
 }
 
 export interface RecallResponse {
-  /** Matches ranked by `score` (highest first). Empty when nothing matched or no store exists yet. */
+  /** Matches ranked by `score` (highest first). Empty when nothing matched. */
   results: RecallMatch[];
   /** The query, echoed back. */
   query: string;
-  /** The effective top-K used by the gateway. */
+  /** The effective top-K applied server-side. */
   topK: number;
   /** Number of results returned (≤ `topK`). */
   count: number;
 }
 
-export interface Memory {
-  /** UUID of the memory. */
-  id: string;
-  /** The stored content. */
-  content: string;
-  /** The scope label. */
-  scope: string;
-  /** ISO-8601 timestamp when the memory was created (server ingestion time). */
-  createdAt: string;
-  /** ISO-8601 event-time this memory is *about*, or `null` when none was supplied. */
-  occurredAt: string | null;
-  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
-  lastAccessedAt: string | null;
-  /** The stored metadata. */
-  metadata: Record<string, unknown>;
-}
-
-/**
- * Eviction order for {@link sweep}:
- * - `"lru"`    — least-recently-accessed first (`lastAccessedAt` ascending). Default.
- * - `"oldest"` — oldest-inserted first (`createdAt` ascending).
- */
-export type SweepStrategy = "lru" | "oldest";
-
-export interface SweepInput {
-  /**
-   * Maximum number of memories to preview/delete (1–10,000). Omit to use the
-   * gateway's default sweep batch (100 rows).
-   */
-  count?: number;
-  /** Eviction order — `"lru"` (default) or `"oldest"`. See {@link SweepStrategy}. */
-  strategy?: SweepStrategy;
-  /**
-   * Preview vs delete. **Defaults to `true`** (a safe preview): the gateway returns
-   * the `candidates` it would evict without deleting anything (`evicted: 0`). Pass
-   * `false` to actually evict.
-   */
-  dryRun?: boolean;
-  /** Optional store selector. Sweep is Neon-only. See {@link MemoryStore}. */
-  store?: MemoryStore;
-}
-
-/** A memory that a `sweep` would evict. */
-export interface MemorySweepCandidate {
-  /** UUID of the memory. */
-  id: string;
-  /** The stored content. */
-  content: string;
-  /** The scope label. */
-  scope: string;
-  /** ISO-8601 timestamp when the memory was created. */
-  createdAt: string;
-  /** ISO-8601 timestamp this memory was last read, or `null` if never recalled since creation. */
-  lastAccessedAt: string | null;
-}
-
-export interface MemorySweepResponse {
-  /** Number of memories evicted (`0` on a `dryRun`). */
-  evicted: number;
-  /**
-   * The memories that *would* be evicted — present on a `dryRun` (the default).
-   * Review them, then {@link forget} specific ids or re-run `sweep` with
-   * `dryRun: false`.
-   */
-  candidates?: MemorySweepCandidate[];
-}
-
-/** Per-call options for {@link get} and {@link forget}. */
-export interface MemoryCallOptions {
-  /** Optional store selector. Pass the same store used at write time. See {@link MemoryStore}. */
-  store?: MemoryStore;
+export interface ForgetInput {
+  /** Ids of the memories to forget. Up to 100 per call. */
+  ids: string[];
+  /** Namespace the memories live in. Omit for your owner's default namespace. */
+  namespace?: string;
 }
 
 // ----- capability operations -----
 
 /**
- * Append a memory to the store (an append-log — no prior memory is mutated). The
- * gateway runs a secret-detection gate first (a detected secret is rejected with a
- * 400 {@link MemoryHttpError}, body `decision: "REJECTED"`), then embeds the
- * content and writes it, returning `decision: "ADDED"`.
- *
- * Byte-identical content, or a near-exact semantic duplicate, in the same owner +
- * scope is a no-op that echoes the existing memory unchanged (`decision: "NOOP"`);
- * nothing new is written.
- *
- * On a full Neon store the gateway returns `507` ({@link MemoryHttpError}); call
- * {@link sweep} (or {@link forget}) to free space, then retry. On Upstash, first
- * provisioning can return `422` when the account/index limit is reached.
+ * Append one memory (an append-log — no prior memory is mutated). A
+ * secret-detection gate runs first server-side (a detected secret is a 400
+ * {@link MemoryHttpError}, `secret_detected`), then the content is embedded and
+ * written.
  */
 export async function append(
   input: AppendInput,
@@ -326,10 +232,9 @@ export async function append(
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<AppendResult> {
   const body: Record<string, unknown> = { content: input.content };
-  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.namespace !== undefined) body.namespace = input.namespace;
   if (input.metadata !== undefined) body.metadata = input.metadata;
   if (input.occurredAt !== undefined) body.occurredAt = input.occurredAt;
-  if (input.store !== undefined) body.store = input.store;
 
   const res = await ensureOk(
     await transport.fetch(`${baseUrl}/v1/memory/append`, {
@@ -344,12 +249,12 @@ export async function append(
 
 /**
  * Recall memories by natural-language query. Returns the top-K matches ranked by
- * score; an empty list when nothing matches or no memory store has been provisioned
- * yet (not an error).
+ * score; an empty list when nothing matches (not an error).
  *
- * After the route gate succeeds, infra, child billing, rate-limit, and timeout
- * failures degrade to an empty result set. Bad requests, missing identity, and
- * ownership failures (`400`/`401`/`403`) surface as {@link MemoryHttpError}.
+ * Recall is relevance search over one namespace, not a recency view — it is not
+ * a way to page through chat history. Bad requests (`invalid_filter`), missing
+ * identity, and ownership failures surface as {@link MemoryHttpError};
+ * infrastructure failures surface as 502/504.
  */
 export async function recall(
   input: RecallInput,
@@ -357,14 +262,11 @@ export async function recall(
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<RecallResponse> {
   const body: Record<string, unknown> = { query: input.query };
-  if (input.scope !== undefined) body.scope = input.scope;
+  if (input.namespace !== undefined) body.namespace = input.namespace;
   if (input.topK !== undefined) body.topK = input.topK;
-  if (input.minSimilarity !== undefined)
-    body.minSimilarity = input.minSimilarity;
   if (input.strategy !== undefined) body.strategy = input.strategy;
   if (input.weight !== undefined) body.weight = input.weight;
   if (input.filter !== undefined) body.filter = input.filter;
-  if (input.store !== undefined) body.store = input.store;
 
   const res = await ensureOk(
     await transport.fetch(`${baseUrl}/v1/memory/recall`, {
@@ -378,93 +280,21 @@ export async function recall(
 }
 
 /**
- * Sweep (evict) memories to reclaim space — consumer-triggered, never automatic.
- * Call it after a `507` on {@link append}, or proactively to compact the store.
- * Eviction is Neon-only today; a store with nothing to sweep returns `{ evicted: 0 }`.
- *
- * `dryRun` **defaults to `true`**: the gateway returns the `candidates` it would
- * evict without deleting anything — review them, then {@link forget} specific ids
- * or re-run with `dryRun: false` to actually evict.
- */
-export async function sweep(
-  input: SweepInput = {},
-  transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
-): Promise<MemorySweepResponse> {
-  const body: Record<string, unknown> = {};
-  if (input.count !== undefined) body.count = input.count;
-  if (input.strategy !== undefined) body.strategy = input.strategy;
-  if (input.dryRun !== undefined) body.dryRun = input.dryRun;
-  if (input.store !== undefined) body.store = input.store;
-
-  const res = await ensureOk(
-    await transport.fetch(`${baseUrl}/v1/memory/sweep`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
-    "Failed to sweep memories",
-  );
-  return (await res.json()) as MemorySweepResponse;
-}
-
-/**
- * Build the `/v1/memory/:id` URL for get/forget, including any store selector.
- */
-function memoryItemUrl(
-  baseUrl: string,
-  id: string,
-  options?: MemoryCallOptions,
-): string {
-  const path = `${baseUrl}/v1/memory/${encodeURIComponent(id)}`;
-  const params = new URLSearchParams();
-  const store = options?.store;
-  if (store) {
-    if (store.backend !== undefined) {
-      params.set("storeBackend", store.backend);
-    }
-    if (store.namespace !== undefined) {
-      params.set("storeNamespace", store.namespace);
-    }
-    if (store.embedder !== undefined) {
-      params.set("storeEmbedderProvider", store.embedder.provider);
-      params.set("storeEmbedderModel", store.embedder.model);
-    }
-  }
-  const query = params.toString();
-  return query ? `${path}?${query}` : path;
-}
-
-/**
- * Fetch a single memory by id. Throws {@link MemoryHttpError} with `status: 404`
- * when the memory doesn't exist or belongs to another owner (existence is not
- * leaked across owners).
- */
-export async function get(
-  id: string,
-  transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
-  options?: MemoryCallOptions,
-): Promise<Memory> {
-  const res = await ensureOk(
-    await transport.fetch(memoryItemUrl(baseUrl, id, options)),
-    `Failed to get memory '${id}'`,
-  );
-  return (await res.json()) as Memory;
-}
-
-/**
- * Forget (hard-delete) a memory by id. Idempotent: a missing or already-deleted
- * id is treated as success by the gateway.
+ * Forget (hard-delete) memories by id. Idempotent and blind: missing or
+ * already-deleted ids are treated as success.
  */
 export async function forget(
-  id: string,
+  input: ForgetInput,
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
-  options?: MemoryCallOptions,
 ): Promise<void> {
-  const res = await transport.fetch(memoryItemUrl(baseUrl, id, options), {
+  const body: Record<string, unknown> = { ids: input.ids };
+  if (input.namespace !== undefined) body.namespace = input.namespace;
+
+  const res = await transport.fetch(`${baseUrl}/v1/memory`, {
     method: "DELETE",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -475,7 +305,38 @@ export async function forget(
       parsed = text;
     }
     throw new MemoryHttpError(
-      `Failed to forget memory '${id}': ${res.status} ${text}`,
+      `Failed to forget memories: ${res.status} ${text}`,
+      res.status,
+      parsed,
+    );
+  }
+  // 204 No Content — nothing to parse.
+}
+
+/**
+ * Drop an entire namespace: every memory in it is deleted and a later append to
+ * the same name starts a fresh namespace. Idempotent: dropping a namespace that
+ * doesn't exist is success.
+ */
+export async function drop(
+  namespace: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  const res = await transport.fetch(
+    `${baseUrl}/v1/memory/namespaces/${encodeURIComponent(namespace)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    throw new MemoryHttpError(
+      `Failed to drop namespace '${namespace}': ${res.status} ${text}`,
       res.status,
       parsed,
     );

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -52,9 +52,8 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.memory).toBe("object");
     expect(typeof sapiom.memory.append).toBe("function");
     expect(typeof sapiom.memory.recall).toBe("function");
-    expect(typeof sapiom.memory.sweep).toBe("function");
-    expect(typeof sapiom.memory.get).toBe("function");
     expect(typeof sapiom.memory.forget).toBe("function");
+    expect(typeof sapiom.memory.drop).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -80,12 +80,15 @@ import type {
   DomainTransfer,
   DnsRecord,
 } from "../domains/index.js";
+import { MemoryHttpError } from "../memory/index.js";
 import type {
   AppendResult,
+  RecallMatch,
   RecallResponse,
-  MemorySweepResponse,
-  Memory,
-  MemoryCallOptions,
+  RetrievalStrategy,
+  ForgetInput,
+  MemoryMetadata,
+  MemoryMetadataValue,
 } from "../memory/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
@@ -495,6 +498,90 @@ function stubModelRunHandle(
  * Create a stub `Sapiom` client. Runs every capability against built-in defaults;
  * pass `overrides` to control the results a step branches on.
  */
+/** One memory row in the stub's in-process store. */
+interface StubMemoryRecord {
+  id: string;
+  content: string;
+  createdAt: string;
+  occurredAt?: string;
+  /** The stored metadata; undefined when empty. */
+  metadata?: MemoryMetadata;
+  /** Leaf view — what recall `filter` keys match against. */
+  flat: Map<string, MemoryMetadataValue>;
+}
+
+/**
+ * Validate flat memory metadata with the same observable rules a caller sees on
+ * the real service: keys are identifiers (`^[a-zA-Z]\w*$` — a leading letter,
+ * then letters, digits, or underscores), values are string/number/boolean
+ * (objects, arrays, and nulls are `invalid_metadata`), and `undefined` values
+ * are absent. Whole-store bounds (key counts, byte caps) are not simulated here.
+ */
+function validateStubMemoryMetadata(
+  metadata: MemoryMetadata,
+): Map<string, MemoryMetadataValue> {
+  const out = new Map<string, MemoryMetadataValue>();
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined) continue;
+    if (key.includes(".")) {
+      throw new MemoryHttpError(
+        `invalid_metadata: key '${key}' must not contain '.' — keys must start with a letter and contain only letters, digits, or underscores`,
+        400,
+        { code: "invalid_metadata" },
+      );
+    }
+    if (!/^[a-zA-Z]\w*$/.test(key)) {
+      throw new MemoryHttpError(
+        `invalid_metadata: key '${key}' is invalid — keys must start with a letter and contain only letters, digits, or underscores`,
+        400,
+        { code: "invalid_metadata" },
+      );
+    }
+    if (
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      throw new MemoryHttpError(
+        `invalid_metadata: value at '${key}' must be a string, number, or boolean`,
+        400,
+        { code: "invalid_metadata" },
+      );
+    }
+    out.set(key, value);
+  }
+  return out;
+}
+
+/** {@link RetrievalStrategy} is type-level only — this is its runtime enumeration for the stub's recall check. */
+const STUB_RETRIEVAL_STRATEGIES: readonly RetrievalStrategy[] = [
+  "semantic",
+  "keyword",
+  "hybrid",
+];
+
+/** A recall filter value matches a record's flattened leaf: `{in}` set or strict scalar equality. */
+function stubMemoryFilterMatches(
+  record: StubMemoryRecord,
+  filter: Record<string, unknown> | undefined,
+): boolean {
+  if (!filter) return true;
+  for (const [key, expected] of Object.entries(filter)) {
+    const actual = record.flat.get(key);
+    if (
+      expected !== null &&
+      typeof expected === "object" &&
+      Array.isArray((expected as { in?: unknown[] }).in)
+    ) {
+      if (!(expected as { in: unknown[] }).in.includes(actual as unknown))
+        return false;
+    } else if (actual !== expected) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function createStubClient(opts: StubClientOptions = {}): Sapiom {
   // Record which override keys actually match a call, so the runner can flag
   // supplied-but-unmatched keys (typos / wrong plural-singular form).
@@ -504,6 +591,11 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
     args: unknown[],
     fallback: () => unknown,
   ) => resolve(overrides, paths, args, fallback);
+
+  // Per-client memory state: namespace → (id → record). See the `memory`
+  // capability below for what is and isn't simulated.
+  const memoryNamespaces = new Map<string, Map<string, StubMemoryRecord>>();
+  let memorySeq = 0;
 
   // Resolve a coding run result, then re-wrap its `sandbox` as a handle so the
   // blocking `run()` path keeps a method-capable Sandbox even when the result was
@@ -1208,51 +1300,109 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           ),
       },
     },
+    // Stateful, semantically faithful memory stub: appends land in an in-process
+    // per-namespace store; recall applies the SDK's filter semantics (flat keys,
+    // `{in}` sets); forget is blind-idempotent; drop clears the namespace. NOT
+    // simulated: relevance ranking (offline — every filter-matching record
+    // returns with score 1, insertion order) and whole-store bounds (key
+    // counts / byte caps).
     memory: {
+      // Deferred so a validation throw inside the fallback REJECTS the returned
+      // promise (the async contract) instead of throwing synchronously.
       append: (input) =>
-        Promise.resolve(
-          r("memory.append", [input], () => ({
-            id: "stub-memory",
-            content: input.content,
-            scope: input.scope ?? "default",
-            decision: "ADDED",
-            createdAt: "2099-01-01T00:00:00Z",
-            occurredAt: input.occurredAt ?? null,
-            metadata: input.metadata ?? {},
-          })) as AppendResult,
+        Promise.resolve().then(
+          () =>
+            r("memory.append", [input], () => {
+              const flat = input.metadata
+                ? validateStubMemoryMetadata(input.metadata)
+                : new Map<string, MemoryMetadataValue>();
+              const metadata =
+                input.metadata !== undefined &&
+                Object.keys(input.metadata).length > 0
+                  ? input.metadata
+                  : undefined;
+              const record: StubMemoryRecord = {
+                id: `stub-memory-${++memorySeq}`,
+                content: input.content,
+                createdAt: "2099-01-01T00:00:00Z",
+                ...(input.occurredAt !== undefined && {
+                  occurredAt: input.occurredAt,
+                }),
+                ...(metadata !== undefined && { metadata }),
+                flat,
+              };
+              const namespace = input.namespace ?? "default";
+              const records =
+                memoryNamespaces.get(namespace) ??
+                new Map<string, StubMemoryRecord>();
+              records.set(record.id, record);
+              memoryNamespaces.set(namespace, records);
+              const result: AppendResult = {
+                id: record.id,
+                content: record.content,
+                createdAt: record.createdAt,
+                ...(record.metadata !== undefined && {
+                  metadata: record.metadata,
+                }),
+                ...(record.occurredAt !== undefined && {
+                  occurredAt: record.occurredAt,
+                }),
+              };
+              return result;
+            }) as AppendResult,
         ),
+      // Deferred so a validation throw inside the fallback REJECTS the returned
+      // promise (the async contract) instead of throwing synchronously.
       recall: (input) =>
-        Promise.resolve(
-          r("memory.recall", [input], () => ({
-            results: [],
-            query: input.query,
-            topK: input.topK ?? 5,
-            count: 0,
-          })) as RecallResponse,
+        Promise.resolve().then(
+          () =>
+            r("memory.recall", [input], () => {
+              if (
+                input.strategy !== undefined &&
+                !STUB_RETRIEVAL_STRATEGIES.includes(input.strategy)
+              ) {
+                const message = `strategy must be one of the following values: ${STUB_RETRIEVAL_STRATEGIES.join(", ")}`;
+                throw new MemoryHttpError(message, 400, { message });
+              }
+              const records = memoryNamespaces.get(
+                input.namespace ?? "default",
+              );
+              const topK = input.topK ?? 5;
+              const results: RecallMatch[] = [...(records?.values() ?? [])]
+                .filter((record) =>
+                  stubMemoryFilterMatches(record, input.filter),
+                )
+                .slice(0, topK)
+                .map((record) => ({
+                  id: record.id,
+                  content: record.content,
+                  score: 1,
+                  createdAt: record.createdAt,
+                  occurredAt: record.occurredAt ?? null,
+                  metadata: record.metadata ?? null,
+                }));
+              return {
+                results,
+                query: input.query,
+                topK,
+                count: results.length,
+              } satisfies RecallResponse;
+            }) as RecallResponse,
         ),
-      sweep: (input) =>
+      forget: (input: ForgetInput) =>
         Promise.resolve(
-          r("memory.sweep", [input], () =>
-            input?.dryRun === false
-              ? { evicted: 0 }
-              : { evicted: 0, candidates: [] },
-          ) as MemorySweepResponse,
+          r("memory.forget", [input], () => {
+            const records = memoryNamespaces.get(input.namespace ?? "default");
+            for (const id of input.ids) records?.delete(id);
+            return undefined;
+          }) as void,
         ),
-      get: (id: string, options?: MemoryCallOptions) =>
+      drop: (namespace: string) =>
         Promise.resolve(
-          r("memory.get", [id, options], () => ({
-            id,
-            content: "(stub) memory content",
-            scope: "default",
-            createdAt: "2099-01-01T00:00:00Z",
-            occurredAt: null,
-            lastAccessedAt: null,
-            metadata: {},
-          })) as Memory,
-        ),
-      forget: (id: string, options?: MemoryCallOptions) =>
-        Promise.resolve(
-          r("memory.forget", [id, options], () => undefined) as void,
+          r("memory.drop", [namespace], () => {
+            memoryNamespaces.delete(namespace);
+            return undefined;
+          }) as void,
         ),
     },
     // Read-only vault (SAP-1471). Stubs return empty/absent — a local run must


### PR DESCRIPTION
## Summary
Aligns the @sapiom/tools memory surface to the v1 wire contract: flat scalar metadata types (string | number | boolean), strategy enum semantic | keyword | hybrid, and namespace-first performance guidance in the docs. The offline stub now mirrors the wire's runtime rejections for both metadata shape and strategy values.

## Changes
- memory types: MemoryMetadata as flat scalar map; RetrievalStrategy = semantic | keyword | hybrid
- stub: rejects invalid metadata shapes (400 invalid_metadata) and invalid strategies (400 with allowed-values message) exactly like the wire
- docs: 'for better performance, use namespace for always-filtered dimensions' guidance on metadata/filter/README sites

## Testing
- [x] pnpm --filter @sapiom/tools build + test: 20 suites / 354 tests green
- [x] Verified live against the gateway in the six-surface e2e matrix (incl. stub-vs-wire parity cells)
