### PR TITLE
feat(agent): per-step capability declarations in the deploy manifest (SAP-1717)

### DIFF
--- a/.changeset/step-capability-declaration.md
+++ b/.changeset/step-capability-declaration.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent": minor
+---
+
+Steps can declare the platform capability they call: `defineStep({ capability: "web.search", ... })`. The build emits it as `capabilityId` on each manifest step (null when undeclared), and `agentManifestSchema` accepts and preserves the field — absent keys (manifests built before the field existed) parse to null, empty-string ids are rejected. The platform indexes the binding for per-step attribution.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -56,6 +56,27 @@ A step declares the transitions it may take (`next` / `terminal` / `canFail` /
 undeclared transition is a compile error. The build reads those same declarations
 to render the orchestration graph without executing anything.
 
+A step may also declare the platform capability it calls, by canonical dotted
+id:
+
+```ts
+const search = defineStep({
+  name: "search",
+  capability: "web.search",
+  next: ["summarize"],
+  async run(input, ctx) {
+    const results = await ctx.sapiom.search.webSearch({ query: input.query });
+    return goto("summarize", results);
+  },
+});
+```
+
+The build emits it into the manifest (`capabilityId`), where the platform
+validates it against the capability registry and uses it for per-step
+attribution — your dashboard shows which step calls which capability (and what
+it costs) before the first run. Steps that declare nothing are simply "runs
+in-process"; the declaration never gates execution.
+
 ## Pausing on a long-running capability
 
 Some `ctx.sapiom` capabilities are **dispatched**: you launch them, they run far

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -20,6 +20,8 @@ import type { AgentDefinition } from "./agent.js";
  *     `next`/`terminal`/`canFail`/`pause` runtime properties (set by
  *     `defineStep`). This is a runtime-value read, exactly like inputSchema —
  *     no type reflection, no AST parsing.
+ *   - capabilityId: the step's declared `capability` (canonical dotted id),
+ *     null when undeclared — the step→capability binding the engine indexes.
  * - name/entry from def; protocol 1 (locked); sdkVersion/artifact from opts.
  */
 export function buildManifest(
@@ -35,6 +37,7 @@ export function buildManifest(
       timeoutMs: number | null;
       inputSchema: Record<string, unknown> | null;
       transitions: ManifestTransition[];
+      capabilityId: string | null;
     }
   > = {};
 
@@ -50,6 +53,9 @@ export function buildManifest(
       timeoutMs: step.timeoutMs ?? null,
       inputSchema,
       transitions: transitionsFor(step),
+      // `|| null` (not `?? null`): an empty string is "no declaration", and
+      // the manifest schema rejects empty ids.
+      capabilityId: step.capability || null,
     };
   }
 

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -8,6 +8,8 @@
  *   4. buildManifest: step with inputSchema → JSON Schema; without → null
  *   5. buildManifest: step with timeoutMs → timeoutMs; without → null
  *   6. buildManifest: protocol is always 1, sdkVersion/artifact from opts
+ *   7. capabilityId: declared → carried; undeclared → null; absent in old
+ *      manifests → parses to null (never stripped); empty string rejected
  */
 import { z } from "zod/v4";
 
@@ -28,7 +30,7 @@ import { defineAgent } from "./agent.js";
 /** A terminal step (declares `terminal: true`) for the schema/inputSchema/timeout tests. */
 function makeStep(
   name: string,
-  opts: { inputSchema?: z.ZodType; timeoutMs?: number } = {},
+  opts: { inputSchema?: z.ZodType; timeoutMs?: number; capability?: string } = {},
 ) {
   return defineStep({
     name,
@@ -36,6 +38,7 @@ function makeStep(
     terminal: true,
     inputSchema: opts.inputSchema,
     timeoutMs: opts.timeoutMs,
+    capability: opts.capability,
     async run() {
       return terminate(null);
     },
@@ -153,6 +156,58 @@ describe("agentManifestSchema", () => {
       steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
     };
     expect(() => agentManifestSchema.parse(good)).not.toThrow();
+  });
+
+  it("preserves a step capabilityId through parse (the engine's edge validation must not strip the binding)", () => {
+    const manifest = {
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: "terminate" }],
+          capabilityId: "web.search",
+        },
+      },
+    };
+    expect(agentManifestSchema.parse(manifest).steps.a.capabilityId).toBe(
+      "web.search",
+    );
+  });
+
+  it("defaults capabilityId to null when absent (manifests built before the field existed)", () => {
+    const preField = {
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: { a: { timeoutMs: null, inputSchema: null, transitions: [] } },
+    };
+    expect(agentManifestSchema.parse(preField).steps.a.capabilityId).toBeNull();
+  });
+
+  it("rejects an empty-string capabilityId (a binding names a capability or is null)", () => {
+    const bad = {
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [],
+          capabilityId: "",
+        },
+      },
+    };
+    expect(() => agentManifestSchema.parse(bad)).toThrow();
   });
 });
 
