### PR TITLE
feat(agent): declare vault secret bindings [superseded]

### DIFF
--- a/.changeset/calm-lions-bind.md
+++ b/.changeset/calm-lions-bind.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent": minor
+---
+
+Add vault secret bindings to agent definitions and manifests. Agents declare only secret-set refs and environment-variable key names; the engine can resolve their values at dispatch without storing values in definitions or manifests.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -56,6 +56,27 @@ A step declares the transitions it may take (`next` / `terminal` / `canFail` /
 undeclared transition is a compile error. The build reads those same declarations
 to render the orchestration graph without executing anything.
 
+## Declaring injected secrets
+
+Declare only the vault secret-set reference and the environment-variable names
+the agent requires. Secret values stay in Vault and are resolved by the workflow
+engine when it dispatches a sandbox step:
+
+```ts
+export const billing = defineAgent({
+  name: "billing",
+  entry: "start",
+  steps: { start },
+  secrets: [
+    { ref: "billing-production", keys: ["STRIPE_SECRET_KEY"] },
+  ],
+});
+```
+
+Every declared key is required. A dispatch fails without exposing values when a
+binding cannot be resolved. Keys must be unique across bindings and cannot use
+engine-owned names (`PATH`, `SAPIOM_*`, or `WORKFLOWS_*`).
+
 ## Pausing on a long-running capability
 
 Some `ctx.sapiom` capabilities are **dispatched**: you launch them, they run far

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,4 +1,5 @@
 import { UnknownStepError } from './errors.js';
+import { secretBindingsSchema, type SecretBinding } from './manifest.js';
 import type { StepDefinition } from './step.js';
 
 /**
@@ -48,6 +49,11 @@ export interface AgentDefinition<
   readonly entry: string;
   readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
   /**
+   * Vault secret-set refs and environment-variable names needed by this agent.
+   * Bindings contain names only; secret values must never appear here.
+   */
+  readonly secrets?: readonly SecretBinding[];
+  /**
    * Phantom marker that carries the entry-step input type so `runner.run(def, input)`
    * can infer it (see TInput in the doc above). The steps map is deliberately
    * type-erased, leaving TInput no structural home — this is its anchor. Never
@@ -91,6 +97,19 @@ export function isLegacyOrchestrationDefinition(val: unknown): val is AgentDefin
   return (val as Record<symbol, unknown>)[LEGACY_ORCHESTRATION_DEFINITION_BRAND] === 1;
 }
 
+function validateSecretsDeclaration(def: { name: string; secrets?: readonly SecretBinding[] }): void {
+  if (def.secrets === undefined) return;
+
+  const parsed = secretBindingsSchema.safeParse(def.secrets);
+  if (parsed.success) return;
+
+  const issue = parsed.error.issues[0];
+  const location = issue?.path.length ? ` at secrets.${issue.path.join('.')}` : '';
+  throw new Error(
+    `Agent '${def.name}' has invalid secret bindings${location}: ${issue?.message ?? 'invalid value'}`,
+  );
+}
+
 /**
  * Validate and return a workflow definition. Checks done here:
  *   1. `name` is non-empty
@@ -125,6 +144,7 @@ export function defineAgent<TInput = unknown, TShared extends Record<string, unk
       throw new Error(`Agent '${def.name}' step name mismatch at key '${key}': step.name='${step.name}'`);
     }
   }
+  validateSecretsDeclaration(def);
   // Attach the brand as a non-enumerable property so it:
   //   - survives esbuild bundling (symbol properties pass through)
   //   - survives dynamic import (the imported object is the same reference)

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -1,6 +1,7 @@
 import { zodToJsonSchema } from "./introspection.js";
 import {
   MANIFEST_PROTOCOL,
+  secretBindingsSchema,
   type ManifestTransition,
   type AgentManifest,
 } from "./manifest.js";
@@ -60,6 +61,9 @@ export function buildManifest(
     sdkVersion: opts.sdkVersion,
     artifact: opts.artifact,
     steps,
+    // Parsing validates and deep-clones only { ref, keys }, so an untyped caller
+    // cannot smuggle secret values or other undeclared fields into the manifest.
+    secrets: secretBindingsSchema.parse(def.secrets ?? []),
   };
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -61,7 +61,7 @@ export type { StepInputContract, AgentInputContract } from './introspection.js';
 
 // Manifest types, Zod schema, and generator — the build→engine contract.
 export { MANIFEST_PROTOCOL, agentManifestSchema } from './manifest.js';
-export type { AgentManifest, AgentStepManifest, ManifestTransition } from './manifest.js';
+export type { AgentManifest, AgentStepManifest, ManifestTransition, SecretBinding } from './manifest.js';
 
 // Manifest generator + graph validation — called by the build phase.
 export { buildManifest, validateGraph, assertValidGraph } from './build-manifest.js';

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -15,6 +15,7 @@ import { buildManifest } from "./build-manifest.js";
 import { goto, pauseUntilSignal, terminate } from "./directives.js";
 import {
   MANIFEST_PROTOCOL,
+  SECRET_BINDING_LIMITS,
   type AgentManifest,
   agentManifestSchema,
 } from "./manifest.js";
@@ -78,6 +79,148 @@ describe("agentManifestSchema", () => {
     expect(parsed.steps["step-a"].transitions).toEqual([
       { kind: "continue", target: "step-b" },
     ]);
+    expect(parsed.secrets).toEqual([]);
+  });
+
+  it("accepts secret bindings containing names only", () => {
+    const parsed = agentManifestSchema.parse({
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {},
+      secrets: [
+        { ref: "billing:prod", keys: ["STRIPE_KEY"] },
+        { ref: "analytics", keys: ["POSTHOG_KEY"] },
+      ],
+    });
+    expect(parsed.secrets).toEqual([
+      { ref: "billing:prod", keys: ["STRIPE_KEY"] },
+      { ref: "analytics", keys: ["POSTHOG_KEY"] },
+    ]);
+  });
+
+  it.each(["PATH", "SAPIOM_API_KEY", "WORKFLOWS_EXECUTION_ID"])(
+    "rejects protected environment key %s",
+    (key) => {
+      expect(() =>
+        agentManifestSchema.parse({
+          protocol: 1,
+          name: "wf",
+          entry: "a",
+          sdkVersion: "0.1.0",
+          artifact: { sha256: "x", entryFile: "f.mjs" },
+          steps: {},
+          secrets: [{ ref: "billing", keys: [key] }],
+        }),
+      ).toThrow("Protected environment key is not allowed");
+    },
+  );
+
+  it("rejects duplicate key names across secret-set refs", () => {
+    expect(() =>
+      agentManifestSchema.parse({
+        protocol: 1,
+        name: "wf",
+        entry: "a",
+        sdkVersion: "0.1.0",
+        artifact: { sha256: "x", entryFile: "f.mjs" },
+        steps: {},
+        secrets: [
+          { ref: "billing", keys: ["API_KEY"] },
+          { ref: "analytics", keys: ["API_KEY"] },
+        ],
+      }),
+    ).toThrow("Secret key names must be unique across bindings");
+  });
+
+  it("rejects bindings beyond collection limits", () => {
+    const tooManyBindings = Array.from(
+      { length: SECRET_BINDING_LIMITS.maxBindings + 1 },
+      (_, index) => ({ ref: `ref-${index}`, keys: [`KEY_${index}`] }),
+    );
+    expect(() =>
+      agentManifestSchema.parse({
+        protocol: 1,
+        name: "wf",
+        entry: "a",
+        sdkVersion: "0.1.0",
+        artifact: { sha256: "x", entryFile: "f.mjs" },
+        steps: {},
+        secrets: tooManyBindings,
+      }),
+    ).toThrow();
+  });
+
+  it.each([
+    [
+      "an overlong ref",
+      [
+        {
+          ref: "r".repeat(SECRET_BINDING_LIMITS.maxRefLength + 1),
+          keys: ["API_KEY"],
+        },
+      ],
+    ],
+    [
+      "an overlong key",
+      [{ ref: "billing", keys: ["K".repeat(SECRET_BINDING_LIMITS.maxKeyLength + 1)] }],
+    ],
+    [
+      "too many keys in one binding",
+      [
+        {
+          ref: "billing",
+          keys: Array.from(
+            { length: SECRET_BINDING_LIMITS.maxKeysPerBinding + 1 },
+            (_, index) => `KEY_${index}`,
+          ),
+        },
+      ],
+    ],
+    [
+      "too many total keys",
+      Array.from({ length: 5 }, (_, bindingIndex) => ({
+        ref: `ref-${bindingIndex}`,
+        keys: Array.from(
+          { length: SECRET_BINDING_LIMITS.maxKeysPerBinding },
+          (_, keyIndex) => `KEY_${bindingIndex}_${keyIndex}`,
+        ),
+      })),
+    ],
+  ])("rejects %s", (_label, secrets) => {
+    expect(() =>
+      agentManifestSchema.parse({
+        protocol: 1,
+        name: "wf",
+        entry: "a",
+        sdkVersion: "0.1.0",
+        artifact: { sha256: "x", entryFile: "f.mjs" },
+        steps: {},
+        secrets,
+      }),
+    ).toThrow();
+  });
+
+  it("strictly rejects fields that could carry secret values without echoing them", () => {
+    const sentinel = "DO_NOT_LEAK_THIS_SECRET_VALUE";
+    let thrown: unknown;
+    try {
+      agentManifestSchema.parse({
+        protocol: 1,
+        name: "wf",
+        entry: "a",
+        sdkVersion: "0.1.0",
+        artifact: { sha256: "x", entryFile: "f.mjs" },
+        steps: {},
+        secrets: [{ ref: "billing", keys: ["API_KEY"], value: sentinel }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).not.toContain(sentinel);
   });
 
   it("rejects a manifest with wrong protocol", () => {
@@ -174,6 +317,57 @@ describe("buildManifest", () => {
     expect(manifest.protocol).toBe(1);
     expect(manifest.sdkVersion).toBe(DUMMY_SDK_VERSION);
     expect(manifest.artifact).toEqual(DUMMY_ARTIFACT);
+    expect(manifest.secrets).toEqual([]);
+  });
+
+  it("emits validated secret bindings and preserves only refs and key names", () => {
+    const def = defineAgent({
+      name: "secret-agent",
+      entry: "start",
+      steps: { start: makeStep("start") },
+      secrets: [
+        { ref: "billing", keys: ["STRIPE_KEY"] },
+        { ref: "analytics", keys: ["POSTHOG_KEY"] },
+      ],
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.secrets).toEqual([
+      { ref: "billing", keys: ["STRIPE_KEY"] },
+      { ref: "analytics", keys: ["POSTHOG_KEY"] },
+    ]);
+    expect(agentManifestSchema.parse(manifest).secrets).toEqual(
+      manifest.secrets,
+    );
+  });
+
+  it("revalidates bindings at build time and never serializes a late-added value", () => {
+    const sentinel = "DO_NOT_LEAK_THIS_SECRET_VALUE";
+    const binding: { ref: string; keys: string[]; value?: string } = {
+      ref: "billing",
+      keys: ["API_KEY"],
+    };
+    const def = defineAgent({
+      name: "mutated-after-definition",
+      entry: "start",
+      steps: { start: makeStep("start") },
+      secrets: [binding],
+    });
+    binding.value = sentinel;
+
+    let thrown: unknown;
+    try {
+      buildManifest(def, {
+        sdkVersion: DUMMY_SDK_VERSION,
+        artifact: DUMMY_ARTIFACT,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).not.toContain(sentinel);
   });
 
   it("carries name and entry from the definition", () => {

--- a/packages/agent/src/manifest.ts
+++ b/packages/agent/src/manifest.ts
@@ -22,6 +22,94 @@ export type ManifestTransition =
   | { readonly kind: 'pause'; readonly signal: string; readonly resumeStep: string };
 
 /**
+ * A vault secret binding declares which named environment variables an agent
+ * needs from one tenant vault secret-set. It never carries secret values.
+ */
+export interface SecretBinding {
+  /** Vault secret-set reference. */
+  readonly ref: string;
+  /** Environment-variable names to inject from that secret-set. */
+  readonly keys: readonly string[];
+}
+
+// Identifier limits and character sets mirror Vault v2. Collection bounds keep
+// manifests and dispatch-time vault requests finite.
+export const SECRET_BINDING_LIMITS = {
+  maxBindings: 32,
+  maxKeysPerBinding: 64,
+  maxTotalKeys: 256,
+  maxRefLength: 256,
+  maxKeyLength: 256,
+} as const;
+
+const SECRET_REF_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const SECRET_KEY_PATTERN = /^[A-Za-z0-9._-]+$/;
+const RESERVED_SECRET_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isProtectedEnvironmentKey(key: string): boolean {
+  return key === 'PATH' || key.startsWith('SAPIOM_') || key.startsWith('WORKFLOWS_');
+}
+
+const secretKeySchema = z
+  .string()
+  .min(1)
+  .max(SECRET_BINDING_LIMITS.maxKeyLength)
+  .regex(SECRET_KEY_PATTERN)
+  .refine((key) => !RESERVED_SECRET_KEYS.has(key), 'Reserved object key is not allowed')
+  .refine((key) => !isProtectedEnvironmentKey(key), 'Protected environment key is not allowed');
+
+export const secretBindingSchema = z
+  .object({
+    ref: z.string().min(1).max(SECRET_BINDING_LIMITS.maxRefLength).regex(SECRET_REF_PATTERN),
+    keys: z.array(secretKeySchema).min(1).max(SECRET_BINDING_LIMITS.maxKeysPerBinding),
+  })
+  .strict();
+
+/**
+ * Runtime schema shared by defineAgent, buildManifest, and AgentManifest.
+ * A key may have exactly one source so sandbox env collision behavior never
+ * depends on declaration order.
+ */
+export const secretBindingsSchema = z
+  .array(secretBindingSchema)
+  .max(SECRET_BINDING_LIMITS.maxBindings)
+  .superRefine((bindings, ctx) => {
+    const refs = new Set<string>();
+    const keys = new Set<string>();
+    let totalKeys = 0;
+
+    for (const [bindingIndex, binding] of bindings.entries()) {
+      if (refs.has(binding.ref)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [bindingIndex, 'ref'],
+          message: 'Secret-set refs must be unique',
+        });
+      }
+      refs.add(binding.ref);
+
+      for (const [keyIndex, key] of binding.keys.entries()) {
+        totalKeys += 1;
+        if (keys.has(key)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [bindingIndex, 'keys', keyIndex],
+            message: 'Secret key names must be unique across bindings',
+          });
+        }
+        keys.add(key);
+      }
+    }
+
+    if (totalKeys > SECRET_BINDING_LIMITS.maxTotalKeys) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Secret bindings may declare at most ${SECRET_BINDING_LIMITS.maxTotalKeys} keys total`,
+      });
+    }
+  });
+
+/**
  * Per-step metadata emitted by the build phase and consumed by the engine.
  * The engine uses this to pre-validate inputs and enforce dispatch deadlines
  * without importing any customer definition code.
@@ -70,6 +158,11 @@ export interface AgentManifest {
   };
   /** Per-step metadata map (keyed by step name). */
   readonly steps: Readonly<Record<string, AgentStepManifest>>;
+  /**
+   * Vault secret key-name bindings to inject at dispatch. Optional for legacy
+   * manifests; the runtime schema defaults it to an empty array.
+   */
+  readonly secrets?: readonly SecretBinding[];
 }
 
 // ---------------------------------------------------------------------------
@@ -103,4 +196,5 @@ export const agentManifestSchema = z.object({
     entryFile: z.string().min(1),
   }),
   steps: z.record(z.string(), workflowStepManifestSchema),
+  secrets: secretBindingsSchema.default([]),
 });

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -35,6 +35,7 @@ import type {
   NextStepDirective,
   PauseUntilSignalDirective,
   RetryDirective,
+  SecretBinding,
   StepLogger,
   TerminateDirective,
 } from './index.js';
@@ -130,6 +131,99 @@ describe('defineAgent', () => {
       steps: { a: makeStep('a'), b: makeStep('b'), c: makeStep('c') },
     });
     expect(Object.keys(def.steps)).toHaveLength(3);
+  });
+
+  it('accepts valid vault secret bindings through the public SecretBinding type', () => {
+    const secrets: readonly SecretBinding[] = [
+      { ref: 'billing:prod', keys: ['STRIPE_KEY'] },
+      { ref: 'analytics', keys: ['POSTHOG_KEY'] },
+    ];
+    const def = defineAgent({
+      name: 'with-secrets',
+      entry: 'start',
+      steps: { start: makeStep('start') },
+      secrets,
+    });
+    expect(def.secrets).toBe(secrets);
+  });
+
+  it.each([
+    { label: 'an invalid ref', secrets: [{ ref: 'bad ref!', keys: ['API_KEY'] }] },
+    { label: 'an invalid key', secrets: [{ ref: 'billing', keys: ['BAD KEY!'] }] },
+    { label: 'no keys', secrets: [{ ref: 'billing', keys: [] }] },
+    { label: 'a reserved object key', secrets: [{ ref: 'billing', keys: ['__proto__'] }] },
+    { label: 'PATH', secrets: [{ ref: 'billing', keys: ['PATH'] }] },
+    { label: 'a SAPIOM_ control key', secrets: [{ ref: 'billing', keys: ['SAPIOM_API_KEY'] }] },
+    {
+      label: 'a WORKFLOWS_ control key',
+      secrets: [{ ref: 'billing', keys: ['WORKFLOWS_EXECUTION_ID'] }],
+    },
+  ])('rejects secret bindings containing $label', ({ secrets }) => {
+    expect(() =>
+      defineAgent({
+        name: 'invalid-secrets',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets,
+      }),
+    ).toThrow('invalid secret bindings');
+  });
+
+  it('rejects duplicate refs', () => {
+    expect(() =>
+      defineAgent({
+        name: 'duplicate-refs',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets: [
+          { ref: 'shared', keys: ['FIRST_KEY'] },
+          { ref: 'shared', keys: ['SECOND_KEY'] },
+        ],
+      }),
+    ).toThrow('Secret-set refs must be unique');
+  });
+
+  it('rejects duplicate environment key names across bindings', () => {
+    expect(() =>
+      defineAgent({
+        name: 'duplicate-keys',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets: [
+          { ref: 'billing', keys: ['API_KEY'] },
+          { ref: 'analytics', keys: ['API_KEY'] },
+        ],
+      }),
+    ).toThrow('Secret key names must be unique across bindings');
+  });
+
+  it('rejects missing keys from untyped callers', () => {
+    expect(() =>
+      defineAgent({
+        name: 'missing-keys',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets: [{ ref: 'billing' }] as unknown as SecretBinding[],
+      }),
+    ).toThrow('invalid secret bindings');
+  });
+
+  it('rejects undeclared binding fields without echoing a possible secret value', () => {
+    const sentinel = 'DO_NOT_LEAK_THIS_SECRET_VALUE';
+    let thrown: unknown;
+    try {
+      defineAgent({
+        name: 'value-in-definition',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+        secrets: [{ ref: 'billing', keys: ['API_KEY'], value: sentinel }] as unknown as SecretBinding[],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(String(thrown)).toContain('invalid secret bindings');
+    expect(String(thrown)).not.toContain(sentinel);
   });
 
   it('attaches a non-enumerable AGENT_DEFINITION_BRAND symbol to the returned object', () => {


### PR DESCRIPTION
## Summary

- add names-only vault secret bindings to `AgentDefinition` and `AgentManifest`
- validate bindings in `defineAgent`, `agentManifestSchema`, and `buildManifest`
- reject duplicate refs/keys, protected engine namespaces, malformed identifiers, and undeclared value-bearing fields
- default legacy manifests to an empty binding list and add a minor Changeset for `@sapiom/agent`

## Security contract

Bindings contain only a vault ref and environment-variable key names. They cannot contain secret values. `PATH`, `SAPIOM_*`, and `WORKFLOWS_*` are rejected, and key collisions are invalid rather than order-dependent.

## Verification

- `pnpm --filter @sapiom/agent typecheck`
- `pnpm --filter @sapiom/agent lint`
- `pnpm --filter @sapiom/agent test` — 5 suites, 102 tests
- `pnpm --filter @sapiom/agent build`
- `pnpm changeset status`
- built declarations export `SecretBinding`; sentinel values are absent from build output

Supersedes #74, which targets the removed/deprecated `@sapiom/orchestration` package.

Refs: SAP-786