### PR TITLE
feat(harness): GET /api/runs/:id/state — live run status endpoint (B2)

### DIFF
--- a/.changeset/harness-runs-state-endpoint.md
+++ b/.changeset/harness-runs-state-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add a harness endpoint that reports a deployed run's live per-step state (status, latency, errors, logs) so the canvas can show progress during a run. The Sapiom credential stays server-side.

--- a/packages/harness/src/core/render-run-state.test.ts
+++ b/packages/harness/src/core/render-run-state.test.ts
@@ -12,7 +12,13 @@ function render(raw: Record<string, unknown>): RunView {
 
 /** A single step's raw body, spread over decode's defaults. */
 function step(raw: Record<string, unknown>): Record<string, unknown> {
-  return { stepName: "s", stepOrder: 0, attempt: 1, status: "completed", ...raw };
+  return {
+    stepName: "s",
+    stepOrder: 0,
+    attempt: 1,
+    status: "completed",
+    ...raw,
+  };
 }
 
 describe("renderRunState — run status", () => {
@@ -33,28 +39,40 @@ describe("renderRunState — run status", () => {
   );
 
   it("carries the execution id through", () => {
-    expect(render({ id: "exec_42", status: "running" }).executionId).toBe("exec_42");
+    expect(render({ id: "exec_42", status: "running" }).executionId).toBe(
+      "exec_42",
+    );
   });
 });
 
 describe("renderRunState — step status folding", () => {
   it.each([
     ["completed", "passed"],
+    ["succeeded", "passed"], // real prod engine vocabulary for a passed step
     ["failed", "failed"],
+    ["threw", "failed"], // real prod engine vocabulary for an error'd step
     ["cancelled", "failed"], // a cancelled step did not pass
     ["canceled", "failed"],
     ["running", "running"],
     ["", "pending"],
     ["queued", "pending"],
   ] as const)("folds step status %s → %s", (raw, expected) => {
-    const view = render({ id: "e1", status: "running", steps: [step({ status: raw })] });
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ status: raw })],
+    });
     expect(view.steps[0].status).toBe(expected);
   });
 });
 
 describe("renderRunState — step id + name", () => {
   it("uses the span id as the stable step id when present", () => {
-    const view = render({ id: "e1", status: "running", steps: [step({ spanId: "span_9" })] });
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ spanId: "span_9" })],
+    });
     expect(view.steps[0].id).toBe("span_9");
   });
 
@@ -68,7 +86,11 @@ describe("renderRunState — step id + name", () => {
   });
 
   it("passes the step name through", () => {
-    const view = render({ id: "e1", status: "running", steps: [step({ stepName: "gather" })] });
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ stepName: "gather" })],
+    });
     expect(view.steps[0].name).toBe("gather");
   });
 });
@@ -78,7 +100,15 @@ describe("renderRunState — cost", () => {
     const view = render({
       id: "e1",
       status: "completed",
-      steps: [step({ cost: { authorizedUsd: "9.99", capturedUsd: "1.20", settleState: "final" } })],
+      steps: [
+        step({
+          cost: {
+            authorizedUsd: "9.99",
+            capturedUsd: "1.20",
+            settleState: "final",
+          },
+        }),
+      ],
     });
     expect(view.steps[0].costUsd).toBe(1.2);
   });
@@ -92,7 +122,15 @@ describe("renderRunState — cost", () => {
     const view = render({
       id: "e1",
       status: "completed",
-      steps: [step({ cost: { authorizedUsd: "0", capturedUsd: "n/a", settleState: "final" } })],
+      steps: [
+        step({
+          cost: {
+            authorizedUsd: "0",
+            capturedUsd: "n/a",
+            settleState: "final",
+          },
+        }),
+      ],
     });
     expect(view.steps[0]).not.toHaveProperty("costUsd");
   });
@@ -101,7 +139,15 @@ describe("renderRunState — cost", () => {
     const view = render({
       id: "e1",
       status: "completed",
-      steps: [step({ cost: { authorizedUsd: "1.00", capturedUsd: "0", settleState: "pending" } })],
+      steps: [
+        step({
+          cost: {
+            authorizedUsd: "1.00",
+            capturedUsd: "0",
+            settleState: "pending",
+          },
+        }),
+      ],
     });
     expect(view.steps[0].costUsd).toBe(0);
   });
@@ -113,7 +159,10 @@ describe("renderRunState — latency", () => {
       id: "e1",
       status: "completed",
       steps: [
-        step({ startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:45.000Z" }),
+        step({
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:00:45.000Z",
+        }),
       ],
     });
     expect(view.steps[0].latencyMs).toBe(45_000);
@@ -124,7 +173,10 @@ describe("renderRunState — latency", () => {
       id: "e1",
       status: "completed",
       steps: [
-        step({ startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.000Z" }),
+        step({
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:00:00.000Z",
+        }),
       ],
     });
     expect(view.steps[0].latencyMs).toBe(0);
@@ -134,7 +186,13 @@ describe("renderRunState — latency", () => {
     const view = render({
       id: "e1",
       status: "running",
-      steps: [step({ status: "running", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: null })],
+      steps: [
+        step({
+          status: "running",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: null,
+        }),
+      ],
     });
     expect(view.steps[0]).not.toHaveProperty("latencyMs");
   });
@@ -143,7 +201,12 @@ describe("renderRunState — latency", () => {
     const view = render({
       id: "e1",
       status: "completed",
-      steps: [step({ startedAt: "not-a-date", finishedAt: "2026-01-01T00:00:45.000Z" })],
+      steps: [
+        step({
+          startedAt: "not-a-date",
+          finishedAt: "2026-01-01T00:00:45.000Z",
+        }),
+      ],
     });
     expect(view.steps[0]).not.toHaveProperty("latencyMs");
   });
@@ -153,7 +216,10 @@ describe("renderRunState — latency", () => {
       id: "e1",
       status: "completed",
       steps: [
-        step({ startedAt: "2026-01-01T00:00:45.000Z", finishedAt: "2026-01-01T00:00:00.000Z" }),
+        step({
+          startedAt: "2026-01-01T00:00:45.000Z",
+          finishedAt: "2026-01-01T00:00:00.000Z",
+        }),
       ],
     });
     expect(view.steps[0]).not.toHaveProperty("latencyMs");
@@ -203,18 +269,30 @@ describe("renderRunState — log slice", () => {
   });
 
   it("omits logSlice when there are no logs", () => {
-    const view = render({ id: "e1", status: "completed", steps: [step({ logs: null })] });
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ logs: null })],
+    });
     expect(view.steps[0]).not.toHaveProperty("logSlice");
   });
 
   it("omits logSlice for an empty log array", () => {
-    const view = render({ id: "e1", status: "completed", steps: [step({ logs: [] })] });
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ logs: [] })],
+    });
     expect(view.steps[0]).not.toHaveProperty("logSlice");
   });
 
   it("keeps the TAIL when the buffer exceeds the cap", () => {
     const long = Array.from({ length: 500 }, (_, i) => `line-${i}`);
-    const view = render({ id: "e1", status: "completed", steps: [step({ logs: long })] });
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ logs: long })],
+    });
     const slice = view.steps[0].logSlice as string;
     expect(slice.length).toBe(4000);
     expect(slice.endsWith("line-499")).toBe(true); // most-recent line survives
