### PR TITLE
feat(examples): scene-to-video generative pipeline template

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,51 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "scene-to-video",
+      "name": "Scene → Images → Video",
+      "description": "Turn a scene description into a stitched short video: LLM shot list → per-shot keyframes → async image-to-video → stitch.",
+      "tags": ["generative", "video", "pipeline", "media"],
+      "sourcePath": "examples/scene-to-video",
+      "capabilities": ["models.run", "contentGeneration.images", "contentGeneration.video"],
+      "whatItDoes": "The richest onboarding template — a real multi-step generative pipeline. An LLM decomposes one scene into a style/identity bible plus an ordered shot list; each shot becomes a keyframe image (fan-out); each keyframe is animated into a short clip via an async image-to-video job that pauses the workflow until a FAL webhook resumes it; the clips are stitched into one video. Exercises three metered capabilities together and shows off async pause/resume + fan-out. A dryRun input returns the plan only, skipping the (higher-cost) image + video generation. Pricier than the other templates — the estimated per-run cost card will be visibly higher.",
+      "steps": [
+        {
+          "name": "decompose",
+          "description": "LLM turns the scene into a style/identity bible + an ordered shot list. Terminates here with the plan when dryRun is set.",
+          "capability": "models.run",
+          "next": ["keyframes"]
+        },
+        {
+          "name": "keyframes",
+          "description": "Generate one keyframe image per shot (fan-out), each persisted for a durable fileId.",
+          "capability": "contentGeneration.images",
+          "next": ["animate"]
+        },
+        {
+          "name": "animate",
+          "description": "Launch an async image-to-video job for one shot and pause until the FAL webhook resumes.",
+          "capability": "contentGeneration.video",
+          "next": ["collect"]
+        },
+        {
+          "name": "collect",
+          "description": "Record the finished clip, then loop back to animate the next shot or advance to stitch.",
+          "next": ["animate", "stitch"]
+        },
+        {
+          "name": "stitch",
+          "description": "Concat the clips into one video (FAL ffmpeg merge), async — pause until ready.",
+          "capability": "contentGeneration.video",
+          "next": ["finalize"]
+        },
+        {
+          "name": "finalize",
+          "description": "Return the stitched video's durable videoFileId + downloadUrl.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/scene-to-video/.gitignore
+++ b/examples/scene-to-video/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.log

--- a/examples/scene-to-video/AGENTS.md
+++ b/examples/scene-to-video/AGENTS.md
@@ -1,0 +1,45 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Scene → Images → Video** — authored against `@sapiom/agent`. It is the richest onboarding template: a real multi-step generative pipeline, not a one-shot text-to-image. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here `ctx.sapiom.models.run`, `ctx.sapiom.contentGeneration.images.create`, and `ctx.sapiom.contentGeneration.video.launch`).
+
+## The graph
+
+```
+decompose ─▶ keyframes ─▶ animate ⇄ collect ─▶ stitch ─▶ finalize
+(models.run) (images.create) (video.launch) (drain)  (video.launch) (terminal)
+```
+
+- **decompose** — an LLM decomposes the scene into a global style/identity **bible** + an ordered shot list. A `dryRun` input terminates here with the plan only (no paid generation).
+- **keyframes** — one keyframe image per shot, **fanned out in-process** (`Promise.all`), each persisted (`storage`) for a durable `fileId`.
+- **animate** — launches an async image-to-video job for one shot and `pauseUntilSignal`s on it. The `pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: 'collect' }` declaration is the graph edge; the FAL webhook fires the signal to resume `collect`.
+- **collect** — records the finished clip, then loops back to `animate` for the next shot or advances to `stitch`.
+- **stitch** — a FAL ffmpeg-merge job concats the clips into one video, again async: pause → resume at `finalize`.
+- **finalize** — terminal; returns the stitched video's `videoFileId` + `downloadUrl`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run, ... })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. Note `ctx.sapiom.llm` does **not** exist; the LLM path is `ctx.sapiom.models.run({ prompt, system, maxTokens })`.
+- **Async pause/resume.** A launched capability (`video.launch`) returns a dispatch handle; `return pauseUntilSignal(handle, { resumeStep })` suspends the step until the job's signal arrives. The step must also **declare** the edge: `pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep }`. The resumed step receives a `VideoResultPayload` (`{ outputs: [{ fileId?, downloadUrl? }] }`).
+- **Why animate is sequential, not one paused step per clip at once.** A paused step waits on a single `(signal, correlationId)` pair. Launching every clip up front and then draining would risk a clip finishing before we've paused on it — its resume signal would have nowhere to land. Launching shot `i` only after shot `i-1` resumes keeps a paused step always waiting before its job can complete.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists (plus the `VIDEO_RESULT_SIGNAL` import).
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** with `{ "dryRun": true }` — runs your **real** step code against **stub capabilities** and traces the full graph offline for free, without any billed generation.
+- **deploy**, then **run** — ship it, then perform a real, billed run: LLM plan → keyframe images → per-shot clips → stitched video.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Cost
+
+This is the priciest template in the gallery: it bills an LLM call, N keyframe **images**, N image-to-**video** clips, and a merge job per run. Use `dryRun` while iterating on the graph, and start with a small `numShots` for real runs.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `animate ⇄ collect` loop advances a single `animateIndex` counter in `ctx.shared`.

--- a/examples/scene-to-video/README.md
+++ b/examples/scene-to-video/README.md
@@ -1,0 +1,71 @@
+# Scene → Images → Video
+
+Turn a single scene description into a stitched short video. The richest
+onboarding template: a real multi-step generative pipeline that exercises three
+metered capabilities together — LLM planning, image generation, and async video —
+and shows off the async pause/resume + per-shot fan-out that separates a Sapiom
+agent from a plain script.
+
+## What it does
+
+```
+decompose ──▶ keyframes ──▶ animate ⇄ collect ──▶ stitch ──▶ finalize
+(models.run)  (images.create) (video.launch) (drain) (video.launch) (terminal)
+```
+
+1. **decompose** — an LLM (`ctx.sapiom.models.run`) turns the scene into a global
+   style/identity **bible** plus an ordered shot list (each shot: `image_prompt`,
+   `motion_prompt`, `duration`, `transition`).
+2. **keyframes** — one keyframe image per shot (`images.create`), **fanned out**
+   concurrently, each persisted for a durable `fileId`.
+3. **animate** — launches an async image-to-video job per shot (`video.launch`)
+   and pauses on it; the FAL webhook resumes `collect` when the clip is ready.
+4. **collect** — records the clip, then loops back to `animate` for the next shot,
+   or advances to `stitch` once every clip is in.
+5. **stitch** — concats the N clips into one video (a FAL ffmpeg-merge job), again
+   async: pause → resume at `finalize`.
+6. **finalize** — terminal; returns `{ videoFileId, downloadUrl, shots }`.
+
+Input: `{ "scene": "a paper boat drifting down a rain-soaked city gutter at night", "numShots": 3 }`.
+Optional: `aspectRatio` (default `"16:9"`), `model` (FAL image-to-video id), and
+`dryRun` (plan only — skip all image/video generation).
+
+## Cost
+
+⚠️ **This is the priciest template in the gallery.** A real run bills an LLM call,
+N keyframe **images**, N image-to-**video** clips, and a merge job — so the
+gallery's estimated per-run cost card (derived from `capabilities`) is visibly
+higher than the other templates. Use `dryRun` while iterating, and keep `numShots`
+small for real runs.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call the metered capabilities.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` with
+   `{ "scene": "...", "dryRun": true }` (capabilities stubbed, free — traces the
+   full graph offline) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real, billed image + video + stitch run).
+
+## Model choice
+
+`animate` defaults to Kling 2.1 Pro image-to-video (`fal-ai/kling-video/v2.1/pro/image-to-video`)
+for quality. Pass a cheaper model via the `model` input (e.g. a Wan or Seedance
+i2v id) to trade quality for cost. Model ids are passed through verbatim.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+- `AGENTS.md` — the authoring loop and why `animate` runs sequentially.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -1,0 +1,378 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
+
+/**
+ * Scene → Images → Video — a real multi-step generative pipeline.
+ *
+ * From one scene description this exercises three metered capabilities together
+ * and shows off the async pause/resume + per-shot fan-out machinery that
+ * separates a Sapiom agent from a plain script:
+ *
+ *   decompose ─▶ keyframes ─▶ animate ⇄ collect ─▶ stitch ─▶ finalize
+ *   (models.run) (images.create) (video.launch)   (drain)  (video.launch) (terminal)
+ *
+ *   1. decompose — an LLM (`ctx.sapiom.models.run`) turns the scene into a global
+ *      style/identity "bible" plus an ordered shot list.
+ *   2. keyframes — one keyframe image per shot (`images.create`), fanned out
+ *      in-process, each persisted for a durable `fileId`.
+ *   3. animate — one shot at a time: launch an async image-to-video job
+ *      (`video.launch`) and `pauseUntilSignal` on it; the FAL webhook resumes
+ *      `collect` when that clip is ready.
+ *   4. collect — record the finished clip, then loop back to `animate` for the
+ *      next shot, or advance to `stitch` once every clip is in.
+ *   5. stitch — concat the N clips into one video (a FAL ffmpeg-merge job), again
+ *      async: pause on it and resume at `finalize`.
+ *   6. finalize — terminal; return the stitched video's durable `videoFileId` +
+ *      `downloadUrl`.
+ *
+ * Why sequential animate rather than launching all clips at once: a paused step
+ * waits on a single `(signal, correlationId)` pair. Launching every clip up front
+ * and then draining would risk a clip finishing before we've paused on it (its
+ * resume signal would have nowhere to land). Launching shot i only after shot
+ * i-1 has resumed keeps a paused step always waiting before its job can complete.
+ *
+ * A `dryRun` guard short-circuits after `decompose` so authors can trace the
+ * graph offline without incurring the (higher) image + video generation cost.
+ */
+
+/** A single planned shot, as the LLM returns it (see {@link parsePlan}). */
+interface Shot {
+  /** Full image prompt for the keyframe — repeats the identity bible verbatim. */
+  image_prompt: string;
+  /** Motion prompt for the clip: subject → action → camera → duration → lighting → style. */
+  motion_prompt: string;
+  /** Clip length in seconds (kept short, ≤10s). */
+  duration: number;
+  /** Transition into the next shot (e.g. "cut", "dissolve"). */
+  transition: string;
+}
+
+/** The LLM's decomposition of the scene: a shared style bible + ordered shots. */
+interface Plan {
+  bible: string;
+  shots: Shot[];
+}
+
+/** A generated keyframe, carried forward to `animate` as the clip's first frame. */
+interface Keyframe {
+  fileId?: string;
+  url: string;
+  downloadUrl?: string;
+}
+
+/** A finished clip, as recorded by `collect` from a resumed video job. */
+interface Clip {
+  fileId?: string;
+  downloadUrl?: string;
+}
+
+/** Trigger input. Only `scene` is required. */
+interface SceneInput {
+  /** The scene / story to turn into a short video. */
+  scene: string;
+  /** How many shots to plan (default 3, clamped 1–6). */
+  numShots?: number;
+  /** Aspect ratio passed to image + video generation (default "16:9"). */
+  aspectRatio?: string;
+  /** Optional video model id, passed through verbatim to `video.launch`. */
+  model?: string;
+  /** When true, plan only — skip all image/video generation and return the plan. */
+  dryRun?: boolean;
+}
+
+interface Shared extends Record<string, unknown> {
+  scene: string;
+  aspectRatio: string;
+  model?: string;
+  bible: string;
+  shots: Shot[];
+  keyframes: Keyframe[];
+  clips: Clip[];
+  /** Index of the next shot to animate; advanced by `collect`. */
+  animateIndex: number;
+}
+
+/**
+ * Default FAL image-to-video model. Kling 2.1 Pro is chosen for quality (the v1
+ * default); swap for a budget model (Wan i2v, Seedance i2v) via the `model` input.
+ */
+const DEFAULT_VIDEO_MODEL = "fal-ai/kling-video/v2.1/pro/image-to-video";
+/** FAL ffmpeg merge endpoint used by `stitch` — concats the clips into one video. */
+const MERGE_MODEL = "fal-ai/ffmpeg-api/merge-videos";
+/** Fan-out bounds on the planned shot list. */
+const DEFAULT_NUM_SHOTS = 3;
+const MAX_SHOTS = 6;
+/** Per-clip cap (seconds) — image-to-video models animate short clips best. */
+const MAX_CLIP_SECONDS = 10;
+
+function clampShots(n: number | undefined): number {
+  if (typeof n !== "number" || !Number.isFinite(n)) return DEFAULT_NUM_SHOTS;
+  return Math.max(1, Math.min(MAX_SHOTS, Math.floor(n)));
+}
+
+function must<T>(v: T | undefined, name: string): T {
+  if (v === undefined) throw new Error(`missing shared state: ${name}`);
+  return v;
+}
+
+/**
+ * Parse the LLM's minified-JSON decomposition defensively. A model may wrap the
+ * JSON in prose or fences, so we slice to the outermost object before parsing and
+ * fall back to a single generic shot when anything is off — the pipeline still
+ * runs end to end rather than failing on a malformed plan. Mirrors `create-listing`'s
+ * `parseDraft`.
+ */
+function parsePlan(
+  output: string | null,
+  scene: string,
+  numShots: number,
+): Plan {
+  const fallbackBible =
+    `Consistent cinematic style. Subject and setting from: "${scene}". ` +
+    `Cohesive color grade, lighting, and lens across every shot.`;
+  const fallback: Plan = {
+    bible: fallbackBible,
+    shots: Array.from({ length: numShots }, (_, i) => ({
+      image_prompt: `${fallbackBible} Shot ${i + 1}: ${scene}. Photographic, no text.`,
+      motion_prompt: `The scene from "${scene}"; a slow push-in; ${MAX_CLIP_SECONDS}s; natural light; cinematic.`,
+      duration: MAX_CLIP_SECONDS,
+      transition: "cut",
+    })),
+  };
+  if (!output) return fallback;
+  try {
+    const json = output.slice(output.indexOf("{"), output.lastIndexOf("}") + 1);
+    const raw = JSON.parse(json) as Partial<Plan>;
+    const bible =
+      typeof raw.bible === "string" && raw.bible.trim()
+        ? raw.bible
+        : fallback.bible;
+    const rawShots = Array.isArray(raw.shots) ? raw.shots : [];
+    const shots: Shot[] = rawShots.slice(0, MAX_SHOTS).map((s, i): Shot => {
+      const shot = (s ?? {}) as Partial<Shot>;
+      const dflt = fallback.shots[Math.min(i, fallback.shots.length - 1)];
+      const duration =
+        typeof shot.duration === "number" && Number.isFinite(shot.duration)
+          ? Math.max(1, Math.min(MAX_CLIP_SECONDS, shot.duration))
+          : dflt.duration;
+      return {
+        image_prompt:
+          typeof shot.image_prompt === "string" && shot.image_prompt.trim()
+            ? shot.image_prompt
+            : dflt.image_prompt,
+        motion_prompt:
+          typeof shot.motion_prompt === "string" && shot.motion_prompt.trim()
+            ? shot.motion_prompt
+            : dflt.motion_prompt,
+        duration,
+        transition:
+          typeof shot.transition === "string" ? shot.transition : "cut",
+      };
+    });
+    return shots.length > 0 ? { bible, shots } : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+const decompose = defineStep({
+  name: "decompose",
+  next: ["keyframes"],
+  terminal: true,
+  async run(input: SceneInput, ctx: AgentExecutionContext<Shared>) {
+    const scene = input.scene?.trim();
+    if (!scene) throw new Error("`scene` is required");
+    const numShots = clampShots(input.numShots);
+    const aspectRatio = input.aspectRatio ?? "16:9";
+
+    const system =
+      "You are a cinematographer decomposing a scene into a shot list for a short video. " +
+      "Write a global style/identity BIBLE (one paragraph fixing the look, subject identity, " +
+      "color, lighting, and lens) and an ordered list of shots. Repeat the bible VERBATIM at " +
+      "the start of every shot's image_prompt so keyframes stay consistent. Order each " +
+      "motion_prompt as subject -> action -> camera -> duration -> lighting -> style. " +
+      `Return between 1 and ${numShots} shots, each clip <= ${MAX_CLIP_SECONDS}s. ` +
+      "Reply with ONLY minified JSON: " +
+      '{"bible":string,"shots":[{"image_prompt":string,"motion_prompt":string,"duration":number,"transition":string}]}.';
+    const prompt = `Scene: ${scene}\nNumber of shots: ${numShots}\nAspect ratio: ${aspectRatio}`;
+
+    ctx.logger.info("decomposing scene", { numShots, aspectRatio });
+    const res = await ctx.sapiom.models.run({
+      prompt,
+      system,
+      maxTokens: 1200,
+    });
+    const plan = parsePlan(res.output, scene, numShots);
+
+    ctx.shared.set("scene", scene);
+    ctx.shared.set("aspectRatio", aspectRatio);
+    if (input.model) ctx.shared.set("model", input.model);
+    ctx.shared.set("bible", plan.bible);
+    ctx.shared.set("shots", plan.shots);
+    ctx.shared.set("clips", []);
+    ctx.shared.set("animateIndex", 0);
+    ctx.logger.info("planned shots", { shots: plan.shots.length });
+
+    // dryRun: trace the graph without incurring image/video generation cost.
+    if (input.dryRun) {
+      ctx.logger.info("dryRun — returning plan only");
+      return terminate({ dryRun: true, bible: plan.bible, shots: plan.shots });
+    }
+    return goto("keyframes", {});
+  },
+});
+
+const keyframes = defineStep({
+  name: "keyframes",
+  next: ["animate"],
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    const shots = must(ctx.shared.get("shots"), "shots");
+    ctx.logger.info("generating keyframes", { shots: shots.length });
+
+    // Fan-out: one keyframe image per shot, generated concurrently. `storage`
+    // persists each output so we get a durable `fileId` + a ready-to-use URL to
+    // hand the animation step as its first frame.
+    const generated = await Promise.all(
+      shots.map((shot) =>
+        ctx.sapiom.contentGeneration.images.create({
+          prompt: shot.image_prompt,
+          numImages: 1,
+          storage: { visibility: "private" },
+        }),
+      ),
+    );
+    const frames: Keyframe[] = generated.map((result, i) => {
+      const img = result.images?.[0];
+      if (!img) throw new Error(`no keyframe image returned for shot ${i + 1}`);
+      return {
+        ...(img.fileId !== undefined && { fileId: img.fileId }),
+        url: img.url,
+        ...(img.downloadUrl !== undefined && { downloadUrl: img.downloadUrl }),
+      };
+    });
+    ctx.shared.set("keyframes", frames);
+    ctx.logger.info("keyframes ready", { count: frames.length });
+    return goto("animate", {});
+  },
+});
+
+const animate = defineStep({
+  name: "animate",
+  next: [],
+  // Async pause/resume: the launched video job fires VIDEO_RESULT_SIGNAL on
+  // completion (the FAL webhook), resuming `collect` with the clip's result.
+  pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: "collect" },
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    const shots = must(ctx.shared.get("shots"), "shots");
+    const frames = must(ctx.shared.get("keyframes"), "keyframes");
+    const index = must(ctx.shared.get("animateIndex"), "animateIndex");
+    const shot = shots[index];
+    const frame = frames[index];
+    const imageUrl = frame.downloadUrl ?? frame.url;
+    const model = ctx.shared.get("model") ?? DEFAULT_VIDEO_MODEL;
+
+    ctx.logger.info("animating shot", { index: index + 1, of: shots.length });
+    // Launch the image-to-video job and pause the step on its result signal. A
+    // fixed seed + the shared aspect ratio keep the clips visually consistent.
+    const handle = await ctx.sapiom.contentGeneration.video.launch({
+      model,
+      prompt: shot.motion_prompt,
+      params: {
+        image_url: imageUrl,
+        duration: shot.duration,
+        aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
+        seed: 42,
+      },
+      storage: { visibility: "private" },
+    });
+    return await pauseUntilSignal(handle, { resumeStep: "collect" });
+  },
+});
+
+const collect = defineStep({
+  name: "collect",
+  next: ["animate", "stitch"],
+  async run(result: VideoResultPayload, ctx: AgentExecutionContext<Shared>) {
+    const shots = must(ctx.shared.get("shots"), "shots");
+    const clips = must(ctx.shared.get("clips"), "clips");
+    const index = must(ctx.shared.get("animateIndex"), "animateIndex");
+
+    const out = result.outputs?.[0];
+    const clip: Clip = {
+      ...(out?.fileId !== undefined && { fileId: out.fileId }),
+      ...(out?.downloadUrl !== undefined && { downloadUrl: out.downloadUrl }),
+    };
+    const nextClips = [...clips, clip];
+    const nextIndex = index + 1;
+    ctx.shared.set("clips", nextClips);
+    ctx.shared.set("animateIndex", nextIndex);
+    ctx.logger.info("collected clip", {
+      collected: nextClips.length,
+      of: shots.length,
+    });
+
+    // More shots to animate? Loop back. Otherwise every clip is in — stitch them.
+    return nextIndex < shots.length ? goto("animate", {}) : goto("stitch", {});
+  },
+});
+
+const stitch = defineStep({
+  name: "stitch",
+  next: [],
+  // Stitching is another async video job (FAL ffmpeg merge): pause on its result
+  // and resume at `finalize` with the stitched video.
+  pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: "finalize" },
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    const scene = must(ctx.shared.get("scene"), "scene");
+    const clips = must(ctx.shared.get("clips"), "clips");
+    // Ready-to-use URLs for the merge input. For a longer-lived reference re-mint
+    // from each clip's `fileId` via `ctx.sapiom.fileStorage.getDownloadUrl(fileId)`.
+    const videoUrls = clips
+      .map((c) => c.downloadUrl)
+      .filter((u): u is string => Boolean(u));
+    ctx.logger.info("stitching clips", { clips: videoUrls.length });
+
+    // `prompt` is required by the capability guard; the merge endpoint ignores it,
+    // so we pass the scene for traceability. `video_urls` is the FAL merge input,
+    // forwarded verbatim via `params`.
+    const handle = await ctx.sapiom.contentGeneration.video.launch({
+      model: MERGE_MODEL,
+      prompt: scene,
+      params: { video_urls: videoUrls },
+      storage: { visibility: "private" },
+    });
+    return await pauseUntilSignal(handle, { resumeStep: "finalize" });
+  },
+});
+
+const finalize = defineStep({
+  name: "finalize",
+  next: [],
+  terminal: true,
+  async run(result: VideoResultPayload, ctx: AgentExecutionContext<Shared>) {
+    const shots = must(ctx.shared.get("shots"), "shots");
+    const out = result.outputs?.[0];
+    ctx.logger.info("pipeline complete", {
+      shots: shots.length,
+      hasVideo: Boolean(out?.fileId),
+    });
+    return terminate({
+      videoFileId: out?.fileId ?? null,
+      downloadUrl: out?.downloadUrl ?? null,
+      shots,
+    });
+  },
+});
+
+export const agent = defineAgent<SceneInput, Shared>({
+  name: "scene-to-video",
+  entry: "decompose",
+  steps: { decompose, keyframes, animate, collect, stitch, finalize },
+});

--- a/examples/scene-to-video/package.json
+++ b/examples/scene-to-video/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-scene-to-video",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: turn a scene description into a stitched short video via an LLM shot list, per-shot keyframe images, and async image-to-video generation.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/scene-to-video/template.json
+++ b/examples/scene-to-video/template.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Turn a single scene description into a stitched short video — the richest onboarding template, a real multi-step generative pipeline rather than a one-shot text-to-image.\n\nFrom one `scene` it exercises three metered capabilities together and shows off the async pause/resume + per-shot fan-out machinery that separates a Sapiom agent from a plain script:\n\n1. **decompose** — an LLM (`ctx.sapiom.models.run`) turns the scene into a global style/identity *bible* plus an ordered shot list (each shot: `image_prompt`, `motion_prompt`, `duration`, `transition`). The bible is repeated verbatim in every image prompt so keyframes stay consistent.\n2. **keyframes** — one keyframe image per shot (`contentGeneration.images.create`), fanned out concurrently, each persisted for a durable `fileId`.\n3. **animate** — launches an async image-to-video job per shot (`contentGeneration.video.launch`) and pauses on it; the FAL webhook resumes the workflow on `contentGeneration.video.result` when the clip is ready.\n4. **collect** — records each finished clip and loops back to animate the next shot, or advances once every clip is in.\n5. **stitch** — concats the clips into one video (a FAL ffmpeg-merge job), again async.\n6. **finalize** — terminal; returns `{ videoFileId, downloadUrl, shots }`.\n\nA `dryRun` input short-circuits after decompose, returning the plan without any billed image/video generation — so you can trace the whole graph offline first.",
+  "useCases": [
+    "Turn a story or scene idea into a short, multi-shot video with consistent style across shots.",
+    "Prototype an ad, teaser, or social clip from a one-line brief.",
+    "Learn how to compose an LLM, image generation, and async image-to-video into one durable pipeline with pause/resume and fan-out."
+  ],
+  "notes": "⚠️ This is the priciest template in the gallery. A real run bills an LLM call, N keyframe images, N image-to-video clips, and a merge job — so the gallery's estimated per-run cost (derived from `capabilities`) is visibly higher than the other templates. Use `dryRun: true` while iterating and keep `numShots` small for real runs.\n\n`run_local` with `{ \"dryRun\": true }` stubs every capability, so you can trace the full graph offline for free before deploying. `animate` runs sequentially (one paused step per clip) so a paused step is always waiting before its video job can complete — see `AGENTS.md` for why. `stitch` uses a FAL ffmpeg-merge job through the same video capability, keeping the metered surface to LLM + images + video.\n\n`animate` defaults to Kling 2.1 Pro image-to-video for quality; pass a cheaper `model` (e.g. a Wan or Seedance i2v id) to trade quality for cost.",
+  "examples": [
+    {
+      "title": "Plan only (dryRun — no billed generation)",
+      "input": {
+        "scene": "a paper boat drifting down a rain-soaked city gutter at night",
+        "numShots": 3,
+        "dryRun": true
+      },
+      "output": {
+        "dryRun": true,
+        "bible": "Moody neo-noir night scene: a small white paper boat on dark rain-slicked asphalt, amber streetlight reflections, shallow depth of field, 35mm anamorphic look, cool blue shadows.",
+        "shots": [
+          {
+            "image_prompt": "Moody neo-noir night scene... Close-up of the paper boat entering a flooded gutter, raindrops rippling the surface.",
+            "motion_prompt": "The paper boat; drifts into frame on the current; slow push-in; 6s; amber streetlight; anamorphic neo-noir.",
+            "duration": 6,
+            "transition": "cut"
+          }
+        ]
+      }
+    },
+    {
+      "title": "Full run",
+      "input": {
+        "scene": "a paper boat drifting down a rain-soaked city gutter at night",
+        "numShots": 3,
+        "aspectRatio": "16:9"
+      },
+      "output": {
+        "videoFileId": "file_abc123",
+        "downloadUrl": "https://files.sapiom.ai/download/file_abc123?sig=...",
+        "shots": [
+          {
+            "image_prompt": "...",
+            "motion_prompt": "...",
+            "duration": 6,
+            "transition": "cut"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/scene-to-video/tsconfig.json
+++ b/examples/scene-to-video/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds a new onboarding gallery template, **Scene → Images → Video** — the richest example in the gallery: a real multi-step generative pipeline rather than a one-shot text-to-image.

From a single `scene` description it exercises three metered capabilities together and demonstrates the async pause/resume + fan-out machinery:

```
decompose ─▶ keyframes ─▶ animate ⇄ collect ─▶ stitch ─▶ finalize
(models.run) (images.create) (video.launch) (drain) (video.launch) (terminal)
```

1. **decompose** — an LLM (`ctx.sapiom.models.run`) turns the scene into a global style/identity *bible* + an ordered shot list; the bible is repeated verbatim in every image prompt for consistency.
2. **keyframes** — one keyframe image per shot (`contentGeneration.images.create`), fanned out concurrently, each persisted for a durable `fileId`.
3. **animate** — launches an async image-to-video job per shot (`contentGeneration.video.launch`) and pauses on it; the webhook resumes `collect` on the video-result signal.
4. **collect** — records the finished clip, then loops back to animate the next shot or advances to stitch.
5. **stitch** — concats the clips into one video (a FAL ffmpeg-merge job), again async.
6. **finalize** — terminal; returns `{ videoFileId, downloadUrl, shots }`.

A `dryRun` input short-circuits after planning so the whole graph can be traced offline for free, without any billed image/video generation.

## Why animate is sequential

A paused step waits on a single `(signal, correlationId)` pair. Launching every clip up front and then draining would risk a clip finishing before we've paused on it — its resume signal would have nowhere to land. Launching shot `i` only after shot `i-1` resumes keeps a paused step always waiting before its job can complete. This is documented in `AGENTS.md`.

## Files

- `examples/scene-to-video/` — `index.ts`, `package.json`, `tsconfig.json`, `template.json`, `README.md`, `AGENTS.md` (mirrors `web-research-digest/`).
- One new `examples/registry.json` gallery entry (`capabilities`: `models.run`, `contentGeneration.images`, `contentGeneration.video`; `tags`: generative, video, pipeline, media).

## Cost note

This is the priciest template in the gallery (LLM + N images + N video clips + a merge job), so its estimated per-run cost card — derived from `capabilities` — is visibly higher than the others. Called out in both the README and the manifest.

## Validation

- `npm run typecheck` passes — confirms every `ctx.sapiom.*` call and the `VIDEO_RESULT_SIGNAL` / `VideoResultPayload` imports resolve against the pinned SDK (`@sapiom/agent` ^0.6, `@sapiom/tools` ^0.20).
- `prettier --check` clean; all JSON validates against the registry/template schemas.
- Graph validated: pause edges count as forward edges, all steps reach a terminal, no dead-ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)