### PR TITLE
chore: add missing changeset for #288 (tools memory v1 contract)

### DIFF
--- a/.changeset/tools-memory-v1-contract.md
+++ b/.changeset/tools-memory-v1-contract.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Align the memory surface to the v1 wire contract: `MemoryMetadata` is a flat scalar map (`string | number | boolean`), retrieval `strategy` is `semantic | keyword | hybrid`, and the offline stub mirrors the wire's runtime rejections for invalid metadata shapes and strategy values (400s). Docs now recommend namespace-first modeling for always-filtered dimensions.


### PR DESCRIPTION
## Summary
PR #288 (feat(tools): align memory surface to v1 contract) merged without a changeset, so the Release PR workflow found nothing to version ("No changesets present") and no version-packages PR was created.

This adds the missing changeset retroactively: **@sapiom/tools: minor** (0.18.0 → 0.19.0).

No code changes — changeset file only. Merging this triggers the Release PR workflow to open the "chore: version packages" PR, which publishes on merge.