### PR TITLE
fix(harness): make the snippet panel's agent slug read-only

### DIFF
--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -91,40 +91,27 @@ test.describe("cURL tab", () => {
   });
 });
 
-test.describe("slug input", () => {
-  test("slug input is pre-filled with the workflow's definitionSlug", async ({ page }) => {
-    const input = page.getByTestId("snippet-slug-input");
-    await expect(input).toHaveValue("ic-diligence-orchestrator");
+test.describe("slug (read-only)", () => {
+  test("shows the deployed agent's slug", async ({ page }) => {
+    await expect(page.getByTestId("snippet-slug")).toHaveText("ic-diligence-orchestrator");
   });
 
-  test("switching to a second deployed workflow updates the slug (no stale value)", async ({
+  test("the slug is read-only — not an editable input (it's the agent's identity, not a rename field)", async ({
     page,
   }) => {
-    await expect(page.getByTestId("snippet-slug-input")).toHaveValue("ic-diligence-orchestrator");
-    // onboarding-flow is a second DEPLOYED fixture — the panel must re-init to
-    // its slug, not keep leasing's (regression guard for the remount fix).
+    await expect(page.getByTestId("snippet-slug-input")).toHaveCount(0);
+    await expect(page.locator(".snippet-panel input")).toHaveCount(0);
+  });
+
+  test("switching to a second deployed workflow shows the new slug (no stale value)", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("snippet-slug")).toHaveText("ic-diligence-orchestrator");
+    // onboarding-flow is a second DEPLOYED fixture — the panel must reflect its
+    // slug, not keep leasing's.
     await page.getByTestId("workflow-onboarding-flow").click();
-    await expect(page.getByTestId("snippet-slug-input")).toHaveValue("onboarding-flow");
-  });
-
-  test("editing the slug updates the snippet code live", async ({ page }) => {
-    const input = page.getByTestId("snippet-slug-input");
-    await input.fill("my-custom-agent");
-
-    const code = page.getByTestId("snippet-code");
-    await expect(code).toContainText('definition: "my-custom-agent"');
-  });
-
-  test("clearing the slug falls back to the placeholder in the snippet", async ({ page }) => {
-    const input = page.getByTestId("snippet-slug-input");
-    await input.fill("");
-
-    const code = page.getByTestId("snippet-code");
-    await expect(code).toContainText('definition: "your-agent-slug"');
-  });
-
-  test("slug input has the correct placeholder attribute", async ({ page }) => {
-    await expect(page.getByTestId("snippet-slug-input")).toHaveAttribute("placeholder", "your-agent-slug");
+    await expect(page.getByTestId("snippet-slug")).toHaveText("onboarding-flow");
+    await expect(page.getByTestId("snippet-code")).toContainText('definition: "onboarding-flow"');
   });
 });
 

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -136,8 +136,8 @@ export function CanvasPane({
 
       {boundWorkflow?.definitionId != null && (
         // key on the workflow path so switching between two *deployed* workflows
-        // remounts the panel — resetting the editable slug/tab to the new agent.
-        // A bare prop change would not re-init the slug useState → stale snippet.
+        // remounts the panel, resetting its tab/copied state to the new agent.
+        // (The slug itself is read-only and derives straight from the prop.)
         <SnippetPanel key={boundWorkflow.path} boundWorkflow={boundWorkflow} />
       )}
 

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -14,9 +14,13 @@ type SnippetTab = "typescript" | "curl";
 /**
  * "Trigger from your code" panel — shown below the canvas header whenever the
  * bound workflow is deployed (definitionId != null). Provides copy-paste
- * TypeScript SDK and cURL snippets pre-filled with the deployed agent's slug.
- * The slug is editable so users can correct it if it differs from what's in
- * sapiom.json, or fill it in manually when the slug is not yet known.
+ * TypeScript SDK and cURL snippets for the deployed agent.
+ *
+ * The slug is READ-ONLY: it is the deployed agent's stable handle
+ * (`defineAgent({ name })`, cached in sapiom.json) and the executions-API
+ * identity — NOT something you rename here. Editing it would only make the
+ * snippet call a non-existent agent (404). To rename an agent, change its
+ * `defineAgent` name in code and redeploy.
  */
 export function SnippetPanel({ boundWorkflow }: SnippetPanelProps): JSX.Element | null {
   // Guard: only render when the workflow is deployed.
@@ -29,13 +33,13 @@ export function SnippetPanel({ boundWorkflow }: SnippetPanelProps): JSX.Element 
 // without the React-hooks-in-conditionals lint error.
 function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
   const [activeTab, setActiveTab] = useState<SnippetTab>("typescript");
-  const [slug, setSlug] = useState<string>(boundWorkflow.definitionSlug ?? "");
   const [copied, setCopied] = useState(false);
 
-  // Effective slug: prefer what the user typed; fall back to placeholder string
-  // in the generated output so there's always something meaningful to copy.
-  const effectiveSlug = slug.trim() || "your-agent-slug";
-  const { typescript, curl } = generateSnippet({ definition: effectiveSlug });
+  // The slug is read straight from the deployed workflow — never user-edited, so
+  // the snippet can only ever reference the real agent. Falls back to a clear
+  // placeholder only if a deployed agent somehow has no cached name.
+  const slug = boundWorkflow.definitionSlug ?? "your-agent-slug";
+  const { typescript, curl } = generateSnippet({ definition: slug });
   const activeSnippet = activeTab === "typescript" ? typescript : curl;
 
   const handleCopy = (): void => {
@@ -58,19 +62,10 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
       </div>
 
       <div className="snippet-slug-row">
-        <label className="snippet-slug-label" htmlFor="snippet-slug-input">
-          Agent slug
-        </label>
-        <input
-          id="snippet-slug-input"
-          className="snippet-slug-input"
-          data-testid="snippet-slug-input"
-          type="text"
-          value={slug}
-          placeholder="your-agent-slug"
-          onChange={(e) => setSlug(e.target.value)}
-          spellCheck={false}
-        />
+        <span className="snippet-slug-label">Agent</span>
+        <code className="snippet-slug" data-testid="snippet-slug">
+          {slug}
+        </code>
       </div>
 
       <div className="snippet-tabs" role="tablist" aria-label="Snippet language">

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2500,28 +2500,19 @@ input {
   flex-shrink: 0;
 }
 
-.snippet-slug-input {
+/* Read-only chip showing the deployed agent's slug (not user-editable). */
+.snippet-slug {
   flex: 1;
   min-width: 0;
+  overflow-x: auto;
   background: var(--bg-3);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-xs);
   padding: 4px 7px;
   color: var(--text);
   font-family: var(--font-mono);
   font-size: 11px;
-  transition: border-color var(--transition-fast);
-}
-
-.snippet-slug-input::placeholder {
-  color: var(--text-faint);
-}
-
-.snippet-slug-input:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--focus-ring);
+  white-space: nowrap;
 }
 
 /* Language tabs --------------------------------------------------------- */


### PR DESCRIPTION
## Why
Beta testing surfaced a real UX trap: the panel's **editable "Agent slug"** field *looked* like a rename control. Typing a new value (e.g. `finance-bro`) didn't rename the agent — it just pointed the generated snippet at a non-existent agent, producing a silent **404** on run. The real agent (`ic-diligence-orchestrator`) was unchanged.

## Fix
The slug is the deployed agent's **identity** (`defineAgent({ name })` = the executions-API handle), which we verified is reliably surfaced as `WorkflowInfo.definitionSlug`. So it's now **read-only** — the panel always shows and uses the real deployed slug; the snippet can't be pointed at a ghost. Renaming is a code change (`defineAgent`) + redeploy, not a text field.

## Changes
- `SnippetPanel.tsx`: remove the editable `<input>` + `slug` state; render the slug as a read-only chip (`data-testid="snippet-slug"`), read straight from `boundWorkflow.definitionSlug`.
- `styles.css`: `.snippet-slug-input` → read-only `.snippet-slug` chip.
- e2e: replace the edit/clear/placeholder tests with read-only ones, incl. an explicit **"not an editable input"** guard + "switching workflows shows the new slug".

## Test plan
- typecheck ✓ · lint ✓ · snippet-panel e2e **15/15** (incl. read-only guard).

Base `feat/harness-snippets` (before F1 ships to main). ≥1 manual claude-review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)