### PR TITLE
fix(harness): separate inspecting a workflow from binding it; keep rail highlight in sync with the canvas

### DIFF
--- a/.changeset/harness-canvas-session-binding.md
+++ b/.changeset/harness-canvas-session-binding.md
@@ -1,0 +1,17 @@
+---
+"@sapiom/harness": patch
+---
+
+fix(harness): separate inspecting a workflow from binding it, and keep the rail highlight in sync with the canvas
+
+Clicking a workflow in the workspace rail used to immediately rebind it to the
+active session, so just *looking* at another workflow clobbered what the session
+was working on. Selecting is now pure inspection (it highlights the row and docks
+the action strip); a session's binding changes only via an explicit "Work on
+this" control on the strip (or by running a macro against the workflow, which is
+already an explicit action).
+
+Switching session tabs now always snaps the rail/strip highlight to that
+session's own binding — including clearing it when the session has no binding, so
+the rail no longer stays lit on the previous session's workflow while the canvas
+shows nothing.

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -240,9 +240,25 @@ test.describe("workspace binding", () => {
     await expect(chip).toContainText("working on leasing");
   });
 
-  test("selecting a different workflow re-binds it and updates the chip", async ({ page }) => {
+  test("inspecting a workflow highlights it WITHOUT rebinding — binding changes only on 'Work on this'", async ({
+    page,
+  }) => {
+    // Clicking rfq in the rail inspects it: the row highlights and the strip
+    // docks to it, but the active session stays bound to leasing (no clobber).
     await page.getByTestId("workflow-rfq").click();
+    await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-selected/);
+    await expect(page.getByTestId("session-workflow-chip")).toContainText("working on leasing");
+
+    // The strip offers to make it the binding; taking that explicit action is
+    // what rebinds and updates the chip.
+    const bind = page.getByTestId("workflow-bind");
+    await expect(bind).toBeEnabled();
+    await bind.click();
     await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
+
+    // Now that it IS the binding, the control reflects that and stops offering.
+    await expect(bind).toHaveAttribute("aria-pressed", "true");
+    await expect(bind).toBeDisabled();
   });
 
   test("the binding is per-session: switching sessions shows that session's own binding", async ({ page }) => {
@@ -252,6 +268,27 @@ test.describe("workspace binding", () => {
     await page.getByTestId("history-trigger").click();
     await page.getByTestId("history-8f2b1c6a-4d3e-4a11-9c2f-1a2b3c4d5e6f").click();
     await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
+  });
+
+  test("switching tabs keeps the rail highlight in sync with the active session's binding (SAP-1631)", async ({
+    page,
+  }) => {
+    // Boot session is bound to leasing → that row is highlighted on load.
+    await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-selected/);
+
+    // The "scratch" background session has no binding. Switching to its tab
+    // must CLEAR the highlight (and leave the canvas empty) rather than
+    // stranding the rail on leasing while the canvas shows nothing — the
+    // rail↔canvas divergence this fixes.
+    await page.getByTestId("session-tab-sess-bg").click();
+    await expect(page.getByTestId("session-tab-sess-bg")).toHaveClass(/is-active/);
+    await expect(page.locator(".workflow-item.is-selected")).toHaveCount(0);
+    await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
+    await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
+
+    // Switching back restores that session's own binding highlight.
+    await page.getByTestId("session-tab-sess-boot").click();
+    await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-selected/);
   });
 });
 
@@ -484,7 +521,10 @@ test.describe("docked workflow action strip", () => {
     // ONE canvas macro: the old two-button visualize / ai-visualize split is
     // gone — Visualize alone covers structure + AI enrichment server-side.
     await expect(strip.getByTestId("macro-ai-visualize")).toHaveCount(0);
-    await expect(strip.locator(".strip-item")).toHaveCount(5);
+    // Five macros — counted apart from the "Work on this" bind control, which
+    // shares the .strip-item layout but is not one of the workflow's macros.
+    await expect(strip.locator(".strip-item:not(.strip-item-bind)")).toHaveCount(5);
+    await expect(strip.getByTestId("workflow-bind")).toBeVisible();
 
     await page.screenshot({ path: "web/e2e/screenshots/app-shell-docked-strip.png", fullPage: true });
   });
