### PR TITLE
feat(examples): Wait-for-Webhook durable pause/resume template (SAP-1829)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,38 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "wait-for-webhook",
+      "name": "Wait-for-Webhook",
+      "description": "Durable pause/resume — start a slow external job, suspend at $0 until a webhook callback fires, then decide.",
+      "tags": ["durable", "pause-resume", "webhook", "async"],
+      "sourcePath": "examples/wait-for-webhook",
+      "capabilities": ["llm.generate"],
+      "whatItDoes": "Starts a slow external async job and registers a resume contract, then suspends the run indefinitely at $0 via pauseUntilSignal — no polling, no held worker, no billed idle time. When an external webhook/callback fires the signal, the run resumes exactly where it left off: the callback payload becomes the resumed step's input, an LLM summarizes it, and the run branches to accept or reject. The sharpest showcase of the platform's durability differentiator.",
+      "steps": [
+        {
+          "name": "kickoff",
+          "description": "Start the external async job, register the resume contract, then pause until the callback signal (resumes at 'decide').",
+          "next": ["decide"]
+        },
+        {
+          "name": "decide",
+          "description": "Resume target — its input is the callback payload; summarize it with an LLM and branch.",
+          "capability": "llm.generate",
+          "next": ["accept", "reject"]
+        },
+        {
+          "name": "accept",
+          "description": "Terminal branch: the callback result was accepted.",
+          "terminal": true
+        },
+        {
+          "name": "reject",
+          "description": "Terminal branch: the callback result was rejected.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/wait-for-webhook/.gitignore
+++ b/examples/wait-for-webhook/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/wait-for-webhook/AGENTS.md
+++ b/examples/wait-for-webhook/AGENTS.md
@@ -1,0 +1,46 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Wait-for-Webhook** — authored against `@sapiom/agent`. It demonstrates durable pause/resume: `kickoff` starts a slow external async job, registers a resume contract, and returns `pauseUntilSignal(...)`; the run then suspends at $0 until an external callback fires the signal; `decide` (the resume target) receives the callback payload as its input, summarizes it with `ctx.sapiom.models.run`, and branches to `accept` or `reject`.
+
+## The pause/resume spine
+
+- **`kickoff`** registers `{ executionId, signal, correlationId: ctx.executionId }` with the external job, then returns `pauseUntilSignal({ signal, resumeStep: "decide", correlationId: ctx.executionId })`. It also carries a static `pause: { signal, resumeStep: "decide" }` annotation — the build-time graph edge that must match the directive.
+- **`decide`** reads the callback payload **directly as its `run` input** — that's the signal payload the external world delivered. Everything else (config, job params, ids) is read back from `ctx.shared`, which survives the pause.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability**. The only billed call is the model summary in `decide` (`ctx.sapiom.models.run`, the live x402 path). Note: `ctx.sapiom.llm` does **not** exist — use `models.run`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` and a `pause: { signal, resumeStep }` annotation; the `resumeStep` is its forward edge.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including the static `pause` annotation.
+- **run_local** — runs your **real** step code against **stub capabilities**. With no `CALLBACK_REGISTER_URL` configured (or `DRY_RUN` set), the `dryRun` guard skips the live external POST and the local runner auto-resumes the pause, so you get the full `kickoff → paused → decide → branch` trace offline for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses.
+
+### Firing the resume signal in dev
+
+A real `run` pauses at `kickoff`. To resume it without a real webhook, fire the signal via the MCP `signal_workflow` / `workflow_signal` tool — the manual stand-in for the callback:
+
+```json
+{
+  "signal": "webhook.callback",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "status": "succeeded", "result": { "note": "job done" } }
+}
+```
+
+The `payload` arrives as `decide`'s input.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities + the `dryRun` guard), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `correlationId` is `ctx.executionId` (stable across the pause), so the resume signal always lands on the right run.

--- a/examples/wait-for-webhook/README.md
+++ b/examples/wait-for-webhook/README.md
@@ -1,0 +1,72 @@
+# Wait-for-Webhook
+
+Durable pause/resume around any slow external callback. The run starts a slow
+external async job, then **suspends indefinitely at $0** until a webhook/callback
+fires — no polling loop, no held worker, no billed idle time — and resumes
+exactly where it left off when the external world is ready.
+
+The direct counter to "agents are too expensive to run": a workflow can wait
+days on a third-party callback and cost nothing until the signal arrives.
+
+## What it does
+
+```
+kickoff  ──(pause: wait for "webhook.callback", $0 while idle)──▶  decide  ─┬─▶  accept  (terminal)
+                                                                            └─▶  reject  (terminal)
+```
+
+1. **kickoff** — starts the external async job and registers a resume contract
+   `{ executionId, signal, correlationId }`, then returns
+   `pauseUntilSignal({ signal, resumeStep: "decide", correlationId })`. The run
+   suspends here at zero cost.
+2. **(paused)** — nothing runs, nothing is billed, for as long as it takes.
+3. **decide** (resume target) — its **input IS the callback payload**. An LLM
+   (`ctx.sapiom.models.run`) summarizes the payload and branches. Everything set
+   before the pause is read back from `ctx.shared`.
+4. **accept | reject** — terminal branches keyed off the decision.
+
+Input: `{ "job": { ... }, "config": { "CALLBACK_REGISTER_URL": "...", "CALLBACK_REGISTER_KEY": "..." } }`.
+With no `CALLBACK_REGISTER_URL` (or `DRY_RUN` set), `kickoff` runs offline via its
+`dryRun` guard.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the `decide` step
+   inherits that authority to call the model.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (offline via the `dryRun` guard, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses).
+
+## Resuming a paused run in dev
+
+A real `run` pauses at `kickoff` and waits for the `webhook.callback` signal.
+Instead of a real webhook, fire it yourself via the MCP `signal_workflow` /
+`workflow_signal` tool. The `correlationId` is the paused run's `executionId`,
+and the `payload` becomes `decide`'s input:
+
+```json
+{
+  "signal": "webhook.callback",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "status": "succeeded", "result": { "note": "job done" } }
+}
+```
+
+The run wakes at `decide`, summarizes that `payload`, and branches to `accept`
+(a success-looking payload) or `reject` (a `status` of `failed`/`error`/etc.).
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/wait-for-webhook/index.ts
+++ b/examples/wait-for-webhook/index.ts
@@ -1,0 +1,272 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Wait-for-Webhook — durable pause/resume around any slow external callback.
+ *
+ * The sharpest showcase of the platform's durability differentiator, and the
+ * direct counter to "agents are too expensive to run": `kickoff` starts a slow
+ * external async job and registers a resume contract, then the run **suspends
+ * indefinitely at $0** via `pauseUntilSignal` — no polling loop, no held worker,
+ * no billed idle time. It resumes only when the external world fires the signal
+ * (a webhook/callback), delivering a result payload that becomes the resumed
+ * step's input. `decide` summarizes that payload with a model and branches to
+ * `accept` or `reject`.
+ *
+ *   kickoff ──(pause: wait for `SIGNAL`, $0 while idle)──▶ decide ─┬─▶ accept
+ *                                                                  └─▶ reject
+ *
+ * Resume contract: `kickoff` registers `{ executionId, signal, correlationId }`
+ * with the external job and pauses; the external caller fires that signal (in
+ * dev, via the MCP `signal_workflow` / `workflow_signal` tool — see README). The
+ * resumed `decide` step's input IS the callback payload; everything else survives
+ * the pause in `ctx.shared`.
+ *
+ * Offline: with no `CALLBACK_REGISTER_URL` configured (or `DRY_RUN` set), the
+ * `dryRun` guard skips the live external POST, so `run_local` traces the full
+ * graph — kickoff → paused → auto-resumed `decide` → branch — for free.
+ */
+
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** The run input: parameters for the external job, plus optional config. */
+interface WaitForWebhookInput {
+  /** Arbitrary parameters handed to the external async job. */
+  job?: Record<string, unknown>;
+  /** Where to register the resume contract. Absent (or `DRY_RUN`) ⇒ offline. */
+  config?: Config;
+}
+
+/**
+ * The callback body delivered by the external webhook — it becomes `decide`'s
+ * input verbatim. Intentionally open: a real job returns whatever it returns.
+ */
+interface CallbackPayload {
+  /** Job-defined outcome, e.g. `"succeeded"` / `"failed"`. Optional. */
+  status?: string;
+  /** The job's result body, whatever shape it has. */
+  result?: unknown;
+  [key: string]: unknown;
+}
+
+interface Decision {
+  decision: "accept" | "reject";
+  summary: string;
+  reasons: string[];
+}
+
+/** Pre-pause state that must survive the suspend, read back after resume. */
+interface Shared extends Record<string, unknown> {
+  config: Config;
+  job: Record<string, unknown>;
+  correlationId: string;
+  jobId: string;
+}
+
+/** The named signal the external callback fires to resume this run. */
+const SIGNAL = "webhook.callback";
+
+// ---- helpers ---------------------------------------------------------------
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/**
+ * True when there's no live external dependency to talk to — no register URL, or
+ * `DRY_RUN` explicitly set. Lets `run_local` exercise the full control flow
+ * offline, mirroring how a real deploy talks to a real job endpoint.
+ */
+function isDryRun(config: Config): boolean {
+  const flag = (config.DRY_RUN ?? "").toLowerCase();
+  return flag === "1" || flag === "true" || !config.CALLBACK_REGISTER_URL;
+}
+
+/**
+ * Register the resume contract with the external job and kick it off. The job is
+ * expected to fire `SIGNAL` (with our `correlationId`) once its result is ready.
+ */
+async function registerJob(
+  config: Config,
+  body: { resume: unknown; job: Record<string, unknown> },
+): Promise<{ jobId: string }> {
+  const url = (config.CALLBACK_REGISTER_URL ?? "").replace(/\/$/, "");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (config.CALLBACK_REGISTER_KEY)
+    headers.authorization = `Bearer ${config.CALLBACK_REGISTER_KEY}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok)
+    throw new Error(
+      `register failed: HTTP ${res.status} ${text.slice(0, 200)}`,
+    );
+  const parsed = (text ? JSON.parse(text) : {}) as { jobId?: string };
+  return { jobId: parsed.jobId ?? "unknown" };
+}
+
+// ---- steps -----------------------------------------------------------------
+const kickoff = defineStep({
+  name: "kickoff",
+  next: [],
+  // Static graph edge: on `SIGNAL`, resume at `decide`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "decide" },
+  async run(input: WaitForWebhookInput, ctx: AgentExecutionContext<Shared>) {
+    const config = input.config ?? {};
+    const job = input.job ?? {};
+    // Everything set before the pause survives in ctx.shared and is read back
+    // in `decide`; the resumed step's *input* is the callback payload itself.
+    ctx.shared.set("config", config);
+    ctx.shared.set("job", job);
+    ctx.shared.set("correlationId", ctx.executionId);
+
+    // Tell the external job how to resume this exact run when its result is ready.
+    const resume = {
+      executionId: ctx.executionId,
+      signal: SIGNAL,
+      correlationId: ctx.executionId,
+    };
+
+    if (isDryRun(config)) {
+      // No live endpoint — skip the POST so run_local flows straight to the pause.
+      ctx.shared.set("jobId", "dry-run");
+      ctx.logger.info("dry run: skipping external job registration", {
+        correlationId: ctx.executionId,
+      });
+    } else {
+      const { jobId } = await registerJob(config, { resume, job });
+      ctx.shared.set("jobId", jobId);
+      ctx.logger.info("external job started; pausing for callback", {
+        jobId,
+        correlationId: ctx.executionId,
+      });
+    }
+
+    // Suspend at $0 until the external world fires SIGNAL for this correlationId.
+    return pauseUntilSignal({
+      signal: SIGNAL,
+      resumeStep: "decide",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const decide = defineStep({
+  name: "decide",
+  next: ["accept", "reject"],
+  // `payload` IS the callback body delivered by the resume signal.
+  async run(payload: CallbackPayload, ctx: AgentExecutionContext<Shared>) {
+    // Pre-pause state survived the suspend and is read back here.
+    const job = must(ctx.shared.get("job"), "job");
+
+    const system =
+      "You are reviewing the result of a slow external async job that was delivered via a webhook callback. " +
+      "Summarize the result and decide whether to ACCEPT it (the job succeeded and the result looks complete " +
+      "and usable) or REJECT it (the job failed, is incomplete, or the result is problematic). " +
+      'Reply with ONLY minified JSON: {"decision":"accept|reject","summary":string,"reasons":string[]}.';
+    const prompt =
+      `Original job request:\n${JSON.stringify(job)}\n\n` +
+      `Callback payload:\n${JSON.stringify(payload)}`;
+
+    const res = await ctx.sapiom.models.run({ prompt, system, maxTokens: 400 });
+    const decision = parseDecision(res.output, payload);
+    ctx.shared.set("decision", decision);
+    ctx.logger.info("callback decided", {
+      decision: decision.decision,
+      reasons: decision.reasons.length,
+    });
+
+    return decision.decision === "accept"
+      ? goto("accept", {})
+      : goto("reject", {});
+  },
+});
+
+const accept = defineStep({
+  name: "accept",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    const decision = must(ctx.shared.get("decision"), "decision") as Decision;
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    ctx.logger.info("accepted", { jobId });
+    return terminate({ jobId, decision: "accept", summary: decision.summary });
+  },
+});
+
+const reject = defineStep({
+  name: "reject",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    const decision = must(ctx.shared.get("decision"), "decision") as Decision;
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    ctx.logger.info("rejected", { jobId, reasons: decision.reasons });
+    return terminate({
+      jobId,
+      decision: "reject",
+      summary: decision.summary,
+      reasons: decision.reasons,
+    });
+  },
+});
+
+// ---- parsing ---------------------------------------------------------------
+/** Extract the decision from the model output; fall back to the payload status. */
+function parseDecision(
+  output: string | null,
+  payload: CallbackPayload,
+): Decision {
+  const status = (payload.status ?? "").toLowerCase();
+  const looksFailed = [
+    "error",
+    "failed",
+    "fail",
+    "rejected",
+    "cancelled",
+    "canceled",
+  ].includes(status);
+  const fallback: Decision = {
+    decision: looksFailed ? "reject" : "accept",
+    summary: `Callback status "${payload.status ?? "unknown"}"; model summary unavailable (defaulted to status).`,
+    reasons: looksFailed ? [`status="${payload.status}"`] : [],
+  };
+  if (!output) return fallback;
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback;
+    const raw = JSON.parse(output.slice(start, end + 1)) as Partial<Decision>;
+    const decision =
+      raw.decision === "accept" || raw.decision === "reject"
+        ? raw.decision
+        : fallback.decision;
+    return {
+      decision,
+      summary: typeof raw.summary === "string" ? raw.summary : fallback.summary,
+      reasons: Array.isArray(raw.reasons)
+        ? raw.reasons.filter((r): r is string => typeof r === "string")
+        : [],
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export const agent = defineAgent<WaitForWebhookInput, Shared>({
+  name: "wait-for-webhook",
+  entry: "kickoff",
+  steps: { kickoff, decide, accept, reject },
+});

--- a/examples/wait-for-webhook/package.json
+++ b/examples/wait-for-webhook/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-wait-for-webhook",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: durable pause/resume — start a slow external job, suspend at $0 until a webhook callback fires, then decide accept/reject.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.5.0",
+    "@sapiom/tools": "^0.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/wait-for-webhook/template.json
+++ b/examples/wait-for-webhook/template.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Durable pause/resume around any slow external callback — the sharpest showcase of the platform's durability differentiator, and the direct counter to \"agents are too expensive to run.\"\n\nThe `kickoff` step starts a slow external async job and registers a resume contract, then the run **suspends indefinitely at $0** via `pauseUntilSignal` — no polling loop, no held worker, no billed idle time. It can wait minutes, hours, or days. When the external world fires the signal (a webhook/callback), the run resumes exactly where it left off: the callback payload becomes the resumed `decide` step's *input*, an LLM (`ctx.sapiom.models.run`) summarizes it, and the run branches to `accept` or `reject`. Everything set before the pause survives in `ctx.shared`.\n\n`pauseUntilSignal` is a runtime primitive, not a metered capability. The only billed call is the model summary in `decide`.",
+  "useCases": [
+    "Wait on a slow third-party job (screening, rendering, batch export) that calls back hours later — at $0 while idle.",
+    "Gate a workflow on an external human/system approval delivered by webhook.",
+    "Bridge an async provider whose result arrives via callback, then branch on the outcome."
+  ],
+  "notes": "`run_local` traces the full graph offline for free: with no `CALLBACK_REGISTER_URL` configured (or `DRY_RUN` set), the `dryRun` guard skips the live external POST, and the local runner auto-resumes the pause — so you see `kickoff → paused → decide → accept|reject` without any external dependency.\n\nA real `deploy` + `run` pauses for real. To resume it in dev, fire the signal via the MCP `signal_workflow` / `workflow_signal` tool with `{ \"signal\": \"webhook.callback\", \"correlationId\": \"<executionId>\", \"payload\": { \"status\": \"succeeded\", \"result\": { ... } } }` — the `payload` becomes `decide`'s input. This is the manual stand-in for the real webhook. See `README.md` and `AGENTS.md`.",
+  "examples": [
+    {
+      "title": "Callback reports success",
+      "input": {
+        "job": { "kind": "render", "assetId": "abc123" },
+        "config": {}
+      },
+      "output": {
+        "jobId": "dry-run",
+        "decision": "accept",
+        "summary": "The external job completed and returned a usable result."
+      }
+    },
+    {
+      "title": "Callback reports failure",
+      "input": {
+        "job": { "kind": "render", "assetId": "abc123" }
+      },
+      "output": {
+        "jobId": "dry-run",
+        "decision": "reject",
+        "summary": "The external job reported a failure status.",
+        "reasons": ["status=\"failed\""]
+      }
+    }
+  ]
+}

--- a/examples/wait-for-webhook/tsconfig.json
+++ b/examples/wait-for-webhook/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds `examples/wait-for-webhook/` — a durable **pause/resume** workflow template, plus one `registry.json` gallery entry. Part of epic **SAP-1823** (grow the onboarding template gallery to 8+).

The sharpest showcase of the platform's durability differentiator, and the direct counter to *"agents are too expensive to run"*: a run starts a slow external async job, **suspends at $0** via `pauseUntilSignal` (no polling loop, no held worker, no billed idle time), and resumes exactly where it left off only when an external webhook fires the signal.

## Behavior

```
kickoff ──(pause: wait for "webhook.callback", $0 while idle)──▶ decide ─┬─▶ accept
                                                                         └─▶ reject
```

- **kickoff** — starts the external job, registers the resume contract `{ executionId, signal, correlationId: ctx.executionId }`, then returns `pauseUntilSignal({ signal, resumeStep: "decide", correlationId })`. Carries the matching static `pause: { signal, resumeStep: "decide" }` annotation.
- **decide** (resume target) — its **input IS the callback payload**; an LLM (`ctx.sapiom.models.run`, the live x402 path — *not* `ctx.sapiom.llm`) summarizes it and branches. Pre-pause state is read back from `ctx.shared`.
- **accept | reject** — terminal branches.

Ported from the hackathon `tenant-screening` workflow, genericized to "wait for any external callback" — no tenant-screening / Ridgeline / Buildium / email specifics remain.

## Offline / dev

- A `dryRun` guard (no `CALLBACK_REGISTER_URL`, or `DRY_RUN` set) skips the live external POST, so `run_local` traces the full graph — `kickoff → paused → auto-resumed decide → branch` — for free.
- README + AGENTS document firing the resume signal in dev via the MCP `signal_workflow` / `workflow_signal` tool with `{ signal, correlationId, payload }`.

## Validation

- ✅ `npm run typecheck` passes (confirms every `ctx.sapiom.*` method used exists at the pinned SDK versions).
- ✅ `buildManifest` + `assertValidGraph` confirm the step graph and the static `pause` annotation (the offline equivalent of MCP `check`).
- ✅ `registry.json` validates against `registry.schema.json` (required fields, `additionalProperties: false`, `next` targets resolve).
- ✅ prettier clean.
- ⏳ `deploy` + real `run` (pause → fire signal → resume) require the live MCP/backend and aren't run in CI.

Mirrors `examples/web-research-digest/` and `examples/hello-agent/` (same file set + SDK pins `@sapiom/agent ^0.5.0`, `@sapiom/tools ^0.16.0`).

Closes SAP-1829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)