### PR TITLE
feat(harness): wire prod + local run logs into the run inspector (SAP-1779, SAP-1780)

### DIFF
--- a/.changeset/harness-wire-run-logs-inspector.md
+++ b/.changeset/harness-wire-run-logs-inspector.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/harness": patch
+---
+
+Wire prod and offline run logs into the Studio's click-into-step run inspector.
+
+- **Prod runs** light up per-step in the inspector as they progress — status, latency, pass/fail, and (when the run carries them) the step's real input and output. The inspector polls the run's state after it starts and stops quietly once the run finishes or can't be found, so a click into any step shows what it actually did.
+- **Offline stub runs** render in the SAME inspector: their streamed per-step trace is mapped into the identical step view (logs, pass/fail, and the input/output each step ran on), so an offline run reads exactly like a real one — just free and untimed, since a stub run records no cost or duration.
+
+Both paths share one step-render shape, so the inspector can never disagree with itself about how a run looks. The inspector names the capability a step called, never a model.

--- a/packages/harness/src/core/render-local-run.test.ts
+++ b/packages/harness/src/core/render-local-run.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import type { LocalStepTrace } from "@sapiom/agent-core";
+
+import type { RunView } from "../shared/types.js";
+import { renderLocalRun } from "./render-local-run.js";
+// The cap lives in the shared, dependency-free log module both mappers use.
+import { LOG_SLICE_MAX } from "./render-log-slice.js";
+
+/**
+ * A single local step-attempt trace over sensible defaults — a `succeeded` step
+ * named `s`, attempt 1, with a string input and no output. Tests override only
+ * the field under test, so an assertion pins exactly one behavior (mutation
+ * tests need each derivation isolated).
+ */
+function trace(overrides: Partial<LocalStepTrace> = {}): LocalStepTrace {
+  return {
+    step: "s",
+    attempt: 1,
+    input: "in",
+    status: "succeeded",
+    logs: [],
+    ...overrides,
+  };
+}
+
+/** Convenience: render a one-step run with the given trace + options. */
+function renderOne(
+  overrides: Partial<LocalStepTrace>,
+  options?: Parameters<typeof renderLocalRun>[1],
+): RunView {
+  return renderLocalRun([trace(overrides)], options);
+}
+
+describe("renderLocalRun — run status", () => {
+  it("folds outcome 'completed' → completed", () => {
+    expect(renderLocalRun([], { outcome: "completed" }).status).toBe("completed");
+  });
+
+  it("folds outcome 'failed' → failed", () => {
+    expect(renderLocalRun([], { outcome: "failed" }).status).toBe("failed");
+  });
+
+  it("folds outcome 'paused' → running (a paused run is not terminal)", () => {
+    expect(renderLocalRun([], { outcome: "paused" }).status).toBe("running");
+  });
+
+  it("folds outcome 'running' → running", () => {
+    expect(renderLocalRun([], { outcome: "running" }).status).toBe("running");
+  });
+
+  it("reports running when no outcome is supplied yet (stream still open)", () => {
+    expect(renderLocalRun([]).status).toBe("running");
+    expect(renderLocalRun([], {}).status).toBe("running");
+  });
+});
+
+describe("renderLocalRun — execution id", () => {
+  it("stamps the caller-supplied execution id", () => {
+    expect(renderLocalRun([], { executionId: "local-42" }).executionId).toBe("local-42");
+  });
+
+  it("defaults to an empty string when the caller has no id yet", () => {
+    expect(renderLocalRun([]).executionId).toBe("");
+    expect(renderLocalRun([], { outcome: "completed" }).executionId).toBe("");
+  });
+});
+
+describe("renderLocalRun — step status folding", () => {
+  it("folds 'succeeded' → passed", () => {
+    expect(renderOne({ status: "succeeded" }).steps[0].status).toBe("passed");
+  });
+
+  it("folds 'threw' → failed (a step that threw did not pass)", () => {
+    expect(renderOne({ status: "threw" }).steps[0].status).toBe("failed");
+  });
+
+  it("folds an unrecognized status → pending (never silently passed)", () => {
+    // Defensive: the union is succeeded|threw, but a mutant that widens the
+    // fold must not turn an unknown value into a green check.
+    const view = renderOne({ status: "weird" as LocalStepTrace["status"] });
+    expect(view.steps[0].status).toBe("pending");
+  });
+});
+
+describe("renderLocalRun — step id + name", () => {
+  it("keys the step id by step name and attempt", () => {
+    expect(renderOne({ step: "gather", attempt: 2 }).steps[0].id).toBe("gather-2");
+  });
+
+  it("distinguishes retries of the same step by attempt in the id", () => {
+    const view = renderLocalRun([
+      trace({ step: "flaky", attempt: 1, status: "threw" }),
+      trace({ step: "flaky", attempt: 2, status: "succeeded" }),
+    ]);
+    expect(view.steps.map((s) => s.id)).toEqual(["flaky-1", "flaky-2"]);
+  });
+
+  it("passes the step name through", () => {
+    expect(renderOne({ step: "gather" }).steps[0].name).toBe("gather");
+  });
+});
+
+describe("renderLocalRun — never fabricates cost or latency", () => {
+  it("omits costUsd on every local step (local runs are free)", () => {
+    const view = renderOne({ status: "succeeded", output: { total: 5 } });
+    expect(view.steps[0]).not.toHaveProperty("costUsd");
+  });
+
+  it("omits latencyMs on every local step (a trace carries no timing)", () => {
+    const view = renderOne({ status: "succeeded" });
+    expect(view.steps[0]).not.toHaveProperty("latencyMs");
+  });
+});
+
+describe("renderLocalRun — input", () => {
+  it("surfaces the input the step ran on", () => {
+    expect(renderOne({ input: { topic: "birds" } }).steps[0].input).toEqual({ topic: "birds" });
+  });
+
+  it("keeps a falsy-but-real input (0) rather than dropping it", () => {
+    expect(renderOne({ input: 0 }).steps[0].input).toBe(0);
+  });
+
+  it("keeps a null input as a real value (null is a payload the step received)", () => {
+    const view = renderOne({ input: null });
+    expect(view.steps[0]).toHaveProperty("input");
+    expect(view.steps[0].input).toBeNull();
+  });
+
+  it("omits input only when it is undefined", () => {
+    const view = renderOne({ input: undefined });
+    expect(view.steps[0]).not.toHaveProperty("input");
+  });
+});
+
+describe("renderLocalRun — output", () => {
+  it("surfaces a captured output", () => {
+    expect(renderOne({ output: { ok: true } }).steps[0].output).toEqual({ ok: true });
+  });
+
+  it("keeps a falsy-but-real output (false) rather than dropping it", () => {
+    expect(renderOne({ output: false }).steps[0].output).toBe(false);
+  });
+
+  it("keeps an empty-string output as a real value", () => {
+    const view = renderOne({ output: "" });
+    expect(view.steps[0]).toHaveProperty("output");
+    expect(view.steps[0].output).toBe("");
+  });
+
+  it("omits output when the step captured none (undefined)", () => {
+    const view = renderOne({ status: "succeeded", output: undefined });
+    expect(view.steps[0]).not.toHaveProperty("output");
+  });
+
+  it("omits output for a step that threw (no value produced)", () => {
+    const view = renderOne({ status: "threw", output: undefined, error: { name: "E", message: "x" } });
+    expect(view.steps[0]).not.toHaveProperty("output");
+  });
+});
+
+describe("renderLocalRun — error", () => {
+  it("surfaces a threw step's error message", () => {
+    const view = renderOne({
+      status: "threw",
+      error: { name: "TypeError", message: "cannot read x" },
+    });
+    expect(view.steps[0].error).toBe("cannot read x");
+  });
+
+  it("omits error on a step that did not throw", () => {
+    expect(renderOne({ status: "succeeded" }).steps[0]).not.toHaveProperty("error");
+  });
+
+  it("omits error when the error object carries an empty message", () => {
+    const view = renderOne({ status: "threw", error: { name: "E", message: "" } });
+    expect(view.steps[0]).not.toHaveProperty("error");
+  });
+});
+
+describe("renderLocalRun — log slice", () => {
+  it("formats { level, msg } entries into compact lines", () => {
+    const view = renderOne({
+      logs: [
+        { level: "info", msg: "start" },
+        { level: "error", msg: "kaboom" },
+      ],
+    });
+    expect(view.steps[0].logSlice).toBe("info start\nerror kaboom");
+  });
+
+  it("omits logSlice when there are no logs", () => {
+    expect(renderOne({ logs: [] }).steps[0]).not.toHaveProperty("logSlice");
+  });
+
+  it("keeps the TAIL when the buffer exceeds the cap", () => {
+    const logs = Array.from({ length: 800 }, (_, i) => ({
+      level: "info" as const,
+      msg: `line-${i}`,
+    }));
+    const slice = renderOne({ logs }).steps[0].logSlice as string;
+    expect(slice.length).toBe(LOG_SLICE_MAX);
+    expect(slice.endsWith("line-799")).toBe(true); // newest survives
+    expect(slice.startsWith("info line-0")).toBe(false); // oldest trimmed off the front
+  });
+});
+
+describe("renderLocalRun — whole run", () => {
+  it("preserves trace order", () => {
+    const view = renderLocalRun([
+      trace({ step: "first" }),
+      trace({ step: "second", status: "threw", error: { name: "E", message: "boom" } }),
+    ]);
+    expect(view.steps.map((s) => s.name)).toEqual(["first", "second"]);
+  });
+
+  it("maps an empty trace list to a run with no steps", () => {
+    expect(renderLocalRun([], { executionId: "local-1", outcome: "completed" })).toEqual({
+      executionId: "local-1",
+      status: "completed",
+      steps: [],
+    });
+  });
+
+  it("emits only the derived keys for a minimal succeeded step (honest absence everywhere)", () => {
+    // input defaults to "in"; a truly minimal step (no output/error/logs) must
+    // carry NO costUsd, latencyMs, output, error, or logSlice.
+    const view = renderLocalRun([trace({ step: "s", attempt: 1 })], {
+      executionId: "local-9",
+      outcome: "completed",
+    });
+    expect(view.steps[0]).toEqual({ id: "s-1", name: "s", status: "passed", input: "in" });
+  });
+
+  it("maps a realistic completed local run end to end", () => {
+    const view = renderLocalRun(
+      [
+        {
+          step: "gather",
+          attempt: 1,
+          input: { topic: "otters" },
+          status: "succeeded",
+          output: { facts: ["float on backs"] },
+          logs: [{ level: "info", msg: "fetched 1 fact" }],
+        },
+      ],
+      { executionId: "local-run-001", outcome: "completed" },
+    );
+    expect(view).toEqual({
+      executionId: "local-run-001",
+      status: "completed",
+      steps: [
+        {
+          id: "gather-1",
+          name: "gather",
+          status: "passed",
+          input: { topic: "otters" },
+          output: { facts: ["float on backs"] },
+          logSlice: "info fetched 1 fact",
+        },
+      ],
+    });
+  });
+
+  it("maps a run that threw on its last step (failed outcome, error surfaced)", () => {
+    const view = renderLocalRun(
+      [
+        trace({ step: "gather", status: "succeeded", output: { n: 1 } }),
+        {
+          step: "summarize",
+          attempt: 1,
+          input: { n: 1 },
+          status: "threw",
+          error: { name: "RangeError", message: "empty" },
+          logs: [],
+        },
+      ],
+      { executionId: "local-run-002", outcome: "failed" },
+    );
+    expect(view.status).toBe("failed");
+    expect(view.steps[1]).toEqual({
+      id: "summarize-1",
+      name: "summarize",
+      status: "failed",
+      input: { n: 1 },
+      error: "empty",
+    });
+  });
+});

