### PR TITLE
feat(harness): live canvas — render the run step graph (C1, stacked on B4)

### DIFF
--- a/.changeset/harness-live-canvas.md
+++ b/.changeset/harness-live-canvas.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Show a live step graph on the canvas while a deployed run executes — steps update from running to passed/failed with latency, driven by the run-state poll loop.

--- a/packages/harness/web/e2e/live-canvas.spec.ts
+++ b/packages/harness/web/e2e/live-canvas.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Mock-mode e2e tests for the live canvas panel (C1).
+ *
+ * Uses `window.__HARNESS_TEST__.publish(message)` to inject bus messages
+ * synchronously, same pattern as smoke.spec.ts. The mock API's getRunState
+ * returns a scripted sequence: 1st call → running, 2nd+ call → failed.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+test("no panel before a run starts", async ({ page }) => {
+  // On fresh load with no execution.started message, the panel must not appear.
+  await expect(page.getByTestId("run-state-panel")).toHaveCount(0);
+});
+
+test("live run panel appears and shows step statuses", async ({ page }) => {
+  // Trigger a prod execution for the active boot session.
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (message: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish({
+      type: "execution.started",
+      harnessSessionId: "sess-boot",
+      executionId: "exec-e2e",
+      target: "prod",
+    });
+  });
+
+  // Panel must become visible.
+  await expect(page.getByTestId("run-state-panel")).toBeVisible();
+
+  // First frame: run is running — badge shows "Running".
+  await expect(page.getByTestId("run-state-status")).toHaveText("Running");
+
+  // A step with data-status="running" must be present.
+  await expect(
+    page.locator('[data-testid="run-step"][data-status="running"]'),
+  ).toBeVisible();
+
+  // The passed step (fetchData, 1400ms) shows latency.
+  const passedStep = page
+    .locator('[data-testid="run-step"][data-status="passed"]')
+    .first();
+  await expect(passedStep).toBeVisible();
+  await expect(passedStep.locator(".run-step-latency")).toHaveText("1.4s");
+
+  // Second frame: wait for the next poll (~2s) to see the failed state.
+  await expect(page.getByTestId("run-state-status")).toHaveText("Failed", {
+    timeout: 6000,
+  });
+
+  // A failed step with the error message must be visible.
+  const failedStep = page.locator(
+    '[data-testid="run-step"][data-status="failed"]',
+  );
+  await expect(failedStep).toBeVisible();
+  await expect(failedStep.locator(".run-step-error")).toHaveText(
+    "Upstream timed out",
+  );
+
+  await page.screenshot({ path: "web/e2e/screenshots/live-canvas.png" });
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -8,7 +8,7 @@
  * at the top — canvas stays mounted behind CSS when Skills is active so a
  * running Visualize enrichment is never disturbed by a tab flip.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import type { HarnessKind, MacroDef, WorkflowInfo } from "@shared/types";
 
@@ -29,6 +29,7 @@ import { useElementTopOffset } from "./lib/use-element-top-offset";
 import { resolveMacroUrl } from "./lib/macro-gating";
 import { CANVAS_MIN, RAIL_MIN, usePaneWidths } from "./lib/use-pane-widths";
 import { useHarnessState } from "./lib/use-harness-state";
+import { useRunPolling } from "./lib/use-run-polling";
 
 type RightTab = "canvas" | "skills";
 
@@ -39,7 +40,9 @@ export const App = (): JSX.Element => {
   // Lifted so the telemetry chip in BrandHeader can open the settings popover
   // from outside SessionBar (which owns the popover's render).
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(null);
+  const [selectedRowEl, setSelectedRowEl] = useState<HTMLDivElement | null>(
+    null,
+  );
   const [stripColEl, setStripColEl] = useState<HTMLDivElement | null>(null);
   const [rightTab, setRightTab] = useState<RightTab>("canvas");
   // Tracks whether Skills has ever been shown — once true, SkillsPanel stays
@@ -52,9 +55,39 @@ export const App = (): JSX.Element => {
   // session state updates) since `api.listSkills.bind(api)` produces a new
   // function object on each render. Must be before any early return (React
   // hooks must be called unconditionally).
-  const listSkills = useMemo(() => harness.api.listSkills.bind(harness.api), [harness.api]);
-  const getSkill = useMemo(() => harness.api.getSkill.bind(harness.api), [harness.api]);
-  const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
+  const listSkills = useMemo(
+    () => harness.api.listSkills.bind(harness.api),
+    [harness.api],
+  );
+  const getSkill = useMemo(
+    () => harness.api.getSkill.bind(harness.api),
+    [harness.api],
+  );
+  const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } =
+    usePaneWidths();
+
+  // Live run polling — tracks deployed run state per executionId.
+  const runViews = useRunPolling(harness.lastMessage);
+
+  // Map: sessionId → latest executionId seen for that session. Updated when
+  // an execution.started bus message arrives with target "prod".
+  const sessionExecRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    const msg = harness.lastMessage;
+    if (msg?.type === "execution.started" && msg.target === "prod") {
+      sessionExecRef.current.set(msg.harnessSessionId, msg.executionId);
+    }
+  }, [harness.lastMessage]);
+
+  // The ref above is written in an effect, which runs AFTER the render that
+  // processed the execution.started message — so on that first render
+  // activeExecId is still undefined and the panel stays hidden until the first
+  // poll resolves (which is what we want: no empty panel before there's data).
+  // This recomputes on every `runViews` update (React state) as polls land.
+  const activeExecId = harness.activeSessionId
+    ? sessionExecRef.current.get(harness.activeSessionId)
+    : undefined;
+  const activeRunView = activeExecId ? runViews.get(activeExecId) : undefined;
 
   // Cmd+K (any platform) or Cmd/Ctrl+P — "jump to" like Cmd+P in Cursor/VS Code.
   // preventDefault so it doesn't fall through to the browser's print/search dialogs.
