### PR TITLE
feat(harness): Ship-area snippet panel — trigger a deployed agent from your code

### DIFF
--- a/packages/harness/src/core/macro-runner.test.ts
+++ b/packages/harness/src/core/macro-runner.test.ts
@@ -6,6 +6,7 @@ const workflow: WorkflowInfo = {
   name: "leasing",
   path: "/Users/demo/acme-app/leasing",
   definitionId: 4821,
+  definitionSlug: "leasing",
   source: "scan",
 };
 

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -53,12 +53,14 @@ describe("WorkflowRegistry", () => {
       name: "@acme/proj-a",
       path: path.join(tmpRoot, "proj-a"),
       definitionId: 42,
+      definitionSlug: null,
       source: "scan",
     });
     expect(byPath.get(path.join(tmpRoot, "proj-b"))).toEqual({
       name: "proj-b",
       path: path.join(tmpRoot, "proj-b"),
       definitionId: null,
+      definitionSlug: null,
       source: "scan",
     });
     expect(byPath.has(path.join(tmpRoot, "a", "b", "c"))).toBe(true);
@@ -88,6 +90,7 @@ describe("WorkflowRegistry", () => {
       name: "not-yet-linked",
       path: projectDir,
       definitionId: null,
+      definitionSlug: null,
       source: "connect",
     });
     expect(await registry.list()).toEqual([info]);

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -28,6 +28,8 @@ function expandHome(inputPath: string): string {
 
 interface SapiomMarker {
   definitionId?: number | null;
+  /** The agent's `defineAgent({ name })`, cached by `link` — the executions-API slug. */
+  name?: string;
 }
 
 // `dir` reaching these sinks is always a resolved absolute path (from
@@ -79,6 +81,7 @@ async function scanDir(root: string, dir: string, depth: number, found: Workflow
       name: await nameFor(safeDir),
       path: safeDir,
       definitionId: marker.definitionId ?? null,
+      definitionSlug: marker.name ?? null,
       source: "scan",
     });
     return;
@@ -207,6 +210,7 @@ export class WorkflowRegistry {
         name: await nameFor(absolutePath),
         path: absolutePath,
         definitionId: marker?.definitionId ?? null,
+        definitionSlug: marker?.name ?? null,
         source: "connect",
       };
       const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);

--- a/packages/harness/src/core/workspace-context.test.ts
+++ b/packages/harness/src/core/workspace-context.test.ts
@@ -11,6 +11,7 @@ const workflow: WorkflowInfo = {
   name: "leasing",
   path: "/Users/demo/acme-app/leasing",
   definitionId: 4821,
+  definitionSlug: "leasing",
   source: "scan",
 };
 
@@ -18,6 +19,7 @@ const otherWorkflow: WorkflowInfo = {
   name: "billing",
   path: "/Users/demo/acme-app/billing",
   definitionId: 4822,
+  definitionSlug: "billing",
   source: "scan",
 };
 

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -15,6 +15,7 @@ const workflow: WorkflowInfo = {
   name: "leasing",
   path: "/Users/demo/acme-app/leasing",
   definitionId: 4821,
+  definitionSlug: "leasing",
   source: "scan",
 };
 
