### PR TITLE
feat(harness): serve ported Studio from the package build + private design-system seam (SAP-1792, SAP-1773)

### DIFF
--- a/.changeset/harness-serve-studio-design-system-seam.md
+++ b/.changeset/harness-serve-studio-design-system-seam.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/harness": patch
+---
+
+Serve the harness web UI from the package build and harden the design-system seam:
+
+- `pnpm build` emits the web app to `dist/web` and the harness server serves it as the SPA (index.html, hashed assets, and client-side deep-route fallback), so `start` and `npx @sapiom/harness` launch the full UI against the real server. Adds a regression test pinning the build → serve path.
+- The design system resolves to the real package when it's installed and falls back to a committed neutral, unbranded token set otherwise — so a public build renders legibly out of the box, with no theme source required. The stylesheet only bridges variable names onto tokens; it never redefines a token.
+
+No behavioral or API changes to the harness server.

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -1,0 +1,101 @@
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createStaticRouter } from "./static.js";
+
+// ---------------------------------------------------------------------------
+// The static router is the SPA-serving seam: `pnpm build` emits the Studio to
+// dist/web (web/vite.config.ts `outDir`), and the harness server mounts this
+// router pointed at that directory as the catch-all. These tests pin that
+// contract — a built bundle is served (index.html, hashed assets, and the SPA
+// deep-route fallback), and an unbuilt tree degrades to the placeholder rather
+// than 404ing — so the launch-critical `build → serve → npx` path can't
+// silently regress.
+// ---------------------------------------------------------------------------
+
+describe("createStaticRouter", () => {
+  let server: ReturnType<express.Express["listen"]>;
+  let baseUrl: string;
+  const tmpDirs: string[] = [];
+
+  function start(webDir: string): void {
+    const app = express();
+    app.use(createStaticRouter(webDir));
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  /** A fixture that mimics a real `vite build` output tree under dist/web. */
+  function makeBuiltWebDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "harness-web-"));
+    tmpDirs.push(dir);
+    mkdirSync(join(dir, "assets"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<!doctype html><html><head><title>Sapiom Studio</title>' +
+        '<script type="module" src="/assets/index-abc123.js"></script>' +
+        '</head><body><div id="root"></div></body></html>',
+    );
+    writeFileSync(
+      join(dir, "assets", "index-abc123.js"),
+      'console.log("studio bundle");',
+    );
+    return dir;
+  }
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe("when the web bundle is built (dist/web present)", () => {
+    it("serves index.html (the built SPA, not the placeholder) at the root", async () => {
+      start(makeBuiltWebDir());
+
+      const res = await fetch(`${baseUrl}/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("<title>Sapiom Studio</title>");
+      expect(html).toContain('<div id="root">');
+      expect(html).not.toContain("hasn't been built yet");
+    });
+
+    it("serves hashed static assets with the correct content type", async () => {
+      start(makeBuiltWebDir());
+
+      const res = await fetch(`${baseUrl}/assets/index-abc123.js`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("javascript");
+      expect(await res.text()).toContain("studio bundle");
+    });
+
+    it("falls back to index.html for unknown deep routes (client-side SPA routing)", async () => {
+      start(makeBuiltWebDir());
+
+      const res = await fetch(`${baseUrl}/some/client/route`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("<title>Sapiom Studio</title>");
+    });
+  });
+
+  describe("when the web bundle has not been built (dist/web absent)", () => {
+    it("serves a placeholder page instead of 404ing, so API/WS testing still works", async () => {
+      const missing = join(tmpdir(), `harness-web-missing-${Date.now()}`);
+      start(missing);
+
+      const res = await fetch(`${baseUrl}/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Sapiom Harness");
+      expect(html).toContain("hasn't been built yet");
+    });
+  });
+});

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -13,11 +13,59 @@
  * The built SPA is emitted to ../dist/web and served statically by the
  * harness server.
  */
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type AliasOptions } from "vite";
 import react from "@vitejs/plugin-react";
 
 const HARNESS_SERVER = "http://localhost:4100";
