### PR TITLE
consume activityTraceId

### DIFF
--- a/.changeset/tools-trace-attribution.md
+++ b/.changeset/tools-trace-attribution.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": patch
+---
+
+Forward activity-trace context on capability and model calls. `Attribution` gains `activityTraceId`, `parentSpanId`, `executionId`, and `stepOrder` — emitted as `x-sapiom-activity-trace-id` / `x-sapiom-parent-span-id` / `x-sapiom-execution-id` / `x-sapiom-step-order`, and read ambiently from the matching `SAPIOM_*` env vars (`attributionFromEnv`) — so calls nest under the calling run and step. Applied once at the shared transport, so every capability inherits it.
+
+`activityTraceId` is deliberately a **separate field/header from `traceId`**: `traceId` (`x-sapiom-trace-id`) remains the Core transaction trace, while `activityTraceId` (`x-sapiom-activity-trace-id`) is the client-minted activity/execution trace — kept apart so the two never collide on one header.
+
+Deprecates `agentName`, `agentId`, and `traceExternalId` (a free-form label / legacy correlation field). They still forward for backward compatibility.

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.4",
-  tools: "0.19.0",
+  agent: "0.6.5",
+  tools: "0.20.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/packages/tools/src/_client/attribution.spec.ts
+++ b/packages/tools/src/_client/attribution.spec.ts
@@ -44,7 +44,8 @@ const call = (transport: Transport) =>
 describe("Attribution → forwarded x-sapiom-* headers (once, all capabilities)", () => {
   it("forwards traceId/parentSpanId/executionId/stepOrder on every capability call", async () => {
     const { transport, calls } = makeTransport({
-      traceId: "t1",
+      traceId: "core-1",
+      activityTraceId: "act-1",
       parentSpanId: "s1",
       executionId: "e1",
       stepOrder: 3,
@@ -52,7 +53,9 @@ describe("Attribution → forwarded x-sapiom-* headers (once, all capabilities)"
 
     await call(transport);
 
-    expect(headerOf(calls[0]!, "x-sapiom-trace-id")).toBe("t1");
+    // Core transaction trace and activity trace ride SEPARATE headers — they never collide.
+    expect(headerOf(calls[0]!, "x-sapiom-trace-id")).toBe("core-1");
+    expect(headerOf(calls[0]!, "x-sapiom-activity-trace-id")).toBe("act-1");
     expect(headerOf(calls[0]!, "x-sapiom-parent-span-id")).toBe("s1");
     expect(headerOf(calls[0]!, "x-sapiom-execution-id")).toBe("e1");
     expect(headerOf(calls[0]!, "x-sapiom-step-order")).toBe("3");
@@ -84,6 +87,7 @@ describe("attributionFromEnv (in-sandbox ambient channel)", () => {
     process.env = { ...saved };
     for (const k of [
       "SAPIOM_TRACE_ID",
+      "SAPIOM_ACTIVITY_TRACE_ID",
       "SAPIOM_PARENT_SPAN_ID",
       "SAPIOM_EXECUTION_ID",
       "SAPIOM_STEP_ORDER",
@@ -99,13 +103,15 @@ describe("attributionFromEnv (in-sandbox ambient channel)", () => {
   });
 
   it("reads the trace env vars, including step-order 0", () => {
-    process.env.SAPIOM_TRACE_ID = "t1";
+    process.env.SAPIOM_TRACE_ID = "core-1";
+    process.env.SAPIOM_ACTIVITY_TRACE_ID = "act-1";
     process.env.SAPIOM_PARENT_SPAN_ID = "s1";
     process.env.SAPIOM_EXECUTION_ID = "e1";
     process.env.SAPIOM_STEP_ORDER = "0";
 
     expect(attributionFromEnv()).toEqual({
-      traceId: "t1",
+      traceId: "core-1",
+      activityTraceId: "act-1",
       parentSpanId: "s1",
       executionId: "e1",
       stepOrder: 0,

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -43,9 +43,15 @@ export interface Attribution {
    * @deprecated A free-form agent id (a label, not the resolved agent). Prefer omitting.
    */
   agentId?: string;
-  /** Trace id this call is attributed to (nests under `parentSpanId`). */
+  /** Core trace id to link this call's transaction to — must reference an existing Core trace. */
   traceId?: string;
-  /** Parent span id this call nests under, within `traceId`. */
+  /**
+   * Activity trace this call's span nests under (the customer-facing execution trace). A distinct,
+   * client-minted id — kept separate from `traceId` (the Core transaction trace) so the two never
+   * collide on one header.
+   */
+  activityTraceId?: string;
+  /** Parent span id this call nests under, within `activityTraceId`. */
   parentSpanId?: string;
   /** Id of the run/execution this call belongs to. */
   executionId?: string;
@@ -102,6 +108,7 @@ function attributionToHeaders(a: Attribution): Record<string, string> {
   if (a.agentName) h["x-sapiom-agent-name"] = a.agentName;
   if (a.agentId) h["x-sapiom-agent-id"] = a.agentId;
   if (a.traceId) h["x-sapiom-trace-id"] = a.traceId;
+  if (a.activityTraceId) h["x-sapiom-activity-trace-id"] = a.activityTraceId;
   if (a.parentSpanId) h["x-sapiom-parent-span-id"] = a.parentSpanId;
   if (a.executionId) h["x-sapiom-execution-id"] = a.executionId;
   // 0 is a valid first-step ordinal — guard on undefined, not falsiness.
@@ -124,6 +131,8 @@ export function attributionFromEnv(): Attribution {
   if (process.env.SAPIOM_AGENT_NAME)
     a.agentName = process.env.SAPIOM_AGENT_NAME;
   if (process.env.SAPIOM_TRACE_ID) a.traceId = process.env.SAPIOM_TRACE_ID;
+  if (process.env.SAPIOM_ACTIVITY_TRACE_ID)
+    a.activityTraceId = process.env.SAPIOM_ACTIVITY_TRACE_ID;
   if (process.env.SAPIOM_PARENT_SPAN_ID)
     a.parentSpanId = process.env.SAPIOM_PARENT_SPAN_ID;
   if (process.env.SAPIOM_EXECUTION_ID)


### PR DESCRIPTION
This pull request updates the tools attribution system to forward a new set of activity-trace context fields on capability and model calls, improving traceability and context propagation. The changes introduce a distinct `activityTraceId` (separate from the core `traceId`), update header and environment variable handling, and deprecate some legacy fields for clarity and future compatibility.

**Trace context and attribution improvements:**

* Added `activityTraceId`, `parentSpanId`, `executionId`, and `stepOrder` fields to the `Attribution` interface, with corresponding headers (`x-sapiom-activity-trace-id`, etc.) and support for reading these from environment variables (`attributionFromEnv`). This ensures calls inherit and forward the correct context for tracing and execution. (`[[1]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL46-R54)`, `[[2]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfR111)`, `[[3]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfR134-R135)`, `[[4]](diffhunk://#diff-564516b0601297291cdfc2f4842c580e2ae7223089844cb63a0aa53fc340d32bR90)`, `[[5]](diffhunk://#diff-564516b0601297291cdfc2f4842c580e2ae7223089844cb63a0aa53fc340d32bL102-R114)`)
* Explicitly separates `activityTraceId` (client-minted activity/execution trace) from `traceId` (core transaction trace), each using its own header to avoid collisions and confusion. (`[[1]](diffhunk://#diff-1523bd1ae6920d8441a652b917122418cb0ada685de06d8c8dc87a916ac85c0fR1-R9)`, `[[2]](diffhunk://#diff-9cf9205829ec99236248c21b95f5a1f705157dc7dc4068cd08c015a0432e9fdfL46-R54)`, `[[3]](diffhunk://#diff-564516b0601297291cdfc2f4842c580e2ae7223089844cb63a0aa53fc340d32bL47-R58)`)
* Updated tests to verify correct forwarding and reading of both trace IDs and related context fields, ensuring the new behavior is covered and legacy fields remain compatible. (`[[1]](diffhunk://#diff-564516b0601297291cdfc2f4842c580e2ae7223089844cb63a0aa53fc340d32bL47-R58)`, `[[2]](diffhunk://#diff-564516b0601297291cdfc2f4842c580e2ae7223089844cb63a0aa53fc340d32bL102-R114)`)

**Deprecations and documentation:**

* Deprecated the `agentName`, `agentId`, and `traceExternalId` fields, which are now considered legacy and should be omitted in favor of the new attribution context, though they are still forwarded for backward compatibility. (`[.changeset/tools-trace-attribution.mdR1-R9](diffhunk://#diff-1523bd1ae6920d8441a652b917122418cb0ada685de06d8c8dc87a916ac85c0fR1-R9)`)

**Documentation and changelog:**

* Added a detailed changeset describing the new attribution context, header separation, and deprecations for clear migration guidance. (`[.changeset/tools-trace-attribution.mdR1-R9](diffhunk://#diff-1523bd1ae6920d8441a652b917122418cb0ada685de06d8c8dc87a916ac85c0fR1-R9)`)