@@ -229,14 +307,23 @@ describe("renderRunState — whole run", () => {
       status: "running",
       steps: [
         step({ stepName: "first", stepOrder: 0, spanId: "a" }),
-        step({ stepName: "second", stepOrder: 1, spanId: "b", status: "running" }),
+        step({
+          stepName: "second",
+          stepOrder: 1,
+          spanId: "b",
+          status: "running",
+        }),
       ],
     });
     expect(view.steps.map((s) => s.name)).toEqual(["first", "second"]);
   });
 
   it("emits only the derived keys for a minimal step (honest absence everywhere)", () => {
-    const view = render({ id: "e1", status: "running", steps: [step({ spanId: "s0" })] });
+    const view = render({
+      id: "e1",
+      status: "running",
+      steps: [step({ spanId: "s0" })],
+    });
     expect(view.steps[0]).toEqual({ id: "s0", name: "s", status: "passed" });
   });
 
@@ -262,7 +349,11 @@ describe("renderRunState — whole run", () => {
           spanId: "span_0001",
           startedAt: "2026-01-01T00:00:00.000Z",
           finishedAt: "2026-01-01T00:00:45.000Z",
-          cost: { authorizedUsd: "0.50", capturedUsd: "0.50", settleState: "final" },
+          cost: {
+            authorizedUsd: "0.50",
+            capturedUsd: "0.50",
+            settleState: "final",
+          },
         },
       ],
     });
@@ -270,7 +361,13 @@ describe("renderRunState — whole run", () => {
       executionId: "exec_0001",
       status: "completed",
       steps: [
-        { id: "span_0001", name: "gather", status: "passed", costUsd: 0.5, latencyMs: 45_000 },
+        {
+          id: "span_0001",
+          name: "gather",
+          status: "passed",
+          costUsd: 0.5,
+          latencyMs: 45_000,
+        },
       ],
     });
   });

--- a/packages/harness/src/core/render-run-state.ts
+++ b/packages/harness/src/core/render-run-state.ts
@@ -15,7 +15,11 @@
  * absence, never a fabricated $0" contract.
  */
 import { isExecutionTerminal } from "@sapiom/agent-core";
-import type { CostNode, ExecutionProjection, StepProjection } from "@sapiom/agent-core";
+import type {
+  CostNode,
+  ExecutionProjection,
+  StepProjection,
+} from "@sapiom/agent-core";
 
 import type { RunView, StepStatus, StepView } from "../shared/types.js";
 
@@ -42,14 +46,21 @@ function toRunStatus(raw: string): RunView["status"] {
 }
 
 /**
- * Fold a step's raw status into a {@link StepStatus}. A cancelled step folds to
- * `failed` (it did not pass — mirrors run-local.ts folding the unreachable
- * 'cancelled' into 'failed'); anything not yet running/passed/failed is
- * `pending` (unstarted, queued, or an unknown value).
+ * Fold a step's raw status into a {@link StepStatus}. Handles the real engine
+ * vocabulary (`succeeded`/`threw` from prod agents surface) plus the earlier
+ * values (`completed`/`failed`/`cancelled`/`canceled`). A cancelled or threw
+ * step folds to `failed` (it did not pass — mirrors run-local.ts); anything
+ * not yet running/passed/failed is `pending` (unstarted, queued, or unknown).
  */
 function toStepStatus(raw: string): StepStatus {
-  if (raw === "completed") return "passed";
-  if (raw === "failed" || raw === "cancelled" || raw === "canceled") return "failed";
+  if (raw === "completed" || raw === "succeeded") return "passed";
+  if (
+    raw === "failed" ||
+    raw === "threw" ||
+    raw === "cancelled" ||
+    raw === "canceled"
+  )
+    return "failed";
   if (raw === "running") return "running";
   return "pending";
 }
