### PR TITLE
fix(harness): stop workspace rail clipping below the fold on first paint (SAP-1645)

### DIFF
--- a/.changeset/agent-core-fallback-bump.md
+++ b/.changeset/agent-core-fallback-bump.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent-core": patch
+---
+
+fix(agent-core): refresh stale offline scaffold version fallback
+
+`VERSION_FALLBACK` drifted after the last version bump (agent `0.6.2` → `0.6.4`,
+tools `0.17.2` → `0.19.0`), so an offline/registry-hiccup scaffold would pin
+versions that no longer match what's published. Bumped to match the workspace
+package.json, which is what the regression test guards.

--- a/.changeset/harness-rail-min-height.md
+++ b/.changeset/harness-rail-min-height.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness": patch
+---
+
+fix(harness): workspace/workflow rail no longer clips below the fold on first paint
+
+`.rail` was missing `min-height: 0`, so as a grid/flex item it grew to its
+content height instead of the grid row's — the nav clipped below the fold and
+`.rail-list`'s `overflow-y: auto` never engaged until a reflow (only a hard
+refresh appeared to fix it). The rail is now constrained to the viewport and
+scrolls internally on the initial render.

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.2",
-  tools: "0.17.2",
+  agent: "0.6.4",
+  tools: "0.19.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -766,7 +766,10 @@ describe("skills router — real server mount proof", () => {
     // then the skills router (which declares /api/skills internally).
     const app = express();
     app.use("/api", createBootTokenMiddleware(BOOT_TOKEN));
