### PR TITLE
feat(harness): renderRunState mapper (decoded projection → RunView)

### DIFF
--- a/packages/harness/src/core/render-run-state.test.ts
+++ b/packages/harness/src/core/render-run-state.test.ts
@@ -1,0 +1,257 @@
+import { decodeExecutionProjection } from "@sapiom/agent-core";
+import { describe, it, expect } from "vitest";
+
+import type { RunView } from "../shared/types.js";
+import { renderRunState } from "./render-run-state.js";
+
+/** Build a decoded projection from a minimal raw body (decode fills the rest) —
+ *  exercises the real inspect→decode→render path the poll endpoint uses. */
+function render(raw: Record<string, unknown>): RunView {
+  return renderRunState(decodeExecutionProjection(raw));
+}
+
+/** A single step's raw body, spread over decode's defaults. */
+function step(raw: Record<string, unknown>): Record<string, unknown> {
+  return { stepName: "s", stepOrder: 0, attempt: 1, status: "completed", ...raw };
+}
+
+describe("renderRunState — run status", () => {
+  it.each([
+    ["completed", "completed"],
+    ["failed", "failed"],
+    ["cancelled", "cancelled"],
+    ["canceled", "cancelled"], // one-L wire spelling normalizes to two-L
+  ] as const)("folds terminal %s → %s", (raw, expected) => {
+    expect(render({ id: "e1", status: raw }).status).toBe(expected);
+  });
+
+  it.each(["running", "paused", "queued", "", "something-new"])(
+    "folds non-terminal %s → running",
+    (raw) => {
+      expect(render({ id: "e1", status: raw }).status).toBe("running");
+    },
+  );
+
+  it("carries the execution id through", () => {
+    expect(render({ id: "exec_42", status: "running" }).executionId).toBe("exec_42");
+  });
+});
+
+describe("renderRunState — step status folding", () => {
+  it.each([
+    ["completed", "passed"],
+    ["failed", "failed"],
+    ["cancelled", "failed"], // a cancelled step did not pass
+    ["canceled", "failed"],
+    ["running", "running"],
+    ["", "pending"],
+    ["queued", "pending"],
+  ] as const)("folds step status %s → %s", (raw, expected) => {
+    const view = render({ id: "e1", status: "running", steps: [step({ status: raw })] });
+    expect(view.steps[0].status).toBe(expected);
+  });
+});
+
+describe("renderRunState — step id + name", () => {
+  it("uses the span id as the stable step id when present", () => {
+    const view = render({ id: "e1", status: "running", steps: [step({ spanId: "span_9" })] });
+    expect(view.steps[0].id).toBe("span_9");
+  });
+
+  it("falls back to a step-order/attempt key when there is no span id", () => {
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ spanId: null, stepOrder: 2, attempt: 3 })],
+    });
+    expect(view.steps[0].id).toBe("step-2-3");
+  });
+
+  it("passes the step name through", () => {
+    const view = render({ id: "e1", status: "running", steps: [step({ stepName: "gather" })] });
+    expect(view.steps[0].name).toBe("gather");
+  });
+});
+
+describe("renderRunState — cost", () => {
+  it("surfaces CAPTURED usd as a number (not authorized)", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ cost: { authorizedUsd: "9.99", capturedUsd: "1.20", settleState: "final" } })],
+    });
+    expect(view.steps[0].costUsd).toBe(1.2);
+  });
+
+  it("omits costUsd entirely on honest absence (no cost on the read)", () => {
+    const view = render({ id: "e1", status: "completed", steps: [step({})] });
+    expect(view.steps[0]).not.toHaveProperty("costUsd");
+  });
+
+  it("omits costUsd when the captured amount is unparseable", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ cost: { authorizedUsd: "0", capturedUsd: "n/a", settleState: "final" } })],
+    });
+    expect(view.steps[0]).not.toHaveProperty("costUsd");
+  });
+
+  it("keeps a genuine zero captured cost as 0 (not absent)", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ cost: { authorizedUsd: "1.00", capturedUsd: "0", settleState: "pending" } })],
+    });
+    expect(view.steps[0].costUsd).toBe(0);
+  });
+});
+
+describe("renderRunState — latency", () => {
+  it("computes finishedAt − startedAt in ms", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [
+        step({ startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:45.000Z" }),
+      ],
+    });
+    expect(view.steps[0].latencyMs).toBe(45_000);
+  });
+
+  it("omits latency while the step is still running (no finishedAt)", () => {
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ status: "running", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: null })],
+    });
+    expect(view.steps[0]).not.toHaveProperty("latencyMs");
+  });
+
+  it("omits latency on an unparseable timestamp", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ startedAt: "not-a-date", finishedAt: "2026-01-01T00:00:45.000Z" })],
+    });
+    expect(view.steps[0]).not.toHaveProperty("latencyMs");
+  });
+
+  it("drops a negative delta (clock skew) rather than showing negative latency", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [
+        step({ startedAt: "2026-01-01T00:00:45.000Z", finishedAt: "2026-01-01T00:00:00.000Z" }),
+      ],
+    });
+    expect(view.steps[0]).not.toHaveProperty("latencyMs");
+  });
+});
+
+describe("renderRunState — error", () => {
+  it("surfaces a failed step's error message", () => {
+    const view = render({
+      id: "e1",
+      status: "failed",
+      steps: [step({ status: "failed", error: { message: "boom" } })],
+    });
+    expect(view.steps[0].error).toBe("boom");
+  });
+
+  it("omits error on a step that did not throw", () => {
+    const view = render({ id: "e1", status: "completed", steps: [step({})] });
+    expect(view.steps[0]).not.toHaveProperty("error");
+  });
+});
+
+describe("renderRunState — log slice", () => {
+  it("formats { ts, level, msg } entries into compact lines", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [
+        step({
+          logs: [
+            { ts: "t0", level: "info", msg: "start" },
+            { ts: "t1", level: "error", message: "kaboom" },
+          ],
+        }),
+      ],
+    });
+    expect(view.steps[0].logSlice).toBe("t0 info start\nt1 error kaboom");
+  });
+
+  it("accepts bare-string log entries", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ logs: ["line one", "line two"] })],
+    });
+    expect(view.steps[0].logSlice).toBe("line one\nline two");
+  });
+
+  it("omits logSlice when there are no logs", () => {
+    const view = render({ id: "e1", status: "completed", steps: [step({ logs: null })] });
+    expect(view.steps[0]).not.toHaveProperty("logSlice");
+  });
+
+  it("omits logSlice for an empty log array", () => {
+    const view = render({ id: "e1", status: "completed", steps: [step({ logs: [] })] });
+    expect(view.steps[0]).not.toHaveProperty("logSlice");
+  });
+
+  it("keeps the TAIL when the buffer exceeds the cap", () => {
+    const long = Array.from({ length: 500 }, (_, i) => `line-${i}`);
+    const view = render({ id: "e1", status: "completed", steps: [step({ logs: long })] });
+    const slice = view.steps[0].logSlice as string;
+    expect(slice.length).toBe(4000);
+    expect(slice.endsWith("line-499")).toBe(true); // most-recent line survives
+    expect(slice.startsWith("line-0")).toBe(false); // oldest lines trimmed off the front
+  });
+});
+
+describe("renderRunState — whole run", () => {
+  it("preserves step order", () => {
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [
+        step({ stepName: "first", stepOrder: 0, spanId: "a" }),
+        step({ stepName: "second", stepOrder: 1, spanId: "b", status: "running" }),
+      ],
+    });
+    expect(view.steps.map((s) => s.name)).toEqual(["first", "second"]);
+  });
+
+  it("emits only the derived keys for a minimal step (honest absence everywhere)", () => {
+    const view = render({ id: "e1", status: "running", steps: [step({ spanId: "s0" })] });
+    expect(view.steps[0]).toEqual({ id: "s0", name: "s", status: "passed" });
+  });
+
+  it("maps a realistic cost-bearing completed run end to end", () => {
+    const view = render({
+      id: "exec_0001",
+      status: "completed",
+      steps: [
+        {
+          stepName: "gather",
+          stepOrder: 0,
+          attempt: 1,
+          status: "completed",
+          spanId: "span_0001",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:00:45.000Z",
+          cost: { authorizedUsd: "0.50", capturedUsd: "0.50", settleState: "final" },
+        },
+      ],
+    });
+    expect(view).toEqual({
+      executionId: "exec_0001",
+      status: "completed",
+      steps: [
+        { id: "span_0001", name: "gather", status: "passed", costUsd: 0.5, latencyMs: 45_000 },
+      ],
+    });
+  });
+});