--- a/packages/harness/src/core/render-local-run.ts
+++ b/packages/harness/src/core/render-local-run.ts
@@ -1,0 +1,130 @@
+/**
+ * renderLocalRun — the pure mapper from an offline stub run's per-step traces
+ * ({@link LocalStepTrace}[], streamed as NDJSON by `POST /api/runs/local`) to
+ * the same {@link RunView} the canvas renders for prod runs. Its twin is
+ * {@link renderRunState} (prod / local-backend); both emit the identical
+ * cost-free {@link StepView} shape, so ONE inspector renders every run source.
+ *
+ * Pure and deterministic: no LLM, no I/O, no clock. Every field is derived from
+ * the traces (plus the caller-supplied execution id and terminal outcome), so
+ * the same function can map a partial trace mid-stream and the final trace at
+ * the end — only the input grows, never this mapping. It is a Stryker target;
+ * the tests are mutation-first.
+ *
+ * Honest absence, matching renderRunState and the SDK's "null is honest absence,
+ * never a fabricated value" contract:
+ *  - **No cost** — local runs are stubbed and free by construction; a StepView
+ *    from here never carries `costUsd` (so the inspector reads "local run ·
+ *    free", never "$0.00").
+ *  - **No latency** — a {@link LocalStepTrace} carries no timing (agent-core's
+ *    in-process dispatcher records none, and agent-core is consumed as-is), so
+ *    `latencyMs` is ABSENT rather than a fabricated `0`.
+ *  - **Output** is present only when the trace captured one (a step that threw,
+ *    or a `continue` with no value, carries none) — but ABSENCE is `undefined`
+ *    on the trace, and a genuine `null`/`false`/`0`/`""` output is a real value
+ *    that passes through.
+ *  - **Input** is always carried by a trace (every attempt ran on some input,
+ *    even `undefined`); it is surfaced whenever it isn't `undefined`.
+ *  - **Logs and errors** collapse to the same `logSlice`/`error` fields prod
+ *    uses, via the shared formatter.
+ */
+import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
+
+import type { RunView, StepStatus, StepView } from "../shared/types.js";
+// Reuse prod's exact log-buffer formatter so a step's `logSlice` is byte-
+// identical whether it came from a prod projection or a local trace — the
+// inspector can never disagree with itself about how a log renders. Imported
+// from the dependency-free module (NOT render-run-state) so this mapper carries
+// no `@sapiom/agent-core`/`node:fs` runtime dep into the browser bundle.
+import { toLogSlice } from "./render-log-slice.js";
+
+/**
+ * Options carrying the run-level facts a `LocalStepTrace[]` alone can't provide.
+ * Both are optional so the mapper can render a live, still-streaming trace (no
+ * terminal summary yet) exactly as it renders the final one.
+ */
+export interface RenderLocalRunOptions {
+  /**
+   * The execution id to stamp on the {@link RunView}. A local run has no
+   * server-issued id, so the caller (the SPA's run store) synthesizes and owns
+   * one; the mapper stays pure by taking it rather than minting time/randomness.
+   * Defaults to an empty string when the caller has none yet.
+   */
+  executionId?: string;
+  /**
+   * The run's terminal outcome from the NDJSON summary line, when it has
+   * arrived. Absent while the stream is still open — the mapper then reports the
+   * run as `running` (steps may still be coming). Passing it flips the run to
+   * its settled status.
+   */
+  outcome?: LocalRunOutcome;
+}
+
+/**
+ * Fold a single step-attempt's status into a {@link StepStatus}. A local trace's
+ * status vocabulary is exactly `succeeded | threw` (see agent-core's
+ * LocalStubDispatcher). `succeeded` → `passed`; `threw` → `failed` (it did not
+ * pass — mirrors renderRunState's fold of `threw`). Anything unrecognized is
+ * `pending` (defensive; the union shouldn't produce it), NEVER silently
+ * `passed`.
+ */
+function toStepStatus(raw: LocalStepTrace["status"]): StepStatus {
+  if (raw === "succeeded") return "passed";
+  if (raw === "threw") return "failed";
+  return "pending";
+}
+
+/**
+ * Fold the run's terminal outcome into the four states the UI draws. A local run
+ * that `paused` is not yet done (the auto-resume loop or a human must advance
+ * it), so it reads as `running`, not a terminal state. An absent outcome (stream
+ * still open) is also `running`. `completed`/`failed` map straight through;
+ * there is no local "cancelled" outcome.
+ */
+function toRunStatus(outcome: LocalRunOutcome | undefined): RunView["status"] {
+  if (outcome === "completed") return "completed";
+  if (outcome === "failed") return "failed";
+  // "paused", "running", or absent (still streaming) — not terminal.
+  return "running";
+}
+
+/**
+ * Map one trace line to its {@link StepView}. Optional fields are assigned only
+ * when they carry a real value, so honest absence survives into the JSON the
+ * inspector reads (a missing field renders nothing rather than a fabricated
+ * zero/empty payload).
+ */
+function toStepView(trace: LocalStepTrace): StepView {
+  const view: StepView = {
+    // Local traces have no OTel span id; the (step, attempt) pair is the stable,
+    // collision-free key across a run's attempts of the same step.
+    id: `${trace.step}-${trace.attempt}`,
+    name: trace.step,
+    status: toStepStatus(trace.status),
+  };
+  // No costUsd, no latencyMs — a local run is free and untimed (see the file
+  // header). Their honest absence is the whole point of the local target.
+  if (trace.input !== undefined) view.input = trace.input;
+  if (trace.output !== undefined) view.output = trace.output;
+  if (trace.error?.message) view.error = trace.error.message;
+  const logSlice = toLogSlice(trace.logs);
+  if (logSlice !== undefined) view.logSlice = logSlice;
+  return view;
+}
+
+/**
+ * Map an offline stub run's traces (plus the caller-owned execution id and, once
+ * known, terminal outcome) to the {@link RunView} the canvas renders. Order-
+ * preserving over `traces` (execution order); total — never throws, mirroring
+ * renderRunState — because the traces are already the decoded wire shape.
+ */
+export function renderLocalRun(
+  traces: LocalStepTrace[],
+  options: RenderLocalRunOptions = {},
+): RunView {
+  return {
+    executionId: options.executionId ?? "",
+    status: toRunStatus(options.outcome),
+    steps: traces.map(toStepView),
+  };
+}

