### PR TITLE
fix(harness): resilient trigger-snippet slug — folder-name fallback + env-aware host

### DIFF
--- a/.changeset/harness-snippet-slug-fallback.md
+++ b/.changeset/harness-snippet-slug-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Make the deployed-agent trigger snippet resilient when the agent's slug can't be resolved from the deployment. The panel now falls back to the project name (and flags it as inferred so you can verify) instead of showing a fill-in placeholder in the read-only slug field, and it targets the configured Agents API host so the copy-paste call reaches the same environment the agent was deployed to.

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ Thumbs.db
 .claude/commands/
 .trees
 
+# Harness runtime output — canvas renders/cache + per-project context the CLI
+# writes into whatever directory it's launched in. Never source.
+.sapiom/
+
 # Local Verdaccio registry (SDK dev loop) — storage + runtime auth, never committed
 .verdaccio/storage/
 .verdaccio/.npmrc

--- a/packages/harness/src/core/definition-slug-resolver.test.ts
+++ b/packages/harness/src/core/definition-slug-resolver.test.ts
@@ -1,23 +1,43 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createDefinitionSlugResolver } from "./definition-slug-resolver.js";
 
 /** Builds a minimal fetch mock that returns a JSON body with a given status. */
 function makeFetch(status: number, body: unknown): typeof fetch {
   return vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
+    status,
     json: async () => body,
   } as Response);
 }
 
 /** Builds a fetch mock that throws (simulates a network error). */
