### PR TITLE
feat(harness): add /api/runs/local NDJSON run-local route (SAP-1774)

### DIFF
--- a/.changeset/harness-run-local-ndjson-route.md
+++ b/.changeset/harness-run-local-ndjson-route.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add `POST /api/runs/local`: run an agent entirely offline against stub capabilities and stream the result back as NDJSON — one per-step trace line, then a terminal summary carrying the run outcome plus which supplied stub keys went unused or had the wrong shape. It runs in a child process, needs no sign-in, and makes no network call, so a local run works signed-out and at zero cost.

--- a/packages/harness/src/core/run-local-bootstrap.test.ts
+++ b/packages/harness/src/core/run-local-bootstrap.test.ts
@@ -1,0 +1,194 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The bootstrap runs a workflow via @sapiom/agent-core's runLocalFromDir; mock
+// it so these unit tests exercise the NDJSON framing + error handling without
+// esbuild-bundling a real project or spawning anything. `vi.hoisted` lets the
+// mock fn be referenced inside the (hoisted) vi.mock factory.
+const { runLocalFromDir } = vi.hoisted(() => ({ runLocalFromDir: vi.fn() }));
+vi.mock("@sapiom/agent-core", () => ({ runLocalFromDir }));
+
+import {
+  parseRunLocalRequest,
+  runBootstrap,
+  type RunLocalSummaryLine,
+} from "./run-local-bootstrap.js";
+
+/** Collect everything written to a sink stream as decoded NDJSON objects. */
+function collect(): {
+  sink: PassThrough;
+  lines: () => Array<Record<string, unknown>>;
+} {
+  const sink = new PassThrough();
+  const chunks: Buffer[] = [];
+  sink.on("data", (c: Buffer) => chunks.push(Buffer.from(c)));
+  return {
+    sink,
+    lines: () =>
+      Buffer.concat(chunks)
+        .toString("utf8")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Record<string, unknown>),
+  };
+}
+
+afterEach(() => {
+  runLocalFromDir.mockReset();
+});
+
+describe("parseRunLocalRequest", () => {
+  it("parses a full request, coercing a non-number maxAttemptsPerStep away", () => {
+    const req = parseRunLocalRequest(
+      JSON.stringify({
+        sourceDir: "/proj/agent",
+        input: { name: "x" },
+        stubs: { version: 1, steps: {} },
+        maxAttemptsPerStep: "3", // wrong type — dropped
+      }),
+    );
+    expect(req).toEqual({
+      sourceDir: "/proj/agent",
+      input: { name: "x" },
+      stubs: { version: 1, steps: {} },
+      maxAttemptsPerStep: undefined,
+    });
+  });
+
+  it("keeps a numeric maxAttemptsPerStep", () => {
+    const req = parseRunLocalRequest(
+      JSON.stringify({ sourceDir: "/proj/agent", maxAttemptsPerStep: 5 }),
+    );
+    expect(req.maxAttemptsPerStep).toBe(5);
+  });
+
+  it("throws a caller-safe error on non-JSON input", () => {
+    expect(() => parseRunLocalRequest("not json")).toThrow(
+      "run-local request is not valid JSON",
+    );
+  });
+
+  it("throws when the payload is not an object", () => {
+    expect(() => parseRunLocalRequest("42")).toThrow(
+      "run-local request must be a JSON object",
+    );
+    expect(() => parseRunLocalRequest("null")).toThrow(
+      "run-local request must be a JSON object",
+    );
+  });
+
+  it("throws when sourceDir is missing or blank", () => {
+    expect(() => parseRunLocalRequest(JSON.stringify({}))).toThrow(
+      "requires a non-empty sourceDir",
+    );
+    expect(() =>
+      parseRunLocalRequest(JSON.stringify({ sourceDir: "   " })),
+    ).toThrow("requires a non-empty sourceDir");
+  });
+});
+
+describe("runBootstrap", () => {
+  it("streams one line per step then a terminal summary, exit 0", async () => {
+    runLocalFromDir.mockResolvedValue({
+      outcome: "completed",
+      executionId: "exec_1",
+      output: { greeting: "hi" },
+      error: undefined,
+      steps: [
+        {
+          step: "greet",
+          attempt: 0,
+          input: { name: "x" },
+          status: "succeeded",
+          output: { greeting: "hi" },
+          logs: [],
+        },
+      ],
+      unusedStubs: [{ step: "greet", key: "web.search" }],
+      stubWarnings: ["greet: models.coding.run stub had the wrong shape"],
+    });
+
+    const { sink, lines } = collect();
+    const code = await runBootstrap({ sourceDir: "/proj/agent" }, sink);
+
+    expect(code).toBe(0);
+    const out = lines();
+    // First line is the step trace, forwarded verbatim.
+    expect(out[0]).toMatchObject({ step: "greet", status: "succeeded" });
+    // Terminal summary carries the run outcome + both stub-hygiene signals.
+    const summary = out[1] as unknown as RunLocalSummaryLine;
+    expect(summary.kind).toBe("summary");
+    expect(summary.outcome).toBe("completed");
+    expect(summary.unusedStubs).toEqual([{ step: "greet", key: "web.search" }]);
+    expect(summary.stubWarnings).toEqual([
+      "greet: models.coding.run stub had the wrong shape",
+    ]);
+  });
+
+  it("surfaces unusedStubs/stubWarnings even for a failed run (still exit 0)", async () => {
+    runLocalFromDir.mockResolvedValue({
+      outcome: "failed",
+      executionId: "exec_2",
+      error: { message: "step threw" },
+      steps: [],
+      unusedStubs: [{ step: "a", key: "b" }],
+      stubWarnings: ["w"],
+    });
+
+    const { sink, lines } = collect();
+    const code = await runBootstrap({ sourceDir: "/proj/agent" }, sink);
+
+    // A failed *run* is a successful *invocation* — exit 0, summary in-band.
+    expect(code).toBe(0);
+    const out = lines();
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      kind: "summary",
+      outcome: "failed",
+      unusedStubs: [{ step: "a", key: "b" }],
+      stubWarnings: ["w"],
+    });
+  });
+
+  it("emits a terminal error line and exit 1 when the run cannot be invoked", async () => {
+    runLocalFromDir.mockRejectedValue(new Error("No index.ts found in /proj."));
+
+    const { sink, lines } = collect();
+    const code = await runBootstrap({ sourceDir: "/proj" }, sink);
+
+    expect(code).toBe(1);
+    const out = lines();
+    expect(out).toEqual([
+      { kind: "error", outcome: "failed", error: "No index.ts found in /proj." },
+    ]);
+  });
+
+  it("forwards input/stubs/maxAttemptsPerStep through to runLocalFromDir", async () => {
+    runLocalFromDir.mockResolvedValue({
+      outcome: "completed",
+      executionId: "e",
+      steps: [],
+      unusedStubs: [],
+      stubWarnings: [],
+    });
+
+    const { sink } = collect();
+    await runBootstrap(
+      {
+        sourceDir: "/proj/agent",
+        input: { a: 1 },
+        stubs: { version: 1, steps: {} },
+        maxAttemptsPerStep: 2,
+      },
+      sink,
+    );
+
+    expect(runLocalFromDir).toHaveBeenCalledWith({
+      sourceDir: "/proj/agent",
+      input: { a: 1 },
+      stubs: { version: 1, steps: {} },
+      maxAttemptsPerStep: 2,
+    });
+  });
+});