@@ -89,23 +122,38 @@ export const App = (): JSX.Element => {
     return <div className="app-status">Loading Sapiom Harness…</div>;
   }
   if (harness.error || !harness.state) {
-    return <div className="app-status app-status-error">Failed to load: {harness.error}</div>;
+    return (
+      <div className="app-status app-status-error">
+        Failed to load: {harness.error}
+      </div>
+    );
   }
 
   const { state } = harness;
-  const activeSession = state.sessions.find((session) => session.id === harness.activeSessionId) ?? null;
+  const activeSession =
+    state.sessions.find((session) => session.id === harness.activeSessionId) ??
+    null;
   const boundWorkflowPath = boundWorkflowPathOf(activeSession);
-  const boundWorkflow = state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
-  const selectedWorkflow = state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ?? null;
+  const boundWorkflow =
+    state.workflows.find((w) => w.path === boundWorkflowPath) ?? null;
+  const selectedWorkflow =
+    state.workflows.find((w) => w.path === harness.selectedWorkflowPath) ??
+    null;
 
   // First-run welcome: this install has never been used (firstRun — the CLI
   // also skips the auto boot session then) and nothing is live yet. Taking
   // either welcome action creates a session, which hides it; a returning
   // user (firstRun absent/false) never sees it at all.
-  const hasLiveSession = state.sessions.some((session) => session.status !== "exited");
-  const showWelcome = state.firstRun === true && !hasLiveSession && !welcomeDismissed;
+  const hasLiveSession = state.sessions.some(
+    (session) => session.status !== "exited",
+  );
+  const showWelcome =
+    state.firstRun === true && !hasLiveSession && !welcomeDismissed;
 
-  const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
+  const handleCreateSession = async (
+    cwd: string,
+    agentHarness: HarnessKind,
+  ): Promise<void> => {
     await harness.createSession({ cwd, harness: agentHarness });
   };
 
@@ -113,7 +161,8 @@ export const App = (): JSX.Element => {
     harness.setSelectedWorkflowPath(path);
     // Selecting a workflow IS "what I'm working on" — bind it to whichever
     // session is currently active so the chip and the agent's context stay in sync.
-    if (harness.activeSessionId) void harness.bindWorkflow(harness.activeSessionId, path);
+    if (harness.activeSessionId)
+      void harness.bindWorkflow(harness.activeSessionId, path);
   };
 
   // Shared by the docked workflow action strip, the canvas empty-state's
