### PR TITLE
feat(harness): Assistant⇄CLI conversation pane with mock stream (SAP-1806)

### DIFF
--- a/packages/harness/web/e2e/conversation.spec.ts
+++ b/packages/harness/web/e2e/conversation.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Conversation pane Playwright smoke tests — mock-mode UI (VITE_MOCK=1).
+ *
+ * The pane is a preview surface reached with `?pane=conversation` (mock only —
+ * see api.isConversationPreview). It is the right-region Assistant ⇄ CLI slot
+ * from SAP-1806: Assistant is the default, renders turns streamed from the mock
+ * stream; CLI is the existing pty terminal, unchanged, one toggle away.
+ *
+ * Coverage:
+ *   - Assistant is the default view; the CLI tab is present but inactive
+ *   - The Assistant renders streamed turns (user prompt + streamed answer)
+ *   - Toggling to CLI reveals the unchanged terminal and hides the Assistant
+ *   - Toggling back keeps the already-streamed turns (panel is kept alive)
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?pane=conversation");
+  await expect(page.getByTestId("conversation-pane")).toBeVisible();
+});
+
+test("Assistant is the default view; CLI is present but not active", async ({
+  page,
+}) => {
+  await expect(page.getByTestId("conversation-tab-assistant")).toHaveClass(
+    /is-active/,
+  );
+  await expect(page.getByTestId("conversation-tab-cli")).not.toHaveClass(
+    /is-active/,
+  );
+  await expect(page.getByTestId("conversation-panel-assistant")).toBeVisible();
+  // The terminal is not mounted until the CLI side is first revealed.
+  await expect(page.locator(".harness-terminal")).toHaveCount(0);
+});
+
+test("the Assistant renders streamed turns from the mock stream", async ({
+  page,
+}) => {
+  // The user's own prompt arrives whole; the assistant's answer streams in as
+  // deltas and settles to a completed turn with accumulated content.
+  const userTurn = page.getByTestId("assistant-turn-u1");
+  await expect(userTurn).toContainText("What does this agent do?", {
+    timeout: 5_000,
+  });
+
+  const assistantTurn = page.getByTestId("assistant-turn-a1");
+  await expect(assistantTurn).toContainText("This agent", { timeout: 5_000 });
+  // Once the stream closes the turn is marked complete (no more caret).
+  await expect(assistantTurn).toHaveAttribute("data-status", "complete", {
+    timeout: 5_000,
+  });
+  await expect(page.getByTestId("assistant-streaming")).toHaveCount(0);
+
+  await page.screenshot({
+    path: "web/e2e/screenshots/conversation-assistant.png",
+    fullPage: true,
+  });
+});
+
+test("toggling to CLI reveals the unchanged terminal and hides the Assistant", async ({
+  page,
+}) => {
+  await page.getByTestId("conversation-tab-cli").click();
+
+  await expect(page.getByTestId("conversation-tab-cli")).toHaveClass(
+    /is-active/,
+  );
+  await expect(page.getByTestId("conversation-panel-cli")).toBeVisible();
+  // The existing pty Terminal component, unchanged.
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  // The Assistant panel stays in the DOM (kept alive) but is not visible.
+  await expect(page.getByTestId("conversation-panel-assistant")).toBeAttached();
+  await expect(
+    page.getByTestId("conversation-panel-assistant"),
+  ).not.toBeVisible();
+
+  await page.screenshot({
+    path: "web/e2e/screenshots/conversation-cli.png",
+    fullPage: true,
+  });
+});
+
+test("toggling back to Assistant keeps the turns that already streamed", async ({
+  page,
+}) => {
+  // Let the mock stream produce its turns first.
+  await expect(page.getByTestId("assistant-turn-a1")).toContainText(
+    "This agent",
+    {
+      timeout: 5_000,
+    },
+  );
+
+  await page.getByTestId("conversation-tab-cli").click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+
+  await page.getByTestId("conversation-tab-assistant").click();
+  await expect(page.getByTestId("conversation-panel-assistant")).toBeVisible();
+  // The turns were not torn down by the round-trip.
+  await expect(page.getByTestId("assistant-turn-u1")).toContainText(
+    "What does this agent do?",
+  );
+  await expect(page.getByTestId("assistant-turn-a1")).toContainText(
+    "This agent",
+  );
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -15,6 +15,7 @@ import type { HarnessKind, MacroDef, WorkflowInfo } from "@shared/types";
 import { BrandHeader } from "./components/BrandHeader";
 import { CanvasPane } from "./components/CanvasPane";
 import { CommandPalette } from "./components/CommandPalette";
+import { ConversationPane } from "./components/ConversationPane";
 import { DeadSessionPane } from "./components/DeadSessionPane";
 import { ImageComposer } from "./components/ImageComposer";
 import { SessionBar } from "./components/SessionBar";
@@ -26,7 +27,7 @@ import { Toast } from "./components/Toast";
 import { WelcomePanel } from "./components/WelcomePanel";
 import { WorkflowActionStrip } from "./components/WorkflowActionStrip";
 import { WorkflowsRail } from "./components/WorkflowsRail";
-import { boundWorkflowPathOf } from "./lib/api";
+import { boundWorkflowPathOf, isConversationPreview } from "./lib/api";
 import { useElementTopOffset } from "./lib/use-element-top-offset";
 import { resolveMacroUrl } from "./lib/macro-gating";
 import { CANVAS_MIN, RAIL_MIN, usePaneWidths } from "./lib/use-pane-widths";
@@ -317,7 +318,12 @@ export const App = (): JSX.Element => {
             onSetSettingsOpen={setSettingsOpen}
           />
           <div className="terminal-slot">
-            {activeSession?.status === "exited" ? (
+            {isConversationPreview() ? (
+              <ConversationPane
+                sessionId={harness.activeSessionId}
+                token={harness.bootToken}
+              />
+            ) : activeSession?.status === "exited" ? (
               <DeadSessionPane
                 session={activeSession}
                 onResume={() => void harness.resumeSession(activeSession.id)}

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -1,0 +1,63 @@
+/**
+ * AssistantPane — renders a conversation as streamed turns.
+ *
+ * Purely presentational: it takes the reduced turns and draws them. The turn
+ * source (the mock stream today, the intelligence spine after S5) is owned by
+ * the parent, which keeps this component trivial to test and indifferent to
+ * where the turns come from. Assistant turns render through the safe-subset
+ * Markdown renderer (shared `chat-*` classes); user turns are plain text.
+ */
+import type { JSX } from "react";
+
+import type { AssistantTurn } from "../lib/assistant-stream";
+import { Markdown } from "./Markdown";
+
+export interface AssistantPaneProps {
+  turns: AssistantTurn[];
+}
+
+export function AssistantPane({ turns }: AssistantPaneProps): JSX.Element {
+  return (
+    <div className="assistant-pane" data-testid="assistant-pane">
+      {turns.length === 0 ? (
+        <div className="assistant-empty" data-testid="assistant-empty">
+          <p>Ask about the agent you have open.</p>
+          <p className="assistant-empty-hint">
+            The assistant explains, debugs, runs, and deploys it — no setup, no
+            Claude Code required. Switch to CLI for the full builder.
+          </p>
+        </div>
+      ) : (
+        <ol className="assistant-turns">
+          {turns.map((turn) => (
+            <li
+              key={turn.id}
+              className={`assistant-turn assistant-turn--${turn.role}`}
+              data-testid={`assistant-turn-${turn.id}`}
+              data-role={turn.role}
+              data-status={turn.status}
+            >
+              <span className="assistant-turn-author">
+                {turn.role === "user" ? "You" : "Assistant"}
+              </span>
+              <div className="assistant-turn-body">
+                {turn.role === "assistant" ? (
+                  <Markdown text={turn.text} />
+                ) : (
+                  <p className="chat-paragraph">{turn.text}</p>
+                )}
+                {turn.status === "streaming" && (
+                  <span
+                    className="assistant-caret"
+                    data-testid="assistant-streaming"
+                    aria-label="streaming"
+                  />
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/ConversationPane.tsx
+++ b/packages/harness/web/src/components/ConversationPane.tsx
@@ -1,0 +1,112 @@
+/**
+ * ConversationPane — the right-region conversation, one slot with an
+ * Assistant ⇄ CLI toggle.
+ *
+ * The Assistant (default) and the CLI are the same kind of thing — a
+ * conversation that acts on your agent — so they share this region instead of
+ * competing for screen. The Assistant is the zero-setup, Sapiom-run default;
+ * the CLI is the user's own Claude Code terminal, opt-in for full-power use.
+ *
+ *   - Assistant: renders streamed turns (mock stream today; the intelligence
+ *     spine after S5). Always mounted so its turns survive a toggle.
+ *   - CLI: the existing pty Terminal, unchanged. Lazy-mounted on first reveal
+ *     and then kept alive (CSS-hidden) so toggling back doesn't tear down and
+ *     re-open the terminal's WebSocket.
+ *
+ * The toggle mirrors the right pane's segmented switch (see App.tsx) — same
+ * markup, classes, and keep-alive discipline — so it reads as one system.
+ */
+import { useState, type JSX } from "react";
+
+import { useAssistantMockStream } from "../lib/use-assistant-mock-stream";
+import { AssistantPane } from "./AssistantPane";
+import { Terminal } from "./Terminal";
+
+type ConversationView = "assistant" | "cli";
+
+export interface ConversationPaneProps {
+  /** Active session for the CLI terminal; null when no session is live. */
+  sessionId: string | null;
+  /** Per-boot token the terminal WebSocket upgrade requires. */
+  token: string;
+}
+
+export function ConversationPane({
+  sessionId,
+  token,
+}: ConversationPaneProps): JSX.Element {
+  // Assistant is the zero-setup default (design §6).
+  const [view, setView] = useState<ConversationView>("assistant");
+  // Track whether the CLI has ever been shown — once true, the Terminal stays
+  // mounted (hidden via CSS) so a toggle round-trip never drops its pty socket.
+  const [cliEverShown, setCliEverShown] = useState(false);
+
+  const turns = useAssistantMockStream();
+
+  return (
+    <div className="conversation-pane" data-testid="conversation-pane">
+      <div
+        className="conversation-tabs"
+        role="tablist"
+        aria-label="Conversation"
+      >
+        <button
+          role="tab"
+          type="button"
+          aria-selected={view === "assistant"}
+          className={
+            "conversation-tab" + (view === "assistant" ? " is-active" : "")
+          }
+          onClick={() => setView("assistant")}
+          data-testid="conversation-tab-assistant"
+        >
+          Assistant
+        </button>
+        <button
+          role="tab"
+          type="button"
+          aria-selected={view === "cli"}
+          className={"conversation-tab" + (view === "cli" ? " is-active" : "")}
+          onClick={() => {
+            setView("cli");
+            setCliEverShown(true);
+          }}
+          data-testid="conversation-tab-cli"
+        >
+          CLI
+        </button>
+      </div>
+
+      {/* Assistant: always mounted so streamed turns survive a toggle. */}
+      <div
+        className={
+          "conversation-panel" + (view === "assistant" ? "" : " is-hidden")
+        }
+        data-testid="conversation-panel-assistant"
+      >
+        <AssistantPane turns={turns} />
+      </div>
+
+      {/* CLI: lazy-mounted on first reveal, then kept alive hidden via CSS. */}
+      {(view === "cli" || cliEverShown) && (
+        <div
+          className={
+            "conversation-panel" + (view === "cli" ? "" : " is-hidden")
+          }
+          data-testid="conversation-panel-cli"
+        >
+          {sessionId ? (
+            <Terminal sessionId={sessionId} token={token} />
+          ) : (
+            <div
+              className="conversation-cli-empty"
+              data-testid="conversation-cli-empty"
+            >
+              No active session — start one to use the CLI.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -73,6 +73,21 @@ export function isFreshMockState(): boolean {
   );
 }
 
+/**
+ * Mock mode only: `?pane=conversation` swaps the center pane for a preview of
+ * the Assistant ⇄ CLI conversation region (SAP-1806), built against a mock
+ * stream. It is a preview flag on purpose — the region's real home is the
+ * right side of the adopted studio shell, wired when that layout lands; this
+ * keeps the pane demonstrable and e2e-testable now without disturbing the
+ * default terminal-first shell (or any existing spec, none of which set it).
+ */
+export function isConversationPreview(): boolean {
+  return (
+    isMockMode() &&
+    new URLSearchParams(window.location.search).get("pane") === "conversation"
+  );
+}
+
 /** `session.boundWorkflowPath` is nullable already, but keeps callers safe against a missing session. */
 export function boundWorkflowPathOf(
   session: HarnessSession | null | undefined,

--- a/packages/harness/web/src/lib/assistant-stream.test.ts
+++ b/packages/harness/web/src/lib/assistant-stream.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the assistant turn reducer.
+ *
+ * Pure, DOM-free — runs under vitest node (the same tier as the SPA's other
+ * logic tests). Covers the turn-rendering fold the pane relies on: opening
+ * turns, accumulating deltas, completion, ordering, and the honest-by-omission
+ * handling of frames that arrive out of order or twice.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  mockConversationScript,
+  reduceTurns,
+  reduceTurnSequence,
+  type AssistantStreamEvent,
+  type AssistantTurn,
+} from "./assistant-stream";
+
+describe("reduceTurns", () => {
+  it("opens a streaming turn on turn.started", () => {
+    const turns = reduceTurns([], {
+      type: "turn.started",
+      id: "a1",
+      role: "assistant",
+    });
+    expect(turns).toEqual<AssistantTurn[]>([
+      { id: "a1", role: "assistant", text: "", status: "streaming" },
+    ]);
+  });
+
+  it("seeds text from turn.started (a whole-turn arrival, e.g. the user prompt)", () => {
+    const turns = reduceTurns([], {
+      type: "turn.started",
+      id: "u1",
+      role: "user",
+      text: "hello",
+    });
+    expect(turns[0]).toMatchObject({
+      role: "user",
+      text: "hello",
+      status: "streaming",
+    });
+  });
+
+  it("appends deltas in arrival order", () => {
+    const events: AssistantStreamEvent[] = [
+      { type: "turn.started", id: "a1", role: "assistant" },
+      { type: "turn.delta", id: "a1", text: "Hel" },
+      { type: "turn.delta", id: "a1", text: "lo" },
+    ];
+    expect(reduceTurnSequence(events)[0].text).toBe("Hello");
+  });
+
+  it("marks a turn complete on turn.completed without touching its text", () => {
+    const events: AssistantStreamEvent[] = [
+      { type: "turn.started", id: "a1", role: "assistant" },
+      { type: "turn.delta", id: "a1", text: "done" },
+      { type: "turn.completed", id: "a1" },
+    ];
+    expect(reduceTurnSequence(events)[0]).toMatchObject({
+      text: "done",
+      status: "complete",
+    });
+  });
+
+  it("preserves first-seen order across interleaved turns", () => {
+    const events: AssistantStreamEvent[] = [
+      { type: "turn.started", id: "u1", role: "user", text: "q" },
+      { type: "turn.started", id: "a1", role: "assistant" },
+      { type: "turn.delta", id: "a1", text: "answer" },
+    ];
+    const turns = reduceTurnSequence(events);
+    expect(turns.map((t) => t.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("ignores a delta for an unknown turn (never conjures one from a partial frame)", () => {
+    const turns = reduceTurns([], {
+      type: "turn.delta",
+      id: "ghost",
+      text: "x",
+    });
+    expect(turns).toEqual([]);
+  });
+
+  it("ignores a completion for an unknown turn", () => {
+    const turns = reduceTurns([], { type: "turn.completed", id: "ghost" });
+    expect(turns).toEqual([]);
+  });
+
+  it("treats a repeated turn.started as a no-op (a replayed opening frame can't duplicate)", () => {
+    const once = reduceTurns([], {
+      type: "turn.started",
+      id: "a1",
+      role: "assistant",
+    });
+    const twice = reduceTurns(once, {
+      type: "turn.started",
+      id: "a1",
+      role: "assistant",
+    });
+    expect(twice).toHaveLength(1);
+  });
+
+  it("does not mutate the input array", () => {
+    const before: AssistantTurn[] = [
+      { id: "a1", role: "assistant", text: "a", status: "streaming" },
+    ];
+    const snapshot = structuredClone(before);
+    reduceTurns(before, { type: "turn.delta", id: "a1", text: "b" });
+    expect(before).toEqual(snapshot);
+  });
+});
+
+describe("mockConversationScript", () => {
+  it("folds into a completed user turn followed by a completed assistant turn", () => {
+    const turns = reduceTurnSequence(
+      mockConversationScript().map((frame) => frame.event),
+    );
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ role: "user", status: "complete" });
+    expect(turns[1]).toMatchObject({ role: "assistant", status: "complete" });
+    // The assistant turn accumulated real content from its deltas.
+    expect(turns[1].text.length).toBeGreaterThan(20);
+  });
+});

--- a/packages/harness/web/src/lib/assistant-stream.ts
+++ b/packages/harness/web/src/lib/assistant-stream.ts
@@ -1,0 +1,143 @@
+/**
+ * Assistant conversation stream — turn model, reducer, and a mock script.
+ *
+ * The Studio's assistant is a conversation that streams *turns* from the
+ * intelligence spine (a Sapiom workflow run on our account, not the user's
+ * Claude Code). That spine — its service and its wire contract — is a separate
+ * workstream; until it lands, this pane is built against the mock script below
+ * so it is buildable and testable on its own.
+ *
+ * This module is deliberately framework-free (no React, no DOM) so the
+ * turn-reduction logic can be unit-tested under the Node vitest runner, the
+ * same tier as the SPA's other pure logic (see assistant-stream.test.ts). The
+ * React glue that plays the script into component state lives in
+ * ./use-assistant-mock-stream.
+ *
+ * Shaped to swap onto the real spine with a source change only: the event
+ * names (`turn.started` / `turn.delta` / `turn.completed`) mirror the "streams
+ * turns" contract, and `reduceTurns` folds a raw event onto ordered turns
+ * exactly as a live subscription would.
+ */
+
+/** Who authored a turn. `user` is the person; `assistant` is the Sapiom-run helper. */
+export type AssistantTurnRole = "user" | "assistant";
+
+/** A turn is `streaming` while deltas are still arriving, then `complete`. */
+export type AssistantTurnStatus = "streaming" | "complete";
+
+/** One conversation turn as the pane renders it — text accumulated from deltas. */
+export interface AssistantTurn {
+  /** Stable id for keyed rendering; also the join key for deltas/completion. */
+  id: string;
+  role: AssistantTurnRole;
+  /** Full text so far (deltas appended in arrival order). */
+  text: string;
+  status: AssistantTurnStatus;
+}
+
+/**
+ * A single frame off the stream. A turn opens with `turn.started`, grows via
+ * zero or more `turn.delta`s, and closes with `turn.completed`. `text` on
+ * `turn.started` seeds a turn that arrives whole (e.g. the user's own prompt).
+ */
+export type AssistantStreamEvent =
+  | { type: "turn.started"; id: string; role: AssistantTurnRole; text?: string }
+  | { type: "turn.delta"; id: string; text: string }
+  | { type: "turn.completed"; id: string };
+
+/**
+ * Fold one stream event onto the current turns, returning a new array
+ * (never mutating the input). Order-preserving: a turn keeps its first-seen
+ * position for the whole run.
+ *
+ * Honest by omission — a `delta`/`completed` for an id that was never
+ * `started` is ignored rather than conjuring a turn from a partial frame; a
+ * repeated `started` for a known id is a no-op so a reconnect that replays the
+ * opening frame can't duplicate a turn.
+ */
+export function reduceTurns(
+  turns: readonly AssistantTurn[],
+  event: AssistantStreamEvent,
+): AssistantTurn[] {
+  switch (event.type) {
+    case "turn.started": {
+      if (turns.some((turn) => turn.id === event.id)) return turns.slice();
+      return [
+        ...turns,
+        {
+          id: event.id,
+          role: event.role,
+          text: event.text ?? "",
+          status: "streaming",
+        },
+      ];
+    }
+    case "turn.delta":
+      return turns.map((turn) =>
+        turn.id === event.id ? { ...turn, text: turn.text + event.text } : turn,
+      );
+    case "turn.completed":
+      return turns.map((turn) =>
+        turn.id === event.id ? { ...turn, status: "complete" } : turn,
+      );
+  }
+}
+
+/** Fold a whole event sequence — convenience for tests and replay. */
+export function reduceTurnSequence(
+  events: readonly AssistantStreamEvent[],
+): AssistantTurn[] {
+  return events.reduce<AssistantTurn[]>(
+    (turns, event) => reduceTurns(turns, event),
+    [],
+  );
+}
+
+/** One scripted frame plus how long to wait before emitting it. */
+export interface ScriptedFrame {
+  event: AssistantStreamEvent;
+  /** Delay (ms) after the previous frame before this one is emitted. */
+  afterMs: number;
+}
+
+/** Inter-delta cadence for the mock — brisk enough to feel live, slow enough
+ *  to read as a stream rather than a paste. */
+const DELTA_MS = 140;
+
+/**
+ * A canned single-agent conversation, shaped like what the spine will stream:
+ * the user asks the operate-only assistant to explain the open agent, and the
+ * assistant answers in streamed deltas. Content is generic on purpose — the
+ * pane is what's under test here, not any particular agent.
+ */
+export function mockConversationScript(): ScriptedFrame[] {
+  const assistantDeltas = [
+    "This agent watches an inbox for new leads. ",
+    "Each message is scored, enriched with company details, ",
+    "and routed to the right rep — or auto-replied when it's clearly spam.\n\n",
+    "It runs three steps: **triage**, **enrich**, then **route**. ",
+    "Ask me to run it, or open a step on the canvas to see its live cost.",
+  ];
+
+  return [
+    {
+      afterMs: 120,
+      event: {
+        type: "turn.started",
+        id: "u1",
+        role: "user",
+        text: "What does this agent do?",
+      },
+    },
+    { afterMs: 0, event: { type: "turn.completed", id: "u1" } },
+    {
+      afterMs: 260,
+      event: { type: "turn.started", id: "a1", role: "assistant" },
+    },
+    ...assistantDeltas.map<ScriptedFrame>((text) => ({
+      afterMs: DELTA_MS,
+      event: { type: "turn.delta", id: "a1", text },
+    })),
+    { afterMs: DELTA_MS, event: { type: "turn.completed", id: "a1" } },
+  ];
+}

--- a/packages/harness/web/src/lib/use-assistant-mock-stream.ts
+++ b/packages/harness/web/src/lib/use-assistant-mock-stream.ts
@@ -1,0 +1,40 @@
+/**
+ * React glue that plays the mock conversation script (assistant-stream.ts)
+ * into turn state, imitating a live subscription to the intelligence spine.
+ *
+ * Mock-mode only: in a real install there is no spine wired yet (that is a
+ * separate workstream), so this yields nothing rather than fabricating turns —
+ * the pane then shows its honest empty state. When the spine lands, this hook
+ * is the single swap point: replace the scripted timers with a subscription to
+ * the event bus and feed the frames through the same `reduceTurns`.
+ */
+import { useEffect, useState } from "react";
+
+import { isMockMode } from "./api";
+import {
+  mockConversationScript,
+  reduceTurns,
+  type AssistantTurn,
+} from "./assistant-stream";
+
+export function useAssistantMockStream(): AssistantTurn[] {
+  const [turns, setTurns] = useState<AssistantTurn[]>([]);
+
+  useEffect(() => {
+    if (!isMockMode()) return;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    let elapsed = 0;
+    for (const { event, afterMs } of mockConversationScript()) {
+      elapsed += afterMs;
+      timers.push(
+        setTimeout(() => setTurns((prev) => reduceTurns(prev, event)), elapsed),
+      );
+    }
+    return () => {
+      for (const timer of timers) clearTimeout(timer);
+    };
+  }, []);
+
+  return turns;
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2393,6 +2393,180 @@ input {
   display: none;
 }
 
+/* ---------------------------------------------------------------------------
+ * Conversation pane — the right-region Assistant ⇄ CLI slot (SAP-1806).
+ * The toggle reuses the right-pane segmented-switch recipe; the panels fill
+ * the height below it and hide (not unmount) the inactive side.
+ * ------------------------------------------------------------------------- */
+.conversation-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.conversation-tabs {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+
+.conversation-tab {
+  padding: 3px 12px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-faint);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.conversation-tab:hover {
+  color: var(--text-dim);
+  background: var(--bg-hover);
+}
+
+.conversation-tab.is-active {
+  color: var(--text);
+  background: var(--bg-1);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-xs);
+}
+
+.conversation-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.conversation-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.conversation-panel.is-hidden {
+  display: none;
+}
+
+.conversation-cli-empty {
+  padding: 16px;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+/* Assistant conversation view */
+.assistant-pane {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.assistant-empty {
+  padding: 8px 4px;
+  color: var(--text-dim);
+  font-size: 12.5px;
+}
+
+.assistant-empty-hint {
+  margin-top: 6px;
+  color: var(--text-faint);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.assistant-turns {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.assistant-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.assistant-turn-author {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.assistant-turn-body {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+
+.assistant-turn--user .assistant-turn-body {
+  color: var(--text);
+}
+
+.assistant-turn-body .chat-paragraph {
+  margin: 0 0 6px;
+}
+
+.assistant-turn-body .chat-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.assistant-turn-body .chat-list {
+  margin: 0 0 6px;
+  padding-left: 18px;
+}
+
+.assistant-turn-body .chat-code-block {
+  font-size: 11px;
+  margin: 6px 0;
+}
+
+.assistant-turn-body .chat-inline-code {
+  font-size: 11px;
+}
+
+/* Streaming caret — a blinking block appended to an in-flight turn. */
+.assistant-caret {
+  display: inline-block;
+  width: 6px;
+  height: 13px;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--accent);
+  border-radius: 1px;
+  animation: assistant-caret-blink 1s step-end infinite;
+}
+
+@keyframes assistant-caret-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
 /* Both child panels (canvas-pane, rail-skills) must fill the slot fully.
    canvas-pane and rail-skills both use display:flex/flex-direction:column
    already; this makes them stretch to occupy the available height. */


### PR DESCRIPTION
## Summary

Adds the right-region **conversation pane** from the Sapiom Studio app-experience design: one slot with an **Assistant ⇄ CLI toggle**. The **Assistant is the zero-setup default** and renders turns streamed from a **mock stream**; the **CLI is the existing pty terminal, unchanged**, one toggle away.

Closes SAP-1806.

## Why a mock stream + a preview flag

Per the ticket, this is built **independent of the spine and of the studio adoption**:

- The Assistant's real turns come from the **intelligence spine** (a Sapiom workflow run on our account, not the user's Claude Code) — a separate workstream (SAP-1807), integrated in **S5**. Until then the pane runs on a mock stream.
- The pane's final home is the **right region of the adopted studio shell** (the Launch rebase). To avoid regressing today's terminal-first shell — and to keep every existing spec green — the pane is mounted behind a **mock-only `?pane=conversation` preview flag** (mirrors the existing `?mockState=fresh` pattern). Nothing on the default path changes; the studio-adoption rebase wires it into the real region.

The mock stream is **mock-mode only** — in a real install with no spine yet, the Assistant shows an honest empty state rather than fabricating turns.

## What's here

- `lib/assistant-stream.ts` — framework-free turn model + order-preserving reducer (`turn.started` / `turn.delta` / `turn.completed` → turns) + a canned mock script. Event names mirror the "streams turns" contract so it swaps onto the spine with a source change only.
- `lib/use-assistant-mock-stream.ts` — React glue that plays the script into turn state (mock-mode gated).
- `components/AssistantPane.tsx` — renders turns (Markdown for assistant text, streaming caret while in flight).
- `components/ConversationPane.tsx` — the Assistant ⇄ CLI toggle, reusing the right pane's segmented-switch styling + keep-alive discipline; the CLI side reuses the unchanged `Terminal`.
- `App.tsx` / `api.ts` — the mock-only preview mount + `isConversationPreview()` helper.
- `styles.css` — `conversation-*` / `assistant-*` styles built on the existing design tokens.

## Acceptance criteria

- [x] The pane toggles Assistant ⇄ CLI; Assistant is default; CLI (terminal) unchanged.
- [x] The Assistant renders streamed turns from a mock stream.
- [x] Component tests for the toggle + turn rendering — vitest for the reducer (turn-rendering logic), Playwright e2e for the toggle + streamed rendering (this repo tests React components in the e2e tier).

## Testing

- `pnpm --filter @sapiom/harness typecheck` — green (server + web)
- `pnpm --filter @sapiom/harness test` — 974 passed (incl. new `assistant-stream.test.ts`)
- `pnpm --filter @sapiom/harness build` — green
- Playwright e2e — 128 passed (incl. new `conversation.spec.ts`); no existing spec affected

## Notes for review

- Preview-flag mount is deliberate (see above); the final placement lands with the studio-adoption rebase.
- Not fixed here (out of scope, pre-existing): `styles.css` has an unclosed `.step-detail-freeform-ask` rule (CSS nesting) that silently absorbs the rules after it — worth a follow-up. New styles were placed before that rule to stay unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)