### PR TITLE
feat(harness): wire Deploy/Prod-run/Run-local buttons to direct routes (SAP-1778)

### DIFF
--- a/.changeset/studio-macro-buttons-direct-routes.md
+++ b/.changeset/studio-macro-buttons-direct-routes.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness": patch
+---
+
+Wire the Studio's Deploy, Prod-run, and Run-local buttons to their direct routes instead of typing a command into the coding agent:
+
+- **Deploy** streams build status and refreshes the workflow once it publishes, flipping the Draft/Deployed state.
+- **Prod-run** starts a real execution and hands the new execution off to the run inspector, so it shows up in the Steps view.
+- **Run-local** runs the workflow offline with capabilities stubbed and reports the outcome — no network, no spend.
+
+These three actions now run without a coding-agent session, so they consume no LLM credits. Debug, Explain, and free-form prompts still go through the coding agent, and Visualize is unchanged.

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -46,6 +46,7 @@ import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { useTemplatePrompt, type StudioTemplate } from "./lib/templates";
 import { track } from "./lib/track";
 import { resolveMacroUrl } from "./lib/macro-gating";
+import { directActionKind } from "./lib/macro-actions";
 import { sessionDisplayName } from "./lib/session-name";
 import { loadUiPrefs, saveUiPrefs } from "./lib/ui-prefs";
 import { CANVAS_MIN, RAIL_MIN, isMobileShell, useMobileShell, usePaneWidths } from "./lib/use-pane-widths";
@@ -501,6 +502,26 @@ export const App = (): JSX.Element => {
         return;
       }
       if (!sessionId) return;
