### PR TITLE
feat(cli): tree/cost render + --follow live mode for agents logs (SAP-1343)

### DIFF
--- a/.changeset/cli-orch-logs-tree-follow.md
+++ b/.changeset/cli-orch-logs-tree-follow.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/cli": minor
+---
+
+`agents logs`: render an execution as a tree with per-node cost (captured primary, authorized ceiling — never collapsed) and add a `--follow`/`--watch` live mode that streams updates until the run reaches a terminal status. `agents logs` (no argument) now renders recent executions tree-aware, grouped by `traceRoot`. A `--verbose` flag adds step timings and dispatch details.

--- a/packages/cli/src/commands/agents/index.ts
+++ b/packages/cli/src/commands/agents/index.ts
@@ -58,6 +58,9 @@ export function registerAgentsCommands(program: Command): void {
     json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.')),
   )
     .option('--build <buildRunId>', 'inspect a build instead of an execution')
+    .option('-f, --follow', 'stream live updates and re-render until the run reaches a terminal status')
+    .option('--watch', 'alias for --follow')
+    .option('--verbose', 'show step errors, timings, and dispatch details')
     .action(action(runLogs));
 
   withHostFlags(json(group.command('signal <executionId>').description('Resume a paused execution.')))

--- a/packages/cli/src/commands/agents/logs.test.ts
+++ b/packages/cli/src/commands/agents/logs.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the `--follow` machinery in `logs.ts`: the {@link LiveRenderer}
+ * in-place/append behavior (including wrapped-row counting), the
+ * {@link followExecution} SSE → terminal / SSE-drop → poll-fallback / abort
+ * paths, and the `noEvents` seam that drops `waitForExecution` to its poll loop.
+ *
+ * All networked calls are injected via `FollowOverrides`, so nothing here touches
+ * a real gateway; abort is driven through an injected `AbortSignal` rather than a
+ * real process signal.
+ */
+import { waitForExecution, type GatewayClient, type ExecutionProjection, type SseEvent } from '@sapiom/agent-core';
+
+import { followExecution, LiveRenderer, noEvents } from './logs.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeExecution(status: string, id = 'exec-1'): ExecutionProjection {
+  return {
+    id,
+    name: 'run',
+    organizationId: null,
+    tenantId: null,
+    status,
+    currentStep: null,
+    currentStepAttempt: 1,
+    version: 1,
+    definitionId: null,
+    buildRunId: null,
+    idempotencyKey: null,
+    pausedSignalName: null,
+    pausedSignalCorrelationId: null,
+    pausedUntil: null,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    finishedAt: null,
+    input: null,
+    sharedState: {},
+    output: null,
+    error: null,
+    pausedStepInputSchema: null,
+    pausedStepInputExample: null,
+    traceRoot: id,
+    rootExecutionId: id,
+    traceParent: null,
+    parentExecutionId: null,
+    traceId: null,
+    children: [],
+    cost: null,
+    steps: [],
+  };
+}
+
+const EV: SseEvent = { type: 'step.started', executionId: 'exec-1', traceRoot: 't1', nodeId: 's1' };
+
+/** A capturing, non-TTY renderer plus a helper to count how many human renders
+ *  happened (each tree render emits exactly one `●` root line). */
+function capturingRenderer(): { renderer: LiveRenderer; renderCount: () => number; output: () => string } {
+  const chunks: string[] = [];
+  const renderer = new LiveRenderer(false, (s) => chunks.push(s));
+  return {
+    renderer,
+    output: () => chunks.join(''),
+    renderCount: () => (chunks.join('').match(/●/g) ?? []).length,
+  };
+}
+
+/** A fake SSE source yielding `events` in order; `hooks[n]` runs synchronously at
+ *  the start of the n-th `next()` call (1-indexed) — used to fire an abort. */
+function fakeWatch(events: SseEvent[], hooks: Record<number, () => void> = {}) {
+  return () => {
+    let i = 0;
+    return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async next(): Promise<IteratorResult<SseEvent, undefined>> {
+        const call = ++i;
+        hooks[call]?.();
+        if (i <= events.length) return { value: events[i - 1], done: false };
+        return { value: undefined, done: true };
+      },
+      async return(): Promise<IteratorResult<SseEvent, undefined>> {
+        return { value: undefined, done: true };
+      },
+    };
+  };
+}
+
+/** A fake SSE source whose first read throws — models a dropped/failed stream. */
+function throwingWatch(message: string) {
+  return () => ({
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next(): Promise<IteratorResult<SseEvent, undefined>> {
+      throw new Error(message);
+    },
+    async return(): Promise<IteratorResult<SseEvent, undefined>> {
+      return { value: undefined, done: true };
+    },
+  });
+}
+
+/** A fake `inspect` that returns each queued projection in turn (repeating the last). */
+function fakeInspect(sequence: ExecutionProjection[]) {
+  let i = 0;
+  return async () => sequence[Math.min(i++, sequence.length - 1)];
+}
+
+const NOOP_RENDER_OPTS = {};
+const FAKE_CLIENT = {} as GatewayClient;
+const sigintBaseline = () => process.listenerCount('SIGINT');
+
+// ── LiveRenderer ──────────────────────────────────────────────────────────────
+
+describe('LiveRenderer', () => {
+  it('appends snapshots separated by a blank line when not a TTY', () => {
+    const chunks: string[] = [];
+    const r = new LiveRenderer(false, (s) => chunks.push(s));
+    r.render(['a']);
+    r.render(['b']);
+    expect(chunks.join('')).toBe('a\n\nb\n');
+  });
+
+  it('clears the previous render in place on a TTY (no wrap)', () => {
+    const chunks: string[] = [];
+    const r = new LiveRenderer(true, (s) => chunks.push(s), () => 80);
+    r.render(['x', 'y']); // two rows
+    r.render(['z']);
+    // Second render moves up over the two prior rows and clears to end of screen.
+    expect(chunks[1]).toBe('\x1b[2A\x1b[0J');
+    expect(chunks[2]).toBe('z\n');
+  });
+
+  it('counts wrapped rows so narrow terminals redraw without corruption', () => {
+    const chunks: string[] = [];
+    const cols = 10;
+    const r = new LiveRenderer(true, (s) => chunks.push(s), () => cols);
+    r.render(['0123456789012']); // width 13 → ceil(13/10) = 2 physical rows
+    r.render(['short']);
+    expect(chunks[1]).toBe('\x1b[2A\x1b[0J'); // moves up 2, not 1
+  });
+});
+
+// ── followExecution ─────────────────────────────────────────────────────────
+
+describe('followExecution', () => {
+  it('renders once and returns when the run is already terminal', async () => {
+    const { renderer, renderCount } = capturingRenderer();
+    const watchSpy = jest.fn(fakeWatch([]));
+    const waitSpy = jest.fn(async () => ({ execution: makeExecution('completed'), reason: 'terminal' as const, done: true }));
+
+    await followExecution('exec-1', FAKE_CLIENT, NOOP_RENDER_OPTS, {
+      inspect: fakeInspect([makeExecution('completed')]),
+      watchExecution: watchSpy,
+      waitForExecution: waitSpy,
+      renderer,
+      jsonMode: false,
+    });
+
+    expect(renderCount()).toBe(1);
+    expect(watchSpy).not.toHaveBeenCalled();
+    expect(waitSpy).not.toHaveBeenCalled();
+    expect(process.listenerCount('SIGINT')).toBe(sigintBaseline());
+  });
+
+  it('re-renders on each SSE event and stops at the terminal status', async () => {
+    const { renderer, renderCount } = capturingRenderer();
+    const waitSpy = jest.fn(async () => ({ execution: makeExecution('completed'), reason: 'terminal' as const, done: true }));
+
+    await followExecution('exec-1', FAKE_CLIENT, NOOP_RENDER_OPTS, {
+      // initial → running, after ev1 → running, after ev2 → completed
+      inspect: fakeInspect([makeExecution('running'), makeExecution('running'), makeExecution('completed')]),
+      watchExecution: fakeWatch([EV, EV]),
+      waitForExecution: waitSpy,
+      renderer,
+      jsonMode: false,
+    });
+
+    expect(renderCount()).toBe(3); // initial + ev1 + terminal
+    expect(waitSpy).not.toHaveBeenCalled(); // never dropped to the fallback
+  });
+
+  it('degrades to the poll fallback when the SSE stream drops', async () => {
+    const { renderer, renderCount } = capturingRenderer();
+    const waitSpy = jest.fn(async () => ({ execution: makeExecution('completed'), reason: 'terminal' as const, done: true }));
+
+    await followExecution('exec-1', FAKE_CLIENT, NOOP_RENDER_OPTS, {
+      inspect: fakeInspect([makeExecution('running')]),
+      watchExecution: throwingWatch('sse handshake failed'),
+      waitForExecution: waitSpy,
+      renderer,
+      jsonMode: false,
+    });
+
+    expect(waitSpy).toHaveBeenCalledTimes(1);
+    expect(renderCount()).toBe(2); // initial + final from the fallback
+  });
+
+  it('keeps polling the fallback through timeouts until terminal', async () => {
+    const { renderer, renderCount } = capturingRenderer();
+    const results = [
+      { execution: makeExecution('running'), reason: 'timeout' as const, done: false },
+      { execution: makeExecution('completed'), reason: 'terminal' as const, done: true },
+    ];
+    let i = 0;
+    const waitSpy = jest.fn(async () => results[i++]);
+
+    await followExecution('exec-1', FAKE_CLIENT, NOOP_RENDER_OPTS, {
+      inspect: fakeInspect([makeExecution('running')]),
+      watchExecution: throwingWatch('drop'),
+      waitForExecution: waitSpy,
+      renderer,
+      jsonMode: false,
+    });
+
+    expect(waitSpy).toHaveBeenCalledTimes(2);
+    expect(renderCount()).toBe(3); // initial + timeout re-render + terminal
+  });
+
+  it('tears down cleanly on abort mid-stream without touching the fallback', async () => {
+    const { renderer, renderCount } = capturingRenderer();
+    const abort = new AbortController();
+    const waitSpy = jest.fn(async () => ({ execution: makeExecution('completed'), reason: 'terminal' as const, done: true }));
+
+    await followExecution('exec-1', FAKE_CLIENT, NOOP_RENDER_OPTS, {
+      inspect: fakeInspect([makeExecution('running'), makeExecution('running')]),
+      // ev1 processed; on the 2nd next() the caller aborts (Ctrl-C analogue)
+      watchExecution: fakeWatch([EV], { 2: () => abort.abort() }),
+      waitForExecution: waitSpy,
+      renderer,
+      jsonMode: false,
+      signal: abort.signal,
+    });
+
+    expect(waitSpy).not.toHaveBeenCalled(); // abort short-circuits before the fallback
+    expect(renderCount()).toBeGreaterThanOrEqual(2); // initial + at least the final
+    expect(process.listenerCount('SIGINT')).toBe(sigintBaseline()); // listener removed
+  });
+});
+
+// ── noEvents / waitForExecution contract (#4) ───────────────────────────────
+
+describe('noEvents drops waitForExecution to its poll loop', () => {
+  it('does NOT treat the immediately-done iterator as "run finished"', async () => {
+    // A client whose inspect read reports running first, then completed. If the
+    // empty iterator were mistaken for completion, wait would return on the first
+    // (running) read; instead it must poll and settle on the completed read.
+    const bodies = [makeExecution('running'), makeExecution('completed')];
+    let i = 0;
+    const client = {
+      get: async () => bodies[Math.min(i++, bodies.length - 1)],
+    } as unknown as GatewayClient;
+
+    const result = await waitForExecution(
+      {
+        executionId: 'exec-1',
+        maxWaitMs: 10_000,
+        watch: () => noEvents(),
+        sleep: async () => {
+          /* resolve immediately — no real delay in tests */
+        },
+        now: Date.now,
+      },
+      client,
+    );
+
+    expect(result.done).toBe(true);
+    expect(result.reason).toBe('terminal');
+    expect(result.execution.status).toBe('completed');
+    expect(i).toBeGreaterThanOrEqual(2); // polled at least twice (running → completed)
+  });
+});