-function makeThrowingFetch(error: Error = new Error("network error")): typeof fetch {
+function makeThrowingFetch(
+  error: Error = new Error("network error"),
+): typeof fetch {
   return vi.fn().mockRejectedValue(error);
 }
 
 describe("createDefinitionSlugResolver", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    // Silence + capture the diagnostic the resolver logs on failure, so the
+    // suite output stays clean and the log-once behaviour is assertable.
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
   it("resolves a definitionId to its slug on a 200 response", async () => {
-    const fetchImpl = makeFetch(200, { id: "188", slug: "ic-diligence-orchestrator", name: "IC Diligence" });
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const fetchImpl = makeFetch(200, {
+      id: "188",
+      slug: "ic-diligence-orchestrator",
+      name: "IC Diligence",
+    });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const slug = await resolver.resolve("188");
 
@@ -34,14 +54,20 @@ describe("createDefinitionSlugResolver", () => {
 
     await resolver.resolve("42");
 
-    expect(fetchImpl).toHaveBeenCalledWith("https://tools.sapiom.ai/agents/v1/definitions/42", {
-      headers: { "x-sapiom-api-key": "my-api-key" },
-    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://tools.sapiom.ai/agents/v1/definitions/42",
+      {
+        headers: { "x-sapiom-api-key": "my-api-key" },
+      },
+    );
   });
 
   it("returns null on a non-2xx response", async () => {
     const fetchImpl = makeFetch(404, { error: "not found" });
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const slug = await resolver.resolve("999");
 
@@ -50,7 +76,10 @@ describe("createDefinitionSlugResolver", () => {
 
   it("returns null when fetch throws (network error)", async () => {
     const fetchImpl = makeThrowingFetch();
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const slug = await resolver.resolve("188");
 
@@ -59,7 +88,10 @@ describe("createDefinitionSlugResolver", () => {
 
   it("returns null without calling fetch when apiKey is null", async () => {
     const fetchImpl = vi.fn();
-    const resolver = createDefinitionSlugResolver({ apiKey: null, fetchImpl: fetchImpl as unknown as typeof fetch });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
 
     const slug = await resolver.resolve("188");
 
@@ -69,7 +101,10 @@ describe("createDefinitionSlugResolver", () => {
 
   it("returns null when the response body has no slug field", async () => {
     const fetchImpl = makeFetch(200, { id: "188", name: "My Agent" });
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const slug = await resolver.resolve("188");
 
@@ -78,7 +113,10 @@ describe("createDefinitionSlugResolver", () => {
 
   it("caches a successful resolution so the second call does not fetch", async () => {
     const fetchImpl = makeFetch(200, { slug: "cached-agent" });
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const first = await resolver.resolve("188");
     const second = await resolver.resolve("188");
@@ -93,10 +131,16 @@ describe("createDefinitionSlugResolver", () => {
     const fetchImpl = vi.fn().mockImplementation(async () => {
       calls++;
       if (calls === 1) throw new Error("transient");
-      return { ok: true, json: async () => ({ slug: "recovered" }) } as Response;
+      return {
+        ok: true,
+        json: async () => ({ slug: "recovered" }),
+      } as Response;
     });
 
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const first = await resolver.resolve("188");
     const second = await resolver.resolve("188");
@@ -108,10 +152,43 @@ describe("createDefinitionSlugResolver", () => {
 
   it("returns null when slug field is not a string (wrong type in body)", async () => {
     const fetchImpl = makeFetch(200, { slug: 42 });
-    const resolver = createDefinitionSlugResolver({ apiKey: "test-key", fetchImpl });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
 
     const slug = await resolver.resolve("188");
 
     expect(slug).toBeNull();
+  });
+
+  it("logs a resolution failure once per definitionId, not on every poll", async () => {
+    const fetchImpl = makeFetch(404, { error: "not found" });
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "test-key",
+      fetchImpl,
+    });
+
+    // Null isn't cached, so all three lookups hit the network — but only the
+    // first failure is logged (the panel polls this endpoint continuously).
+    await resolver.resolve("777");
+    await resolver.resolve("777");
+    await resolver.resolve("777");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(String(errorSpy.mock.calls[0][0])).toContain("definitionId=777");
+    expect(String(errorSpy.mock.calls[0][0])).toContain("HTTP 404");
+  });
+
+  it("does not log when there is no api key (a harness without auth is expected)", async () => {
+    const resolver = createDefinitionSlugResolver({
+      apiKey: null,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    });
+
+    await resolver.resolve("188");
+
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/harness/src/core/definition-slug-resolver.ts
+++ b/packages/harness/src/core/definition-slug-resolver.ts
@@ -15,7 +15,11 @@
 /** Returns the agents API base URL, honouring the same env-var precedence as
  *  @sapiom/tools's DEFAULT_BASE_URL. */
 export function resolveAgentsBaseUrl(): string {
-  return process.env.SAPIOM_AGENTS_URL ?? process.env.SAPIOM_TOOLS_BASE ?? "https://tools.sapiom.ai";
+  return (
+    process.env.SAPIOM_AGENTS_URL ??
+    process.env.SAPIOM_TOOLS_BASE ??
+    "https://tools.sapiom.ai"
+  );
 }
 
 export interface DefinitionSlugResolver {
@@ -37,9 +41,27 @@ export function createDefinitionSlugResolver(opts: {
 }): DefinitionSlugResolver {
   const { apiKey, baseUrl = resolveAgentsBaseUrl(), fetchImpl = fetch } = opts;
   const cache = new Map<string, string>();
+  // Each id's resolution failure is logged at most once. resolve() runs on
+  // every /api/state and /api/workflows poll and null results are deliberately
+  // not cached (so a transient failure stays retryable), so without this a
+  // persistent failure — e.g. the harness signed into an account that can't
+  // see this agent — would reprint on every poll. One line per id is enough to
+  // diagnose why the snippet panel fell back to the project name.
+  const loggedFailures = new Set<string>();
+  const warnOnce = (definitionId: string, reason: string): void => {
+    if (loggedFailures.has(definitionId)) return;
+    loggedFailures.add(definitionId);
+    console.error(
+      `[harness] could not resolve deployed-agent slug for definitionId=${definitionId} ` +
+        `at ${baseUrl} (${reason}); the snippet panel will fall back to the project name — ` +
+        `check the harness is signed into the account that owns this agent`,
+    );
+  };
 
   return {
     async resolve(definitionId: string): Promise<string | null> {
+      // Not signed in: expected (a harness launched without auth), not a
+      // failure worth logging — the panel's project-name fallback covers it.
       if (!apiKey) return null;
 
       const cached = cache.get(definitionId);
@@ -51,15 +73,24 @@ export function createDefinitionSlugResolver(opts: {
           headers: { "x-sapiom-api-key": apiKey },
         });
 
-        if (!response.ok) return null;
+        if (!response.ok) {
+          warnOnce(definitionId, `HTTP ${response.status}`);
+          return null;
+        }
 
         const body = (await response.json()) as Record<string, unknown>;
         const slug = typeof body.slug === "string" ? body.slug : null;
         if (slug !== null) {
           cache.set(definitionId, slug);
+        } else {
+          warnOnce(definitionId, "response had no string `slug` field");
         }
         return slug;
-      } catch {
+      } catch (err) {
+        warnOnce(
+          definitionId,
+          err instanceof Error ? err.message : String(err),
+        );
         return null;
       }
     },

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -7,7 +7,10 @@
  * src/shared/types.ts for the full protocol contract.
  */
 
-import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  type Server as HttpServer,
+} from "node:http";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +28,18 @@ import type {
 } from "../shared/types.js";
 import { resolveStatePaths } from "../core/paths.js";
 import { seedExampleProject } from "../core/example-seed.js";
-import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.js";
+import {
+  SessionManager,
+  type LaunchOptsBuilder,
+} from "../core/session-manager.js";
 import { TaskManager } from "../core/task-manager.js";
 import { createClaudeCodeAdapter } from "../core/adapters/claude-code.js";
 import { createCodexAdapter } from "../core/adapters/codex.js";
-import { WorkflowRegistry, type WorkflowRegistryLike, createWorkflowsRouter } from "../core/workflow-registry.js";
+import {
+  WorkflowRegistry,
+  type WorkflowRegistryLike,
+  createWorkflowsRouter,
+} from "../core/workflow-registry.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
 import { createEventStore } from "../core/collector/store.js";
 import { createHarnessEmitter } from "../core/collector/analytics-emitter.js";
@@ -37,7 +47,11 @@ import { migrateHarnessIdentity } from "../core/collector/identity-migration.js"
 import { normalizeHookEvent } from "../core/collector/normalizer.js";
 import { enrichTurnCompleted } from "../core/collector/transcript.js";
 import { createSeqCounter } from "../core/collector/seq.js";
-import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "../core/collector/codex-tailer.js";
+import {
+  findRolloutFile,
+  tailCodexRollout,
+  type CodexTailerHandle,
+} from "../core/collector/codex-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
 import { pruneDeadRecentDirs } from "../cli/settings.js";
 import type { HarnessIdentity } from "../cli/auth.js";
@@ -45,24 +59,42 @@ import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
 import { generateSystemPromptFile } from "../core/inject/system-prompt.js";
 import { generateSkillsPlugin } from "../core/inject/skills-plugin.js";
-import { removeGeneratedSessionDir, sweepGeneratedDirs } from "../core/inject/retention.js";
+import {
+  removeGeneratedSessionDir,
+  sweepGeneratedDirs,
+} from "../core/inject/retention.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
 import { WorkspaceWatcherManager } from "../core/workspace-watcher.js";
 import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
-import { writeHarnessContext, harnessContextFileExists } from "../core/workspace-context.js";
+import {
+  writeHarnessContext,
+  harnessContextFileExists,
+} from "../core/workspace-context.js";
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
-import { renderCanvasForSession, renderWorkflowRenderFile } from "../core/canvas-render.js";
+import {
+  renderCanvasForSession,
+  renderWorkflowRenderFile,
+} from "../core/canvas-render.js";
 import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
-import { createDefinitionSlugResolver, resolveAgentsBaseUrl } from "../core/definition-slug-resolver.js";
+import {
+  createDefinitionSlugResolver,
+  resolveAgentsBaseUrl,
+} from "../core/definition-slug-resolver.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createRestRouter } from "./rest.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
 import { attachWebSocketRouters } from "./ws-router.js";
-import { createIngestRouter, processIngest, type IngestDeps, type IngestRequestBody, type IngestSessionContext } from "./ingest.js";
+import {
+  createIngestRouter,
+  processIngest,
+  type IngestDeps,
+  type IngestRequestBody,
+  type IngestSessionContext,
+} from "./ingest.js";
 import { createCanvasRouter } from "./canvas.js";
 import { createCanvasRenderRouter } from "./canvas-render.js";
 import { createMacrosRouter } from "./macros.js";
@@ -194,16 +226,22 @@ function packageRoot(): string {
 /** Whether two workflow lists are equivalent for the rail's purposes —
  *  compares the fields the SPA actually renders/keys on, order-insensitive, so
  *  a rescan that turned up nothing new doesn't trigger a needless broadcast. */
-function workflowListsEqual(a: readonly WorkflowInfo[], b: readonly WorkflowInfo[]): boolean {
+function workflowListsEqual(
+  a: readonly WorkflowInfo[],
+  b: readonly WorkflowInfo[],
+): boolean {
   if (a.length !== b.length) return false;
-  const key = (w: WorkflowInfo): string => `${w.path} ${w.name} ${w.definitionId ?? ""} ${w.source}`;
+  const key = (w: WorkflowInfo): string =>
+    `${w.path} ${w.name} ${w.definitionId ?? ""} ${w.source}`;
   const setA = new Set(a.map(key));
   return b.every((w) => setA.has(key(w)));
 }
 
 function readVersion(): string {
   try {
-    const pkg = JSON.parse(readFileSync(join(packageRoot(), "package.json"), "utf8")) as {
+    const pkg = JSON.parse(
+      readFileSync(join(packageRoot(), "package.json"), "utf8"),
+    ) as {
       version?: string;
     };
     return pkg.version ?? "0.0.0";
@@ -222,14 +260,22 @@ function readVersion(): string {
  * so the remote `sapiom` MCP is actually authenticated — a factory rather
  * than a plain function since it's per-server-instance state.
  */
-function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: string): LaunchOptsBuilder {
+function createDefaultBuildLaunchOpts(
+  apiKey: string | null,
+  generatedRoot?: string,
+): LaunchOptsBuilder {
   return async (harnessSessionId) => {
-    const [settings, mcpConfigFile, systemPromptFile, pluginDir] = await Promise.all([
-      generateClaudeSettings({ harnessSessionId, generatedRoot }),
-      generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT, apiKey, generatedRoot }),
-      generateSystemPromptFile(harnessSessionId, { generatedRoot }),
-      generateSkillsPlugin(harnessSessionId, { generatedRoot }),
-    ]);
+    const [settings, mcpConfigFile, systemPromptFile, pluginDir] =
+      await Promise.all([
+        generateClaudeSettings({ harnessSessionId, generatedRoot }),
+        generateMcpConfig(harnessSessionId, {
+          environment: process.env.SAPIOM_ENVIRONMENT,
+          apiKey,
+          generatedRoot,
+        }),
+        generateSystemPromptFile(harnessSessionId, { generatedRoot }),
+        generateSkillsPlugin(harnessSessionId, { generatedRoot }),
+      ]);
     return {
       settingsFile: settings.settingsPath,
       mcpConfigFile,
@@ -239,11 +285,14 @@ function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: str
   };
 }
 
-export const startServer = async (options: HarnessServerOptions): Promise<HarnessServer> => {
+export const startServer = async (
+  options: HarnessServerOptions,
+): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
   const identity = options.identity ?? null;
   const statePaths = resolveStatePaths(options.stateRoot);
-  const machineId = options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
+  const machineId =
+    options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
 
   // One-way identity migration: seed ~/.sapiom/analytics.json from the
   // legacy harness machine-id so existing installs keep the same anonymous_id
@@ -265,13 +314,20 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   /** Returns a copy of the workflow list with definitionSlug filled in from
    *  the Agents API for any workflow that has a definitionId but no slug.
    *  Resolves all lookups in parallel. Never mutates the registry. */
-  const enrichWorkflows = async (workflows: WorkflowInfo[]): Promise<WorkflowInfo[]> => {
+  const enrichWorkflows = async (
+    workflows: WorkflowInfo[],
+  ): Promise<WorkflowInfo[]> => {
     return Promise.all(
       workflows.map(async (workflow) => {
-        if (workflow.definitionId == null || (workflow.definitionSlug != null && workflow.definitionSlug !== "")) {
+        if (
+          workflow.definitionId == null ||
+          (workflow.definitionSlug != null && workflow.definitionSlug !== "")
+        ) {
           return workflow;
         }
-        const resolved = await slugResolver.resolve(String(workflow.definitionId));
+        const resolved = await slugResolver.resolve(
+          String(workflow.definitionId),
+        );
         if (resolved == null) return workflow;
         return { ...workflow, definitionSlug: resolved };
       }),
@@ -287,7 +343,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
 
   const bus = new EventBus();
   const canvasWatcher = new CanvasWatcherManager({
-    onChange: (harnessSessionId) => bus.publish({ type: "canvas.reload", harnessSessionId }),
+    onChange: (harnessSessionId) =>
+      bus.publish({ type: "canvas.reload", harnessSessionId }),
   });
   // The harness's own infrastructure shouldn't ever show up as a "discovered"
   // dev server in the Preview pane — a mention of our own listening port (in
@@ -306,7 +363,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     if (collectorPort !== null) excludedPorts.add(collectorPort);
   }
   const portDetector = new PortDetector({
-    onPort: (harnessSessionId, port, url) => bus.publish({ type: "port.detected", harnessSessionId, port, url }),
+    onPort: (harnessSessionId, port, url) =>
+      bus.publish({ type: "port.detected", harnessSessionId, port, url }),
     excludedPorts,
   });
 
@@ -317,7 +375,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // itself (to rewrite every open session's context file on a registry change) —
   // no circularity, since only writeSessionContext is threaded into SessionManager's
   // constructor, and it doesn't need sessionManager.
-  const workflowRegistry = new WorkflowRegistry(options.workflowsRegistryPath ?? statePaths.workflows);
+  const workflowRegistry = new WorkflowRegistry(
+    options.workflowsRegistryPath ?? statePaths.workflows,
+  );
   // Boot-time hygiene, before the first list(): drop registry entries whose
   // path no longer exists on disk (deleted projects, temp dirs a crashed run
   // left registered) so the rail — and every harness-context.json written
@@ -326,7 +386,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   try {
     const prunedWorkflows = await workflowRegistry.prune();
     for (const workflow of prunedWorkflows) {
-      console.error(`[harness] pruned workflow registry entry with missing path: ${workflow.path}`);
+      console.error(
+        `[harness] pruned workflow registry entry with missing path: ${workflow.path}`,
+      );
     }
   } catch (err) {
     console.error("[harness] workflow registry prune failed:", err);
@@ -358,9 +420,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
    * SessionManager's create()/resume(), the PATCH bind/unbind route, and
    * scanWorkflowsAndBroadcast's rewrite-all-open-sessions step below.
    */
-  const writeSessionContext = async (session: HarnessSession): Promise<void> => {
+  const writeSessionContext = async (
+    session: HarnessSession,
+  ): Promise<void> => {
     const boundWorkflow = session.boundWorkflowPath
-      ? (workflowsCache.find((w) => w.path === session.boundWorkflowPath) ?? null)
+      ? (workflowsCache.find((w) => w.path === session.boundWorkflowPath) ??
+        null)
       : null;
     await writeHarnessContext(session, boundWorkflow, workflowsCache);
   };
@@ -373,7 +438,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const generatedRoot = options.generatedRoot ?? statePaths.generated;
   const pendingGeneratedRemovals = new Map<string, Promise<void>>();
   const innerBuildLaunchOpts =
-    options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
+    options.buildLaunchOpts ??
+    createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
   const buildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId, req) => {
     await pendingGeneratedRemovals.get(harnessSessionId);
     return innerBuildLaunchOpts(harnessSessionId, req);
@@ -394,7 +460,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   });
   await sessionManager.init();
 
-  const sessionSweepTimer = setInterval(() => sessionManager.sweepDeadSessions(), SESSION_LIVENESS_SWEEP_MS);
+  const sessionSweepTimer = setInterval(
+    () => sessionManager.sweepDeadSessions(),
+    SESSION_LIVENESS_SWEEP_MS,
+  );
   sessionSweepTimer.unref?.();
 
   // Background tasks (canvas enrichment today): headless one-shot agent
@@ -410,9 +479,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     collectorUrl: options.collectorUrl,
     buildLaunchOpts,
     onCleanup: (taskId) => {
-      void removeGeneratedSessionDir(taskId, { generatedRoot }).catch((err: unknown) => {
-        console.error("[harness] task generated-dir cleanup failed:", err);
-      });
+      void removeGeneratedSessionDir(taskId, { generatedRoot }).catch(
+        (err: unknown) => {
+          console.error("[harness] task generated-dir cleanup failed:", err);
+        },
+      );
     },
   });
   taskManager.onStatusChange((task) => {
@@ -444,7 +515,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // Pruning here is what lets a deleted workflow drop out (a plain scan only
   // ever merges in); it respects the same ENOENT/ENOTDIR-only guard as the
   // boot prune, so a merely-unbuilt or unreadable project stays put.
-  const rescanWorkspaceForSession = async (harnessSessionId: string): Promise<void> => {
+  const rescanWorkspaceForSession = async (
+    harnessSessionId: string,
+  ): Promise<void> => {
     const session = sessionManager.get(harnessSessionId);
     if (!session || session.status === "exited") return;
     const before = workflowsCache;
@@ -494,7 +567,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // (only the active tab does) — this is the lightweight substitute that lets
   // every session's tab show a busy pulse regardless of which one is active.
   sessionManager.onActivity((harnessSessionId) => {
-    bus.publish({ type: "session.activity", harnessSessionId, at: new Date().toISOString() });
+    bus.publish({
+      type: "session.activity",
+      harnessSessionId,
+      at: new Date().toISOString(),
+    });
   });
 
   // Nothing else triggers a scan (the only other entry point is the SPA's
@@ -510,14 +587,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // merged registry) — callers use this to decide whether THIS scan turned
   // up something new worth an unprompted canvas render, without conflating
   // it with unrelated workflows some earlier scan already found elsewhere.
-  const scanWorkflowsAndBroadcast = async (root: string): Promise<WorkflowInfo[]> => {
+  const scanWorkflowsAndBroadcast = async (
+    root: string,
+  ): Promise<WorkflowInfo[]> => {
     const found = await workflowRegistry.scan(root);
     workflowsCache = await workflowRegistry.list();
     // Rewrite every open session's context file before broadcasting — a
     // listener reacting to workflows.changed (the SPA, or an agent that
     // happens to re-read the file right then) must never see the
     // notification before the file it describes is actually updated.
-    await Promise.all(sessionManager.list().map((session) => writeSessionContext(session)));
+    await Promise.all(
+      sessionManager.list().map((session) => writeSessionContext(session)),
+    );
     bus.publish({ type: "workflows.changed" });
     return found;
   };
@@ -549,14 +630,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     await enrichment.ensureFresh(session, workflowsCache);
   };
   const autoRenderCanvas = async (session: HarnessSession): Promise<void> => {
-    await renderCanvasForSession(session, workflowsCache, { preserveExistingOnFailure: true });
+    await renderCanvasForSession(session, workflowsCache, {
+      preserveExistingOnFailure: true,
+    });
     await enrichment.ensureFresh(session, workflowsCache);
   };
 
-  const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
-    console.error("[harness] initial workflow scan failed:", err);
-    return [] as WorkflowInfo[];
-  });
+  const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch(
+    (err: unknown) => {
+      console.error("[harness] initial workflow scan failed:", err);
+      return [] as WorkflowInfo[];
+    },
+  );
 
   const eventStorePath = options.eventStorePath ?? statePaths.events;
   const eventStore = createEventStore(eventStorePath);
@@ -566,12 +651,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // so the sweep's read→filter→rename window never races a concurrent append.
   // Fire-and-forget — a slow FS is no reason to delay server startup.
   const runNdjsonSweep = (): void => {
-    void eventStore.runExclusive(() => sweepNdjson(eventStorePath)).catch((err: unknown) => {
-      console.error("[harness] events.ndjson retention sweep failed:", err);
-    });
+    void eventStore
+      .runExclusive(() => sweepNdjson(eventStorePath))
+      .catch((err: unknown) => {
+        console.error("[harness] events.ndjson retention sweep failed:", err);
+      });
   };
   runNdjsonSweep();
-  const ndjsonRetentionTimer = setInterval(runNdjsonSweep, NDJSON_RETENTION_SWEEP_MS);
+  const ndjsonRetentionTimer = setInterval(
+    runNdjsonSweep,
+    NDJSON_RETENTION_SWEEP_MS,
+  );
   ndjsonRetentionTimer.unref?.();
 
   const harnessVersion = readVersion();
@@ -589,7 +679,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     },
   });
 
-  const resolveIngestSession = (harnessSessionId: string): IngestSessionContext | undefined => {
+  const resolveIngestSession = (
+    harnessSessionId: string,
+  ): IngestSessionContext | undefined => {
     const session = sessionManager.get(harnessSessionId);
     if (!session) return undefined;
     return {
@@ -621,10 +713,16 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       sessionManager,
       adapters,
       version: readVersion(),
-      identity: identity ? { userId: identity.userId, organizationName: identity.organizationName } : null,
+      identity: identity
+        ? {
+            userId: identity.userId,
+            organizationName: identity.organizationName,
+          }
+        : null,
       listWorkflows: () => workflowRegistry.list().then(enrichWorkflows),
       listMacros: () => DEFAULT_MACROS,
-      findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
+      findWorkflow: (workflowPath) =>
+        workflowsCache.find((w) => w.path === workflowPath) ?? null,
       writeWorkspaceContext: writeSessionContext,
       renderCanvas,
       onTelemetryOptInChange: (optIn) => batcher.setTelemetryOptIn(optIn),
@@ -640,10 +738,14 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
             if (session) return autoRenderCanvas(session);
           })
           .catch((err: unknown) => {
-            console.error("[harness] workflow scan on session create failed:", err);
+            console.error(
+              "[harness] workflow scan on session create failed:",
+              err,
+            );
           });
       },
       launchDir,
+      agentsBaseUrl: resolveAgentsBaseUrl(),
       availableHarnesses: options.availableHarnesses,
       listTasks: () => taskManager.list(),
       firstRun: options.firstRun,
@@ -688,9 +790,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     createSkillsRouter(),
     createMacrosRouter({
       listMacros: () => DEFAULT_MACROS,
-      findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
-      getSessionCwd: (harnessSessionId) => sessionManager.get(harnessSessionId)?.cwd ?? null,
-      getBoundWorkflowPath: (harnessSessionId) => sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
+      findWorkflow: (workflowPath) =>
+        workflowsCache.find((w) => w.path === workflowPath) ?? null,
+      getSessionCwd: (harnessSessionId) =>
+        sessionManager.get(harnessSessionId)?.cwd ?? null,
+      getBoundWorkflowPath: (harnessSessionId) =>
+        sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
       // The visualize macro is a FORCE refresh, not a plain re-render:
       // invalidate the extraction + enrichment caches, re-render the base
       // instantly, re-spawn the enrichment task. Its refusals map to the
@@ -705,7 +810,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         // bracketed paste and never submits.
         await sessionManager.submitInput(harnessSessionId, text, submit);
       },
-      runBackgroundTask: async (harnessSessionId, macro, prompt, workflowPath) => {
+      runBackgroundTask: async (
+        harnessSessionId,
+        macro,
+        prompt,
+        workflowPath,
+      ) => {
         // The router already 404'd on an unknown session (getSessionCwd),
         // so the session is present here; its harness kind decides whether
         // a headless run is even possible (TaskNotSupportedError → 400).
@@ -781,13 +891,19 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // format has no line of its own for, and stop.
   const codexTailers = new Map<string, CodexTailerHandle>();
 
-  async function discoverCodexRolloutPath(session: HarnessSession): Promise<string | null> {
+  async function discoverCodexRolloutPath(
+    session: HarnessSession,
+  ): Promise<string | null> {
     const deadline = Date.now() + CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS;
     const sinceMs = Date.parse(session.createdAt);
     for (;;) {
       const found = await findRolloutFile(
         session.agentSessionId
-          ? { cwd: session.cwd, agentSessionId: session.agentSessionId, homeDir: options.codexHomeDir }
+          ? {
+              cwd: session.cwd,
+              agentSessionId: session.agentSessionId,
+              homeDir: options.codexHomeDir,
+            }
           : {
               cwd: session.cwd,
               sinceMs: Number.isNaN(sinceMs) ? undefined : sinceMs,
@@ -796,7 +912,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       );
       if (found) return found;
       if (Date.now() >= deadline) return null;
-      await new Promise((resolve) => setTimeout(resolve, CODEX_ROLLOUT_DISCOVERY_POLL_MS));
+      await new Promise((resolve) =>
+        setTimeout(resolve, CODEX_ROLLOUT_DISCOVERY_POLL_MS),
+      );
     }
   }
 
@@ -827,12 +945,19 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       // real prior history that should stay unemitted.
       startFromBeginning: !session.agentSessionId,
       onEvent: (hookEvent, payload) => {
-        const body: IngestRequestBody = { hookEvent, harnessSessionId, payload };
-        void processIngest(body, ingestDeps, seqCounter).catch((err: unknown) => {
-          console.error("[harness] codex tailer ingest error:", err);
-        });
+        const body: IngestRequestBody = {
+          hookEvent,
+          harnessSessionId,
+          payload,
+        };
+        void processIngest(body, ingestDeps, seqCounter).catch(
+          (err: unknown) => {
+            console.error("[harness] codex tailer ingest error:", err);
+          },
+        );
       },
-      onError: (err) => console.error("[harness] codex tailer parse error:", err),
+      onError: (err) =>
+        console.error("[harness] codex tailer parse error:", err),
     });
     codexTailers.set(harnessSessionId, tailer);
   }
@@ -852,7 +977,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     } else if (session.status === "exited") {
       const tailer = codexTailers.get(session.id);
       if (tailer) {
-        tailer.emitSessionEnd(session.exitCode != null ? `pty exited (code ${session.exitCode})` : undefined);
+        tailer.emitSessionEnd(
+          session.exitCode != null
+            ? `pty exited (code ${session.exitCode})`
+            : undefined,
+        );
         codexTailers.delete(session.id);
       }
     }
@@ -863,7 +992,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   app.use(
     createCanvasRouter((harnessSessionId) => {
       const session = sessionManager.get(harnessSessionId);
-      return session ? { cwd: session.cwd, boundWorkflowPath: session.boundWorkflowPath } : undefined;
+      return session
+        ? { cwd: session.cwd, boundWorkflowPath: session.boundWorkflowPath }
+        : undefined;
     }),
   );
 
@@ -872,10 +1003,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const webDir = options.webDir ?? join(packageRoot(), "dist", "web");
   app.use(createStaticRouter(webDir));
 
-  app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-    console.error("[harness] unhandled request error:", err);
-    res.status(500).json({ error: "internal error" });
-  });
+  app.use(
+    (
+      err: unknown,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      console.error("[harness] unhandled request error:", err);
+      res.status(500).json({ error: "internal error" });
+    },
+  );
 
   const httpServer: HttpServer = createHttpServer(app);
 
@@ -885,7 +1023,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     {
       path: "/ws/terminal",
       wss: terminalWss,
-      onConnection: createTerminalWebSocketHandler(sessionManager, options.bootToken),
+      onConnection: createTerminalWebSocketHandler(
+        sessionManager,
+        options.bootToken,
+      ),
     },
     {
       path: "/ws/events",
@@ -923,7 +1064,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   }
 
   const address = httpServer.address();
-  const actualPort = typeof address === "object" && address ? address.port : options.port;
+  const actualPort =
+    typeof address === "object" && address ? address.port : options.port;
   // Covers the ephemeral `port: 0` case (tests) where `options.port` above
   // was 0 and therefore never a real port to exclude — the actual bound
   // port is only known now.
@@ -951,7 +1093,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       // itself is bounded (KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS
       // = 2500ms); the outer timeout here is a final safety net above that.
       const SHUTDOWN_KILL_TIMEOUT_MS = 5_000;
-      const killsSettled = Promise.all([sessionManager.killAll(), taskManager.killAll()]);
+      const killsSettled = Promise.all([
+        sessionManager.killAll(),
+        taskManager.killAll(),
+      ]);
       let shutdownTimerHandle: ReturnType<typeof setTimeout> | undefined;
       const shutdownTimeout = new Promise<void>((resolve) => {
         shutdownTimerHandle = setTimeout(resolve, SHUTDOWN_KILL_TIMEOUT_MS);

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -14,9 +14,24 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir: () => tmpHome };
 });
 
-import type { HarnessAdapter, HarnessKind, HarnessSession, MacroDef, SpawnSpec, WorkflowInfo } from "../shared/types.js";
-import { SessionManager, SessionNotReadyError, UnknownSessionError } from "../core/session-manager.js";
-import { AdapterNotFoundError, SessionAlreadyLiveError, SessionNotResumeableError } from "../core/errors.js";
+import type {
+  HarnessAdapter,
+  HarnessKind,
+  HarnessSession,
+  MacroDef,
+  SpawnSpec,
+  WorkflowInfo,
+} from "../shared/types.js";
+import {
+  SessionManager,
+  SessionNotReadyError,
+  UnknownSessionError,
+} from "../core/session-manager.js";
+import {
+  AdapterNotFoundError,
+  SessionAlreadyLiveError,
+  SessionNotResumeableError,
+} from "../core/errors.js";
 import { createRestRouter, type RestRouterOptions } from "./rest.js";
 
 const TOKEN_HEADER = { "X-Harness-Token": "unused-in-router-tests" };
@@ -129,6 +144,20 @@ describe("createRestRouter", () => {
       expect(body.firstRun).toBe(false);
     });
 
+    it("omits agentsBaseUrl when the caller doesn't supply it", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect("agentsBaseUrl" in body).toBe(false);
+    });
+
+    it("surfaces agentsBaseUrl when supplied", async () => {
+      start({ agentsBaseUrl: "https://tools.sapiom.ai" });
+      const res = await fetch(`${baseUrl}/state`);
+      const body = (await res.json()) as { agentsBaseUrl: string };
+      expect(body.agentsBaseUrl).toBe("https://tools.sapiom.ai");
+    });
+
     it("reflects identity, sessions, workflows, and macros from their sources", async () => {
       const session: HarnessSession = {
         id: "s1",
@@ -143,8 +172,19 @@ describe("createRestRouter", () => {
         boundWorkflowPath: null,
         ready: true,
       };
-      const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, definitionSlug: "leasing", source: "scan" };
-      const macro: MacroDef = { id: "run_local", label: "Run local", icon: "Play", action: { kind: "inject", text: "x" } };
+      const workflow: WorkflowInfo = {
+        name: "leasing",
+        path: "/tmp/leasing",
+        definitionId: 1,
+        definitionSlug: "leasing",
+        source: "scan",
+      };
+      const macro: MacroDef = {
+        id: "run_local",
+        label: "Run local",
+        icon: "Play",
+        action: { kind: "inject", text: "x" },
+      };
 
       start({
         sessionManager: fakeSessionManager([session]),
@@ -180,7 +220,10 @@ describe("createRestRouter", () => {
     it("returns defaults before anything is persisted", async () => {
       start();
       const res = await fetch(`${baseUrl}/settings`);
-      expect(await res.json()).toEqual({ telemetryOptIn: false, recentDirs: [] });
+      expect(await res.json()).toEqual({
+        telemetryOptIn: false,
+        recentDirs: [],
+      });
     });
 
     it("persists a patch and returns the merged result", async () => {
@@ -190,10 +233,16 @@ describe("createRestRouter", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ telemetryOptIn: true }),
       });
-      expect(await res.json()).toEqual({ telemetryOptIn: true, recentDirs: [] });
+      expect(await res.json()).toEqual({
+        telemetryOptIn: true,
+        recentDirs: [],
+      });
 
       const reread = await fetch(`${baseUrl}/settings`);
-      expect(await reread.json()).toEqual({ telemetryOptIn: true, recentDirs: [] });
+      expect(await reread.json()).toEqual({
+        telemetryOptIn: true,
+        recentDirs: [],
+      });
     });
 
     it("calls onTelemetryOptInChange only when telemetryOptIn actually changes", async () => {
@@ -243,24 +292,39 @@ describe("createRestRouter", () => {
   describe("POST /sample-project", () => {
     it("501s when no seeder is wired up", async () => {
       start();
-      const res = await fetch(`${baseUrl}/sample-project`, { method: "POST", headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sample-project`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(501);
     });
 
     it("returns the seeder's result", async () => {
-      const seeded = { root: "/tmp/sample", projectDir: "/tmp/sample/order-triage", created: true };
+      const seeded = {
+        root: "/tmp/sample",
+        projectDir: "/tmp/sample/order-triage",
+        created: true,
+      };
       const seedSampleProject = vi.fn().mockResolvedValue(seeded);
       start({ seedSampleProject });
 
-      const res = await fetch(`${baseUrl}/sample-project`, { method: "POST", headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sample-project`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(seeded);
       expect(seedSampleProject).toHaveBeenCalledOnce();
     });
 
     it("propagates a seeding failure as a server error, not a hang", async () => {
-      start({ seedSampleProject: vi.fn().mockRejectedValue(new Error("disk full")) });
-      const res = await fetch(`${baseUrl}/sample-project`, { method: "POST", headers: TOKEN_HEADER });
+      start({
+        seedSampleProject: vi.fn().mockRejectedValue(new Error("disk full")),
+      });
+      const res = await fetch(`${baseUrl}/sample-project`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(500);
     });
   });
@@ -342,7 +406,11 @@ describe("createRestRouter", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ ok: true });
-      expect(sessionManager.submitInput).toHaveBeenCalledWith("sess-1", "hello", true);
+      expect(sessionManager.submitInput).toHaveBeenCalledWith(
+        "sess-1",
+        "hello",
+        true,
+      );
     });
 
     it("400s a malformed body (missing text)", async () => {
@@ -357,7 +425,9 @@ describe("createRestRouter", () => {
 
     it("404s when submitInput reports no live pty for the session", async () => {
       const sessionManager = fakeSessionManager();
-      (sessionManager.submitInput as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      (
+        sessionManager.submitInput as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(false);
       start({ sessionManager });
 
       const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
@@ -370,9 +440,9 @@ describe("createRestRouter", () => {
 
     it("409s with a UI-visible reason when the session isn't ready yet (SessionNotReadyError) — never silently swallows the input", async () => {
       const sessionManager = fakeSessionManager();
-      (sessionManager.submitInput as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new SessionNotReadyError("sess-1"),
-      );
+      (
+        sessionManager.submitInput as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new SessionNotReadyError("sess-1"));
       start({ sessionManager });
 
       const res = await fetch(`${baseUrl}/sessions/sess-1/input`, {
@@ -389,7 +459,13 @@ describe("createRestRouter", () => {
   });
 
   describe("PATCH /sessions/:id/workflow", () => {
-    const workflow: WorkflowInfo = { name: "leasing", path: "/tmp/leasing", definitionId: 1, definitionSlug: "leasing", source: "scan" };
+    const workflow: WorkflowInfo = {
+      name: "leasing",
+      path: "/tmp/leasing",
+      definitionId: 1,
+      definitionSlug: "leasing",
+      source: "scan",
+    };
     const baseSession: HarnessSession = {
       id: "sess-1",
       agentSessionId: null,
@@ -406,30 +482,49 @@ describe("createRestRouter", () => {
 
     it("binds a known workflow: validates it, updates the session, and writes the context file", async () => {
       const sessionManager = fakeSessionManager([baseSession]);
-      start({ sessionManager, findWorkflow: (p) => (p === workflow.path ? workflow : null) });
-
-      const res = await fetch(`${baseUrl}/sessions/${baseSession.id}/workflow`, {
-        method: "PATCH",
-        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
-        body: JSON.stringify({ workflowPath: workflow.path }),
+      start({
+        sessionManager,
+        findWorkflow: (p) => (p === workflow.path ? workflow : null),
       });
+
+      const res = await fetch(
+        `${baseUrl}/sessions/${baseSession.id}/workflow`,
+        {
+          method: "PATCH",
+          headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+          body: JSON.stringify({ workflowPath: workflow.path }),
+        },
+      );
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as HarnessSession;
       expect(body.boundWorkflowPath).toBe(workflow.path);
-      expect(sessionManager.setBoundWorkflowPath).toHaveBeenCalledWith(baseSession.id, workflow.path);
+      expect(sessionManager.setBoundWorkflowPath).toHaveBeenCalledWith(
+        baseSession.id,
+        workflow.path,
+      );
       // setBoundWorkflowPath() mutates the fake manager's session in place —
       // the route hands the whole (already-updated) session to the callee,
       // which resolves the bound workflow against the live registry itself.
       expect(writeWorkspaceContext).toHaveBeenCalledWith(
-        expect.objectContaining({ id: baseSession.id, cwd: "/tmp/proj", boundWorkflowPath: workflow.path }),
+        expect.objectContaining({
+          id: baseSession.id,
+          cwd: "/tmp/proj",
+          boundWorkflowPath: workflow.path,
+        }),
       );
     });
 
     it("unbinds with workflowPath: null, writing boundWorkflow: null to the context file", async () => {
-      const bound: HarnessSession = { ...baseSession, boundWorkflowPath: workflow.path };
+      const bound: HarnessSession = {
+        ...baseSession,
+        boundWorkflowPath: workflow.path,
+      };
       const sessionManager = fakeSessionManager([bound]);
-      start({ sessionManager, findWorkflow: (p) => (p === workflow.path ? workflow : null) });
+      start({
+        sessionManager,
+        findWorkflow: (p) => (p === workflow.path ? workflow : null),
+      });
 
       const res = await fetch(`${baseUrl}/sessions/${bound.id}/workflow`, {
         method: "PATCH",
@@ -441,7 +536,11 @@ describe("createRestRouter", () => {
       const body = (await res.json()) as HarnessSession;
       expect(body.boundWorkflowPath).toBeNull();
       expect(writeWorkspaceContext).toHaveBeenCalledWith(
-        expect.objectContaining({ id: bound.id, cwd: "/tmp/proj", boundWorkflowPath: null }),
+        expect.objectContaining({
+          id: bound.id,
+          cwd: "/tmp/proj",
+          boundWorkflowPath: null,
+        }),
       );
     });
 
@@ -449,11 +548,14 @@ describe("createRestRouter", () => {
       const sessionManager = fakeSessionManager([baseSession]);
       start({ sessionManager, findWorkflow: () => null });
 
-      const res = await fetch(`${baseUrl}/sessions/${baseSession.id}/workflow`, {
-        method: "PATCH",
-        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
-        body: JSON.stringify({ workflowPath: "/not/registered" }),
-      });
+      const res = await fetch(
+        `${baseUrl}/sessions/${baseSession.id}/workflow`,
+        {
+          method: "PATCH",
+          headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+          body: JSON.stringify({ workflowPath: "/not/registered" }),
+        },
+      );
 
       expect(res.status).toBe(400);
       expect(sessionManager.setBoundWorkflowPath).not.toHaveBeenCalled();
@@ -473,14 +575,16 @@ describe("createRestRouter", () => {
     it("400s a malformed body (missing workflowPath)", async () => {
       const sessionManager = fakeSessionManager([baseSession]);
       start({ sessionManager });
-      const res = await fetch(`${baseUrl}/sessions/${baseSession.id}/workflow`, {
-        method: "PATCH",
-        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
-        body: JSON.stringify({}),
-      });
+      const res = await fetch(
+        `${baseUrl}/sessions/${baseSession.id}/workflow`,
+        {
+          method: "PATCH",
+          headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
       expect(res.status).toBe(400);
     });
-
   });
 
   describe("POST /sessions/:id/resume — error class → HTTP status mapping", () => {
@@ -505,8 +609,12 @@ describe("createRestRouter", () => {
       // checks instanceof, the message can say anything.
       const sessionManager = fakeSessionManager();
       const err = new UnknownSessionError("xyz");
-      Object.defineProperty(err, "message", { value: "session xyz could not be located" });
-      (sessionManager.resume as ReturnType<typeof vi.fn>).mockRejectedValue(err);
+      Object.defineProperty(err, "message", {
+        value: "session xyz could not be located",
+      });
+      (sessionManager.resume as ReturnType<typeof vi.fn>).mockRejectedValue(
+        err,
+      );
       start({ sessionManager });
 
       const res = await fetch(`${baseUrl}/sessions/xyz/resume`, {
@@ -603,8 +711,12 @@ describe("createRestRouter", () => {
       const res = await fetch(`${baseUrl}/harnesses`);
       const body = (await res.json()) as Array<{ id: string; mode: string }>;
 
-      const embeddedIds = body.filter((a) => a.mode === "embedded").map((a) => a.id);
-      const externalIds = body.filter((a) => a.mode === "external").map((a) => a.id);
+      const embeddedIds = body
+        .filter((a) => a.mode === "embedded")
+        .map((a) => a.id);
+      const externalIds = body
+        .filter((a) => a.mode === "external")
+        .map((a) => a.id);
 
       expect(embeddedIds).toContain("claude-code");
       expect(embeddedIds).toContain("codex");
@@ -623,7 +735,11 @@ describe("createRestRouter", () => {
     it("claude-code appears as mode:embedded and not experimental", async () => {
       start();
       const res = await fetch(`${baseUrl}/harnesses`);
-      const body = (await res.json()) as Array<{ id: string; mode: string; experimental: boolean }>;
+      const body = (await res.json()) as Array<{
+        id: string;
+        mode: string;
+        experimental: boolean;
+      }>;
       const claudeCode = body.find((a) => a.id === "claude-code");
       expect(claudeCode).toBeDefined();
       expect(claudeCode!.mode).toBe("embedded");
@@ -642,7 +758,9 @@ describe("createRestRouter", () => {
     const liveManagers: SessionManager[] = [];
 
     beforeEach(async () => {
-      smDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-rest-ext-test-"));
+      smDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "harness-rest-ext-test-"),
+      );
     });
 
     afterEach(async () => {
@@ -705,7 +823,10 @@ describe("createRestRouter", () => {
         lastActiveAt: new Date().toISOString(),
       });
 
-      start({ sessionManager: sessionManager as unknown as RestRouterOptions["sessionManager"] });
+      start({
+        sessionManager:
+          sessionManager as unknown as RestRouterOptions["sessionManager"],
+      });
 
       const res = await fetch(`${baseUrl}/sessions/${session.id}/resume`, {
         method: "POST",
@@ -729,7 +850,10 @@ describe("createRestRouter", () => {
         lastActiveAt: new Date().toISOString(),
       });
 
-      start({ sessionManager: sessionManager as unknown as RestRouterOptions["sessionManager"] });
+      start({
+        sessionManager:
+          sessionManager as unknown as RestRouterOptions["sessionManager"],
+      });
 
       const res = await fetch(`${baseUrl}/sessions/${session.id}/input`, {
         method: "POST",
@@ -760,7 +884,9 @@ describe("skills router — real server mount proof", () => {
   let skillsRoot: string;
 
   beforeEach(async () => {
-    skillsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-skills-mount-"));
+    skillsRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "harness-skills-mount-"),
+    );
 
     // Mirror the real server/index.ts mount: boot-token middleware on /api,
     // then the skills router (which declares /api/skills internally).
@@ -811,6 +937,8 @@ describe("skills router — real server mount proof", () => {
     const res = await fetch(`${baseUrl}/api/skills`, { headers: TOKEN_HEADER });
     expect(res.status).toBe(200);
     const body = (await res.json()) as Array<{ id: string; source: string }>;
-    expect(body.some((s) => s.id === "my-skill" && s.source === "user")).toBe(true);
+    expect(body.some((s) => s.id === "my-skill" && s.source === "user")).toBe(
+      true,
+    );
   });
 });

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -27,8 +27,17 @@ import type {
   WorkflowInfo,
 } from "../shared/types.js";
 import { SPAWNABLE_HARNESS_KINDS } from "../shared/types.js";
-import { AdapterNotFoundError, ExternalHarnessError, SessionAlreadyLiveError, SessionNotResumeableError } from "../core/errors.js";
-import { SessionNotReadyError, UnknownSessionError, type SessionManager } from "../core/session-manager.js";
+import {
+  AdapterNotFoundError,
+  ExternalHarnessError,
+  SessionAlreadyLiveError,
+  SessionNotResumeableError,
+} from "../core/errors.js";
+import {
+  SessionNotReadyError,
+  UnknownSessionError,
+  type SessionManager,
+} from "../core/session-manager.js";
 import { listHarnessAdapters } from "../core/adapters/registry.js";
 import { loadSettings, saveSettings } from "../cli/settings.js";
 
@@ -74,11 +83,16 @@ const UI_EVENT_NAMES: readonly UiEventName[] = [
  * carry arbitrary content). Keyed and value length-capped so the endpoint
  * cannot be used as a vector to push large payloads through the remote batcher.
  */
-const uiTrackDataValue = z.union([z.string().max(256), z.number(), z.boolean()]);
-const uiTrackDataSchema = z.record(z.string().max(64), uiTrackDataValue).refine(
-  (obj) => Object.keys(obj).length <= 20,
-  { message: "data must have at most 20 keys" },
-);
+const uiTrackDataValue = z.union([
+  z.string().max(256),
+  z.number(),
+  z.boolean(),
+]);
+const uiTrackDataSchema = z
+  .record(z.string().max(64), uiTrackDataValue)
+  .refine((obj) => Object.keys(obj).length <= 20, {
+    message: "data must have at most 20 keys",
+  });
 
 const uiTrackSchema = z.object({
   event: z.enum(UI_EVENT_NAMES as [UiEventName, ...UiEventName[]]),
@@ -123,6 +137,11 @@ export interface RestRouterOptions {
   /** The directory the CLI was launched against — surfaced in AppState so the
    * SPA can prefill the new-session modal with it. */
   launchDir: string;
+  /** The Agents API base URL (env-configurable) — surfaced in AppState so the
+   * snippet panel's executions host matches where the server resolves slugs.
+   * Omitted by tests, leaving AppState.agentsBaseUrl absent (the SPA then uses
+   * the SDK's default host). */
+  agentsBaseUrl?: string;
   /** Background tasks known to this boot (TaskManager.list) — surfaced in
    *  AppState so a page load mid-run shows the canvas activity state without
    *  waiting for the next task.status frame. Optional: omitted by callers
@@ -160,8 +179,12 @@ export interface RestRouterOptions {
    * about UI analytics don't need to stub these).
    */
   uiTrack?: {
-    store: { append(event: import("../shared/types.js").AnalyticsEvent): Promise<void> };
-    batcher: { enqueue(event: import("../shared/types.js").AnalyticsEvent): void };
+    store: {
+      append(event: import("../shared/types.js").AnalyticsEvent): Promise<void>;
+    };
+    batcher: {
+      enqueue(event: import("../shared/types.js").AnalyticsEvent): void;
+    };
     /** Per-boot seq counter shared with the ingest pipeline. */
     nextSeq: (sessionId: string) => number;
     machineId: string;
@@ -171,7 +194,14 @@ export interface RestRouterOptions {
 }
 
 export function createRestRouter(options: RestRouterOptions): Router {
-  const { sessionManager, adapters, version, identity, listWorkflows, listMacros } = options;
+  const {
+    sessionManager,
+    adapters,
+    version,
+    identity,
+    listWorkflows,
+    listMacros,
+  } = options;
   const router = Router();
   router.use(express.json());
 
@@ -188,11 +218,22 @@ export function createRestRouter(options: RestRouterOptions): Router {
         workflows: await listWorkflows(),
         macros: listMacros(),
         launchDir: options.launchDir,
-        ...(options.availableHarnesses ? { availableHarnesses: options.availableHarnesses } : {}),
+        ...(options.availableHarnesses
+          ? { availableHarnesses: options.availableHarnesses }
+          : {}),
         ...(options.listTasks ? { tasks: options.listTasks() } : {}),
-        ...(options.firstRun !== undefined ? { firstRun: options.firstRun } : {}),
-        ...(options.consentSource !== undefined ? { consentSource: options.consentSource } : {}),
-        ...(options.consentEnvReason !== undefined ? { consentEnvReason: options.consentEnvReason } : {}),
+        ...(options.firstRun !== undefined
+          ? { firstRun: options.firstRun }
+          : {}),
+        ...(options.consentSource !== undefined
+          ? { consentSource: options.consentSource }
+          : {}),
+        ...(options.consentEnvReason !== undefined
+          ? { consentEnvReason: options.consentEnvReason }
+          : {}),
+        ...(options.agentsBaseUrl
+          ? { agentsBaseUrl: options.agentsBaseUrl }
+          : {}),
       };
       res.json(state);
     } catch (err) {
@@ -236,7 +277,11 @@ export function createRestRouter(options: RestRouterOptions): Router {
   // existing session-creation path.
   router.post("/sample-project", async (_req, res, next) => {
     if (!options.seedSampleProject) {
-      res.status(501).json({ error: "sample project seeding is not available on this server" });
+      res
+        .status(501)
+        .json({
+          error: "sample project seeding is not available on this server",
+        });
       return;
     }
     try {
@@ -396,7 +441,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
         err instanceof SessionAlreadyLiveError ||
         err instanceof SessionNotResumeableError
       ) {
-        res.status(409).json({ error: err.message, code: (err as { code: string }).code });
+        res
+          .status(409)
+          .json({ error: err.message, code: (err as { code: string }).code });
         return;
       }
       next(err);
@@ -421,14 +468,21 @@ export function createRestRouter(options: RestRouterOptions): Router {
     }
     try {
       const submit = parsed.data.submit ?? true;
-      const ok = await sessionManager.submitInput(req.params.id, parsed.data.text, submit);
+      const ok = await sessionManager.submitInput(
+        req.params.id,
+        parsed.data.text,
+        submit,
+      );
       if (!ok) {
         res.status(404).json({ error: "session not found or has no live pty" });
         return;
       }
       res.json({ ok: true });
     } catch (err) {
-      if (err instanceof SessionNotReadyError || err instanceof ExternalHarnessError) {
+      if (
+        err instanceof SessionNotReadyError ||
+        err instanceof ExternalHarnessError
+      ) {
         res.status(409).json({ error: err.message, code: err.code });
         return;
       }
@@ -465,7 +519,8 @@ export function createRestRouter(options: RestRouterOptions): Router {
     // Respond immediately — fire-and-forget from the client's perspective.
     res.json({ ok: true });
 
-    const { store, batcher, nextSeq, machineId, userId, tenantId } = options.uiTrack;
+    const { store, batcher, nextSeq, machineId, userId, tenantId } =
+      options.uiTrack;
     const { event, data, harnessSessionId } = parsed.data;
     // Use the provided session id for seq tracking; fall back to a synthetic
     // one-use id so ui events without a session still get a valid seq.

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -304,7 +304,12 @@ export type TerminalControlMessage = TerminalResizeMessage;
 export type BusMessage =
   | { type: "session.status"; session: HarnessSession }
   | { type: "canvas.reload"; harnessSessionId: string }
-  | { type: "port.detected"; harnessSessionId: string; port: number; url: string }
+  | {
+      type: "port.detected";
+      harnessSessionId: string;
+      port: number;
+      url: string;
+    }
   | { type: "workflows.changed" }
   /**
    * Full snapshot of one background task, re-broadcast on every change
@@ -530,7 +535,11 @@ export interface AppState {
    * don't run the consent flow (tests, mocks — treated as "stored-explicit"
    * by the UI, i.e. no notice).
    */
-  consentSource?: "env-forced-off" | "stored-explicit" | "prompted" | "default-silent";
+  consentSource?:
+    | "env-forced-off"
+    | "stored-explicit"
+    | "prompted"
+    | "default-silent";
   /**
    * When consentSource === "env-forced-off", which env var forced it off —
    * rendered in the tracking indicator as "off (env)" with the var name.
@@ -562,6 +571,14 @@ export interface AppState {
    *  terminal. Optional so AppState constructed without the CLI (tests,
    *  mocks) reads as a returning user by default. */
   firstRun?: boolean;
+  /** The Agents API base URL this harness resolves and triggers against — the
+   *  same env-configurable base the server uses to resolve deployed-agent slugs
+   *  (`SAPIOM_AGENTS_URL` / `SAPIOM_TOOLS_BASE`, else the prod default). The
+   *  snippet panel renders it as the executions host so the copy-paste cURL/SDK
+   *  call hits the same environment the agent was deployed to. Optional: omitted
+   *  by callers that construct AppState without the CLI (tests, mocks); the SPA
+   *  then falls back to the SDK's own default host. */
+  agentsBaseUrl?: string;
 }
 
 /** `POST /api/sample-project` response — the seeded (or reused) example. */

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1,7 +1,8 @@
 /**
  * Mock-mode UI smoke test — runs against `vite dev` with VITE_MOCK=1 (see
  * playwright.config.ts), no harness server required. Fixtures live in
- * ../src/lib/mock-data.ts: 3 workflows (one deployed), a running "boot"
+ * ../src/lib/mock-data.ts: 4 workflows (three deployed — one with an
+ * unresolved slug — plus one undeployed), a running "boot"
  * session (the server auto-creates one at launch), a second running
  * background session ("scratch", not the active tab on load — demonstrates
  * the tab strip and busy pulse), and 2 exited sessions kept around as
@@ -17,7 +18,9 @@ test.beforeEach(async ({ page }) => {
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
-test("renders the three panes plus the brand header, with no separate action rail", async ({ page }) => {
+test("renders the three panes plus the brand header, with no separate action rail", async ({
+  page,
+}) => {
   await expect(page.locator(".brand-header")).toBeVisible();
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.locator(".center-pane")).toBeVisible();
@@ -28,10 +31,15 @@ test("renders the three panes plus the brand header, with no separate action rai
   // strip now, anchored to the selected row, not in a standalone column.
   await expect(page.locator(".rail-actions")).toHaveCount(0);
 
-  await page.screenshot({ path: "web/e2e/screenshots/app-shell.png", fullPage: true });
+  await page.screenshot({
+    path: "web/e2e/screenshots/app-shell.png",
+    fullPage: true,
+  });
 });
 
-test("viewport-locked shell: the page never scrolls even when terminal content overflows", async ({ page }) => {
+test("viewport-locked shell: the page never scrolls even when terminal content overflows", async ({
+  page,
+}) => {
   // Simulate a terminal that's rendered far more than the pane can show —
   // injected as a raw sibling in .terminal-slot (bypassing Terminal.tsx's own
   // overflow:hidden wrapper) so this also exercises the grid/flex containment
@@ -51,13 +59,21 @@ test("viewport-locked shell: the page never scrolls even when terminal content o
   expect(root.scrollHeight).toBe(root.clientHeight);
 });
 
-test("theme: defaults to light, toggles to dark, and the choice persists across reload", async ({ page }) => {
+test("theme: defaults to light, toggles to dark, and the choice persists across reload", async ({
+  page,
+}) => {
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
-  await page.screenshot({ path: "web/e2e/screenshots/theme-light.png", fullPage: true });
+  await page.screenshot({
+    path: "web/e2e/screenshots/theme-light.png",
+    fullPage: true,
+  });
 
   await page.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-  await page.screenshot({ path: "web/e2e/screenshots/theme-dark.png", fullPage: true });
+  await page.screenshot({
+    path: "web/e2e/screenshots/theme-dark.png",
+    fullPage: true,
+  });
 
   await page.reload();
   await expect(page.locator(".rail-workflows")).toBeVisible();
@@ -70,26 +86,38 @@ test("theme: defaults to light, toggles to dark, and the choice persists across 
 test.describe("theme — system preference", () => {
   test.use({ colorScheme: "dark" });
 
-  test("honors prefers-color-scheme when there's no stored preference yet", async ({ page }) => {
+  test("honors prefers-color-scheme when there's no stored preference yet", async ({
+    page,
+  }) => {
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   });
 });
 
-test("brand header shows the Sapiom wordmark and signed-in identity", async ({ page }) => {
+test("brand header shows the Sapiom wordmark and signed-in identity", async ({
+  page,
+}) => {
   await expect(page.locator(".brand-name")).toHaveText("Sapiom");
   await expect(page.locator(".brand-product")).toHaveText("Harness");
   const identity = page.getByTestId("brand-identity");
   await expect(identity).toContainText("Acme (mock)");
-  await expect(page.locator(".identity-dot")).toHaveAttribute("data-authenticated", "true");
+  await expect(page.locator(".identity-dot")).toHaveAttribute(
+    "data-authenticated",
+    "true",
+  );
 });
 
-test("auto-selects the running boot session on initial load", async ({ page }) => {
+test("auto-selects the running boot session on initial load", async ({
+  page,
+}) => {
   // The server auto-creates a session in launchDir at boot — the app should
   // never open to an empty terminal pane.
   await expect(page.locator(".terminal-empty")).toHaveCount(0);
   const bootTab = page.getByTestId("session-tab-sess-boot");
   await expect(bootTab).toHaveClass(/is-active/);
-  await expect(bootTab.locator(".session-dot")).toHaveAttribute("data-status", "running");
+  await expect(bootTab.locator(".session-dot")).toHaveAttribute(
+    "data-status",
+    "running",
+  );
 });
 
 test("session tabs: one per non-exited session, switching is instant, and the '+' opens the new-session modal", async ({
@@ -116,7 +144,9 @@ test("session tabs: one per non-exited session, switching is instant, and the '+
   await page.getByRole("button", { name: "Cancel" }).click();
 });
 
-test("session tabs: Cmd/Ctrl+1..9 switches directly to that tab", async ({ page }) => {
+test("session tabs: Cmd/Ctrl+1..9 switches directly to that tab", async ({
+  page,
+}) => {
   const bootTab = page.getByTestId("session-tab-sess-boot");
   const bgTab = page.getByTestId("session-tab-sess-bg");
   await expect(bootTab).toHaveClass(/is-active/);
@@ -131,7 +161,9 @@ test("session tabs: Cmd/Ctrl+1..9 switches directly to that tab", async ({ page 
   await expect(bootTab).toHaveClass(/is-active/);
 });
 
-test("session tabs: a busy tab shows a pulse that clears once output goes quiet", async ({ page }) => {
+test("session tabs: a busy tab shows a pulse that clears once output goes quiet", async ({
+  page,
+}) => {
   // mock-data's MOCK_ACTIVITY_SESSION_ID ("sess-bg") gets one simulated
   // session.activity ping shortly after load — see lib/events.ts.
   const busyDot = page.getByTestId("session-tab-busy-sess-bg");
@@ -142,8 +174,12 @@ test("session tabs: a busy tab shows a pulse that clears once output goes quiet"
   await expect(busyDot).toHaveCount(0, { timeout: 6_000 });
 });
 
-test("workflows rail lists the fixtures and selecting one drives macro gating", async ({ page }) => {
-  await expect(page.locator(".workflow-item")).toHaveCount(3);
+test("workflows rail lists the fixtures and selecting one drives macro gating", async ({
+  page,
+}) => {
+  // Four fixtures: leasing (deployed), rfq (undeployed), onboarding-flow
+  // (deployed), claims-triage (deployed but slug unresolved).
+  await expect(page.locator(".workflow-item")).toHaveCount(4);
 
   // "leasing" is deployed (has a definitionId) — selecting it enables the deploy-link macro.
   const openProd = page.getByTestId("macro-open_prod");
@@ -156,36 +192,56 @@ test("workflows rail lists the fixtures and selecting one drives macro gating", 
   await page.getByTestId("workflow-rfq").click();
   await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-selected/);
   await expect(openProd).toBeDisabled();
-  await expect(openProd).toHaveAttribute("aria-label", "Open prod: Not deployed yet");
+  await expect(openProd).toHaveAttribute(
+    "aria-label",
+    "Open prod: Not deployed yet",
+  );
 
   await page.getByTestId("workflow-action-strip").hover();
-  await expect(page.locator(".strip-item-reason")).toHaveText("Not deployed yet");
-  await page.screenshot({ path: "web/e2e/screenshots/action-strip-expanded.png" });
+  await expect(page.locator(".strip-item-reason")).toHaveText(
+    "Not deployed yet",
+  );
+  await page.screenshot({
+    path: "web/e2e/screenshots/action-strip-expanded.png",
+  });
 });
 
-test("inject macros are enabled once the boot session and a deployed workflow are active", async ({ page }) => {
+test("inject macros are enabled once the boot session and a deployed workflow are active", async ({
+  page,
+}) => {
   await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-selected/);
   await expect(page.getByTestId("macro-run_local")).toBeEnabled();
   await expect(page.getByTestId("macro-deploy")).toBeEnabled();
 });
 
 test.describe("workspace binding", () => {
-  test("the rail groups workflows into a tree: active session's directory first, others below", async ({ page }) => {
+  test("the rail groups workflows into a tree: active session's directory first, others below", async ({
+    page,
+  }) => {
     // Boot session's cwd is /Users/demo/acme-app, which owns "leasing".
     const activeGroup = page.getByTestId("workspace-group-acme-app");
     await expect(activeGroup).toBeVisible();
-    await expect(page.locator(".workspace-group.is-active")).toContainText("acme-app");
+    await expect(page.locator(".workspace-group.is-active")).toContainText(
+      "acme-app",
+    );
 
     // "rfq" lives under /Users/demo/rfq-workflows, a different known session's directory.
-    await expect(page.getByTestId("workspace-group-rfq-workflows")).toBeVisible();
+    await expect(
+      page.getByTestId("workspace-group-rfq-workflows"),
+    ).toBeVisible();
 
     // "onboarding-flow" isn't under any known session's directory.
     await expect(page.getByText("Other")).toBeVisible();
 
-    await page.screenshot({ path: "web/e2e/screenshots/workspace-tree.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/workspace-tree.png",
+      fullPage: true,
+    });
   });
 
-  test("the boot session's default binding shows a chip on load", async ({ page }) => {
+  test("the boot session's default binding shows a chip on load", async ({
+    page,
+  }) => {
     // Fixture: sess-boot is pre-bound to leasing, so the chip renders without
     // any interaction — useful for anyone eyeballing mock mode, not just tests.
     const chip = page.getByTestId("session-workflow-chip");
@@ -193,22 +249,34 @@ test.describe("workspace binding", () => {
     await expect(chip).toContainText("working on leasing");
   });
 
-  test("selecting a different workflow re-binds it and updates the chip", async ({ page }) => {
+  test("selecting a different workflow re-binds it and updates the chip", async ({
+    page,
+  }) => {
     await page.getByTestId("workflow-rfq").click();
-    await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+    await expect(page.getByTestId("session-workflow-chip")).toContainText(
+      "working on rfq",
+    );
   });
 
-  test("the binding is per-session: switching sessions shows that session's own binding", async ({ page }) => {
-    await expect(page.getByTestId("session-workflow-chip")).toContainText("leasing");
+  test("the binding is per-session: switching sessions shows that session's own binding", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("session-workflow-chip")).toContainText(
+      "leasing",
+    );
 
     // Switch to a session that's never had anything bound.
     await page.getByTestId("history-trigger").click();
-    await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
+    await page
+      .getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f")
+      .click();
     await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
   });
 });
 
-test("new-session modal: directory picker navigates and validates", async ({ page }) => {
+test("new-session modal: directory picker navigates and validates", async ({
+  page,
+}) => {
   await page.getByTestId("new-session-btn").click();
   await expect(page.getByText("New session")).toBeVisible();
 
@@ -222,7 +290,9 @@ test("new-session modal: directory picker navigates and validates", async ({ pag
   // Type-ahead: an unrecognized tail filters the nearest real ancestor's children.
   await input.fill("/Users/demo/rf");
   await expect(page.getByTestId("dir-picker-item-rfq-workflows")).toBeVisible();
-  await expect(page.getByTestId("dir-picker-item-onboarding-flow")).toHaveCount(0);
+  await expect(page.getByTestId("dir-picker-item-onboarding-flow")).toHaveCount(
+    0,
+  );
 
   // Clicking a listed directory drills into it.
   await page.getByTestId("dir-picker-item-rfq-workflows").click();
@@ -245,9 +315,13 @@ test("new-session modal: directory picker navigates and validates", async ({ pag
   await expect(page.getByText("New session")).toBeHidden();
 });
 
-test("resuming a history entry switches the active session, and it rejoins the tab strip", async ({ page }) => {
+test("resuming a history entry switches the active session, and it rejoins the tab strip", async ({
+  page,
+}) => {
   await page.getByTestId("history-trigger").click();
-  await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
+  await page
+    .getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f")
+    .click();
   const tab = page.getByTestId("session-tab-sess-leasing");
   await expect(tab).toHaveClass(/is-active/);
   await expect(tab).toContainText("Build the leasing pipeline");
@@ -266,10 +340,15 @@ test.describe("dead sessions never trap the user", () => {
     await expect(pane).toContainText("exit code 0");
     await expect(page.locator(".harness-terminal")).toHaveCount(0);
 
-    await page.screenshot({ path: "web/e2e/screenshots/dead-session-pane.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/dead-session-pane.png",
+      fullPage: true,
+    });
   });
 
-  test("Resume on a dead session starts it running again and it becomes a tab", async ({ page }) => {
+  test("Resume on a dead session starts it running again and it becomes a tab", async ({
+    page,
+  }) => {
     await page.getByTestId("history-trigger").click();
     await page.getByTestId("exited-session-sess-leasing").click();
     await page.getByTestId("dead-session-resume").click();
@@ -280,7 +359,9 @@ test.describe("dead sessions never trap the user", () => {
     await expect(tab).toContainText("Build the leasing pipeline");
   });
 
-  test("Close on a dead session removes it and falls back to another running session", async ({ page }) => {
+  test("Close on a dead session removes it and falls back to another running session", async ({
+    page,
+  }) => {
     // The boot session is running, so falling back to it is always possible here.
     await page.getByTestId("history-trigger").click();
     await page.getByTestId("exited-session-sess-leasing").click();
@@ -288,10 +369,14 @@ test.describe("dead sessions never trap the user", () => {
 
     await expect(page.getByTestId("dead-session-pane")).toHaveCount(0);
     await expect(page.locator(".terminal-empty")).toHaveCount(0);
-    await expect(page.getByTestId("session-tab-sess-boot")).toHaveClass(/is-active/);
+    await expect(page.getByTestId("session-tab-sess-boot")).toHaveClass(
+      /is-active/,
+    );
 
     await page.getByTestId("history-trigger").click();
-    await expect(page.getByTestId("exited-session-sess-leasing")).toHaveCount(0);
+    await expect(page.getByTestId("exited-session-sess-leasing")).toHaveCount(
+      0,
+    );
   });
 });
 
@@ -302,7 +387,9 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
     await page.getByTestId("palette-trigger").click();
     const list = page.getByTestId("command-palette-list");
     await expect(list).toBeVisible();
-    await expect(page.getByTestId("command-palette-item-0")).toContainText("acme-app"); // the running boot session
+    await expect(page.getByTestId("command-palette-item-0")).toContainText(
+      "acme-app",
+    ); // the running boot session
 
     await page.screenshot({ path: "web/e2e/screenshots/command-palette.png" });
 
@@ -316,20 +403,30 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
   test("fuzzy filters by the typed query", async ({ page }) => {
     await page.getByTestId("palette-trigger").click();
     await page.getByTestId("command-palette-input").fill("leasing");
-    await expect(page.getByTestId("command-palette-item-0")).toContainText("leasing");
+    await expect(page.getByTestId("command-palette-item-0")).toContainText(
+      "leasing",
+    );
   });
 
-  test("Enter on a workflow hit starts a new session there", async ({ page }) => {
+  test("Enter on a workflow hit starts a new session there", async ({
+    page,
+  }) => {
     await page.getByTestId("palette-trigger").click();
     await page.getByTestId("command-palette-input").fill("onboarding-flow");
     await page.keyboard.press("Enter");
-    await expect(page.locator(".session-tab.is-active")).toContainText("onboarding-flow");
+    await expect(page.locator(".session-tab.is-active")).toContainText(
+      "onboarding-flow",
+    );
   });
 
-  test("Enter on a session hit switches to it instead of starting a new one", async ({ page }) => {
+  test("Enter on a session hit switches to it instead of starting a new one", async ({
+    page,
+  }) => {
     // Resume a different session first so switching back is observable.
     await page.getByTestId("history-trigger").click();
-    await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
+    await page
+      .getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f")
+      .click();
     const leasingTab = page.getByTestId("session-tab-sess-leasing");
     await expect(leasingTab).toHaveClass(/is-active/);
 
@@ -339,7 +436,9 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
     await expect(leasingTab).not.toHaveClass(/is-active/);
   });
 
-  test("a path-shaped query uses live GET /api/fs/list completion instead of fuzzy matching", async ({ page }) => {
+  test("a path-shaped query uses live GET /api/fs/list completion instead of fuzzy matching", async ({
+    page,
+  }) => {
     await page.getByTestId("palette-trigger").click();
     await page.getByTestId("command-palette-input").fill("/Users/demo");
 
@@ -348,16 +447,26 @@ test.describe("command palette (Cmd+K / Cmd+P quick-jump)", () => {
     await expect(dirItem).toContainText("acme-app");
 
     await dirItem.click();
-    await expect(page.locator(".session-tab.is-active")).toContainText("acme-app");
+    await expect(page.locator(".session-tab.is-active")).toContainText(
+      "acme-app",
+    );
   });
 });
 
-test("canvas pane shows its empty state for the active session", async ({ page }) => {
-  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
-  await expect(page.locator(".canvas-empty")).toContainText(".sapiom/canvas/index.html");
+test("canvas pane shows its empty state for the active session", async ({
+  page,
+}) => {
+  await expect(page.locator(".canvas-empty")).toContainText(
+    "Nothing generated yet",
+  );
+  await expect(page.locator(".canvas-empty")).toContainText(
+    ".sapiom/canvas/index.html",
+  );
 });
 
-test("settings popover: identity, telemetry toggle, and it persists across close/reopen", async ({ page }) => {
+test("settings popover: identity, telemetry toggle, and it persists across close/reopen", async ({
+  page,
+}) => {
   const trigger = page.getByTestId("settings-trigger");
   const toggle = page.getByTestId("telemetry-toggle");
 
@@ -376,7 +485,10 @@ test("settings popover: identity, telemetry toggle, and it persists across close
 
   // Reopening should reflect the same (mutated) state, not reset to the fixture default.
   await trigger.click();
-  await expect(page.getByTestId("telemetry-toggle")).toHaveAttribute("aria-checked", "true");
+  await expect(page.getByTestId("telemetry-toggle")).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
 });
 
 test("visualize macro is one click — no subject dialog", async ({ page }) => {
@@ -386,32 +498,47 @@ test("visualize macro is one click — no subject dialog", async ({ page }) => {
 
   // No modal, no free-text field — the click alone fires the macro.
   await expect(page.locator(".modal-backdrop")).toHaveCount(0);
-  await expect(page.getByPlaceholder("What should the agent visualize?")).toHaveCount(0);
+  await expect(
+    page.getByPlaceholder("What should the agent visualize?"),
+  ).toHaveCount(0);
 
   // MockApi.runMacro has no other observable effect (it's a no-op against real
   // infra), so the test hook is what confirms the click actually fired — and
   // fired with no subject, since that plumbing is gone.
   await page.waitForFunction(
-    () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
+    () =>
+      (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } })
+        .__HARNESS_TEST__?.lastMacroRun,
   );
   const lastRun = await page.evaluate(
     () =>
-      (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
-        .__HARNESS_TEST__.lastMacroRun,
+      (
+        window as unknown as {
+          __HARNESS_TEST__: {
+            lastMacroRun?: { id: string; req: { subject?: string } };
+          };
+        }
+      ).__HARNESS_TEST__.lastMacroRun,
   );
   expect(lastRun?.id).toBe("visualize");
   expect(lastRun?.req.subject).toBeUndefined();
 });
 
 test.describe("docked workflow action strip", () => {
-  test("rows carry no inline icons and show their full untruncated name", async ({ page }) => {
+  test("rows carry no inline icons and show their full untruncated name", async ({
+    page,
+  }) => {
     await expect(page.locator(".workflow-row-actions")).toHaveCount(0);
 
     // "onboarding-flow" is the longest fixture name — it's the one that used
     // to get squeezed into "onboarding-fl…" by the old inline row icons.
-    const name = page.getByTestId("workflow-onboarding-flow").locator(".workflow-name");
+    const name = page
+      .getByTestId("workflow-onboarding-flow")
+      .locator(".workflow-name");
     await expect(name).toHaveText("onboarding-flow");
-    const overflowing = await name.evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+    const overflowing = await name.evaluate(
+      (el) => el.scrollWidth > el.clientWidth + 1,
+    );
     expect(overflowing).toBe(false);
   });
 
@@ -439,15 +566,23 @@ test.describe("docked workflow action strip", () => {
     await expect(strip.getByTestId("macro-ai-visualize")).toHaveCount(0);
     await expect(strip.locator(".strip-item")).toHaveCount(5);
 
-    await page.screenshot({ path: "web/e2e/screenshots/app-shell-docked-strip.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/app-shell-docked-strip.png",
+      fullPage: true,
+    });
   });
 
-  test("the strip is icon-only at rest and expands to icon+label on hover", async ({ page }) => {
+  test("the strip is icon-only at rest and expands to icon+label on hover", async ({
+    page,
+  }) => {
     const strip = page.getByTestId("workflow-action-strip");
 
     const restBox = await strip.boundingBox();
     expect(restBox?.width ?? 0).toBeLessThan(30);
-    await expect(page.locator(".strip-item-text").first()).toHaveCSS("opacity", "0");
+    await expect(page.locator(".strip-item-text").first()).toHaveCSS(
+      "opacity",
+      "0",
+    );
 
     await strip.hover();
     await expect(async () => {
@@ -462,13 +597,20 @@ test.describe("docked workflow action strip", () => {
     // background must be fully opaque (`rgb(...)`, no alpha channel), not
     // the translucent `--accent-dim` it used to render with, which let the
     // terminal's own text bleed through and read as broken.
-    const backgroundColor = await strip.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const backgroundColor = await strip.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
     expect(backgroundColor).toMatch(/^rgb\(/);
 
-    await page.screenshot({ path: "web/e2e/screenshots/strip-hover-expanded.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/strip-hover-expanded.png",
+      fullPage: true,
+    });
   });
 
-  test("the strip also expands on keyboard focus, not just mouse hover", async ({ page }) => {
+  test("the strip also expands on keyboard focus, not just mouse hover", async ({
+    page,
+  }) => {
     const strip = page.getByTestId("workflow-action-strip");
     const restBox = await strip.boundingBox();
     expect(restBox?.width ?? 0).toBeLessThan(30);
@@ -483,10 +625,15 @@ test.describe("docked workflow action strip", () => {
     await expect(page.getByTestId("macro-run_local")).toBeFocused();
     await expect(strip.getByText("Run local")).toBeVisible();
 
-    await page.screenshot({ path: "web/e2e/screenshots/strip-keyboard-focus-expanded.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/strip-keyboard-focus-expanded.png",
+      fullPage: true,
+    });
   });
 
-  test("the strip moves when selection changes, and the notch tracks the new row", async ({ page }) => {
+  test("the strip moves when selection changes, and the notch tracks the new row", async ({
+    page,
+  }) => {
     const rfqRow = page.getByTestId("workflow-rfq");
     await rfqRow.locator(".workflow-item-trigger").click();
 
@@ -508,7 +655,10 @@ test.describe("docked workflow action strip", () => {
     // The notch is sized to the row, not the whole multi-icon strip below it.
     expect(notchBox?.height ?? 0).toBeLessThan(stripBox?.height ?? Infinity);
 
-    await page.screenshot({ path: "web/e2e/screenshots/workflow-action-strip-moved.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/workflow-action-strip-moved.png",
+      fullPage: true,
+    });
   });
 
   test("the canvas header stays fully on-screen even when the app is narrower than the default pane widths", async ({
@@ -528,10 +678,15 @@ test.describe("docked workflow action strip", () => {
     expect(btnBox).not.toBeNull();
     expect((btnBox?.x ?? 0) + (btnBox?.width ?? 0)).toBeLessThanOrEqual(900);
 
-    await page.screenshot({ path: "web/e2e/screenshots/narrow-viewport-header.png", fullPage: true });
+    await page.screenshot({
+      path: "web/e2e/screenshots/narrow-viewport-header.png",
+      fullPage: true,
+    });
   });
 
-  test("the header's deployed dot is pinned to a fixed slot regardless of name length", async ({ page }) => {
+  test("the header's deployed dot is pinned to a fixed slot regardless of name length", async ({
+    page,
+  }) => {
     // "leasing" (short) and "onboarding-flow" (long) are both deployed in
     // the fixtures specifically to exercise this — the dot used to trail
     // right after the name, so it visibly jumped between the two.
@@ -539,41 +694,70 @@ test.describe("docked workflow action strip", () => {
     const leasingBox = await dot.boundingBox();
     expect(leasingBox).not.toBeNull();
 
-    await page.getByTestId("workflow-onboarding-flow").locator(".workflow-item-trigger").click();
-    await expect(page.getByTestId("workflow-actions-header")).toContainText("onboarding-flow");
+    await page
+      .getByTestId("workflow-onboarding-flow")
+      .locator(".workflow-item-trigger")
+      .click();
+    await expect(page.getByTestId("workflow-actions-header")).toContainText(
+      "onboarding-flow",
+    );
     const onboardingBox = await dot.boundingBox();
     expect(onboardingBox).not.toBeNull();
 
     expect(onboardingBox?.x).toBeCloseTo(leasingBox?.x ?? 0, 0);
 
     await dot.hover();
-    await expect(page.locator(".workflow-dot-pinned")).toHaveAttribute("data-tooltip", "Deployed to production");
-    await page.screenshot({ path: "web/e2e/screenshots/header-dot-pinned.png", fullPage: true });
+    await expect(page.locator(".workflow-dot-pinned")).toHaveAttribute(
+      "data-tooltip",
+      "Deployed to production",
+    );
+    await page.screenshot({
+      path: "web/e2e/screenshots/header-dot-pinned.png",
+      fullPage: true,
+    });
   });
 
-  test("the header's action is re-visualize, not a no-op iframe reload", async ({ page }) => {
-    const reVisualizeBtn = page.getByTestId("workflow-actions-header").getByTestId("canvas-revisualize");
+  test("the header's action is re-visualize, not a no-op iframe reload", async ({
+    page,
+  }) => {
+    const reVisualizeBtn = page
+      .getByTestId("workflow-actions-header")
+      .getByTestId("canvas-revisualize");
     await expect(reVisualizeBtn).toBeEnabled();
-    await expect(reVisualizeBtn).toHaveAttribute("data-tooltip", "Re-visualize");
+    await expect(reVisualizeBtn).toHaveAttribute(
+      "data-tooltip",
+      "Re-visualize",
+    );
 
     await reVisualizeBtn.click();
 
     // Clicking it fires the same one-click Visualize macro the strip and the
     // empty-state CTA use — not a bare reload with no new content.
     await page.waitForFunction(
-      () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
+      () =>
+        (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } })
+          .__HARNESS_TEST__?.lastMacroRun,
     );
     const lastRun = await page.evaluate(
       () =>
-        (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
-          .__HARNESS_TEST__.lastMacroRun,
+        (
+          window as unknown as {
+            __HARNESS_TEST__: {
+              lastMacroRun?: { id: string; req: { subject?: string } };
+            };
+          }
+        ).__HARNESS_TEST__.lastMacroRun,
     );
     expect(lastRun?.id).toBe("visualize");
 
     // The pane itself swaps in the new render once canvas.reload arrives —
     // that part is unchanged, and still the only thing that flips the iframe in.
     await page.evaluate(() => {
-      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({
         type: "canvas.reload",
         harnessSessionId: "sess-boot",
       });
@@ -582,9 +766,15 @@ test.describe("docked workflow action strip", () => {
   });
 });
 
-test("canvas empty state explains itself and offers a one-click Visualize CTA", async ({ page }) => {
-  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
-  await expect(page.locator(".canvas-empty")).toContainText(".sapiom/canvas/index.html");
+test("canvas empty state explains itself and offers a one-click Visualize CTA", async ({
+  page,
+}) => {
+  await expect(page.locator(".canvas-empty")).toContainText(
+    "Nothing generated yet",
+  );
+  await expect(page.locator(".canvas-empty")).toContainText(
+    ".sapiom/canvas/index.html",
+  );
 
   await page.screenshot({ path: "web/e2e/screenshots/canvas-empty-state.png" });
 
@@ -595,25 +785,38 @@ test("canvas empty state explains itself and offers a one-click Visualize CTA", 
   // One click and done — no dialog, no free-text field.
   await expect(page.locator(".modal-backdrop")).toHaveCount(0);
   await page.waitForFunction(
-    () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
+    () =>
+      (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } })
+        .__HARNESS_TEST__?.lastMacroRun,
   );
   const lastRun = await page.evaluate(
     () =>
-      (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
-        .__HARNESS_TEST__.lastMacroRun,
+      (
+        window as unknown as {
+          __HARNESS_TEST__: {
+            lastMacroRun?: { id: string; req: { subject?: string } };
+          };
+        }
+      ).__HARNESS_TEST__.lastMacroRun,
   );
   expect(lastRun?.id).toBe("visualize");
   expect(lastRun?.req.subject).toBeUndefined();
 });
 
-test("the canvas is a single controlled surface — no separate preview tab or port suggestions", async ({ page }) => {
+test("the canvas is a single controlled surface — no separate preview tab or port suggestions", async ({
+  page,
+}) => {
   await expect(page.locator(".canvas-mode-toggle")).toHaveCount(0);
   await expect(page.getByTestId("preview-chip")).toHaveCount(0);
 
   // A detected-port bus message must render nothing in this surface — the
   // canvas only ever shows the session's own generated content.
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "port.detected",
       harnessSessionId: "sess-boot",
       port: 4000,
@@ -621,24 +824,39 @@ test("the canvas is a single controlled surface — no separate preview tab or p
     });
   });
   await expect(page.getByTestId("preview-chip")).toHaveCount(0);
-  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+  await expect(page.locator(".canvas-empty")).toContainText(
+    "Nothing generated yet",
+  );
 });
 
-test("a canvas.reload bus message swaps the empty state for the generated iframe", async ({ page }) => {
-  await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+test("a canvas.reload bus message swaps the empty state for the generated iframe", async ({
+  page,
+}) => {
+  await expect(page.locator(".canvas-empty")).toContainText(
+    "Nothing generated yet",
+  );
 
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "canvas.reload",
       harnessSessionId: "sess-boot",
     });
   });
 
   await expect(page.locator(".canvas-empty")).toHaveCount(0);
-  await expect(page.locator(".canvas-iframe")).toHaveAttribute("src", /^\/canvas\/sess-boot\/\?theme=(light|dark)$/);
+  await expect(page.locator(".canvas-iframe")).toHaveAttribute(
+    "src",
+    /^\/canvas\/sess-boot\/\?theme=(light|dark)$/,
+  );
 });
 
-test("a stale enrichment renders with the 'stale — Refresh' chip in the served canvas document", async ({ page }) => {
+test("a stale enrichment renders with the 'stale — Refresh' chip in the served canvas document", async ({
+  page,
+}) => {
   // The chip is server-rendered (core/canvas-render.ts marks an enrichment
   // whose fingerprint no longer matches the sources) — serve the REAL
   // renderer's output for that state into the pane's iframe and assert the
@@ -653,7 +871,10 @@ test("a stale enrichment renders with the 'stale — Refresh' chip in the served
         edges: [],
       },
       { title: "leasing", badges: ["local only"] },
-      { enrichment: { summary: "Handles lease applications end to end" }, stale: true },
+      {
+        enrichment: { summary: "Handles lease applications end to end" },
+        stale: true,
+      },
     ),
   );
   await page.route("**/canvas/sess-boot/**", async (route) => {
@@ -661,20 +882,30 @@ test("a stale enrichment renders with the 'stale — Refresh' chip in the served
   });
 
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "canvas.reload",
       harnessSessionId: "sess-boot",
     });
   });
 
   const frame = page.frameLocator(".canvas-iframe");
-  await expect(frame.locator(".canvas-badge--stale")).toHaveText("stale — Refresh");
+  await expect(frame.locator(".canvas-badge--stale")).toHaveText(
+    "stale — Refresh",
+  );
   // The stale enrichment stays DISPLAYED — the chip marks it, never hides it.
-  await expect(frame.locator(".canvas-subtitle")).toHaveText("Handles lease applications end to end");
+  await expect(frame.locator(".canvas-subtitle")).toHaveText(
+    "Handles lease applications end to end",
+  );
   await page.screenshot({ path: "web/e2e/screenshots/canvas-stale-chip.png" });
 });
 
-test("a pending canvas load shows a skeleton over the iframe — never a blank pane", async ({ page }) => {
+test("a pending canvas load shows a skeleton over the iframe — never a blank pane", async ({
+  page,
+}) => {
   // Stall the canvas document so the load stays pending long enough to assert
   // on the skeleton deterministically.
   let releaseCanvas = (): void => {};
@@ -683,11 +914,18 @@ test("a pending canvas load shows a skeleton over the iframe — never a blank p
   });
   await page.route("**/canvas/sess-boot/**", async (route) => {
     await gate;
-    await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<html><body>diagram</body></html>",
+    });
   });
 
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "canvas.reload",
       harnessSessionId: "sess-boot",
     });
@@ -695,7 +933,9 @@ test("a pending canvas load shows a skeleton over the iframe — never a blank p
 
   // While the iframe document is in flight: skeleton visible, no bare pane.
   await expect(page.getByTestId("canvas-loading")).toBeVisible();
-  await expect(page.getByTestId("canvas-loading")).toContainText("Rendering diagram");
+  await expect(page.getByTestId("canvas-loading")).toContainText(
+    "Rendering diagram",
+  );
 
   releaseCanvas();
   await expect(page.getByTestId("canvas-loading")).toHaveCount(0);
@@ -708,11 +948,18 @@ test("switching the bound workflow refetches the canvas immediately — the serv
   let canvasRequests = 0;
   await page.route("**/canvas/sess-boot/**", async (route) => {
     canvasRequests += 1;
-    await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<html><body>diagram</body></html>",
+    });
   });
 
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "canvas.reload",
       harnessSessionId: "sess-boot",
     });
@@ -725,7 +972,9 @@ test("switching the bound workflow refetches the canvas immediately — the serv
   // its own (the served document changes with the binding) — no canvas.reload
   // round-trip required first.
   await page.getByTestId("workflow-rfq").click();
-  await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+  await expect(page.getByTestId("session-workflow-chip")).toContainText(
+    "working on rfq",
+  );
   await expect.poll(() => canvasRequests).toBeGreaterThan(requestsBeforeBind);
 });
 
@@ -747,15 +996,24 @@ test.describe("background-task canvas states", () => {
     errorTail: null as string | null,
   };
 
-  const publish = (page: import("@playwright/test").Page, task: unknown): Promise<void> =>
+  const publish = (
+    page: import("@playwright/test").Page,
+    task: unknown,
+  ): Promise<void> =>
     page.evaluate((t) => {
-      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({
         type: "task.status",
         task: t,
       });
     }, task);
 
-  test("a running task shows the live activity state, streaming status lines as they arrive", async ({ page }) => {
+  test("a running task shows the live activity state, streaming status lines as they arrive", async ({
+    page,
+  }) => {
     await publish(page, { ...baseTask, status: "running" });
 
     const activity = page.getByTestId("canvas-task-activity");
@@ -768,17 +1026,30 @@ test.describe("background-task canvas states", () => {
       status: "running",
       statusLines: ["Agent started", "Read steps/route.ts"],
     });
-    await expect(page.getByTestId("canvas-task-lines")).toContainText("Read steps/route.ts");
+    await expect(page.getByTestId("canvas-task-lines")).toContainText(
+      "Read steps/route.ts",
+    );
 
-    await page.screenshot({ path: "web/e2e/screenshots/canvas-task-activity.png" });
+    await page.screenshot({
+      path: "web/e2e/screenshots/canvas-task-activity.png",
+    });
 
     // Completion clears the activity state; a canvas.reload for the written
     // index.html (the real server fires one via the canvas watcher) swaps in
     // the generated iframe.
-    await publish(page, { ...baseTask, status: "completed", endedAt: new Date().toISOString(), exitCode: 0 });
+    await publish(page, {
+      ...baseTask,
+      status: "completed",
+      endedAt: new Date().toISOString(),
+      exitCode: 0,
+    });
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
     await page.evaluate(() => {
-      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({
         type: "canvas.reload",
         harnessSessionId: "sess-boot",
       });
@@ -786,11 +1057,19 @@ test.describe("background-task canvas states", () => {
     await expect(page.locator(".canvas-iframe")).toBeVisible();
   });
 
-  test("activity only shows on the pane of the session that triggered the task", async ({ page }) => {
-    await publish(page, { ...baseTask, harnessSessionId: "sess-bg", status: "running" });
+  test("activity only shows on the pane of the session that triggered the task", async ({
+    page,
+  }) => {
+    await publish(page, {
+      ...baseTask,
+      harnessSessionId: "sess-bg",
+      status: "running",
+    });
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
     // sess-boot's own pane still shows its ordinary empty state.
-    await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+    await expect(page.locator(".canvas-empty")).toContainText(
+      "Nothing generated yet",
+    );
   });
 
   test("activity is scoped to the BOUND WORKFLOW — another workflow's task never bleeds into this pane", async ({
@@ -798,9 +1077,15 @@ test.describe("background-task canvas states", () => {
   }) => {
     // Same session, but the task targets a workflow that is NOT the pane's
     // current binding (sess-boot is bound to leasing) — hidden.
-    await publish(page, { ...baseTask, workflowPath: "/Users/demo/onboarding-flow", status: "running" });
+    await publish(page, {
+      ...baseTask,
+      workflowPath: "/Users/demo/onboarding-flow",
+      status: "running",
+    });
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
-    await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+    await expect(page.locator(".canvas-empty")).toContainText(
+      "Nothing generated yet",
+    );
 
     // The bound workflow's own task shows...
     await publish(page, { ...baseTask, id: "task-2", status: "running" });
@@ -809,7 +1094,9 @@ test.describe("background-task canvas states", () => {
     // ...and switching the binding mid-run hides it again: the rfq pane must
     // not show leasing's enrichment progress.
     await page.getByTestId("workflow-rfq").click();
-    await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+    await expect(page.getByTestId("session-workflow-chip")).toContainText(
+      "working on rfq",
+    );
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
   });
 
@@ -819,10 +1106,17 @@ test.describe("background-task canvas states", () => {
     // Bring up the canvas iframe first — simulates the deterministic render
     // that fires immediately when the user clicks Visualize.
     await page.route("**/canvas/sess-boot/**", async (route) => {
-      await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+      await route.fulfill({
+        contentType: "text/html",
+        body: "<html><body>diagram</body></html>",
+      });
     });
     await page.evaluate(() => {
-      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({
         type: "canvas.reload",
         harnessSessionId: "sess-boot",
       });
@@ -842,7 +1136,9 @@ test.describe("background-task canvas states", () => {
     // The overlay class is applied so the strip sits on top of the iframe.
     await expect(activity).toHaveClass(/canvas-task-activity--overlay/);
 
-    await page.screenshot({ path: "web/e2e/screenshots/canvas-enrichment-overlay.png" });
+    await page.screenshot({
+      path: "web/e2e/screenshots/canvas-enrichment-overlay.png",
+    });
 
     // Status lines stream through normally.
     await publish(page, {
@@ -850,22 +1146,38 @@ test.describe("background-task canvas states", () => {
       status: "running",
       statusLines: ["Reading steps/intake.ts"],
     });
-    await expect(page.getByTestId("canvas-task-lines")).toContainText("Reading steps/intake.ts");
+    await expect(page.getByTestId("canvas-task-lines")).toContainText(
+      "Reading steps/intake.ts",
+    );
     await expect(page.locator(".canvas-iframe")).toBeVisible();
 
     // Task completes: activity strip disappears, iframe stays.
-    await publish(page, { ...baseTask, status: "completed", endedAt: new Date().toISOString(), exitCode: 0 });
+    await publish(page, {
+      ...baseTask,
+      status: "completed",
+      endedAt: new Date().toISOString(),
+      exitCode: 0,
+    });
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
     await expect(page.locator(".canvas-iframe")).toBeVisible();
   });
 
-  test("failure view is full-screen (no iframe behind it) — unchanged from before", async ({ page }) => {
+  test("failure view is full-screen (no iframe behind it) — unchanged from before", async ({
+    page,
+  }) => {
     // Get an iframe up first, then trigger a failure.
     await page.route("**/canvas/sess-boot/**", async (route) => {
-      await route.fulfill({ contentType: "text/html", body: "<html><body>diagram</body></html>" });
+      await route.fulfill({
+        contentType: "text/html",
+        body: "<html><body>diagram</body></html>",
+      });
     });
     await page.evaluate(() => {
-      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({
         type: "canvas.reload",
         harnessSessionId: "sess-boot",
       });
@@ -884,10 +1196,14 @@ test.describe("background-task canvas states", () => {
     await expect(page.getByTestId("canvas-task-failed")).toBeVisible();
     await expect(page.locator(".canvas-iframe")).toHaveCount(0);
 
-    await page.screenshot({ path: "web/e2e/screenshots/canvas-failure-fullscreen.png" });
+    await page.screenshot({
+      path: "web/e2e/screenshots/canvas-failure-fullscreen.png",
+    });
   });
 
-  test("a failed task shows the error tail with retry and dismiss affordances", async ({ page }) => {
+  test("a failed task shows the error tail with retry and dismiss affordances", async ({
+    page,
+  }) => {
     await publish(page, {
       ...baseTask,
       status: "failed",
@@ -900,29 +1216,41 @@ test.describe("background-task canvas states", () => {
     await expect(failed).toBeVisible();
     await expect(failed).toContainText("Visualize failed");
     await expect(failed).toContainText("API connection lost");
-    await page.screenshot({ path: "web/e2e/screenshots/canvas-task-failed.png" });
+    await page.screenshot({
+      path: "web/e2e/screenshots/canvas-task-failed.png",
+    });
 
     // Retry re-fires the same macro (MockApi records it for us to read back)
     // — for an enrichment task that's the visualize force refresh.
     await page.getByTestId("canvas-task-retry").click();
     await page.waitForFunction(
-      () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
+      () =>
+        (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } })
+          .__HARNESS_TEST__?.lastMacroRun,
     );
     const lastRun = await page.evaluate(
       () =>
-        (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string } } }).__HARNESS_TEST__.lastMacroRun,
+        (
+          window as unknown as {
+            __HARNESS_TEST__: { lastMacroRun?: { id: string } };
+          }
+        ).__HARNESS_TEST__.lastMacroRun,
     );
     expect(lastRun?.id).toBe("visualize");
 
     // Dismiss hides the failure panel and returns the pane to its usual state.
     await page.getByTestId("canvas-task-dismiss").click();
     await expect(page.getByTestId("canvas-task-failed")).toHaveCount(0);
-    await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+    await expect(page.locator(".canvas-empty")).toContainText(
+      "Nothing generated yet",
+    );
   });
 });
 
 test.describe("resizable panes", () => {
-  test("dragging the rail handle resizes the rail and persists across reload", async ({ page }) => {
+  test("dragging the rail handle resizes the rail and persists across reload", async ({
+    page,
+  }) => {
     const handle = page.getByTestId("resize-handle-rail");
     const railBefore = await page.locator(".rail-workflows").boundingBox();
     const handleBox = await handle.boundingBox();
@@ -931,7 +1259,9 @@ test.describe("resizable panes", () => {
     const y = handleBox.y + handleBox.height / 2;
     await page.mouse.move(handleBox.x + handleBox.width / 2, y);
     await page.mouse.down();
-    await page.mouse.move(handleBox.x + handleBox.width / 2 + 80, y, { steps: 5 });
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 80, y, {
+      steps: 5,
+    });
     await page.mouse.up();
 
     const railAfter = await page.locator(".rail-workflows").boundingBox();
@@ -940,10 +1270,14 @@ test.describe("resizable panes", () => {
     await page.reload();
     await expect(page.locator(".rail-workflows")).toBeVisible();
     const railReloaded = await page.locator(".rail-workflows").boundingBox();
-    expect(Math.abs((railReloaded?.width ?? 0) - (railAfter?.width ?? 0))).toBeLessThan(3);
+    expect(
+      Math.abs((railReloaded?.width ?? 0) - (railAfter?.width ?? 0)),
+    ).toBeLessThan(3);
   });
 
-  test("dragging the canvas handle resizes the canvas pane", async ({ page }) => {
+  test("dragging the canvas handle resizes the canvas pane", async ({
+    page,
+  }) => {
     const handle = page.getByTestId("resize-handle-canvas");
     const canvasBefore = await page.locator(".canvas-pane").boundingBox();
     const handleBox = await handle.boundingBox();
@@ -953,14 +1287,18 @@ test.describe("resizable panes", () => {
     await page.mouse.move(handleBox.x + handleBox.width / 2, y);
     await page.mouse.down();
     // Dragging the canvas handle toward the terminal (left) grows the canvas.
-    await page.mouse.move(handleBox.x + handleBox.width / 2 - 80, y, { steps: 5 });
+    await page.mouse.move(handleBox.x + handleBox.width / 2 - 80, y, {
+      steps: 5,
+    });
     await page.mouse.up();
 
     const canvasAfter = await page.locator(".canvas-pane").boundingBox();
     expect((canvasAfter?.width ?? 0) - canvasBefore.width).toBeGreaterThan(60);
   });
 
-  test("rail and canvas widths cannot be dragged past their min-width floors", async ({ page }) => {
+  test("rail and canvas widths cannot be dragged past their min-width floors", async ({
+    page,
+  }) => {
     const railHandle = page.getByTestId("resize-handle-rail");
     let box = await railHandle.boundingBox();
     if (!box) throw new Error("expected bounding box");
@@ -968,7 +1306,8 @@ test.describe("resizable panes", () => {
     await page.mouse.down();
     await page.mouse.move(box.x - 1000, box.y + box.height / 2, { steps: 5 });
     await page.mouse.up();
-    const railWidth = (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
+    const railWidth =
+      (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
     expect(railWidth).toBeGreaterThanOrEqual(178); // RAIL_MIN = 180, small rounding slack
     expect(railWidth).toBeLessThan(195);
 
@@ -979,12 +1318,15 @@ test.describe("resizable panes", () => {
     await page.mouse.down();
     await page.mouse.move(box.x + 1000, box.y + box.height / 2, { steps: 5 });
     await page.mouse.up();
-    const canvasWidth = (await page.locator(".canvas-pane").boundingBox())?.width ?? 0;
+    const canvasWidth =
+      (await page.locator(".canvas-pane").boundingBox())?.width ?? 0;
     expect(canvasWidth).toBeGreaterThanOrEqual(278); // CANVAS_MIN = 280, small rounding slack
     expect(canvasWidth).toBeLessThan(295);
   });
 
-  test("double-clicking a handle resets it to its default width", async ({ page }) => {
+  test("double-clicking a handle resets it to its default width", async ({
+    page,
+  }) => {
     const handle = page.getByTestId("resize-handle-rail");
     const box = await handle.boundingBox();
     if (!box) throw new Error("expected bounding box");
@@ -995,14 +1337,21 @@ test.describe("resizable panes", () => {
     await page.mouse.up();
 
     await handle.dblclick();
-    const railWidth = (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
+    const railWidth =
+      (await page.locator(".rail-workflows").boundingBox())?.width ?? 0;
     expect(Math.abs(railWidth - 220)).toBeLessThan(3);
   });
 });
 
-test("the canvas iframe carries the app's theme and flips on toggle", async ({ page }) => {
+test("the canvas iframe carries the app's theme and flips on toggle", async ({
+  page,
+}) => {
   await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
       type: "canvas.reload",
       harnessSessionId: "sess-boot",
     });
@@ -1014,4 +1363,3 @@ test("the canvas iframe carries the app's theme and flips on toggle", async ({ p
   await page.getByTestId("theme-toggle").click();
   await expect(iframe).toHaveAttribute("src", /theme=dark/);
 });
-

--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -5,6 +5,8 @@
  *   - "leasing"  → deployed (definitionId: 4821, definitionSlug: "ic-diligence-orchestrator")
  *   - "rfq"      → undeployed (definitionId: null, definitionSlug: null)
  *   - "onboarding-flow" → deployed (definitionId: 9001, definitionSlug: "onboarding-flow")
+ *   - "claims-triage" → deployed but slug unresolved (definitionId: 7314,
+ *     definitionSlug: null) — exercises the project-name fallback + "inferred" note
  *
  * On initial load, "leasing" is pre-bound and pre-selected (the boot session's
  * boundWorkflowPath is "/Users/demo/acme-app/leasing"). The snippet panel
@@ -20,18 +22,24 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe("snippet panel visibility", () => {
-  test("shows the snippet panel when a deployed workflow is bound", async ({ page }) => {
+  test("shows the snippet panel when a deployed workflow is bound", async ({
+    page,
+  }) => {
     // leasing is deployed — the panel should be visible on initial load.
     await expect(page.getByTestId("snippet-panel")).toBeVisible();
   });
 
-  test("hides the snippet panel when an undeployed workflow is selected", async ({ page }) => {
+  test("hides the snippet panel when an undeployed workflow is selected", async ({
+    page,
+  }) => {
     // Click rfq (no definitionId) — panel must disappear.
     await page.getByTestId("workflow-rfq").click();
     await expect(page.getByTestId("snippet-panel")).toHaveCount(0);
   });
 
-  test("shows the panel again after switching from undeployed back to deployed", async ({ page }) => {
+  test("shows the panel again after switching from undeployed back to deployed", async ({
+    page,
+  }) => {
     await page.getByTestId("workflow-rfq").click();
     await expect(page.getByTestId("snippet-panel")).toHaveCount(0);
 
@@ -41,20 +49,26 @@ test.describe("snippet panel visibility", () => {
 });
 
 test.describe("TypeScript tab (default)", () => {
-  test("default tab is TypeScript and contains the SDK call with the correct slug", async ({ page }) => {
+  test("default tab is TypeScript and contains the SDK call with the correct slug", async ({
+    page,
+  }) => {
     const panel = page.getByTestId("snippet-panel");
     const code = panel.getByTestId("snippet-code");
 
     // TS tab is active by default.
     await expect(panel.getByTestId("snippet-tab-ts")).toHaveClass(/is-active/);
-    await expect(panel.getByTestId("snippet-tab-curl")).not.toHaveClass(/is-active/);
+    await expect(panel.getByTestId("snippet-tab-curl")).not.toHaveClass(
+      /is-active/,
+    );
 
     // Content assertions.
-    await expect(code).toContainText('agents.run({');
+    await expect(code).toContainText("agents.run({");
     await expect(code).toContainText('definition: "ic-diligence-orchestrator"');
   });
 
-  test("TypeScript snippet does NOT contain forbidden patterns", async ({ page }) => {
+  test("TypeScript snippet does NOT contain forbidden patterns", async ({
+    page,
+  }) => {
     const code = page.getByTestId("snippet-code");
     const text = await code.textContent();
     expect(text).not.toContain("Authorization");
@@ -66,15 +80,23 @@ test.describe("TypeScript tab (default)", () => {
 });
 
 test.describe("cURL tab", () => {
-  test("switching to the cURL tab shows the HTTP snippet with the correct endpoint and header", async ({ page }) => {
+  test("switching to the cURL tab shows the HTTP snippet with the correct endpoint and header", async ({
+    page,
+  }) => {
     const panel = page.getByTestId("snippet-panel");
     await panel.getByTestId("snippet-tab-curl").click();
 
-    await expect(panel.getByTestId("snippet-tab-curl")).toHaveClass(/is-active/);
-    await expect(panel.getByTestId("snippet-tab-ts")).not.toHaveClass(/is-active/);
+    await expect(panel.getByTestId("snippet-tab-curl")).toHaveClass(
+      /is-active/,
+    );
+    await expect(panel.getByTestId("snippet-tab-ts")).not.toHaveClass(
+      /is-active/,
+    );
 
     const code = panel.getByTestId("snippet-code");
-    await expect(code).toContainText("POST https://tools.sapiom.ai/agents/v1/definitions/ic-diligence-orchestrator/executions");
+    await expect(code).toContainText(
+      "POST https://tools.sapiom.ai/agents/v1/definitions/ic-diligence-orchestrator/executions",
+    );
     await expect(code).toContainText("x-sapiom-api-key: YOUR_SAPIOM_API_KEY");
   });
 
@@ -93,7 +115,9 @@ test.describe("cURL tab", () => {
 
 test.describe("slug (read-only)", () => {
   test("shows the deployed agent's slug", async ({ page }) => {
-    await expect(page.getByTestId("snippet-slug")).toHaveText("ic-diligence-orchestrator");
+    await expect(page.getByTestId("snippet-slug")).toHaveText(
+      "ic-diligence-orchestrator",
+    );
   });
 
   test("the slug is read-only — not an editable input (it's the agent's identity, not a rename field)", async ({
@@ -106,12 +130,18 @@ test.describe("slug (read-only)", () => {
   test("switching to a second deployed workflow shows the new slug (no stale value)", async ({
     page,
   }) => {
-    await expect(page.getByTestId("snippet-slug")).toHaveText("ic-diligence-orchestrator");
+    await expect(page.getByTestId("snippet-slug")).toHaveText(
+      "ic-diligence-orchestrator",
+    );
     // onboarding-flow is a second DEPLOYED fixture — the panel must reflect its
     // slug, not keep leasing's.
     await page.getByTestId("workflow-onboarding-flow").click();
-    await expect(page.getByTestId("snippet-slug")).toHaveText("onboarding-flow");
-    await expect(page.getByTestId("snippet-code")).toContainText('definition: "onboarding-flow"');
+    await expect(page.getByTestId("snippet-slug")).toHaveText(
+      "onboarding-flow",
+    );
+    await expect(page.getByTestId("snippet-code")).toContainText(
+      'definition: "onboarding-flow"',
+    );
   });
 });
 
@@ -148,7 +178,9 @@ test.describe("copy button", () => {
     await panel.getByTestId("snippet-copy").click();
     await expect(panel.getByTestId("snippet-copy")).toHaveText("Copied");
 
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
     expect(clipboardText).toContain("agents.run");
     expect(clipboardText).toContain("ic-diligence-orchestrator");
   });
@@ -165,20 +197,70 @@ test.describe("copy button", () => {
     await panel.getByTestId("snippet-copy").click();
     await expect(panel.getByTestId("snippet-copy")).toHaveText("Copied");
 
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
     expect(clipboardText).toContain("curl -X POST");
     expect(clipboardText).toContain("ic-diligence-orchestrator");
     expect(clipboardText).toContain("x-sapiom-api-key: YOUR_SAPIOM_API_KEY");
   });
 });
 
+test.describe("slug fallback when the deployment slug is unresolved", () => {
+  test("shows the project name as the slug (deployed but slug unresolved)", async ({
+    page,
+  }) => {
+    await page.getByTestId("workflow-claims-triage").click();
+    await expect(page.getByTestId("snippet-panel")).toBeVisible();
+    await expect(page.getByTestId("snippet-slug")).toHaveText("claims-triage");
+    await expect(page.getByTestId("snippet-code")).toContainText(
+      'definition: "claims-triage"',
+    );
+  });
+
+  test("shows the 'inferred from the project name' note only in the fallback case", async ({
+    page,
+  }) => {
+    // Resolved slug (leasing, the default binding) — no note.
+    await expect(page.getByTestId("snippet-slug")).toHaveText(
+      "ic-diligence-orchestrator",
+    );
+    await expect(page.getByTestId("snippet-slug-inferred")).toHaveCount(0);
+
+    // Unresolved slug (claims-triage) — the note appears.
+    await page.getByTestId("workflow-claims-triage").click();
+    await expect(page.getByTestId("snippet-slug-inferred")).toBeVisible();
+    await expect(page.getByTestId("snippet-slug-inferred")).toContainText(
+      "Inferred from the project name",
+    );
+  });
+
+  test("the 'your-agent-slug' placeholder never appears — resolved or fallback", async ({
+    page,
+  }) => {
+    // Resolved case (leasing).
+    await expect(page.getByTestId("snippet-panel")).not.toContainText(
+      "your-agent-slug",
+    );
+    // Fallback case (claims-triage).
+    await page.getByTestId("workflow-claims-triage").click();
+    await expect(page.getByTestId("snippet-panel")).not.toContainText(
+      "your-agent-slug",
+    );
+  });
+});
+
 test.describe("panel structure", () => {
   test("panel has the expected title", async ({ page }) => {
-    await expect(page.getByTestId("snippet-panel")).toContainText("Trigger from your code");
+    await expect(page.getByTestId("snippet-panel")).toContainText(
+      "Trigger from your code",
+    );
   });
 
   test("panel includes the idempotencyKey helper hint", async ({ page }) => {
-    await expect(page.getByTestId("snippet-panel")).toContainText("idempotencyKey");
+    await expect(page.getByTestId("snippet-panel")).toContainText(
+      "idempotencyKey",
+    );
   });
 
   test("links to the dashboard where users get an API key (for use outside the harness)", async ({
@@ -186,9 +268,14 @@ test.describe("panel structure", () => {
   }) => {
     const link = page.getByTestId("snippet-api-key-link");
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute("href", "https://app.sapiom.ai/settings?tab=api-keys");
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://app.sapiom.ai/settings?tab=api-keys",
+    );
     await expect(link).toHaveAttribute("target", "_blank");
     await expect(link).toHaveAttribute("rel", /noreferrer/);
-    await expect(page.getByTestId("snippet-panel")).toContainText("YOUR_SAPIOM_API_KEY");
+    await expect(page.getByTestId("snippet-panel")).toContainText(
+      "YOUR_SAPIOM_API_KEY",
+    );
   });
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -39,7 +39,9 @@ export const App = (): JSX.Element => {
   // Lifted so the telemetry chip in BrandHeader can open the settings popover
   // from outside SessionBar (which owns the popover's render).
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(null);
+  const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(
+    null,
+  );
   const [stripColEl, setStripColEl] = useState<HTMLDivElement | null>(null);
   const [rightTab, setRightTab] = useState<RightTab>("canvas");
   // Tracks whether Skills has ever been shown — once true, SkillsPanel stays
@@ -52,9 +54,16 @@ export const App = (): JSX.Element => {
   // session state updates) since `api.listSkills.bind(api)` produces a new
   // function object on each render. Must be before any early return (React
   // hooks must be called unconditionally).
-  const listSkills = useMemo(() => harness.api.listSkills.bind(harness.api), [harness.api]);
-  const getSkill = useMemo(() => harness.api.getSkill.bind(harness.api), [harness.api]);
-  const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
+  const listSkills = useMemo(
+    () => harness.api.listSkills.bind(harness.api),
+    [harness.api],
+  );
+  const getSkill = useMemo(
+    () => harness.api.getSkill.bind(harness.api),
+    [harness.api],
+  );
+  const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } =
+    usePaneWidths();
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
@@ -89,23 +98,38 @@ export const App = (): JSX.Element => {
     return <div className="app-status">Loading Sapiom Harness…</div>;
   }
   if (harness.error || !harness.state) {
-    return <div className="app-status app-status-error">Failed to load: {harness.error}</div>;
+    return (
+      <div className="app-status app-status-error">
+        Failed to load: {harness.error}
+      </div>
+    );
   }
 
   const { state } = harness;
-  const activeSession = state.sessions.find((session) => session.id === harness.activeSessionId) ?? null;
+  const activeSession =
+    state.sessions.find((session) => session.id === harness.activeSessionId) ??
+    null;
   const boundWorkflowPath = boundWorkflowPathOf(activeSession);
-  const boundWorkflow = state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
-  const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
+  const boundWorkflow =
+    state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
+  const selectedWorkflow =
+    state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ??
+    null;
 
   // First-run welcome: this install has never been used (firstRun — the CLI
   // also skips the auto boot session then) and nothing is live yet. Taking
   // either welcome action creates a session, which hides it; a returning
   // user (firstRun absent/false) never sees it at all.
-  const hasLiveSession = state.sessions.some((session) => session.status !== "exited");
-  const showWelcome = state.firstRun === true && !hasLiveSession && !welcomeDismissed;
+  const hasLiveSession = state.sessions.some(
+    (session) => session.status !== "exited",
+  );
+  const showWelcome =
+    state.firstRun === true && !hasLiveSession && !welcomeDismissed;
 
-  const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
+  const handleCreateSession = async (
+    cwd: string,
+    agentHarness: HarnessKind,
+  ): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
   };
 
@@ -113,7 +137,8 @@ export const App = (): JSX.Element => {
     harness.setSelectedWorkflowPath(path);
     // Selecting a workflow IS "what I'm working on" — bind it to whichever
     // session is currently active so the chip and the agent's context stay in sync.
-    if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
+    if (harness.activeSessionId)
+      void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
   // Shared by the docked workflow action strip, the canvas empty-state's
@@ -123,10 +148,17 @@ export const App = (): JSX.Element => {
   // nullable for macros that don't require one when nothing's bound yet.
   // Every macro is one click — there's no subject/free-text step on this
   // side; the agent is the interface for anything more specific.
-  const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef): void => {
+  const handleRunMacroForWorkflow = (
+    workflow: WorkflowInfo | null,
+    macro: MacroDef,
+  ): void => {
     if (workflow) handleSelectWorkflow(workflow.path);
     if (macro.action.kind === "open-url") {
-      window.open(resolveMacroUrl(macro.action.url, workflow), "_blank", "noopener,noreferrer");
+      window.open(
+        resolveMacroUrl(macro.action.url, workflow),
+        "_blank",
+        "noopener,noreferrer",
+      );
       return;
     }
     if (!harness.activeSessionId) return;
@@ -142,20 +174,23 @@ export const App = (): JSX.Element => {
         authenticated={state.authenticated}
         organizationName={state.organizationName}
         onOpenPalette={() => setPaletteOpen(true)}
-        telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+        telemetryOptIn={
+          harness.settings?.telemetryOptIn ?? state.telemetryOptIn
+        }
         consentSource={state.consentSource}
         consentEnvReason={state.consentEnvReason}
         onOpenSettings={() => setSettingsOpen(true)}
       />
 
-      {state.consentSource === "default-silent" && !harness.settings?.telemetryNoticeDismissed && (
-        <TelemetryNotice
-          onDismiss={() => {
-            void harness.updateSettings({ telemetryNoticeDismissed: true });
-          }}
-          onOpenSettings={() => setSettingsOpen(true)}
-        />
-      )}
+      {state.consentSource === "default-silent" &&
+        !harness.settings?.telemetryNoticeDismissed && (
+          <TelemetryNotice
+            onDismiss={() => {
+              void harness.updateSettings({ telemetryNoticeDismissed: true });
+            }}
+            onOpenSettings={() => setSettingsOpen(true)}
+          />
+        )}
 
       <div
         className="app"
@@ -189,7 +224,9 @@ export const App = (): JSX.Element => {
               height={rowAnchor.height}
               activeSessionId={harness.activeSessionId}
               macros={state.macros}
-              onRunMacro={(macro) => handleRunMacroForWorkflow(selectedWorkflow, macro)}
+              onRunMacro={(macro) =>
+                handleRunMacroForWorkflow(selectedWorkflow, macro)
+              }
             />
           )}
         </div>
@@ -210,7 +247,9 @@ export const App = (): JSX.Element => {
             sessions={state.sessions}
             activeSessionId={harness.activeSessionId}
             onSelectSession={harness.setActiveSessionId}
-            onResumeHistory={(summary) => void harness.resumeFromHistory(summary)}
+            onResumeHistory={(summary) =>
+              void harness.resumeFromHistory(summary)
+            }
             history={harness.history}
             historyLoading={harness.historyLoading}
             onOpenHistory={(cwd) => void harness.loadHistory(cwd)}
@@ -221,7 +260,9 @@ export const App = (): JSX.Element => {
             boundWorkflowName={boundWorkflow?.name ?? null}
             authenticated={state.authenticated}
             organizationName={state.organizationName}
-            telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+            telemetryOptIn={
+              harness.settings?.telemetryOptIn ?? state.telemetryOptIn
+            }
             onToggleTelemetry={async (next) => {
               await harness.updateSettings({ telemetryOptIn: next });
             }}
@@ -237,7 +278,10 @@ export const App = (): JSX.Element => {
                 onClose={() => void harness.closeSession(activeSession.id)}
               />
             ) : harness.activeSessionId ? (
-              <Terminal sessionId={harness.activeSessionId} token={harness.bootToken} />
+              <Terminal
+                sessionId={harness.activeSessionId}
+                token={harness.bootToken}
+              />
             ) : showWelcome ? (
               <WelcomePanel
                 recentDirs={harness.settings?.recentDirs ?? []}
@@ -250,7 +294,9 @@ export const App = (): JSX.Element => {
                 onDismiss={() => setWelcomeDismissed(true)}
               />
             ) : (
-              <div className="terminal-empty">No active session — click "+ new" to start one.</div>
+              <div className="terminal-empty">
+                No active session — click "+ new" to start one.
+              </div>
             )}
           </div>
         </div>
@@ -268,11 +314,17 @@ export const App = (): JSX.Element => {
 
         {/* Right pane: Canvas | Skills segmented switch + panels */}
         <div className="right-pane">
-          <div className="right-pane-tabs" role="tablist" aria-label="Right pane">
+          <div
+            className="right-pane-tabs"
+            role="tablist"
+            aria-label="Right pane"
+          >
             <button
               role="tab"
               aria-selected={rightTab === "canvas"}
-              className={"right-pane-tab" + (rightTab === "canvas" ? " is-active" : "")}
+              className={
+                "right-pane-tab" + (rightTab === "canvas" ? " is-active" : "")
+              }
               onClick={() => setRightTab("canvas")}
               data-testid="right-tab-canvas"
             >
@@ -281,8 +333,13 @@ export const App = (): JSX.Element => {
             <button
               role="tab"
               aria-selected={rightTab === "skills"}
-              className={"right-pane-tab" + (rightTab === "skills" ? " is-active" : "")}
-              onClick={() => { setRightTab("skills"); setSkillsPanelEverShown(true); }}
+              className={
+                "right-pane-tab" + (rightTab === "skills" ? " is-active" : "")
+              }
+              onClick={() => {
+                setRightTab("skills");
+                setSkillsPanelEverShown(true);
+              }}
               data-testid="right-tab-skills"
             >
               Skills
@@ -291,7 +348,12 @@ export const App = (): JSX.Element => {
 
           {/* Canvas: always mounted so a running Visualize enrichment is never
               disturbed when the user flips to Skills — hidden via CSS only. */}
-          <div className={"right-pane-panel" + (rightTab === "canvas" ? "" : " is-hidden")} data-testid="right-panel-canvas">
+          <div
+            className={
+              "right-pane-panel" + (rightTab === "canvas" ? "" : " is-hidden")
+            }
+            data-testid="right-panel-canvas"
+          >
             <CanvasPane
               sessionId={harness.activeSessionId}
               lastMessage={harness.lastMessage}
@@ -299,7 +361,10 @@ export const App = (): JSX.Element => {
               activeSessionId={harness.activeSessionId}
               macros={state.macros}
               tasks={harness.tasks}
-              onRunMacro={(macro) => handleRunMacroForWorkflow(boundWorkflow, macro)}
+              onRunMacro={(macro) =>
+                handleRunMacroForWorkflow(boundWorkflow, macro)
+              }
+              agentsBaseUrl={state.agentsBaseUrl}
             />
           </div>
 
@@ -310,7 +375,9 @@ export const App = (): JSX.Element => {
               state and scroll position survive tab flips. */}
           {(rightTab === "skills" || skillsPanelEverShown) && (
             <div
-              className={"right-pane-panel" + (rightTab === "skills" ? "" : " is-hidden")}
+              className={
+                "right-pane-panel" + (rightTab === "skills" ? "" : " is-hidden")
+              }
               data-testid="right-panel-skills"
             >
               <SkillsPanel
@@ -318,7 +385,9 @@ export const App = (): JSX.Element => {
                 getSkill={getSkill}
                 isActive={rightTab === "skills"}
                 activeSession={activeSession}
-                onUseSkill={(sessionId, text) => void harness.useSkill(sessionId, text)}
+                onUseSkill={(sessionId, text) =>
+                  void harness.useSkill(sessionId, text)
+                }
               />
             </div>
           )}
@@ -337,7 +406,9 @@ export const App = (): JSX.Element => {
         />
       )}
 
-      {harness.toast && <Toast message={harness.toast} onDismiss={harness.dismissToast} />}
+      {harness.toast && (
+        <Toast message={harness.toast} onDismiss={harness.dismissToast} />
+      )}
     </div>
   );
 };

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
-import type { BackgroundTask, BusMessage, MacroDef, WorkflowInfo } from "@shared/types";
+import type {
+  BackgroundTask,
+  BusMessage,
+  MacroDef,
+  WorkflowInfo,
+} from "@shared/types";
 
 import { isMockMode } from "../lib/api";
 import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
@@ -22,6 +27,9 @@ interface CanvasPaneProps {
   /** All background tasks (any session) — filtered to `sessionId` here. */
   tasks: BackgroundTask[];
   onRunMacro: (macro: MacroDef) => void;
+  /** The Agents API base URL (from AppState) — forwarded to the snippet panel
+   *  so its executions host matches where the server resolved the slug. */
+  agentsBaseUrl?: string;
 }
 
 export function CanvasPane({
@@ -32,6 +40,7 @@ export function CanvasPane({
   macros,
   tasks,
   onRunMacro,
+  agentsBaseUrl,
 }: CanvasPaneProps): JSX.Element {
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
@@ -45,7 +54,9 @@ export function CanvasPane({
   const [frameLoading, setFrameLoading] = useState(true);
   // Failed-task panels the user has explicitly dismissed (client-side only —
   // the task record itself stays in the server's list).
-  const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(new Set());
+  const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   // Passed through to the served canvas so a kit-based template can match the
   // app's current theme instead of always rendering dark. Legacy canvases
@@ -71,7 +82,10 @@ export function CanvasPane({
 
   useEffect(() => {
     if (!lastMessage || !sessionId) return;
-    if (lastMessage.type === "canvas.reload" && lastMessage.harnessSessionId === sessionId) {
+    if (
+      lastMessage.type === "canvas.reload" &&
+      lastMessage.harnessSessionId === sessionId
+    ) {
       setHasGeneratedContent(true);
       setFrameLoading(true);
       setReloadKey((key) => key + 1);
@@ -105,15 +119,20 @@ export function CanvasPane({
       task.harnessSessionId === sessionId &&
       (task.workflowPath == null || task.workflowPath === boundWorkflowPath),
   );
-  const runningTask = sessionTasks.find((task) => task.status === "running") ?? null;
+  const runningTask =
+    sessionTasks.find((task) => task.status === "running") ?? null;
   const latestFinished = sessionTasks
     .filter((task) => task.status !== "running")
     .sort((a, b) => (b.endedAt ?? "").localeCompare(a.endedAt ?? ""))[0];
   const failedTask =
-    !runningTask && latestFinished?.status === "failed" && !dismissedTaskIds.has(latestFinished.id)
+    !runningTask &&
+    latestFinished?.status === "failed" &&
+    !dismissedTaskIds.has(latestFinished.id)
       ? latestFinished
       : null;
-  const retryMacro = failedTask ? (macros.find((macro) => macro.id === failedTask.macroId) ?? null) : null;
+  const retryMacro = failedTask
+    ? (macros.find((macro) => macro.id === failedTask.macroId) ?? null)
+    : null;
 
   // The header's action IS Visualize now — one click re-fires the same macro
   // that generated what's already on screen; the pane itself swaps in the
@@ -138,17 +157,25 @@ export function CanvasPane({
         // key on the workflow path so switching between two *deployed* workflows
         // remounts the panel, resetting its tab/copied state to the new agent.
         // (The slug itself is read-only and derives straight from the prop.)
-        <SnippetPanel key={boundWorkflow.path} boundWorkflow={boundWorkflow} />
+        <SnippetPanel
+          key={boundWorkflow.path}
+          boundWorkflow={boundWorkflow}
+          agentsBaseUrl={agentsBaseUrl}
+        />
       )}
 
       {!sessionId ? (
-        <div className="canvas-empty">Start a session to see its canvas here.</div>
+        <div className="canvas-empty">
+          Start a session to see its canvas here.
+        </div>
       ) : failedTask ? (
         <div className="canvas-task-failed" data-testid="canvas-task-failed">
           <p className="canvas-task-title">
             <Icon name="TriangleAlert" size={14} /> {failedTask.label} failed.
           </p>
-          {failedTask.errorTail && <pre className="canvas-task-error">{failedTask.errorTail}</pre>}
+          {failedTask.errorTail && (
+            <pre className="canvas-task-error">{failedTask.errorTail}</pre>
+          )}
           <div className="canvas-task-actions">
             {retryMacro && (
               <button
@@ -175,20 +202,26 @@ export function CanvasPane({
           </div>
         </div>
       ) : runningTask && !hasGeneratedContent ? (
-        <div className="canvas-task-activity" data-testid="canvas-task-activity">
+        <div
+          className="canvas-task-activity"
+          data-testid="canvas-task-activity"
+        >
           <div className="canvas-task-title">
             <span className="canvas-task-spinner" aria-hidden="true" />
             <span>{runningTask.label} is running…</span>
           </div>
           {runningTask.statusLines.length > 0 && (
             <ul className="canvas-task-lines" data-testid="canvas-task-lines">
-              {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
-                <li key={`${index}-${line}`}>{line}</li>
-              ))}
+              {runningTask.statusLines
+                .slice(-ACTIVITY_LINES_SHOWN)
+                .map((line, index) => (
+                  <li key={`${index}-${line}`}>{line}</li>
+                ))}
             </ul>
           )}
           <p className="canvas-empty-hint">
-            Running as a background task — your session stays free. The canvas reloads here when it finishes.
+            Running as a background task — your session stays free. The canvas
+            reloads here when it finishes.
           </p>
         </div>
       ) : probing ? (
@@ -214,14 +247,18 @@ export function CanvasPane({
             </button>
           )}
           <p className="canvas-empty-hint">
-            Ask your agent to visualize, or write HTML directly to <code>.sapiom/canvas/index.html</code> — this pane
-            hot-reloads whenever it changes.
+            Ask your agent to visualize, or write HTML directly to{" "}
+            <code>.sapiom/canvas/index.html</code> — this pane hot-reloads
+            whenever it changes.
           </p>
         </div>
       ) : (
         <div className="canvas-frame-wrap">
           {frameLoading && (
-            <div className="canvas-loading canvas-loading--overlay" data-testid="canvas-loading">
+            <div
+              className="canvas-loading canvas-loading--overlay"
+              data-testid="canvas-loading"
+            >
               <span className="canvas-task-spinner" aria-hidden="true" />
               <p className="canvas-empty-hint">Rendering diagram…</p>
             </div>
@@ -236,14 +273,20 @@ export function CanvasPane({
                 <span>{runningTask.label} is running…</span>
               </div>
               {runningTask.statusLines.length > 0 && (
-                <ul className="canvas-task-lines" data-testid="canvas-task-lines">
-                  {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
-                    <li key={`${index}-${line}`}>{line}</li>
-                  ))}
+                <ul
+                  className="canvas-task-lines"
+                  data-testid="canvas-task-lines"
+                >
+                  {runningTask.statusLines
+                    .slice(-ACTIVITY_LINES_SHOWN)
+                    .map((line, index) => (
+                      <li key={`${index}-${line}`}>{line}</li>
+                    ))}
                 </ul>
               )}
               <p className="canvas-empty-hint">
-                Running as a background task — your session stays free. The canvas reloads here when it finishes.
+                Running as a background task — your session stays free. The
+                canvas reloads here when it finishes.
               </p>
             </div>
           )}

--- a/packages/harness/web/src/components/SnippetPanel.tsx
+++ b/packages/harness/web/src/components/SnippetPanel.tsx
@@ -13,6 +13,10 @@ const SAPIOM_API_KEYS_URL = "https://app.sapiom.ai/settings?tab=api-keys";
 interface SnippetPanelProps {
   /** The workflow currently bound to the active session. */
   boundWorkflow: WorkflowInfo;
+  /** The Agents API base URL (from AppState) — the executions host the snippet
+   *  targets, so it matches where the server resolved the slug. Undefined in
+   *  tests/mocks, where generateSnippet falls back to the SDK's default host. */
+  agentsBaseUrl?: string;
 }
 
 type SnippetTab = "typescript" | "curl";
@@ -28,24 +32,43 @@ type SnippetTab = "typescript" | "curl";
  * snippet call a non-existent agent (404). To rename an agent, change its
  * `defineAgent` name in code and redeploy.
  */
-export function SnippetPanel({ boundWorkflow }: SnippetPanelProps): JSX.Element | null {
+export function SnippetPanel({
+  boundWorkflow,
+  agentsBaseUrl,
+}: SnippetPanelProps): JSX.Element | null {
   // Guard: only render when the workflow is deployed.
   if (boundWorkflow.definitionId == null) return null;
 
-  return <SnippetPanelInner boundWorkflow={boundWorkflow} />;
+  return (
+    <SnippetPanelInner
+      boundWorkflow={boundWorkflow}
+      agentsBaseUrl={agentsBaseUrl}
+    />
+  );
 }
 
 // Split into an inner component so hooks are always called after the null-guard
 // without the React-hooks-in-conditionals lint error.
-function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
+function SnippetPanelInner({
+  boundWorkflow,
+  agentsBaseUrl,
+}: SnippetPanelProps): JSX.Element {
   const [activeTab, setActiveTab] = useState<SnippetTab>("typescript");
   const [copied, setCopied] = useState(false);
 
-  // The slug is read straight from the deployed workflow — never user-edited, so
-  // the snippet can only ever reference the real agent. Falls back to a clear
-  // placeholder only if a deployed agent somehow has no cached name.
-  const slug = boundWorkflow.definitionSlug ?? "your-agent-slug";
-  const { typescript, curl } = generateSnippet({ definition: slug });
+  // The slug is the deployed agent's stable handle — never user-edited. Prefer
+  // the slug resolved from the deployment (definitionSlug); when that lookup
+  // hasn't resolved (e.g. the harness isn't signed into the account that owns
+  // the agent), fall back to the project's own name — for a conventionally
+  // named agent project that IS the slug, far better than a fill-in placeholder
+  // sitting in a read-only field. `slugInferred` drives the "verify this" note
+  // shown only in that fallback case.
+  const slugInferred = boundWorkflow.definitionSlug == null;
+  const slug = boundWorkflow.definitionSlug ?? boundWorkflow.name;
+  const { typescript, curl } = generateSnippet({
+    definition: slug,
+    baseUrl: agentsBaseUrl,
+  });
   const activeSnippet = activeTab === "typescript" ? typescript : curl;
 
   const handleCopy = (): void => {
@@ -73,13 +96,28 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
           {slug}
         </code>
       </div>
+      {slugInferred && (
+        <p
+          className="snippet-slug-inferred"
+          data-testid="snippet-slug-inferred"
+        >
+          Inferred from the project name — confirm it matches your deployed
+          agent.
+        </p>
+      )}
 
-      <div className="snippet-tabs" role="tablist" aria-label="Snippet language">
+      <div
+        className="snippet-tabs"
+        role="tablist"
+        aria-label="Snippet language"
+      >
         <button
           role="tab"
           aria-selected={activeTab === "typescript"}
           aria-controls="snippet-code-panel"
-          className={"snippet-tab" + (activeTab === "typescript" ? " is-active" : "")}
+          className={
+            "snippet-tab" + (activeTab === "typescript" ? " is-active" : "")
+          }
           data-testid="snippet-tab-ts"
           onClick={() => setActiveTab("typescript")}
         >
@@ -97,7 +135,11 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         </button>
       </div>
 
-      <div className="snippet-code-wrap" role="tabpanel" id="snippet-code-panel">
+      <div
+        className="snippet-code-wrap"
+        role="tabpanel"
+        id="snippet-code-panel"
+      >
         <pre className="snippet-code" data-testid="snippet-code">
           <code>{activeSnippet}</code>
         </pre>
@@ -124,7 +166,8 @@ function SnippetPanelInner({ boundWorkflow }: SnippetPanelProps): JSX.Element {
         </a>
       </p>
       <p className="snippet-hint">
-        Optionally add <code>idempotencyKey</code> to the body to deduplicate retries.
+        Optionally add <code>idempotencyKey</code> to the body to deduplicate
+        retries.
       </p>
     </div>
   );

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -2,19 +2,28 @@
  * Fixture data for `VITE_MOCK=1` — lets the SPA render fully without a
  * running harness server (see MockApi in ./api).
  */
-import type { HarnessSession, HarnessSettings, MacroDef, SessionSummary, WorkflowInfo } from "@shared/types";
+import type {
+  HarnessSession,
+  HarnessSettings,
+  MacroDef,
+  SessionSummary,
+  WorkflowInfo,
+} from "@shared/types";
 import type { SkillMeta } from "./api";
 
 const now = Date.now();
-const minutesAgo = (n: number): string => new Date(now - n * 60_000).toISOString();
-const daysAgo = (n: number): string => new Date(now - n * 24 * 60 * 60_000).toISOString();
+const minutesAgo = (n: number): string =>
+  new Date(now - n * 60_000).toISOString();
+const daysAgo = (n: number): string =>
+  new Date(now - n * 24 * 60 * 60_000).toISOString();
 
 /** The directory the harness itself was launched from (`npx @sapiom/harness [dir]`). */
 export const MOCK_LAUNCH_DIR = "/Users/demo/acme-app";
 
 /** Where MockApi.seedSampleProject pretends the example project landed —
  *  mirrors the real HARNESS_PATHS.sampleProject location. */
-export const MOCK_SAMPLE_PROJECT_ROOT = "/Users/demo/.sapiom/harness/sample-project";
+export const MOCK_SAMPLE_PROJECT_ROOT =
+  "/Users/demo/.sapiom/harness/sample-project";
 
 export const MOCK_SESSIONS: HarnessSession[] = [
   {
@@ -91,7 +100,13 @@ export const MOCK_ACTIVITY_SESSION_ID = "sess-bg";
 export const MOCK_FS_TREE: Record<string, string[]> = {
   "/": ["Users"],
   "/Users": ["demo"],
-  "/Users/demo": ["acme-app", "rfq-workflows", "onboarding-flow", "scratch"],
+  "/Users/demo": [
+    "acme-app",
+    "rfq-workflows",
+    "onboarding-flow",
+    "claims-triage",
+    "scratch",
+  ],
   "/Users/demo/acme-app": ["leasing", "src", "docs"],
   "/Users/demo/acme-app/leasing": [],
   "/Users/demo/acme-app/src": [],
@@ -100,6 +115,7 @@ export const MOCK_FS_TREE: Record<string, string[]> = {
   "/Users/demo/rfq-workflows/src": [],
   "/Users/demo/rfq-workflows/tests": [],
   "/Users/demo/onboarding-flow": [],
+  "/Users/demo/claims-triage": [],
   "/Users/demo/scratch": [],
 };
 
@@ -137,11 +153,40 @@ export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
 };
 
 export const MOCK_WORKFLOWS: WorkflowInfo[] = [
-  { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821, definitionSlug: "ic-diligence-orchestrator", source: "scan" },
-  { name: "rfq", path: "/Users/demo/rfq-workflows", definitionId: null, definitionSlug: null, source: "scan" },
+  {
+    name: "leasing",
+    path: "/Users/demo/acme-app/leasing",
+    definitionId: 4821,
+    definitionSlug: "ic-diligence-orchestrator",
+    source: "scan",
+  },
+  {
+    name: "rfq",
+    path: "/Users/demo/rfq-workflows",
+    definitionId: null,
+    definitionSlug: null,
+    source: "scan",
+  },
   // Deployed like "leasing" but with a much longer name — exercises the
   // canvas header's deployed-dot staying pinned regardless of name length.
-  { name: "onboarding-flow", path: "/Users/demo/onboarding-flow", definitionId: 9001, definitionSlug: "onboarding-flow", source: "connect" },
+  {
+    name: "onboarding-flow",
+    path: "/Users/demo/onboarding-flow",
+    definitionId: 9001,
+    definitionSlug: "onboarding-flow",
+    source: "connect",
+  },
+  // Deployed (has a definitionId) but its slug hasn't resolved — e.g. the
+  // harness isn't signed into the account that owns it. The snippet panel must
+  // fall back to the project name (this `name`) and show the "inferred" note,
+  // never a fill-in placeholder in the read-only slug field.
+  {
+    name: "claims-triage",
+    path: "/Users/demo/claims-triage",
+    definitionId: 7314,
+    definitionSlug: null,
+    source: "connect",
+  },
 ];
 
 export const MOCK_MACROS: MacroDef[] = [
@@ -149,28 +194,43 @@ export const MOCK_MACROS: MacroDef[] = [
     id: "run_local",
     label: "Run local",
     icon: "Play",
-    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents run --target local", submit: true },
+    action: {
+      kind: "inject",
+      text: "cd {{workflow.path}} && sapiom agents run --target local",
+      submit: true,
+    },
     requiresWorkflow: true,
   },
   {
     id: "deploy",
     label: "Deploy",
     icon: "Cloud",
-    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents deploy", submit: true },
+    action: {
+      kind: "inject",
+      text: "cd {{workflow.path}} && sapiom agents deploy",
+      submit: true,
+    },
     requiresWorkflow: true,
   },
   {
     id: "prod_run",
     label: "Prod run",
     icon: "Zap",
-    action: { kind: "inject", text: "cd {{workflow.path}} && sapiom agents run --target prod", submit: true },
+    action: {
+      kind: "inject",
+      text: "cd {{workflow.path}} && sapiom agents run --target prod",
+      submit: true,
+    },
     requiresWorkflow: true,
   },
   {
     id: "open_prod",
     label: "Open prod",
     icon: "ExternalLink",
-    action: { kind: "open-url", url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}" },
+    action: {
+      kind: "open-url",
+      url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}",
+    },
     requiresWorkflow: true,
   },
   {
@@ -187,26 +247,33 @@ export const MOCK_MACROS: MacroDef[] = [
 
 export const MOCK_SETTINGS: HarnessSettings = {
   telemetryOptIn: false,
-  recentDirs: ["/Users/demo/acme-app", "/Users/demo/rfq-workflows", "/Users/demo/onboarding-flow"],
+  recentDirs: [
+    "/Users/demo/acme-app",
+    "/Users/demo/rfq-workflows",
+    "/Users/demo/onboarding-flow",
+  ],
 };
 
 export const MOCK_SKILLS: SkillMeta[] = [
   {
     id: "sapiom-agent-authoring",
     name: "Agent Authoring",
-    description: "Build, test, and deploy a Sapiom agent — a controlled, multi-step, deployable automation.",
+    description:
+      "Build, test, and deploy a Sapiom agent — a controlled, multi-step, deployable automation.",
     source: "package",
   },
   {
     id: "frontend-design",
     name: "Frontend Design",
-    description: "Create distinctive, production-grade frontend interfaces with high design quality.",
+    description:
+      "Create distinctive, production-grade frontend interfaces with high design quality.",
     source: "user",
   },
   {
     id: "code-review",
     name: "Code Review",
-    description: "Systematic review of code changes for correctness, style, and security.",
+    description:
+      "Systematic review of code changes for correctness, style, and security.",
     source: "user",
   },
 ];
@@ -262,4 +329,3 @@ Systematic review of code changes for correctness, style, and security.
 - [ ] Tests cover the happy path and key error cases
 `,
 };
-

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2,7 +2,8 @@
   /* Shared, theme-independent tokens. */
   --radius: 6px;
   --font-sans:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* Border-radius scale — mirrors the product's own (base --radius: 6px,
@@ -22,7 +23,8 @@
   --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.1);
 
   /* Matches Tailwind's default transition-all duration/easing, used
      everywhere the product animates hover/focus/disabled state. */
@@ -417,7 +419,10 @@ input {
 .app {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 220px) 32px minmax(360px, 1fr) minmax(280px, 420px);
+  grid-template-columns: minmax(180px, 220px) 32px minmax(360px, 1fr) minmax(
+      280px,
+      420px
+    );
   flex: 1;
   min-height: 0;
   overflow-x: auto;
@@ -2500,6 +2505,16 @@ input {
   flex-shrink: 0;
 }
 
+/* Shown only when the slug couldn't be resolved from the deployment and the
+   panel fell back to the project name — nudges the user to verify it. */
+.snippet-slug-inferred {
+  margin: 0;
+  padding: 0 10px 6px;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-faint);
+}
+
 /* Read-only chip showing the deployed agent's slug (not user-editable). */
 .snippet-slug {
   flex: 1;
@@ -2675,5 +2690,3 @@ input {
   scrollbar-width: thin;
   scrollbar-color: rgba(161, 161, 170, 0.75) transparent;
 }
-
-


### PR DESCRIPTION
## What & why

Beta testing surfaced that the "Trigger from your code" panel showed the `your-agent-slug` placeholder for a **deployed** agent whenever the harness couldn't resolve the slug from the deployment (e.g. the harness is signed into a different account/env than where the agent lives). With the slug field now read-only, a fill-in placeholder produces a **broken snippet the user can't fix**. This makes the panel resilient.

## Changes

1. **Folder-name fallback** — `SnippetPanel` slug is now `definitionSlug ?? boundWorkflow.name` (the project name, always present) instead of `?? "your-agent-slug"`. For a conventionally-named agent project the folder name *is* the slug, so the snippet is correct even when the deployment lookup fails. The placeholder is gone.
2. **Inferred note** — when the fallback is in use (`definitionSlug == null`), the panel shows *"Inferred from the project name — confirm it matches your deployed agent."* (`data-testid="snippet-slug-inferred"`), so a read-only value is never silently wrong.
3. **Env-aware snippet host** — new optional `AppState.agentsBaseUrl` (server sets it to `resolveAgentsBaseUrl()`), threaded `App → CanvasPane → SnippetPanel → generateSnippet({ baseUrl })`, so the copy-paste call targets the same environment the slug was resolved against. Tests/mocks omit it → SPA uses the SDK default host.
4. **Log-once diagnostics** — `createDefinitionSlugResolver` now logs once per definition id on a resolution failure (non-2xx / no slug / thrown). `resolve()` runs on every poll and null isn't cached, so this is once-per-id to avoid spam; silent when there's no api key (an unauthenticated harness is expected).

Also: **gitignore the harness runtime `.sapiom/` output** (canvas renders/cache/context the CLI writes into any launch dir — never source).

## Testing
- `typecheck` ✓, `lint` ✓
- Unit: resolver suite (11, incl. new log-once) ✓; new `rest.test.ts` `agentsBaseUrl` omit/surface pair ✓
- e2e (mock tier): full suite **119 passed**, incl. new `snippet-panel.spec.ts` fallback describe (project-name slug, inferred note, no `your-agent-slug`)
- Pre-existing `rest.test.ts > skills router …` failure is unrelated (fails identically on the clean base)

## Review & hygiene
- 1 code-reviewer pass (APPROVE); all 3 non-blocking items applied (mock `.status` + tightened assertion, `agentsBaseUrl` test pair, `MOCK_FS_TREE` entry).
- Open-source hygiene: added lines scanned clean — no secrets/internal system names/ticket ids. Patch changeset, public-safe wording.
- ⚠️ **Pre-existing (not in this PR):** the mock fixtures use `ic-diligence-orchestrator` (a real agent name) as demo data across `mock-data.ts` / `snippet-panel.spec.ts` / `definition-slug-resolver.test.ts` (from A1/A2). Recommend scrubbing to a generic demo slug before F1 ships to `main`.

Base: `feat/harness-snippets` (stacked F1 integration branch).