@@ -586,7 +626,10 @@ test.describe("docked workflow action strip", () => {
     const leasingBox = await dot.boundingBox();
     expect(leasingBox).not.toBeNull();
 
+    // The canvas header names the BOUND workflow, so bind onboarding-flow
+    // (inspect it, then "Work on this") to bring its long name into the header.
     await page.getByTestId("workflow-onboarding-flow").locator(".workflow-item-trigger").click();
+    await page.getByTestId("workflow-bind").click();
     await expect(page.getByTestId("workflow-actions-header")).toContainText("onboarding-flow");
     const onboardingBox = await dot.boundingBox();
     expect(onboardingBox).not.toBeNull();
@@ -768,10 +811,11 @@ test("switching the bound workflow refetches the canvas immediately — the serv
   await expect.poll(() => canvasRequests).toBeGreaterThan(0);
   const requestsBeforeBind = canvasRequests;
 
-  // Re-bind to a different workflow: the pane must refetch the same URL on
-  // its own (the served document changes with the binding) — no canvas.reload
-  // round-trip required first.
+  // Re-bind to a different workflow (inspect it, then "Work on this"): the pane
+  // must refetch the same URL on its own (the served document changes with the
+  // binding) — no canvas.reload round-trip required first.
   await page.getByTestId("workflow-rfq").click();
+  await page.getByTestId("workflow-bind").click();
   await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
   await expect.poll(() => canvasRequests).toBeGreaterThan(requestsBeforeBind);
 });
@@ -856,6 +900,7 @@ test.describe("background-task canvas states", () => {
     // ...and switching the binding mid-run hides it again: the rfq pane must
     // not show leasing's enrichment progress.
     await page.getByTestId("workflow-rfq").click();
+    await page.getByTestId("workflow-bind").click();
     await expect(page.getByTestId("session-workflow-chip")).toContainText("working on rfq");
     await expect(page.getByTestId("canvas-task-activity")).toHaveCount(0);
   });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -109,22 +109,33 @@ export const App = (): JSX.Element => {
     await harness.createSession({ cwd, harness: agentHarness });
   };
 
+  // Pure inspection: highlight a workflow in the rail and dock its action strip
+  // WITHOUT touching the active session's binding. Clicking around the rail to
+  // look at workflows must never clobber "what I'm working on" — rebinding is
+  // its own explicit action (handleBindWorkflow / the strip's "Work on this").
   const handleSelectWorkflow = (path: string): void => {
     harness.setSelectedWorkflowPath(path);
-    // Selecting a workflow IS "what I'm working on" — bind it to whichever
-    // session is currently active so the chip and the agent's context stay in sync.
+  };
+
+  // Explicitly makes a workflow the active session's binding ("what I'm working
+  // on"): selects it too so the highlight, the strip, the chip, and the canvas
+  // all land on the same workflow. This is the ONLY path that changes a
+  // session's binding from the rail side.
+  const handleBindWorkflow = (path: string): void => {
+    harness.setSelectedWorkflowPath(path);
     if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
   // Shared by the docked workflow action strip, the canvas empty-state's
   // Visualize CTA, and anything else that fires a macro. Running a macro
-  // against a workflow also (re-)binds it, so acting on a workflow that isn't
-  // the current binding switches "what I'm working on" too. `workflow` is
+  // against a workflow is an explicit action on it, so it (re-)binds too — the
+  // canvas is served from the session's binding, so a render-canvas macro on
+  // an unbound workflow would otherwise draw into the wrong root. `workflow` is
   // nullable for macros that don't require one when nothing's bound yet.
   // Every macro is one click — there's no subject/free-text step on this
   // side; the agent is the interface for anything more specific.
   const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef): void => {
-    if (workflow) handleSelectWorkflow(workflow.path);
+    if (workflow) handleBindWorkflow(workflow.path);
     if (macro.action.kind === "open-url") {
       window.open(resolveMacroUrl(macro.action.url, workflow), "_blank", "noopener,noreferrer");
       return;
@@ -188,7 +199,9 @@ export const App = (): JSX.Element => {
               top={rowAnchor.top}
               height={rowAnchor.height}
               activeSessionId={harness.activeSessionId}
+              boundWorkflowPath={boundWorkflowPath}
               macros={state.macros}
+              onBind={() => handleBindWorkflow(selectedWorkflow.path)}
               onRunMacro={(macro) => handleRunMacroForWorkflow(selectedWorkflow, macro)}
             />
           )}

--- a/packages/harness/web/src/components/WorkflowActionStrip.tsx
+++ b/packages/harness/web/src/components/WorkflowActionStrip.tsx
@@ -10,7 +10,12 @@ interface WorkflowActionStripProps {
   top: number;
   height: number;
   activeSessionId: string | null;
+  /** The active session's current binding — used to show whether the selected
+   *  workflow is the one being worked on, or offer to make it so. */
+  boundWorkflowPath: string | null;
   macros: MacroDef[];
+  /** Binds the selected workflow to the active session ("Work on this"). */
+  onBind: () => void;
   onRunMacro: (macro: MacroDef) => void;
 }
 
@@ -33,16 +38,41 @@ export function WorkflowActionStrip({
   top,
   height,
   activeSessionId,
+  boundWorkflowPath,
   macros,
+  onBind,
   onRunMacro,
 }: WorkflowActionStripProps): JSX.Element {
   const notchStyle: CSSProperties = { top, height };
   const stripStyle: CSSProperties = { top };
 
+  const isBound = workflow.path === boundWorkflowPath;
+  // The bind control is disabled both when it's already the binding (nothing to
+  // do) and when there's no session to bind to — with a reason in the latter
+  // case, mirroring how macros surface their own disabled reasons.
+  const bindReason = !activeSessionId ? "Start a session first" : isBound ? "You're working on this" : null;
+  const bindLabel = isBound ? "Working on this" : "Work on this";
+
   return (
     <>
       <div className="workflow-action-strip-notch" style={notchStyle} data-testid="workflow-action-strip-notch" />
       <div className="workflow-action-strip" style={stripStyle} data-testid="workflow-action-strip">
+        <button
+          className={"strip-item strip-item-bind" + (isBound ? " is-bound" : "")}
+          data-testid="workflow-bind"
+          aria-label={bindReason ? `${bindLabel}: ${bindReason}` : bindLabel}
+          aria-pressed={isBound}
+          disabled={Boolean(bindReason)}
+          onClick={onBind}
+        >
+          <span className="strip-item-icon">
+            <Icon name={isBound ? "Radio" : "Plug"} size={15} />
+          </span>
+          <span className="strip-item-text">
+            <span className="strip-item-label">{bindLabel}</span>
+            {bindReason && !activeSessionId && <span className="strip-item-reason">{bindReason}</span>}
+          </span>
+        </button>
         {macros.map((macro) => {
           const disabledReason = macroDisabledReason(macro, workflow, activeSessionId);
           return (

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -130,13 +130,16 @@ export function useHarnessState(): HarnessStateHook {
     };
   }, []);
 
-  // Switching sessions follows that session's own binding (if any) rather than
-  // leaving the rail highlighted on whatever the previous session had selected.
+  // Switching sessions snaps the rail/strip selection to that session's own
+  // binding so the highlight always matches the canvas (which is driven by the
+  // active session's binding). Crucially this also CLEARS the selection when
+  // the new session has no binding — otherwise the rail stayed highlighted on
+  // the previous session's workflow while the canvas showed nothing, the
+  // rail↔canvas divergence users hit on every tab switch to an unbound session.
   useEffect(() => {
     if (!activeSessionId) return;
     const session = state?.sessions.find((s) => s.id === activeSessionId);
-    const bound = boundWorkflowPathOf(session);
-    if (bound) setSelectedWorkflowPath(bound);
+    setSelectedWorkflowPath(boundWorkflowPathOf(session));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSessionId]);
 

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -575,6 +575,24 @@ input {
   text-align: left;
 }
 
+/* The "Work on this" bind control sits above the macros as the primary action
+   for the selected workflow — a hairline separates it from the action set so
+   it reads as a distinct decision ("what am I working on") rather than one more
+   macro. */
+.strip-item-bind {
+  padding-bottom: 7px;
+  margin-bottom: 3px;
+  border-bottom: 1px solid var(--border);
+  border-radius: 6px 6px 0 0;
+}
+
+/* Once it IS the active session's binding, the control shows the accent so the
+   strip echoes what the canvas and the "working on" chip already say. */
+.strip-item-bind.is-bound,
+.strip-item-bind.is-bound:disabled {
+  color: var(--accent);
+}
+
 .center-pane {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

In the harness SPA, the workspace rail conflated two different intents:

1. **View = rebind.** Clicking a workflow in the rail *rebound* it to the active session. So just inspecting another workflow clobbered what that session was working on ("what I'm working on").
2. **Rail ↔ canvas divergence on tab switch.** The rail highlight is driven by the selected-workflow, the canvas by the active session's own binding. Switching to a session that had no binding left the rail lit on the *previous* session's workflow while the canvas showed nothing.

## Fix

**Separate view from rebind.**
- Clicking a rail row is now pure inspection: it highlights the row and docks the action strip, and no longer touches the active session's binding.
- Binding changes only via an explicit **"Work on this"** control at the top of the workflow action strip (or by running a macro against the workflow — already an explicit action, and required because the canvas is served from the session's binding, so a render-canvas macro on an unbound workflow would otherwise draw into the wrong root). When the selected workflow already *is* the active session's binding, the control reads "Working on this" (accented, disabled).

**Keep the rail highlight in sync with the canvas on tab switch.**
- Switching session tabs now always snaps the rail/strip highlight to that session's own binding — **including clearing it** when the session is unbound. Previously the sync only happened when the new session *had* a binding, which is what caused the divergence.

## Acceptance criteria

- [x] Switching tabs always shows the active session's own canvas and its rail highlight matches (clears when unbound).
- [x] Inspecting another workflow does not change what the active session is bound to.

## Tests

Mock-mode Playwright coverage (`web/e2e/smoke.spec.ts`):
- New: inspecting a workflow highlights it *without* rebinding; an explicit "Work on this" is what rebinds and updates the "working on" chip.
- New: switching to an unbound session clears the rail highlight and leaves the canvas empty (the divergence regression).
- Updated the existing tests that relied on click-to-rebind to go through the explicit bind control instead.

Full local gate green: `build`, `typecheck`, `lint`, `test` (779 + 69 unit) all pass; e2e `smoke` 55 + `consent`/`dismiss`/`skills`/`welcome` 47 pass.

Fixes SAP-1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)