### PR TITLE
feat(harness): resolve the real deployed agent slug for the trigger snippet

### DIFF
--- a/packages/harness/src/core/definition-slug-resolver.test.ts
+++ b/packages/harness/src/core/definition-slug-resolver.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDefinitionSlugResolver } from "./definition-slug-resolver.js";
+
+/** Builds a minimal fetch mock that returns a JSON body with a given status. */
+function makeFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as Response);
+}
+
+/** Builds a fetch mock that throws (simulates a network error). */
+function makeThrowingFetch(error: Error = new Error("network error")): typeof fetch {
+  return vi.fn().mockRejectedValue(error);
+}
+
+describe("createDefinitionSlugResolver", () => {
+  it("resolves a definitionId to its slug on a 200 response", async () => {
+    const fetchImpl = makeFetch(200, { id: "188", slug: "ic-diligence-orchestrator", name: "IC Diligence" });
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const slug = await resolver.resolve("188");
+
+    expect(slug).toBe("ic-diligence-orchestrator");
+  });
+
+  it("calls the correct URL with the api key header", async () => {
+    const fetchImpl = makeFetch(200, { slug: "my-agent" });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "my-api-key",
+      baseUrl: "https://tools.sapiom.ai",
+      fetchImpl,
+    });
+
+    await resolver.resolve("42");
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://tools.sapiom.ai/agents/v1/definitions/42", {
+      headers: { "x-sapiom-api-key": "my-api-key" },
+    });
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    const fetchImpl = makeFetch(404, { error: "not found" });
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const slug = await resolver.resolve("999");
+
+    expect(slug).toBeNull();
+  });
+
+  it("returns null when fetch throws (network error)", async () => {
+    const fetchImpl = makeThrowingFetch();
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const slug = await resolver.resolve("188");
+
+    expect(slug).toBeNull();
+  });
+
+  it("returns null without calling fetch when apiKey is null", async () => {
+    const fetchImpl = vi.fn();
+    const resolver = createDefinitionSlugResolver({ apiKey: null, fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const slug = await resolver.resolve("188");
+
+    expect(slug).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the response body has no slug field", async () => {
+    const fetchImpl = makeFetch(200, { id: "188", name: "My Agent" });
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const slug = await resolver.resolve("188");
+
+    expect(slug).toBeNull();
+  });
+
+  it("caches a successful resolution so the second call does not fetch", async () => {
+    const fetchImpl = makeFetch(200, { slug: "cached-agent" });
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const first = await resolver.resolve("188");
+    const second = await resolver.resolve("188");
+
+    expect(first).toBe("cached-agent");
+    expect(second).toBe("cached-agent");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a null resolution (allows retry after transient failure)", async () => {
+    let calls = 0;
+    const fetchImpl = vi.fn().mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new Error("transient");
+      return { ok: true, json: async () => ({ slug: "recovered" }) } as Response;
+    });
+
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const first = await resolver.resolve("188");
+    const second = await resolver.resolve("188");
+
+    expect(first).toBeNull();
+    expect(second).toBe("recovered");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when slug field is not a string (wrong type in body)", async () => {
+    const fetchImpl = makeFetch(200, { slug: 42 });
+    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+
+    const slug = await resolver.resolve("188");
+
+    expect(slug).toBeNull();
+  });
+});