@@ -65,7 +76,10 @@ function toCostUsd(cost: CostNode | null): number | undefined {
 /** `finishedAt − startedAt` in ms; `undefined` while still running (no finish)
  *  or when either timestamp is unparseable. A negative delta (clock skew) is
  *  dropped rather than shown as a misleading negative latency. */
-function toLatencyMs(startedAt: string | null, finishedAt: string | null): number | undefined {
+function toLatencyMs(
+  startedAt: string | null,
+  finishedAt: string | null,
+): number | undefined {
   if (!startedAt || !finishedAt) return undefined;
   const start = Date.parse(startedAt);
   const end = Date.parse(finishedAt);
@@ -79,9 +93,15 @@ function toLatencyMs(startedAt: string | null, finishedAt: string | null): numbe
 function formatLogEntry(entry: unknown): string {
   if (typeof entry === "string") return entry;
   if (entry !== null && typeof entry === "object") {
-    const e = entry as { ts?: unknown; level?: unknown; msg?: unknown; message?: unknown };
+    const e = entry as {
+      ts?: unknown;
+      level?: unknown;
+      msg?: unknown;
+      message?: unknown;
+    };
     const parts = [e.ts, e.level, e.msg ?? e.message].filter(
-      (p): p is string | number => typeof p === "string" || typeof p === "number",
+      (p): p is string | number =>
+        typeof p === "string" || typeof p === "number",
     );
     if (parts.length > 0) return parts.map(String).join(" ");
   }
@@ -94,7 +114,9 @@ function toLogSlice(logs: unknown): string | undefined {
   if (!Array.isArray(logs) || logs.length === 0) return undefined;
   const text = logs.map(formatLogEntry).join("\n").trim();
   if (text === "") return undefined;
-  return text.length > LOG_SLICE_MAX ? text.slice(text.length - LOG_SLICE_MAX) : text;
+  return text.length > LOG_SLICE_MAX
+    ? text.slice(text.length - LOG_SLICE_MAX)
+    : text;
 }
 
 /** Map one projection step to its render view. Optional fields are assigned only

--- a/packages/harness/src/core/run-state.test.ts
+++ b/packages/harness/src/core/run-state.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createRunStateFetcher, resolveAgentsBaseUrl } from "./run-state.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal mock Response with a given status and JSON body. */
+function makeFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/**
+ * A realistic raw execution projection for a generic "invoice-sync" agent.
+ * Uses `status:"succeeded"` on the passing step to exercise the real prod
+ * engine vocabulary end-to-end (the key gotcha this module fixes).
+ */
+const RAW_SUCCESS_DOC = {
+  id: "exec_invoice_001",
+  name: "invoice-sync",
+  status: "completed",
+  currentStep: null,
+  startedAt: "2026-07-01T10:00:00.000Z",
+  finishedAt: "2026-07-01T10:00:30.000Z",
+  steps: [
+    {
+      id: "step_0",
+      stepName: "validateInput",
+      stepOrder: 0,
+      attempt: 1,
+      status: "succeeded", // real prod engine vocabulary — NOT "completed"
+      spanId: "span_validate",
+      startedAt: "2026-07-01T10:00:00.000Z",
+      finishedAt: "2026-07-01T10:00:10.000Z",
+      logs: [
+        {
+          ts: "2026-07-01T10:00:01.000Z",
+          level: "info",
+          msg: "Validating invoice payload",
+        },
+        {
+          ts: "2026-07-01T10:00:09.000Z",
+          level: "info",
+          msg: "Validation passed",
+        },
+      ],
+      error: null,
+    },
+    {
+      id: "step_1",
+      stepName: "chargeCard",
+      stepOrder: 1,
+      attempt: 1,
+      status: "failed",
+      spanId: "span_charge",
+      startedAt: "2026-07-01T10:00:10.000Z",
+      finishedAt: "2026-07-01T10:00:30.000Z",
+      logs: [],
+      error: { message: "Card declined: insufficient funds" },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentsBaseUrl", () => {
+  it("defaults to the tools base when no env vars are set", () => {
+    const saved = {
+      agents: process.env.SAPIOM_AGENTS_URL,
+      tools: process.env.SAPIOM_TOOLS_BASE,
+    };
+    delete process.env.SAPIOM_AGENTS_URL;
+    delete process.env.SAPIOM_TOOLS_BASE;
+    expect(resolveAgentsBaseUrl()).toBe("https://tools.sapiom.ai");
+    if (saved.agents !== undefined)
+      process.env.SAPIOM_AGENTS_URL = saved.agents;
+    if (saved.tools !== undefined) process.env.SAPIOM_TOOLS_BASE = saved.tools;
+  });
+
+  it("prefers SAPIOM_AGENTS_URL over SAPIOM_TOOLS_BASE", () => {
+    const saved = {
+      agents: process.env.SAPIOM_AGENTS_URL,
+      tools: process.env.SAPIOM_TOOLS_BASE,
+    };
+    process.env.SAPIOM_AGENTS_URL = "https://agents.example.com";
+    process.env.SAPIOM_TOOLS_BASE = "https://tools.example.com";
+    expect(resolveAgentsBaseUrl()).toBe("https://agents.example.com");
+    if (saved.agents !== undefined)
+      process.env.SAPIOM_AGENTS_URL = saved.agents;
+    else delete process.env.SAPIOM_AGENTS_URL;
+    if (saved.tools !== undefined) process.env.SAPIOM_TOOLS_BASE = saved.tools;
+    else delete process.env.SAPIOM_TOOLS_BASE;
+  });
+});
+
+describe("createRunStateFetcher — no apiKey", () => {
+  it("returns 503 without calling the network when apiKey is null", async () => {
+    const mockFetch = vi.fn();
+    const fetcher = createRunStateFetcher({
+      apiKey: null,
+      fetchImpl: mockFetch,
+    });
+    const result = await fetcher.fetch("exec_invoice_001");
+    expect(result).toEqual({
+      ok: false,
+      status: 503,
+      error: "harness is not signed in to Sapiom",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRunStateFetcher — success path (proves succeeded→passed fix end-to-end)", () => {
+  it("maps a two-step doc with succeeded+failed steps to a correct RunView", async () => {
+    const mockFetch = makeFetch(200, RAW_SUCCESS_DOC);
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("exec_invoice_001");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return; // type narrowing
+
+    const { runView } = result;
+    expect(runView.executionId).toBe("exec_invoice_001");
+    expect(runView.status).toBe("completed");
+
+    // Step 0: succeeded → passed (the critical real-vocab mapping)
+    expect(runView.steps[0].status).toBe("passed");
+    expect(runView.steps[0].name).toBe("validateInput");
+    expect(runView.steps[0].latencyMs).toBe(10_000); // 10:00:00 → 10:00:10
+    expect(runView.steps[0].logSlice).toContain("Validation passed");
+    expect(runView.steps[0]).not.toHaveProperty("error");
+
+    // Step 1: failed → failed
+    expect(runView.steps[1].status).toBe("failed");
+    expect(runView.steps[1].name).toBe("chargeCard");
+    expect(runView.steps[1].error).toBe("Card declined: insufficient funds");
+  });
+
+  it("uses the correct URL and x-sapiom-api-key header", async () => {
+    const mockFetch = makeFetch(200, RAW_SUCCESS_DOC);
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-my-key",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    await fetcher.fetch("exec_invoice_001");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://agents.test/agents/v1/executions/exec_invoice_001",
+      { headers: { "x-sapiom-api-key": "sk-my-key" } },
+    );
+  });
+});
+
+describe("createRunStateFetcher — error paths", () => {
+  it("returns 404 when the gateway responds 404", async () => {
+    const mockFetch = makeFetch(404, { error: "not found" });
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("exec_missing");
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "execution not found",
+    });
+
+    // Verify URL construction with the correct execution id
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://agents.test/agents/v1/executions/exec_missing",
+      expect.objectContaining({ headers: { "x-sapiom-api-key": "sk-test" } }),
+    );
+  });
+
+  it("returns 502 when the gateway responds with a non-2xx non-404 status", async () => {
+    const mockFetch = makeFetch(500, { error: "internal server error" });
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("exec_invoice_001");
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: "gateway responded 500",
+    });
+  });
+
+  it("returns 502 when fetch throws a network error", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValue(new Error("connection refused"));
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("exec_invoice_001");
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: "gateway unreachable",
+    });
+  });
+
+  it("returns 502 when the response body is malformed JSON (json() throws)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: () => Promise.reject(new SyntaxError("Unexpected token")),
+    } as unknown as Response);
+
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test",
+      baseUrl: "https://agents.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("exec_invoice_001");
+    expect(result).toEqual({
+      ok: false,
+      status: 502,
+      error: "could not decode execution",
+    });
+  });
+});