+
+const DS_PACKAGE = "@sapiom/design-system";
+const DS_NEUTRAL_DIR = fileURLToPath(new URL("./src/styles/ds-neutral", import.meta.url));
+
+/**
+ * Resolve the design-system seam: prefer the private `@sapiom/design-system`
+ * package when it's actually installed (official CI, authed to the private
+ * registry), and fall back to the committed neutral token set otherwise
+ * (public clones, this repo's own CI without the private registry).
+ *
+ * The only consumer is `styles.css`'s two CSS `@import "@sapiom/design-system/*"`
+ * lines, resolved through Vite's alias resolver. When the private package is
+ * present we DON'T alias the bare specifier at all — Vite resolves it to the
+ * real package in node_modules (branded tokens). When it's absent we alias it
+ * to `ds-neutral` (unbranded tokens) so the import still resolves and the app
+ * renders legibly. Either way `styles.css` is unchanged — the swap is 100% at
+ * the build seam.
+ *
+ * Rule: the private package and the neutral fallback expose the SAME token
+ * NAMES; only the values differ. Never redefine a token in `styles.css` (it
+ * bridges the upstream frontend var names onto these tokens via `var()` only).
+ *
+ * TODO(SAP-1773, CI): the "use the private package" half needs the official
+ * build to install `@sapiom/design-system` from the private registry before
+ * `build:web` (an authed `.npmrc`/registry step in the release workflow). That
+ * private-registry/publish infra is not set up in this repo; until it is,
+ * every build here resolves to the neutral fallback. Public clones must never
+ * install it — the package is `private: true`, off public npm, and no brand
+ * values are committed to this repo.
+ */
+function designSystemAlias(): AliasOptions {
+  const require = createRequire(import.meta.url);
+  let privatePackagePresent = false;
+  try {
+    // Probe for the package's manifest rather than its main entry: the design
+    // system is CSS-only (no JS main), so `resolve("@sapiom/design-system")`
+    // can throw ERR_PACKAGE_PATH_NOT_EXPORTED even when it IS installed.
+    require.resolve(`${DS_PACKAGE}/package.json`);
+    privatePackagePresent = true;
+  } catch {
+    privatePackagePresent = false;
+  }
+
+  // When present, add no alias — let Vite resolve the real package. When
+  // absent, redirect the bare specifier (and its subpaths) to ds-neutral.
+  return privatePackagePresent ? {} : { [DS_PACKAGE]: DS_NEUTRAL_DIR };
+}
 
 export default defineConfig({
   // The config lives in web/ but is invoked from the package root via
@@ -31,11 +79,10 @@ export default defineConfig({
       // (packages/harness/src/shared/types.ts) so the web and server always
       // build against one source of truth — no vendored copy to drift.
       "@shared/types": fileURLToPath(new URL("../src/shared/types.ts", import.meta.url)),
-      // The design system is a private package. Public builds resolve it to a
-      // committed neutral fallback so `@import "@sapiom/design-system/*"` in
-      // styles.css resolves and the app renders legibly; official builds swap
-      // this alias for the private package.
-      "@sapiom/design-system": fileURLToPath(new URL("./src/styles/ds-neutral", import.meta.url)),
+      // The design system is a private package. Official builds (private
+      // package installed) render branded; public clones fall back to a
+      // committed neutral token set. See designSystemAlias() above.
+      ...designSystemAlias(),
     },
   },
   build: {


### PR DESCRIPTION
Implements two tightly-coupled tickets as one cohesive PR: **G1b (SAP-1792)** re-integrates the ported Studio web into the `@sapiom/harness` build + server serving, and **G3 (SAP-1773)** hardens the private design-system seam.

## G1b — serve wiring (SAP-1792)
G1a (SAP-1767) ported the studio into `packages/harness/web/` and pointed vite's `outDir` at `../dist/web`, which matches the harness server's pre-existing static-serve path (`createStaticRouter` → `dist/web`, wired since V0). So the build → serve → launch chain is already end-to-end functional; verified by a runtime smoke test of the built server:

- `pnpm --filter @sapiom/harness build` emits `dist/web` (index.html + hashed assets) and `dist/cli/bin.js` / `dist/server`.
- `start` (`node dist/cli/bin.js`) serves the real studio SPA at `/` (title `Sapiom Studio`, hashed asset 200 w/ correct content-type, SPA deep-route fallback 200), while `/api` keeps its 401 auth gate.
- `npm pack` includes `dist/web`, so `npx @sapiom/harness` launches the packaged studio.

The gap this PR closes: that launch-critical serve path had **zero test coverage**. Added `src/server/static.test.ts` (4 tests) pinning the contract — built bundle serves index.html + assets + SPA fallback; unbuilt tree degrades to the placeholder rather than 404ing.

## G3 — private design-system seam (SAP-1773)
The `@sapiom/design-system` alias was **unconditional** (always → `ds-neutral`). Per the ticket, it must prefer the private package when present and fall back to neutral otherwise. `web/vite.config.ts` now probes for the installed package (`require.resolve("@sapiom/design-system/package.json")`, manifest-not-main because the DS is CSS-only) and:

- **present** (official CI, authed registry) → adds no alias; Vite resolves the real branded package.
- **absent** (public clones, this repo's CI) → aliases to the committed neutral `ds-neutral` token set.

Validated bidirectionally: a simulated private package (distinct sentinel tokens, in gitignored `node_modules` only) makes the built CSS carry the private values and drop the neutral brand; removing it reverts to neutral. `styles.css` is untouched — it only bridges the upstream frontend var names (`--bg-*`/`--text*`/`--accent*`) onto the design tokens via `var()`, never redefining a token. No brand palette is committed.

## CI-swap TODO (open item)
The "use the private package in official builds" half needs the release workflow to install `@sapiom/design-system` from the **private registry** (an authed `.npmrc`/registry step) before `build:web`. That private-registry/publish infra isn't set up in this repo, so this PR ships the **alias seam + committed neutral fallback** and documents the CI install step as a `TODO(SAP-1773, CI)` in `web/vite.config.ts`. Until wired, every build here resolves neutral. `tsconfig` `paths` keep the neutral fallback default (there are zero TS imports of the package — the only consumer is CSS `@import`, governed by the Vite alias).

## Scope / constraints
- Config-focused: only `web/vite.config.ts` + a new server test + a patch changeset. **No `App.tsx` / web-component / `styles.css` / `ds-neutral` edits** (owned by other Batch-2 leaves).
- Build + typecheck green; full unit suite green (82 files / 1064 tests, incl. the 4 new). Note: the real-pty suites (`transcript-replay`, `workspace-rescan`) are flaky under concurrency in the sandbox — they pass in isolation and in CI.
- PATCH changeset. Public repo: no leaks, no brand palette committed.

Linear: SAP-1792, SAP-1773

🤖 Generated with [Claude Code](https://claude.com/claude-code)