### PR TITLE
feat(examples): add scheduled-research-brief workflow template (SAP-1827)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,40 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "scheduled-research-brief",
+      "name": "Scheduled Research Brief",
+      "description": "On a cron cadence, research a topic and email a short, LLM-curated, sourced brief.",
+      "tags": ["research", "search", "scheduled", "llm"],
+      "sourcePath": "examples/scheduled-research-brief",
+      "capabilities": ["web.search", "models.run"],
+      "whatItDoes": "The scheduled, LLM-curated, delivered evolution of web-research-digest. On each tick it web-searches a topic, scrapes the top candidates for full text, hands them to an LLM (models.run — the live x402-served model) to rank and curate a short sourced brief, then delivers it by email. Ships with a schedule input (topic + cron cadence) so it reads as a standing \"morning brief\" agent; a dryRun guard gates the real send. Fork web-research-digest for a one-shot digest, this for a standing brief.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Web-search the topic for candidate sources.",
+          "capability": "web.search",
+          "next": ["scrape"]
+        },
+        {
+          "name": "scrape",
+          "description": "Read the top candidates for full article text.",
+          "capability": "web.search",
+          "next": ["curate"]
+        },
+        {
+          "name": "curate",
+          "description": "Rank and curate the findings into a sourced brief with an LLM.",
+          "capability": "models.run",
+          "next": ["deliver"]
+        },
+        {
+          "name": "deliver",
+          "description": "Email the brief to the configured recipient (dry-run skips the send).",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/scheduled-research-brief/.gitignore
+++ b/examples/scheduled-research-brief/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/scheduled-research-brief/AGENTS.md
+++ b/examples/scheduled-research-brief/AGENTS.md
@@ -1,0 +1,44 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Scheduled Research Brief** — authored against `@sapiom/agent`. It has four steps: `search` (calls `web.search`) → `scrape` (calls `web.scrape`) → `curate` (calls `models.run`, the live LLM) → `deliver` (emails the brief). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.search.webSearch(...)`, `ctx.sapiom.models.run(...)`, `ctx.sapiom.email.messages.send(...)`).
+
+It is the scheduled, LLM-curated, delivered evolution of `web-research-digest`. That template formats a digest in-process (no LLM, no delivery); this one adds real LLM curation (`models.run`) and email delivery on a cron cadence.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **Keep the edges slim.** The scraped article bodies are the only large data here; they stay bounded (truncated, capped count) and die at the `curate` boundary — they never enter `ctx.shared`. Large shared state stalls transitions on the cloud engine (the `backlog-nudge` boundary lesson).
+- **Gate real side effects behind `dryRun`.** `deliver` sends email only on a live run with `dryRun` off and a recipient resolved; otherwise it returns the computed brief as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient is read from the vault (`ctx.sapiom.vault.get("scheduled-research-brief", "RECIPIENT")`) inside `deliver`, not carried through `ctx.shared`. The same seam is where a bring-your-own delivery token would be read.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `web.search` / `web.scrape` / `models.run` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `deliver` skips the (stubbed) send and returns the preview. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed search + scrape + LLM curation, and deliver the brief. Attach the `schedule` as a cron trigger to run it on a cadence.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`). To deliver into Sapiom **memory** instead — a searchable long-term store rather than an inbox — swap the send in `deliver` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: brief,
+  scope: deliverTo ?? "research-brief", // reuse deliverTo as the memory scope
+  metadata: { topic, sources },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipient, so you can drop the vault lookup — or keep it to override the scope. Recall past briefs later with `ctx.sapiom.memory.recall({ query, scope })`.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/scheduled-research-brief/README.md
+++ b/examples/scheduled-research-brief/README.md
@@ -1,0 +1,65 @@
+# Scheduled Research Brief
+
+Research a topic and email a short, sourced brief — on a cron cadence. The
+scheduled, LLM-curated, delivered sibling of
+[`web-research-digest`](../web-research-digest).
+
+## What it does
+
+```
+search  ──▶  scrape  ──▶  curate  ──▶  deliver  (terminal)
+(web.search)  (web.scrape)  (models.run)  (email)
+```
+
+1. **search** — takes a `topic`, calls `ctx.sapiom.search.webSearch` for
+   candidate results.
+2. **scrape** — reads the top candidates for full article text
+   (`ctx.sapiom.search.scrape`), degrading per-item on failure. Bodies are
+   truncated and stay bounded — they never enter shared state.
+3. **curate** — hands the ranked, scraped sources to an LLM
+   (`ctx.sapiom.models.run` — the live x402-served model) to synthesize a short
+   sourced brief. This is the step `web-research-digest` deliberately omits (it
+   formats in-process, no LLM).
+4. **deliver** — emails the brief to the recipient. A `dryRun` guard computes the
+   brief but skips the real send; the recipient is read from the Sapiom vault at
+   runtime, never persisted.
+
+Input: `{ "topic": "AI agent reliability incidents", "schedule": "0 8 * * *", "deliverTo": "you@example.com" }`.
+
+- `topic` and `schedule` are the two knobs — what to research, and how often.
+- `deliverTo` sets the recipient; omit it to use the vault-configured default.
+- `dryRun: true` returns the brief as a preview without emailing anyone.
+
+### `web-research-digest` vs. this
+
+Fork [`web-research-digest`](../web-research-digest) for a **one-shot** digest
+that formats in-process — no LLM, no delivery. Fork **this** for a **standing**
+brief: LLM-curated, emailed, on a cron cadence.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` to skip delivery, free) → `sapiom_dev_agents_link`
+   → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real, billed
+   search + scrape + LLM curation, and a delivered brief).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the
+   deployed agent.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/scheduled-research-brief/index.ts
+++ b/examples/scheduled-research-brief/index.ts
@@ -1,0 +1,313 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import type { Sapiom } from "@sapiom/tools";
+
+/**
+ * Scheduled Research Brief — the scheduled, LLM-curated, delivered sibling of
+ * `web-research-digest`.
+ *
+ * On each tick it searches the web for a `topic`, scrapes the top candidates for
+ * full article text, asks an LLM (`ctx.sapiom.models.run` — the live x402-served
+ * model, NOT a hardcoded formatter) to rank + curate the findings into a short
+ * sourced brief, then delivers that brief by email. It ships with a `schedule`
+ * input so it reads as a standing "morning brief" agent rather than a manual
+ * one-shot.
+ *
+ * Composition, in one legible graph:
+ *   search (web.search) → scrape (web.scrape) → curate (models.run) → deliver (email)
+ *
+ * vs. `web-research-digest`: fork THAT for a one-shot digest that formats
+ * in-process (no LLM, no delivery); fork THIS for a standing, LLM-curated brief
+ * that lands in an inbox on a cron cadence.
+ *
+ * Side-effect discipline (copied from `mushroom-cloud` / `backlog-nudge`):
+ *   - `dryRun` gates the real send: it computes the brief and returns it as a
+ *     preview without emailing anyone. `run_local` uses this to trace the whole
+ *     graph offline (capabilities stubbed) for free before a billed, delivering
+ *     deploy + run.
+ *   - The recipient is resolved from the Sapiom vault at runtime and never
+ *     persisted in execution state — the same seam you'd read a delivery secret
+ *     from if you swapped in a bring-your-own channel (see `AGENTS.md`).
+ *   - Each edge carries a slim payload; the large scraped bodies stay bounded and
+ *     die at the `curate` boundary — they never enter `ctx.shared` (big shared
+ *     state stalls transitions, per the `backlog-nudge` boundary lesson).
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Default cadence when the caller doesn't pass one: 08:00 every day. */
+const DEFAULT_SCHEDULE = "0 8 * * *";
+/** How many search hits to consider as scrape candidates. */
+const MAX_CANDIDATES = 5;
+/** How many candidates to actually scrape (keeps latency + cost bounded). */
+const MAX_SCRAPES = 4;
+/** Truncate each scraped body — the ONLY large data on the search→curate path. */
+const MAX_BODY_CHARS = 1200;
+/** Vault ref holding delivery config (e.g. a default RECIPIENT). Read at runtime. */
+const DELIVERY_VAULT_REF = "scheduled-research-brief";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "research-brief";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** What to research on each tick. */
+  topic: string;
+  /** Cron cadence this brief is meant to run on (e.g. "0 8 * * *"). */
+  schedule?: string;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Compute the brief but skip the real send. `run_local` passes this. */
+  dryRun?: boolean;
+}
+
+/** Slim search hit carried across the search → scrape boundary. */
+interface Candidate {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/** A candidate plus its (bounded) scraped body — the scrape → curate payload. */
+interface ScrapedSource extends Candidate {
+  /** Extracted article text (markdown, truncated); absent when scraping failed. */
+  content?: string;
+}
+
+/** The slim source reference that crosses curate → deliver and lands in output. */
+interface Source {
+  title: string;
+  url: string;
+}
+
+interface Shared extends Record<string, unknown> {
+  topic: string;
+  schedule: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  brief: string;
+  sources: Source[];
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (`vault.get` returns null), not an error — the caller then
+ * falls back to a dry-run preview. This is also the seam where a bring-your-own
+ * delivery secret would be read; it is never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Research Brief",
+  });
+  return inbox.inboxId;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const search = defineStep({
+  name: "search",
+  next: ["scrape"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const topic = input.topic?.trim() ?? "";
+    ctx.shared.set("topic", topic);
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    if (!topic) {
+      // Nothing to research — hand an empty candidate list to the next step so
+      // the graph still traces end to end.
+      return goto("scrape", { candidates: [] as Candidate[] });
+    }
+
+    ctx.logger.info("searching the web", { topic });
+    const hits = await ctx.sapiom.search.webSearch({
+      query: topic,
+      intent: "links",
+    });
+    const candidates: Candidate[] = hits.results
+      .slice(0, MAX_CANDIDATES)
+      .map((r) => ({ title: r.title, url: r.url, snippet: r.snippet }));
+    ctx.logger.info("search returned candidates", { count: candidates.length });
+    return goto("scrape", { candidates });
+  },
+});
+
+const scrape = defineStep({
+  name: "scrape",
+  next: ["curate"],
+  async run(input: { candidates: Candidate[] }, ctx: Ctx) {
+    const candidates = input.candidates ?? [];
+    const sources: ScrapedSource[] = [];
+    let scraped = 0;
+    for (const c of candidates) {
+      // Beyond the scrape budget we still forward the candidate — the snippet
+      // alone is useful curation context.
+      if (scraped >= MAX_SCRAPES) {
+        sources.push(c);
+        continue;
+      }
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: c.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        scraped += 1;
+        sources.push({
+          title: page.metadata?.title || c.title,
+          url: c.url,
+          snippet: c.snippet,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Scrapes fail routinely (paywalls, timeouts); degrade per-item, never
+        // throw — a curated brief from the survivors beats an aborted run.
+        ctx.logger.warn("scrape failed; keeping snippet only", {
+          url: c.url,
+          err: String(err),
+        });
+        sources.push(c);
+      }
+    }
+    ctx.logger.info("scraped candidates", { scraped, total: sources.length });
+    return goto("curate", { sources });
+  },
+});
+
+const curate = defineStep({
+  name: "curate",
+  next: ["deliver"],
+  async run(input: { sources: ScrapedSource[] }, ctx: Ctx) {
+    const topic = ctx.shared.get("topic") || "your topic";
+    const sources = input.sources ?? [];
+    // Slim references only — the scraped bodies stop here and never reach shared
+    // state or the deliver boundary.
+    const slimSources: Source[] = sources.map((s) => ({
+      title: s.title,
+      url: s.url,
+    }));
+
+    let brief: string;
+    if (sources.length === 0) {
+      brief = `# Research brief: ${topic}\n\n_No sources were found for this topic._`;
+    } else {
+      const research = sources
+        .map(
+          (s, i) =>
+            `[${i + 1}] ${s.title} (${s.url})\n${(s.content || s.snippet).slice(0, MAX_BODY_CHARS)}`,
+        )
+        .join("\n\n");
+      // The live, x402-served model does the ranking + synthesis — this is the
+      // capability web-research-digest deliberately avoids (it formats in-process).
+      const curation = await ctx.sapiom.models.run({
+        system:
+          "You are a research analyst writing a short morning brief. Given a " +
+          "TOPIC and a set of web SOURCES (each: [n] title, url, extracted text), " +
+          "rank them by relevance and credibility, drop thin or duplicate items, " +
+          "and write markdown with: a 2-3 sentence summary, then 3-5 bullet " +
+          "takeaways that each cite their source as a [n] reference, then a " +
+          "'## Sources' list mapping each [n] to its title and url. Output ONLY " +
+          "the markdown brief — no preamble, no code fences.",
+        prompt: `TOPIC: ${topic}\n\nSOURCES:\n${research}`,
+        maxTokens: 800,
+      });
+      brief =
+        (curation.output ?? "").trim() ||
+        `# Research brief: ${topic}\n\n_The model returned no content._`;
+    }
+
+    ctx.shared.set("brief", brief);
+    ctx.shared.set("sources", slimSources);
+    ctx.logger.info("curated brief", {
+      topic,
+      chars: brief.length,
+      sources: slimSources.length,
+    });
+    return goto("deliver", { brief, sources: slimSources });
+  },
+});
+
+const deliver = defineStep({
+  name: "deliver",
+  next: [],
+  terminal: true,
+  async run(input: { brief: string; sources: Source[] }, ctx: Ctx) {
+    const topic = ctx.shared.get("topic") || "your topic";
+    const schedule = ctx.shared.get("schedule") || DEFAULT_SCHEDULE;
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const brief = input.brief ?? "";
+    const sources = input.sources ?? [];
+    const subject = `Research brief: ${topic}`;
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // The safe path: a dry run — or a live run with no recipient configured yet —
+    // returns the computed brief without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        topic,
+        schedule,
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        brief,
+        sources,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: brief,
+    });
+    ctx.logger.info("brief delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      topic,
+      schedule,
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      messageId: sent.messageId,
+      sources,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "scheduled-research-brief",
+  entry: "search",
+  steps: { search, scrape, curate, deliver },
+});

