### PR TITLE
feat(harness): web poll loop for live run state (B4, stacked on B2)

### DIFF
--- a/.changeset/harness-web-poll-loop.md
+++ b/.changeset/harness-web-poll-loop.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add the web poll loop that fetches a run's live state during execution — polling on a fixed cadence, stopping when the run finishes, and pausing while the tab is hidden.

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 // web/e2e/*.spec.ts are Playwright tests (see web/e2e/playwright.config.ts,
@@ -5,8 +6,18 @@ import { defineConfig } from "vitest/config";
 // than part of the default `test` script. Vitest's default glob would
 // otherwise try (and fail) to execute them here too.
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirrors the "@shared/*" path alias in web/tsconfig.json so that web
+      // unit tests can import types from the shared contract without a server.
+      "@shared": fileURLToPath(new URL("src/shared", import.meta.url)),
+    },
+  },
   test: {
-    include: ["src/**/*.test.ts"],
+    // web/src/**/*.test.ts are DOM-free unit tests (run under node, same as
+    // src/**/*.test.ts). This glob may be de-duplicated when the feature
+    // branches land on main.
+    include: ["src/**/*.test.ts", "web/src/**/*.test.ts"],
     // Guard: analytics-core is live-by-default — an unconfigured emitter
     // delivers to the real production collector. The setup file sets
     // SAPIOM_TELEMETRY_DISABLED=1 globally; tests that assert delivery opt

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   InjectInputRequest,
   MacroDef,
   RunMacroRequest,
+  RunView,
   SampleProjectSeedResponse,
   SessionSummary,
   WorkflowInfo,
@@ -33,7 +34,18 @@ export interface SkillDetail extends SkillMeta {
   body: string;
 }
 
-import { MOCK_FS_TREE, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SAMPLE_PROJECT_ROOT, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_SKILLS, MOCK_SKILL_BODIES, MOCK_WORKFLOWS } from "./mock-data";
+import {
+  MOCK_FS_TREE,
+  MOCK_HISTORY,
+  MOCK_LAUNCH_DIR,
+  MOCK_MACROS,
+  MOCK_SAMPLE_PROJECT_ROOT,
+  MOCK_SESSIONS,
+  MOCK_SETTINGS,
+  MOCK_SKILLS,
+  MOCK_SKILL_BODIES,
+  MOCK_WORKFLOWS,
+} from "./mock-data";
 
 export type { FsDirEntry, FsListResponse };
 
@@ -48,11 +60,16 @@ export function isMockMode(): boolean {
  * welcome panel without a real server.
  */
 export function isFreshMockState(): boolean {
-  return isMockMode() && new URLSearchParams(window.location.search).get("mockState") === "fresh";
+  return (
+    isMockMode() &&
+    new URLSearchParams(window.location.search).get("mockState") === "fresh"
+  );
 }
 
 /** `session.boundWorkflowPath` is nullable already, but keeps callers safe against a missing session. */
-export function boundWorkflowPathOf(session: HarnessSession | null | undefined): string | null {
+export function boundWorkflowPathOf(
+  session: HarnessSession | null | undefined,
+): string | null {
   return session?.boundWorkflowPath ?? null;
 }
 
@@ -78,7 +95,8 @@ export class ApiError extends Error {
 
 /** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
 export function getBootToken(): string {
-  const injected = (window as unknown as { __HARNESS__?: { token?: string } }).__HARNESS__;
+  const injected = (window as unknown as { __HARNESS__?: { token?: string } })
+    .__HARNESS__;
   if (injected?.token) return injected.token;
   return new URLSearchParams(window.location.search).get("token") ?? "";
 }
@@ -99,7 +117,10 @@ export interface HarnessApi {
   getSettings(): Promise<HarnessSettings>;
   updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings>;
   listDir(path?: string): Promise<FsListResponse>;
-  bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession>;
+  bindWorkflow(
+    sessionId: string,
+    workflowPath: string | null,
+  ): Promise<HarnessSession>;
   /** Seeds (or reuses) the bundled example project; the caller follows up
    *  with a normal createSession against the returned root. */
   seedSampleProject(): Promise<SampleProjectSeedResponse>;
@@ -107,6 +128,8 @@ export interface HarnessApi {
   listSkills(): Promise<SkillMeta[]>;
   /** Fetch the full detail (including markdown body) for a single skill. */
   getSkill(id: string): Promise<SkillDetail>;
+  /** Fetch the current live render state for a run (polled during execution). */
+  getRunState(executionId: string, signal?: AbortSignal): Promise<RunView>;
 }
 
 class RealApi implements HarnessApi {
@@ -124,7 +147,11 @@ class RealApi implements HarnessApi {
       let reason: string | undefined;
       try {
         const parsed: unknown = body ? JSON.parse(body) : undefined;
-        if (parsed && typeof parsed === "object" && typeof (parsed as { error?: unknown }).error === "string") {
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof (parsed as { error?: unknown }).error === "string"
+        ) {
           reason = (parsed as { error: string }).error;
         }
       } catch {
@@ -145,7 +172,10 @@ class RealApi implements HarnessApi {
   }
 
   createSession(req: CreateSessionRequest): Promise<HarnessSession> {
-    return this.request<HarnessSession>("/api/sessions", { method: "POST", body: JSON.stringify(req) });
+    return this.request<HarnessSession>("/api/sessions", {
+      method: "POST",
+      body: JSON.stringify(req),
+    });
   }
 
   listSessions(): Promise<HarnessSession[]> {
@@ -153,22 +183,33 @@ class RealApi implements HarnessApi {
   }
 
   sessionHistory(cwd: string): Promise<SessionSummary[]> {
-    return this.request<SessionSummary[]>(`/api/sessions/history?cwd=${encodeURIComponent(cwd)}`);
+    return this.request<SessionSummary[]>(
+      `/api/sessions/history?cwd=${encodeURIComponent(cwd)}`,
+    );
   }
 
   resumeSession(id: string): Promise<HarnessSession> {
-    return this.request<HarnessSession>(`/api/sessions/${encodeURIComponent(id)}/resume`, { method: "POST" });
+    return this.request<HarnessSession>(
+      `/api/sessions/${encodeURIComponent(id)}/resume`,
+      { method: "POST" },
+    );
   }
 
   async killSession(id: string): Promise<void> {
-    await this.request<{ ok: true }>(`/api/sessions/${encodeURIComponent(id)}`, { method: "DELETE" });
+    await this.request<{ ok: true }>(
+      `/api/sessions/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    );
   }
 
   async injectInput(id: string, req: InjectInputRequest): Promise<void> {
-    await this.request<{ ok: true }>(`/api/sessions/${encodeURIComponent(id)}/input`, {
-      method: "POST",
-      body: JSON.stringify(req),
-    });
+    await this.request<{ ok: true }>(
+      `/api/sessions/${encodeURIComponent(id)}/input`,
+      {
+        method: "POST",
+        body: JSON.stringify(req),
+      },
+    );
   }
 
   listWorkflows(): Promise<WorkflowInfo[]> {
@@ -176,11 +217,17 @@ class RealApi implements HarnessApi {
   }
 
   connectWorkflow(path: string): Promise<WorkflowInfo> {
-    return this.request<WorkflowInfo>("/api/workflows/connect", { method: "POST", body: JSON.stringify({ path }) });
+    return this.request<WorkflowInfo>("/api/workflows/connect", {
+      method: "POST",
+      body: JSON.stringify({ path }),
+    });
   }
 
   scanWorkflows(root: string): Promise<WorkflowInfo[]> {
-    return this.request<WorkflowInfo[]>("/api/workflows/scan", { method: "POST", body: JSON.stringify({ root }) });
+    return this.request<WorkflowInfo[]>("/api/workflows/scan", {
+      method: "POST",
+      body: JSON.stringify({ root }),
+    });
   }
 
   listMacros(): Promise<MacroDef[]> {
@@ -188,10 +235,13 @@ class RealApi implements HarnessApi {
   }
 
   async runMacro(id: string, req: RunMacroRequest): Promise<void> {
-    await this.request<{ ok: true }>(`/api/macros/${encodeURIComponent(id)}/run`, {
-      method: "POST",
-      body: JSON.stringify(req),
-    });
+    await this.request<{ ok: true }>(
+      `/api/macros/${encodeURIComponent(id)}/run`,
+      {
+        method: "POST",
+        body: JSON.stringify(req),
+      },
+    );
   }
 
   getSettings(): Promise<HarnessSettings> {
@@ -199,7 +249,10 @@ class RealApi implements HarnessApi {
   }
 
   updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings> {
-    return this.request<HarnessSettings>("/api/settings", { method: "PATCH", body: JSON.stringify(patch) });
+    return this.request<HarnessSettings>("/api/settings", {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    });
   }
 
   listDir(path?: string): Promise<FsListResponse> {
@@ -207,16 +260,24 @@ class RealApi implements HarnessApi {
     return this.request<FsListResponse>(`/api/fs/list${query}`);
   }
 
-  bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession> {
+  bindWorkflow(
+    sessionId: string,
+    workflowPath: string | null,
+  ): Promise<HarnessSession> {
     const body: BindWorkflowRequest = { workflowPath };
-    return this.request<HarnessSession>(`/api/sessions/${encodeURIComponent(sessionId)}/workflow`, {
-      method: "PATCH",
-      body: JSON.stringify(body),
-    });
+    return this.request<HarnessSession>(
+      `/api/sessions/${encodeURIComponent(sessionId)}/workflow`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      },
+    );
   }
 
   seedSampleProject(): Promise<SampleProjectSeedResponse> {
-    return this.request<SampleProjectSeedResponse>("/api/sample-project", { method: "POST" });
+    return this.request<SampleProjectSeedResponse>("/api/sample-project", {
+      method: "POST",
+    });
   }
 
   listSkills(): Promise<SkillMeta[]> {
@@ -226,9 +287,17 @@ class RealApi implements HarnessApi {
   getSkill(id: string): Promise<SkillDetail> {
     return this.request<SkillDetail>(`/api/skills/${encodeURIComponent(id)}`);
   }
+
+  getRunState(executionId: string, signal?: AbortSignal): Promise<RunView> {
+    return this.request<RunView>(
+      `/api/runs/${encodeURIComponent(executionId)}/state`,
+      { signal },
+    );
+  }
 }
 
-const delay = (ms = 180): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const delay = (ms = 180): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 /** In-memory, mutable copies of the fixtures — mutations persist for the tab's lifetime, reset on reload. */
 class MockApi implements HarnessApi {
@@ -238,9 +307,14 @@ class MockApi implements HarnessApi {
   // telemetryOptIn starts true so the chip shows "analytics on" from the first render.
   private readonly promptedConsent =
     typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("mockConsentSource") === "prompted";
-  private sessions = this.fresh ? [] : MOCK_SESSIONS.map((session) => ({ ...session }));
-  private workflows = this.fresh ? [] : MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
+    new URLSearchParams(window.location.search).get("mockConsentSource") ===
+      "prompted";
+  private sessions = this.fresh
+    ? []
+    : MOCK_SESSIONS.map((session) => ({ ...session }));
+  private workflows = this.fresh
+    ? []
+    : MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
   private settings: HarnessSettings = this.fresh
     ? { ...MOCK_SETTINGS, recentDirs: [] }
     : {
@@ -256,12 +330,17 @@ class MockApi implements HarnessApi {
     //   ?mockConsentSource=default-silent  → shows TelemetryNotice
     //   ?mockConsentSource=stored-explicit → off chip (telemetryOptIn=false)
     //   ?mockConsentSource=prompted        → on chip (telemetryOptIn=true in mock)
-    const mockConsentSource = typeof window !== "undefined"
-      ? new URLSearchParams(window.location.search).get("mockConsentSource") as AppState["consentSource"] ?? "stored-explicit"
-      : "stored-explicit";
-    const mockEnvReason = typeof window !== "undefined"
-      ? new URLSearchParams(window.location.search).get("mockEnvReason") ?? null
-      : null;
+    const mockConsentSource =
+      typeof window !== "undefined"
+        ? ((new URLSearchParams(window.location.search).get(
+            "mockConsentSource",
+          ) as AppState["consentSource"]) ?? "stored-explicit")
+        : "stored-explicit";
+    const mockEnvReason =
+      typeof window !== "undefined"
+        ? (new URLSearchParams(window.location.search).get("mockEnvReason") ??
+          null)
+        : null;
     // When consent was answered via a TTY prompt ("prompted"), the user
     // necessarily said yes — mirror that in the mock so the chip shows "on".
     const telemetryOptIn =
@@ -312,17 +391,27 @@ class MockApi implements HarnessApi {
 
   async resumeSession(id: string): Promise<HarnessSession> {
     await delay(300);
-    const existing = this.sessions.find((session) => session.agentSessionId === id || session.id === id);
+    const existing = this.sessions.find(
+      (session) => session.agentSessionId === id || session.id === id,
+    );
     if (!existing) throw new Error(`mock: no session to resume for ${id}`);
-    const resumed = { ...existing, status: "running" as const, lastActiveAt: new Date().toISOString() };
-    this.sessions = this.sessions.map((session) => (session.id === resumed.id ? resumed : session));
+    const resumed = {
+      ...existing,
+      status: "running" as const,
+      lastActiveAt: new Date().toISOString(),
+    };
+    this.sessions = this.sessions.map((session) =>
+      session.id === resumed.id ? resumed : session,
+    );
     return resumed;
   }
 
   async killSession(id: string): Promise<void> {
     await delay();
     this.sessions = this.sessions.map((session) =>
-      session.id === id ? { ...session, status: "exited" as const, exitCode: 0 } : session,
+      session.id === id
+        ? { ...session, status: "exited" as const, exitCode: 0 }
+        : session,
     );
   }
 
@@ -338,7 +427,11 @@ class MockApi implements HarnessApi {
       // Consumed exactly once — cleared immediately so the next submit succeeds.
       if (win.__MOCK_INJECT_FAIL_ONCE__) {
         win.__MOCK_INJECT_FAIL_ONCE__ = false;
-        throw new ApiError(409, `POST /api/sessions/${id}/input → 409: Session is still initialising`, "Session is still initialising");
+        throw new ApiError(
+          409,
+          `POST /api/sessions/${id}/input → 409: Session is still initialising`,
+          "Session is still initialising",
+        );
       }
       // Record the submission for Playwright to assert on — same pattern as
       // runMacro's lastMacroRun and seedSampleProject's lastSampleSeed.
@@ -382,8 +475,13 @@ class MockApi implements HarnessApi {
     // effect, so Playwright reads this back to assert what a click actually
     // sent (e.g. that Visualize fires with no subject — it's one-click now).
     if (typeof window !== "undefined") {
-      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
-      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), lastMacroRun: { id, req } };
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        lastMacroRun: { id, req },
+      };
     }
   }
 
@@ -392,7 +490,9 @@ class MockApi implements HarnessApi {
     return this.settings;
   }
 
-  async updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings> {
+  async updateSettings(
+    patch: Partial<HarnessSettings>,
+  ): Promise<HarnessSettings> {
     await delay();
     this.settings = { ...this.settings, ...patch };
     return this.settings;
@@ -407,27 +507,44 @@ class MockApi implements HarnessApi {
     let normalized = requested;
     while (!(normalized in MOCK_FS_TREE) && normalized !== "/") {
       const segments = normalized.split("/").filter(Boolean);
-      normalized = segments.length <= 1 ? "/" : "/" + segments.slice(0, -1).join("/");
+      normalized =
+        segments.length <= 1 ? "/" : "/" + segments.slice(0, -1).join("/");
     }
     if (!(normalized in MOCK_FS_TREE)) normalized = MOCK_LAUNCH_DIR;
 
     const names = MOCK_FS_TREE[normalized] ?? [];
     const segments = normalized.split("/").filter(Boolean);
     // Matches path.dirname("/") === "/" — root's own parent is itself, never null.
-    const parent = normalized === "/" ? "/" : segments.length <= 1 ? "/" : "/" + segments.slice(0, -1).join("/");
+    const parent =
+      normalized === "/"
+        ? "/"
+        : segments.length <= 1
+          ? "/"
+          : "/" + segments.slice(0, -1).join("/");
     return {
       path: normalized,
       parent,
-      dirs: names.map((name) => ({ name, path: normalized === "/" ? `/${name}` : `${normalized}/${name}` })),
+      dirs: names.map((name) => ({
+        name,
+        path: normalized === "/" ? `/${name}` : `${normalized}/${name}`,
+      })),
     };
   }
 
-  async bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession> {
+  async bindWorkflow(
+    sessionId: string,
+    workflowPath: string | null,
+  ): Promise<HarnessSession> {
     await delay(150);
     const existing = this.sessions.find((session) => session.id === sessionId);
     if (!existing) throw new Error(`mock: no session to bind for ${sessionId}`);
-    const bound: HarnessSession = { ...existing, boundWorkflowPath: workflowPath };
-    this.sessions = this.sessions.map((session) => (session.id === sessionId ? bound : session));
+    const bound: HarnessSession = {
+      ...existing,
+      boundWorkflowPath: workflowPath,
+    };
+    this.sessions = this.sessions.map((session) =>
+      session.id === sessionId ? bound : session,
+    );
     return bound;
   }
 
@@ -442,8 +559,13 @@ class MockApi implements HarnessApi {
     // lastMacroRun: seeding has no other observable effect in mock mode, so
     // Playwright reads this back to assert the click actually seeded.
     if (typeof window !== "undefined") {
-      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
-      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), lastSampleSeed: response };
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        lastSampleSeed: response,
+      };
     }
     return response;
   }
@@ -452,9 +574,14 @@ class MockApi implements HarnessApi {
     await delay(150);
     // Test-only escape hatch: record the call count for Playwright assertions.
     if (typeof window !== "undefined") {
-      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
       const prev = (win.__HARNESS_TEST__?.listSkillsCallCount as number) ?? 0;
-      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), listSkillsCallCount: prev + 1 };
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        listSkillsCallCount: prev + 1,
+      };
     }
     return MOCK_SKILLS;
   }
@@ -462,8 +589,31 @@ class MockApi implements HarnessApi {
   async getSkill(id: string): Promise<SkillDetail> {
     await delay(100);
     const found = MOCK_SKILLS.find((s) => s.id === id);
-    if (!found) throw new ApiError(404, `GET /api/skills/${id} → 404`, `Unknown skill '${id}'`);
-    return { ...found, body: MOCK_SKILL_BODIES[id] ?? `# ${found.name}\n\n${found.description}` };
+    if (!found)
+      throw new ApiError(
+        404,
+        `GET /api/skills/${id} → 404`,
+        `Unknown skill '${id}'`,
+      );
+    return {
+      ...found,
+      body: MOCK_SKILL_BODIES[id] ?? `# ${found.name}\n\n${found.description}`,
+    };
+  }
+
+  async getRunState(
+    executionId: string,
+    _signal?: AbortSignal,
+  ): Promise<RunView> {
+    await delay(100);
+    return {
+      executionId,
+      status: "completed",
+      steps: [
+        { id: "step-1", name: "fetchData", status: "passed" },
+        { id: "step-2", name: "processResult", status: "passed" },
+      ],
+    };
   }
 }
 
@@ -475,10 +625,20 @@ class MockApi implements HarnessApi {
 export function interceptMockTrack(): void {
   if (!isMockMode()) return;
   const originalFetch = window.fetch.bind(window);
-  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  window.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
     if (url === "/api/track" && init?.method === "POST") {
-      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
       let body: unknown;
       try {
         body = JSON.parse(typeof init.body === "string" ? init.body : "{}");
@@ -486,8 +646,14 @@ export function interceptMockTrack(): void {
         body = {};
       }
       const prev = (win.__HARNESS_TEST__?.trackEvents as unknown[]) ?? [];
-      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), trackEvents: [...prev, body] };
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        trackEvents: [...prev, body],
+      };
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }
     return originalFetch(input, init);
   };

--- a/packages/harness/web/src/lib/run-poll-controller.test.ts
+++ b/packages/harness/web/src/lib/run-poll-controller.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for `createRunPollController`.
+ *
+ * All tests run under vitest with fake timers (node environment — DOM-free).
+ * `vi.advanceTimersByTimeAsync` is used throughout so that microtasks flush
+ * after each timer advance, matching the async-resolved fetch promises.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunView } from "@shared/types";
+import { createRunPollController } from "./run-poll-controller";
+import type { RunPollDeps } from "./run-poll-controller";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRunView(
+  status: RunView["status"],
+  executionId = "exec-1",
+): RunView {
+  return {
+    executionId,
+    status,
+    steps: [],
+  };
+}
+
+const POLL_MS = 100;
+
+function setup(fetchImpl: RunPollDeps["fetchRunState"]) {
+  const onUpdate = vi.fn<(executionId: string, runView: RunView) => void>();
+  const controller = createRunPollController({
+    fetchRunState: fetchImpl,
+    onUpdate,
+    pollMs: POLL_MS,
+  });
+  return { controller, onUpdate };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("createRunPollController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts polling on start: immediate fetch triggers onUpdate once", async () => {
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockResolvedValue(makeRunView("running"));
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    // Let the immediate poll's promise resolve.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith("exec-1", makeRunView("running"));
+
+    controller.stopAll();
+  });
+
+  it("polls on the interval: onUpdate is called 3 times total after two ticks", async () => {
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockResolvedValue(makeRunView("running"));
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    // Immediate fetch.
+    await vi.advanceTimersByTimeAsync(0);
+    // First interval tick.
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    // Second interval tick.
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(onUpdate).toHaveBeenCalledTimes(3);
+
+    controller.stopAll();
+  });
+
+  it("stops on terminal status: no further fetches after completed", async () => {
+    let callCount = 0;
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockImplementation(() => {
+        callCount++;
+        const status: RunView["status"] =
+          callCount === 1 ? "running" : "completed";
+        return Promise.resolve(makeRunView(status));
+      });
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    // Immediate fetch → "running".
+    await vi.advanceTimersByTimeAsync(0);
+    // First tick → "completed" (triggers stop).
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+
+    const countAfterTerminal = fetch.mock.calls.length;
+    expect(countAfterTerminal).toBe(2);
+
+    // Advance more time — no new fetches should fire.
+    await vi.advanceTimersByTimeAsync(POLL_MS * 5);
+
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect((onUpdate.mock.calls[1] as unknown[])[1]).toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("pause/resume: setPaused(true) suppresses fetches; setPaused(false) resumes them", async () => {
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockResolvedValue(makeRunView("running"));
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    // Immediate fetch before pausing.
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.setPaused(true);
+
+    // Advance two ticks — should NOT fetch while paused.
+    await vi.advanceTimersByTimeAsync(POLL_MS * 2);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    controller.setPaused(false);
+
+    // Next tick after resuming should fetch again.
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+
+    controller.stopAll();
+  });
+
+  it("idempotent start: calling start twice does not double the interval", async () => {
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockResolvedValue(makeRunView("running"));
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    controller.start("exec-1"); // second call — should be no-op
+
+    // Immediate fetch.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The immediate poll runs exactly once despite start being called twice.
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // Advance one tick — exactly one more fetch (not two).
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+
+    controller.stopAll();
+  });
+
+  it("stopAll aborts in-flight: the in-flight signal is aborted after stopAll", async () => {
+    let capturedSignal: AbortSignal | null = null;
+
+    // A fetch that never resolves — we just capture the signal.
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockImplementation((_id, signal) => {
+        capturedSignal = signal;
+        return new Promise<RunView>(() => {
+          // intentionally never resolves
+        });
+      });
+    const { controller } = setup(fetch);
+
+    controller.start("exec-1");
+    // Trigger the immediate fetch so the signal is captured.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(false);
+
+    controller.stopAll();
+
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
+  });
+
+  it("no overlap: a second tick does not start a new fetch while one is in flight", async () => {
+    let resolveFirst!: (v: RunView) => void;
+
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<RunView>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue(makeRunView("running"));
+
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-1");
+    // Immediate fetch is in flight (never resolved yet).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // Advance one tick — still in flight, so the interval should not start a second fetch.
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // Now resolve the first fetch.
+    resolveFirst(makeRunView("running"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    // The next interval tick should now fire normally.
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    controller.stopAll();
+  });
+});

--- a/packages/harness/web/src/lib/run-poll-controller.ts
+++ b/packages/harness/web/src/lib/run-poll-controller.ts
@@ -1,0 +1,109 @@
+/**
+ * Transport-agnostic poll controller for live run state.
+ *
+ * The controller fetches a RunView on a fixed cadence and stops when the run
+ * reaches a terminal status. The `fetchRunState` dependency is the only seam
+ * that couples this to HTTP — swapping it for a WebSocket push source requires
+ * no change to the controller's public API or the hook that consumes it.
+ */
+import type { RunView } from "@shared/types";
+
+export interface RunPollDeps {
+  fetchRunState: (executionId: string, signal: AbortSignal) => Promise<RunView>;
+  onUpdate: (executionId: string, runView: RunView) => void;
+  /** Interval between fetches in milliseconds. Default 2000. */
+  pollMs?: number;
+}
+
+export interface RunPollController {
+  /** Start polling for `executionId`. Idempotent: a second call for the same
+   *  id is a no-op (the existing interval keeps running). */
+  start(executionId: string): void;
+  /** Stop polling for `executionId` and abort any in-flight fetch for it. */
+  stop(executionId: string): void;
+  /** Stop and abort everything. */
+  stopAll(): void;
+  /** `true` → skip issuing new fetches on each tick (leaves intervals running
+   *  and does NOT abort in-flight requests). `false` → resume. */
+  setPaused(paused: boolean): void;
+}
+
+interface PerIdState {
+  intervalId: ReturnType<typeof setInterval>;
+  inFlight: AbortController | null;
+}
+
+export function createRunPollController(deps: RunPollDeps): RunPollController {
+  const { fetchRunState, onUpdate, pollMs = 2000 } = deps;
+
+  const tracked = new Map<string, PerIdState>();
+  let paused = false;
+
+  async function poll(executionId: string): Promise<void> {
+    if (paused) return;
+
+    const entry = tracked.get(executionId);
+    if (!entry) return;
+
+    // Skip if a fetch for this id is still in flight — no overlap.
+    if (entry.inFlight !== null) return;
+
+    const ac = new AbortController();
+    entry.inFlight = ac;
+
+    try {
+      const runView = await fetchRunState(executionId, ac.signal);
+      // Clear in-flight marker before acting on the result so that `stop`
+      // called inside `onUpdate` or on terminal detection sees a clean state.
+      const still = tracked.get(executionId);
+      if (still) still.inFlight = null;
+
+      onUpdate(executionId, runView);
+
+      if (runView.status !== "running") {
+        stop(executionId);
+      }
+    } catch {
+      // Aborts (from stop/stopAll) and transient network errors are both
+      // silently swallowed — the interval will retry on the next tick.
+      const still = tracked.get(executionId);
+      if (still) still.inFlight = null;
+    }
+  }
+
+  function start(executionId: string): void {
+    if (tracked.has(executionId)) return; // idempotent
+
+    const entry: PerIdState = {
+      intervalId: setInterval(() => {
+        void poll(executionId);
+      }, pollMs),
+      inFlight: null,
+    };
+    tracked.set(executionId, entry);
+
+    // Immediate first fetch — no wait for the first interval tick.
+    void poll(executionId);
+  }
+
+  function stop(executionId: string): void {
+    const entry = tracked.get(executionId);
+    if (!entry) return;
+
+    clearInterval(entry.intervalId);
+    entry.inFlight?.abort();
+    tracked.delete(executionId);
+  }
+
+  function stopAll(): void {
+    for (const id of [...tracked.keys()]) {
+      stop(id);
+    }
+  }
+
+  function setPaused(value: boolean): void {
+    paused = value;
+  }
+
+  return { start, stop, stopAll, setPaused };
+}

--- a/packages/harness/web/src/lib/use-run-polling.ts
+++ b/packages/harness/web/src/lib/use-run-polling.ts
@@ -1,0 +1,78 @@
+/**
+ * Thin React hook that drives the run-poll controller from the event bus.
+ *
+ * When an `execution.started` bus message arrives with `target === "prod"`, the
+ * controller starts polling `/api/runs/:id/state` every ~2 s. The returned map
+ * is updated live as each poll resolves; polling stops automatically when the
+ * run reaches a terminal status (completed / failed / cancelled).
+ *
+ * App wiring (passing `lastMessage` down, rendering the map) is intentionally
+ * deferred to the next leaf (C1) — this file is machinery only.
+ */
+import { useEffect, useRef, useState } from "react";
+
+import type { BusMessage, RunView } from "@shared/types";
+
+import { createApi } from "./api";
+import { createRunPollController } from "./run-poll-controller";
+import type { RunPollController } from "./run-poll-controller";
+
+// Module-level singleton — same pattern as use-harness-state's `const api`.
+const api = createApi();
+
+export function useRunPolling(
+  lastMessage: BusMessage | null,
+): Map<string, RunView> {
+  const [runViews, setRunViews] = useState<Map<string, RunView>>(new Map());
+  const controllerRef = useRef<RunPollController | null>(null);
+
+  // Lazy-init the controller once; it persists for the component's lifetime.
+  if (controllerRef.current === null) {
+    controllerRef.current = createRunPollController({
+      fetchRunState: (id, signal) => api.getRunState(id, signal),
+      onUpdate: (id, rv) =>
+        setRunViews((prev) => {
+          const next = new Map(prev);
+          next.set(id, rv);
+          return next;
+        }),
+    });
+  }
+
+  // Start polling when an execution begins on the prod target.
+  useEffect(() => {
+    if (
+      lastMessage?.type === "execution.started" &&
+      lastMessage.target === "prod"
+    ) {
+      controllerRef.current!.start(lastMessage.executionId);
+    }
+  }, [lastMessage]);
+
+  // Pause / resume when the tab visibility changes.
+  useEffect(() => {
+    const controller = controllerRef.current!;
+
+    const onVisibilityChange = (): void => {
+      controller.setPaused(document.hidden);
+    };
+
+    // Reflect the initial hidden state in case the hook mounts in a background tab.
+    controller.setPaused(document.hidden);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  // Stop all polling on unmount.
+  useEffect(() => {
+    const controller = controllerRef.current!;
+    return () => {
+      controller.stopAll();
+    };
+  }, []);
+
+  return runViews;
+}


### PR DESCRIPTION
## What & why (F2 — runtime analytics, leaf B4)

The web-side poll loop that will drive the live canvas. On an `execution.started` bus message (`target:"prod"`) it polls the B2 endpoint `GET /api/runs/:id/state` every ~2s and exposes the latest `RunView`.

**Invariants (the whole point):** stops on terminal status (`!== "running"`), pauses while the tab is hidden (`visibilitychange`), aborts the in-flight fetch on teardown, and never overlaps fetches for the same id.

## Design
- `run-poll-controller.ts` — a **pure, DOM-free, transport-agnostic** controller (the tested heart). `fetchRunState` is the only HTTP seam, so a future WebSocket push swaps the source without touching the controller or the hook.
- `use-run-polling.ts` — a thin React hook wiring the controller to `lastMessage`, tab visibility, and `api.getRunState`, returning `Map<executionId, RunView>`.
- `api.getRunState(id, signal)` — client method for the B2 route.

**Deliberately no rendering / no App.tsx wiring here** — that's the next leaf (C1), which consumes this hook and paints the step graph on the canvas. The hook is exported and ready.

## Testing
- `typecheck` ✓, server `lint` ✓ (web files are eslint-ignored by the harness config, same as existing web code; covered by typecheck + prettier + review)
- New unit test `run-poll-controller.test.ts` (**7 tests**, vitest fake timers via `advanceTimersByTimeAsync`): start→immediate fetch, interval cadence, **stop-on-terminal**, **pause/resume**, idempotent start, **stopAll aborts in-flight**, **no-overlap**. Each asserts something a broken impl would fail.
- Broadened the vitest `include` to run `web/src/**/*.test.ts` (DOM-free, node) + a `@shared` alias — mirrors the F1 branch; de-dupe at main-merge.
- Full suite **858 passed**; the lone failure (`rest.test.ts > skills router …`) is pre-existing on the clean base.

## Review & hygiene
- 1 code-reviewer pass (APPROVE); its one nit (payment-flavored mock step names) fixed → generic `fetchData`/`processResult`.
- Added lines scanned clean; no secrets / real agent names / internal ticket IDs. Patch changeset.

## Stacking
Stacked on **#309 (B2)** — base is `evtran0209/b2-runs-state-endpoint`, so this diff shows B4 only. **Merge #309 first**, then retarget this to `feat/harness-runtime-analytics`.