--- a/packages/harness/src/core/render-log-slice.test.ts
+++ b/packages/harness/src/core/render-log-slice.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+
+import { formatLogEntry, toLogSlice, LOG_SLICE_MAX } from "./render-log-slice.js";
+
+describe("formatLogEntry", () => {
+  it("returns a bare string entry unchanged", () => {
+    expect(formatLogEntry("just a line")).toBe("just a line");
+  });
+
+  it("returns an empty string for an empty-string entry (the string branch, not stringified)", () => {
+    // Kills the `typeof entry === "string"` guard mutants: a "" entry must come
+    // straight back as "", NOT the String("") of some other branch.
+    expect(formatLogEntry("")).toBe("");
+  });
+
+  it("joins ts + level + msg from an object entry", () => {
+    expect(formatLogEntry({ ts: "t0", level: "info", msg: "start" })).toBe("t0 info start");
+  });
+
+  it("falls back to `message` when `msg` is absent", () => {
+    expect(formatLogEntry({ ts: "t1", level: "error", message: "kaboom" })).toBe("t1 error kaboom");
+  });
+
+  it("prefers `msg` over `message` when both are present", () => {
+    expect(formatLogEntry({ level: "info", msg: "chosen", message: "ignored" })).toBe("info chosen");
+  });
+
+  it("keeps numeric fields (e.g. a ms epoch ts), stringifying them", () => {
+    expect(formatLogEntry({ ts: 1700000000000, level: "info", msg: "boot" })).toBe("1700000000000 info boot");
+  });
+
+  it("drops non-string/number fields rather than printing 'undefined'", () => {
+    // level is an object here → filtered out; only the string msg survives.
+    expect(formatLogEntry({ level: { nested: true }, msg: "only-msg" })).toBe("only-msg");
+  });
+
+  it("stringifies an object with NO usable ts/level/msg/message fields (empty parts → fallback)", () => {
+    // parts.length is 0 → the `> 0` guard is false → String(entry) fallback.
+    // Kills the `parts.length > 0` → `>= 0`/`true` mutants (they would wrongly
+    // return "" from an empty join instead of the stringified object).
+    const out = formatLogEntry({ irrelevant: 1 });
+    expect(out).toBe("[object Object]");
+    expect(out).not.toBe("");
+  });
+
+  it("stringifies a null entry (not treated as an object)", () => {
+    // Kills the `entry !== null && ...` operand mutants: null must fall through
+    // to String(null), not be indexed as an object.
+    expect(formatLogEntry(null)).toBe("null");
+  });
+
+  it("stringifies a number entry", () => {
+    expect(formatLogEntry(42)).toBe("42");
+  });
+});
+
+describe("toLogSlice", () => {
+  it("returns undefined for a non-array", () => {
+    expect(toLogSlice(null)).toBeUndefined();
+    expect(toLogSlice("not an array")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty array", () => {
+    expect(toLogSlice([])).toBeUndefined();
+  });
+
+  it("joins entries with newlines", () => {
+    expect(toLogSlice(["one", "two", "three"])).toBe("one\ntwo\nthree");
+  });
+
+  it("returns undefined when the joined text is only whitespace (trim → empty)", () => {
+    // Kills the `.trim()` removal and the `text === ""` guard mutants: a log of
+    // blank strings must be treated as "no usable logs", not an empty slice.
+    expect(toLogSlice(["", "   ", ""])).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace off the joined text", () => {
+    expect(toLogSlice(["  padded  "])).toBe("padded");
+  });
+
+  it("returns the whole text unchanged when it is exactly at the cap (boundary)", () => {
+    // length === LOG_SLICE_MAX must NOT slice (kills the `> ` → `>= ` mutant).
+    const exact = "x".repeat(LOG_SLICE_MAX);
+    const out = toLogSlice([exact]) as string;
+    expect(out.length).toBe(LOG_SLICE_MAX);
+    expect(out).toBe(exact);
+  });
+
+  it("keeps the TAIL (drops the oldest chars) when the text exceeds the cap", () => {
+    const over = "a".repeat(LOG_SLICE_MAX) + "TAIL";
+    const out = toLogSlice([over]) as string;
+    expect(out.length).toBe(LOG_SLICE_MAX);
+    expect(out.endsWith("TAIL")).toBe(true); // newest survives
+    expect(out.startsWith("a")).toBe(true); // some leading a's remain, but trimmed
+    // Exactly LOG_SLICE_MAX chars kept from the END: "TAIL" (4) + (MAX-4) a's.
+    expect(out).toBe("a".repeat(LOG_SLICE_MAX - 4) + "TAIL");
+  });
+});

--- a/packages/harness/src/core/render-log-slice.ts
+++ b/packages/harness/src/core/render-log-slice.ts
@@ -1,0 +1,55 @@
+/**
+ * render-log-slice — the shared, dependency-free formatter for a step's executor
+ * log buffer. Both run mappers use it so a step's `logSlice` is byte-identical
+ * whether it came from a prod {@link import("./render-run-state.js").renderRunState}
+ * projection or a local {@link import("./render-local-run.js").renderLocalRun}
+ * trace — the inspector can never disagree with itself about how a log renders.
+ *
+ * Kept in its OWN module (rather than in render-run-state.ts) precisely because
+ * it has NO `@sapiom/agent-core` dependency: render-run-state pulls in agent-core
+ * runtime helpers (e.g. `isExecutionTerminal`) that reach for `node:fs`, which
+ * must never enter the browser bundle. The local-run mapper is imported by the
+ * SPA, so it depends on THIS pure module instead — no Node built-ins ride along.
+ *
+ * Pure and deterministic: no I/O, no clock. Safe in both Node and the browser.
+ */
+
+/**
+ * Cap on the characters of a step's executor log buffer surfaced in `logSlice`.
+ * The TAIL is kept (most recent lines) because failures surface at the end of a
+ * log. This is a payload guard on the poll/stream response; the debug-macro
+ * context extractor does the final, smaller trim for prompt injection.
+ */
+export const LOG_SLICE_MAX = 4000;
+
+/** One executor log entry → a compact line. Accepts the `{ ts, level, msg }`
+ *  wire shape (or `message`), a bare string, or anything else (stringified).
+ *  A local trace's `{ level, msg }` entry is a subset of this same shape. */
+export function formatLogEntry(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  if (entry !== null && typeof entry === "object") {
+    const e = entry as {
+      ts?: unknown;
+      level?: unknown;
+      msg?: unknown;
+      message?: unknown;
+    };
+    const parts = [e.ts, e.level, e.msg ?? e.message].filter(
+      (p): p is string | number =>
+        typeof p === "string" || typeof p === "number",
+    );
+    if (parts.length > 0) return parts.map(String).join(" ");
+  }
+  return String(entry);
+}
+
+/** Format the executor log buffer into a trimmed, tail-preserving slice, or
+ *  `undefined` when there are no usable logs. */
+export function toLogSlice(logs: unknown): string | undefined {
+  if (!Array.isArray(logs) || logs.length === 0) return undefined;
+  const text = logs.map(formatLogEntry).join("\n").trim();
+  if (text === "") return undefined;
+  return text.length > LOG_SLICE_MAX
+    ? text.slice(text.length - LOG_SLICE_MAX)
+    : text;
+}

--- a/packages/harness/src/core/render-run-state.test.ts
+++ b/packages/harness/src/core/render-run-state.test.ts
@@ -313,6 +313,56 @@ describe("renderRunState — log slice", () => {
   });
 });
 