--- a/examples/scheduled-research-brief/package.json
+++ b/examples/scheduled-research-brief/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-scheduled-research-brief",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a cron cadence, search + scrape a topic, curate the findings into a sourced brief with an LLM (models.run), and deliver it by email.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/scheduled-research-brief/template.json
+++ b/examples/scheduled-research-brief/template.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "A cron-scheduled, delivered evolution of `web-research-digest`: on each tick it researches a topic and emails you a short, sourced brief.\n\nThe graph is a legible multi-capability composition — `search` (web.search) → `scrape` (web.scrape) → `curate` (models.run, the live x402-served LLM) → `deliver` (email). Unlike `web-research-digest`, which formats its digest in-process with no LLM, this one hands the ranked, scraped sources to `ctx.sapiom.models.run` to curate a brief, then delivers it.\n\nIt ships with a `schedule` input (a cron cadence) so it reads as a standing \"morning brief\" agent rather than a manual one-shot. A `dryRun` guard gates the real send, and the recipient is read from the Sapiom vault at runtime — never persisted in state.\n\nRelationship: fork `web-research-digest` for a one-shot, in-process digest; fork this for a standing, LLM-curated brief that lands in an inbox on a cadence.",
+  "useCases": [
+    "Wake up to a curated, sourced brief on a topic you track — competitors, a research area, a market.",
+    "Turn a recurring \"what's new in X?\" question into a scheduled email you never have to trigger by hand.",
+    "Learn how to compose search → scrape → LLM curation → delivery in one agent, with a safe dry-run path."
+  ],
+  "notes": "`run_local` stubs every capability, and passing `dryRun: true` computes the brief but skips the real email — so you can trace the full search → scrape → curate → deliver graph offline for free. A real `deploy` + `run` performs a billed search, scrape, and LLM curation and sends the brief.\n\nTwo knobs define the agent: `topic` (what to research) and `schedule` (the cron cadence). Set the recipient with the `deliverTo` input, or store a default under the `scheduled-research-brief` vault ref (key `RECIPIENT`) — it's read at runtime, never persisted.\n\nTo run it on a cadence, deploy it and attach the `schedule` as a cron trigger. `AGENTS.md` documents the authoring loop and how to swap email for memory delivery.",
+  "examples": [
+    {
+      "title": "A daily brief on AI agent reliability",
+      "input": {
+        "topic": "AI agent reliability incidents",
+        "schedule": "0 8 * * *",
+        "dryRun": true
+      },
+      "output": {
+        "topic": "AI agent reliability incidents",
+        "schedule": "0 8 * * *",
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "Research brief: AI agent reliability incidents",
+        "brief": "# Research brief: AI agent reliability incidents\n\nRecent reporting highlights a rise in production incidents traced to autonomous agents...\n\n- An agent deleted a production database, then reported the outage itself [1]\n- Enterprises are adding guardrails after customer-facing rollbacks [2]\n\n## Sources\n1. [Agent deletes prod database](https://example.com/incident)\n2. [Guardrails after rollbacks](https://example.com/guardrails)",
+        "sources": [
+          {
+            "title": "Agent deletes prod database",
+            "url": "https://example.com/incident"
+          },
+          {
+            "title": "Guardrails after rollbacks",
+            "url": "https://example.com/guardrails"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/scheduled-research-brief/tsconfig.json
+++ b/examples/scheduled-research-brief/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Closes SAP-1827.

The scheduled, LLM-curated, delivered sibling of `web-research-digest`. Grows the onboarding gallery (epic SAP-1823) with a template that demonstrates multi-capability composition, live LLM curation, scheduled execution, and safe side-effecting delivery.

## What it does

```
search  ──▶  scrape  ──▶  curate  ──▶  deliver  (terminal)
(web.search)  (web.scrape)  (models.run)  (email)
```

Given a `topic` and a `schedule` (cron), on each tick it web-searches the topic, scrapes the top candidates for full text, asks an LLM (`ctx.sapiom.models.run` — the live x402-served model) to rank + curate a short sourced brief, then emails it. Ships with a `schedule` input so it reads as a standing "morning brief" agent, not a manual one-shot.

## What it demonstrates (vs. `web-research-digest`)

- **Multi-capability composition** — `web.search` → scrape → `models.run` → delivery, in one legible graph.
- **The `models.run` path** (live LLM curation) that `web-research-digest` deliberately avoids (it formats in-process, no LLM).
- **Scheduled execution** via a `schedule` (cron) input — deploy it and attach the schedule as a cron trigger.
- **`dryRun` guard + vault-at-runtime** for a template with a real external side effect (delivery), copied from `mushroom-cloud` / `backlog-nudge`.

## Design notes

- **`dryRun` gates the real send** — computes the brief and returns it as a preview without emailing. This is the path `run_local` uses to trace the whole graph offline for free before a billed, delivering deploy + run.
- **Recipient read from the vault at runtime** (`scheduled-research-brief` ref, key `RECIPIENT`) — never persisted in execution state. Explicit `deliverTo` input wins. Same seam a bring-your-own delivery token would use.
- **Slim boundaries** — scraped bodies stay bounded and die at the `curate` boundary; they never enter `ctx.shared` (the `backlog-nudge` lesson: big shared state stalls transitions).
- **Email is the default channel**; memory delivery is documented as a one-line extension in `AGENTS.md`.

## Changes

- New `examples/scheduled-research-brief/` mirroring `web-research-digest` (index.ts, package.json, tsconfig.json, template.json `manifestVersion 1`, README.md, AGENTS.md, .gitignore).
- One `examples/registry.json` entry: `capabilities: ["web.search", "models.run"]`, `tags: ["research", "search", "scheduled", "llm"]`, steps `search→scrape→curate→deliver` (deliver terminal); slug = dir = sourcePath.
- Pins `@sapiom/agent ^0.6.0` / `@sapiom/tools ^0.20.0` (the `vault` namespace does not exist before ~0.19, so the earlier `^0.16` sibling pin would fail typecheck).

## Validation

- `npm install && npm run typecheck` — passes clean against published `@sapiom/tools@0.20.1` / `@sapiom/agent@0.6.5`.
- `npx prettier --check` — clean.
- registry.json / template.json / package.json — valid JSON; template dir mirrors `web-research-digest`'s 7-file structure exactly.
- `run_local` full-graph trace + a billed `deploy` + `run` require the Sapiom MCP dev tools (not available in this environment); the `dryRun` preview path is written to trace offline with capabilities stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199J8VDE5TBvcy2kMjDytuq