@@ -279,6 +334,36 @@ describe("buildManifest", () => {
     // finalize: neither
     expect(manifest.steps.finalize.timeoutMs).toBeNull();
     expect(manifest.steps.finalize.inputSchema).toBeNull();
+  });
+
+  it("step with capability → capabilityId carried through (the step→capability binding)", () => {
+    const def = defineAgent({
+      name: "wf",
+      entry: "search",
+      steps: { search: makeStep("search", { capability: "web.search" }) },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.steps.search.capabilityId).toBe("web.search");
+    // The emitted manifest must survive the engine's schema validation intact.
+    expect(agentManifestSchema.parse(manifest).steps.search.capabilityId).toBe(
+      "web.search",
+    );
+  });
+
+  it("step without capability → capabilityId: null in manifest (honest runs-in-process)", () => {
+    const def = defineAgent({
+      name: "wf",
+      entry: "plain",
+      steps: { plain: makeStep("plain") },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    expect(manifest.steps.plain.capabilityId).toBeNull();
   });
 
   it("defaulted field is NOT in required in the manifest JSON Schema (AJV pre-check must not be stricter than Zod)", () => {

--- a/packages/agent/src/manifest.ts
+++ b/packages/agent/src/manifest.ts
@@ -47,6 +47,15 @@ export interface AgentStepManifest {
    * per-kind); the renderer draws one edge per entry. `reachable ⊆ declared`.
    */
   readonly transitions: readonly ManifestTransition[];
+  /**
+   * The canonical dotted id of the platform capability this step declares it
+   * calls (`step.capability`, e.g. `web.search`), or null when the step
+   * declares none. The engine validates the id against the capability
+   * registry at index time and binds the step to it for attribution.
+   * Optional in the type for compatibility with manifests built before the
+   * field existed; the schema defaults it to null on parse.
+   */
+  readonly capabilityId?: string | null;
 }
 
 /**
@@ -87,6 +96,11 @@ const workflowStepManifestSchema = z.object({
   timeoutMs: z.union([z.number().int().positive(), z.null()]),
   inputSchema: z.union([z.record(z.string(), z.unknown()), z.null()]),
   transitions: z.array(manifestTransitionSchema),
+  // Absent on manifests built before the field existed → parses to null.
+  // Present ids must be non-empty (strict like timeoutMs); `z.object` strips
+  // unknown keys, so without this entry the engine would silently drop the
+  // binding at its validation edge.
+  capabilityId: z.union([z.string().min(1), z.null()]).default(null),
 });
 
 /**

--- a/packages/agent/src/step.ts
+++ b/packages/agent/src/step.ts
@@ -81,6 +81,14 @@ export interface StepDefinition<TShared extends Record<string, unknown> = Record
   readonly pause?: { readonly signal: string; readonly resumeStep: string };
   readonly inputSchema?: ZodType<unknown>;
   readonly timeoutMs?: number;
+  /**
+   * The canonical dotted id of the platform capability this step calls
+   * (e.g. `web.search`), if the author declared one. A declaration, not an
+   * enforcement: the platform validates the id against the capability
+   * registry at build/index time and uses it for per-step attribution in
+   * dashboards. Undeclared means "runs in-process / no single capability".
+   */
+  readonly capability?: string;
   run(input: unknown, ctx: AgentExecutionContext<TShared>): Promise<NextStepDirective>;
 }
 
@@ -113,6 +121,8 @@ export function defineStep<
   pause?: PauseDecl;
   inputSchema?: ZodType<TIn>;
   timeoutMs?: number;
+  /** Canonical dotted capability id this step calls (e.g. `web.search`). */
+  capability?: string;
   // Arrow-property (not method) type so `def.run` can be read as a value below
   // without tripping @typescript-eslint/unbound-method.
   run: (
@@ -128,6 +138,9 @@ export function defineStep<
     ...(def.pause ? { pause: def.pause } : {}),
     ...(def.inputSchema ? { inputSchema: def.inputSchema as ZodType<unknown> } : {}),
     ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+    // Truthiness on purpose: an empty-string declaration is "no declaration",
+    // so '' never reaches the manifest (whose schema rejects empty ids).
+    ...(def.capability ? { capability: def.capability } : {}),
     run: def.run as unknown as (input: unknown, ctx: AgentExecutionContext<TShared>) => Promise<NextStepDirective>,
   };
 }


### PR DESCRIPTION
## What

A step can now declare the platform capability it calls, by canonical dotted id:

```ts
const search = defineStep({
  name: "search",
  capability: "web.search",
  next: ["summarize"],
  async run(input, ctx) { ... },
});
```

- `buildManifest` emits it as `capabilityId` on each manifest step — `null` when undeclared (honest "runs in-process"), same runtime-property read as `timeoutMs`/`inputSchema`.
- `AgentStepManifest` gains `capabilityId?: string | null` (optional in the type so manifests built before the field existed remain valid values).
- `workflowStepManifestSchema` accepts and preserves the field: absent → parses to `null`, empty string → rejected (strict like `timeoutMs`).

## Why the schema entry is load-bearing

The engine validates received manifests with `agentManifestSchema` from this package, and `z.object` **strips unknown keys**. Without the schema entry, an emitted `capabilityId` would be silently deleted at the engine's validation edge before it ever reached the recorder that indexes it — the emit alone would no-op. One of the new tests pins exactly this: a built manifest survives `agentManifestSchema.parse` with the binding intact.

## Compatibility

Additive; no protocol bump.
- Old manifest + new schema → `capabilityId` defaults to `null` (today's behavior).
- New manifest + old engine schema → field stripped, feature inert, nothing breaks (activates when the engine bumps its `@sapiom/agent` dependency).
- Steps that declare nothing are unchanged.

The engine side (reading `capabilityId` off manifest steps + validating declared ids against the capability registry at index time) already exists — this is the producer half that makes it carry real data: per-step capability attribution in dashboards, populated before the first run.

## Tests

- `buildManifest`: declared → carried through (and survives schema parse); undeclared → `null`.
- Schema: preserves a present id; defaults absent → `null`; rejects `""`.
- Full workspace: build, typecheck, lint green; agent 82/82, agent-core 118, agent-runtime 26, tools 354, mcp 70, cli 69, sandbox 58, core 132 all passing.

Changeset: minor for `@sapiom/agent`. README documents the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)