--- a/packages/harness/src/core/run-local-bootstrap.ts
+++ b/packages/harness/src/core/run-local-bootstrap.ts
@@ -1,0 +1,214 @@
+/**
+ * run-local bootstrap — the child-process entrypoint behind
+ * `POST /api/runs/local`.
+ *
+ * It runs an agent entirely in-process against stub capabilities
+ * (`runLocalFromDir` from @sapiom/agent-core) and writes the result as an
+ * NDJSON stream to stdout: one line per {@link LocalStepTrace}, then a single
+ * terminal summary line `{ outcome, output, error, unusedStubs, stubWarnings }`.
+ * Fully offline and zero-cost — run-local resolves every `ctx.sapiom.*` call
+ * from stubs and never touches the network.
+ *
+ * Why a separate child process (not an in-process import):
+ *  1. `runLocalFromDir` esbuild-bundles and dynamically `import()`s a workflow
+ *     project the harness doesn't control, so a stray top-level side effect,
+ *     infinite loop, or crash in someone else's step body is bounded to this
+ *     one child instead of taking the long-lived harness server down.
+ *  2. It sidesteps a Vite/Vitest limitation: the dynamic `import(\`file://…\`)`
+ *     inside the loader gets intercepted by the SSR dynamic-import-vars
+ *     transform when pulled into a Vitest module graph, and mishandles the
+ *     tmpdir `file://` URL on darwin. A plain child `node` process never goes
+ *     through that transform. (Mirrors the reasoning in canvas-manifest-check.)
+ *
+ * Contract with the route ({@link createActionsRouter}):
+ *  - Request arrives as one JSON object on **stdin**: `{ sourceDir, input?,
+ *    stubs?, maxAttemptsPerStep? }`.
+ *  - Output is line-oriented JSON on **stdout** — the route forwards each line
+ *    through unchanged, so the shapes here ARE the wire shapes the SPA parses.
+ *  - Diagnostics go to **stderr**; the route keeps a bounded tail for failures.
+ *  - Exit 0 once the terminal line is written (even for a failed run — a failed
+ *    *run* is a successful *invocation*); exit 1 only when no run happened
+ *    (bad request, load error) after writing a terminal `error` line.
+ */
+import {
+  runLocalFromDir,
+  type LocalStepTrace,
+  type LocalRunOutcome,
+  type StubFile,
+} from "@sapiom/agent-core";
+
+/** The request shape the route writes to this child's stdin. */
+export interface RunLocalRequest {
+  /** Absolute path to the agent project directory (contains `index.ts`). */
+  sourceDir: string;
+  /** The workflow's entry-step input (optional; agent-core defaults it). */
+  input?: unknown;
+  /** Explicit stub overrides. When omitted the project's committed
+   *  `.sapiom-dev/stubs.json` is used (agent-core's own precedence). */
+  stubs?: StubFile;
+  /** Per-step attempt cap (optional; agent-core defaults it). */
+  maxAttemptsPerStep?: number;
+}
+
+/**
+ * The terminal NDJSON line, written after every per-step trace line. Carries
+ * the run-level outcome and the two stub-hygiene signals the inspector surfaces
+ * (WB15-2): `unusedStubs` (supplied keys that matched no capability call) and
+ * `stubWarnings` (keys that matched but carried the wrong shape).
+ *
+ * `kind: "summary"` discriminates it from a step-trace line so a consumer never
+ * has to guess which line is terminal.
+ */
+export interface RunLocalSummaryLine {
+  kind: "summary";
+  outcome: LocalRunOutcome;
+  output?: unknown;
+  error?: unknown;
+  unusedStubs: Array<{ step: string; key: string }>;
+  stubWarnings: string[];
+}
+
+/**
+ * The terminal line written when the run could not be *invoked* at all — a
+ * malformed request, an unreadable stub file, a project that fails to load.
+ * `outcome` is always `"failed"`; the child then exits non-zero. Distinct from
+ * a `summary` line, which represents a run that actually executed (even if that
+ * run's own outcome was `failed`).
+ */
+export interface RunLocalErrorLine {
+  kind: "error";
+  outcome: "failed";
+  error: string;
+}
+
+/** Read the entire request payload from a readable stream as one UTF-8 string. */
+async function readAll(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * Parse the stdin payload into a {@link RunLocalRequest}. Throws a plain Error
+ * with a caller-safe message (no key material, no provider names) on anything
+ * that isn't a JSON object carrying a non-empty string `sourceDir`.
+ */
+export function parseRunLocalRequest(raw: string): RunLocalRequest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("run-local request is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("run-local request must be a JSON object");
+  }
+  const body = parsed as Record<string, unknown>;
+  const sourceDir = body.sourceDir;
+  if (typeof sourceDir !== "string" || sourceDir.trim() === "") {
+    throw new Error("run-local request requires a non-empty sourceDir");
+  }
+  return {
+    sourceDir,
+    input: body.input,
+    stubs: body.stubs as StubFile | undefined,
+    maxAttemptsPerStep:
+      typeof body.maxAttemptsPerStep === "number"
+        ? body.maxAttemptsPerStep
+        : undefined,
+  };
+}
+
+/** Serialize one step trace as a single NDJSON line (newline-terminated). */
+function traceLine(step: LocalStepTrace): string {
+  return JSON.stringify(step) + "\n";
+}
+
+/** Serialize the terminal summary as a single NDJSON line. */
+function summaryLine(line: RunLocalSummaryLine): string {
+  return JSON.stringify(line) + "\n";
+}
+
+/**
+ * Run the request and emit its NDJSON stream to `out`. Returns the process exit
+ * code: 0 when a run executed (any outcome), 1 when the run could not be
+ * invoked (a terminal `error` line is emitted first). Never throws — every
+ * failure becomes an in-band terminal line, because a half-written stream with
+ * a thrown stack on stderr is far harder for the route to reason about than a
+ * clean terminal line plus an exit code.
+ */
+export async function runBootstrap(
+  request: RunLocalRequest,
+  out: NodeJS.WritableStream,
+): Promise<number> {
+  try {
+    const result = await runLocalFromDir({
+      sourceDir: request.sourceDir,
+      input: request.input,
+      stubs: request.stubs,
+      maxAttemptsPerStep: request.maxAttemptsPerStep,
+    });
+
+    // One line per step-attempt, in execution order — the consumer parses them
+    // incrementally rather than buffering the whole trace as a single blob.
+    for (const step of result.steps) {
+      out.write(traceLine(step));
+    }
+
+    const summary: RunLocalSummaryLine = {
+      kind: "summary",
+      outcome: result.outcome,
+      output: result.output,
+      error: result.error,
+      unusedStubs: result.unusedStubs,
+      stubWarnings: result.stubWarnings,
+    };
+    out.write(summaryLine(summary));
+    return 0;
+  } catch (err) {
+    const errorLine: RunLocalErrorLine = {
+      kind: "error",
+      outcome: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+    out.write(JSON.stringify(errorLine) + "\n");
+    return 1;
+  }
+}
+
+/**
+ * Entrypoint: read the request from stdin, run it, exit with the run's code.
+ * A stdin/read failure (or a request that can't be parsed) also degrades to a
+ * terminal `error` line + exit 1 — the route always sees a well-formed final
+ * line regardless of how the child failed.
+ */
+async function main(): Promise<void> {
+  let request: RunLocalRequest;
+  try {
+    request = parseRunLocalRequest(await readAll(process.stdin));
+  } catch (err) {
+    const errorLine: RunLocalErrorLine = {
+      kind: "error",
+      outcome: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+    process.stdout.write(JSON.stringify(errorLine) + "\n");
+    process.exitCode = 1;
+    return;
+  }
+  process.exitCode = await runBootstrap(request, process.stdout);
+}
+
+// Only self-invoke when run as the child entrypoint, never when imported by a
+// unit test (which drives runBootstrap / parseRunLocalRequest directly). The
+// built entry is dist/core/run-local-bootstrap.js; import.meta.url ends with
+// this module's own file, and process.argv[1] is the script node was told to
+// run — they share a basename only for the real child launch.
+const invokedAsScript =
+  typeof process.argv[1] === "string" &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedAsScript) {
+  void main();
+}

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -1,8 +1,15 @@
+import { EventEmitter } from "node:events";
 import type { AddressInfo } from "node:net";
+import { PassThrough } from "node:stream";
 import express from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createActionsRouter, type ActionsRouterOpts } from "./actions.js";