+      // Deploy / Prod-run / Run-local run via the DIRECT harness routes (no
+      // Claude Code, no user LLM credits). Once a macro is a direct action we
+      // NEVER fall through to the pty-inject runMacro — the buttons are already
+      // gated (require a workflow / a deploy), so a missing prerequisite here is
+      // a no-op, never a silent revert to the Claude Code path.
+      const direct = directActionKind(macro.id);
+      if (direct !== null) {
+        if (direct === "deploy" && workflow) {
+          void harness.deploy(workflow.path);
+        } else if (direct === "prod-run" && workflow?.definitionId != null) {
+          // definitionId is present (the button is deploy-gated); the runs route
+          // wants it as a string.
+          void harness.startProdRun(sessionId, String(workflow.definitionId));
+        } else if (direct === "run-local" && workflow) {
+          void harness.runLocal(sessionId, workflow.path);
+        }
+        return;
+      }
+      // Visualize (render-canvas) and every inject macro (Debug / Explain /
+      // free-form) keep their existing path through runMacro.
       void harness.runMacro(macro.id, {
         harnessSessionId: sessionId,
         workflowPath: workflow?.path,

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { terminalDeployEvent, type DeployStreamEvent } from "./api";
+import { parseNdjsonLine, terminalDeployEvent, type DeployStreamEvent } from "./api";
 
 describe("terminalDeployEvent", () => {
   it("returns the terminal ready event", () => {
@@ -46,5 +46,25 @@ describe("terminalDeployEvent", () => {
 
   it("synthesizes an error for an empty stream", () => {
     expect(terminalDeployEvent([])).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
+  });
+});
+
+describe("parseNdjsonLine (deploy stream)", () => {
+  it("parses a well-formed deploy event line", () => {
+    expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"building","definitionId":"42"}')).toEqual({
+      phase: "building",
+      definitionId: "42",
+    });
+  });
+
+  it("drops a bare `null` line instead of forwarding it (SAP-1778 review)", () => {
+    // JSON.parse("null") === null: a stray null line must be silently dropped,
+    // never handed to the deploy consumer (where it could throw downstream).
+    expect(parseNdjsonLine<DeployStreamEvent>("null")).toBeUndefined();
+  });
+
+  it("drops blank and non-JSON noise lines", () => {
+    expect(parseNdjsonLine<DeployStreamEvent>("   ")).toBeUndefined();
+    expect(parseNdjsonLine<DeployStreamEvent>("Build succeeded in 12ms")).toBeUndefined();
   });
 });

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { terminalDeployEvent, type DeployStreamEvent } from "./api";
+
+describe("terminalDeployEvent", () => {
+  it("returns the terminal ready event", () => {
+    const events: DeployStreamEvent[] = [
+      { phase: "building", definitionId: "42" },
+      { phase: "ready", definitionId: "42", buildRunId: "b1", status: "succeeded" },
+    ];
+    expect(terminalDeployEvent(events)).toEqual({
+      phase: "ready",
+      definitionId: "42",
+      buildRunId: "b1",
+      status: "succeeded",
+    });
+  });
+
+  it("returns the terminal error event", () => {
+    const events: DeployStreamEvent[] = [
+      { phase: "building", definitionId: "42" },
+      { phase: "error", code: "BUILD_FAILED", message: "boom" },
+    ];
+    expect(terminalDeployEvent(events)).toEqual({ phase: "error", code: "BUILD_FAILED", message: "boom" });
+  });
+
+  it("returns the LAST terminal event when more than one is present", () => {
+    // Defensive: pick the final terminal line, not the first.
+    const events: DeployStreamEvent[] = [
+      { phase: "error", code: "A", message: "first" },
+      { phase: "ready", definitionId: "42", buildRunId: "b1", status: "succeeded" },
+    ];
+    expect(terminalDeployEvent(events)).toMatchObject({ phase: "ready" });
+  });
+
+  it("synthesizes an error when the stream carried no terminal line", () => {
+    // A stream that only ever said "building" (server died mid-build) still
+    // yields a definite failure outcome, never a building line.
+    const events: DeployStreamEvent[] = [{ phase: "building", definitionId: "42" }];
+    expect(terminalDeployEvent(events)).toEqual({
+      phase: "error",
+      code: "NO_OUTPUT",
+      message: "deploy produced no terminal status",
+    });
+  });
+
+  it("synthesizes an error for an empty stream", () => {
+    expect(terminalDeployEvent([])).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
+  });
+});

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -488,19 +488,12 @@ class RealApi implements HarnessApi {
       buffer += chunk;
       let newline = buffer.indexOf("\n");
       while (newline !== -1) {
-        const raw = buffer.slice(0, newline).trim();
+        const raw = buffer.slice(0, newline);
         buffer = buffer.slice(newline + 1);
-        if (raw !== "") {
-          let parsed: T | undefined;
-          try {
-            parsed = JSON.parse(raw) as T;
-          } catch {
-            parsed = undefined; // non-JSON noise — skip.
-          }
-          if (parsed !== undefined) {
-            collected.push(parsed);
-            onLine?.(parsed);
-          }
+        const parsed = parseNdjsonLine<T>(raw);
+        if (parsed !== undefined) {
+          collected.push(parsed);
+          onLine?.(parsed);
         }
         newline = buffer.indexOf("\n");
       }
@@ -515,6 +508,27 @@ class RealApi implements HarnessApi {
     flush(decoder.decode() + "\n");
     return collected;
   }
+}
+
+/**
+ * Parse one NDJSON line from a generic stream (used by the deploy stream), or
+ * `undefined` for a line that carries no value: blank, non-JSON noise, OR a
+ * bare `null` (`JSON.parse("null")`). Rejecting `null` here — not just
+ * `undefined` — means a stray `null` line is dropped rather than forwarded to
+ * the consumer, which would otherwise receive it as an event and could throw
+ * downstream. Mirrors {@link parseRunLocalLine}'s null rejection. Pure — no
+ * I/O — so it is unit-testable without a live stream.
+ */
+export function parseNdjsonLine<T>(raw: string): T | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return undefined; // non-JSON noise — skip.
+  }
+  return parsed === null ? undefined : (parsed as T);
 }
 
 /**

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -54,6 +54,10 @@ export interface RunLocalArgs {
   sourceDir: string;
   /** The workflow's entry-step input (optional; agent-core defaults it). */
   input?: unknown;
+  /** Explicit per-capability stub overrides; omitted → the project's committed
+   *  dev stubs are used. Left as an opaque record here — the SPA only forwards
+   *  it, agent-core owns the schema. */
+  stubs?: unknown;
   /** Per-step attempt cap (optional; agent-core defaults it). */
   maxAttemptsPerStep?: number;
 }
@@ -76,6 +80,31 @@ export type RunLocalLine =
       stubWarnings: string[];
     }
   | { kind: "error"; outcome: "failed"; error: string };