--- a/packages/harness/src/core/run-state.ts
+++ b/packages/harness/src/core/run-state.ts
@@ -1,0 +1,101 @@
+/**
+ * run-state — fetches a prod execution projection from the agents surface and
+ * renders it to a {@link RunView} the canvas can poll.
+ *
+ * WHY the agents surface: deployed agent runs are owned by the agents runtime
+ * (`GET /agents/v1/executions/:id`), not the core-capabilities surface. The
+ * response is the full ExecutionProjection JSON (same shape agent-core's
+ * decodeExecutionProjection consumes).
+ *
+ * WHY the key stays server-side: the Sapiom API key is a harness credential that
+ * must never reach the browser. The harness server fetches on behalf of the
+ * canvas, so the SPA polls a local `/api/runs/:id/state` endpoint (no key in the
+ * request) rather than calling the upstream surface directly.
+ *
+ * NOTE: this env-precedence helper for the agents base URL is duplicated
+ * elsewhere in the harness; consolidate into one shared helper when convenient.
+ */
+
+import { decodeExecutionProjection } from "@sapiom/agent-core";
+
+import type { RunView } from "../shared/types.js";
+import { renderRunState } from "./render-run-state.js";
+
+/** Resolve the agents surface base URL from the environment. */
+export function resolveAgentsBaseUrl(): string {
+  return (
+    process.env.SAPIOM_AGENTS_URL ??
+    process.env.SAPIOM_TOOLS_BASE ??
+    "https://tools.sapiom.ai"
+  );
+}
+
+export type RunStateResult =
+  | { ok: true; runView: RunView }
+  | { ok: false; status: number; error: string };
+
+export interface RunStateFetcherOpts {
+  apiKey: string | null;
+  baseUrl?: string;
+  /** Injectable fetch implementation — defaults to global fetch. Test seam. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface RunStateFetcher {
+  fetch(executionId: string): Promise<RunStateResult>;
+}
+
+/**
+ * Create a fetcher that resolves an execution's current render state from the
+ * agents surface. The fetcher is intentionally non-throwing: all error paths
+ * return a typed {@link RunStateResult} with `ok: false` so the router can
+ * forward the appropriate HTTP status without a try/catch at the call site.
+ */
+export function createRunStateFetcher(
+  opts: RunStateFetcherOpts,
+): RunStateFetcher {
+  const { apiKey, baseUrl = resolveAgentsBaseUrl(), fetchImpl = fetch } = opts;
+
+  return {
+    async fetch(executionId: string): Promise<RunStateResult> {
+      // No API key — do not touch the network; the harness is not signed in.
+      if (!apiKey) {
+        return {
+          ok: false,
+          status: 503,
+          error: "harness is not signed in to Sapiom",
+        };
+      }
+
+      let res: Response;
+      try {
+        res = await fetchImpl(
+          `${baseUrl}/agents/v1/executions/${encodeURIComponent(executionId)}`,
+          { headers: { "x-sapiom-api-key": apiKey } },
+        );
+      } catch {
+        return { ok: false, status: 502, error: "gateway unreachable" };
+      }
+
+      if (res.status === 404) {
+        return { ok: false, status: 404, error: "execution not found" };
+      }
+
+      if (!res.ok) {
+        return {
+          ok: false,
+          status: 502,
+          error: `gateway responded ${res.status}`,
+        };
+      }
+
+      try {
+        const raw = (await res.json()) as Record<string, unknown>;
+        const runView = renderRunState(decodeExecutionProjection(raw));
+        return { ok: true, runView };
+      } catch {
+        return { ok: false, status: 502, error: "could not decode execution" };
+      }
+    },
+  };
+}

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -7,7 +7,10 @@
  * src/shared/types.ts for the full protocol contract.
  */
 
-import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  type Server as HttpServer,
+} from "node:http";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +28,17 @@ import type {
 } from "../shared/types.js";
 import { resolveStatePaths } from "../core/paths.js";
 import { seedExampleProject } from "../core/example-seed.js";
-import { SessionManager, type LaunchOptsBuilder } from "../core/session-manager.js";
+import {
+  SessionManager,
+  type LaunchOptsBuilder,
+} from "../core/session-manager.js";
 import { TaskManager } from "../core/task-manager.js";
 import { createClaudeCodeAdapter } from "../core/adapters/claude-code.js";
 import { createCodexAdapter } from "../core/adapters/codex.js";
-import { WorkflowRegistry, createWorkflowsRouter } from "../core/workflow-registry.js";
+import {
+  WorkflowRegistry,
+  createWorkflowsRouter,
+} from "../core/workflow-registry.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
 import { createEventStore } from "../core/collector/store.js";
 import { createHarnessEmitter } from "../core/collector/analytics-emitter.js";
@@ -37,7 +46,11 @@ import { migrateHarnessIdentity } from "../core/collector/identity-migration.js"
 import { normalizeHookEvent } from "../core/collector/normalizer.js";
 import { enrichTurnCompleted } from "../core/collector/transcript.js";
 import { createSeqCounter } from "../core/collector/seq.js";
-import { findRolloutFile, tailCodexRollout, type CodexTailerHandle } from "../core/collector/codex-tailer.js";
+import {
+  findRolloutFile,
+  tailCodexRollout,
+  type CodexTailerHandle,
+} from "../core/collector/codex-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
 import { pruneDeadRecentDirs } from "../cli/settings.js";
 import type { HarnessIdentity } from "../cli/auth.js";
@@ -45,15 +58,24 @@ import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
 import { generateSystemPromptFile } from "../core/inject/system-prompt.js";
 import { generateSkillsPlugin } from "../core/inject/skills-plugin.js";
-import { removeGeneratedSessionDir, sweepGeneratedDirs } from "../core/inject/retention.js";
+import {
+  removeGeneratedSessionDir,
+  sweepGeneratedDirs,
+} from "../core/inject/retention.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
 import { WorkspaceWatcherManager } from "../core/workspace-watcher.js";
 import { ExecutionDetector } from "../core/execution-detector.js";
 import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
-import { writeHarnessContext, harnessContextFileExists } from "../core/workspace-context.js";
+import {
+  writeHarnessContext,
+  harnessContextFileExists,
+} from "../core/workspace-context.js";
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
-import { renderCanvasForSession, renderWorkflowRenderFile } from "../core/canvas-render.js";
+import {
+  renderCanvasForSession,
+  renderWorkflowRenderFile,
+} from "../core/canvas-render.js";
 import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
 import { createBootTokenMiddleware } from "./auth.js";
@@ -62,12 +84,20 @@ import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
 import { attachWebSocketRouters } from "./ws-router.js";
-import { createIngestRouter, processIngest, type IngestDeps, type IngestRequestBody, type IngestSessionContext } from "./ingest.js";
+import {
+  createIngestRouter,
+  processIngest,
+  type IngestDeps,
+  type IngestRequestBody,
+  type IngestSessionContext,
+} from "./ingest.js";
 import { createCanvasRouter } from "./canvas.js";
 import { createCanvasRenderRouter } from "./canvas-render.js";
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 import { createSkillsRouter } from "./skills.js";
+import { createRunsRouter } from "./runs.js";
+import { resolveAgentsBaseUrl } from "../core/run-state.js";
 
 /**
  * Codex has no hook system — its rollout file is polled into existence
@@ -194,16 +224,22 @@ function packageRoot(): string {
 /** Whether two workflow lists are equivalent for the rail's purposes —
  *  compares the fields the SPA actually renders/keys on, order-insensitive, so
  *  a rescan that turned up nothing new doesn't trigger a needless broadcast. */