+import {
+  createActionsRouter,
+  resolveRunLocalBootstrapPath,
+  type ActionsRouterOpts,
+  type RunLocalChildProcess,
+} from "./actions.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,6 +39,65 @@ function parseNdjson(text: string): Array<Record<string, unknown>> {
     .map((l) => l.trim())
     .filter(Boolean)
     .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+/**
+ * A scripted stand-in for the run-local bootstrap child. `stdout`/`stderr` are
+ * real streams the test pushes lines into; `exit`/`error` are emitted via the
+ * inner emitter. `stdinChunks` records what the route wrote so a test can
+ * assert the request was forwarded. No real process is ever spawned.
+ */
+class FakeChild extends EventEmitter implements RunLocalChildProcess {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdinChunks: string[] = [];
+  readonly stdin = new (class extends PassThrough {
+    constructor(private readonly parent: FakeChild) {
+      super();
+    }
+    override end(chunk?: unknown): this {
+      if (typeof chunk === "string") this.parent.stdinChunks.push(chunk);
+      return this;
+    }
+  })(this);
+
+  /** Emit a line on stdout (the route reads it via readline). */
+  emitLine(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + "\n");
+  }
+  /** Emit raw text on stdout (for the non-JSON-noise case). */
+  emitRaw(text: string): void {
+    this.stdout.write(text);
+  }
+  /** Close stdout then signal process exit. */
+  finish(code: number | null): void {
+    this.stdout.end();
+    this.stderr.end();
+    // Let the readline "line" handlers drain before the exit handler runs.
+    setImmediate(() => this.emit("exit", code));
+  }
+}
+
+/**
+ * A `runLocalSpawn` seam that hands back a {@link FakeChild} and a `whenSpawned`
+ * promise, so a test can await "the route has spawned the child and attached
+ * its stdout/exit/error listeners" before driving it — deterministic instead of
+ * racing on `setImmediate` against the HTTP round-trip.
+ */
+function spawnFake(): {
+  child: FakeChild;
+  spawn: () => FakeChild;
+  whenSpawned: Promise<FakeChild>;
+} {
+  const child = new FakeChild();
+  let resolve!: (c: FakeChild) => void;
+  const whenSpawned = new Promise<FakeChild>((r) => (resolve = r));
+  const spawn = (): FakeChild => {
+    // Resolve on the next tick so the route finishes wiring listeners first.
+    setImmediate(() => resolve(child));
+    return child;
+  };
+  return { child, spawn, whenSpawned };
 }
 
 // ---------------------------------------------------------------------------