+describe("renderRunState — per-step input/output", () => {
+  it("surfaces a real per-step input", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ input: { topic: "otters" } })],
+    });
+    expect(view.steps[0].input).toEqual({ topic: "otters" });
+  });
+
+  it("surfaces a real per-step output", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ output: { facts: 3 } })],
+    });
+    expect(view.steps[0].output).toEqual({ facts: 3 });
+  });
+
+  it("omits input on honest absence (the read carried none → decoded null)", () => {
+    // decodeStep collapses a missing input to null; null is the absence
+    // sentinel and must render as ABSENT, not a fabricated `null` payload.
+    const view = render({ id: "e1", status: "completed", steps: [step({})] });
+    expect(view.steps[0]).not.toHaveProperty("input");
+  });
+
+  it("omits output on honest absence (decoded null)", () => {
+    const view = render({ id: "e1", status: "completed", steps: [step({})] });
+    expect(view.steps[0]).not.toHaveProperty("output");
+  });
+
+  it("keeps a falsy-but-real input (0) rather than dropping it", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ input: 0 })],
+    });
+    expect(view.steps[0].input).toBe(0);
+  });
+
+  it("keeps a falsy-but-real output (false) rather than dropping it", () => {
+    const view = render({
+      id: "e1",
+      status: "completed",
+      steps: [step({ output: false })],
+    });
+    expect(view.steps[0].output).toBe(false);
+  });
+});
+
 describe("renderRunState — whole run", () => {
   it("preserves step order", () => {
     const view = render({

--- a/packages/harness/src/core/render-run-state.ts
+++ b/packages/harness/src/core/render-run-state.ts
@@ -22,14 +22,11 @@ import type {
 } from "@sapiom/agent-core";
 
 import type { RunView, StepStatus, StepView } from "../shared/types.js";
-
-/**
- * Cap on the characters of a step's executor log buffer surfaced in `logSlice`.
- * The TAIL is kept (most recent lines) because failures surface at the end of a
- * log. This is a payload guard on the poll response; the debug-macro context
- * extractor does the final, smaller trim for prompt injection.
- */
-const LOG_SLICE_MAX = 4000;
+// The log-buffer formatter lives in its own dependency-free module so the
+// local-run mapper (imported by the browser SPA) can share the SAME formatter
+// WITHOUT dragging this file's `@sapiom/agent-core` runtime import — and its
+// `node:fs` reach — into the web bundle.
+import { toLogSlice } from "./render-log-slice.js";
 
 /**
  * Fold the run's lifecycle status into the four states the UI distinguishes.
@@ -88,37 +85,6 @@ function toLatencyMs(
   return delta >= 0 ? delta : undefined;
 }
 
-/** One executor log entry → a compact line. Accepts the `{ ts, level, msg }`
- *  wire shape (or `message`), a bare string, or anything else (stringified). */
-function formatLogEntry(entry: unknown): string {
-  if (typeof entry === "string") return entry;
-  if (entry !== null && typeof entry === "object") {
-    const e = entry as {
-      ts?: unknown;
-      level?: unknown;
-      msg?: unknown;
-      message?: unknown;
-    };
-    const parts = [e.ts, e.level, e.msg ?? e.message].filter(
-      (p): p is string | number =>
-        typeof p === "string" || typeof p === "number",
-    );
-    if (parts.length > 0) return parts.map(String).join(" ");
-  }
-  return String(entry);
-}
-
-/** Format the executor log buffer into a trimmed, tail-preserving slice, or
- *  `undefined` when there are no usable logs. */
-function toLogSlice(logs: unknown): string | undefined {
-  if (!Array.isArray(logs) || logs.length === 0) return undefined;
-  const text = logs.map(formatLogEntry).join("\n").trim();
-  if (text === "") return undefined;
-  return text.length > LOG_SLICE_MAX
-    ? text.slice(text.length - LOG_SLICE_MAX)
-    : text;
-}
-
 /** Map one projection step to its render view. Optional fields are assigned only
  *  when present so absence stays absent (not `undefined`) in the JSON payload. */
 function toStepView(step: StepProjection): StepView {
@@ -134,6 +100,14 @@ function toStepView(step: StepProjection): StepView {
   if (step.error?.message) view.error = step.error.message;
   const logSlice = toLogSlice(step.logs);
   if (logSlice !== undefined) view.logSlice = logSlice;
+  // Real per-step IO for the inspector's "Last run" block. The decoder
+  // collapses an absent input/output to `null` (its absence sentinel), so a
+  // `null` here means "the read carried nothing" — surfaced as ABSENT, never a
+  // fabricated payload. Any non-null value (including `0`, `false`, `""`) is a
+  // real payload and passes through. Capability, not model: these are the
+  // step's own values, with no provider/model surfaced.
+  if (step.input !== null) view.input = step.input;
+  if (step.output !== null) view.output = step.output;
   return view;
 }
 

--- a/packages/harness/stryker.conf.json
+++ b/packages/harness/stryker.conf.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-js/master/packages/api/schema/stryker-core.json",
-  "_comment": "Mutation testing for the harness's high-value PURE functions only: the run-state render mapper, the deploy trigger-snippet builder, and the step-context/link derivation. Each mutated file has a fast, co-located unit suite (see vitest.config.mutation.ts). Stateful/side-effecting code (server, pty, watchers, timer-driven poll controller), types, the index barrel, and cost surfaces slated for removal are deliberately NOT mutated. As the run-local mapper and deploy/run request builders land, add them here alongside their specs.",
+  "_comment": "Mutation testing for the harness's high-value PURE functions only: the prod + local run-state render mappers, the shared log-slice formatter, the deploy trigger-snippet builder, and the step-context/link derivation. Each mutated file has a fast, co-located unit suite (see vitest.config.mutation.ts). Stateful/side-effecting code (server, pty, watchers, timer-driven poll controller), types, the index barrel, and cost surfaces slated for removal are deliberately NOT mutated. As the deploy/run request builders land, add them here alongside their specs.",
   "testRunner": "vitest",
   "plugins": ["@stryker-mutator/vitest-runner"],
   "coverageAnalysis": "perTest",
   "mutate": [
     "src/core/render-run-state.ts",
+    "src/core/render-local-run.ts",
+    "src/core/render-log-slice.ts",
     "web/src/lib/generate-snippet.ts",
     "web/src/lib/extract-step-context.ts"
   ],

--- a/packages/harness/vitest.config.mutation.ts
+++ b/packages/harness/vitest.config.mutation.ts
@@ -28,6 +28,8 @@ export default defineConfig({
   test: {
     include: [
       "src/core/render-run-state.test.ts",
+      "src/core/render-local-run.test.ts",
+      "src/core/render-log-slice.test.ts",
       "web/src/lib/generate-snippet.test.ts",
       "web/src/lib/extract-step-context.test.ts",
     ],

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -25,6 +25,8 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 
+import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
+
 // Skill types (matched to the server-side SkillMeta/SkillDetail in
 // src/server/skills.ts — kept here rather than in shared/types.ts since they
 // are only consumed by the SPA, never by CLI or server logic).
@@ -37,6 +39,41 @@ export interface SkillMeta {
 export interface SkillDetail extends SkillMeta {
   body: string;
 }
+
+/**
+ * Body for `POST /api/runs/local` — run the agent project at `sourceDir`
+ * entirely offline against stub capabilities. `sourceDir` is the only required
+ * field; the rest are forwarded to the run-local bootstrap as-is. Needs no API
+ * key and makes no network call (zero cost) — mirrors the server's
+ * `RunLocalRequest` without importing a server module into the browser bundle.
+ */
+export interface RunLocalArgs {
+  /** Absolute path to the agent project directory (contains `index.ts`). */
+  sourceDir: string;
+  /** The workflow's entry-step input (optional; agent-core defaults it). */
+  input?: unknown;
+  /** Per-step attempt cap (optional; agent-core defaults it). */
+  maxAttemptsPerStep?: number;
+}
+
+/**
+ * One parsed line of the `/api/runs/local` NDJSON stream. Either a per-step
+ * trace (a {@link LocalStepTrace}, discriminated by the ABSENCE of `kind`) or a
+ * terminal line: a `summary` for a run that executed (carrying the outcome and
+ * the two stub-hygiene signals), or an `error` for a run that could not be
+ * invoked at all. The shapes mirror the bootstrap's own wire contract.
+ */
+export type RunLocalLine =
+  | ({ kind?: undefined } & LocalStepTrace)
+  | {
+      kind: "summary";
+      outcome: LocalRunOutcome;
+      output?: unknown;
+      error?: unknown;
+      unusedStubs: Array<{ step: string; key: string }>;
+      stubWarnings: string[];
+    }
+  | { kind: "error"; outcome: "failed"; error: string };
 
 import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SAMPLE_PROJECT_ROOT, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_SKILLS, MOCK_SKILL_BODIES, MOCK_WORKFLOWS } from "./mock-data";
 
@@ -159,6 +196,15 @@ export interface HarnessApi {
    *  GET /api/runs/:id/state = inspect -> decode -> renderRunState. Poll
    *  after an execution.started bus message until the run is terminal. */
   getRunState(executionId: string): Promise<RunView>;
+  /**
+   * Run the workflow at `args.sourceDir` OFFLINE against stub capabilities and
+   * stream its NDJSON result (`POST /api/runs/local`): `onLine` is called once
+   * per parsed line, in order — each per-step {@link LocalStepTrace} as it
+   * arrives, then a terminal `summary` (or `error`) line. Resolves when the
+   * stream ends; rejects only on a transport failure (never on a failed *run* —
+   * a failed run is a normal terminal line). Fully offline: no key, no cost.
+   */
+  runLocal(args: RunLocalArgs, onLine: (line: RunLocalLine) => void): Promise<void>;
 }
 
 class RealApi implements HarnessApi {
@@ -293,6 +339,82 @@ class RealApi implements HarnessApi {
   getRunState(executionId: string): Promise<RunView> {
     return this.request<RunView>(`/api/runs/${encodeURIComponent(executionId)}/state`);
   }
+
+  async runLocal(args: RunLocalArgs, onLine: (line: RunLocalLine) => void): Promise<void> {
+    const res = await fetch("/api/runs/local", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Token": getBootToken(),
+      },
+      body: JSON.stringify(args),
+    });
+    // A 4xx here is a bad REQUEST (e.g. missing sourceDir) — the run never
+    // started, so there is no NDJSON body to read; surface it like any other
+    // API error. A failed *run* is NOT this path: it comes back 200 with a
+    // terminal `error`/`summary` line the caller handles in onLine.
+    if (!res.ok || !res.body) {
+      const body = await res.text().catch(() => "");
+      throw new ApiError(res.status, `POST /api/runs/local → ${res.status}${body ? `: ${body}` : ""}`, undefined);
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const drain = (chunk: string, flush: boolean): void => {
+      buffer += chunk;
+      const { lines, rest } = splitNdjson(buffer, flush);
+      buffer = rest;
+      for (const raw of lines) {
+        const parsed = parseRunLocalLine(raw);
+        if (parsed) onLine(parsed);
+      }
+    };
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      drain(decoder.decode(value, { stream: true }), false);
+    }
+    // Flush the decoder + any trailing line without a newline terminator.
+    drain(decoder.decode(), true);
+  }
+}
+
+/**
+ * Split an NDJSON buffer into complete lines plus the unterminated remainder.
+ * When `flush` is true the whole buffer is treated as complete (end of stream),
+ * so a final line without a trailing newline is not lost. Pure — no I/O — so
+ * the incremental parsing is unit-testable without a live stream.
+ */
+export function splitNdjson(buffer: string, flush: boolean): { lines: string[]; rest: string } {
+  const parts = buffer.split("\n");
+  if (flush) {
+    return { lines: parts.filter((line) => line.trim() !== ""), rest: "" };
+  }
+  // The last element is either "" (buffer ended on a newline) or a partial line
+  // still being received — keep it in `rest` until its newline arrives.
+  const rest = parts.pop() ?? "";
+  return { lines: parts.filter((line) => line.trim() !== ""), rest };
+}
+
+/**
+ * Parse one NDJSON line into a {@link RunLocalLine}, or null for a line that
+ * isn't a JSON object (stray stdout noise the server may not have filtered).
+ * Defensive by design — a run-local child streams another program's stdout, so
+ * anything unrecognized degrades to "skip this line", never a throw.
+ */
+export function parseRunLocalLine(raw: string): RunLocalLine | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  // A contract line is a JSON OBJECT — reject null and arrays (a bare array or
+  // scalar is noise, not a trace/summary/error line).
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  return parsed as RunLocalLine;
 }
 
 const delay = (ms = 180): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -620,6 +742,46 @@ class MockApi implements HarnessApi {
       status: "completed",
       steps: executionId.includes("local") ? steps.map(({ costUsd: _costUsd, ...rest }) => rest) : steps,
     };
+  }
+
+  // A deterministic OFFLINE stub run: emits per-step traces (logs + IO, no
+  // cost/latency — a local trace carries none) then a terminal summary, spaced
+  // so the inspector visibly lights up step-by-step. Lets the mock/demo build
+  // and Playwright exercise the run-local inspector with no server, mirroring
+  // the real NDJSON stream's ordering (traces first, terminal line last).
+  async runLocal(_args: RunLocalArgs, onLine: (line: RunLocalLine) => void): Promise<void> {
+    const traces: LocalStepTrace[] = [
+      {
+        step: "intake",
+        attempt: 1,
+        input: { applicant: "Ada" },
+        status: "succeeded",
+        output: { ok: true },
+        logs: [{ level: "info", msg: "parsed application" }],
+      },
+      {
+        step: "screen",
+        attempt: 1,
+        input: { ok: true },
+        status: "succeeded",
+        output: { score: 720 },
+        logs: [{ level: "info", msg: "stubbed credit check" }],
+      },
+      {
+        step: "approve",
+        attempt: 1,
+        input: { score: 720 },
+        status: "succeeded",
+        output: { approved: true },
+        logs: [],
+      },
+    ];
+    for (const trace of traces) {
+      await delay(140);
+      onLine(trace);
+    }
+    await delay(140);
+    onLine({ kind: "summary", outcome: "completed", output: { approved: true }, unusedStubs: [], stubWarnings: [] });
   }
 }
 

--- a/packages/harness/web/src/lib/run-local-stream.test.ts
+++ b/packages/harness/web/src/lib/run-local-stream.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import { parseRunLocalLine, splitNdjson } from "./api";
+
+describe("splitNdjson — incremental (flush=false)", () => {
+  it("returns complete lines and holds the unterminated remainder", () => {
+    const { lines, rest } = splitNdjson('{"a":1}\n{"b":2}\n{"c":3', false);
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+    expect(rest).toBe('{"c":3'); // partial last line kept for the next chunk
+  });
+
+  it("keeps an empty remainder when the buffer ends exactly on a newline", () => {
+    const { lines, rest } = splitNdjson('{"a":1}\n', false);
+    expect(lines).toEqual(['{"a":1}']);
+    expect(rest).toBe("");
+  });
+
+  it("holds a whole line back until its newline arrives (no premature emit)", () => {
+    const { lines, rest } = splitNdjson('{"a":1}', false);
+    expect(lines).toEqual([]);
+    expect(rest).toBe('{"a":1}');
+  });
+
+  it("drops blank lines between records", () => {
+    const { lines } = splitNdjson('{"a":1}\n\n{"b":2}\n', false);
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+  });
+});
+
+describe("splitNdjson — flush (end of stream)", () => {
+  it("treats the whole buffer as complete, including a final unterminated line", () => {
+    const { lines, rest } = splitNdjson('{"a":1}\n{"b":2}', true);
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+    expect(rest).toBe(""); // nothing left pending at end of stream
+  });
+
+  it("yields no lines for an empty flush", () => {
+    expect(splitNdjson("", true)).toEqual({ lines: [], rest: "" });
+  });
+});
+
+describe("parseRunLocalLine", () => {
+  it("parses a per-step trace line (no kind discriminant)", () => {
+    const line = parseRunLocalLine('{"step":"gather","attempt":1,"input":{},"status":"succeeded","logs":[]}');
+    expect(line).toMatchObject({ step: "gather", status: "succeeded" });
+    expect(line && "kind" in line ? line.kind : undefined).toBeUndefined();
+  });
+
+  it("parses a terminal summary line", () => {
+    const line = parseRunLocalLine('{"kind":"summary","outcome":"completed","unusedStubs":[],"stubWarnings":[]}');
+    expect(line).toEqual({ kind: "summary", outcome: "completed", unusedStubs: [], stubWarnings: [] });
+  });
+
+  it("parses a terminal error line", () => {
+    const line = parseRunLocalLine('{"kind":"error","outcome":"failed","error":"bad project"}');
+    expect(line).toEqual({ kind: "error", outcome: "failed", error: "bad project" });
+  });
+
+  it("returns null for non-JSON noise (an esbuild banner, a stray console write)", () => {
+    expect(parseRunLocalLine("Build succeeded in 12ms")).toBeNull();
+  });
+
+  it("returns null for a blank line", () => {
+    expect(parseRunLocalLine("   ")).toBeNull();
+  });
+
+  it("returns null for a JSON non-object (a bare array or scalar)", () => {
+    expect(parseRunLocalLine("[1,2,3]")).toBeNull();
+    expect(parseRunLocalLine("42")).toBeNull();
+  });
+});

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -14,9 +14,19 @@ import type {
 
 import type { HarnessEntry } from "@shared/types";
 
-import { ApiError, boundWorkflowPathOf, createApi, getBootToken, type FsListResponse, type HarnessApi } from "./api";
+import {
+  ApiError,
+  boundWorkflowPathOf,
+  createApi,
+  getBootToken,
+  type FsListResponse,
+  type HarnessApi,
+  type RunLocalLine,
+} from "./api";
 import { type ConnectivityErrorInput } from "./connectivity";
 import { subscribeEvents } from "./events";
+import { renderLocalRun } from "@shared/render-local-run";
+import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
 const api = createApi();
 
@@ -92,6 +102,16 @@ export interface HarnessStateHook {
   bindWorkflow: (sessionId: string, workflowPath: string | null) => Promise<void>;
   updateSettings: (patch: Partial<HarnessSettings>) => Promise<HarnessSettings>;
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
+  /**
+   * Runs the workflow at `sourceDir` OFFLINE against stub capabilities and
+   * streams the result into the SAME run store the prod poller feeds — so the
+   * click-into-step inspector renders a local stub run exactly as it renders a
+   * prod run (per-step logs + pass/fail + IO), just `target: "local"` (free,
+   * untimed). Resolves when the stream ends; a failed *run* is a normal
+   * terminal state (surfaced in the run), not a rejection. Fully offline: no
+   * key, no cost, works signed-out.
+   */
+  runLocal: (sessionId: string, sourceDir: string, input?: unknown) => Promise<void>;
   /**
    * Submits text to a session's pty via POST /api/sessions/:id/input.
    * Throws `ApiError` on HTTP errors — callers handle 409 (session not ready)
@@ -251,6 +271,92 @@ export function useHarnessState(): HarnessStateHook {
     void poll();
     runPollers.current.set(sessionId, setInterval(() => void poll(), 2000));
   }, []);
+
+  // Monotonic counter for synthesizing local-run execution ids. A local run has
+  // no server-issued id (it never touches the backend), so the store mints one;
+  // it MUST contain "local" so every cost/target check that keys off the id
+  // (e.g. the mock run-state convention) reads it as free.
+  const localRunSeq = useRef(0);
+
+  /**
+   * Run an offline stub run and stream it into the shared run store. The NDJSON
+   * arrives per-step: each {@link LocalStepTrace} line appends to a local buffer
+   * that is re-mapped through `renderLocalRun` and written to `runsByExecution`,
+   * so the inspector lights up step-by-step (same store, same shape, same
+   * inspector as a prod run). The terminal `summary`/`error` line supplies the
+   * run's final outcome; a run that could not be invoked becomes a single
+   * failed step so the failure is still visible rather than silent.
+   */
+  const runLocal = useCallback(
+    async (sessionId: string, sourceDir: string, input?: unknown): Promise<void> => {
+      localRunSeq.current += 1;
+      const executionId = `local-${Date.now()}-${localRunSeq.current}`;
+      // Attribution + observation facts captured now, exactly like a prod run
+      // (see startRunPolling) — a later re-bind must not re-attribute this run.
+      const workflowPath = boundWorkflowPathOf(sessionsRef.current.find((s) => s.id === sessionId));
+      const observedAt = Date.now();
+      const traces: LocalStepTrace[] = [];
+      let outcome: LocalRunOutcome | undefined;
+
+      // Register the run so runsBySession surfaces it, and drop any explicit run
+      // pick so the session follows this fresh run (mirrors startRunPolling).
+      setRunIdsBySession((prev) => {
+        const ids = prev.get(sessionId) ?? [];
+        if (ids.includes(executionId)) return prev;
+        return new Map(prev).set(sessionId, [...ids, executionId]);
+      });
+      setPickedRunBySession((prev) => {
+        if (!prev.has(sessionId)) return prev;
+        const next = new Map(prev);
+        next.delete(sessionId);
+        return next;
+      });
+
+      const publish = (): void => {
+        const run = renderLocalRun(traces, { executionId, outcome });
+        setRunsByExecution((prev) =>
+          new Map(prev).set(executionId, { run, target: "local", workflowPath, observedAt }),
+        );
+      };
+      // Seed an empty running RunView up front so the Steps tab switches to this
+      // run immediately, before the first trace line lands.
+      publish();
+
+      const onLine = (line: RunLocalLine): void => {
+        if (line.kind === "summary") {
+          outcome = line.outcome;
+        } else if (line.kind === "error") {
+          // The run could not be invoked (bad project / stub file). Represent it
+          // as a failed run carrying one failed step so the inspector shows the
+          // reason instead of an empty, silently-failed run.
+          outcome = "failed";
+          traces.push({
+            step: "run-local",
+            attempt: 1,
+            input,
+            status: "threw",
+            error: { name: "RunLocalError", message: line.error },
+            logs: [],
+          });
+        } else {
+          // A per-step trace line (no `kind`).
+          traces.push(line);
+        }
+        publish();
+      };
+
+      try {
+        await api.runLocal({ sourceDir, input }, onLine);
+      } catch (err) {
+        // Transport failure (the stream itself broke) — mark the run failed so
+        // it doesn't spin as "running" forever, and toast the reason.
+        outcome = "failed";
+        publish();
+        setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
+      }
+    },
+    [],
+  );
 
   const selectRun = useCallback(
     (sessionId: string, executionId: string) => {
@@ -649,6 +755,7 @@ export function useHarnessState(): HarnessStateHook {
     bindWorkflow,
     updateSettings,
     runMacro,
+    runLocal,
     injectInput,
     useSkill,
     showToast,

--- a/packages/harness/web/tsconfig.json
+++ b/packages/harness/web/tsconfig.json
@@ -14,6 +14,7 @@
     "types": ["vite/client", "node"],
     "paths": {
       "@shared/types": ["../src/shared/types.ts"],
+      "@shared/render-local-run": ["../src/core/render-local-run.ts"],
       "@sapiom/design-system/*": ["./src/styles/ds-neutral/*"]
     }
   },

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -79,6 +79,13 @@ export default defineConfig({
       // (packages/harness/src/shared/types.ts) so the web and server always
       // build against one source of truth — no vendored copy to drift.
       "@shared/types": fileURLToPath(new URL("../src/shared/types.ts", import.meta.url)),
+      // The local-run mapper is a pure fn shared with the server (its canonical
+      // home is src/core/render-local-run.ts, per the ticket). The SPA imports
+      // the SAME implementation to map an offline stub run's NDJSON traces into
+      // the RunView the inspector renders — one mapper, no client/server drift.
+      // It pulls in only the `LocalStepTrace` *type* from agent-core (erased at
+      // build), so no agent-core runtime code enters the browser bundle.
+      "@shared/render-local-run": fileURLToPath(new URL("../src/core/render-local-run.ts", import.meta.url)),
       // The design system is a private package. Official builds (private
       // package installed) render branded; public clones fall back to a
       // committed neutral token set. See designSystemAlias() above.


### PR DESCRIPTION
## What

Wires **prod** and **offline (stub)** run logs into the SAME Studio click-into-step run inspector — two tightly-coupled leaves shipped together because both feed one inspector.

### C1 — UP-04 prod wire (SAP-1779)
- The studio's `execution.started` → `/api/runs/:id/state` poller already drove the inspector; this adds the step's **real input/output** to what it surfaces, by mapping the projection's per-step IO in `renderRunState`. Honest absence is preserved: the decoder collapses an absent input/output to `null`, so a `null` renders as **absent** (never a fabricated payload) while a falsy-but-real value (`0`/`false`/`""`) passes through.
- 404 already stops the poller quietly (no runaway); verified.
- Step-name → node-id join re-verified: `StepView.name` is the manifest step name, matched by `runStepFor` — unchanged.

### C2 — run-local NDJSON → mapper → inspector (SAP-1780)
- New pure `renderLocalRun` (`packages/harness/src/core/render-local-run.ts`): `LocalStepTrace[]` → `RunView`/`StepView`, sharing prod's exact `StepView` shape and log formatter. **No cost, no latency** — a stub run records neither (agent-core consumed as-is), so those stay absent rather than fabricated. **Mutation-first** unit tests (Stryker: **100%** on the mapper).
- The SPA consumes the `/api/runs/local` **NDJSON** stream (incremental line splitter + defensive line parser — both pure, both unit-tested), maps each line through `renderLocalRun`, and writes the run into the **same run store the prod poller feeds** — so an offline stub run renders in the identical inspector as a prod run, live and per-step. Terminal `summary`/`error` lines set the run outcome.

### Supporting
- Extracted the log-slice formatter into a new **dependency-free** `render-log-slice.ts` so the browser-imported local mapper carries **no `@sapiom/agent-core` / `node:fs` runtime dep** (web bundle stays at ~1872 modules — no agent-core runtime pulled in).
- Added `render-local-run.ts` + `render-log-slice.ts` to the Stryker mutate set (with specs). **Overall mutation score 94.67%.**

## Serve capability, not model
No provider/model names surfaced; no cost surfaces added (cost-strip is a separate leaf). ds-neutral. Patch changeset.

## App.tsx
**Not touched.** `runLocal` is exposed on the state hook as the consumer seam; the Run-local button repoint (macro buttons) and the run e2e are separate leaves.

## Verification
- `pnpm --filter @sapiom/harness build` ✅ (1872 modules, agent-core runtime absent from web bundle)
- `typecheck` ✅ (src + web)
- `test` ✅ **1130 passing** (84 files)
- `test:mutation` ✅ 94.67% overall, `render-local-run.ts` 100%, `render-log-slice.ts` 88.24%
- `lint` ✅
- Not run here: `test:ui` (Playwright) — no run-trigger UI added in this leaf (that + run e2e = separate leaves).

Linear: SAP-1779, SAP-1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)