+
+// ---------------------------------------------------------------------------
+// Direct-action wire shapes (matched to src/server/actions.ts). SPA-only — the
+// browser consumes these streams but never the server modules that emit them,
+// so (like SkillMeta above) they live here rather than in shared/types.ts.
+// ---------------------------------------------------------------------------
+
+/**
+ * One line of the `POST /api/workflows/:id/deploy` NDJSON stream (mirrors
+ * `DeployStreamEvent` in src/server/actions.ts): a `building` line up front,
+ * then exactly one terminal `ready` | `error` line closing the stream.
+ */
+export type DeployStreamEvent =
+  | { phase: "building"; definitionId: string }
+  | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
+  | { phase: "error"; code: string; message: string; hint?: string };
+
+/** The `POST /api/runs` response — the started prod execution's id, which the
+ *  live-canvas path then polls via `getRunState`. */
+export interface RunResponse {
+  executionId: string;
+}
+
+/** Callback fired once per NDJSON line as a direct-action stream is consumed. */
+export type StreamLineHandler<T> = (line: T) => void;
 
 export type { FsDirEntry, FsListResponse };
 
@@ -205,6 +234,22 @@ export interface HarnessApi {
    * a failed run is a normal terminal line). Fully offline: no key, no cost.
    */
   runLocal(args: RunLocalArgs, onLine: (line: RunLocalLine) => void): Promise<void>;
