### PR TITLE
fix: repair post-release SDK CI drift

### DIFF
--- a/.changeset/tidy-cats-scaffold.md
+++ b/.changeset/tidy-cats-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Keep the offline scaffold fallbacks aligned with the published `@sapiom/agent` and `@sapiom/tools` versions.

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.2",
-  tools: "0.17.2",
+  agent: "0.6.3",
+  tools: "0.18.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -766,7 +766,7 @@ describe("skills router — real server mount proof", () => {
     // then the skills router (which declares /api/skills internally).
     const app = express();
     app.use("/api", createBootTokenMiddleware(BOOT_TOKEN));
-    app.use(createSkillsRouter({ userSkillsRoot: skillsRoot }));
+    app.use(createSkillsRouter({ userSkillsRoot: skillsRoot, showUserSkills: true }));
 
     await new Promise<void>((resolve) => {
       server = app.listen(0, "127.0.0.1", resolve);


### PR DESCRIPTION
## Summary

Fixes the two pre-existing CI regressions exposed by sapiom-js #290 after main's release changes.

- align `agent-core`'s offline scaffold fallbacks with current published workspace versions:
  - `@sapiom/agent` 0.6.3
  - `@sapiom/tools` 0.18.0
- add an `@sapiom/agent-core` patch changeset
- make the real-server harness skill-listing test explicitly enable the user-skill surface it asserts (the product default intentionally hides personal skills)

## Verification

- full monorepo build passed
- full monorepo typecheck passed
- full monorepo lint passed
- agent-core scaffold suite: 13/13 passed
- harness REST suite: 43/43 passed
- affected package typecheck/lint passed
- changeset status passed
- `git diff --check`

The full local monorepo test command also encounters existing macOS-only node-pty fixture failures; CI runs those on Ubuntu.