### PR TITLE
feat(harness): link to the dashboard for an API key in the snippet panel

### DIFF
--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -180,4 +180,15 @@ test.describe("panel structure", () => {
   test("panel includes the idempotencyKey helper hint", async ({ page }) => {
     await expect(page.getByTestId("snippet-panel")).toContainText("idempotencyKey");
   });
+
+  test("links to the dashboard where users get an API key (for use outside the harness)", async ({
+    page,
+  }) => {
+    const link = page.getByTestId("snippet-api-key-link");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "https://app.sapiom.ai/settings");
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", /noreferrer/);
+    await expect(page.getByTestId("snippet-panel")).toContainText("YOUR_SAPIOM_API_KEY");
+  });
 });

--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -186,7 +186,7 @@ test.describe("panel structure", () => {
   }) => {
     const link = page.getByTestId("snippet-api-key-link");
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute("href", "https://app.sapiom.ai/settings");
+    await expect(link).toHaveAttribute("href", "https://app.sapiom.ai/settings?tab=api-keys");
     await expect(link).toHaveAttribute("target", "_blank");
     await expect(link).toHaveAttribute("rel", /noreferrer/);
     await expect(page.getByTestId("snippet-panel")).toContainText("YOUR_SAPIOM_API_KEY");

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -4,6 +4,12 @@ import type { WorkflowInfo } from "@shared/types";
 
 import { generateSnippet } from "../lib/generate-snippet";
 
+/** Sapiom dashboard page where a user mints/manages the tenant API key that the
+ *  snippet's `YOUR_SAPIOM_API_KEY` placeholder stands in for. Needed to run a
+ *  deployed agent from outside the harness (the harness's own session key is
+ *  not a copy-pasteable credential for a user's code). */
+const SAPIOM_API_KEYS_URL = "https://app.sapiom.ai/settings";
+
 interface SnippetPanelProps {
   /** The workflow currently bound to the active session. */
   boundWorkflow: WorkflowInfo;
@@ -105,6 +111,18 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         </button>
       </div>
 
+      <p className="snippet-hint">
+        Replace <code>YOUR_SAPIOM_API_KEY</code> with a key from your{" "}
+        <a
+          className="snippet-link"
+          data-testid="snippet-api-key-link"
+          href={SAPIOM_API_KEYS_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Sapiom dashboard →
+        </a>
+      </p>
       <p className="snippet-hint">
         Optionally add <code>idempotencyKey</code> to the body to deduplicate retries.
       </p>

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -8,7 +8,7 @@ import { generateSnippet } from "../lib/generate-snippet";
  *  snippet's `YOUR_SAPIOM_API_KEY` placeholder stands in for. Needed to run a
  *  deployed agent from outside the harness (the harness's own session key is
  *  not a copy-pasteable credential for a user's code). */
-const SAPIOM_API_KEYS_URL = "https://app.sapiom.ai/settings";
+const SAPIOM_API_KEYS_URL = "https://app.sapiom.ai/settings?tab=api-keys";
 
 interface SnippetPanelProps {
   /** The workflow currently bound to the active session. */

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2641,6 +2641,16 @@ input {
   color: var(--text-dim);
 }
 
+.snippet-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.snippet-link:hover {
+  text-decoration: underline;
+}
+
 /* Scrollbars — thin thumb-only styling, matching the product's own
    (rgba(161, 161, 170, 0.75), 8px, no visible track) in both themes. */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Why
Beta testing exposed a dead end: the snippet's `YOUR_SAPIOM_API_KEY` placeholder gave **no pointer to where to get a real key**. To run a deployed agent from their own code/CI, a user needs a **tenant API key from the dashboard** — the harness's own authenticated session credential is not a copy-pasteable key for external use (and surfacing it is a security risk). Without this link, the "trigger from your code" flow is unusable outside the harness.

## Change
- Add a **"Sapiom dashboard →"** link beneath the snippet, pointing at `https://app.sapiom.ai/settings` (the dashboard's API Keys page — `(dashboard)/settings` → `SettingsApiKeys`/`CreateApiKeyModal`), with copy "Replace `YOUR_SAPIOM_API_KEY` with a key from your Sapiom dashboard →". `target="_blank"` + `rel="noreferrer"`.
- `.snippet-link` style; e2e assertion (visible, correct href/target/rel).

## Test plan
- typecheck ✓ · lint ✓ · snippet-panel e2e **16/16** (incl. the new link test).

Base `feat/harness-snippets`. ≥1 manual claude-review pass. (Dashboard URL is prod `app.sapiom.ai` for now; making it env-aware is part of the separate env-aware-host follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)