+  /**
+   * Deploy the agent linked to `workflowPath` (Deploy button) — POST
+   * /api/workflows/:id/deploy. The server holds the API key and drives the
+   * build; NO Claude Code, no user LLM credits. `onEvent` fires per NDJSON
+   * line as the build streams (`building` → terminal `ready`/`error`); the
+   * promise resolves with the terminal event. Rejects (ApiError) only on the
+   * request itself failing (e.g. 409 not-linked) — a build *failure* resolves
+   * with a `phase: "error"` terminal event, since the request succeeded.
+   */
+  deploy(workflowPath: string, onEvent?: StreamLineHandler<DeployStreamEvent>): Promise<DeployStreamEvent>;
+  /**
+   * Start a real prod execution (Prod-run button) — POST /api/runs. Runs
+   * server-side with the held key; NO Claude Code. Returns the new
+   * `{ executionId }`, which the caller hands to the run-inspector poller.
+   */
+  run(req: { definitionId: string; input?: unknown }): Promise<RunResponse>;
 }
 
 class RealApi implements HarnessApi {
@@ -377,6 +422,99 @@ class RealApi implements HarnessApi {
     // Flush the decoder + any trailing line without a newline terminator.
     drain(decoder.decode(), true);
   }
+
+  async deploy(
+    workflowPath: string,
+    onEvent?: StreamLineHandler<DeployStreamEvent>,
+  ): Promise<DeployStreamEvent> {
+    // The workflow id in the route path is its absolute path (the server's
+    // resolveWorkflow matches on path — see createActionsRouter mount).
+    const events = await this.streamNdjson<DeployStreamEvent>(
+      `/api/workflows/${encodeURIComponent(workflowPath)}/deploy`,
+      { method: "POST" },
+      onEvent,
+    );
+    return terminalDeployEvent(events);
+  }
+
+  async run(req: { definitionId: string; input?: unknown }): Promise<RunResponse> {
+    return this.request<RunResponse>("/api/runs", { method: "POST", body: JSON.stringify(req) });
+  }
+
+  /**
+   * POST to an NDJSON route and parse the response body line by line, invoking
+   * `onLine` for each well-formed JSON line as it arrives and returning every
+   * parsed line. Non-JSON lines (stray banner/console noise the server may not
+   * have filtered) are skipped — the same "degrade, never throw" stance the
+   * server's own stream forwarders take. Throws `ApiError` on a non-2xx status,
+   * matching `request()`, so a rejected request (e.g. 409/503) surfaces the
+   * same way a normal call would rather than as an empty stream.
+   */
+  private async streamNdjson<T>(
+    path: string,
+    init: RequestInit,
+    onLine?: StreamLineHandler<T>,
+  ): Promise<T[]> {
+    const res = await fetch(path, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Token": getBootToken(),
+        ...init.headers,
+      },
+    });
+    if (!res.ok || !res.body) {
+      const body = await res.text().catch(() => "");
+      let reason: string | undefined;
+      try {
+        const parsed: unknown = body ? JSON.parse(body) : undefined;
+        if (parsed && typeof parsed === "object" && typeof (parsed as { error?: unknown }).error === "string") {
+          reason = (parsed as { error: string }).error;
+        }
+      } catch {
+        // Not JSON — reason stays undefined.
+      }
+      throw new ApiError(
+        res.status,
+        `${init.method ?? "GET"} ${path} → ${res.status}${body ? `: ${body}` : ""}`,
+        reason,
+      );
+    }
+    const collected: T[] = [];
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const flush = (chunk: string): void => {
+      buffer += chunk;
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const raw = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (raw !== "") {
+          let parsed: T | undefined;
+          try {
+            parsed = JSON.parse(raw) as T;
+          } catch {
+            parsed = undefined; // non-JSON noise — skip.
+          }
+          if (parsed !== undefined) {
+            collected.push(parsed);
+            onLine?.(parsed);
+          }
+        }
+        newline = buffer.indexOf("\n");
+      }
+    };
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      flush(decoder.decode(value, { stream: true }));
+    }
+    // A final line with no trailing newline (the server always terminates lines,
+    // but be defensive).
+    flush(decoder.decode() + "\n");
+    return collected;
+  }
 }
 
 /**
@@ -415,6 +553,17 @@ export function parseRunLocalLine(raw: string): RunLocalLine | null {
   // scalar is noise, not a trace/summary/error line).
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
   return parsed as RunLocalLine;
+}
+
+/** The terminal deploy event (the `ready`/`error` line), or a synthesized
+ *  `error` when the stream ended without one — the button always gets a
+ *  definite outcome. */
+export function terminalDeployEvent(events: DeployStreamEvent[]): DeployStreamEvent {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.phase === "ready" || event.phase === "error") return event;
+  }
+  return { phase: "error", code: "NO_OUTPUT", message: "deploy produced no terminal status" };
 }
 
 const delay = (ms = 180): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -777,6 +926,60 @@ class MockApi implements HarnessApi {
     }
     await delay(140);
     onLine({ kind: "summary", outcome: "completed", output: { approved: true }, unusedStubs: [], stubWarnings: [] });
+  }
+
+  // The direct actions have no network in mock mode: they synthesize the same
+  // NDJSON shapes the real server streams, drive `onLine`/`onEvent` so the
+  // consuming UI is exercised, and record the call on __HARNESS_TEST__ so
+  // Playwright can assert the button hit the DIRECT path — never a pty inject
+  // (lastMacroRun) — which is the whole point of the direct-action button handler.
+
+  async deploy(
+    workflowPath: string,
+    onEvent?: StreamLineHandler<DeployStreamEvent>,
+  ): Promise<DeployStreamEvent> {
+    this.recordDirectAction("deploy", { workflowPath });
+    const building: DeployStreamEvent = { phase: "building", definitionId: "mock-def" };
+    onEvent?.(building);
+    await delay(400);
+    const ready: DeployStreamEvent = {
+      phase: "ready",
+      definitionId: "mock-def",
+      buildRunId: "mock-build-1",
+      status: "succeeded",
+    };
+    onEvent?.(ready);
+    // Mirror the real server: a successful deploy links the workflow, so its
+    // definitionId flips. Reflect that in the fixture so the Draft→Deployed
+    // chip and the deploy-gated actions light up after a mock deploy.
+    this.workflows = this.workflows.map((w) =>
+      w.path === workflowPath && w.definitionId == null
+        ? { ...w, definitionId: 4242, definitionSlug: w.definitionSlug ?? "mock-agent" }
+        : w,
+    );
+    return ready;
+  }
+
+  async run(req: { definitionId: string; input?: unknown }): Promise<RunResponse> {
+    this.recordDirectAction("run", req);
+    await delay(200);
+    // A fresh, non-"local" id so the run-state fixture returns the prod
+    // steps and the inspector poller has something to follow.
+    return { executionId: `exec-mock-prod-${Date.now()}` };
+  }
+
+  /** Test-only escape hatch (mock mode only): record a direct-action call so
+   *  Playwright can assert the button used the DIRECT route rather than the pty
+   *  inject path. Same pattern as lastMacroRun/lastInjectInput. */
+  private recordDirectAction(action: "deploy" | "run" | "runLocal", req: unknown): void {
+    if (typeof window === "undefined") return;
+    const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
+    const prev = (win.__HARNESS_TEST__?.directActions as unknown[]) ?? [];
+    win.__HARNESS_TEST__ = {
+      ...(win.__HARNESS_TEST__ ?? {}),
+      directActions: [...prev, { action, req }],
+      lastDirectAction: { action, req },
+    };
   }
 }
 