--- a/packages/harness/src/core/definition-slug-resolver.ts
+++ b/packages/harness/src/core/definition-slug-resolver.ts
@@ -1,0 +1,67 @@
+/**
+ * Serve-time enrichment: resolves a deployed agent's `definitionSlug` from the
+ * Sapiom Agents API by its `definitionId`. The registry only knows the id (from
+ * `sapiom.json`'s `{ "definitionId": "188" }`) — the slug lives server-side,
+ * keyed by id.
+ *
+ * Resolution is cached in-memory (id→slug is stable once deployed; a slug
+ * never changes for a given id) so repeat calls across requests are free.
+ * Null resolutions are NOT cached: a transient network failure should be
+ * retryable without a server restart.
+ *
+ * Mirrors `@sapiom/tools`'s DEFAULT_BASE_URL for the base URL resolution.
+ */
+
+/** Returns the agents API base URL, honouring the same env-var precedence as
+ *  @sapiom/tools's DEFAULT_BASE_URL. */
+export function resolveAgentsBaseUrl(): string {
+  return process.env.SAPIOM_AGENTS_URL ?? process.env.SAPIOM_TOOLS_BASE ?? "https://tools.sapiom.ai";
+}
+
+export interface DefinitionSlugResolver {
+  resolve(definitionId: string): Promise<string | null>;
+}
+
+/**
+ * Creates a resolver that fetches `GET /agents/v1/definitions/<id>` with the
+ * caller's API key and returns the `slug` field from the response.
+ *
+ * Safe to call from any request handler: never throws, returns null on any
+ * failure (network, 4xx, missing field, unparseable body).
+ */
+export function createDefinitionSlugResolver(opts: {
+  apiKey: string | null;
+  baseUrl?: string;
+  /** Injectable for unit tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}): DefinitionSlugResolver {
+  const { apiKey, baseUrl = resolveAgentsBaseUrl(), fetchImpl = fetch } = opts;
+  const cache = new Map<string, string>();
+
+  return {
+    async resolve(definitionId: string): Promise<string | null> {
+      if (!apiKey) return null;
+
+      const cached = cache.get(definitionId);
+      if (cached !== undefined) return cached;
+
+      try {
+        const url = `${baseUrl}/agents/v1/definitions/${encodeURIComponent(definitionId)}`;
+        const response = await fetchImpl(url, {
+          headers: { "x-sapiom-api-key": apiKey },
+        });
+
+        if (!response.ok) return null;
+
+        const body = (await response.json()) as Record<string, unknown>;
+        const slug = typeof body.slug === "string" ? body.slug : null;
+        if (slug !== null) {
+          cache.set(definitionId, slug);
+        }
+        return slug;
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -222,7 +222,19 @@ export class WorkflowRegistry {
   }
 }
 
-export function createWorkflowsRouter(registry: WorkflowRegistry): ExpressRouter {
+/**
+ * The subset of {@link WorkflowRegistry} the workflows router depends on. Typed
+ * structurally so a caller can pass a wrapper (e.g. one that enriches `list()`
+ * with resolved slugs) without an unsafe cast — a missing method is then a
+ * compile error, not a runtime crash.
+ */
+export interface WorkflowRegistryLike {
+  list(): Promise<WorkflowInfo[]>;
+  scan(root: string): Promise<WorkflowInfo[]>;
+  connectPath(inputPath: string): Promise<WorkflowInfo>;
+}
+
+export function createWorkflowsRouter(registry: WorkflowRegistryLike): ExpressRouter {
   const router = Router();
 
   router.get("/api/workflows", async (_req, res) => {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -29,7 +29,7 @@ import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.
 import { TaskManager } from "../core/task-manager.js";
 import { createClaudeCodeAdapter } from "../core/adapters/claude-code.js";
 import { createCodexAdapter } from "../core/adapters/codex.js";
-import { WorkflowRegistry, createWorkflowsRouter } from "../core/workflow-registry.js";
+import { WorkflowRegistry, type WorkflowRegistryLike, createWorkflowsRouter } from "../core/workflow-registry.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
 import { createEventStore } from "../core/collector/store.js";
 import { createHarnessEmitter } from "../core/collector/analytics-emitter.js";
@@ -55,6 +55,7 @@ import { ensureCanvasTemplate } from "../core/canvas-template.js";
 import { renderCanvasForSession, renderWorkflowRenderFile } from "../core/canvas-render.js";
 import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
+import { createDefinitionSlugResolver, resolveAgentsBaseUrl } from "../core/definition-slug-resolver.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
@@ -250,6 +251,33 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // already exists or when HOME is unwritable.
   await migrateHarnessIdentity(statePaths.machineId);
   const launchDir = options.launchDir ?? process.cwd();
+
+  // Serve-time slug enrichment: resolves each workflow's definitionSlug from
+  // the Sapiom Agents API when it's absent (deployed sapiom.json files carry
+  // only { "definitionId": "188" }, not the slug). Constructed once per server
+  // boot; caches successful id→slug resolutions in-memory (ids are stable).
+  // Never throws — a failed resolution leaves definitionSlug as-is.
+  const slugResolver = createDefinitionSlugResolver({
+    apiKey: identity?.apiKey ?? null,
+    baseUrl: resolveAgentsBaseUrl(),
+  });
+
+  /** Returns a copy of the workflow list with definitionSlug filled in from
+   *  the Agents API for any workflow that has a definitionId but no slug.
+   *  Resolves all lookups in parallel. Never mutates the registry. */
+  const enrichWorkflows = async (workflows: WorkflowInfo[]): Promise<WorkflowInfo[]> => {
+    return Promise.all(
+      workflows.map(async (workflow) => {
+        if (workflow.definitionId == null || (workflow.definitionSlug != null && workflow.definitionSlug !== "")) {
+          return workflow;
+        }
+        const resolved = await slugResolver.resolve(String(workflow.definitionId));
+        if (resolved == null) return workflow;
+        return { ...workflow, definitionSlug: resolved };
+      }),
+    );
+  };
+
   const adapters: Partial<Record<HarnessKind, HarnessAdapter>> =
     options.adapters ??
     ({
@@ -594,7 +622,7 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       adapters,
       version: readVersion(),
       identity: identity ? { userId: identity.userId, organizationName: identity.organizationName } : null,
-      listWorkflows: () => workflowRegistry.list(),
+      listWorkflows: () => workflowRegistry.list().then(enrichWorkflows),
       listMacros: () => DEFAULT_MACROS,
       findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
       writeWorkspaceContext: writeSessionContext,
@@ -645,8 +673,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       listWorkflows: () => workflowsCache,
     }),
   );
+  // Wrap the registry so GET /api/workflows also returns enriched slugs —
+  // the same enrichWorkflows pass that /api/state uses above. Only `list()` is
+  // wrapped; scan/connect write through to the real registry untouched. Typed
+  // as WorkflowRegistryLike so this wrapper needs no unsafe cast.
+  const enrichedWorkflowRegistry: WorkflowRegistryLike = {
+    list: () => workflowRegistry.list().then(enrichWorkflows),
+    scan: (root: string) => workflowRegistry.scan(root),
+    connectPath: (inputPath: string) => workflowRegistry.connectPath(inputPath),
+  };
   app.use(
-    createWorkflowsRouter(workflowRegistry),
+    createWorkflowsRouter(enrichedWorkflowRegistry),
     createFsRouter(),
     createSkillsRouter(),
     createMacrosRouter({


### PR DESCRIPTION
## Why
Beta testing exposed that the snippet showed a `your-agent-slug` **template for every agent**. Root cause: deployed agents' `sapiom.json` contains only `{ "definitionId": "188" }` — **no `name`** — so A2's "read name from sapiom.json" produced a null slug for all of them.

## Fix
The slug lives on the **server**, keyed by `definitionId`. The harness holds a credential (`identity.apiKey`), so it now resolves `definitionId → slug` from the Agents API and enriches the workflows served to the SPA. Verified live: `GET /agents/v1/definitions/188 → { slug: "ic-diligence-orchestrator" }`.

## Changes
- **`definition-slug-resolver.ts`** (+ 9 unit tests): `GET {base}/agents/v1/definitions/{id}` with `x-sapiom-api-key`, returns `.slug`; in-memory cache (success only), env-aware base (`SAPIOM_AGENTS_URL ?? SAPIOM_TOOLS_BASE ?? tools.sapiom.ai`), **never throws**.
- **`index.ts`**: construct the resolver with `identity.apiKey`; `enrichWorkflows` fills `definitionSlug` (only when `definitionId` set + slug missing, parallel, immutable) on both `AppState.workflows` and `GET /api/workflows`. Registry stays pure (serve-time enrichment; nothing persisted).
- **`workflow-registry.ts`**: `WorkflowRegistryLike` interface so the enriching wrapper is typed structurally — **no `as unknown as` cast** (addressed the review's one concern).

## Test plan
- typecheck ✓ · lint ✓ · `definition-slug-resolver` unit **9/9** · full unit suite green (1 pre-existing env-dependent skills flake, fails on base too) · mock e2e green.
- Reviewed (code-reviewer → safe-to-merge; its cast nit fixed).
- **Human test:** rebuild the harness, bind a deployed agent → the panel shows its real slug (e.g. `ic-diligence-orchestrator`) instead of the template.

Base `feat/harness-snippets`, before F1 ships. Note: a **pre-existing NUL byte** in `index.ts` (present on `main`) is unrelated to this change — worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)