@@ -357,6 +423,255 @@ describe("createActionsRouter", () => {
       expect(res.status).toBe(503);
       expect(coreDeps.run).not.toHaveBeenCalled();
       expect(coreDeps.createClient).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── POST /api/runs/local ──────────────────────────────────────────────────
+
+  describe("POST /api/runs/local", () => {
+    it("streams per-step NDJSON then the terminal summary, forwarded verbatim", async () => {
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({
+        apiKey: null, // run-local needs no key — works signed out.
+        resolveWorkflow: () => null,
+        runLocalSpawn: spawn,
+      });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent", input: { name: "x" } }),
+      });
+
+      // Drive the scripted child once the route has wired its listeners.
+      await whenSpawned;
+      child.emitLine({
+        step: "greet",
+        attempt: 0,
+        input: { name: "x" },
+        status: "succeeded",
+        output: { greeting: "hi" },
+        logs: [],
+      });
+      child.emitLine({
+        kind: "summary",
+        outcome: "completed",
+        output: { greeting: "hi" },
+        unusedStubs: [{ step: "greet", key: "web.search" }],
+        stubWarnings: [],
+      });
+      child.finish(0);
+
+      const res = await resPromise;
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+
+      const lines = parseNdjson(await res.text());
+      expect(lines[0]).toMatchObject({ step: "greet", status: "succeeded" });
+      expect(lines[1]).toEqual({
+        kind: "summary",
+        outcome: "completed",
+        output: { greeting: "hi" },
+        unusedStubs: [{ step: "greet", key: "web.search" }],
+        stubWarnings: [],
+      });
+
+      // The request was piped to the child's stdin as one JSON object.
+      expect(JSON.parse(child.stdinChunks.join(""))).toEqual({
+        sourceDir: "/proj/agent",
+        input: { name: "x" },
+        maxAttemptsPerStep: undefined,
+      });
+    });
+
+    it("surfaces unusedStubs/stubWarnings on the terminal line", async () => {
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+
+      await whenSpawned;
+      child.emitLine({
+        kind: "summary",
+        outcome: "failed",
+        unusedStubs: [{ step: "s", key: "models.coding.launch" }],
+        stubWarnings: ["s: web.search stub had the wrong shape"],
+      });
+      child.finish(0);
+
+      const lines = parseNdjson(await (await resPromise).text());
+      expect(lines[0]).toMatchObject({
+        outcome: "failed",
+        unusedStubs: [{ step: "s", key: "models.coding.launch" }],
+        stubWarnings: ["s: web.search stub had the wrong shape"],
+      });
+    });
+
+    it("forwards a summary still buffered when the process exit fires first", async () => {
+      // The race the route hardens against: `exit` can arrive before readline
+      // has drained the last stdout chunk. Emitting the summary and firing exit
+      // synchronously (without FakeChild.finish's setImmediate) reproduces it —
+      // the summary must still be forwarded, with no synthesized error appended.
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+
+      await whenSpawned;
+      child.emitLine({
+        kind: "summary",
+        outcome: "completed",
+        unusedStubs: [],
+        stubWarnings: [],
+      });
+      child.emit("exit", 0); // exit BEFORE stdout is closed/drained
+      child.stdout.end(); // readline "close" now fires → settle()
+      child.stderr.end();
+
+      const lines = parseNdjson(await (await resPromise).text());
+      // Exactly the one real summary — no trailing synthesized error line.
+      expect(lines).toEqual([
+        { kind: "summary", outcome: "completed", unusedStubs: [], stubWarnings: [] },
+      ]);
+    });
+
+    it("returns 400 when sourceDir is missing (no child spawned)", async () => {
+      const spawn = vi.fn(() => new FakeChild());
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const res = await fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: {} }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("sourceDir is required");
+      expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-JSON noise on stdout (forwards only well-formed lines)", async () => {
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+
+      await whenSpawned;
+      child.emitRaw("some esbuild warning to stdout\n"); // noise — dropped
+      child.emitLine({ kind: "summary", outcome: "completed", unusedStubs: [], stubWarnings: [] });
+      child.finish(0);
+
+      const lines = parseNdjson(await (await resPromise).text());
+      // parseNdjson JSON.parses every non-blank line, so a forwarded noise line
+      // would throw here — asserting exactly one (the summary) proves the route
+      // dropped the non-JSON line.
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ kind: "summary", outcome: "completed" });
+    });
+
+    it("synthesizes a terminal error line when the child crashes before emitting one", async () => {
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+
+      await whenSpawned;
+      child.stderr.write("Failed to bundle the agent.\n");
+      child.finish(1); // nonzero exit, no terminal line was written
+
+      const lines = parseNdjson(await (await resPromise).text());
+      expect(lines).toEqual([
+        {
+          kind: "error",
+          outcome: "failed",
+          error: "Failed to bundle the agent.",
+        },
+      ]);
+    });
+
+    it("does not double-report when both error and exit fire", async () => {
+      const { child, spawn, whenSpawned } = spawnFake();
+      start({ apiKey: null, resolveWorkflow: () => null, runLocalSpawn: spawn });
+
+      const resPromise = fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+
+      await whenSpawned; // the route's error+exit listeners are now attached.
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("error", new Error("spawn ENOENT"));
+      child.emit("exit", null);
+
+      const lines = parseNdjson(await (await resPromise).text());
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ kind: "error", outcome: "failed" });
+    });
+
+    it("answers in-band with a terminal error line when the spawn itself throws", async () => {
+      start({
+        apiKey: null,
+        resolveWorkflow: () => null,
+        runLocalSpawn: () => {
+          throw new Error("node binary not found");
+        },
+      });
+
+      const res = await fetch(`${baseUrl}/api/runs/local`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sourceDir: "/proj/agent" }),
+      });
+      // The request itself is valid, so it's a 200 NDJSON stream whose single
+      // line is the terminal error.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+      const lines = parseNdjson(await res.text());
+      expect(lines).toEqual([
+        {
+          kind: "error",
+          outcome: "failed",
+          error: "node binary not found",
+        },
+      ]);
+    });
+  });
+
+  // ── bootstrap path resolution (pure) ──────────────────────────────────────
+
+  describe("resolveRunLocalBootstrapPath", () => {
+    it("resolves the built .js sibling from a dist actions module URL", () => {
+      const p = resolveRunLocalBootstrapPath(
+        "file:///app/packages/harness/dist/server/actions.js",
+      );
+      expect(p).toBe(
+        "/app/packages/harness/dist/core/run-local-bootstrap.js",
+      );
+    });
+
+    it("resolves the .ts sibling from a src actions module URL (dev/tsx)", () => {
+      const p = resolveRunLocalBootstrapPath(
+        "file:///app/packages/harness/src/server/actions.ts",
+      );
+      expect(p).toBe("/app/packages/harness/src/core/run-local-bootstrap.ts");
     });
   });
 });

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -16,7 +16,18 @@
  * show "building…" the moment the build kicks off and a terminal line when it
  * settles. Prod-run is a single request/response returning `{ executionId }`,
  * which the existing live-canvas path then polls via the runs router.
