### PR TITLE
fix(harness): remote sapiom MCP URL follows SAPIOM_ENVIRONMENT (ECO-213)

### DIFF
--- a/.changeset/harness-remote-mcp-url-follows-env.md
+++ b/.changeset/harness-remote-mcp-url-follows-env.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/harness": patch
+---
+
+fix(harness): remote `sapiom` MCP URL follows `SAPIOM_ENVIRONMENT`
+
+The injected remote `sapiom` MCP server URL was hardcoded to production
+(`https://api.sapiom.ai/v1/mcp`), so running against a non-prod environment
+minted auth against `api.sapiom.dev` but sent remote tool calls to
+`api.sapiom.ai` — every call 401'd. The URL is now derived from the resolved
+environment via `resolveEnvironment`, so `SAPIOM_ENVIRONMENT=dev`/`staging`
+points at `https://api.sapiom.dev/v1/mcp`, with production remaining the
+default.

--- a/packages/harness/src/core/inject/mcp-config.test.ts
+++ b/packages/harness/src/core/inject/mcp-config.test.ts
@@ -52,6 +52,29 @@ describe("generateMcpConfig", () => {
     expect(config.mcpServers["sapiom-dev"].env).toEqual({ SAPIOM_ENVIRONMENT: "staging" });
   });
 
+  it("points the remote sapiom URL at the resolved environment", async () => {
+    const staging = JSON.parse(
+      await fs.readFile(await generateMcpConfig("session-staging", { environment: "staging" }), "utf-8"),
+    );
+    expect(staging.mcpServers.sapiom.url).toBe("https://api.sapiom.dev/v1/mcp");
+
+    const dev = JSON.parse(
+      await fs.readFile(await generateMcpConfig("session-dev", { environment: "dev" }), "utf-8"),
+    );
+    expect(dev.mcpServers.sapiom.url).toBe("https://api.sapiom.dev/v1/mcp");
+  });
+
+  it("reads SAPIOM_ENVIRONMENT from the process env for the remote URL", async () => {
+    process.env.SAPIOM_ENVIRONMENT = "staging";
+    const config = JSON.parse(await fs.readFile(await generateMcpConfig("session-env"), "utf-8"));
+    expect(config.mcpServers.sapiom.url).toBe("https://api.sapiom.dev/v1/mcp");
+  });
+
+  it("defaults the remote URL to production when no environment is set", async () => {
+    const config = JSON.parse(await fs.readFile(await generateMcpConfig("session-prod"), "utf-8"));
+    expect(config.mcpServers.sapiom.url).toBe("https://api.sapiom.ai/v1/mcp");
+  });
+
   it("isolates sessions into separate directories", async () => {
     const a = await generateMcpConfig("session-a");
     const b = await generateMcpConfig("session-b");

--- a/packages/harness/src/core/inject/mcp-config.ts
+++ b/packages/harness/src/core/inject/mcp-config.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { resolveEnvironment } from "@sapiom/mcp/auth";
 import { HARNESS_PATHS } from "../../shared/types.js";
 import { expandHome } from "../../cli/paths.js";
 
@@ -40,11 +41,13 @@ export async function generateMcpConfig(
     ? { SAPIOM_ENVIRONMENT: sapiomEnvironment }
     : undefined;
 
+  const { apiURL } = await resolveEnvironment(sapiomEnvironment);
+
   const config = {
     mcpServers: {
       sapiom: {
         type: "http",
-        url: "https://api.sapiom.ai/v1/mcp",
+        url: `${apiURL}/v1/mcp`,
         ...(options.apiKey ? { headers: { "x-api-key": options.apiKey } } : {}),
       },
       "sapiom-dev": {


### PR DESCRIPTION
## Summary

The injected remote `sapiom` MCP server URL in `packages/harness/src/core/inject/mcp-config.ts` was hardcoded to production (`https://api.sapiom.ai/v1/mcp`), ignoring the already-resolved `SAPIOM_ENVIRONMENT`. Running the harness against a non-prod environment minted auth/credentials against `api.sapiom.dev` but sent every remote tool call to `api.sapiom.ai` with a staging key — a 401 on every remote tool call.

The URL is now derived from `resolveEnvironment` (from `@sapiom/mcp/auth`), which already honors `SAPIOM_ENVIRONMENT` / `~/.sapiom/credentials.json` and the `production`/`staging` presets.

## Acceptance criteria

- [x] With `SAPIOM_ENVIRONMENT=dev`/`staging`, the generated `mcp-config.json` points the remote `sapiom` MCP at `https://api.sapiom.dev/v1/mcp`.
- [x] Prod remains the default when no environment is set.
- [x] Test coverage in `mcp-config.test.ts` for the env-derived URL.

## Testing

- `pnpm vitest run src/core/inject/mcp-config.test.ts` — 9/9 pass
- `pnpm typecheck` — clean

## Follow-up (out of scope)

The ticket notes that harness auth (`packages/harness/src/cli/auth.ts`) does not read `SAPIOM_API_KEY` from the environment, unlike the SDK/CLI. Left untouched here — worth a separate ticket.

Resolves ECO-213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)