### PR TITLE
feat(harness): persistent workspace membership store + CRUD routes (SAP-1810)

### DIFF
--- a/packages/harness/src/core/errors.ts
+++ b/packages/harness/src/core/errors.ts
@@ -3,8 +3,10 @@
  * so callers can react programmatically to specific failure modes instead of
  * parsing error message strings.
  *
- * HTTP mappings (server/rest.ts, server/macros.ts):
+ * HTTP mappings (server/rest.ts, server/macros.ts, server/workspaces.ts):
  *   UnknownSessionError       → 404
+ *   UnknownWorkspaceError     → 404
+ *   InvalidWorkspaceNameError → 400
  *   SessionNotReadyError      → 409
  *   SessionAlreadyLiveError   → 409
  *   SessionNotResumeableError → 409
@@ -35,6 +37,28 @@ export class HarnessError extends Error {
 export class UnknownSessionError extends HarnessError {
   constructor(id: string) {
     super("UNKNOWN_SESSION", `Unknown session "${id}"`);
+  }
+}
+
+/**
+ * Thrown when a workspace operation references an id that does not exist in
+ * the store (rename/delete/assign/unassign a workspace that was never created
+ * or has been removed). Maps to HTTP 404.
+ */
+export class UnknownWorkspaceError extends HarnessError {
+  constructor(id: string) {
+    super("UNKNOWN_WORKSPACE", `Unknown workspace "${id}"`);
+  }
+}
+
+/**
+ * Thrown when a workspace create/rename is given a name that is empty (or only
+ * whitespace). Names are the user-facing identity of a workspace, so a blank
+ * one is rejected rather than silently coerced. Maps to HTTP 400.
+ */
+export class InvalidWorkspaceNameError extends HarnessError {
+  constructor() {
+    super("INVALID_WORKSPACE_NAME", "Workspace name must be a non-empty string");
   }
 }
 

--- a/packages/harness/src/core/paths.test.ts
+++ b/packages/harness/src/core/paths.test.ts
@@ -27,6 +27,7 @@ describe("resolveStatePaths", () => {
     expect(paths.machineId).toBe(path.join(root, "machine-id"));
     expect(paths.sessions).toBe(path.join(root, "sessions.json"));
     expect(paths.workflows).toBe(path.join(root, "workflows.json"));
+    expect(paths.workspaces).toBe(path.join(root, "workspaces.json"));
     expect(paths.events).toBe(path.join(root, "events.ndjson"));
     expect(paths.settings).toBe(path.join(root, "settings.json"));
     expect(paths.generated).toBe(path.join(root, "generated"));
@@ -39,6 +40,7 @@ describe("resolveStatePaths", () => {
     expect(paths.machineId).toBe("/scratch/state/machine-id");
     expect(paths.sessions).toBe("/scratch/state/sessions.json");
     expect(paths.workflows).toBe("/scratch/state/workflows.json");
+    expect(paths.workspaces).toBe("/scratch/state/workspaces.json");
     expect(paths.events).toBe("/scratch/state/events.ndjson");
     expect(paths.settings).toBe("/scratch/state/settings.json");
     expect(paths.generated).toBe("/scratch/state/generated");

--- a/packages/harness/src/core/paths.ts
+++ b/packages/harness/src/core/paths.ts
@@ -23,6 +23,7 @@ export interface HarnessStatePaths {
   machineId: string;
   sessions: string;
   workflows: string;
+  workspaces: string;
   events: string;
   settings: string;
   generated: string;
@@ -50,6 +51,7 @@ export function resolveStatePaths(stateRoot?: string): HarnessStatePaths {
     machineId: join(root, relativeToHome(HARNESS_PATHS.machineId)),
     sessions: join(root, relativeToHome(HARNESS_PATHS.sessions)),
     workflows: join(root, relativeToHome(HARNESS_PATHS.workflows)),
+    workspaces: join(root, relativeToHome(HARNESS_PATHS.workspaces)),
     events: join(root, relativeToHome(HARNESS_PATHS.events)),
     settings: join(root, relativeToHome(HARNESS_PATHS.settings)),
     generated: join(root, relativeToHome(HARNESS_PATHS.generated)),

--- a/packages/harness/src/core/workspace-store.test.ts
+++ b/packages/harness/src/core/workspace-store.test.ts
@@ -1,0 +1,193 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { InvalidWorkspaceNameError, UnknownWorkspaceError } from "./errors.js";
+import { WorkspaceStore } from "./workspace-store.js";
+
+describe("WorkspaceStore", () => {
+  let tmpRoot: string;
+  let storePath: string;
+  let store: WorkspaceStore;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-workspace-store-"));
+    storePath = path.join(tmpRoot, "state", "workspaces.json");
+    store = new WorkspaceStore(storePath);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("starts empty when no store file exists", async () => {
+    expect(await store.list()).toEqual([]);
+  });
+
+  describe("create", () => {
+    it("creates an empty workspace with a stable id and timestamps", async () => {
+      const ws = await store.create("acme-crm");
+      expect(ws.name).toBe("acme-crm");
+      expect(ws.agentPaths).toEqual([]);
+      expect(ws.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(ws.createdAt).toBe(ws.updatedAt);
+      expect(await store.list()).toEqual([ws]);
+    });
+
+    it("trims the name and rejects empty / whitespace-only names", async () => {
+      const ws = await store.create("  spaced  ");
+      expect(ws.name).toBe("spaced");
+      await expect(store.create("")).rejects.toBeInstanceOf(InvalidWorkspaceNameError);
+      await expect(store.create("   ")).rejects.toBeInstanceOf(InvalidWorkspaceNameError);
+    });
+
+    it("assigns a distinct id to each workspace, even with the same name", async () => {
+      const a = await store.create("dupe");
+      const b = await store.create("dupe");
+      expect(a.id).not.toBe(b.id);
+      expect(await store.list()).toHaveLength(2);
+    });
+  });
+
+  describe("rename", () => {
+    it("renames in place (same id) and bumps updatedAt", async () => {
+      const ws = await store.create("old", "2020-01-01T00:00:00.000Z");
+      const renamed = await store.rename(ws.id, "  new  ", "2020-01-02T00:00:00.000Z");
+      expect(renamed.id).toBe(ws.id);
+      expect(renamed.name).toBe("new");
+      expect(renamed.createdAt).toBe("2020-01-01T00:00:00.000Z");
+      expect(renamed.updatedAt).toBe("2020-01-02T00:00:00.000Z");
+    });
+
+    it("throws UnknownWorkspaceError for an unknown id", async () => {
+      await expect(store.rename("nope", "x")).rejects.toBeInstanceOf(UnknownWorkspaceError);
+    });
+
+    it("rejects an empty new name", async () => {
+      const ws = await store.create("keep");
+      await expect(store.rename(ws.id, "  ")).rejects.toBeInstanceOf(InvalidWorkspaceNameError);
+      expect((await store.list())[0].name).toBe("keep");
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes a workspace and persists the deletion", async () => {
+      const a = await store.create("a");
+      const b = await store.create("b");
+      await store.remove(a.id);
+      expect((await store.list()).map((w) => w.id)).toEqual([b.id]);
+
+      const reloaded = new WorkspaceStore(storePath);
+      expect((await reloaded.list()).map((w) => w.id)).toEqual([b.id]);
+    });
+
+    it("throws UnknownWorkspaceError for an unknown id", async () => {
+      await expect(store.remove("nope")).rejects.toBeInstanceOf(UnknownWorkspaceError);
+    });
+  });
+
+  describe("assignAgent / unassignAgent", () => {
+    it("assigns agents by path in order and bumps updatedAt", async () => {
+      const ws = await store.create("w", "2020-01-01T00:00:00.000Z");
+      await store.assignAgent(ws.id, "/repos/crm-manager", "2020-01-02T00:00:00.000Z");
+      const after = await store.assignAgent(ws.id, "/repos/lead-handler", "2020-01-03T00:00:00.000Z");
+      expect(after.agentPaths).toEqual(["/repos/crm-manager", "/repos/lead-handler"]);
+      expect(after.updatedAt).toBe("2020-01-03T00:00:00.000Z");
+    });
+
+    it("assign is idempotent — no duplicate and no updatedAt bump", async () => {
+      const ws = await store.create("w", "2020-01-01T00:00:00.000Z");
+      await store.assignAgent(ws.id, "/repos/a", "2020-01-02T00:00:00.000Z");
+      const again = await store.assignAgent(ws.id, "/repos/a", "2020-01-09T00:00:00.000Z");
+      expect(again.agentPaths).toEqual(["/repos/a"]);
+      expect(again.updatedAt).toBe("2020-01-02T00:00:00.000Z");
+    });
+
+    it("unassigns a member and is a no-op for a non-member", async () => {
+      const ws = await store.create("w", "2020-01-01T00:00:00.000Z");
+      await store.assignAgent(ws.id, "/repos/a", "2020-01-02T00:00:00.000Z");
+      const removed = await store.unassignAgent(ws.id, "/repos/a", "2020-01-03T00:00:00.000Z");
+      expect(removed.agentPaths).toEqual([]);
+      expect(removed.updatedAt).toBe("2020-01-03T00:00:00.000Z");
+
+      const noop = await store.unassignAgent(ws.id, "/repos/never", "2020-01-09T00:00:00.000Z");
+      expect(noop.agentPaths).toEqual([]);
+      expect(noop.updatedAt).toBe("2020-01-03T00:00:00.000Z");
+    });
+
+    it("throws UnknownWorkspaceError when the workspace is gone", async () => {
+      await expect(store.assignAgent("nope", "/repos/a")).rejects.toBeInstanceOf(UnknownWorkspaceError);
+      await expect(store.unassignAgent("nope", "/repos/a")).rejects.toBeInstanceOf(UnknownWorkspaceError);
+    });
+  });
+
+  describe("persistence & stability", () => {
+    it("persists workspaces + memberships and reloads them for a fresh instance", async () => {
+      const ws = await store.create("acme");
+      await store.assignAgent(ws.id, "/repos/crm-manager");
+      await store.assignAgent(ws.id, "/repos/enricher");
+
+      const reloaded = new WorkspaceStore(storePath);
+      const list = await reloaded.list();
+      expect(list).toHaveLength(1);
+      expect(list[0].name).toBe("acme");
+      expect(list[0].agentPaths).toEqual(["/repos/crm-manager", "/repos/enricher"]);
+    });
+
+    it("membership survives regardless of any open-session state (nothing recomputes it)", async () => {
+      // The store has no session/cwd inputs at all: reloading a persisted file
+      // yields exactly what was written, proving membership can never be
+      // re-derived from which terminals happen to be open.
+      const ws = await store.create("stable");
+      await store.assignAgent(ws.id, "/repos/a");
+      const reloaded = new WorkspaceStore(storePath);
+      expect((await reloaded.list())[0].agentPaths).toEqual(["/repos/a"]);
+    });
+  });
+
+  describe("write serialization & atomicity", () => {
+    it("concurrent creates all survive in the persisted file", async () => {
+      const N = 8;
+      await Promise.all(Array.from({ length: N }, (_, i) => store.create(`ws-${i}`)));
+
+      const reloaded = new WorkspaceStore(storePath);
+      const names = new Set((await reloaded.list()).map((w) => w.name));
+      for (let i = 0; i < N; i++) expect(names.has(`ws-${i}`)).toBe(true);
+    });
+
+    it("concurrent assigns to the same workspace all survive (no lost update)", async () => {
+      const ws = await store.create("w");
+      const N = 8;
+      await Promise.all(
+        Array.from({ length: N }, (_, i) => store.assignAgent(ws.id, `/repos/agent-${i}`)),
+      );
+
+      const reloaded = new WorkspaceStore(storePath);
+      const paths = new Set((await reloaded.list())[0].agentPaths);
+      for (let i = 0; i < N; i++) expect(paths.has(`/repos/agent-${i}`)).toBe(true);
+    });
+
+    it("persist uses atomic tmp-file + rename so a mid-write crash cannot tear workspaces.json", async () => {
+      await store.create("w");
+      const raw = await fs.readFile(storePath, "utf8");
+      expect(Array.isArray(JSON.parse(raw))).toBe(true);
+      await expect(fs.access(`${storePath}.tmp`)).rejects.toThrow();
+    });
+
+    it("a failed persist does not poison the queue — subsequent writes succeed", async () => {
+      // Make the store path a DIRECTORY so writeFile throws EISDIR.
+      const badPath = path.join(tmpRoot, "workspaces-dir");
+      await fs.mkdir(badPath, { recursive: true });
+      const broken = new WorkspaceStore(badPath);
+
+      await expect(broken.create("x")).rejects.toThrow();
+
+      await fs.rmdir(badPath);
+      await broken.create("ok");
+      const list = await broken.list();
+      expect(list).toHaveLength(1);
+      expect(list[0].name).toBe("ok");
+    });
+  });
+});

--- a/packages/harness/src/core/workspace-store.ts
+++ b/packages/harness/src/core/workspace-store.ts
@@ -1,0 +1,198 @@
+/**
+ * Workspace membership store (design.md §4 — the "Workspace" noun; E3).
+ *
+ * A persistent, user-owned mapping of named workspaces → member agents that
+ * survives session (and server) open/close. It replaces the old cwd-derived
+ * bucketing that recomputed the rail's grouping from whichever terminals were
+ * open — the whole point here is that membership is **saved and stable** and
+ * is never inferred from open sessions.
+ *
+ * Persisted to HARNESS_PATHS.workspaces (`~/.sapiom/harness/workspaces.json`)
+ * as `Workspace[]`. The store is a close sibling of {@link WorkflowRegistry}:
+ * same load-once / atomic-persist / serialized-write-queue shape, so the two
+ * behave identically under concurrent mutation and crash-mid-write. Exposes
+ * only the model + CRUD; the Express surface lives in server/workspaces.ts.
+ *
+ * Mutations are transactional: each computes the next state immutably, writes
+ * it to disk, and only then commits it in memory — so a failed write leaves
+ * both disk and the in-memory list untouched (no phantom entry that a later
+ * successful write would then persist).
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { HARNESS_PATHS, type Workspace } from "../shared/types.js";
+import { InvalidWorkspaceNameError, UnknownWorkspaceError } from "./errors.js";
+
+function expandHome(inputPath: string): string {
+  if (inputPath === "~") return os.homedir();
+  if (inputPath.startsWith("~/")) return path.join(os.homedir(), inputPath.slice(2));
+  return inputPath;
+}
+
+/** Trims a candidate name and rejects an empty/whitespace-only result. */
+function normalizeName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) throw new InvalidWorkspaceNameError();
+  return trimmed;
+}
+
+export class WorkspaceStore {
+  private workspaces: Workspace[] = [];
+  private loaded = false;
+  /** Serializes mutations so concurrent create/rename/assign calls can't
+   *  interleave and drop each other's writes from the persisted file. Mirrors
+   *  WorkflowRegistry.writeQueue (workflow-registry.ts:109). */
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly storePath: string = expandHome(HARNESS_PATHS.workspaces)) {}
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.storePath, "utf8");
+      this.workspaces = JSON.parse(raw) as Workspace[];
+    } catch {
+      this.workspaces = [];
+    }
+    this.loaded = true;
+  }
+
+  /**
+   * Writes `next` to disk atomically, then commits it in memory. On any write
+   * error the in-memory list is left untouched (and the error rethrown), so a
+   * failed mutation can never leave memory ahead of disk. Atomic write: temp
+   * file in the same directory (so rename is same-filesystem and thus atomic
+   * on POSIX), then rename over the target — a crash mid-write leaves the .tmp
+   * file, not a torn workspaces.json. Mirrors WorkflowRegistry.persist().
+   */
+  private async commit(next: Workspace[]): Promise<void> {
+    const dir = path.dirname(this.storePath);
+    await fs.mkdir(dir, { recursive: true });
+    const tmpPath = `${this.storePath}.tmp`;
+    await fs.writeFile(tmpPath, JSON.stringify(next, null, 2));
+    await fs.rename(tmpPath, this.storePath);
+    this.workspaces = next;
+  }
+
+  /** Chains `run` onto the write queue so concurrent mutations never
+   *  interleave — a failed run never poisons later ones. */
+  private enqueue<T>(run: () => Promise<T>): Promise<T> {
+    const next = this.writeQueue.catch(() => {}).then(run);
+    this.writeQueue = next.then(
+      () => {},
+      () => {},
+    );
+    return next;
+  }
+
+  /** Locates a workspace by id or throws UnknownWorkspaceError. */
+  private require(id: string): Workspace {
+    const workspace = this.workspaces.find((w) => w.id === id);
+    if (!workspace) throw new UnknownWorkspaceError(id);
+    return workspace;
+  }
+
+  /** All workspaces, in creation order. */
+  async list(): Promise<Workspace[]> {
+    await this.ensureLoaded();
+    return this.workspaces;
+  }
+
+  /** Creates a new, empty workspace with the given display name. */
+  async create(name: string, now = new Date().toISOString()): Promise<Workspace> {
+    const trimmed = normalizeName(name);
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const workspace: Workspace = {
+        id: crypto.randomUUID(),
+        name: trimmed,
+        agentPaths: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      await this.commit([...this.workspaces, workspace]);
+      return workspace;
+    });
+  }
+
+  /** Renames a workspace. Throws UnknownWorkspaceError if `id` is unknown. */
+  async rename(id: string, name: string, now = new Date().toISOString()): Promise<Workspace> {
+    const trimmed = normalizeName(name);
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const existing = this.require(id);
+      const updated: Workspace = { ...existing, name: trimmed, updatedAt: now };
+      await this.commit(this.workspaces.map((w) => (w.id === id ? updated : w)));
+      return updated;
+    });
+  }
+
+  /** Deletes a workspace. Throws UnknownWorkspaceError if `id` is unknown. */
+  async remove(id: string): Promise<void> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      this.require(id);
+      await this.commit(this.workspaces.filter((w) => w.id !== id));
+    });
+  }
+
+  /**
+   * Assigns an agent (by registry `path`) to a workspace. Idempotent — a path
+   * already in the workspace is a no-op that neither duplicates it nor bumps
+   * `updatedAt` (and writes nothing). Throws UnknownWorkspaceError if `id` is
+   * unknown.
+   */
+  async assignAgent(id: string, agentPath: string, now = new Date().toISOString()): Promise<Workspace> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const existing = this.require(id);
+      if (existing.agentPaths.includes(agentPath)) return existing;
+      const updated: Workspace = {
+        ...existing,
+        agentPaths: [...existing.agentPaths, agentPath],
+        updatedAt: now,
+      };
+      await this.commit(this.workspaces.map((w) => (w.id === id ? updated : w)));
+      return updated;
+    });
+  }
+
+  /**
+   * Removes an agent from a workspace. Idempotent — removing a path that isn't
+   * a member is a no-op (writes nothing). Throws UnknownWorkspaceError if `id`
+   * is unknown.
+   */
+  async unassignAgent(id: string, agentPath: string, now = new Date().toISOString()): Promise<Workspace> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const existing = this.require(id);
+      if (!existing.agentPaths.includes(agentPath)) return existing;
+      const updated: Workspace = {
+        ...existing,
+        agentPaths: existing.agentPaths.filter((p) => p !== agentPath),
+        updatedAt: now,
+      };
+      await this.commit(this.workspaces.map((w) => (w.id === id ? updated : w)));
+      return updated;
+    });
+  }
+}
+
+/**
+ * The subset of {@link WorkspaceStore} the workspaces router depends on. Typed
+ * structurally (mirrors {@link WorkflowRegistryLike}) so a caller can pass a
+ * wrapper without an unsafe cast — a missing method is a compile error, not a
+ * runtime crash.
+ */
+export interface WorkspaceStoreLike {
+  list(): Promise<Workspace[]>;
+  create(name: string): Promise<Workspace>;
+  rename(id: string, name: string): Promise<Workspace>;
+  remove(id: string): Promise<void>;
+  assignAgent(id: string, agentPath: string): Promise<Workspace>;
+  unassignAgent(id: string, agentPath: string): Promise<Workspace>;
+}

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -41,6 +41,7 @@ import {
   type WorkflowRegistryLike,
   createWorkflowsRouter,
 } from "../core/workflow-registry.js";