+ *
+ * Run-local (`POST /api/runs/local`) is the offline sibling: it spawns the
+ * run-local bootstrap child, which runs the workflow in-process against stub
+ * capabilities and streams NDJSON back — one {@link LocalStepTrace} per line,
+ * then a terminal summary carrying `unusedStubs`/`stubWarnings`. It needs no
+ * API key and makes no network call, so it works signed-out and at zero cost.
  */
+
+import { spawn as spawnChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { Router } from "express";
 import {
@@ -31,6 +42,7 @@ import {
 } from "@sapiom/agent-core";
 
 import { resolveCoreBaseUrl } from "../core/definition-slug-resolver.js";
+import type { RunLocalRequest } from "../core/run-local-bootstrap.js";
 
 /**
  * A registered workflow the actions router can act on — the subset of
@@ -72,6 +84,80 @@ const DEFAULT_CORE_DEPS: ActionsCoreDeps = {
   readConfig: coreReadConfig,
 };
 
+/**
+ * The slice of node's ChildProcess the run-local route uses — injectable so
+ * tests drive a fake child (a scripted stdout stream) without spawning a real
+ * `node` process. Mirrors {@link TaskProcess} in task-manager.ts.
+ */
+export interface RunLocalChildProcess {
+  /** Where the request JSON is written; closed immediately after. */
+  stdin: NodeJS.WritableStream | null;
+  /** Line-oriented NDJSON the route forwards to the HTTP response. */
+  stdout: NodeJS.ReadableStream | null;
+  /** Diagnostics; a bounded tail is kept for failure reporting. */
+  stderr: NodeJS.ReadableStream | null;
+  on(event: "exit", listener: (code: number | null) => void): unknown;
+  on(event: "error", listener: (err: Error) => void): unknown;
+}
+
+/** Spawn the run-local bootstrap child. Test seam — defaults to `node`ing the
+ *  compiled bootstrap. */
+export type RunLocalSpawnFn = () => RunLocalChildProcess;
+
+/**
+ * Resolve the compiled run-local bootstrap entry. This module lives at
+ * `dist/server/actions.js` (built) or `src/server/actions.ts` (tsx dev /
+ * vitest) — the bootstrap is its sibling one directory over in `core/`, with
+ * the same `.js`/`.ts` extension as this file. Reading the extension off
+ * `import.meta.url` (rather than hard-coding `.js`) keeps a real dev-server
+ * spawn resolvable too. Exported for unit coverage of the path math.
+ */
+export function resolveRunLocalBootstrapPath(moduleUrl: string): string {
+  const here = fileURLToPath(moduleUrl);
+  const ext = here.endsWith(".ts") ? ".ts" : ".js";
+  return join(dirname(here), "..", "core", `run-local-bootstrap${ext}`);
+}
+
+/**
+ * The default spawn: `node <bootstrap>` with `cwd` set to this package's root
+ * so the bootstrap's `import "@sapiom/agent-core"` resolves against the
+ * harness's real dependency (same technique as canvas-manifest-check). A `.ts`
+ * bootstrap (dev only) is loaded through the `tsx` register hook; the built
+ * `.js` runs on bare node. stdin is piped so the route can write the request.
+ */
+function defaultRunLocalSpawn(): RunLocalChildProcess {
+  const bootstrap = resolveRunLocalBootstrapPath(import.meta.url);
+  const nodeArgs = bootstrap.endsWith(".ts")
+    ? ["--import", "tsx", bootstrap]
+    : [bootstrap];
+  return spawnChildProcess(process.execPath, nodeArgs, {
+    cwd: join(dirname(fileURLToPath(import.meta.url)), "..", ".."),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+/** Bounded stderr tail kept per run-local child for failure display. */
+const RUN_LOCAL_STDERR_TAIL_CHARS = 2_000;
+
+/**
+ * The run-local request body the SPA POSTs. `sourceDir` is required; the rest
+ * mirror {@link RunLocalRequest} and are forwarded to the bootstrap as-is.
+ */
+function parseRunLocalBody(body: unknown): RunLocalRequest | null {
+  if (typeof body !== "object" || body === null) return null;
+  const b = body as Record<string, unknown>;
+  if (typeof b.sourceDir !== "string" || b.sourceDir.trim() === "") return null;
+  return {
+    sourceDir: b.sourceDir,
+    input: b.input,
+    stubs: b.stubs as RunLocalRequest["stubs"],
+    maxAttemptsPerStep:
+      typeof b.maxAttemptsPerStep === "number"
+        ? b.maxAttemptsPerStep
+        : undefined,
+  };
+}
+
 export interface ActionsRouterOpts {
   /** Sapiom API key for the workflows surface; null when unauthenticated. */
   apiKey: string | null;
@@ -89,6 +175,13 @@ export interface ActionsRouterOpts {
   resolveWorkflow: (id: string) => ActionWorkflow | null;
   /** Injectable core operations. Test seam; defaults to the real exports. */
   coreDeps?: Partial<ActionsCoreDeps>;
+  /**
+   * Spawn the run-local bootstrap child. Undocumented for prod — a test seam
+   * only (defaults to `node`ing the compiled bootstrap), so a test can stream a
+   * scripted trace without spawning a real process, mirroring `fetchImpl` in
+   * runs.ts and the `spawnProcess` seam in task-manager.ts.
+   */
+  runLocalSpawn?: RunLocalSpawnFn;
 }
 
 /**
@@ -139,13 +232,16 @@ function toDeployErrorEvent(
  * Create the actions router. Mounts:
  *   - `POST /api/workflows/:id/deploy` — NDJSON build-status stream.
  *   - `POST /api/runs` — `{ executionId }` for a started prod execution.
+ *   - `POST /api/runs/local` — NDJSON offline stub-run trace + summary.
  *
- * Both run server-side with the held API key and never involve Claude Code.
+ * Deploy and prod-run run server-side with the held API key; run-local is fully
+ * offline and needs no key. None of them ever involve Claude Code.
  */
 export function createActionsRouter(opts: ActionsRouterOpts): Router {
   const router = Router();
   const deps: ActionsCoreDeps = { ...DEFAULT_CORE_DEPS, ...opts.coreDeps };
   const baseUrl = opts.coreBaseUrl ?? resolveCoreBaseUrl();
+  const runLocalSpawn = opts.runLocalSpawn ?? defaultRunLocalSpawn;
 
   /**
    * POST /api/workflows/:id/deploy
@@ -263,6 +359,142 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
           .status(502)
           .json({ error: err instanceof Error ? err.message : String(err) });
       }
+    }
+  });
+
+  /**
+   * POST /api/runs/local  { sourceDir, input?, stubs?, maxAttemptsPerStep? }
+   *
+   * Runs the workflow at `sourceDir` entirely offline against stub
+   * capabilities, in a child process (the run-local bootstrap), and streams the
+   * result back as NDJSON: one {@link LocalStepTrace} per line, then a terminal
+   * summary line `{ kind: "summary", outcome, output, error, unusedStubs,
+   * stubWarnings }`. A run that could not be invoked at all (bad project, bad
+   * stub file) yields a terminal `{ kind: "error", outcome: "failed", error }`
+   * line instead. Needs no API key and makes no network call — zero cost.
+   *
+   * The child owns the wire shapes; this handler validates the request, pipes
+   * it to the child's stdin, forwards each stdout line unchanged, and (only if
+   * the child dies without a terminal line) synthesizes one from its stderr so
+   * the stream always ends well-formed.
+   *
+   * 200  NDJSON stream (a failed *run* is still a 200 — the request succeeded;
+   *      the outcome is in-band on the terminal line).
+   * 400  sourceDir missing/empty
+   */
+  router.post("/api/runs/local", (req, res) => {
+    const request = parseRunLocalBody(req.body);
+    if (!request) {
+      res.status(400).json({ error: "sourceDir is required" });
+      return;
+    }
+
+    let child: RunLocalChildProcess;
+    try {
+      child = runLocalSpawn();
+    } catch (err) {
+      // Never launched (e.g. the node binary or bootstrap is missing) — the
+      // request itself is fine, so answer in-band with a terminal error line.
+      res.status(200);
+      res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      res.write(
+        JSON.stringify({
+          kind: "error",
+          outcome: "failed",
+          error: err instanceof Error ? err.message : String(err),
+        }) + "\n",
+      );
+      res.end();
+      return;
+    }
+
+    // Headers are committed before the (potentially long) run streams.
+    res.status(200);
+    res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store");
+
+    // Hand the request to the child, then close its stdin so the bootstrap's
+    // read-to-EOF completes.
+    child.stdin?.end(JSON.stringify(request));
+
+    // Forward each well-formed JSON line straight through — the bootstrap emits
+    // exactly the wire shapes, so no re-shaping happens here. A line that isn't
+    // JSON is stray stdout noise (an esbuild banner, a dependency's console
+    // write) and is dropped rather than corrupting the NDJSON stream — the same
+    // "degrade, never throw" stance as core/task-stream.ts.
+    let sawTerminalLine = false;
+    const onLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (trimmed === "") return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return; // non-JSON noise — not part of the contract.
+      }
+      // A `summary`/`error` line is terminal — track it so a crash after the
+      // summary isn't double-reported as a failure.
+      const kind = (parsed as { kind?: unknown }).kind;
+      if (kind === "summary" || kind === "error") sawTerminalLine = true;
+      res.write(trimmed + "\n");
+    };
+
+    // Keep a bounded stderr tail for the crash path (never forwarded inline —
+    // stderr is diagnostics, not part of the NDJSON contract).
+    let stderrTail = "";
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrTail = (stderrTail + String(chunk)).slice(
+        -RUN_LOCAL_STDERR_TAIL_CHARS,
+      );
+    });
+
+    // End the response exactly once (mirrors task-manager's finish() guard).
+    // `crashReason` is captured from `exit`/`error` but the terminal decision is
+    // deferred to `settle()` so a still-buffered summary line is never clobbered.
+    let settled = false;
+    let crashReason: string | null = null;
+    const settle = (): void => {
+      if (settled) return;
+      settled = true;
+      // Only synthesize a terminal line when the child produced none — otherwise
+      // the stream already ended well-formed with the bootstrap's own summary.
+      if (!sawTerminalLine) {
+        res.write(
+          JSON.stringify({
+            kind: "error",
+            outcome: "failed",
+            error:
+              stderrTail.trim() || crashReason || "run-local produced no output",
+          }) + "\n",
+        );
+      }
+      res.end();
+    };
+
+    // Drive the terminal decision off stdout's close (readline "close" fires
+    // only after every line has been emitted), so a summary line buffered when
+    // `exit` arrives is still forwarded first. If there's no stdout at all, fall
+    // back to `exit`/`error` directly.
+    if (child.stdout) {
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", onLine);
+      lines.on("close", settle);
+      child.on("error", (err) => {
+        crashReason = err.message;
+      });
+      child.on("exit", (code) => {
+        crashReason ??= `run-local process exited with code ${code ?? "null"}`;
+      });
+    } else {
+      child.on("error", (err) => {
+        crashReason = err.message;
+        settle();
+      });
+      child.on("exit", (code) => {
+        crashReason ??= `run-local process exited with code ${code ?? "null"}`;
+        settle();
+      });
     }
   });
 


### PR DESCRIPTION
## Summary

Adds `POST /api/runs/local` to the harness actions router (A2, extends A1's `createActionsRouter`). It spawns a **child-process bootstrap** that imports the project's `runLocalFromDir` (`@sapiom/agent-core`), runs the agent entirely in-process against stub capabilities, and streams the result back as **NDJSON**: one `LocalStepTrace` per line, then a terminal summary line. Fully offline, needs no API key, zero cost.

### What's here
- **`packages/harness/src/core/run-local-bootstrap.ts`** (new) — the child entrypoint. Reads a `{ sourceDir, input?, stubs?, maxAttemptsPerStep? }` request on stdin, calls `runLocalFromDir`, writes each step trace as an NDJSON line to stdout, then a terminal `{ kind: "summary", outcome, output, error, unusedStubs, stubWarnings }`. A run that can't be invoked at all (bad project / bad stub file) yields a terminal `{ kind: "error", outcome: "failed", error }` and exit 1. A child process is used for the same reasons as `canvas-manifest-check`: it bounds the blast radius of running an untrusted workflow's step bodies, and sidesteps the Vite/Vitest `file://` dynamic-import transform trap in `runLocalFromDir`'s loader.
- **`packages/harness/src/server/actions.ts`** — adds the `POST /api/runs/local` route: validates the request, spawns the bootstrap (injectable `runLocalSpawn` seam, mirroring `fetchImpl`/`coreDeps`), pipes the request to the child's stdin, and forwards each well-formed JSON stdout line straight through. Non-JSON stdout noise is dropped (the `core/task-stream.ts` "degrade, never throw" stance). If the child dies before emitting a terminal line, the route synthesizes one from the stderr tail so the stream always ends well-formed. `error`+`exit` are guarded so the response ends exactly once. Run-local needs **no `apiKey`** (offline).
- Tests mirror the existing `actions.test.ts` seams (a scripted `FakeChild` fed through a deterministic `whenSpawned` signal) plus unit tests for the bootstrap's pure fns and the path resolver.

## Acceptance
- [x] `POST /api/runs/local` streams NDJSON `LocalStepTrace` + terminal summary, offline.
- [x] `unusedStubs`/`stubWarnings` surfaced in the terminal line.

## Testing
- `pnpm --filter '@sapiom/harness...' build` + `pnpm --filter @sapiom/harness build` — green.
- `pnpm --filter @sapiom/harness test` — **1004/1004** green; `typecheck` + `lint` green.
- Offline end-to-end smoke of the built bootstrap against a temp single-step agent: streamed a `LocalStepTrace` line + a `summary` line with `unusedStubs: [{ step, key }]`, exit 0, no network.
- Server-side only — **zero `web/` files touched**, so the Playwright (`test:ui`) tier is unaffected by construction.

## Notes
- PATCH changeset for `@sapiom/harness`.
- Public repo: no provider/model names, internal ticket refs, infra names, or URL overrides in code or changeset.

Linear: SAP-1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)