### PR TITLE
add more attribution keys

### DIFF
--- a/.changeset/tools-trace-attribution.md
+++ b/.changeset/tools-trace-attribution.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": minor
+---
+
+Forward activity-trace context on capability and model calls. `Attribution` gains `parentSpanId`, `executionId`, and `stepOrder` — emitted as `x-sapiom-parent-span-id` / `x-sapiom-execution-id` / `x-sapiom-step-order`, and read ambiently from `SAPIOM_PARENT_SPAN_ID` / `SAPIOM_EXECUTION_ID` / `SAPIOM_STEP_ORDER` (`attributionFromEnv`) — so calls nest under the calling run and step. Applied once at the shared transport, so every capability inherits it.
+
+Deprecates `agentName`, `agentId`, and `traceExternalId` (a free-form label / legacy correlation field). They still forward for backward compatibility; prefer `traceId` plus the new fields.

--- a/packages/tools/src/_client/attribution.spec.ts
+++ b/packages/tools/src/_client/attribution.spec.ts
@@ -1,0 +1,121 @@
+import { Transport, attributionFromEnv, type Attribution } from "./index.js";
+import { capabilityCall } from "./capability-call.js";
+
+// Mirrors capability-call.spec's fetch-capture harness, but with attribution set on the
+// Transport — proving the trace context is forwarded ONCE at the single choke point
+// (`Transport.fetch`), so every capability inherits it with no per-tool wiring.
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function makeTransport(attribution: Attribution): {
+  transport: Transport;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return {
+    transport: new Transport({ apiKey: "k", fetch: fetchMock, attribution }),
+    calls,
+  };
+}
+
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+const makeError = (m: string): Error => new Error(m);
+
+const call = (transport: Transport) =>
+  capabilityCall(
+    "web.scrape",
+    { url: "https://example.com" },
+    { transport, baseUrl: "https://api.test", makeError, errorPrefix: "x" },
+  );
+
+describe("Attribution → forwarded x-sapiom-* headers (once, all capabilities)", () => {
+  it("forwards traceId/parentSpanId/executionId/stepOrder on every capability call", async () => {
+    const { transport, calls } = makeTransport({
+      traceId: "t1",
+      parentSpanId: "s1",
+      executionId: "e1",
+      stepOrder: 3,
+    });
+
+    await call(transport);
+
+    expect(headerOf(calls[0]!, "x-sapiom-trace-id")).toBe("t1");
+    expect(headerOf(calls[0]!, "x-sapiom-parent-span-id")).toBe("s1");
+    expect(headerOf(calls[0]!, "x-sapiom-execution-id")).toBe("e1");
+    expect(headerOf(calls[0]!, "x-sapiom-step-order")).toBe("3");
+  });
+
+  it("emits step-order '0' — the first step is a valid ordinal, not omitted", async () => {
+    const { transport, calls } = makeTransport({ stepOrder: 0 });
+
+    await call(transport);
+
+    expect(headerOf(calls[0]!, "x-sapiom-step-order")).toBe("0");
+  });
+
+  it("omits headers for absent fields", async () => {
+    const { transport, calls } = makeTransport({ traceId: "t1" });
+
+    await call(transport);
+
+    expect(headerOf(calls[0]!, "x-sapiom-trace-id")).toBe("t1");
+    expect(headerOf(calls[0]!, "x-sapiom-parent-span-id")).toBeUndefined();
+    expect(headerOf(calls[0]!, "x-sapiom-execution-id")).toBeUndefined();
+    expect(headerOf(calls[0]!, "x-sapiom-step-order")).toBeUndefined();
+  });
+});
+
+describe("attributionFromEnv (in-sandbox ambient channel)", () => {
+  const saved = process.env;
+  beforeEach(() => {
+    process.env = { ...saved };
+    for (const k of [
+      "SAPIOM_TRACE_ID",
+      "SAPIOM_PARENT_SPAN_ID",
+      "SAPIOM_EXECUTION_ID",
+      "SAPIOM_STEP_ORDER",
+      "SAPIOM_TRACE_EXTERNAL_ID",
+      "SAPIOM_AGENT_ID",
+      "SAPIOM_AGENT_NAME",
+    ]) {
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    process.env = saved;
+  });
+
+  it("reads the trace env vars, including step-order 0", () => {
+    process.env.SAPIOM_TRACE_ID = "t1";
+    process.env.SAPIOM_PARENT_SPAN_ID = "s1";
+    process.env.SAPIOM_EXECUTION_ID = "e1";
+    process.env.SAPIOM_STEP_ORDER = "0";
+
+    expect(attributionFromEnv()).toEqual({
+      traceId: "t1",
+      parentSpanId: "s1",
+      executionId: "e1",
+      stepOrder: 0,
+    });
+  });
+
+  it("omits absent fields and ignores a non-numeric step-order", () => {
+    expect(attributionFromEnv()).toEqual({});
+
+    process.env.SAPIOM_STEP_ORDER = "not-a-number";
+    expect(attributionFromEnv().stepOrder).toBeUndefined();
+  });
+});

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -34,13 +34,26 @@ import {
  * optional and maps 1:1 to an `x-sapiom-*` header the collapsed flow understands.
  */
 export interface Attribution {
-  /** Human-readable agent name. Mutually exclusive with `agentId` (gateway-enforced). */
+  /**
+   * @deprecated A free-form agent label, not a resolved agent. Prefer omitting — the agent a call
+   * belongs to is resolved from the authenticated request.
+   */
   agentName?: string;
-  /** Agent UUID. Mutually exclusive with `agentName` (gateway-enforced). */
+  /**
+   * @deprecated A free-form agent id (a label, not the resolved agent). Prefer omitting.
+   */
   agentId?: string;
-  /** Sapiom trace id to attribute this call to. */
+  /** Trace id this call is attributed to (nests under `parentSpanId`). */
   traceId?: string;
-  /** Your own external trace / correlation id. */
+  /** Parent span id this call nests under, within `traceId`. */
+  parentSpanId?: string;
+  /** Id of the run/execution this call belongs to. */
+  executionId?: string;
+  /** Ordinal of the step this call was made from (0-based). */
+  stepOrder?: number;
+  /**
+   * @deprecated Legacy correlation field. Use `traceId`.
+   */
   traceExternalId?: string;
   /** Arbitrary JSON object stored with the transaction. Must be an object. */
   metadata?: Record<string, unknown>;
@@ -89,6 +102,10 @@ function attributionToHeaders(a: Attribution): Record<string, string> {
   if (a.agentName) h["x-sapiom-agent-name"] = a.agentName;
   if (a.agentId) h["x-sapiom-agent-id"] = a.agentId;
   if (a.traceId) h["x-sapiom-trace-id"] = a.traceId;
+  if (a.parentSpanId) h["x-sapiom-parent-span-id"] = a.parentSpanId;
+  if (a.executionId) h["x-sapiom-execution-id"] = a.executionId;
+  // 0 is a valid first-step ordinal — guard on undefined, not falsiness.
+  if (a.stepOrder !== undefined) h["x-sapiom-step-order"] = String(a.stepOrder);
   if (a.traceExternalId) h["x-sapiom-trace-external-id"] = a.traceExternalId;
   if (a.metadata) h["x-sapiom-metadata"] = JSON.stringify(a.metadata);
   return h;
@@ -107,6 +124,14 @@ export function attributionFromEnv(): Attribution {
   if (process.env.SAPIOM_AGENT_NAME)
     a.agentName = process.env.SAPIOM_AGENT_NAME;
   if (process.env.SAPIOM_TRACE_ID) a.traceId = process.env.SAPIOM_TRACE_ID;
+  if (process.env.SAPIOM_PARENT_SPAN_ID)
+    a.parentSpanId = process.env.SAPIOM_PARENT_SPAN_ID;
+  if (process.env.SAPIOM_EXECUTION_ID)
+    a.executionId = process.env.SAPIOM_EXECUTION_ID;
+  if (process.env.SAPIOM_STEP_ORDER) {
+    const n = Number(process.env.SAPIOM_STEP_ORDER);
+    if (Number.isFinite(n)) a.stepOrder = n;
+  }
   if (process.env.SAPIOM_TRACE_EXTERNAL_ID)
     a.traceExternalId = process.env.SAPIOM_TRACE_EXTERNAL_ID;
   return a;


### PR DESCRIPTION
This pull request enhances trace context propagation in the `@sapiom/tools` package by forwarding additional activity-trace fields on all capability and model calls. It introduces new attribution fields for improved traceability, ensures these are emitted as headers and read from environment variables, and provides comprehensive tests. Legacy fields are deprecated but remain for backward compatibility.

**Trace context propagation and attribution enhancements:**

* The `Attribution` interface gains new fields: `parentSpanId`, `executionId`, and `stepOrder`, which are forwarded as `x-sapiom-parent-span-id`, `x-sapiom-execution-id`, and `x-sapiom-step-order` headers, and are read from `SAPIOM_PARENT_SPAN_ID`, `SAPIOM_EXECUTION_ID`, and `SAPIOM_STEP_ORDER` environment variables. This enables proper nesting of calls under the correct run and step context. [[1]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL37-R56) [[2]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfR105-R108) [[3]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfR127-R134) [[4]](diffhunk://#diff-1523bd1ae6920d8441a652b917122418cb0ada685de06d8c8dc87a916ac85c0fR1-R7)

* The new trace context fields are applied at the shared transport layer, ensuring every capability call inherits them without requiring per-tool wiring.

**Deprecations for legacy fields:**

* The `agentName`, `agentId`, and `traceExternalId` fields in `Attribution` are now deprecated in favor of `traceId` and the new fields, but are still forwarded for backward compatibility. [[1]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL37-R56) [[2]](diffhunk://#diff-1523bd1ae6920d8441a652b917122418cb0ada685de06d8c8dc87a916ac85c0fR1-R7)

**Testing and validation:**

* Adds a new test suite in `attribution.spec.ts` to verify that the new trace context fields are correctly forwarded as headers, that the environment variable reading logic works (including handling of `stepOrder`), and that headers are omitted when fields are absent.