-function workflowListsEqual(a: readonly WorkflowInfo[], b: readonly WorkflowInfo[]): boolean {
+function workflowListsEqual(
+  a: readonly WorkflowInfo[],
+  b: readonly WorkflowInfo[],
+): boolean {
   if (a.length !== b.length) return false;
-  const key = (w: WorkflowInfo): string => `${w.path} ${w.name} ${w.definitionId ?? ""} ${w.source}`;
+  const key = (w: WorkflowInfo): string =>
+    `${w.path} ${w.name} ${w.definitionId ?? ""} ${w.source}`;
   const setA = new Set(a.map(key));
   return b.every((w) => setA.has(key(w)));
 }
 
 function readVersion(): string {
   try {
-    const pkg = JSON.parse(readFileSync(join(packageRoot(), "package.json"), "utf8")) as {
+    const pkg = JSON.parse(
+      readFileSync(join(packageRoot(), "package.json"), "utf8"),
+    ) as {
       version?: string;
     };
     return pkg.version ?? "0.0.0";
@@ -222,14 +258,22 @@ function readVersion(): string {
  * so the remote `sapiom` MCP is actually authenticated — a factory rather
  * than a plain function since it's per-server-instance state.
  */
-function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: string): LaunchOptsBuilder {
+function createDefaultBuildLaunchOpts(
+  apiKey: string | null,
+  generatedRoot?: string,
+): LaunchOptsBuilder {
   return async (harnessSessionId) => {
-    const [settings, mcpConfigFile, systemPromptFile, pluginDir] = await Promise.all([
-      generateClaudeSettings({ harnessSessionId, generatedRoot }),
-      generateMcpConfig(harnessSessionId, { environment: process.env.SAPIOM_ENVIRONMENT, apiKey, generatedRoot }),
-      generateSystemPromptFile(harnessSessionId, { generatedRoot }),
-      generateSkillsPlugin(harnessSessionId, { generatedRoot }),
-    ]);
+    const [settings, mcpConfigFile, systemPromptFile, pluginDir] =
+      await Promise.all([
+        generateClaudeSettings({ harnessSessionId, generatedRoot }),
+        generateMcpConfig(harnessSessionId, {
+          environment: process.env.SAPIOM_ENVIRONMENT,
+          apiKey,
+          generatedRoot,
+        }),
+        generateSystemPromptFile(harnessSessionId, { generatedRoot }),
+        generateSkillsPlugin(harnessSessionId, { generatedRoot }),
+      ]);
     return {
       settingsFile: settings.settingsPath,
       mcpConfigFile,
@@ -239,11 +283,14 @@ function createDefaultBuildLaunchOpts(apiKey: string | null, generatedRoot?: str
   };
 }
 
-export const startServer = async (options: HarnessServerOptions): Promise<HarnessServer> => {
+export const startServer = async (
+  options: HarnessServerOptions,
+): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
   const identity = options.identity ?? null;
   const statePaths = resolveStatePaths(options.stateRoot);
-  const machineId = options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
+  const machineId =
+    options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
 
   // One-way identity migration: seed ~/.sapiom/analytics.json from the
   // legacy harness machine-id so existing installs keep the same anonymous_id
@@ -260,7 +307,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
 
   const bus = new EventBus();
   const canvasWatcher = new CanvasWatcherManager({
-    onChange: (harnessSessionId) => bus.publish({ type: "canvas.reload", harnessSessionId }),
+    onChange: (harnessSessionId) =>
+      bus.publish({ type: "canvas.reload", harnessSessionId }),
   });
   // The harness's own infrastructure shouldn't ever show up as a "discovered"
   // dev server in the Preview pane — a mention of our own listening port (in
@@ -279,7 +327,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     if (collectorPort !== null) excludedPorts.add(collectorPort);
   }
   const portDetector = new PortDetector({
-    onPort: (harnessSessionId, port, url) => bus.publish({ type: "port.detected", harnessSessionId, port, url }),
+    onPort: (harnessSessionId, port, url) =>
+      bus.publish({ type: "port.detected", harnessSessionId, port, url }),
     excludedPorts,
   });
   // Same tool.call output feed as portDetector: catch `✓ Started execution
@@ -288,7 +337,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // result, not polled, so only prod-run announcements flow through here.
   const executionDetector = new ExecutionDetector({
     onExecution: (harnessSessionId, executionId, target) =>
-      bus.publish({ type: "execution.started", harnessSessionId, executionId, target }),
+      bus.publish({
+        type: "execution.started",
+        harnessSessionId,
+        executionId,
+        target,
+      }),
   });
 
   // Declared before sessionManager: writeSessionContext (sessionManager's
@@ -298,7 +352,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // itself (to rewrite every open session's context file on a registry change) —
   // no circularity, since only writeSessionContext is threaded into SessionManager's
   // constructor, and it doesn't need sessionManager.
-  const workflowRegistry = new WorkflowRegistry(options.workflowsRegistryPath ?? statePaths.workflows);
+  const workflowRegistry = new WorkflowRegistry(
+    options.workflowsRegistryPath ?? statePaths.workflows,
+  );
   // Boot-time hygiene, before the first list(): drop registry entries whose
   // path no longer exists on disk (deleted projects, temp dirs a crashed run
   // left registered) so the rail — and every harness-context.json written
@@ -307,7 +363,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   try {
     const prunedWorkflows = await workflowRegistry.prune();
     for (const workflow of prunedWorkflows) {
-      console.error(`[harness] pruned workflow registry entry with missing path: ${workflow.path}`);
+      console.error(
+        `[harness] pruned workflow registry entry with missing path: ${workflow.path}`,
+      );
     }
   } catch (err) {
     console.error("[harness] workflow registry prune failed:", err);
@@ -339,9 +397,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
    * SessionManager's create()/resume(), the PATCH bind/unbind route, and
    * scanWorkflowsAndBroadcast's rewrite-all-open-sessions step below.
    */
-  const writeSessionContext = async (session: HarnessSession): Promise<void> => {
+  const writeSessionContext = async (
+    session: HarnessSession,
+  ): Promise<void> => {
     const boundWorkflow = session.boundWorkflowPath
-      ? (workflowsCache.find((w) => w.path === session.boundWorkflowPath) ?? null)
+      ? (workflowsCache.find((w) => w.path === session.boundWorkflowPath) ??
+        null)
       : null;
     await writeHarnessContext(session, boundWorkflow, workflowsCache);
   };
@@ -354,7 +415,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const generatedRoot = options.generatedRoot ?? statePaths.generated;
   const pendingGeneratedRemovals = new Map<string, Promise<void>>();
   const innerBuildLaunchOpts =
-    options.buildLaunchOpts ?? createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
+    options.buildLaunchOpts ??
+    createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
   const buildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId, req) => {
     await pendingGeneratedRemovals.get(harnessSessionId);
     return innerBuildLaunchOpts(harnessSessionId, req);
@@ -375,7 +437,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   });
   await sessionManager.init();
 
-  const sessionSweepTimer = setInterval(() => sessionManager.sweepDeadSessions(), SESSION_LIVENESS_SWEEP_MS);
+  const sessionSweepTimer = setInterval(
+    () => sessionManager.sweepDeadSessions(),
+    SESSION_LIVENESS_SWEEP_MS,
+  );
   sessionSweepTimer.unref?.();
 
   // Background tasks (canvas enrichment today): headless one-shot agent
@@ -391,9 +456,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     collectorUrl: options.collectorUrl,
     buildLaunchOpts,
     onCleanup: (taskId) => {
-      void removeGeneratedSessionDir(taskId, { generatedRoot }).catch((err: unknown) => {
-        console.error("[harness] task generated-dir cleanup failed:", err);
-      });
+      void removeGeneratedSessionDir(taskId, { generatedRoot }).catch(
+        (err: unknown) => {
+          console.error("[harness] task generated-dir cleanup failed:", err);
+        },
+      );
     },
   });
   taskManager.onStatusChange((task) => {
@@ -425,7 +492,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // Pruning here is what lets a deleted workflow drop out (a plain scan only
   // ever merges in); it respects the same ENOENT/ENOTDIR-only guard as the
   // boot prune, so a merely-unbuilt or unreadable project stays put.
-  const rescanWorkspaceForSession = async (harnessSessionId: string): Promise<void> => {
+  const rescanWorkspaceForSession = async (
+    harnessSessionId: string,
+  ): Promise<void> => {
     const session = sessionManager.get(harnessSessionId);
     if (!session || session.status === "exited") return;
     const before = workflowsCache;
@@ -476,7 +545,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // (only the active tab does) — this is the lightweight substitute that lets
   // every session's tab show a busy pulse regardless of which one is active.
   sessionManager.onActivity((harnessSessionId) => {
-    bus.publish({ type: "session.activity", harnessSessionId, at: new Date().toISOString() });
+    bus.publish({
+      type: "session.activity",
+      harnessSessionId,
+      at: new Date().toISOString(),
+    });
   });
 
   // Nothing else triggers a scan (the only other entry point is the SPA's
@@ -492,14 +565,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // merged registry) — callers use this to decide whether THIS scan turned
   // up something new worth an unprompted canvas render, without conflating
   // it with unrelated workflows some earlier scan already found elsewhere.
-  const scanWorkflowsAndBroadcast = async (root: string): Promise<WorkflowInfo[]> => {
+  const scanWorkflowsAndBroadcast = async (
+    root: string,
+  ): Promise<WorkflowInfo[]> => {
     const found = await workflowRegistry.scan(root);
     workflowsCache = await workflowRegistry.list();
     // Rewrite every open session's context file before broadcasting — a
     // listener reacting to workflows.changed (the SPA, or an agent that
     // happens to re-read the file right then) must never see the
     // notification before the file it describes is actually updated.
-    await Promise.all(sessionManager.list().map((session) => writeSessionContext(session)));
+    await Promise.all(
+      sessionManager.list().map((session) => writeSessionContext(session)),
+    );
     bus.publish({ type: "workflows.changed" });
     return found;
   };
@@ -531,14 +608,18 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     await enrichment.ensureFresh(session, workflowsCache);
   };
   const autoRenderCanvas = async (session: HarnessSession): Promise<void> => {
-    await renderCanvasForSession(session, workflowsCache, { preserveExistingOnFailure: true });
+    await renderCanvasForSession(session, workflowsCache, {
+      preserveExistingOnFailure: true,
+    });
     await enrichment.ensureFresh(session, workflowsCache);
   };
 
-  const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch((err: unknown) => {
-    console.error("[harness] initial workflow scan failed:", err);
-    return [] as WorkflowInfo[];
-  });
+  const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch(
+    (err: unknown) => {
+      console.error("[harness] initial workflow scan failed:", err);
+      return [] as WorkflowInfo[];
+    },
+  );
 
   const eventStorePath = options.eventStorePath ?? statePaths.events;
   const eventStore = createEventStore(eventStorePath);
@@ -548,12 +629,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // so the sweep's read→filter→rename window never races a concurrent append.
   // Fire-and-forget — a slow FS is no reason to delay server startup.
   const runNdjsonSweep = (): void => {
-    void eventStore.runExclusive(() => sweepNdjson(eventStorePath)).catch((err: unknown) => {
-      console.error("[harness] events.ndjson retention sweep failed:", err);
-    });
+    void eventStore
+      .runExclusive(() => sweepNdjson(eventStorePath))
+      .catch((err: unknown) => {
+        console.error("[harness] events.ndjson retention sweep failed:", err);
+      });
   };
   runNdjsonSweep();
-  const ndjsonRetentionTimer = setInterval(runNdjsonSweep, NDJSON_RETENTION_SWEEP_MS);
+  const ndjsonRetentionTimer = setInterval(
+    runNdjsonSweep,
+    NDJSON_RETENTION_SWEEP_MS,
+  );
   ndjsonRetentionTimer.unref?.();
 
   const harnessVersion = readVersion();
@@ -571,7 +657,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     },
   });
 
-  const resolveIngestSession = (harnessSessionId: string): IngestSessionContext | undefined => {
+  const resolveIngestSession = (
+    harnessSessionId: string,
+  ): IngestSessionContext | undefined => {
     const session = sessionManager.get(harnessSessionId);
     if (!session) return undefined;
     return {
@@ -603,10 +691,16 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       sessionManager,
       adapters,
       version: readVersion(),
-      identity: identity ? { userId: identity.userId, organizationName: identity.organizationName } : null,
+      identity: identity
+        ? {
+            userId: identity.userId,
+            organizationName: identity.organizationName,
+          }
+        : null,
       listWorkflows: () => workflowRegistry.list(),
       listMacros: () => DEFAULT_MACROS,
-      findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
+      findWorkflow: (workflowPath) =>
+        workflowsCache.find((w) => w.path === workflowPath) ?? null,
       writeWorkspaceContext: writeSessionContext,
       renderCanvas,
       onTelemetryOptInChange: (optIn) => batcher.setTelemetryOptIn(optIn),
@@ -622,7 +716,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
             if (session) return autoRenderCanvas(session);
           })
           .catch((err: unknown) => {
-            console.error("[harness] workflow scan on session create failed:", err);
+            console.error(
+              "[harness] workflow scan on session create failed:",
+              err,
+            );
           });
       },
       launchDir,
@@ -656,14 +753,23 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     }),
   );
   app.use(
+    createRunsRouter({
+      apiKey: identity?.apiKey ?? null,
+      baseUrl: resolveAgentsBaseUrl(),
+    }),
+  );
+  app.use(
     createWorkflowsRouter(workflowRegistry),
     createFsRouter(),
     createSkillsRouter(),
     createMacrosRouter({
       listMacros: () => DEFAULT_MACROS,
-      findWorkflow: (workflowPath) => workflowsCache.find((w) => w.path === workflowPath) ?? null,
-      getSessionCwd: (harnessSessionId) => sessionManager.get(harnessSessionId)?.cwd ?? null,
-      getBoundWorkflowPath: (harnessSessionId) => sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
+      findWorkflow: (workflowPath) =>
+        workflowsCache.find((w) => w.path === workflowPath) ?? null,
+      getSessionCwd: (harnessSessionId) =>
+        sessionManager.get(harnessSessionId)?.cwd ?? null,
+      getBoundWorkflowPath: (harnessSessionId) =>
+        sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
       // The visualize macro is a FORCE refresh, not a plain re-render:
       // invalidate the extraction + enrichment caches, re-render the base
       // instantly, re-spawn the enrichment task. Its refusals map to the
@@ -678,7 +784,12 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
         // bracketed paste and never submits.
         await sessionManager.submitInput(harnessSessionId, text, submit);
       },
-      runBackgroundTask: async (harnessSessionId, macro, prompt, workflowPath) => {
+      runBackgroundTask: async (
+        harnessSessionId,
+        macro,
+        prompt,
+        workflowPath,
+      ) => {
         // The router already 404'd on an unknown session (getSessionCwd),
         // so the session is present here; its harness kind decides whether
         // a headless run is even possible (TaskNotSupportedError → 400).
@@ -758,13 +869,19 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   // format has no line of its own for, and stop.
   const codexTailers = new Map<string, CodexTailerHandle>();
 
-  async function discoverCodexRolloutPath(session: HarnessSession): Promise<string | null> {
+  async function discoverCodexRolloutPath(
+    session: HarnessSession,
+  ): Promise<string | null> {
     const deadline = Date.now() + CODEX_ROLLOUT_DISCOVERY_TIMEOUT_MS;
     const sinceMs = Date.parse(session.createdAt);
     for (;;) {
       const found = await findRolloutFile(
         session.agentSessionId
-          ? { cwd: session.cwd, agentSessionId: session.agentSessionId, homeDir: options.codexHomeDir }
+          ? {
+              cwd: session.cwd,
+              agentSessionId: session.agentSessionId,
+              homeDir: options.codexHomeDir,
+            }
           : {
               cwd: session.cwd,
               sinceMs: Number.isNaN(sinceMs) ? undefined : sinceMs,
@@ -773,7 +890,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       );
       if (found) return found;
       if (Date.now() >= deadline) return null;
-      await new Promise((resolve) => setTimeout(resolve, CODEX_ROLLOUT_DISCOVERY_POLL_MS));
+      await new Promise((resolve) =>
+        setTimeout(resolve, CODEX_ROLLOUT_DISCOVERY_POLL_MS),
+      );
     }
   }
 
@@ -804,12 +923,19 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       // real prior history that should stay unemitted.
       startFromBeginning: !session.agentSessionId,
       onEvent: (hookEvent, payload) => {
-        const body: IngestRequestBody = { hookEvent, harnessSessionId, payload };
-        void processIngest(body, ingestDeps, seqCounter).catch((err: unknown) => {
-          console.error("[harness] codex tailer ingest error:", err);
-        });
+        const body: IngestRequestBody = {
+          hookEvent,
+          harnessSessionId,
+          payload,
+        };
+        void processIngest(body, ingestDeps, seqCounter).catch(
+          (err: unknown) => {
+            console.error("[harness] codex tailer ingest error:", err);
+          },
+        );
       },
-      onError: (err) => console.error("[harness] codex tailer parse error:", err),
+      onError: (err) =>
+        console.error("[harness] codex tailer parse error:", err),
     });
     codexTailers.set(harnessSessionId, tailer);
   }
@@ -829,7 +955,11 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     } else if (session.status === "exited") {
       const tailer = codexTailers.get(session.id);
       if (tailer) {
-        tailer.emitSessionEnd(session.exitCode != null ? `pty exited (code ${session.exitCode})` : undefined);
+        tailer.emitSessionEnd(
+          session.exitCode != null
+            ? `pty exited (code ${session.exitCode})`
+            : undefined,
+        );
         codexTailers.delete(session.id);
       }
     }
@@ -840,7 +970,9 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   app.use(
     createCanvasRouter((harnessSessionId) => {
       const session = sessionManager.get(harnessSessionId);
-      return session ? { cwd: session.cwd, boundWorkflowPath: session.boundWorkflowPath } : undefined;
+      return session
+        ? { cwd: session.cwd, boundWorkflowPath: session.boundWorkflowPath }
+        : undefined;
     }),
   );
 
@@ -849,10 +981,17 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   const webDir = options.webDir ?? join(packageRoot(), "dist", "web");
   app.use(createStaticRouter(webDir));
 
-  app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-    console.error("[harness] unhandled request error:", err);
-    res.status(500).json({ error: "internal error" });
-  });
+  app.use(
+    (
+      err: unknown,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      console.error("[harness] unhandled request error:", err);
+      res.status(500).json({ error: "internal error" });
+    },
+  );
 
   const httpServer: HttpServer = createHttpServer(app);
 
@@ -862,7 +1001,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
     {
       path: "/ws/terminal",
       wss: terminalWss,
-      onConnection: createTerminalWebSocketHandler(sessionManager, options.bootToken),
+      onConnection: createTerminalWebSocketHandler(
+        sessionManager,
+        options.bootToken,
+      ),
     },
     {
       path: "/ws/events",
@@ -900,7 +1042,8 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
   }
 
   const address = httpServer.address();
-  const actualPort = typeof address === "object" && address ? address.port : options.port;
+  const actualPort =
+    typeof address === "object" && address ? address.port : options.port;
   // Covers the ephemeral `port: 0` case (tests) where `options.port` above
   // was 0 and therefore never a real port to exclude — the actual bound
   // port is only known now.
@@ -928,7 +1071,10 @@ export const startServer = async (options: HarnessServerOptions): Promise<Harnes
       // itself is bounded (KILL_ESCALATION_MS + KILL_ESCALATION_CONFIRM_MS
       // = 2500ms); the outer timeout here is a final safety net above that.
       const SHUTDOWN_KILL_TIMEOUT_MS = 5_000;
-      const killsSettled = Promise.all([sessionManager.killAll(), taskManager.killAll()]);
+      const killsSettled = Promise.all([
+        sessionManager.killAll(),
+        taskManager.killAll(),
+      ]);
       let shutdownTimerHandle: ReturnType<typeof setTimeout> | undefined;
       const shutdownTimeout = new Promise<void>((resolve) => {
         shutdownTimerHandle = setTimeout(resolve, SHUTDOWN_KILL_TIMEOUT_MS);

--- a/packages/harness/src/server/runs.test.ts
+++ b/packages/harness/src/server/runs.test.ts
@@ -1,0 +1,122 @@
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createRunsRouter } from "./runs.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal mock Response with a given status and JSON body. */
+function makeFetch(status: number, body: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/**
+ * A realistic raw execution projection with one succeeded step (real prod
+ * engine vocabulary) and one failed step.
+ */
+const VALID_EXECUTION_DOC = {
+  id: "exec_invoice_002",
+  name: "invoice-sync",
+  status: "completed",
+  currentStep: null,
+  startedAt: "2026-07-01T10:00:00.000Z",
+  finishedAt: "2026-07-01T10:00:30.000Z",
+  steps: [
+    {
+      id: "step_0",
+      stepName: "validateInput",
+      stepOrder: 0,
+      attempt: 1,
+      status: "succeeded",
+      spanId: "span_validate",
+      startedAt: "2026-07-01T10:00:00.000Z",
+      finishedAt: "2026-07-01T10:00:10.000Z",
+      logs: [],
+      error: null,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("createRunsRouter", () => {
+  let server: ReturnType<express.Express["listen"]>;
+  let baseUrl: string;
+
+  function start(opts: Parameters<typeof createRunsRouter>[0]) {
+    const app = express();
+    // The boot-token middleware is not mounted here — we test the router in
+    // isolation (pure routing behaviour), same pattern as rest.test.ts.
+    app.use(express.json());
+    app.use(createRunsRouter(opts));
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  describe("GET /api/runs/:executionId/state — 200 path", () => {
+    it("returns 200 with a RunView when the upstream returns a valid execution", async () => {
+      start({
+        apiKey: "sk-test-key",
+        baseUrl: "https://agents.test",
+        fetchImpl: makeFetch(200, VALID_EXECUTION_DOC),
+      });
+
+      const res = await fetch(`${baseUrl}/api/runs/exec_invoice_002/state`);
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.executionId).toBe("exec_invoice_002");
+      expect(body.status).toBe("completed");
+      const steps = body.steps as Array<Record<string, unknown>>;
+      expect(steps).toHaveLength(1);
+      expect(steps[0].name).toBe("validateInput");
+      // "succeeded" folds to "passed" — the key real-vocab fix
+      expect(steps[0].status).toBe("passed");
+    });
+  });
+
+  describe("GET /api/runs/:executionId/state — 404 path", () => {
+    it("forwards 404 when the upstream says the execution does not exist", async () => {
+      start({
+        apiKey: "sk-test-key",
+        baseUrl: "https://agents.test",
+        fetchImpl: makeFetch(404, { error: "not found" }),
+      });
+
+      const res = await fetch(`${baseUrl}/api/runs/exec_missing/state`);
+      expect(res.status).toBe(404);
+
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("execution not found");
+    });
+  });
+
+  describe("GET /api/runs/:executionId/state — 503 (no credentials)", () => {
+    it("returns 503 when the harness has no API key (apiKey: null)", async () => {
+      // fetchImpl is not expected to be called — pass a spy to verify that.
+      const spy = vi.fn();
+      start({ apiKey: null, fetchImpl: spy });
+
+      const res = await fetch(`${baseUrl}/api/runs/exec_invoice_002/state`);
+      expect(res.status).toBe(503);
+
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("harness is not signed in to Sapiom");
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/harness/src/server/runs.ts
+++ b/packages/harness/src/server/runs.ts
@@ -1,0 +1,69 @@
+/**
+ * Runs router — backs GET /api/runs/:executionId/state.
+ *
+ * Returns a {@link RunView} for a running or finished prod agents execution,
+ * so the web canvas can poll live status. The Sapiom API key is held
+ * server-side and never forwarded to the browser — the router fetches on
+ * behalf of the canvas via {@link createRunStateFetcher}.
+ */
+
+import { Router } from "express";
+
+import { createRunStateFetcher } from "../core/run-state.js";
+
+export interface RunsRouterOpts {
+  /** Sapiom API key for the agents surface; null when the harness is not authenticated. */
+  apiKey: string | null;
+  /** Override the agents base URL (resolved from env by default). Test seam. */
+  baseUrl?: string;
+  /**
+   * Injectable fetch implementation forwarded to the fetcher. Undocumented for
+   * prod — exists as a test seam only, mirroring the pattern used elsewhere in
+   * the harness resolver suite.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Create the runs router. Mounts `GET /api/runs/:executionId/state` and
+ * delegates to {@link createRunStateFetcher} for the upstream call.
+ */
+export function createRunsRouter(opts: RunsRouterOpts): Router {
+  const router = Router();
+  const fetcher = createRunStateFetcher({
+    apiKey: opts.apiKey,
+    baseUrl: opts.baseUrl,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  /**
+   * GET /api/runs/:executionId/state
+   *
+   * Returns a {@link RunView} for the given execution id. The harness fetches
+   * the execution projection from the agents surface (key stays server-side)
+   * and maps it through decodeExecutionProjection → renderRunState before
+   * responding. Designed for polling by the web canvas.
+   *
+   * 200  RunView JSON — execution found and decoded
+   * 400  executionId missing or empty
+   * 404  execution not found on the agents surface
+   * 502  upstream error or decode failure
+   * 503  harness is not signed in to Sapiom
+   */
+  router.get("/api/runs/:executionId/state", async (req, res) => {
+    const id = req.params.executionId;
+    if (!id || typeof id !== "string" || id.trim() === "") {
+      res.status(400).json({ error: "executionId is required" });
+      return;
+    }
+
+    const result = await fetcher.fetch(id);
+    if (result.ok) {
+      res.json(result.runView);
+    } else {
+      res.status(result.status).json({ error: result.error });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## What & why (F2 — runtime analytics, leaf B2)

Adds the harness server endpoint the live canvas will poll during a run:

```
GET /api/runs/:executionId/state  →  200 RunView | 400 | 404 | 502 | 503
```

Server-side flow (the Sapiom credential **never reaches the browser**):
`fetch tools.sapiom.ai/agents/v1/executions/{id}` (x-sapiom-api-key = harness credential) → `decodeExecutionProjection` (agent-core) → `renderRunState` (B1) → `RunView`.

## Design note (verified against prod)
A live `GET` against a real execution confirmed the **agents surface** returns the full projection (`steps[]` with status, timestamps, errors, `logs[]`) — same shape `decodeExecutionProjection` consumes — so B1's `renderRunState` is reused as-is. The design doc's `api.sapiom.ai` + `sk_` assumption was stale (same host correction we made in F1); both surfaces actually return the identical doc, and the agents surface uses the credential the harness already deploys with.

**Cost is deferred:** the execution-detail endpoint is cost-agnostic (no per-step cost on either surface). v0 ships status/latency/errors/**logs** (the logs→debug-macro fuel); per-step cost is a fast-follow (`/executions/:id/spend` byStep merge).

## Correctness fix included
The real engine step status is **`succeeded`** (not `completed`), which B1's `toStepStatus` mapped to `pending` — finished steps would have rendered grey. Fixed to fold the real vocabulary: `succeeded`→passed, `threw`→failed. B1's test table extended to cover both.

## Testing
- `typecheck` ✓, `lint` ✓
- New unit: `run-state.test.ts` (9 — incl. an end-to-end proof that a `succeeded` step maps to `passed` through decode→render, with latency/logSlice/error assertions), `runs.test.ts` (3, real express mount)
- `render-run-state.test.ts` +2 (`succeeded`→passed, `threw`→failed)
- Full suite **851 passed**; the one failure (`rest.test.ts > skills router …`) is pre-existing on the clean base.

## Review & hygiene
- 1 code-reviewer pass (APPROVE); its one nit (internal branch terminology in a comment) fixed.
- Added lines scanned clean; fixtures are generic (`invoice-sync`), no secrets / real agent names / internal ticket IDs. Patch changeset, public-safe wording.
- 409 (local id) deferred — local runs don't poll in v0. `resolveAgentsBaseUrl` is duplicated with F1's resolver; consolidate at main-merge.

Base: `feat/harness-runtime-analytics` (stacked F2 integration branch).