--- a/packages/cli/src/commands/agents/logs.ts
+++ b/packages/cli/src/commands/agents/logs.ts
@@ -2,6 +2,9 @@ import {
   AgentOperationError,
   type ExecutionProjection,
   type GatewayClient,
+  type SseEvent,
+  type WaitForExecutionOptions,
+  type WaitForExecutionResult,
   inspect,
   inspectBuild,
   isExecutionTerminal,
@@ -69,11 +72,24 @@ const FOLLOW_POLL_WINDOW_MS = 10_000;
 
 /** An empty event source — passed to `waitForExecution` in the fallback so it
  *  skips SSE entirely and drops straight to its internal poll loop. */
-const noEvents = (): AsyncIterable<never> => ({
+export const noEvents = (): AsyncIterable<never> => ({
   [Symbol.asyncIterator]: () => ({
     next: async (): Promise<IteratorResult<never, undefined>> => ({ done: true, value: undefined }),
   }),
 });
+
+/** Injectable seams for {@link followExecution} — the networked calls and the
+ *  render sink. Production passes nothing; tests supply fakes to drive the
+ *  SSE → fallback → abort paths deterministically without a real gateway. */
+export interface FollowOverrides {
+  inspect?: (opts: { executionId: string }, client: GatewayClient) => Promise<ExecutionProjection>;
+  watchExecution?: (opts: { executionId: string; signal?: AbortSignal }, client: GatewayClient) => AsyncIterable<SseEvent>;
+  waitForExecution?: (opts: WaitForExecutionOptions, client: GatewayClient) => Promise<WaitForExecutionResult>;
+  renderer?: LiveRenderer;
+  jsonMode?: boolean;
+  /** An extra abort trigger in addition to Ctrl-C (tests drive teardown through this). */
+  signal?: AbortSignal;
+}
 
 /**
  * Stream an execution live: render once, then wake on each {@link watchExecution}
@@ -83,9 +99,17 @@ const noEvents = (): AsyncIterable<never> => ({
  * SSE handshake fails or the stream drops mid-run, it degrades to the
  * `waitForExecution` poll loop for the rest of the run — no functional regression.
  */
-async function followExecution(executionId: string, client: GatewayClient, renderOpts: RenderOptions): Promise<void> {
-  const jsonMode = isJsonMode();
-  const renderer = new LiveRenderer(Boolean(process.stdout.isTTY));
+export async function followExecution(
+  executionId: string,
+  client: GatewayClient,
+  renderOpts: RenderOptions,
+  overrides: FollowOverrides = {},
+): Promise<void> {
+  const inspectFn = overrides.inspect ?? inspect;
+  const watchFn = overrides.watchExecution ?? watchExecution;
+  const waitFn = overrides.waitForExecution ?? waitForExecution;
+  const jsonMode = overrides.jsonMode ?? isJsonMode();
+  const renderer = overrides.renderer ?? new LiveRenderer(Boolean(process.stdout.isTTY));
 
   const emit = (ex: ExecutionProjection, final: boolean): void => {
     // JSON is a machine contract: emit only the final, authoritative projection
@@ -97,7 +121,7 @@ async function followExecution(executionId: string, client: GatewayClient, rende
     }
   };
 
-  let ex = await inspect({ executionId }, client);
+  let ex = await inspectFn({ executionId }, client);
   if (isExecutionTerminal(ex.status)) {
     emit(ex, true);
     return;
@@ -106,22 +130,45 @@ async function followExecution(executionId: string, client: GatewayClient, rende
 
   const abort = new AbortController();
   let aborted = false;
-  const onSigint = (): void => {
+  const doAbort = (): void => {
     aborted = true;
     abort.abort();
   };
-  process.once('SIGINT', onSigint);
+  process.once('SIGINT', doAbort);
+  if (overrides.signal) {
+    if (overrides.signal.aborted) doAbort();
+    else overrides.signal.addEventListener('abort', doAbort, { once: true });
+  }
+
+  // A poll sleep that wakes immediately on Ctrl-C, and a clock that reads past
+  // the deadline once aborted — together these make `waitForExecution` in the
+  // fallback return promptly on abort (within one refetch) instead of blocking
+  // for the rest of a poll window.
+  const abortableSleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      if (abort.signal.aborted) return resolve();
+      const onAbort = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        abort.signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      abort.signal.addEventListener('abort', onAbort, { once: true });
+    });
+  const abortAwareNow = (): number => (aborted ? Number.MAX_SAFE_INTEGER : Date.now());
 
   try {
     // Primary path: wake on each SSE event, refetch, re-render. Manual iterator
     // (not for-await) so teardown is explicit — `events.return()` in the finally
     // aborts the underlying fetch even when we break early or throw.
-    const events = watchExecution({ executionId, signal: abort.signal }, client)[Symbol.asyncIterator]();
+    const events = watchFn({ executionId, signal: abort.signal }, client)[Symbol.asyncIterator]();
     try {
       for (;;) {
         const next = await events.next(); // resolves on each event (heartbeats filtered)
         if (next.done || aborted) break;
-        ex = await inspect({ executionId }, client);
+        ex = await inspectFn({ executionId }, client);
         if (isExecutionTerminal(ex.status)) {
           emit(ex, true);
           return;
@@ -139,56 +186,77 @@ async function followExecution(executionId: string, client: GatewayClient, rende
     }
 
     // Fallback: inherit `waitForExecution` poll + settle semantics, re-rendering
-    // each window. Stops on terminal or a pause that needs an external signal.
+    // each window. Stops on terminal, a pause that needs an external signal, or
+    // Ctrl-C (the abort-aware sleep/clock make the current window return at once).
     for (;;) {
-      const result = await waitForExecution(
-        { executionId, maxWaitMs: FOLLOW_POLL_WINDOW_MS, watch: () => noEvents() },
-        client,
-      );
-      ex = result.execution;
       if (aborted) {
         emit(ex, true);
         return;
       }
-      if (result.done || result.reason === 'needs-signal') {
+      const result = await waitFn(
+        { executionId, maxWaitMs: FOLLOW_POLL_WINDOW_MS, watch: () => noEvents(), sleep: abortableSleep, now: abortAwareNow },
+        client,
+      );
+      ex = result.execution;
+      if (aborted || result.done || result.reason === 'needs-signal') {
         emit(ex, true);
         return;
       }
       emit(ex, false); // reason === 'timeout' — still in flight, keep polling
     }
   } finally {
-    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGINT', doAbort);
+    overrides.signal?.removeEventListener('abort', doAbort);
     if (aborted) renderer.finish();
   }
 }
 
+/** Count code points — a good-enough display width for the CLI's charset (ASCII
+ *  plus width-1 box/status glyphs); avoids counting UTF-16 surrogate pairs
+ *  twice. Not full East-Asian-width aware, which the log content never needs. */
+function displayWidth(line: string): number {
+  return Array.from(line).length;
+}
+
 /**
  * Renders successive snapshots to stdout. In a TTY it clears the previous render
- * (cursor up + clear-to-end) so the tree updates in place; otherwise it appends
- * each snapshot separated by a blank line. Purely stdout side effects — the tree
- * formatting itself lives in the pure `render` module.
+ * and redraws in place; otherwise it appends each snapshot separated by a blank
+ * line. Purely stdout side effects — the tree formatting lives in the pure
+ * `render` module.
+ *
+ * In-place clearing counts PHYSICAL rows, not logical lines: a headline wider
+ * than the terminal wraps to multiple rows, so moving the cursor up by the line
+ * count would leave stale wrapped rows and corrupt the redraw on narrow
+ * terminals. `columns` is read fresh each render so a resize is (mostly) tolerated.
  */
-class LiveRenderer {
-  private lastLineCount = 0;
+export class LiveRenderer {
+  private lastRows = 0;
 
   constructor(
     private readonly tty: boolean,
     private readonly write: (s: string) => void = (s) => void process.stdout.write(s),
+    private readonly columns: () => number = () => process.stdout.columns || 80,
   ) {}
 
+  /** Physical rows a set of lines occupies at the given width (min 1 per line). */
+  private rowsFor(lines: string[], cols: number): number {
+    const width = cols > 0 ? cols : 80;
+    return lines.reduce((rows, line) => rows + Math.max(1, Math.ceil(displayWidth(line) / width)), 0);
+  }
+
   render(lines: string[]): void {
-    if (this.lastLineCount > 0) {
-      // Move up over the previous render and clear to end of screen (TTY), or
-      // separate successive snapshots with a blank line (non-TTY / piped).
-      if (this.tty) this.write(`\x1b[${this.lastLineCount}A\x1b[0J`);
+    if (this.lastRows > 0) {
+      // Move up over the previous render's physical rows and clear to end of
+      // screen (TTY), or separate successive snapshots with a blank line.
+      if (this.tty) this.write(`\x1b[${this.lastRows}A\x1b[0J`);
       else this.write('\n');
     }
     this.write(lines.join('\n') + '\n');
-    this.lastLineCount = lines.length;
+    this.lastRows = this.tty ? this.rowsFor(lines, this.columns()) : lines.length;
   }
 
   /** Leave the cursor on a fresh line after an interrupted (Ctrl-C) follow. */
   finish(): void {
-    if (this.tty && this.lastLineCount > 0) this.write('\n');
+    if (this.tty && this.lastRows > 0) this.write('\n');
   }
 }

--- a/packages/cli/src/commands/agents/logs.ts
+++ b/packages/cli/src/commands/agents/logs.ts
@@ -1,19 +1,33 @@
-import { inspect, inspectBuild, listExecutions, AgentOperationError } from '@sapiom/agent-core';
+import {
+  AgentOperationError,
+  type ExecutionProjection,
+  type GatewayClient,
+  inspect,
+  inspectBuild,
+  isExecutionTerminal,
+  listExecutions,
+  waitForExecution,
+  watchExecution,
+} from '@sapiom/agent-core';
 
 import { type CliTarget, makeClient } from '../../lib/client.js';
 import { readConfig, requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
+import { renderExecutionList, renderExecutionTree, type RenderOptions } from './render.js';
 
 /**
- * `sapiom agents logs [executionId]` — inspect an execution (its steps
- * and errors), a build (`--build`), or recent executions (no argument).
+ * `sapiom agents logs [executionId]` — inspect an execution (its steps, child
+ * runs, and per-node cost), a build (`--build`), or recent executions (no
+ * argument). With `--follow` / `--watch` an execution streams live and
+ * re-renders on every change until it reaches a terminal status.
  */
 export async function runLogs(
   executionId: string | undefined,
-  opts: { build?: string; host?: string; target?: CliTarget },
+  opts: { build?: string; host?: string; target?: CliTarget; follow?: boolean; watch?: boolean; verbose?: boolean },
 ): Promise<void> {
   try {
     const dir = process.cwd();
+    const renderOpts: RenderOptions = { verbose: Boolean(opts.verbose) };
 
     if (opts.build) {
       const cfg = requireConfig(dir);
@@ -30,23 +44,151 @@ export async function runLogs(
     if (!executionId) {
       const executions = await listExecutions(client);
       if (isJsonMode()) ok({ executions });
-      else ok({}, executions.map((e) => `${e.executionId}  ${e.status}  ${e.name}`));
+      else ok({}, renderExecutionList(executions));
+      return;
+    }
+
+    if (opts.follow || opts.watch) {
+      await followExecution(executionId, client, renderOpts);
       return;
     }
 
     const ex = await inspect({ executionId }, client);
-    if (isJsonMode()) {
-      ok({ execution: ex });
-      return;
-    }
-    const lines = [`execution ${ex.id}: ${ex.status}${ex.currentStep ? ` (at ${ex.currentStep})` : ''}`];
-    for (const step of ex.steps) {
-      lines.push(`  ${step.status === 'failed' ? '✗' : '·'} ${step.stepName} #${step.attempt} — ${step.status}`);
-      if (step.error?.message) lines.push(`      ${step.error.message}`);
-    }
-    ok({}, lines);
+    if (isJsonMode()) ok({ execution: ex });
+    else ok({}, renderExecutionTree(ex, renderOpts));
   } catch (err) {
     if (err instanceof AgentOperationError) throw new CliError(err.toStructured());
     throw err;
+  }
+}
+
+/** Re-render window in the SSE-drop poll fallback (ms). Bounds how often the
+ *  fallback re-reads and re-renders; each chunk inherits `waitForExecution`'s
+ *  poll + settle semantics (incl. auto-resume pause handling). */
+const FOLLOW_POLL_WINDOW_MS = 10_000;
+
+/** An empty event source — passed to `waitForExecution` in the fallback so it
+ *  skips SSE entirely and drops straight to its internal poll loop. */
+const noEvents = (): AsyncIterable<never> => ({
+  [Symbol.asyncIterator]: () => ({
+    next: async (): Promise<IteratorResult<never, undefined>> => ({ done: true, value: undefined }),
+  }),
+});
+
+/**
+ * Stream an execution live: render once, then wake on each {@link watchExecution}
+ * SSE event, refetch the canonical projection, and re-render until the run
+ * reaches a terminal status. In a TTY the tree is redrawn in place; otherwise
+ * each snapshot is appended. Ctrl-C aborts the stream and returns cleanly. If the
+ * SSE handshake fails or the stream drops mid-run, it degrades to the
+ * `waitForExecution` poll loop for the rest of the run — no functional regression.
+ */
+async function followExecution(executionId: string, client: GatewayClient, renderOpts: RenderOptions): Promise<void> {
+  const jsonMode = isJsonMode();
+  const renderer = new LiveRenderer(Boolean(process.stdout.isTTY));
+
+  const emit = (ex: ExecutionProjection, final: boolean): void => {
+    // JSON is a machine contract: emit only the final, authoritative projection
+    // once (avoids ambiguous concatenated JSON). Humans get every live frame.
+    if (jsonMode) {
+      if (final) ok({ execution: ex });
+    } else {
+      renderer.render(renderExecutionTree(ex, renderOpts));
+    }
+  };
+
+  let ex = await inspect({ executionId }, client);
+  if (isExecutionTerminal(ex.status)) {
+    emit(ex, true);
+    return;
+  }
+  emit(ex, false);
+
+  const abort = new AbortController();
+  let aborted = false;
+  const onSigint = (): void => {
+    aborted = true;
+    abort.abort();
+  };
+  process.once('SIGINT', onSigint);
+
+  try {
+    // Primary path: wake on each SSE event, refetch, re-render. Manual iterator
+    // (not for-await) so teardown is explicit — `events.return()` in the finally
+    // aborts the underlying fetch even when we break early or throw.
+    const events = watchExecution({ executionId, signal: abort.signal }, client)[Symbol.asyncIterator]();
+    try {
+      for (;;) {
+        const next = await events.next(); // resolves on each event (heartbeats filtered)
+        if (next.done || aborted) break;
+        ex = await inspect({ executionId }, client);
+        if (isExecutionTerminal(ex.status)) {
+          emit(ex, true);
+          return;
+        }
+        emit(ex, false);
+      }
+    } catch {
+      // SSE unavailable / dropped — fall through to the poll fallback below.
+    } finally {
+      await events.return?.(undefined);
+    }
+    if (aborted) {
+      emit(ex, true);
+      return;
+    }
+
+    // Fallback: inherit `waitForExecution` poll + settle semantics, re-rendering
+    // each window. Stops on terminal or a pause that needs an external signal.
+    for (;;) {
+      const result = await waitForExecution(
+        { executionId, maxWaitMs: FOLLOW_POLL_WINDOW_MS, watch: () => noEvents() },
+        client,
+      );
+      ex = result.execution;
+      if (aborted) {
+        emit(ex, true);
+        return;
+      }
+      if (result.done || result.reason === 'needs-signal') {
+        emit(ex, true);
+        return;
+      }
+      emit(ex, false); // reason === 'timeout' — still in flight, keep polling
+    }
+  } finally {
+    process.removeListener('SIGINT', onSigint);
+    if (aborted) renderer.finish();
+  }
+}
+
+/**
+ * Renders successive snapshots to stdout. In a TTY it clears the previous render
+ * (cursor up + clear-to-end) so the tree updates in place; otherwise it appends
+ * each snapshot separated by a blank line. Purely stdout side effects — the tree
+ * formatting itself lives in the pure `render` module.
+ */
+class LiveRenderer {
+  private lastLineCount = 0;
+
+  constructor(
+    private readonly tty: boolean,
+    private readonly write: (s: string) => void = (s) => void process.stdout.write(s),
+  ) {}
+
+  render(lines: string[]): void {
+    if (this.lastLineCount > 0) {
+      // Move up over the previous render and clear to end of screen (TTY), or
+      // separate successive snapshots with a blank line (non-TTY / piped).
+      if (this.tty) this.write(`\x1b[${this.lastLineCount}A\x1b[0J`);
+      else this.write('\n');
+    }
+    this.write(lines.join('\n') + '\n');
+    this.lastLineCount = lines.length;
+  }
+
+  /** Leave the cursor on a fresh line after an interrupted (Ctrl-C) follow. */
+  finish(): void {
+    if (this.tty && this.lastLineCount > 0) this.write('\n');
   }
 }

--- a/packages/cli/src/commands/agents/render.test.ts
+++ b/packages/cli/src/commands/agents/render.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the pure `render` module: the execution tree, the tree-aware
+ * list, and the cost formatter. These lock in the two load-bearing contracts —
+ * captured/authorized cost is never collapsed, and a null cost is honest absence
+ * (never a fabricated `$0`) — plus the tree shape (steps, nested child runs,
+ * orphan child edges) and list grouping by `traceRoot`.
+ */
+import type { CostNode, ExecutionProjection, ExecutionRef, StepProjection } from '@sapiom/agent-core';
+
+import { formatCost, renderExecutionList, renderExecutionTree } from './render.js';
+
+function makeStep(partial: Partial<StepProjection> = {}): StepProjection {
+  return {
+    stepName: 'step',
+    stepOrder: 0,
+    attempt: 1,
+    status: 'succeeded',
+    spanId: null,
+    startedAt: null,
+    finishedAt: null,
+    input: null,
+    output: null,
+    sharedStateAfter: null,
+    nextDirective: null,
+    cost: null,
+    logs: null,
+    events: [],
+    error: null,
+    dispatch: null,
+    ...partial,
+  };
+}
+
+function makeExecution(partial: Partial<ExecutionProjection> = {}): ExecutionProjection {
+  return {
+    id: 'exec-1',
+    name: 'run',
+    organizationId: null,
+    tenantId: null,
+    status: 'running',
+    currentStep: null,
+    currentStepAttempt: 1,
+    version: 1,
+    definitionId: null,
+    buildRunId: null,
+    idempotencyKey: null,
+    pausedSignalName: null,
+    pausedSignalCorrelationId: null,
+    pausedUntil: null,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    finishedAt: null,
+    input: null,
+    sharedState: {},
+    output: null,
+    error: null,
+    pausedStepInputSchema: null,
+    pausedStepInputExample: null,
+    traceRoot: 'exec-1',
+    rootExecutionId: 'exec-1',
+    traceParent: null,
+    parentExecutionId: null,
+    traceId: null,
+    children: [],
+    cost: null,
+    steps: [],
+    ...partial,
+  };
+}
+
+function makeRef(partial: Partial<ExecutionRef> = {}): ExecutionRef {
+  return { executionId: 'ref-1', traceRoot: 'ref-1', name: '', status: 'running', ...partial };
+}
+
+const cost = (
+  captured: string,
+  authorized: string,
+  settleState: CostNode['settleState'] = 'final',
+): CostNode => ({ capturedUsd: captured, authorizedUsd: authorized, settleState });
+
+describe('formatCost', () => {
+  it('returns null on honest absence — never a fabricated $0', () => {
+    expect(formatCost(null)).toBeNull();
+  });
+
+  it('keeps captured and authorized separate (never collapsed)', () => {
+    expect(formatCost(cost('0.42', '1.00'))).toBe('$0.42 captured · ≤ $1.00 auth');
+  });
+
+  it('shows a present zero cost (known zero, not absence)', () => {
+    expect(formatCost(cost('0', '0'))).toBe('$0 captured · ≤ $0 auth');
+  });
+
+  it('appends a settlement affordance while settling', () => {
+    expect(formatCost(cost('0.10', '0.50', 'settling'))).toBe('$0.10 captured · ≤ $0.50 auth · settling…');
+  });
+
+  it('appends a pending affordance for an estimate-only node', () => {
+    expect(formatCost(cost('0', '0.50', 'pending'))).toBe('$0 captured · ≤ $0.50 auth · pending');
+  });
+});
+
+describe('renderExecutionTree', () => {
+  it('renders the run as the root with per-node cost and each step as a branch', () => {
+    const ex = makeExecution({
+      id: 'exec-1',
+      status: 'running',
+      currentStep: 'generate',
+      cost: cost('0.42', '1.00', 'settling'),
+      steps: [
+        makeStep({ stepName: 'plan', attempt: 1, status: 'succeeded', cost: cost('0.01', '0.01') }),
+        makeStep({
+          stepName: 'generate',
+          stepOrder: 1,
+          attempt: 2,
+          status: 'running',
+          cost: cost('0.41', '0.99', 'settling'),
+        }),
+      ],
+    });
+
+    expect(renderExecutionTree(ex)).toEqual([
+      '● exec-1 — running (at generate)   $0.42 captured · ≤ $1.00 auth · settling…',
+      '├─ ✓ plan #1 — succeeded   $0.01 captured · ≤ $0.01 auth',
+      '└─ ▶ generate #2 — running   $0.41 captured · ≤ $0.99 auth · settling…',
+    ]);
+  });
+
+  it('omits cost entirely when a node has none (honest absence)', () => {
+    const ex = makeExecution({ steps: [makeStep({ stepName: 'plan', cost: null })] });
+    const lines = renderExecutionTree(ex);
+    expect(lines[0]).toBe('● exec-1 — running');
+    expect(lines[1]).toBe('└─ ✓ plan #1 — succeeded');
+    expect(lines.join('\n')).not.toContain('$');
+  });
+
+  it('shows a failed step error and nests its dispatched child run', () => {
+    const ex = makeExecution({
+      steps: [
+        makeStep({
+          stepName: 'boom',
+          status: 'failed',
+          error: { message: 'kaboom', trace: null, traceUnavailableReason: null },
+        }),
+        makeStep({
+          stepName: 'dispatch',
+          stepOrder: 1,
+          status: 'running',
+          dispatch: { childExecutionId: 'child-9', targetType: 'agent', correlationId: 'corr-1', status: 'pending' },
+        }),
+      ],
+      children: [makeRef({ executionId: 'child-9', traceRoot: 'exec-1', name: 'deploy-preview', status: 'running' })],
+    });
+
+    expect(renderExecutionTree(ex)).toEqual([
+      '● exec-1 — running',
+      '├─ ✗ boom #1 — failed',
+      '│  ↳ error: kaboom',
+      '└─ ▶ dispatch #1 — running',
+      '   └─ ▶ child-9 — running (deploy-preview)',
+    ]);
+  });
+
+  it('appends child edges not reached via a step dispatch rather than dropping them', () => {
+    const ex = makeExecution({
+      steps: [makeStep({ stepName: 'plan' })],
+      children: [makeRef({ executionId: 'orphan-1', traceRoot: 'exec-1', name: 'sub', status: 'completed' })],
+    });
+
+    expect(renderExecutionTree(ex)).toEqual([
+      '● exec-1 — running',
+      '├─ ✓ plan #1 — succeeded',
+      '└─ ✓ orphan-1 — completed (sub)',
+    ]);
+  });
+
+  it('adds timings and dispatch details in verbose mode', () => {
+    const ex = makeExecution({
+      steps: [
+        makeStep({
+          stepName: 'gen',
+          status: 'running',
+          startedAt: '2026-01-01T00:00:01.000Z',
+          finishedAt: null,
+          dispatch: { childExecutionId: 'c1', targetType: 'agent', correlationId: 'corr-x', status: 'pending' },
+        }),
+      ],
+      children: [],
+    });
+
+    const lines = renderExecutionTree(ex, { verbose: true });
+    expect(lines.some((l) => l.includes('↳ 2026-01-01T00:00:01.000Z → (running)'))).toBe(true);
+    expect(lines.some((l) => l.includes('↳ dispatch agent · corr corr-x (pending)'))).toBe(true);
+  });
+});
+
+describe('renderExecutionList', () => {
+  it('renders an honest empty marker for no executions', () => {
+    expect(renderExecutionList([])).toEqual(['(no executions)']);
+  });
+
+  it('renders standalone rows (traceRoot === own id) as top-level runs', () => {
+    const refs = [
+      makeRef({ executionId: 'a', traceRoot: 'a', name: 'first', status: 'completed' }),
+      makeRef({ executionId: 'b', traceRoot: 'b', name: '', status: 'running' }),
+    ];
+    expect(renderExecutionList(refs)).toEqual(['✓ a — completed (first)', '▶ b — running']);
+  });
+
+  it('groups a dispatch tree under its root, nesting children by traceRoot', () => {
+    const refs = [
+      makeRef({ executionId: 'root', traceRoot: 'root', name: 'parent', status: 'running' }),
+      makeRef({ executionId: 'kid', traceRoot: 'root', name: 'child', status: 'completed' }),
+    ];
+    expect(renderExecutionList(refs)).toEqual(['▶ root — running (parent)', '└─ ✓ kid — completed (child)']);
+  });
+
+  it('synthesizes a root when only children reference a traceRoot', () => {
+    const refs = [makeRef({ executionId: 'kid', traceRoot: 'ghost-root', name: 'child', status: 'running' })];
+    expect(renderExecutionList(refs)).toEqual(['· ghost-root — (root)', '└─ ▶ kid — running (child)']);
+  });
+});

--- a/packages/cli/src/commands/agents/render.ts
+++ b/packages/cli/src/commands/agents/render.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure renderers for the `sapiom agents logs` human output: an
+ * {@link ExecutionProjection} as a tree (steps + dispatched child runs, per-node
+ * cost) and a `listExecutions()` result as a tree-aware {@link ExecutionRef}
+ * grouping. Pure and deterministic — no I/O, no clock — so the same functions
+ * drive the one-shot render and the `--follow` re-render, and are snapshot-tested
+ * directly.
+ *
+ * Two contracts are load-bearing here and match the SDK projection semantics:
+ *   - Cost NEVER collapses `capturedUsd` (settled) and `authorizedUsd` (the
+ *     hold / ceiling) into a single number — both are always shown side by side.
+ *   - A `null` cost is honest absence (the execution-detail read is cost-agnostic
+ *     today) and renders as NOTHING — never a fabricated `$0`. A present cost of
+ *     `"0"` is a known zero and IS shown.
+ */
+import type { CostNode, DispatchRef, ExecutionProjection, ExecutionRef, StepProjection } from '@sapiom/agent-core';
+
+/** Render toggles. Compact (default) shows one line per node plus any error;
+ *  verbose adds timings and dispatch details. */
+export interface RenderOptions {
+  verbose?: boolean;
+}
+
+/**
+ * Status → glyph, folding the real engine vocabulary the projection carries
+ * (`succeeded`/`threw` from the agents surface) plus the earlier
+ * `completed`/`failed`/`cancelled` values. Anything not yet running/passed/failed
+ * (queued, unknown, pending) is the neutral `·` — mirrors the harness renderer's
+ * status fold so the CLI and canvas never disagree on what a status means.
+ */
+function statusGlyph(status: string): string {
+  if (status === 'succeeded' || status === 'completed') return '✓';
+  if (status === 'failed' || status === 'threw' || status === 'cancelled' || status === 'canceled') return '✗';
+  if (status === 'running') return '▶';
+  return '·';
+}
+
+/**
+ * Format a per-node cost, keeping captured and authorized separate (never
+ * collapsed) and appending a settlement affordance while a node is still
+ * settling. Returns `null` for honest absence (a null cost) so callers append
+ * nothing — never a fabricated `$0`.
+ */
+export function formatCost(cost: CostNode | null): string | null {
+  if (!cost) return null;
+  const settle =
+    cost.settleState === 'settling' ? ' · settling…' : cost.settleState === 'pending' ? ' · pending' : '';
+  return `$${cost.capturedUsd} captured · ≤ $${cost.authorizedUsd} auth${settle}`;
+}
+
+/** Append a formatted cost to a headline, or leave it untouched on honest absence. */
+function withCost(base: string, cost: CostNode | null): string {
+  const c = formatCost(cost);
+  return c ? `${base}   ${c}` : base;
+}
+
+/** A node in the render tree: a headline, optional detail sub-lines (error,
+ *  timings), and nested children (dispatched child runs). */
+interface TreeNode {
+  headline: string;
+  sublines: string[];
+  children: TreeNode[];
+}
+
+/**
+ * Emit `children` under `prefix` with box-drawing connectors, recursing into
+ * each node's own children. The last child uses `└─` (and blank continuation);
+ * every other uses `├─` (and a `│` continuation) so vertical guides line up.
+ */
+function pushChildren(children: TreeNode[], prefix: string, lines: string[]): void {
+  children.forEach((child, i) => {
+    const last = i === children.length - 1;
+    const branch = last ? '└─ ' : '├─ ';
+    const cont = last ? '   ' : '│  ';
+    lines.push(prefix + branch + child.headline);
+    for (const sub of child.sublines) lines.push(prefix + cont + sub);
+    pushChildren(child.children, prefix + cont, lines);
+  });
+}
+
+/** Headline for a step-attempt node. */
+function stepHeadline(step: StepProjection): string {
+  const base = `${statusGlyph(step.status)} ${step.stepName} #${step.attempt} — ${step.status}`;
+  return withCost(base, step.cost);
+}
+
+/** Detail sub-lines for a step: its error (always) and, when verbose, timings
+ *  and the dispatch edge. Cost/settleState already ride on the headline. */
+function stepSublines(step: StepProjection, opts: RenderOptions): string[] {
+  const out: string[] = [];
+  if (step.error?.message) out.push(`↳ error: ${step.error.message}`);
+  if (opts.verbose) {
+    if (step.startedAt) {
+      out.push(`↳ ${step.startedAt} → ${step.finishedAt ?? '(running)'}`);
+    }
+    if (step.dispatch) {
+      out.push(`↳ dispatch ${step.dispatch.targetType} · corr ${step.dispatch.correlationId} (${step.dispatch.status})`);
+    }
+    if (step.error && !step.error.trace && step.error.traceUnavailableReason) {
+      out.push(`↳ trace: ${step.error.traceUnavailableReason}`);
+    }
+  }
+  return out;
+}
+
+/** Leaf node for a dispatched child run. Prefers the typed {@link ExecutionRef}
+ *  edge (carries name + status); falls back to the {@link DispatchRef} when the
+ *  child edge is absent, degrading honestly rather than fabricating a name. */
+function childNode(ref: ExecutionRef | undefined, dispatch: DispatchRef): TreeNode {
+  if (ref) {
+    const name = ref.name ? ` (${ref.name})` : '';
+    return {
+      headline: `${statusGlyph(ref.status)} ${ref.executionId} — ${ref.status}${name}`,
+      sublines: [],
+      children: [],
+    };
+  }
+  return {
+    headline: `${statusGlyph(dispatch.status)} ${dispatch.childExecutionId} — ${dispatch.status} (${dispatch.targetType})`,
+    sublines: [],
+    children: [],
+  };
+}
+
+/** Leaf node for an {@link ExecutionRef} (a child edge or a list row). */
+function refNode(ref: ExecutionRef): TreeNode {
+  const name = ref.name ? ` (${ref.name})` : '';
+  return {
+    headline: `${statusGlyph(ref.status)} ${ref.executionId} — ${ref.status}${name}`,
+    sublines: [],
+    children: [],
+  };
+}
+
+/**
+ * Render one {@link ExecutionProjection} as a tree: the run as the root, its
+ * steps as branches (ordered as the projection delivers them), and each step's
+ * dispatched child run nested beneath it. Any child edge in `children` not
+ * reached through a step's dispatch is appended under the run so no child is
+ * ever silently dropped. Per-node cost rides on every headline that has one.
+ */
+export function renderExecutionTree(ex: ExecutionProjection, opts: RenderOptions = {}): string[] {
+  const root = withCost(`● ${ex.id} — ${ex.status}${ex.currentStep ? ` (at ${ex.currentStep})` : ''}`, ex.cost);
+  const lines = [root];
+
+  const shownChildIds = new Set<string>();
+  const stepNodes: TreeNode[] = ex.steps.map((step) => {
+    const node: TreeNode = { headline: stepHeadline(step), sublines: stepSublines(step, opts), children: [] };
+    if (step.dispatch) {
+      const ref = ex.children.find((c) => c.executionId === step.dispatch!.childExecutionId);
+      node.children.push(childNode(ref, step.dispatch));
+      shownChildIds.add(step.dispatch.childExecutionId);
+    }
+    return node;
+  });
+
+  // Child edges not reached via a step dispatch (e.g. dispatch not yet populated)
+  // still belong to the tree — append them under the run rather than lose them.
+  const orphans = ex.children.filter((c) => !shownChildIds.has(c.executionId)).map(refNode);
+
+  pushChildren([...stepNodes, ...orphans], '', lines);
+  return lines;
+}
+
+/**
+ * Render a `listExecutions()` result as a tree-aware view: rows are grouped by
+ * `traceRoot` (first-seen order preserved) so a dispatch tree renders as a root
+ * with its children nested. Per the SDK's documented server-side gap most list
+ * rows degrade `traceRoot` to their own id, so they render as standalone
+ * top-level runs — honest, not a fabricated hierarchy.
+ */
+export function renderExecutionList(refs: ExecutionRef[]): string[] {
+  if (refs.length === 0) return ['(no executions)'];
+
+  const order: string[] = [];
+  const groups = new Map<string, ExecutionRef[]>();
+  for (const r of refs) {
+    const root = r.traceRoot || r.executionId;
+    if (!groups.has(root)) {
+      groups.set(root, []);
+      order.push(root);
+    }
+    groups.get(root)!.push(r);
+  }
+
+  const lines: string[] = [];
+  for (const rootId of order) {
+    const group = groups.get(rootId)!;
+    const rootRef = group.find((r) => r.executionId === rootId);
+    const children = group.filter((r) => r.executionId !== rootId);
+    lines.push(rootRef ? refNode(rootRef).headline : `· ${rootId} — (root)`);
+    pushChildren(children.map(refNode), '', lines);
+  }
+  return lines;
+}


### PR DESCRIPTION
## Summary

Makes `sapiom agents logs` reflect the same tree + cost + live state as the UI, closing out the CLI leg of the S5 SDK inspection-parity epic. Renders the `ExecutionProjection` as a tree with per-node cost (replacing the old flat lines) and adds a `--follow`/`--watch` mode that streams live via `watchExecution()`.

> **Note on ticket paths:** SAP-1343 references `orchestrations/logs.ts` and `@sapiom/orchestration-core`. The merged work from siblings SAP-1341/1342 actually lives at `packages/cli/src/commands/agents/logs.ts` importing from `@sapiom/agent-core` — this PR implements against the real command surface.

## What changed

- **Tree + cost render** (`render.ts`, pure/snapshot-tested):
  - `agents logs <id>` renders the run as the root, steps as branches, and each step's dispatched child run nested beneath it. Child edges not reached via a step dispatch are still appended (never silently dropped).
  - Per-node cost shows `capturedUsd` (primary) and `authorizedUsd` (ceiling) side by side — **never collapsed** — with a `settling…`/`pending` affordance. A `null` cost renders as nothing (honest absence, never a fabricated `$0`); a present `"0"` is shown as a known zero.
  - `agents logs` (no argument) renders recent executions tree-aware, grouped by `traceRoot` (degrading honestly to standalone rows per the SDK's documented server-side gap).
- **`--follow` / `--watch` live mode** (`logs.ts`): consumes the `watchExecution()` SSE async-iterator, refetches `inspect()` on each event, and re-renders (in place on a TTY, appended otherwise) until terminal. Ctrl-C aborts the stream and returns cleanly; an SSE handshake failure or mid-run drop degrades to the `waitForExecution` poll loop for the rest of the run.
- **`--verbose`** adds step timings and dispatch details.

## Acceptance criteria

- [x] `agents logs <id>` renders the run as a tree with per-node captured/authorized cost.
- [x] `agents logs` (no arg) lists executions tree-aware.
- [x] `agents logs <id> --follow` streams live and re-renders until terminal.
- [x] Clean teardown on Ctrl-C / stream end; graceful degradation on SSE drop.
- [x] No internal hostnames/customer data in help text or examples (public repo).

## Testing

- New `render.test.ts` (11 cases): tree shape, nested child runs, orphan child edges, list grouping by `traceRoot`, cost never-collapse, honest absence, and settle/pending affordances.
- `pnpm build && pnpm typecheck && pnpm lint && pnpm test` all green across the workspace (83 CLI tests pass).

Closes SAP-1343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)