--- a/packages/harness/src/core/render-run-state.test.ts
+++ b/packages/harness/src/core/render-run-state.test.ts
@@ -119,6 +119,17 @@ describe("renderRunState — latency", () => {
     expect(view.steps[0].latencyMs).toBe(45_000);
   });
 
+  it("keeps a genuine zero-duration step as 0 (not absent)", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [
+        step({ startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.000Z" }),
+      ],
+    });
+    expect(view.steps[0].latencyMs).toBe(0);
+  });
+
   it("omits latency while the step is still running (no finishedAt)", () => {
     const view = render({
       id: "e1",
@@ -227,6 +238,15 @@ describe("renderRunState — whole run", () => {
   it("emits only the derived keys for a minimal step (honest absence everywhere)", () => {
     const view = render({ id: "e1", status: "running", steps: [step({ spanId: "s0" })] });
     expect(view.steps[0]).toEqual({ id: "s0", name: "s", status: "passed" });
+  });
+
+  it("emits only the derived keys for a minimal RUNNING step too", () => {
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ spanId: "s1", status: "running" })],
+    });
+    expect(view.steps[0]).toEqual({ id: "s1", name: "s", status: "running" });
   });
 
   it("maps a realistic cost-bearing completed run end to end", () => {

--- a/packages/harness/src/core/render-run-state.ts
+++ b/packages/harness/src/core/render-run-state.ts
@@ -22,8 +22,8 @@ import type { RunView, StepStatus, StepView } from "../shared/types.js";
 /**
  * Cap on the characters of a step's executor log buffer surfaced in `logSlice`.
  * The TAIL is kept (most recent lines) because failures surface at the end of a
- * log. This is a payload guard on the poll response; the debug-macro extractor
- * (C2) does the final, smaller trim for prompt injection.
+ * log. This is a payload guard on the poll response; the debug-macro context
+ * extractor does the final, smaller trim for prompt injection.
  */
 const LOG_SLICE_MAX = 4000;
 

--- a/packages/harness/src/core/render-run-state.ts
+++ b/packages/harness/src/core/render-run-state.ts
@@ -1,0 +1,129 @@
+/**
+ * renderRunState — the ONE pure mapper from a decoded {@link ExecutionProjection}
+ * to the canvas's {@link RunView} render state.
+ *
+ * Pure and deterministic: no LLM, no I/O, no clock. Every field is derived from
+ * the decoded projection, so the same function drives the polling path today and
+ * a future WebSocket push (only the data source swaps, never this mapping). Cost
+ * and latency are read straight from the projection and rendered statically — the
+ * LLM is only ever invoked later by an explicit debug-macro press, never to
+ * compute what's shown here.
+ *
+ * Honest absence is preserved end to end: a step with no cost on this read gets
+ * no `costUsd` (not `0`), a still-running step gets no `latencyMs`, and a step
+ * with no logs gets no `logSlice` — matching the SDK's "null cost is honest
+ * absence, never a fabricated $0" contract.
+ */
+import { isExecutionTerminal } from "@sapiom/agent-core";
+import type { CostNode, ExecutionProjection, StepProjection } from "@sapiom/agent-core";
+
+import type { RunView, StepStatus, StepView } from "../shared/types.js";
+
+/**
+ * Cap on the characters of a step's executor log buffer surfaced in `logSlice`.
+ * The TAIL is kept (most recent lines) because failures surface at the end of a
+ * log. This is a payload guard on the poll response; the debug-macro extractor
+ * (C2) does the final, smaller trim for prompt injection.
+ */
+const LOG_SLICE_MAX = 4000;
+
+/**
+ * Fold the run's lifecycle status into the four states the UI distinguishes.
+ * Reuses `isExecutionTerminal` (agent-core's single source of truth for "won't
+ * advance on its own") so a newly-added terminal status can never be misdrawn as
+ * still-running: anything non-terminal (running, paused, queued, unknown) is
+ * `running`; the terminal set normalizes `canceled` → `cancelled`.
+ */
+function toRunStatus(raw: string): RunView["status"] {
+  if (!isExecutionTerminal(raw)) return "running";
+  if (raw === "completed") return "completed";
+  if (raw === "failed") return "failed";
+  return "cancelled"; // the only remaining terminal statuses: "cancelled" / "canceled"
+}
+
+/**
+ * Fold a step's raw status into a {@link StepStatus}. A cancelled step folds to
+ * `failed` (it did not pass — mirrors run-local.ts folding the unreachable
+ * 'cancelled' into 'failed'); anything not yet running/passed/failed is
+ * `pending` (unstarted, queued, or an unknown value).
+ */
+function toStepStatus(raw: string): StepStatus {
+  if (raw === "completed") return "passed";
+  if (raw === "failed" || raw === "cancelled" || raw === "canceled") return "failed";
+  if (raw === "running") return "running";
+  return "pending";
+}
+
+/** Captured USD as a number; `undefined` on honest absence (null cost) or an
+ *  unparseable amount — never a fabricated `0`. */
+function toCostUsd(cost: CostNode | null): number | undefined {
+  if (!cost) return undefined;
+  const n = Number(cost.capturedUsd);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** `finishedAt − startedAt` in ms; `undefined` while still running (no finish)
+ *  or when either timestamp is unparseable. A negative delta (clock skew) is
+ *  dropped rather than shown as a misleading negative latency. */
+function toLatencyMs(startedAt: string | null, finishedAt: string | null): number | undefined {
+  if (!startedAt || !finishedAt) return undefined;
+  const start = Date.parse(startedAt);
+  const end = Date.parse(finishedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return undefined;
+  const delta = end - start;
+  return delta >= 0 ? delta : undefined;
+}
+
+/** One executor log entry → a compact line. Accepts the `{ ts, level, msg }`
+ *  wire shape (or `message`), a bare string, or anything else (stringified). */
+function formatLogEntry(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  if (entry !== null && typeof entry === "object") {
+    const e = entry as { ts?: unknown; level?: unknown; msg?: unknown; message?: unknown };
+    const parts = [e.ts, e.level, e.msg ?? e.message].filter(
+      (p): p is string | number => typeof p === "string" || typeof p === "number",
+    );
+    if (parts.length > 0) return parts.map(String).join(" ");
+  }
+  return String(entry);
+}
+
+/** Format the executor log buffer into a trimmed, tail-preserving slice, or
+ *  `undefined` when there are no usable logs. */
+function toLogSlice(logs: unknown): string | undefined {
+  if (!Array.isArray(logs) || logs.length === 0) return undefined;
+  const text = logs.map(formatLogEntry).join("\n").trim();
+  if (text === "") return undefined;
+  return text.length > LOG_SLICE_MAX ? text.slice(text.length - LOG_SLICE_MAX) : text;
+}
+
+/** Map one projection step to its render view. Optional fields are assigned only
+ *  when present so absence stays absent (not `undefined`) in the JSON payload. */
+function toStepView(step: StepProjection): StepView {
+  const view: StepView = {
+    id: step.spanId ?? `step-${step.stepOrder}-${step.attempt}`,
+    name: step.stepName,
+    status: toStepStatus(step.status),
+  };
+  const costUsd = toCostUsd(step.cost);
+  if (costUsd !== undefined) view.costUsd = costUsd;
+  const latencyMs = toLatencyMs(step.startedAt, step.finishedAt);
+  if (latencyMs !== undefined) view.latencyMs = latencyMs;
+  if (step.error?.message) view.error = step.error.message;
+  const logSlice = toLogSlice(step.logs);
+  if (logSlice !== undefined) view.logSlice = logSlice;
+  return view;
+}
+
+/**
+ * Map a decoded {@link ExecutionProjection} to the {@link RunView} the canvas
+ * renders. Order-preserving over `steps`; total (never throws) because the
+ * projection is already the decoded, degradation-tolerant shape.
+ */
+export function renderRunState(decoded: ExecutionProjection): RunView {
+  return {
+    executionId: decoded.id,
+    status: toRunStatus(decoded.status),
+    steps: decoded.steps.map(toStepView),
+  };
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -357,8 +357,8 @@ export interface StepView {
   latencyMs?: number;
   /** Terminal error message; present only for a failed step that recorded one. */
   error?: string;
-  /** Trimmed, tail-preserving executor log lines — the debug-macro context
-   *  source (C2 further trims/combines for injection). Absent when no logs. */
+  /** Tail-preserving, character-capped executor log text — the debug-macro
+   *  context source (trimmed further before injection). Absent when no logs. */
   logSlice?: string;
 }
 

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -323,6 +323,54 @@ export type BusMessage =
   | { type: "session.activity"; harnessSessionId: string; at: string };
 
 // ---------------------------------------------------------------------------
+// Runtime analytics — live run render state (see core/render-run-state.ts)
+// ---------------------------------------------------------------------------
+//
+// The transport-agnostic shape the canvas renders a run from. The server
+// produces it (GET /api/runs/:id/state = inspect → decode → renderRunState);
+// the web poll loop and canvas consume it. Deliberately DERIVED, never raw:
+// every field is computed deterministically from the decoded
+// ExecutionProjection — no LLM, no I/O — so the same RunView drives both the
+// polling path today and a future WebSocket push (only the source swaps).
+
+/**
+ * A step's render status, folded from the raw projection step status into the
+ * four states the canvas draws. `cancelled`/`failed` both fold to `failed`
+ * (a cancelled step did not pass — mirrors run-local.ts); anything not yet
+ * `running`/`passed`/`failed` is `pending`.
+ */
+export type StepStatus = "pending" | "running" | "passed" | "failed";
+
+/** One step as the canvas renders it — status plus the deterministically
+ *  derived cost/latency/error/log slice. Optional fields are ABSENT (not
+ *  `undefined`/`0`) when the decoded projection carries no value — honest
+ *  absence, matching the SDK's cost-is-nullable philosophy. */
+export interface StepView {
+  /** Stable id for keyed rendering — the OTel span id, else a step-order key. */
+  id: string;
+  /** Human step label (the projection's stepName). */
+  name: string;
+  status: StepStatus;
+  /** Captured USD for this step; absent when the read carries no cost. */
+  costUsd?: number;
+  /** finishedAt − startedAt in ms; absent while running or on bad timestamps. */
+  latencyMs?: number;
+  /** Terminal error message; present only for a failed step that recorded one. */
+  error?: string;
+  /** Trimmed, tail-preserving executor log lines — the debug-macro context
+   *  source (C2 further trims/combines for injection). Absent when no logs. */
+  logSlice?: string;
+}
+
+/** A whole run as the canvas renders it. `status` is the run lifecycle folded
+ *  to the four states the UI distinguishes; `steps` is order-preserving. */
+export interface RunView {
+  executionId: string;
+  status: "running" | "completed" | "failed" | "cancelled";
+  steps: StepView[];
+}
+
+// ---------------------------------------------------------------------------
 // Adapter registry (GET /api/harnesses)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The single pure, deterministic mapper from a decoded `ExecutionProjection` to the canvas's `RunView` render state — the correctness core of the runtime-analytics feature. No LLM, no I/O:

- **run-status fold** reuses agent-core's `isExecutionTerminal` as the single source of truth (so a newly-added terminal status can't be misdrawn as still-running); normalizes `canceled` → `cancelled`.
- **step-status fold** (`completed`→passed, `failed`/`cancelled`→failed, `running`→running, else pending — mirrors `run-local.ts`).
- **cost / latency / error / logSlice** derived from the projection with **honest absence preserved** (no fabricated `$0` / `0ms`; a tail-preserving cap on the log slice).

The same `RunView` will drive polling today and a future WebSocket push — only the data source swaps, never this mapping.

Linear: SAP-1601

## Changes
- `src/shared/types.ts` — add `RunView` / `StepView` / `StepStatus` to the integration-boundary types (produced server-side, consumed by the web poll loop + canvas).
- `src/core/render-run-state.ts` — the `renderRunState(decoded)` mapper.
- `src/core/render-run-state.test.ts` — 38 mutation-first unit tests (exact-output, every status branch, honest-absence, tail-trim) built through the real `decodeExecutionProjection` → `renderRunState` pipeline.

## Test plan
- `pnpm --filter @sapiom/harness test render-run-state` → **38/38 pass**
- `pnpm --filter @sapiom/harness typecheck` (server + web) — clean
- `pnpm --filter @sapiom/harness lint` — clean
- Stryker mutation runner is wired once across all three F2 pure fns in the feature's final leaf; these tests are written mutation-first to the ≥80% bar.

## Stack & review
- Base: `feat/harness-runtime-analytics` (feature integration branch; merges to `main` once F2 is complete + e2e-tested).
- First in the F2 stack; **B3 is stacked on top of this PR**.
- sapiom-js has 0 CI reviewers → ≥1 manual claude-review pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)