--- a/packages/harness/web/src/lib/macro-actions.test.ts
+++ b/packages/harness/web/src/lib/macro-actions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { directActionKind } from "./macro-actions";
+
+describe("directActionKind", () => {
+  it("maps the three direct-action macros to their kind", () => {
+    // These three no longer inject into the pty — they hit the direct routes.
+    expect(directActionKind("deploy")).toBe("deploy");
+    expect(directActionKind("prod_run")).toBe("prod-run");
+    expect(directActionKind("run_local")).toBe("run-local");
+  });
+
+  it("returns null for macros that keep their existing behaviour", () => {
+    // open-url and render-canvas macros are untouched by the direct-route work.
+    expect(directActionKind("open_prod")).toBeNull();
+    expect(directActionKind("visualize")).toBeNull();
+  });
+
+  it("returns null for Debug / Explain / free-form inject macros", () => {
+    // The prompt-inject surfaces (composer library + any future inject macro)
+    // must never be re-routed to a direct action — they still type into the pty.
+    expect(directActionKind("debug")).toBeNull();
+    expect(directActionKind("explain")).toBeNull();
+    expect(directActionKind("some_free_form_macro")).toBeNull();
+    expect(directActionKind("")).toBeNull();
+  });
+
+  it("does not treat a lookalike id as a direct action (exact match only)", () => {
+    // Guards against a prototype-chain or prefix match sneaking a non-direct
+    // macro onto the direct path.
+    expect(directActionKind("toString")).toBeNull();
+    expect(directActionKind("deploy_v2")).toBeNull();
+    expect(directActionKind("run_local_dry")).toBeNull();
+  });
+});

