### PR TITLE
fix(harness): detect MCP-tool-started runs + guard runaway polling

### DIFF
--- a/.changeset/harness-detect-mcp-runs.md
+++ b/.changeset/harness-detect-mcp-runs.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Show the live run canvas for runs started via the agent tooling, not just the CLI. The run detector now recognizes the run tool's `executionId` result in addition to the CLI's start line, so pressing Prod Run lights up the live step graph. Also stop polling a run whose state can't be fetched after repeated attempts, so a stale or malformed id can't poll indefinitely.

--- a/packages/harness/src/core/execution-detector.test.ts
+++ b/packages/harness/src/core/execution-detector.test.ts
@@ -10,7 +10,9 @@ function makeDetector() {
 
 describe("parseExecutionIds", () => {
   it("extracts the id from the CLI's start line (ignoring the check-mark prefix)", () => {
-    expect(parseExecutionIds("✓ Started execution exec_0001")).toEqual(["exec_0001"]);
+    expect(parseExecutionIds("✓ Started execution exec_0001")).toEqual([
+      "exec_0001",
+    ]);
   });
 
   it("extracts the id when embedded in surrounding output", () => {
@@ -23,30 +25,70 @@ describe("parseExecutionIds", () => {
   it("stops the id at the first non-id char (bracket, ANSI reset, whitespace, ...)", () => {
     // Anything outside [A-Za-z0-9_-] terminates the id, so a colored CLI's
     // reset sequence (ESC + "[0m") after the id still yields just exec_9.
-    expect(parseExecutionIds("Started execution exec_9[0m done")).toEqual(["exec_9"]);
-    expect(parseExecutionIds("Started execution exec_9 done")).toEqual(["exec_9"]);
-  });
-
-  it("finds multiple distinct announcements in order", () => {
-    expect(parseExecutionIds("Started execution exec_a then Started execution exec_b")).toEqual([
-      "exec_a",
-      "exec_b",
+    expect(parseExecutionIds("Started execution exec_9[0m done")).toEqual([
+      "exec_9",
+    ]);
+    expect(parseExecutionIds("Started execution exec_9 done")).toEqual([
+      "exec_9",
     ]);
   });
 
+  it("finds multiple distinct announcements in order", () => {
+    expect(
+      parseExecutionIds(
+        "Started execution exec_a then Started execution exec_b",
+      ),
+    ).toEqual(["exec_a", "exec_b"]);
+  });
+
   it("returns empty when there is no announcement", () => {
-    expect(parseExecutionIds("Compiled successfully. Started the dev server.")).toEqual([]);
+    expect(
+      parseExecutionIds("Compiled successfully. Started the dev server."),
+    ).toEqual([]);
   });
 
   it("does not match a different verb ('Starting' / 'started the')", () => {
-    expect(parseExecutionIds("Starting execution now; started the run")).toEqual([]);
+    expect(
+      parseExecutionIds("Starting execution now; started the run"),
+    ).toEqual([]);
+  });
+
+  it("extracts the id from the MCP run tool's JSON result (executionId field)", () => {
+    // The common path: the coding agent starts the run via the MCP tool, whose
+    // result carries the id as a field — NOT the CLI's "Started execution" line.
+    expect(
+      parseExecutionIds('{"status":"enqueued","executionId":"47663"}'),
+    ).toEqual(["47663"]);
+  });
+
+  it("extracts the id from an executionId field with assorted separators", () => {
+    expect(parseExecutionIds("executionId: 47663")).toEqual(["47663"]);
+    expect(parseExecutionIds("executionId=exec_9")).toEqual(["exec_9"]);
+    expect(parseExecutionIds('executionId : "abc-1"')).toEqual(["abc-1"]);
+  });
+
+  it("catches both the CLI line and an executionId field in the same text", () => {
+    expect(
+      parseExecutionIds(
+        'Started execution exec_a ... {"executionId":"exec_b"}',
+      ),
+    ).toEqual(["exec_a", "exec_b"]);
+  });
+
+  it("does not match the bare word 'execution' without the CLI verb or the Id field", () => {
+    // Guards against over-broad matching: "execution 47663" alone (e.g. prose or
+    // an inspect line) must NOT fire — only "Started execution" or "executionId".
+    expect(parseExecutionIds("inspecting execution 47663 now")).toEqual([]);
   });
 });
 
 describe("ExecutionDetector.feed", () => {
   it("emits once for an id in a single chunk, tagged prod", () => {
     const { detector, onExecution } = makeDetector();
-    detector.feed("some noise\nStarted execution exec_0001\nnext line\n", "sess-1");
+    detector.feed(
+      "some noise\nStarted execution exec_0001\nnext line\n",
+      "sess-1",
+    );
     expect(onExecution).toHaveBeenCalledWith("sess-1", "exec_0001", "prod");
   });
 
@@ -54,6 +96,12 @@ describe("ExecutionDetector.feed", () => {
     const { detector, onExecution } = makeDetector();
     detector.feed("running the agent...\n", "sess-1");
     expect(onExecution).not.toHaveBeenCalled();
+  });
+
+  it("emits for the MCP run tool's structured result (executionId field), tagged prod", () => {
+    const { detector, onExecution } = makeDetector();
+    detector.feed('{"status":"enqueued","executionId":"47663"}\n', "sess-1");
+    expect(onExecution).toHaveBeenCalledWith("sess-1", "47663", "prod");
   });
 
   it("detects an id split across two chunks", () => {
@@ -66,7 +114,10 @@ describe("ExecutionDetector.feed", () => {
 
   it("dedupes repeated appearances of the same (session, id)", () => {
     const { detector, onExecution } = makeDetector();
-    detector.feed("Started execution exec_1\nStarted execution exec_1\n", "sess-1");
+    detector.feed(
+      "Started execution exec_1\nStarted execution exec_1\n",
+      "sess-1",
+    );
     detector.feed("still Started execution exec_1\n", "sess-1");
     expect(onExecution).toHaveBeenCalledTimes(1);
   });

--- a/packages/harness/src/core/execution-detector.ts
+++ b/packages/harness/src/core/execution-detector.ts
@@ -1,13 +1,16 @@
 /**
  * Execution detection — mirrors {@link PortDetector} (core/port-detector.ts).
  *
- * When the coding agent runs `sapiom agents run`, the CLI prints
- * `✓ Started execution <executionId>`. This detector is fed the SAME tool.call
- * output PortDetector is (server/index.ts `onNormalizedEvent`) and fires
- * `onExecution` once per distinct (session, executionId) it finds — so the SPA
- * can start polling that run's live state without changing how runs are
- * triggered. The integrator wires `onExecution` to broadcast
- * `{ type: "execution.started", … }` on /ws/events.
+ * A run can start two ways in the harness, and this catches both:
+ *  1. The CLI prints `✓ Started execution <executionId>` (`sapiom agents run`).
+ *  2. The coding agent starts the run via the MCP run tool — the common path —
+ *     whose result carries the id as an `executionId` field
+ *     (`"executionId":"<id>"` / `executionId: <id>`).
+ * The detector is fed the SAME tool.call output PortDetector is (server/index.ts
+ * `onNormalizedEvent`, including the tool RESPONSE summary), so an MCP-triggered
+ * run is caught without changing how runs are triggered. It fires `onExecution`
+ * once per distinct (session, executionId); the integrator wires that to
+ * broadcast `{ type: "execution.started", … }` on /ws/events.
  *
  * Same streaming-safe design as PortDetector: a match touching the very end of
  * the buffered text is held back (the id may still be growing in the next
@@ -19,10 +22,14 @@
  *  `exec_ab12…`). Id-safe characters only, so a trailing space, newline, or
  *  ANSI reset ends the match rather than being captured into the id. */
 const EXECUTION_ID = String.raw`[A-Za-z0-9_-]+`;
-const EXECUTION_PATTERN_SOURCE = String.raw`Started execution (${EXECUTION_ID})`;
+/** Two anchors, one capture group: the CLI's `Started execution <id>` line, or
+ *  the `executionId` field from the run tool's structured result (quote/colon/
+ *  space/equals between the key and the id). Both are start-time signals tied to
+ *  a real run, so a match always refers to a run the user is actually driving. */
+const EXECUTION_PATTERN_SOURCE = String.raw`(?:Started execution |executionId["'\s:=]+)(${EXECUTION_ID})`;
 
-/** Long enough to hold the literal "Started execution " anchor split across a
- *  chunk boundary, plus a few id characters either side. */
+/** Long enough to hold either anchor ("Started execution " / `executionId":"`)
+ *  split across a chunk boundary, plus a few id characters either side. */
 const TAIL_SAFETY = 48;
 
 /**
@@ -45,7 +52,11 @@ export function parseExecutionIds(text: string): string[] {
 export type ExecutionTarget = "prod" | "local";
 
 export interface ExecutionDetectorDeps {
-  onExecution(harnessSessionId: string, executionId: string, target: ExecutionTarget): void;
+  onExecution(
+    harnessSessionId: string,
+    executionId: string,
+    target: ExecutionTarget,
+  ): void;
 }
 
 /**
@@ -77,7 +88,8 @@ export class ExecutionDetector {
       this.tryEmit(harnessSessionId, match[1]);
     }
 
-    const retainFrom = pendingFrom ?? Math.max(0, combined.length - TAIL_SAFETY);
+    const retainFrom =
+      pendingFrom ?? Math.max(0, combined.length - TAIL_SAFETY);
     this.buffers.set(harnessSessionId, combined.slice(retainFrom));
   }
 
@@ -93,7 +105,8 @@ export class ExecutionDetector {
     if (!pending) return;
     // Re-parse the whole pending buffer (vs an inline loop) — same result, and
     // tryEmit dedupes so a match already emitted by feed() is a harmless no-op.
-    for (const id of parseExecutionIds(pending)) this.tryEmit(harnessSessionId, id);
+    for (const id of parseExecutionIds(pending))
+      this.tryEmit(harnessSessionId, id);
     this.buffers.delete(harnessSessionId);
   }
 

--- a/packages/harness/web/src/lib/run-poll-controller.test.ts
+++ b/packages/harness/web/src/lib/run-poll-controller.test.ts
@@ -229,4 +229,43 @@ describe("createRunPollController", () => {
 
     controller.stopAll();
   });
+
+  it("gives up after too many consecutive failures (a bad/404 id can't poll forever)", async () => {
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockRejectedValue(new Error("404"));
+    const { controller, onUpdate } = setup(fetch);
+
+    controller.start("exec-bad");
+    // Immediate fetch = failure #1, then drive far past the cap.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(POLL_MS * 20);
+
+    // MAX_CONSECUTIVE_FAILURES is 5 → it stops after the 5th failure, forever.
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("a successful read resets the failure streak (intermittent errors don't trip the cap)", async () => {
+    let n = 0;
+    const fetch = vi
+      .fn<(id: string, signal: AbortSignal) => Promise<RunView>>()
+      .mockImplementation(() => {
+        n += 1;
+        // Fail 4×, succeed on the 5th (resets streak), then fail forever.
+        if (n === 5) return Promise.resolve(makeRunView("running"));
+        return Promise.reject(new Error("transient"));
+      });
+    const { controller } = setup(fetch);
+
+    controller.start("exec-1");
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(POLL_MS * 20);
+
+    // The success at call 5 resets the streak, so it survives past 5 and only
+    // stops after 5 MORE consecutive fails (calls 6–10) → 10 total.
+    expect(fetch).toHaveBeenCalledTimes(10);
+
+    controller.stopAll();
+  });
 });

--- a/packages/harness/web/src/lib/run-poll-controller.ts
+++ b/packages/harness/web/src/lib/run-poll-controller.ts
@@ -28,9 +28,16 @@ export interface RunPollController {
   setPaused(paused: boolean): void;
 }
 
+/** Consecutive failed fetches (non-2xx / network / mangled id) after which an
+ *  id stops polling — so a bad or truncated id can't 404 forever. Set above the
+ *  brief enqueued→queryable window (a real run becomes queryable within a poll
+ *  or two), so a genuine run is never dropped. */
+const MAX_CONSECUTIVE_FAILURES = 5;
+
 interface PerIdState {
   intervalId: ReturnType<typeof setInterval>;
   inFlight: AbortController | null;
+  failures: number;
 }
 
 export function createRunPollController(deps: RunPollDeps): RunPollController {
@@ -56,7 +63,10 @@ export function createRunPollController(deps: RunPollDeps): RunPollController {
       // Clear in-flight marker before acting on the result so that `stop`
       // called inside `onUpdate` or on terminal detection sees a clean state.
       const still = tracked.get(executionId);
-      if (still) still.inFlight = null;
+      if (still) {
+        still.inFlight = null;
+        still.failures = 0; // a good read clears the failure streak
+      }
 
       onUpdate(executionId, runView);
 
@@ -64,10 +74,16 @@ export function createRunPollController(deps: RunPollDeps): RunPollController {
         stop(executionId);
       }
     } catch {
-      // Aborts (from stop/stopAll) and transient network errors are both
-      // silently swallowed — the interval will retry on the next tick.
+      // Aborts (from stop/stopAll) and transient errors both land here. Clear
+      // the in-flight marker and count the failure; after too many in a row we
+      // give up on this id so a bad/truncated id can't poll forever. (An abort
+      // from stop() already deleted the entry, so it never counts here.)
       const still = tracked.get(executionId);
-      if (still) still.inFlight = null;
+      if (still) {
+        still.inFlight = null;
+        still.failures += 1;
+        if (still.failures >= MAX_CONSECUTIVE_FAILURES) stop(executionId);
+      }
     }
   }
 
@@ -79,6 +95,7 @@ export function createRunPollController(deps: RunPollDeps): RunPollController {
         void poll(executionId);
       }, pollMs),
       inFlight: null,
+      failures: 0,
     };
     tracked.set(executionId, entry);
 


### PR DESCRIPTION
## What & why (live-testing-caught fix, stacked on C1)

On a real **Prod Run**, the live canvas never appeared. Root cause (found by live testing): the `ExecutionDetector` only matched the CLI's `✓ Started execution <id>` line — but in the harness the coding agent starts runs via the **MCP run tool**, whose result carries the id as an **`executionId` field**. The detector is already fed that (via the tool response summary), it just didn't match the shape.

## Changes
1. **Broaden detection** — `EXECUTION_PATTERN_SOURCE` now matches both `Started execution <id>` (CLI) **and** `executionId["'\s:=]+<id>` (the run tool's structured result). One capture group; streaming/dedupe unchanged. Guarded against matching the bare word "execution" (prose/inspect lines).
2. **Runaway-poll guard** — the poll controller now stops an id after `MAX_CONSECUTIVE_FAILURES` (5) consecutive failed fetches (a success resets the streak), so a stale/malformed id can't 404 forever. Aborts from `stop()` never count.

## Testing
- typecheck ✓, lint ✓
- `execution-detector.test.ts` +4 (MCP JSON shape, separators, mixed CLI+field, negative "bare execution")
- `run-poll-controller.test.ts` +2 (stop-after-5, success-resets-streak)
- Full suite **865 passed** (lone `rest.test.ts > skills router` failure is pre-existing on the clean base).

## Review & hygiene
- 1 code-reviewer pass (APPROVE, no blockers; noted a self-limiting `executionId:null`→"null" edge that the poll-guard caps at 5 fetches).
- Added lines clean; generic ids only. Patch changeset.

## Note
This fixes the *detection* path for real Prod Runs. Live testing also surfaced a likely *separate* issue — the run-state poll failing in-harness (same credential/env symptom as the earlier slug fallback) — being diagnosed separately.

Stacked on C1 → B4 → B2 → `feat/harness-runtime-analytics`.