-    app.use(createSkillsRouter({ userSkillsRoot: skillsRoot }));
+    // showUserSkills is opt-in (off by default so a dev's ~/.claude/skills don't
+    // clutter the product list) — enable it here since this suite proves that
+    // user skills under the configured root ARE served when turned on.
+    app.use(createSkillsRouter({ userSkillsRoot: skillsRoot, showUserSkills: true }));
 
     await new Promise<void>((resolve) => {
       server = app.listen(0, "127.0.0.1", resolve);

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -51,6 +51,53 @@ test("viewport-locked shell: the page never scrolls even when terminal content o
   expect(root.scrollHeight).toBe(root.clientHeight);
 });
 
+test("workspace rail stays inside the viewport and scrolls internally on first paint (SAP-1645)", async ({
+  page,
+}) => {
+  // Regression: .rail lacked `min-height: 0`, so as a grid/flex item it grew to
+  // its content height instead of the grid row's — the nav clipped below the
+  // fold and .rail-list's overflow-y:auto never engaged until a reflow (only a
+  // hard refresh "fixed" it). Verified at 900px and a shorter window, without
+  // any reload — this asserts correct containment on the initial paint.
+  for (const height of [900, 600]) {
+    await page.setViewportSize({ width: 1280, height });
+
+    // Stress the rail with far more nav content than the viewport can show,
+    // injected into the real .rail-list so the whole containment chain
+    // (.app grid → .rail → .rail-list) is exercised, not a synthetic node.
+    await page.evaluate(() => {
+      const existing = document.querySelector('[data-testid="rail-overflow-filler"]');
+      if (existing) existing.remove();
+      const list = document.querySelector(".rail-list");
+      const filler = document.createElement("div");
+      filler.setAttribute("data-testid", "rail-overflow-filler");
+      filler.style.height = "4000px";
+      filler.style.flex = "0 0 auto";
+      list?.appendChild(filler);
+    });
+
+    const rail = page.locator(".rail-workflows");
+    const railBox = await rail.boundingBox();
+    // The rail must be constrained to the viewport, not expanded to its content.
+    expect(railBox).not.toBeNull();
+    expect(railBox!.y + railBox!.height).toBeLessThanOrEqual(height + 1);
+
+    // The overflow now lives on .rail-list, which actually scrolls.
+    const list = await page.locator(".rail-list").evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+
+    // No full-page scroll was introduced by the overflowing rail.
+    const root = await page.evaluate(() => {
+      const el = document.scrollingElement as HTMLElement;
+      return { scrollHeight: el.scrollHeight, clientHeight: el.clientHeight };
+    });
+    expect(root.scrollHeight).toBe(root.clientHeight);
+  }
+});
+
 test("theme: defaults to light, toggles to dark, and the choice persists across reload", async ({ page }) => {
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   await page.screenshot({ path: "web/e2e/screenshots/theme-light.png", fullPage: true });

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -591,6 +591,11 @@ input {
   flex-direction: column;
   background: var(--bg-1);
   min-width: 0;
+  /* Grid/flex items default to min-height:auto, so without this the rail grows
+     to its content height instead of the grid row's — clipping the nav below
+     the fold and stopping .rail-list's overflow-y:auto from ever engaging until
+     a reflow (the "a refresh fixes it" bug). Mirrors .center-pane above. */
+  min-height: 0;
 }
 
 .rail-workflows {


### PR DESCRIPTION
## Problem

On first load of `npx @sapiom/harness` (0.1.3), the left workspace/workflow nav is cut off — lower items clip below the fold and don't scroll. A hard refresh (⌘R) appears to "fix" it. Reported symptom: sidebar bounding box measured ~1120px inside a 900px viewport with no engaged scroll on first paint.

## Root cause

`.rail` (a grid item inside `.app`, and a flex column) was missing `min-height: 0`. Grid/flex items default to `min-height: auto`, so `.rail` grew to its **content** height instead of the grid row's height. That pushed the nav below the fold, and because `.app` is `overflow-y: hidden`, the excess was clipped rather than scrolled. `.rail-list`'s `overflow-y: auto` never engaged because the rail itself expanded to fit the list. Only a reflow (hard refresh) recomputed it — the classic "a refresh fixes it" tell.

`.center-pane` already sets `min-height: 0` for exactly this reason; `.rail` just didn't.

## Fix

Add `min-height: 0` to `.rail` (one line + explanatory comment).

## Checked the flagged branch

Per the ticket, I confirmed `origin/feat/harness-scroll-regression` does **not** address this — it viewport-locks the shell (`html,body,#root { overflow: hidden }`, already on `main`) so the whole *page* can't scroll, but its `.rail` still lacks `min-height: 0`. This is the complementary, still-missing piece.

## Tests

Added a mock-mode Playwright regression test (`smoke.spec.ts`) that stresses the rail with overflowing content at **900px and a shorter (600px) viewport**, asserting on first paint (no reload):
- the rail stays inside the viewport (`rail.y + rail.height ≤ viewport height`),
- `.rail-list` scrolls internally (`scrollHeight > clientHeight`),
- no full-page scroll is introduced (`scrollingElement.scrollHeight === clientHeight`).

Verified the test **fails without the fix** (rail measured 4321px in a 900px viewport) and passes with it. Full `smoke.spec.ts` suite: 54 passed. Typecheck, lint, and build clean. (One pre-existing `rest.test.ts` failure is a local `ENOTDIR` env issue, unrelated — confirmed it also fails on clean `main`.)

## Acceptance criteria

- [x] Nav scrolls within the viewport on first paint — no refresh needed.
- [x] Verified at 900px height and shorter windows.
- [x] No horizontal or full-page scroll introduced.

Fixes SAP-1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jx5dm5SYv3zHgDCYvRGiBg

---

## Also folded in: fix pre-existing red `main` (agent-core scaffold fallback)

CI's shared `test` job was red before this PR — `main` itself has been failing on `packages/agent-core` `scaffold.test.ts` since `#293 "version packages"`. The hand-maintained `VERSION_FALLBACK` in `scaffold.ts` drifted from the bumped workspace versions (agent `0.6.2`→`0.6.4`, tools `0.17.2`→`0.19.0`), and the drift-guard test caught it. Bumped the fallback to match. Unrelated to the harness fix, but folded in here to get CI green (same fix shape as the prior `#191` standalone). 13/13 scaffold tests pass.


**Second pre-existing red on `main` (harness skills-router test):** `rest.test.ts`'s "serves user skills from the configured root" mounted `createSkillsRouter` without `showUserSkills: true`. Commit `5b8dacc` made user skills opt-in and updated the sibling `skills.test.ts` but missed this "real server mount proof" suite, so it went red on main (user skills excluded from the list by default). Enabled the flag on that mount. All 779 harness tests pass.