@@ -123,10 +172,17 @@ export const App = (): JSX.Element => {
   // nullable for macros that don't require one when nothing's bound yet.
   // Every macro is one click — there's no subject/free-text step on this
   // side; the agent is the interface for anything more specific.
-  const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef): void => {
+  const handleRunMacroForWorkflow = (
+    workflow: WorkflowInfo | null,
+    macro: MacroDef,
+  ): void => {
     if (workflow) handleSelectWorkflow(workflow.path);
     if (macro.action.kind === "open-url") {
-      window.open(resolveMacroUrl(macro.action.url, workflow), "_blank", "noopener,noreferrer");
+      window.open(
+        resolveMacroUrl(macro.action.url, workflow),
+        "_blank",
+        "noopener,noreferrer",
+      );
       return;
     }
     if (!harness.activeSessionId) return;
@@ -142,20 +198,23 @@ export const App = (): JSX.Element => {
         authenticated={state.authenticated}
         organizationName={state.organizationName}
         onOpenPalette={() => setPaletteOpen(true)}
-        telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+        telemetryOptIn={
+          harness.settings?.telemetryOptIn ?? state.telemetryOptIn
+        }
         consentSource={state.consentSource}
         consentEnvReason={state.consentEnvReason}
         onOpenSettings={() => setSettingsOpen(true)}
       />
 
-      {state.consentSource === "default-silent" && !harness.settings?.telemetryNoticeDismissed && (
-        <TelemetryNotice
-          onDismiss={() => {
-            void harness.updateSettings({ telemetryNoticeDismissed: true });
-          }}
-          onOpenSettings={() => setSettingsOpen(true)}
-        />
-      )}
+      {state.consentSource === "default-silent" &&
+        !harness.settings?.telemetryNoticeDismissed && (
+          <TelemetryNotice
+            onDismiss={() => {
+              void harness.updateSettings({ telemetryNoticeDismissed: true });
+            }}
+            onOpenSettings={() => setSettingsOpen(true)}
+          />
+        )}
 
       <div
         className="app"
@@ -189,7 +248,9 @@ export const App = (): JSX.Element => {
               height={rowAnchor.height}
               activeSessionId={harness.activeSessionId}
               macros={state.macros}
-              onRunMacro={(macro) => handleRunMacroForWorkflow(selectedWorkflow, macro)}
+              onRunMacro={(macro) =>
+                handleRunMacroForWorkflow(selectedWorkflow, macro)
+              }
             />
           )}
         </div>
@@ -210,7 +271,9 @@ export const App = (): JSX.Element => {
             sessions={state.sessions}
             activeSessionId={harness.activeSessionId}
             onSelectSession={harness.setActiveSessionId}
-            onResumeHistory={(summary) => void harness.resumeFromHistory(summary)}
+            onResumeHistory={(summary) =>
+              void harness.resumeFromHistory(summary)
+            }
             history={harness.history}
             historyLoading={harness.historyLoading}
             onOpenHistory={(cwd) => void harness.loadHistory(cwd)}
@@ -221,7 +284,9 @@ export const App = (): JSX.Element => {
             boundWorkflowName={boundWorkflow?.name ?? null}
             authenticated={state.authenticated}
             organizationName={state.organizationName}
-            telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+            telemetryOptIn={
+              harness.settings?.telemetryOptIn ?? state.telemetryOptIn
+            }
             onToggleTelemetry={async (next) => {
               await harness.updateSettings({ telemetryOptIn: next });
             }}
@@ -237,7 +302,10 @@ export const App = (): JSX.Element => {
                 onClose={() => void harness.closeSession(activeSession.id)}
               />
             ) : harness.activeSessionId ? (
-              <Terminal sessionId={harness.activeSessionId} token={harness.bootToken} />
+              <Terminal
+                sessionId={harness.activeSessionId}
+                token={harness.bootToken}
+              />
             ) : showWelcome ? (
               <WelcomePanel
                 recentDirs={harness.settings?.recentDirs ?? []}
@@ -250,7 +318,9 @@ export const App = (): JSX.Element => {
                 onDismiss={() => setWelcomeDismissed(true)}
               />
             ) : (
-              <div className="terminal-empty">No active session — click "+ new" to start one.</div>
+              <div className="terminal-empty">
+                No active session — click "+ new" to start one.
+              </div>
             )}
           </div>
         </div>
@@ -268,11 +338,17 @@ export const App = (): JSX.Element => {
 
         {/* Right pane: Canvas | Skills segmented switch + panels */}
         <div className="right-pane">
-          <div className="right-pane-tabs" role="tablist" aria-label="Right pane">
+          <div
+            className="right-pane-tabs"
+            role="tablist"
+            aria-label="Right pane"
+          >
             <button
               role="tab"
               aria-selected={rightTab === "canvas"}
-              className={"right-pane-tab" + (rightTab === "canvas" ? " is-active" : "")}
+              className={
+                "right-pane-tab" + (rightTab === "canvas" ? " is-active" : "")
+              }
               onClick={() => setRightTab("canvas")}
               data-testid="right-tab-canvas"
             >
@@ -281,8 +357,13 @@ export const App = (): JSX.Element => {
             <button
               role="tab"
               aria-selected={rightTab === "skills"}
-              className={"right-pane-tab" + (rightTab === "skills" ? " is-active" : "")}
-              onClick={() => { setRightTab("skills"); setSkillsPanelEverShown(true); }}
+              className={
+                "right-pane-tab" + (rightTab === "skills" ? " is-active" : "")
+              }
+              onClick={() => {
+                setRightTab("skills");
+                setSkillsPanelEverShown(true);
+              }}
               data-testid="right-tab-skills"
             >
               Skills
@@ -291,7 +372,12 @@ export const App = (): JSX.Element => {
 
           {/* Canvas: always mounted so a running Visualize enrichment is never
               disturbed when the user flips to Skills — hidden via CSS only. */}
-          <div className={"right-pane-panel" + (rightTab === "canvas" ? "" : " is-hidden")} data-testid="right-panel-canvas">
+          <div
+            className={
+              "right-pane-panel" + (rightTab === "canvas" ? "" : " is-hidden")
+            }
+            data-testid="right-panel-canvas"
+          >
             <CanvasPane
               sessionId={harness.activeSessionId}
               lastMessage={harness.lastMessage}
@@ -299,7 +385,10 @@ export const App = (): JSX.Element => {
               activeSessionId={harness.activeSessionId}
               macros={state.macros}
               tasks={harness.tasks}
-              onRunMacro={(macro) => handleRunMacroForWorkflow(boundWorkflow, macro)}
+              onRunMacro={(macro) =>
+                handleRunMacroForWorkflow(boundWorkflow, macro)
+              }
+              runView={activeRunView}
             />
           </div>
 
@@ -310,7 +399,9 @@ export const App = (): JSX.Element => {
               state and scroll position survive tab flips. */}
           {(rightTab === "skills" || skillsPanelEverShown) && (
             <div
-              className={"right-pane-panel" + (rightTab === "skills" ? "" : " is-hidden")}
+              className={
+                "right-pane-panel" + (rightTab === "skills" ? "" : " is-hidden")
+              }
               data-testid="right-panel-skills"
             >
               <SkillsPanel
@@ -318,7 +409,9 @@ export const App = (): JSX.Element => {
                 getSkill={getSkill}
                 isActive={rightTab === "skills"}
                 activeSession={activeSession}
-                onUseSkill={(sessionId, text) => void harness.useSkill(sessionId, text)}
+                onUseSkill={(sessionId, text) =>
+                  void harness.useSkill(sessionId, text)
+                }
               />
             </div>
           )}
@@ -337,7 +430,9 @@ export const App = (): JSX.Element => {
         />
       )}
 
-      {harness.toast && <Toast message={harness.toast} onDismiss={harness.dismissToast} />}
+      {harness.toast && (
+        <Toast message={harness.toast} onDismiss={harness.dismissToast} />
+      )}
     </div>
   );
 };

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
 import type { JSX } from "react";
-import type { BackgroundTask, BusMessage, MacroDef, WorkflowInfo } from "@shared/types";
+import type {
+  BackgroundTask,
+  BusMessage,
+  MacroDef,
+  RunView,
+  WorkflowInfo,
+} from "@shared/types";
 
 import { isMockMode } from "../lib/api";
 import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
 import { getTheme, subscribeTheme } from "../lib/theme";
 import { track } from "../lib/track";
 import { Icon } from "./Icon";
+import { RunStatePanel } from "./RunStatePanel";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 
 /** How many of a running task's trailing status lines the activity view shows. */
@@ -21,6 +28,8 @@ interface CanvasPaneProps {
   /** All background tasks (any session) — filtered to `sessionId` here. */
   tasks: BackgroundTask[];
   onRunMacro: (macro: MacroDef) => void;
+  /** Live run state for the active session's current execution, if any. */
+  runView?: RunView;
 }
 
 export function CanvasPane({
@@ -31,6 +40,7 @@ export function CanvasPane({
   macros,
   tasks,
   onRunMacro,
+  runView,
 }: CanvasPaneProps): JSX.Element {
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
@@ -44,7 +54,9 @@ export function CanvasPane({
   const [frameLoading, setFrameLoading] = useState(true);
   // Failed-task panels the user has explicitly dismissed (client-side only —
   // the task record itself stays in the server's list).
-  const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(new Set());
+  const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   // Passed through to the served canvas so a kit-based template can match the
   // app's current theme instead of always rendering dark. Legacy canvases
@@ -70,7 +82,10 @@ export function CanvasPane({
 
   useEffect(() => {
     if (!lastMessage || !sessionId) return;
-    if (lastMessage.type === "canvas.reload" && lastMessage.harnessSessionId === sessionId) {
+    if (
+      lastMessage.type === "canvas.reload" &&
+      lastMessage.harnessSessionId === sessionId
+    ) {
       setHasGeneratedContent(true);
       setFrameLoading(true);
       setReloadKey((key) => key + 1);
@@ -104,15 +119,20 @@ export function CanvasPane({
       task.harnessSessionId === sessionId &&
       (task.workflowPath == null || task.workflowPath === boundWorkflowPath),
   );
-  const runningTask = sessionTasks.find((task) => task.status === "running") ?? null;
+  const runningTask =
+    sessionTasks.find((task) => task.status === "running") ?? null;
   const latestFinished = sessionTasks
     .filter((task) => task.status !== "running")
     .sort((a, b) => (b.endedAt ?? "").localeCompare(a.endedAt ?? ""))[0];
   const failedTask =
-    !runningTask && latestFinished?.status === "failed" && !dismissedTaskIds.has(latestFinished.id)
+    !runningTask &&
+    latestFinished?.status === "failed" &&
+    !dismissedTaskIds.has(latestFinished.id)
       ? latestFinished
       : null;
-  const retryMacro = failedTask ? (macros.find((macro) => macro.id === failedTask.macroId) ?? null) : null;
+  const retryMacro = failedTask
+    ? (macros.find((macro) => macro.id === failedTask.macroId) ?? null)
+    : null;
 
   // The header's action IS Visualize now — one click re-fires the same macro
   // that generated what's already on screen; the pane itself swaps in the
@@ -133,14 +153,20 @@ export function CanvasPane({
         />
       )}
 
+      {runView && <RunStatePanel runView={runView} />}
+
       {!sessionId ? (
-        <div className="canvas-empty">Start a session to see its canvas here.</div>
+        <div className="canvas-empty">
+          Start a session to see its canvas here.
+        </div>
       ) : failedTask ? (
         <div className="canvas-task-failed" data-testid="canvas-task-failed">
           <p className="canvas-task-title">
             <Icon name="TriangleAlert" size={14} /> {failedTask.label} failed.
           </p>
-          {failedTask.errorTail && <pre className="canvas-task-error">{failedTask.errorTail}</pre>}
+          {failedTask.errorTail && (
+            <pre className="canvas-task-error">{failedTask.errorTail}</pre>
+          )}
           <div className="canvas-task-actions">
             {retryMacro && (
               <button
@@ -167,20 +193,26 @@ export function CanvasPane({
           </div>
         </div>
       ) : runningTask && !hasGeneratedContent ? (
-        <div className="canvas-task-activity" data-testid="canvas-task-activity">
+        <div
+          className="canvas-task-activity"
+          data-testid="canvas-task-activity"
+        >
           <div className="canvas-task-title">
             <span className="canvas-task-spinner" aria-hidden="true" />
             <span>{runningTask.label} is running…</span>
           </div>
           {runningTask.statusLines.length > 0 && (
             <ul className="canvas-task-lines" data-testid="canvas-task-lines">
-              {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
-                <li key={`${index}-${line}`}>{line}</li>
-              ))}
+              {runningTask.statusLines
+                .slice(-ACTIVITY_LINES_SHOWN)
+                .map((line, index) => (
+                  <li key={`${index}-${line}`}>{line}</li>
+                ))}
             </ul>
           )}
           <p className="canvas-empty-hint">
-            Running as a background task — your session stays free. The canvas reloads here when it finishes.
+            Running as a background task — your session stays free. The canvas
+            reloads here when it finishes.
           </p>
         </div>
       ) : probing ? (
@@ -206,14 +238,18 @@ export function CanvasPane({
             </button>
           )}
           <p className="canvas-empty-hint">
-            Ask your agent to visualize, or write HTML directly to <code>.sapiom/canvas/index.html</code> — this pane
-            hot-reloads whenever it changes.
+            Ask your agent to visualize, or write HTML directly to{" "}
+            <code>.sapiom/canvas/index.html</code> — this pane hot-reloads
+            whenever it changes.
           </p>
         </div>
       ) : (
         <div className="canvas-frame-wrap">
           {frameLoading && (
-            <div className="canvas-loading canvas-loading--overlay" data-testid="canvas-loading">
+            <div
+              className="canvas-loading canvas-loading--overlay"
+              data-testid="canvas-loading"
+            >
               <span className="canvas-task-spinner" aria-hidden="true" />
               <p className="canvas-empty-hint">Rendering diagram…</p>
             </div>
@@ -228,14 +264,20 @@ export function CanvasPane({
                 <span>{runningTask.label} is running…</span>
               </div>
               {runningTask.statusLines.length > 0 && (
-                <ul className="canvas-task-lines" data-testid="canvas-task-lines">
-                  {runningTask.statusLines.slice(-ACTIVITY_LINES_SHOWN).map((line, index) => (
-                    <li key={`${index}-${line}`}>{line}</li>
-                  ))}
+                <ul
+                  className="canvas-task-lines"
+                  data-testid="canvas-task-lines"
+                >
+                  {runningTask.statusLines
+                    .slice(-ACTIVITY_LINES_SHOWN)
+                    .map((line, index) => (
+                      <li key={`${index}-${line}`}>{line}</li>
+                    ))}
                 </ul>
               )}
               <p className="canvas-empty-hint">
-                Running as a background task — your session stays free. The canvas reloads here when it finishes.
+                Running as a background task — your session stays free. The
+                canvas reloads here when it finishes.
               </p>
             </div>
           )}

--- a/packages/harness/web/src/components/RunStatePanel.tsx
+++ b/packages/harness/web/src/components/RunStatePanel.tsx
@@ -1,0 +1,72 @@
+/**
+ * Presentational live-run panel.
+ *
+ * Consumes a transport-agnostic RunView — the same shape regardless of whether
+ * state arrives via HTTP polling (today) or a future WebSocket push. No fetching
+ * happens here: this component renders whatever the caller provides.
+ */
+import type { JSX } from "react";
+import type { RunView, StepView } from "@shared/types";
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function runStatusLabel(status: RunView["status"]): string {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+function StepRow({ step }: { step: StepView }): JSX.Element {
+  return (
+    <li className="run-step" data-status={step.status} data-testid="run-step">
+      <span className="run-step-dot" data-status={step.status} aria-hidden />
+      <span className="run-step-name">{step.name}</span>
+      {step.latencyMs != null && (
+        <span className="run-step-latency">
+          {formatLatency(step.latencyMs)}
+        </span>
+      )}
+      {step.status === "failed" && step.error && (
+        <p className="run-step-error">{step.error}</p>
+      )}
+    </li>
+  );
+}
+
+export function RunStatePanel({ runView }: { runView: RunView }): JSX.Element {
+  const passedCount = runView.steps.filter((s) => s.status === "passed").length;
+
+  return (
+    // A plain div (not a <section>) to match the sibling content blocks in
+    // CanvasPane and avoid an unlabeled landmark region for screen readers.
+    <div className="run-state-panel" data-testid="run-state-panel">
+      <div className="run-state-header">
+        <span
+          className="run-state-status"
+          data-status={runView.status}
+          data-testid="run-state-status"
+        >
+          {runStatusLabel(runView.status)}
+        </span>
+        <span className="run-state-count">
+          {passedCount}/{runView.steps.length}
+        </span>
+      </div>
+      <ol className="run-steps">
+        {runView.steps.map((step) => (
+          <StepRow key={step.id} step={step} />
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -303,6 +303,8 @@ const delay = (ms = 180): Promise<void> =>
 class MockApi implements HarnessApi {
   // `?mockState=fresh` = brand-new install: nothing yet, firstRun set — see isFreshMockState().
   private readonly fresh = isFreshMockState();
+  // Per-executionId call counter — drives the scripted poll sequence for demos/e2e.
+  private readonly runStateCallCounts = new Map<string, number>();
   // `?mockConsentSource=prompted` mirrors a user who answered yes at the TTY prompt:
   // telemetryOptIn starts true so the chip shows "analytics on" from the first render.
   private readonly promptedConsent =
@@ -606,12 +608,36 @@ class MockApi implements HarnessApi {
     _signal?: AbortSignal,
   ): Promise<RunView> {
     await delay(100);
+    const callCount = (this.runStateCallCounts.get(executionId) ?? 0) + 1;
+    this.runStateCallCounts.set(executionId, callCount);
+
+    // 1st poll: show a run in progress with one completed step and one running.
+    if (callCount === 1) {
+      return {
+        executionId,
+        status: "running",
+        steps: [
+          { id: "s1", name: "fetchData", status: "passed", latencyMs: 1400 },
+          { id: "s2", name: "processResult", status: "running" },
+          { id: "s3", name: "finalize", status: "pending" },
+        ],
+      };
+    }
+
+    // 2nd+ poll: the second step failed, run is terminal.
     return {
       executionId,
-      status: "completed",
+      status: "failed",
       steps: [
-        { id: "step-1", name: "fetchData", status: "passed" },
-        { id: "step-2", name: "processResult", status: "passed" },
+        { id: "s1", name: "fetchData", status: "passed", latencyMs: 1400 },
+        {
+          id: "s2",
+          name: "processResult",
+          status: "failed",
+          latencyMs: 3000,
+          error: "Upstream timed out",
+        },
+        { id: "s3", name: "finalize", status: "pending" },
       ],
     };
   }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2,7 +2,8 @@
   /* Shared, theme-independent tokens. */
   --radius: 6px;
   --font-sans:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* Border-radius scale — mirrors the product's own (base --radius: 6px,
@@ -22,7 +23,8 @@
   --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.1);
 
   /* Matches Tailwind's default transition-all duration/easing, used
      everywhere the product animates hover/focus/disabled state. */
@@ -417,7 +419,10 @@ input {
 .app {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 220px) 32px minmax(360px, 1fr) minmax(280px, 420px);
+  grid-template-columns: minmax(180px, 220px) 32px minmax(360px, 1fr) minmax(
+      280px,
+      420px
+    );
   flex: 1;
   min-height: 0;
   overflow-x: auto;
@@ -2455,6 +2460,146 @@ input {
 
 /* Skills footer */
 
+/* Live run-state panel (RunStatePanel) ----------------------------------- */
+
+/* Subtle card that sits above the canvas state chain — shows while a deployed
+   run is in progress or just finished. Matches the canvas-task-* aesthetic. */
+.run-state-panel {
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  margin: 8px 10px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.run-state-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Status badge chip — small uppercase-ish label colored by run status. */
+.run-state-status {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-md);
+  border: 1px solid currentColor;
+}
+
+.run-state-status[data-status="running"] {
+  color: var(--accent);
+  background: var(--accent-dim);
+  border-color: var(--accent-border);
+}
+
+.run-state-status[data-status="completed"] {
+  color: var(--green);
+  background: transparent;
+}
+
+.run-state-status[data-status="failed"] {
+  color: var(--red);
+  background: transparent;
+}
+
+.run-state-status[data-status="cancelled"] {
+  color: var(--text-faint);
+  background: transparent;
+}
+
+.run-state-count {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  margin-left: auto;
+}
+
+/* Step list */
+
+.run-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.run-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+/* Status indicator dot — 8px, colored by step status. */
+.run-step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.run-step-dot[data-status="passed"] {
+  background: var(--green);
+}
+
+.run-step-dot[data-status="failed"] {
+  background: var(--red);
+}
+
+.run-step-dot[data-status="running"] {
+  background: var(--accent);
+  animation: session-tab-busy-pulse 1.2s ease-in-out infinite;
+}
+
+.run-step-dot[data-status="pending"] {
+  background: var(--text-faint);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-step-dot[data-status="running"] {
+    animation: none;
+  }
+}
+
+.run-step-name {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-step[data-status="pending"] .run-step-name {
+  color: var(--text-faint);
+}
+
+.run-step-latency {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.run-step-error {
+  width: 100%;
+  margin: 2px 0 0;
+  padding-left: 14px; /* indent under the dot */
+  font-size: 11px;
+  color: var(--red);
+  line-height: 1.4;
+}
+
 /* Scrollbars — thin thumb-only styling, matching the product's own
    (rgba(161, 161, 170, 0.75), 8px, no visible track) in both themes. */
 ::-webkit-scrollbar {
@@ -2479,5 +2624,3 @@ input {
   scrollbar-width: thin;
   scrollbar-color: rgba(161, 161, 170, 0.75) transparent;
 }
-
-


### PR DESCRIPTION
## What & why (F2 — runtime analytics, leaf C1) — the visible payoff

Makes F2 **visible**. Wires the B4 poll loop into the app and renders a **live step graph** on the canvas pane while a deployed run executes. Each step updates in place: **running (pulse) → passed (green) / failed (red)**, with latency, and a failed step surfaces its error.

Verified working (screenshot from the e2e): a run shows `FAILED · 1/3`, `● fetchData 1.4s` (green), `● processResult 3.0s` (red) → *"Upstream timed out"*, `● finalize` (pending).

## How it fits together
- `RunStatePanel.tsx` — presentational; consumes the transport-agnostic `RunView` (never a raw poll response), so a future WebSocket push needs zero view changes.
- `CanvasPane` — renders the panel above the existing canvas states (additive; doesn't disturb empty/probing/iframe/failed states).
- `App` — calls `useRunPolling`, maps `sessionId → executionId` (from `execution.started`), and passes the active session's `RunView` down. The panel stays hidden until the first poll resolves (no empty flash).
- `MockApi.getRunState` — a small scripted running→failed sequence so the mock tier demonstrates transitions.

## Testing
- `typecheck` ✓, server `lint` ✓
- New e2e `live-canvas.spec.ts` (**2 tests**): publishes `execution.started` via the `__HARNESS_TEST__` hook → asserts the **running frame** (Running badge, running step, latency) then the **failed frame** (Failed badge, red step, error text); plus a "no panel before a run starts" gate test. Full e2e suite **102 passed**.
- Unit suite **858 passed** (lone `rest.test.ts > skills router` failure is pre-existing on the clean base).

## Review & hygiene
- 1 code-reviewer pass (APPROVE, no blockers); took 2 of its 3 suggestions (clarifying comment on the intentional render-timing; `<section>`→`<div>` for a11y). Skipped the 3rd (teal `--green`/`--accent` overlap is the intentional brand palette; a global token change is out of scope).
- Added lines scanned clean; generic fixtures only, no secrets / real agent names / internal ticket IDs. Patch changeset. Screenshots dir is gitignored (no binary committed).

## Stack
`evtran0209/c1-live-canvas` → **B4** → **B2** → `feat/harness-runtime-analytics`. This diff is C1-only. Merge order: #309 (B2) → #310 (B4) → this, each retargeted to `feat/harness-runtime-analytics` as the one below it lands.