--- a/packages/harness/web/src/lib/macro-actions.ts
+++ b/packages/harness/web/src/lib/macro-actions.ts
@@ -1,0 +1,50 @@
+/**
+ * Direct-action macro routing (pure).
+ *
+ * Three of the action-rail macros no longer inject a `sapiom …` command into
+ * the agent's pty — they call the harness server's direct routes instead, so
+ * the action runs server-side (Deploy / Prod-run) or in-process (Run-local)
+ * with **no Claude Code and no user LLM credits**:
+ *
+ *   - `deploy`    → POST /api/workflows/:id/deploy  (build-status NDJSON stream)
+ *   - `prod_run`  → POST /api/runs                  ({ executionId } → inspector)
+ *   - `run_local` → POST /api/runs/local            (offline stub-run NDJSON)
+ *
+ * Every other macro is untouched: `open_prod` (open-url), `visualize`
+ * (render-canvas), and any inject macro — including the Debug / Explain /
+ * free-form prompt-inserts surfaced through the composer library — still go
+ * through their existing path.
+ *
+ * This module is the single source of truth for that split so the wiring at the
+ * call site stays a thin `switch`, and the mapping is unit-testable without a
+ * DOM. It is pure: no React, no I/O.
+ */
+
+/** The direct server-backed action a macro maps to, or `null` for a macro that
+ *  keeps its existing (inject / open-url / render-canvas) behaviour. */
+export type DirectActionKind = "deploy" | "prod-run" | "run-local";
+
+/**
+ * The macro ids that are now direct actions, mapped to their kind. Keyed by the
+ * macro `id` the registry ships (`src/core/macros.ts`) so a rename there fails
+ * loudly here rather than silently falling back to the pty inject path.
+ */
+const DIRECT_ACTION_BY_MACRO_ID: Readonly<Record<string, DirectActionKind>> = {
+  deploy: "deploy",
+  prod_run: "prod-run",
+  run_local: "run-local",
+};
+
+/**
+ * Classify a macro by id: the direct action it performs, or `null` when the
+ * macro should keep its existing behaviour (open-url, render-canvas, or a pty
+ * inject — e.g. Debug / Explain / free-form). The caller routes a non-null
+ * result to the matching direct API method and a `null` result to `runMacro`.
+ */
+export function directActionKind(macroId: string): DirectActionKind | null {
+  // hasOwn (not `record[id] ?? null`) so an inherited key like "toString" never
+  // resolves to a function off Object.prototype.
+  return Object.prototype.hasOwnProperty.call(DIRECT_ACTION_BY_MACRO_ID, macroId)
+    ? DIRECT_ACTION_BY_MACRO_ID[macroId]
+    : null;
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -103,6 +103,21 @@ export interface HarnessStateHook {
   updateSettings: (patch: Partial<HarnessSettings>) => Promise<HarnessSettings>;
   runMacro: (id: string, req: RunMacroRequest) => Promise<void>;
   /**
+   * Deploy the agent linked to `workflowPath` via the DIRECT route (Deploy
+   * button) — server-side, no Claude Code. Streams build status into the toast
+   * slot; refreshes the registry on success so the Draft→Deployed chip flips.
+   * Never rejects on a build failure (surfaced as a toast), matching runMacro's
+   * fire-and-forget click contract.
+   */
+  deploy: (workflowPath: string) => Promise<void>;
+  /**
+   * Start a real prod execution via the DIRECT route (Prod-run button) — no
+   * Claude Code — then hand the returned `executionId` to the run-inspector
+   * poller so the run shows up in the Steps tab exactly as a CLI-launched run
+   * does. Errors go to the toast slot.
+   */
+  startProdRun: (sessionId: string, definitionId: string, input?: unknown) => Promise<void>;
+  /**
    * Runs the workflow at `sourceDir` OFFLINE against stub capabilities and
    * streams the result into the SAME run store the prod poller feeds — so the
    * click-into-step inspector renders a local stub run exactly as it renders a
@@ -700,6 +715,47 @@ export function useHarnessState(): HarnessStateHook {
     }
   }, []);
 
+  // Deploy via the direct route: stream build status to the toast, then refresh
+  // the registry so a linked/rebuilt workflow's Deployed chip flips. Swallows
+  // failures into the toast (like runMacro) — its caller fires it unawaited.
+  const deploy = useCallback(
+    async (workflowPath: string): Promise<void> => {
+      setToast("Deploying — building on Sapiom…");
+      try {
+        const terminal = await api.deploy(workflowPath, (event) => {
+          if (event.phase === "building") setToast("Deploying — building on Sapiom…");
+        });
+        if (terminal.phase === "ready") {
+          setToast("Deployed to Sapiom.");
+          // A successful deploy links/rebuilds the agent — re-read the registry
+          // so definitionId (the Draft→Deployed truth) and the deploy-gated
+          // actions update without waiting on a bus refresh.
+          await refreshWorkflows();
+        } else if (terminal.phase === "error") {
+          setToast(terminal.hint ? `Deploy failed: ${terminal.message} (${terminal.hint})` : `Deploy failed: ${terminal.message}`);
+        }
+      } catch (err) {
+        setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
+      }
+    },
+    [refreshWorkflows],
+  );
+
+  // Prod-run via the direct route: start the execution server-side, then feed
+  // the returned executionId into the SAME poller a CLI-launched run uses
+  // (startRunPolling) so it lands in the Steps tab / run picker identically.
+  const startProdRun = useCallback(
+    async (sessionId: string, definitionId: string, input?: unknown): Promise<void> => {
+      try {
+        const { executionId } = await api.run({ definitionId, input });
+        startRunPolling(sessionId, executionId, "prod");
+      } catch (err) {
+        setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
+      }
+    },
+    [startRunPolling],
+  );
+
   const dismissToast = useCallback(() => setToast(null), []);
 
   // Unlike runMacro (which swallows errors into a toast), injectInput lets the
@@ -755,6 +811,8 @@ export function useHarnessState(): HarnessStateHook {
     bindWorkflow,
     updateSettings,
     runMacro,
+    deploy,
+    startProdRun,
     runLocal,
     injectInput,
     useSkill,


### PR DESCRIPTION
## Summary

Wires the Studio's action-rail so **Deploy / Prod-run / Run-local** call the direct harness-server routes instead of typing a `sapiom …` command into the coding agent. Each action now runs server-side (Deploy / Prod-run) or in-process (Run-local) with **no coding-agent session and no user LLM credits**.

| Button | Route | Behaviour |
| --- | --- | --- |
| **Deploy** | `POST /api/workflows/:id/deploy` | Consumes the build-status NDJSON stream (`building` → terminal `ready`/`error`); on success refreshes the registry so the Draft→Deployed chip flips. |
| **Prod-run** | `POST /api/runs` | Starts the execution and hands the returned `{ executionId }` to the run-inspector via the **same poller a CLI-launched run uses** (`startRunPolling`), so it lands in the Steps tab identically. |
| **Run-local** | `POST /api/runs/local` | Consumes the offline stub-run NDJSON stream to completion and surfaces the outcome. No network, no spend. |

**Unchanged:** Debug / Explain / free-form still inject into the coding agent (composer library + any inject macro); **Visualize** (render-canvas) and open-url macros are untouched.

## Changes

- `web/src/lib/api.ts` — `api.deploy` / `api.run` / `api.runLocal` on both `RealApi` and `MockApi`, plus a shared NDJSON stream reader and two pure terminal-line pickers (`terminalDeployEvent`, `terminalRunLocalLine`). Client-side wire types (matched to `src/server/actions.ts` + `src/core/run-local-bootstrap.ts`) live here (SPA-only), same convention as `SkillMeta`.
- `web/src/lib/use-harness-state.ts` — `deploy` / `startProdRun` / `runLocal` hook methods.
- `web/src/lib/macro-actions.ts` (new) — pure `directActionKind(macroId)` classifier so the dispatch point stays a thin switch and the split is unit-testable.
- `web/src/App.tsx` — **minimal** edit: the shared `handleRunMacroForWorkflow` choke-point branches on `directActionKind` before falling back to `runMacro`. Both existing call sites (SessionStepsBar + CanvasPane) route through it unchanged.
- New unit tests: `macro-actions.test.ts` (classifier + prototype-chain guard) and `api.test.ts` (terminal-line pickers).
- PATCH changeset.

## Acceptance

- [x] Deploy / Prod-run / Run-local perform the action via the routes — **no Claude Code pty write** (the MockApi records `directActions` and never `lastMacroRun` for these).
- [x] Debug / Explain / free-form still inject; Visualize unchanged.
- [x] Prod-run's `executionId` hands off to the run-inspector.

## Testing

- `pnpm --filter @sapiom/harness typecheck` — clean.
- `pnpm --filter @sapiom/harness test` — **1074 passed** (incl. 14 new).
- `pnpm --filter @sapiom/harness build` — succeeds (server + web).
- `pnpm --filter @sapiom/harness test:ui` — **53 passed / 71 failed**, but the failing set is **byte-identical** to the base branch (`feat/harness-studio-launch`) run in a clean worktree (also 53/71, `comm` set-diff empty both ways). The 71 are the unreconciled studio-port Playwright specs (they target a removed `workflow-action-strip` / `macro-*` surface + other pre-existing gaps) — **this PR adds zero e2e regressions**. A4 is the dedicated e2e for A3.

Linear: SAP-1778

🤖 Generated with [Claude Code](https://claude.com/claude-code)