@@ -156,7 +157,7 @@ describe("macros router", () => {
   });
 
   it("prefers an explicit workflowPath on the request over the session's bound workflow", async () => {
-    const otherWorkflow: WorkflowInfo = { name: "rfq", path: "/Users/demo/acme-app/rfq", definitionId: 7, source: "scan" };
+    const otherWorkflow: WorkflowInfo = { name: "rfq", path: "/Users/demo/acme-app/rfq", definitionId: 7, definitionSlug: "rfq", source: "scan" };
     const deps = makeDeps({
       findWorkflow: (p) => (p === workflow.path ? workflow : p === otherWorkflow.path ? otherWorkflow : null),
       getBoundWorkflowPath: (id) => (id === "sess-1" ? otherWorkflow.path : null),
@@ -185,7 +186,7 @@ describe("macros router", () => {
      * the injected text is inert — the subshell can never actually execute.
      */
     function makeWithPath(p: string) {
-      const evil: WorkflowInfo = { name: "evil", path: p, definitionId: null, source: "scan" };
+      const evil: WorkflowInfo = { name: "evil", path: p, definitionId: null, definitionSlug: null, source: "scan" };
       return makeDeps({
         findWorkflow: (wp) => (wp === p ? evil : null),
         getBoundWorkflowPath: () => p,

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -143,7 +143,7 @@ describe("createRestRouter", () => {
         boundWorkflowPath: null,
         ready: true,
       };
-      const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, source: "scan" };
+      const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, definitionSlug: "leasing", source: "scan" };
       const macro: MacroDef = { id: "run_local", label: "Run local", icon: "Play", action: { kind: "inject", text: "x" } };
 
       start({
@@ -389,7 +389,7 @@ describe("createRestRouter", () => {
   });
 
   describe("PATCH /sessions/:id/workflow", () => {
-    const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, source: "scan" };
+    const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, definitionSlug: "leasing", source: "scan" };
     const baseSession: HarnessSession = {
       id: "sess-1",
       agentSessionId: null,

--- a/packages/harness/src/server/skills.test.ts
+++ b/packages/harness/src/server/skills.test.ts
@@ -306,6 +306,7 @@ describe("macro path quoting", () => {
         name: "my workflow",
         path: "/Users/demo/my workflow",
         definitionId: null,
+        definitionSlug: null,
         source: "scan",
       },
       sessionCwd: "/Users/demo",

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -619,6 +619,10 @@ export interface WorkflowInfo {
   path: string;
   /** From sapiom.json once linked; null before first link. */
   definitionId: number | null;
+  /** The deployed agent's slug — the `defineAgent({ name })` that sapiom.json
+   *  caches as `name`, used as the executions-API handle
+   *  (`/agents/v1/definitions/{slug}/executions`). Null before first link. */
+  definitionSlug: string | null;
   /** How it entered the registry. */
   source: "scan" | "connect";
 }

--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -97,6 +97,16 @@ test.describe("slug input", () => {
     await expect(input).toHaveValue("ic-diligence-orchestrator");
   });
 
+  test("switching to a second deployed workflow updates the slug (no stale value)", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("snippet-slug-input")).toHaveValue("ic-diligence-orchestrator");
+    // onboarding-flow is a second DEPLOYED fixture — the panel must re-init to
+    // its slug, not keep leasing's (regression guard for the remount fix).
+    await page.getByTestId("workflow-onboarding-flow").click();
+    await expect(page.getByTestId("snippet-slug-input")).toHaveValue("onboarding-flow");
+  });
+
   test("editing the slug updates the snippet code live", async ({ page }) => {
     const input = page.getByTestId("snippet-slug-input");
     await input.fill("my-custom-agent");

--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * F1 "Trigger from your code" snippet panel — mock-mode UI tests.
+ *
+ * Fixtures (from mock-data.ts):
+ *   - "leasing"  → deployed (definitionId: 4821, definitionSlug: "ic-diligence-orchestrator")
+ *   - "rfq"      → undeployed (definitionId: null, definitionSlug: null)
+ *   - "onboarding-flow" → deployed (definitionId: 9001, definitionSlug: "onboarding-flow")
+ *
+ * On initial load, "leasing" is pre-bound and pre-selected (the boot session's
+ * boundWorkflowPath is "/Users/demo/acme-app/leasing"). The snippet panel
+ * should be visible immediately.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  // Ensure the leasing workflow is selected (it's the default boot binding).
+  await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-selected/);
+});
+
+test.describe("snippet panel visibility", () => {
+  test("shows the snippet panel when a deployed workflow is bound", async ({ page }) => {
+    // leasing is deployed — the panel should be visible on initial load.
+    await expect(page.getByTestId("snippet-panel")).toBeVisible();
+  });
+
+  test("hides the snippet panel when an undeployed workflow is selected", async ({ page }) => {
+    // Click rfq (no definitionId) — panel must disappear.
+    await page.getByTestId("workflow-rfq").click();
+    await expect(page.getByTestId("snippet-panel")).toHaveCount(0);
+  });
+
+  test("shows the panel again after switching from undeployed back to deployed", async ({ page }) => {
+    await page.getByTestId("workflow-rfq").click();
+    await expect(page.getByTestId("snippet-panel")).toHaveCount(0);
+
+    await page.getByTestId("workflow-leasing").click();
+    await expect(page.getByTestId("snippet-panel")).toBeVisible();
+  });
+});
+
+test.describe("TypeScript tab (default)", () => {
+  test("default tab is TypeScript and contains the SDK call with the correct slug", async ({ page }) => {
+    const panel = page.getByTestId("snippet-panel");
+    const code = panel.getByTestId("snippet-code");
+
+    // TS tab is active by default.
+    await expect(panel.getByTestId("snippet-tab-ts")).toHaveClass(/is-active/);
+    await expect(panel.getByTestId("snippet-tab-curl")).not.toHaveClass(/is-active/);
+
+    // Content assertions.
+    await expect(code).toContainText('agents.run({');
+    await expect(code).toContainText('definition: "ic-diligence-orchestrator"');
+  });
+
+  test("TypeScript snippet does NOT contain forbidden patterns", async ({ page }) => {
+    const code = page.getByTestId("snippet-code");
+    const text = await code.textContent();
+    expect(text).not.toContain("Authorization");
+    expect(text).not.toContain("Bearer");
+    expect(text).not.toContain("api.sapiom.ai");
+    expect(text).not.toContain("/triggers");
+    expect(text).not.toMatch(/sk_[A-Za-z0-9]/);
+  });
+});
+
+test.describe("cURL tab", () => {
+  test("switching to the cURL tab shows the HTTP snippet with the correct endpoint and header", async ({ page }) => {
+    const panel = page.getByTestId("snippet-panel");
+    await panel.getByTestId("snippet-tab-curl").click();
+
+    await expect(panel.getByTestId("snippet-tab-curl")).toHaveClass(/is-active/);
+    await expect(panel.getByTestId("snippet-tab-ts")).not.toHaveClass(/is-active/);
+
+    const code = panel.getByTestId("snippet-code");
+    await expect(code).toContainText("POST https://tools.sapiom.ai/agents/v1/definitions/ic-diligence-orchestrator/executions");
+    await expect(code).toContainText("x-sapiom-api-key: YOUR_SAPIOM_API_KEY");
+  });
+
+  test("cURL snippet does NOT contain forbidden patterns", async ({ page }) => {
+    const panel = page.getByTestId("snippet-panel");
+    await panel.getByTestId("snippet-tab-curl").click();
+
+    const text = await panel.getByTestId("snippet-code").textContent();
+    expect(text).not.toContain("Authorization");
+    expect(text).not.toContain("Bearer");
+    expect(text).not.toContain("api.sapiom.ai");
+    expect(text).not.toContain("/triggers");
+    expect(text).not.toMatch(/sk_[A-Za-z0-9]/);
+  });
+});
+
+test.describe("slug input", () => {
+  test("slug input is pre-filled with the workflow's definitionSlug", async ({ page }) => {
+    const input = page.getByTestId("snippet-slug-input");
+    await expect(input).toHaveValue("ic-diligence-orchestrator");
+  });
+
+  test("editing the slug updates the snippet code live", async ({ page }) => {
+    const input = page.getByTestId("snippet-slug-input");
+    await input.fill("my-custom-agent");
+
+    const code = page.getByTestId("snippet-code");
+    await expect(code).toContainText('definition: "my-custom-agent"');
+  });
+
+  test("clearing the slug falls back to the placeholder in the snippet", async ({ page }) => {
+    const input = page.getByTestId("snippet-slug-input");
+    await input.fill("");
+
+    const code = page.getByTestId("snippet-code");
+    await expect(code).toContainText('definition: "your-agent-slug"');
+  });
+
+  test("slug input has the correct placeholder attribute", async ({ page }) => {
+    await expect(page.getByTestId("snippet-slug-input")).toHaveAttribute("placeholder", "your-agent-slug");
+  });
+});
+
+test.describe("copy button", () => {
+  test("copy button shows 'Copied' confirmation after click and reverts", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const panel = page.getByTestId("snippet-panel");
+    const copyBtn = panel.getByTestId("snippet-copy");
+    await expect(copyBtn).toHaveText("Copy");
+
+    await copyBtn.click();
+
+    // Brief confirmation appears.
+    await expect(copyBtn).toHaveText("Copied");
+
+    // After ~2s the button reverts — use a generous timeout.
+    await expect(copyBtn).toHaveText("Copy", { timeout: 4_000 });
+  });
+
+  test("copy button writes the TS snippet to the clipboard (TS tab)", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const panel = page.getByTestId("snippet-panel");
+    // TS tab is active by default.
+    await expect(panel.getByTestId("snippet-tab-ts")).toHaveClass(/is-active/);
+
+    await panel.getByTestId("snippet-copy").click();
+    await expect(panel.getByTestId("snippet-copy")).toHaveText("Copied");
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toContain("agents.run");
+    expect(clipboardText).toContain("ic-diligence-orchestrator");
+  });
+
+  test("copy button writes the cURL snippet to the clipboard when on the cURL tab", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const panel = page.getByTestId("snippet-panel");
+    await panel.getByTestId("snippet-tab-curl").click();
+
+    await panel.getByTestId("snippet-copy").click();
+    await expect(panel.getByTestId("snippet-copy")).toHaveText("Copied");
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toContain("curl -X POST");
+    expect(clipboardText).toContain("ic-diligence-orchestrator");
+    expect(clipboardText).toContain("x-sapiom-api-key: YOUR_SAPIOM_API_KEY");
+  });
+});
+
+test.describe("panel structure", () => {
+  test("panel has the expected title", async ({ page }) => {
+    await expect(page.getByTestId("snippet-panel")).toContainText("Trigger from your code");
+  });
+
+  test("panel includes the idempotencyKey helper hint", async ({ page }) => {
+    await expect(page.getByTestId("snippet-panel")).toContainText("idempotencyKey");
+  });
+});

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -7,6 +7,7 @@ import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
 import { getTheme, subscribeTheme } from "../lib/theme";
 import { track } from "../lib/track";
 import { Icon } from "./Icon";
+import { SnippetPanel } from "./SnippetPanel";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 
 /** How many of a running task's trailing status lines the activity view shows. */
@@ -131,6 +132,10 @@ export function CanvasPane({
           onReVisualize={handleReVisualize}
           reVisualizeDisabledReason={visualizeDisabledReason}
         />
+      )}
+
+      {boundWorkflow?.definitionId != null && (
+        <SnippetPanel boundWorkflow={boundWorkflow} />
       )}
 
       {!sessionId ? (

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -135,7 +135,10 @@ export function CanvasPane({
       )}
 
       {boundWorkflow?.definitionId != null && (
-        <SnippetPanel boundWorkflow={boundWorkflow} />
+        // key on the workflow path so switching between two *deployed* workflows
+        // remounts the panel — resetting the editable slug/tab to the new agent.
+        // A bare prop change would not re-init the slug useState → stale snippet.
+        <SnippetPanel key={boundWorkflow.path} boundWorkflow={boundWorkflow} />
       )}
 
       {!sessionId ? (

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import type { JSX } from "react";
+import type { WorkflowInfo } from "@shared/types";
+
+import { generateSnippet } from "../lib/generate-snippet";
+
+interface SnippetPanelProps {
+  /** The workflow currently bound to the active session. */
+  boundWorkflow: WorkflowInfo;
+}
+
+type SnippetTab = "typescript" | "curl";
+
+/**
+ * "Trigger from your code" panel — shown below the canvas header whenever the
+ * bound workflow is deployed (definitionId != null). Provides copy-paste
+ * TypeScript SDK and cURL snippets pre-filled with the deployed agent's slug.
+ * The slug is editable so users can correct it if it differs from what's in
+ * sapiom.json, or fill it in manually when the slug is not yet known.
+ */
+export function SnippetPanel({ boundWorkflow }: SnippetPanelProps): JSX.Element | null {
+  // Guard: only render when the workflow is deployed.
+  if (boundWorkflow.definitionId == null) return null;
+
+  return <SnippetPanelInner boundWorkflow={boundWorkflow} />;
+}
+
+// Split into an inner component so hooks are always called after the null-guard
+// without the React-hooks-in-conditionals lint error.
+function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
+  const [activeTab, setActiveTab] = useState<SnippetTab>("typescript");
+  const [slug, setSlug] = useState<string>(boundWorkflow.definitionSlug ?? "");
+  const [copied, setCopied] = useState(false);
+
+  // Effective slug: prefer what the user typed; fall back to placeholder string
+  // in the generated output so there's always something meaningful to copy.
+  const effectiveSlug = slug.trim() || "your-agent-slug";
+  const { typescript, curl } = generateSnippet({ definition: effectiveSlug });
+  const activeSnippet = activeTab === "typescript" ? typescript : curl;
+
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(activeSnippet)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        // Clipboard blocked (e.g. a non-secure context) — leave the button as
+        // "Copy" rather than falsely confirming; never throw into the UI.
+      });
+  };
+
+  return (
+    <div className="snippet-panel" data-testid="snippet-panel">
+      <div className="snippet-panel-header">
+        <span className="snippet-panel-title">Trigger from your code</span>
+      </div>
+
+      <div className="snippet-slug-row">
+        <label className="snippet-slug-label" htmlFor="snippet-slug-input">
+          Agent slug
+        </label>
+        <input
+          id="snippet-slug-input"
+          className="snippet-slug-input"
+          data-testid="snippet-slug-input"
+          type="text"
+          value={slug}
+          placeholder="your-agent-slug"
+          onChange={(e) => setSlug(e.target.value)}
+          spellCheck={false}
+        />
+      </div>
+
+      <div className="snippet-tabs" role="tablist" aria-label="Snippet language">
+        <button
+          role="tab"
+          aria-selected={activeTab === "typescript"}
+          className={"snippet-tab" + (activeTab === "typescript" ? " is-active" : "")}
+          data-testid="snippet-tab-ts"
+          onClick={() => setActiveTab("typescript")}
+        >
+          TypeScript (SDK)
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === "curl"}
+          className={"snippet-tab" + (activeTab === "curl" ? " is-active" : "")}
+          data-testid="snippet-tab-curl"
+          onClick={() => setActiveTab("curl")}
+        >
+          cURL (HTTP)
+        </button>
+      </div>
+
+      <div className="snippet-code-wrap">
+        <pre className="snippet-code" data-testid="snippet-code">
+          <code>{activeSnippet}</code>
+        </pre>
+        <button
+          className={"snippet-copy" + (copied ? " is-copied" : "")}
+          data-testid="snippet-copy"
+          aria-label={copied ? "Copied" : "Copy snippet"}
+          onClick={handleCopy}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+
+      <p className="snippet-hint">
+        Optionally add <code>idempotencyKey</code> to the body to deduplicate retries.
+      </p>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -77,6 +77,7 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         <button
           role="tab"
           aria-selected={activeTab === "typescript"}
+          aria-controls="snippet-code-panel"
           className={"snippet-tab" + (activeTab === "typescript" ? " is-active" : "")}
           data-testid="snippet-tab-ts"
           onClick={() => setActiveTab("typescript")}
@@ -86,6 +87,7 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         <button
           role="tab"
           aria-selected={activeTab === "curl"}
+          aria-controls="snippet-code-panel"
           className={"snippet-tab" + (activeTab === "curl" ? " is-active" : "")}
           data-testid="snippet-tab-curl"
           onClick={() => setActiveTab("curl")}
@@ -94,7 +96,7 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         </button>
       </div>
 
-      <div className="snippet-code-wrap">
+      <div className="snippet-code-wrap" role="tabpanel" id="snippet-code-panel">
         <pre className="snippet-code" data-testid="snippet-code">
           <code>{activeSnippet}</code>
         </pre>

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -360,6 +360,7 @@ class MockApi implements HarnessApi {
       name: path.split("/").filter(Boolean).pop() ?? path,
       path,
       definitionId: null,
+      definitionSlug: null,
       source: "connect",
     };
     this.workflows = [...this.workflows.filter((w) => w.path !== path), info];

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -137,11 +137,11 @@ export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
 };
 
 export const MOCK_WORKFLOWS: WorkflowInfo[] = [
-  { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821, source: "scan" },
-  { name: "rfq", path: "/Users/demo/rfq-workflows", definitionId: null, source: "scan" },
+  { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821, definitionSlug: "ic-diligence-orchestrator", source: "scan" },
+  { name: "rfq", path: "/Users/demo/rfq-workflows", definitionId: null, definitionSlug: null, source: "scan" },
   // Deployed like "leasing" but with a much longer name — exercises the
   // canvas header's deployed-dot staying pinned regardless of name length.
-  { name: "onboarding-flow", path: "/Users/demo/onboarding-flow", definitionId: 9001, source: "connect" },
+  { name: "onboarding-flow", path: "/Users/demo/onboarding-flow", definitionId: 9001, definitionSlug: "onboarding-flow", source: "connect" },
 ];
 
 export const MOCK_MACROS: MacroDef[] = [

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2455,6 +2455,201 @@ input {
 
 /* Skills footer */
 
+/* Snippet panel (F1 "Trigger from your code") ----------------------------- */
+
+/* Sits below WorkflowActionsHeader in the canvas pane — only visible when
+   the bound workflow is deployed (definitionId != null). Styled to feel like
+   a quiet information card: muted background, no heavy chrome, code block in
+   the same monospace voice as the rest of the harness. */
+.snippet-panel {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+  font-size: 12px;
+}
+
+.snippet-panel-header {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px 4px;
+}
+
+.snippet-panel-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+/* Slug input row -------------------------------------------------------- */
+
+.snippet-slug-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px 6px;
+}
+
+.snippet-slug-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.snippet-slug-input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
+  padding: 4px 7px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  transition: border-color var(--transition-fast);
+}
+
+.snippet-slug-input::placeholder {
+  color: var(--text-faint);
+}
+
+.snippet-slug-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Language tabs --------------------------------------------------------- */
+
+.snippet-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 10px 6px;
+}
+
+/* Matches the .right-pane-tab recipe: transparent at rest, outlined when
+   active — one consistent tab visual language across the harness. */
+.snippet-tab {
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-faint);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.snippet-tab:hover {
+  color: var(--text-dim);
+  background: var(--bg-hover);
+}
+
+.snippet-tab.is-active {
+  color: var(--text);
+  background: var(--bg-1);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-xs);
+}
+
+.snippet-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Code block ------------------------------------------------------------ */
+
+.snippet-code-wrap {
+  position: relative;
+  margin: 0 10px 4px;
+}
+
+.snippet-code {
+  margin: 0;
+  padding: 8px 10px;
+  padding-right: 52px; /* leave room for the copy button */
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  overflow-x: auto;
+  white-space: pre;
+  /* Constrain height so a long snippet doesn't push the rest of the pane
+     off screen — the canvas content below it is more important. */
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+/* Copy button ----------------------------------------------------------- */
+
+/* Positioned in the top-right corner of the code block so it never
+   obscures the first line's content. Small and quiet at rest; brief
+   "Copied" confirmation replaces the label for ~2s after a successful
+   write. */
+.snippet-copy {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-faint);
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.snippet-copy:hover:not(.is-copied) {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.snippet-copy.is-copied {
+  color: var(--accent);
+  border-color: var(--accent-border);
+  background: var(--accent-dim);
+  cursor: default;
+}
+
+.snippet-copy:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Helper text ----------------------------------------------------------- */
+
+.snippet-hint {
+  margin: 0;
+  padding: 4px 10px 8px;
+  font-size: 10.5px;
+  color: var(--text-faint);
+  line-height: 1.4;
+}
+
+.snippet-hint code {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
 /* Scrollbars — thin thumb-only styling, matching the product's own
    (rgba(161, 161, 170, 0.75), 8px, no visible track) in both themes. */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
The F1 "Trigger from your code" panel — the user-facing half of Feature 1. After a deploy, the canvas shows copy-paste **TypeScript (SDK)** + **cURL (HTTP)** snippets for the bound agent, pre-filled with its slug and editable. Consumes A1's `generateSnippet` (`tools.sapiom.ai` + `x-sapiom-api-key`) — verified against the live executions endpoint.

Linear: SAP-1605

## Slug auto-fill (resolved open question)
The executions endpoint addresses an agent by its **slug = the `defineAgent({ name })`** (confirmed in prod: `POST tools.sapiom.ai/agents/v1/definitions/<name>/executions`). The harness previously surfaced only a numeric `definitionId`, so this PR:
- reads `name` from `sapiom.json` in the workflow registry and exposes it as **`WorkflowInfo.definitionSlug`**;
- auto-fills the panel's slug from it, **editable**, with a `your-agent-slug` fallback when unlinked — so it can never emit a silently-wrong slug.

## Changes
- **web:** `SnippetPanel.tsx` (tabs, copy + confirmation, editable slug, `idempotencyKey` hint) mounted in `CanvasPane` after the actions header, **shown only for a deployed workflow**; `.snippet-*` styles.
- **server:** `WorkflowInfo.definitionSlug` + registry marker read of `sapiom.json` `name`.
- **mock/tests:** `definitionSlug` on mock workflows + 9 `WorkflowInfo` literals updated for the new required field.
- **e2e:** `web/e2e/snippet-panel.spec.ts` (mock tier).

## Test plan
- `typecheck` / `lint` — clean.
- `test:ui` — full mock e2e green, incl. the new snippet-panel spec (16 tests): visibility toggle, TS/cURL content, **negative asserts** (no `Authorization`/`Bearer`/`api.sapiom.ai`/`/triggers`/`sk_`), slug edit/fallback, copy.
- Unit suite green (the single red is the pre-existing env-dependent skills test — fails on base too).

## Stack & review
- Base `feat/harness-snippets` (stacks on the merged A1). ≥1 manual claude-review pass (0 CI reviewers). Snippet unchanged from A1 (idempotencyKey/`$SAPIOM_API_KEY` intentionally kept as optional helper text, not baked in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)