+import { WorkspaceStore } from "../core/workspace-store.js";
 import { DEFAULT_MACROS } from "../core/macros.js";
 import { createEventStore } from "../core/collector/store.js";
 import { createHarnessEmitter } from "../core/collector/analytics-emitter.js";
@@ -103,6 +104,7 @@ import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 import { createSkillsRouter } from "./skills.js";
 import { createRunsRouter } from "./runs.js";
+import { createWorkspacesRouter } from "./workspaces.js";
 // resolveAgentsBaseUrl is imported above from definition-slug-resolver.js
 // (an identical helper); the runs router reuses it for its agents base URL.
 import { resolveCoreBaseUrl } from "../core/run-spend.js";
@@ -167,6 +169,8 @@ export interface HarnessServerOptions {
   collectorUrl?: string;
   /** Workflow registry file. Defaults to `<stateRoot>/workflows.json`. */
   workflowsRegistryPath?: string;
+  /** Workspace membership store file. Defaults to `<stateRoot>/workspaces.json`. */
+  workspacesStorePath?: string;
   /** Local analytics ndjson sink. Defaults to `<stateRoot>/events.ndjson`. */
   eventStorePath?: string;
   /** Overrides the home directory codex rollout discovery scans
@@ -422,6 +426,12 @@ export const startServer = async (
   } catch (err) {
     console.error("[harness] recent-dirs prune failed:", err);
   }
+  // Persistent, user-owned workspace membership (design.md §4). Independent of
+  // the workflow registry: membership is saved and stable, never recomputed
+  // from open sessions, so it needs no boot-time prune tied to session state.
+  const workspaceStore = new WorkspaceStore(
+    options.workspacesStorePath ?? statePaths.workspaces,
+  );
   let workflowsCache: WorkflowInfo[] = await workflowRegistry.list();
   const workflowsCacheTimer = setInterval(() => {
     void workflowRegistry.list().then((list) => {
@@ -817,6 +827,7 @@ export const startServer = async (
   );
   app.use(
     createWorkflowsRouter(enrichedWorkflowRegistry),
+    createWorkspacesRouter(workspaceStore),
     createFsRouter(),
     createSkillsRouter(),
     createMacrosRouter({

--- a/packages/harness/src/server/workspaces.test.ts
+++ b/packages/harness/src/server/workspaces.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Workspaces router tests — exercise the HTTP surface end-to-end against a
+ * real WorkspaceStore backed by an isolated tmp file (no network, no real
+ * home). express.json() is mounted ahead of the router exactly as the real
+ * server does for /api (server/index.ts).
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { WorkspaceStore } from "../core/workspace-store.js";
+import type { Workspace } from "../shared/types.js";
+import { createWorkspacesRouter } from "./workspaces.js";
+
+let tmpRoot: string;
+let store: WorkspaceStore;
+let server: ReturnType<express.Express["listen"]>;
+let baseUrl: string;
+
+function start(): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use(createWorkspacesRouter(store));
+  return new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+}
+
+async function api(method: string, url: string, body?: unknown): Promise<Response> {
+  return fetch(`${baseUrl}${url}`, {
+    method,
+    headers: body === undefined ? {} : { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-workspaces-router-"));
+  store = new WorkspaceStore(path.join(tmpRoot, "workspaces.json"));
+  await start();
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("GET /api/workspaces", () => {
+  it("returns an empty array initially", async () => {
+    const res = await api("GET", "/api/workspaces");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+});
+
+describe("POST /api/workspaces", () => {
+  it("creates a workspace and returns 201", async () => {
+    const res = await api("POST", "/api/workspaces", { name: "acme" });
+    expect(res.status).toBe(201);
+    const ws = (await res.json()) as Workspace;
+    expect(ws.name).toBe("acme");
+    expect(ws.agentPaths).toEqual([]);
+    expect(ws.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("400s when name is missing or blank", async () => {
+    expect((await api("POST", "/api/workspaces", {})).status).toBe(400);
+    expect((await api("POST", "/api/workspaces", { name: "   " })).status).toBe(400);
+  });
+});
+
+describe("PATCH /api/workspaces/:id", () => {
+  it("renames a workspace", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "old" })).json()) as Workspace;
+    const res = await api("PATCH", `/api/workspaces/${created.id}`, { name: "new" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Workspace).name).toBe("new");
+  });
+
+  it("404s for an unknown id", async () => {
+    const res = await api("PATCH", "/api/workspaces/nope", { name: "x" });
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { code: string }).code).toBe("UNKNOWN_WORKSPACE");
+  });
+
+  it("400s for a blank name", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "keep" })).json()) as Workspace;
+    expect((await api("PATCH", `/api/workspaces/${created.id}`, { name: "" })).status).toBe(400);
+  });
+});
+
+describe("DELETE /api/workspaces/:id", () => {
+  it("deletes a workspace", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "gone" })).json()) as Workspace;
+    const res = await api("DELETE", `/api/workspaces/${created.id}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(await (await api("GET", "/api/workspaces")).json()).toEqual([]);
+  });
+
+  it("404s for an unknown id", async () => {
+    expect((await api("DELETE", "/api/workspaces/nope")).status).toBe(404);
+  });
+});
+
+describe("agent membership", () => {
+  it("assigns and unassigns an agent by path", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "w" })).json()) as Workspace;
+
+    const assigned = (await (
+      await api("POST", `/api/workspaces/${created.id}/agents`, { agentPath: "/repos/crm" })
+    ).json()) as Workspace;
+    expect(assigned.agentPaths).toEqual(["/repos/crm"]);
+
+    const unassigned = (await (
+      await api("DELETE", `/api/workspaces/${created.id}/agents`, { agentPath: "/repos/crm" })
+    ).json()) as Workspace;
+    expect(unassigned.agentPaths).toEqual([]);
+  });
+
+  it("400s when agentPath is missing", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "w" })).json()) as Workspace;
+    expect((await api("POST", `/api/workspaces/${created.id}/agents`, {})).status).toBe(400);
+  });
+
+  it("404s when assigning to an unknown workspace", async () => {
+    const res = await api("POST", "/api/workspaces/nope/agents", { agentPath: "/repos/x" });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("persistence through the API", () => {
+  it("a workspace created via POST is readable by a fresh store instance", async () => {
+    const created = (await (await api("POST", "/api/workspaces", { name: "persisted" })).json()) as Workspace;
+    await api("POST", `/api/workspaces/${created.id}/agents`, { agentPath: "/repos/a" });
+
+    const reloaded = new WorkspaceStore(path.join(tmpRoot, "workspaces.json"));
+    const list = await reloaded.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].agentPaths).toEqual(["/repos/a"]);
+  });
+});

--- a/packages/harness/src/server/workspaces.ts
+++ b/packages/harness/src/server/workspaces.ts
@@ -1,0 +1,105 @@
+/**
+ * Workspaces CRUD router — the `/api/workspaces` surface from
+ * src/shared/types.ts, exposing the persistent workspace membership store
+ * (core/workspace-store.ts) to the SPA. The integrator mounts it (and
+ * express.json()) on the shared app; see server/index.ts.
+ *
+ *   GET    /api/workspaces                → Workspace[]
+ *   POST   /api/workspaces                { name } → Workspace
+ *   PATCH  /api/workspaces/:id            { name } → Workspace   (rename)
+ *   DELETE /api/workspaces/:id            → { ok: true }
+ *   POST   /api/workspaces/:id/agents     { agentPath } → Workspace   (assign)
+ *   DELETE /api/workspaces/:id/agents     { agentPath } → Workspace   (unassign)
+ */
+
+import { Router, type Request, type Response, type Router as ExpressRouter } from "express";
+
+import { HarnessError, InvalidWorkspaceNameError, UnknownWorkspaceError } from "../core/errors.js";
+import type { WorkspaceStoreLike } from "../core/workspace-store.js";
+
+/** Maps a thrown error to a JSON error response. Typed harness errors get
+ *  their stable code + a specific status; anything else is a 500. */
+function sendError(res: Response, err: unknown): void {
+  if (err instanceof UnknownWorkspaceError) {
+    res.status(404).json({ error: err.message, code: err.code });
+    return;
+  }
+  if (err instanceof InvalidWorkspaceNameError) {
+    res.status(400).json({ error: err.message, code: err.code });
+    return;
+  }
+  if (err instanceof HarnessError) {
+    res.status(400).json({ error: err.message, code: err.code });
+    return;
+  }
+  res.status(500).json({ error: (err as Error).message });
+}
+
+/** Reads a required non-empty string field from a JSON body, or 400s. */
+function requireStringField(req: Request, res: Response, field: string): string | null {
+  const value = (req.body as Record<string, unknown> | undefined)?.[field];
+  if (typeof value !== "string" || !value.trim()) {
+    res.status(400).json({ error: `${field} is required` });
+    return null;
+  }
+  return value;
+}
+
+export function createWorkspacesRouter(store: WorkspaceStoreLike): ExpressRouter {
+  const router = Router();
+
+  router.get("/api/workspaces", async (_req, res) => {
+    res.json(await store.list());
+  });
+
+  router.post("/api/workspaces", async (req, res) => {
+    const name = requireStringField(req, res, "name");
+    if (name === null) return;
+    try {
+      res.status(201).json(await store.create(name));
+    } catch (err) {
+      sendError(res, err);
+    }
+  });
+
+  router.patch("/api/workspaces/:id", async (req, res) => {
+    const name = requireStringField(req, res, "name");
+    if (name === null) return;
+    try {
+      res.json(await store.rename(req.params.id, name));
+    } catch (err) {
+      sendError(res, err);
+    }
+  });
+
+  router.delete("/api/workspaces/:id", async (req, res) => {
+    try {
+      await store.remove(req.params.id);
+      res.json({ ok: true });
+    } catch (err) {
+      sendError(res, err);
+    }
+  });
+
+  router.post("/api/workspaces/:id/agents", async (req, res) => {
+    const agentPath = requireStringField(req, res, "agentPath");
+    if (agentPath === null) return;
+    try {
+      res.json(await store.assignAgent(req.params.id, agentPath));
+    } catch (err) {
+      sendError(res, err);
+    }
+  });
+
+  router.delete("/api/workspaces/:id/agents", async (req, res) => {
+    const agentPath = requireStringField(req, res, "agentPath");
+    if (agentPath === null) return;
+    try {
+      res.json(await store.unassignAgent(req.params.id, agentPath));
+    } catch (err) {
+      sendError(res, err);
+    }
+  });
+
+  return router;
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -22,6 +22,8 @@ export const HARNESS_PATHS = {
   sessions: `${HARNESS_HOME}/sessions.json`,
   /** Workflow registry — WorkflowInfo[] as JSON. */
   workflows: `${HARNESS_HOME}/workflows.json`,
+  /** Persistent, user-owned workspace membership — Workspace[] as JSON. */
+  workspaces: `${HARNESS_HOME}/workspaces.json`,
   /** Local analytics sink (one AnalyticsEvent per line). Always written. */
   events: `${HARNESS_HOME}/events.ndjson`,
   /** User settings (opt-in state, macros overrides). */
@@ -612,6 +614,12 @@ export interface CollectorBatch {
 // GET    /api/workflows                 → WorkflowInfo[]
 // POST   /api/workflows/connect         { path } → WorkflowInfo
 // POST   /api/workflows/scan            { root } → WorkflowInfo[]
+// GET    /api/workspaces                → Workspace[]
+// POST   /api/workspaces                CreateWorkspaceRequest → Workspace
+// PATCH  /api/workspaces/:id            RenameWorkspaceRequest → Workspace
+// DELETE /api/workspaces/:id            → { ok: true }
+// POST   /api/workspaces/:id/agents     WorkspaceAgentRequest → Workspace   (assign)
+// DELETE /api/workspaces/:id/agents     WorkspaceAgentRequest → Workspace   (unassign)
 // GET    /api/macros                    → MacroDef[]
 // POST   /api/macros/:id/run            RunMacroRequest → { ok: true }
 // GET    /api/settings                  → HarnessSettings
@@ -666,6 +674,22 @@ export interface AttachImageResponse {
  *  must be a path already known to the workflow registry (scan/connect). */
 export interface BindWorkflowRequest {
   workflowPath: string | null;
+}
+
+/** `POST /api/workspaces` body — create a workspace with a display name. */
+export interface CreateWorkspaceRequest {
+  name: string;
+}
+
+/** `PATCH /api/workspaces/:id` body — rename a workspace. */
+export interface RenameWorkspaceRequest {
+  name: string;
+}
+
+/** `POST`/`DELETE /api/workspaces/:id/agents` body — assign or unassign an
+ *  agent by its workflow-registry `path` (see {@link Workspace.agentPaths}). */
+export interface WorkspaceAgentRequest {
+  agentPath: string;
 }
 
 /** The trimmed workflow shape embedded in HarnessWorkspaceContext — just
@@ -816,6 +840,33 @@ export interface WorkflowInfo {
   definitionSlug: string | null;
   /** How it entered the registry. */
   source: "scan" | "connect";
+}
+
+/**
+ * A persistent, user-owned group of agents (design.md §4 — the "Workspace"
+ * noun; the rail spine). Membership is **saved and stable**: it is set by the
+ * user (create / rename / assign / unassign) and never recomputed from which
+ * terminals or sessions happen to be open. This is the replacement for the
+ * old cwd-derived bucketing that re-sorted the rail whenever a session opened
+ * or closed.
+ */
+export interface Workspace {
+  /** Stable id (uuid), assigned on create. A rename never changes it. */
+  id: string;
+  /** User-chosen display name. */
+  name: string;
+  /**
+   * Member agents, identified by their workflow-registry `path` (the agent's
+   * project directory — the same stable key {@link WorkflowInfo} is keyed by).
+   * Order is membership (assignment) order; each path appears at most once.
+   * A path that isn't currently in the registry is still a valid member — the
+   * rail shows it as broken rather than silently dropping it.
+   */
+  agentPaths: string[];
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last mutation (rename / assign / unassign). */
+  updatedAt: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Builds the **persistent, user-owned workspace membership store** — the rail spine from `plans/sapiom-studio/modules/app-experience/design.md` §4 (the "Workspace" noun). It replaces the ephemeral cwd-derived agent bucketing: membership is **saved and stable** and is never recomputed from which terminals/sessions happen to be open.

This is the server/state half of **E3** (SAP-1798). The three-noun cleanup (SAP-1813) and rail wiring (SAP-1814) consume this store's model + routes.

## What changed

- **`core/workspace-store.ts`** (new) — `WorkspaceStore`, persisted to `~/.sapiom/harness/workspaces.json` as `Workspace[]`. Mirrors `WorkflowRegistry`'s load-once / atomic-write / serialized-write-queue shape. Mutations are **transactional**: the next state is written to disk before it's committed in memory, so a failed write never leaves a phantom in-memory entry.
- **`server/workspaces.ts`** (new) — `createWorkspacesRouter` over a structural `WorkspaceStoreLike`, exposing:
  - `GET /api/workspaces` → `Workspace[]`
  - `POST /api/workspaces` `{ name }` → `Workspace` (201)
  - `PATCH /api/workspaces/:id` `{ name }` → `Workspace` (rename)
  - `DELETE /api/workspaces/:id` → `{ ok: true }`
  - `POST /api/workspaces/:id/agents` `{ agentPath }` → `Workspace` (assign)
  - `DELETE /api/workspaces/:id/agents` `{ agentPath }` → `Workspace` (unassign)
- **`shared/types.ts`** — `Workspace` model (`id`, `name`, `agentPaths`, `createdAt`, `updatedAt`), request types, and the REST surface comment block. Agents are referenced by their workflow-registry `path` (the same stable key `WorkflowInfo` uses).
- **`core/paths.ts`** — `workspaces` state path.
- **`core/errors.ts`** — `UnknownWorkspaceError` (404), `InvalidWorkspaceNameError` (400).
- **`server/index.ts`** — instantiates the store and mounts the router; adds a `workspacesStorePath` option (defaults under `stateRoot`).

## Design notes

- **Why a separate store, not the workflow registry:** workspaces are a distinct user-owned noun with their own lifecycle and must not be coupled to registry scan/prune (which is driven by what's on disk). A path that's no longer in the registry stays a valid member — the rail shows it as broken rather than silently dropping it (design.md §4).
- Assign/unassign are **idempotent** (no duplicate, no `updatedAt` bump, no write on a no-op).

## Testing

- `core/workspace-store.test.ts` — persistence across instances, CRUD, name trimming/validation, membership stability, idempotency, concurrent-write serialization, atomic-write, failed-write leaves memory untouched.
- `server/workspaces.test.ts` — full HTTP surface end-to-end against a real store (status codes, error codes, persistence through the API).
- Also extends `paths.test.ts`.

Gates: `build:server` (tsc) ✓ · `typecheck` (server + web) ✓ · `lint` ✓ · full harness unit suite **995 passed** ✓.

## Acceptance criteria

- [x] Workspaces + memberships persist across restarts.
- [x] CRUD works via routes; membership stable regardless of open sessions.
- [x] Store unit-tested.

Closes SAP-1810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)