### PR TITLE
feat(harness): expand canvas preview

### DIFF
--- a/packages/harness/src/core/canvas-template.test.ts
+++ b/packages/harness/src/core/canvas-template.test.ts
@@ -50,6 +50,12 @@ describe("renderCanvasDocument", () => {
     expect(html).toMatch(/params\.get\("theme"\)/);
   });
 
+  it("allows wide previews to use a large canvas pane", () => {
+    const html = renderCanvasDocument("");
+    expect(html).toContain("width: 100%; max-width: 1600px");
+    expect(html).not.toContain("max-width: 1100px");
+  });
+
   it("ships the SVG defs (glow filter, arrow markers) every node/edge pattern references", () => {
     const html = renderCanvasDocument("");
     expect(html).toContain('id="canvas-glow"');

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -74,7 +74,7 @@ html, body {
   margin: 0; min-height: 100%; background: var(--canvas-bg); color: var(--canvas-text);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
-#canvas-root { max-width: 1100px; margin: 0 auto; padding: 24px 20px; display: flex; flex-direction: column; gap: 18px; }
+#canvas-root { width: 100%; max-width: 1600px; margin: 0 auto; padding: 24px 20px; display: flex; flex-direction: column; gap: 18px; }
 
 /* --- structural classes: keep these, and their names, untouched --- */
 .canvas-panel { background: var(--canvas-panel); border: 1px solid var(--canvas-border); border-radius: 16px; padding: 20px; }

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -960,6 +960,22 @@ test.describe("resizable panes", () => {
     expect((canvasAfter?.width ?? 0) - canvasBefore.width).toBeGreaterThan(60);
   });
 
+  test("the canvas pane can grow beyond the old 720px ceiling on a wide viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 720 });
+    const handle = page.getByTestId("resize-handle-canvas");
+    const handleBox = await handle.boundingBox();
+    if (!handleBox) throw new Error("expected canvas handle bounding box");
+
+    const y = handleBox.y + handleBox.height / 2;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2 - 600, y, { steps: 8 });
+    await page.mouse.up();
+
+    const canvasWidth = (await page.locator(".canvas-pane").boundingBox())?.width ?? 0;
+    expect(canvasWidth).toBeGreaterThan(900);
+  });
+
   test("rail and canvas widths cannot be dragged past their min-width floors", async ({ page }) => {
     const railHandle = page.getByTestId("resize-handle-rail");
     let box = await railHandle.boundingBox();
@@ -1014,4 +1030,3 @@ test("the canvas iframe carries the app's theme and flips on toggle", async ({ p
   await page.getByTestId("theme-toggle").click();
   await expect(iframe).toHaveAttribute("src", /theme=dark/);
 });
-

--- a/packages/harness/web/src/lib/use-pane-widths.ts
+++ b/packages/harness/web/src/lib/use-pane-widths.ts
@@ -12,7 +12,7 @@ export const RAIL_MIN = 180;
 export const RAIL_MAX = 480;
 export const RAIL_DEFAULT = 220;
 export const CANVAS_MIN = 280;
-export const CANVAS_MAX = 720;
+export const CANVAS_MAX = 1440;
 export const CANVAS_DEFAULT = 420;
 
 function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary

Expands the Sapiom Harness canvas so large workflow diagrams can use substantially more of a wide display.

## Changes

- Increase the draggable Canvas pane maximum from 720px to 1440px.
- Increase generated canvas document width from 1100px to 1600px while retaining responsive 100% sizing.
- Add template coverage for the wider document shell.
- Add a Chromium regression test proving the pane can grow beyond the former 720px ceiling.

## Motivation

The Canvas resize handle stopped at 720px even when the viewport had additional space. Wide workflow diagrams therefore remained horizontally constrained and required unnecessary scrolling.

## Testing

- `pnpm --filter @sapiom/harness... build`
- `pnpm --filter @sapiom/harness exec vitest run src/core/canvas-template.test.ts` — 19 passed
- `pnpm --filter @sapiom/harness typecheck`
- `pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts --grep "old 720px ceiling"` — 1 passed
- Regression check confirmed the browser test fails at exactly 720px with the old limit and passes with the new limit.

## Screenshots / Demo

The browser regression exercises a 1920px viewport and verifies the Canvas pane grows beyond 900px; the old implementation stops at 720px.

## Checklist

- [x] Code follows project conventions
- [x] Build and focused tests pass
- [x] No hardcoded secrets
- [x] Diff is limited to the harness canvas sizing change