### PR TITLE
fix(harness): restore resolveCoreBaseUrl after cost-strip removed run-spend (A1↔B2 integration fixup)

### DIFF
--- a/.changeset/restore-resolve-core-base-url.md
+++ b/.changeset/restore-resolve-core-base-url.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Restore the `resolveCoreBaseUrl` helper that the actions router relies on to derive the core API base URL. It is now co-located with `resolveAgentsBaseUrl` (its only dependency) instead of living in a since-removed module, so the harness server builds and the actions router self-defaults its base URL again.

--- a/packages/harness/src/core/definition-slug-resolver.ts
+++ b/packages/harness/src/core/definition-slug-resolver.ts
@@ -22,6 +22,34 @@ export function resolveAgentsBaseUrl(): string {
   );
 }
 
+/**
+ * Resolve the CORE surface base URL (`api.<env>`), distinct from the agents
+ * host (`tools.<env>`) resolved above. A run lives in the agents env, and any
+ * core-surface call for that run must target the MATCHING core env — otherwise
+ * a prod run queried against dev 401s. So we DERIVE the core host from the
+ * agents host (`tools.<env>` → `api.<env>`) rather than reading
+ * `SAPIOM_API_URL`, which in some setups points at a different env than the
+ * agents surface. An explicit `SAPIOM_CORE_URL` still wins for full control.
+ *
+ * Co-located with {@link resolveAgentsBaseUrl} (its sole dependency) so the two
+ * env-precedence helpers live together.
+ */
+export function resolveCoreBaseUrl(): string {
+  const override = process.env.SAPIOM_CORE_URL;
+  if (override) return override;
+  const agents = resolveAgentsBaseUrl();
+  try {
+    const url = new URL(agents);
+    if (url.hostname.startsWith("tools.")) {
+      url.hostname = `api.${url.hostname.slice("tools.".length)}`;
+      return url.origin;
+    }
+  } catch {
+    // Unparseable agents URL — fall through to the prod default.
+  }
+  return "https://api.sapiom.ai";
+}
+
 export interface DefinitionSlugResolver {
   resolve(definitionId: string): Promise<string | null>;
 }

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -30,7 +30,7 @@ import {
   type SapiomConfig,
 } from "@sapiom/agent-core";
 
-import { resolveCoreBaseUrl } from "../core/run-spend.js";
+import { resolveCoreBaseUrl } from "../core/definition-slug-resolver.js";
 
 /**
  * A registered workflow the actions router can act on — the subset of

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -824,7 +824,8 @@ export const startServer = async (
   app.use(
     createActionsRouter({
       apiKey: identity?.apiKey ?? null,
-      coreBaseUrl: resolveCoreBaseUrl(),
+      // coreBaseUrl omitted: the router self-defaults via resolveCoreBaseUrl()
+      // (see actions.ts), which derives the core host from the agents env.
       resolveWorkflow: (id) =>
         workflowsCache.find((w) => w.path === id) ?? null,
     }),


### PR DESCRIPTION
## The break

The `feat/harness-studio-launch` integration branch did **not** build. A1 (#324) added `packages/harness/src/server/actions.ts`, which imports `resolveCoreBaseUrl` from `../core/run-spend.js`. B2 (#322) then deleted `core/run-spend.ts` as part of the spend/transactions cost-strip. So after both landed, `resolveCoreBaseUrl` was defined nowhere:

- `actions.ts:33` imported it from a non-existent module.
- `index.ts:827` called `resolveCoreBaseUrl()` — a symbol it never even imported.

Result: 2 TS errors + 6 test suites (that transitively import `actions.ts`) failed to load.

## The relocation

`resolveCoreBaseUrl` is a general env-precedence util (`SAPIOM_CORE_URL` override → derive `api.<env>` from the agents host `tools.<env>` → prod default), **not** cost/spend-specific. Its only dependency is `resolveAgentsBaseUrl`. I recovered the exact impl from before the delete (`701abd8`) and co-located it with `resolveAgentsBaseUrl` in `core/definition-slug-resolver.ts` — the copy of `resolveAgentsBaseUrl` that `server/index.ts` already imports — so the two env helpers live together and there's no awkward import cycle. No cost/`RunSpend` code was brought back.

- `server/actions.ts:33` — import changed from `../core/run-spend.js` → `../core/definition-slug-resolver.js`.
- `server/index.ts:827` — dropped the `coreBaseUrl: resolveCoreBaseUrl()` arg; the router already self-defaults (`actions.ts:148`: `opts.coreBaseUrl ?? resolveCoreBaseUrl()`). No new import needed in `index.ts`.

Scope is strictly the dangling-util repair. The actions-router → key-provider wiring is a separate follow-up (#33), out of scope. No other files touched.

## Before / after

**Before:** `pnpm --filter @sapiom/harness build` failed (2 TS errors); 6 suites failed to load (`actions.test.ts`, `codex-session-lifecycle`, `codex-tailer-wiring`, `generated-retention`, `state-isolation`, `workspace-rescan`).

**After** (deps built first via `pnpm --filter '@sapiom/harness...' build`):

- `pnpm --filter @sapiom/harness build` — green (tsc + vite both clean).
- `pnpm --filter @sapiom/harness typecheck` — green (server + web tsconfigs).
- `pnpm --filter @sapiom/harness test` — 950/956 tests pass, 72/73 files pass. The only failing file is `transcript-replay.test.ts` (6 tests) — all `node-pty posix_spawnp failed`, a known env-only issue unrelated to this change.
- The 6 previously-failing suites, run explicitly, all recover: **6 files / 23 tests passed.**

Linear: <fixup ticket under Epic A>

🤖 Generated with [Claude Code](https://claude.com/claude-code)