### PR TITLE
feat(examples): Slack notifier — Vault-backed bring-your-own-API template (SAP-1828)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -3,6 +3,43 @@
   "version": 1,
   "templates": [
     {
+      "id": "slack-notifier",
+      "name": "Slack Notifier",
+      "description": "Post a message to Slack using your own credential from the Vault — the 'bring your own API' on-ramp.",
+      "tags": ["integration", "starter", "slack"],
+      "sourcePath": "examples/slack-notifier",
+      "capabilities": ["vault"],
+      "whatItDoes": "Takes a message (and optional channel), reads your Slack credential from the Vault at runtime, and posts to Slack via a direct `fetch` — either `chat.postMessage` with a bot token or an incoming-webhook URL. The teaching template for connecting an external service: store a secret, read it at runtime, call an API. No secret is ever baked into code, and a dryRun / no-credential guard lets `run_local` trace the whole graph offline. Slack is just the hook — repoint the endpoint + Vault key to call any API.",
+      "steps": [
+        {
+          "name": "validate",
+          "description": "Check the message and resolve config (auth mode, channel).",
+          "next": ["post", "rejected"]
+        },
+        {
+          "name": "post",
+          "description": "Read the Slack credential from the Vault and post the message.",
+          "capability": "vault",
+          "next": ["posted", "failed"]
+        },
+        {
+          "name": "posted",
+          "description": "Return the post confirmation (channel + timestamp).",
+          "terminal": true
+        },
+        {
+          "name": "failed",
+          "description": "The Slack API call errored.",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "Input failed validation; nothing was posted.",
+          "terminal": true
+        }
+      ]
+    },
+    {
       "id": "web-research-digest",
       "name": "Web Research Digest",
       "description": "Search the web for a topic and return a concise, sourced digest.",

--- a/examples/slack-notifier/.gitignore
+++ b/examples/slack-notifier/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json

--- a/examples/slack-notifier/AGENTS.md
+++ b/examples/slack-notifier/AGENTS.md
@@ -1,0 +1,57 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Slack Notifier**
+— authored against `@sapiom/agent`. It has three worker paths from two steps:
+`validate` (checks input, resolves config) → `post` (reads a credential from the
+Vault and calls Slack via `fetch`), plus the terminal steps `posted` / `failed`
+/ `rejected`. Inside a step's `run`, Sapiom capabilities are pre-auth'd on
+`ctx.sapiom` (here, `ctx.sapiom.vault.get("slack", ...)`).
+
+The lesson is the "bring your own API" shape: **store a secret in the Vault,
+read it at runtime, call an external API with it.** Slack has no Sapiom
+capability namespace, so we call it directly with `fetch`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. `ctx.sapiom.vault.get(ref, key)` returns `string | null`.
+- **Never bake a secret into code.** Read it at runtime from the Vault. The
+  `post` step already does this; the `VAULT_REF` / key constants at the top of
+  `index.ts` are the only things to change when repointing to another API.
+- The `dryRun` / no-credential guard keeps the graph runnable offline. Keep it:
+  `run_local` stubs the Vault (returns null), and `dryRun` skips the network, so
+  the full graph traces for free before a token is set.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point
+you'd run tests in any project — reach for the local suite. You don't need to
+run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full
+  local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so
+  the Vault read returns null and the `no-credential` guard skips the post; the
+  agent runs end to end offline for free and returns a per-step trace.
+- **deploy**, then set your Slack token in the Vault (see `README.md`), then
+  **run** — posts to Slack for real.
+
+> Write each step the way it should run in production. `run_local` adapts to
+> your code (stub capabilities), not the other way around — never weaken or drop
+> real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Slack's `chat.postMessage` has no idempotency key, so a retry after a
+successful post but failed ack could double-post — keep the post in its own step
+so a retry re-runs only the post, and capture any non-deterministic values
+(timestamps, ids) once, passing them forward via `goto(...)` or `ctx.shared`.

--- a/examples/slack-notifier/README.md
+++ b/examples/slack-notifier/README.md
@@ -1,0 +1,85 @@
+# Slack Notifier
+
+Post a message to Slack using **your own** credential, stored in the Sapiom
+Vault. This is the "bring your own API" on-ramp: store a secret, read it at
+runtime, call an external service. Slack is just the concrete hook — the pattern
+transfers to any API.
+
+## What it does
+
+```
+validate  ──▶  post  ──▶  posted   (terminal)
+              (vault +    ├▶  failed    (terminal, on API error)
+               fetch)     └▶  ...
+validate  ──▶  rejected   (terminal, on bad input)
+```
+
+1. **validate** — checks the message (non-empty, under the length cap) and
+   resolves config (auth mode, channel). Bad input → `rejected`.
+2. **post** — reads your credential with `ctx.sapiom.vault.get("slack", ...)`
+   and calls Slack via `fetch`:
+   - `bot` mode (default) — a bot token calls `chat.postMessage`; returns the
+     resolved channel id + message `ts`.
+   - `webhook` mode — an incoming-webhook URL; the channel is baked into the URL.
+
+Input: `{ "message": "Deploy finished :rocket:", "channel": "#general" }`.
+
+## Where the key lives (and how it's injected)
+
+The Slack credential is **never** in code. It lives in the Sapiom Vault, scoped
+to this workflow (`workflow:{definitionId}`), under the ref `slack`:
+
+| Auth mode        | Vault key     | What to store                                   |
+| ---------------- | ------------- | ----------------------------------------------- |
+| `bot` (default)  | `bot_token`   | A Slack bot token (`xoxb-…`) with `chat:write`. |
+| `webhook`        | `webhook_url` | A Slack incoming-webhook URL.                   |
+
+On `deploy`, the agent is authorized to read the Vault via the injected
+`SAPIOM_API_KEY` leaf token, so `ctx.sapiom.vault.get(...)` resolves your secret
+at runtime with no extra wiring.
+
+Set the token after deploy (until the in-UI "set a secret at creation" flow
+lands):
+
+```bash
+curl -X POST "$SAPIOM_API_URL/workflows/definitions/$DEFINITION_ID/secrets" \
+  -H "Authorization: Bearer $SAPIOM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "ref": "slack", "secrets": { "bot_token": "xoxb-your-token" } }'
+```
+
+## Swap Slack for any other API
+
+This template is a shape, not a Slack integration. To notify Discord,
+PagerDuty, or your own service instead:
+
+1. In `index.ts`, change the `fetch` URL (and request body) to your API.
+2. Change `VAULT_REF` / the secret key to match your credential.
+3. Store your API's key in the Vault under that ref (same `POST .../secrets`).
+
+Everything else — validation, the `dryRun` / no-key guard, reading the secret at
+runtime — stays the same.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the `post` step
+   inherits that authority to read the Vault.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (Vault stubbed, no
+   network, free) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → set
+   your token (above) → `sapiom_dev_agents_run` (posts to Slack for real).
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/slack-notifier/index.ts
+++ b/examples/slack-notifier/index.ts
@@ -1,0 +1,300 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Slack Notifier — the "bring your own API" teaching template.
+ *
+ * The lesson: store *your own* credential in the Sapiom Vault, then call an
+ * external API with it at runtime. The concrete hook is Slack ("post a message
+ * to my channel"), but the shape is transferable — swap the endpoint and the
+ * secret key and you can call any API you can reach with a token.
+ *
+ * Slack has no Sapiom capability namespace, so the deployed agent calls the
+ * Slack API directly via `fetch`, using a credential read from the Vault
+ * (`ctx.sapiom.vault.get(ref, key)`) — never baked into code. Two auth modes:
+ *
+ *   - `bot` (default) — a bot token calls `chat.postMessage`; returns the
+ *     resolved channel id + message `ts` (timestamp).
+ *   - `webhook` — an incoming-webhook URL; the channel is baked into the URL,
+ *     so there is no `ts` to return.
+ *
+ * SAFETY / onboarding: `dryRun` (set by `run_local`) exercises the full control
+ * flow — validate → post — without touching the network. A missing credential
+ * is treated the same way (a "no-key guard"), so you can trace the graph before
+ * you have set a token. A real `deploy` + `run` posts to Slack for real.
+ *
+ * Where the key lives: after you deploy, set your token in the Vault under the
+ * ref `slack` (key `bot_token` or `webhook_url`) — scoped to this workflow. See
+ * README.md for the exact command and how to generalize this to any API.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Vault ref that holds this workflow's Slack credential. */
+const VAULT_REF = "slack";
+/** Vault key for a bot token (used by the `bot` auth mode). */
+const BOT_TOKEN_KEY = "bot_token";
+/** Vault key for an incoming-webhook URL (used by the `webhook` auth mode). */
+const WEBHOOK_KEY = "webhook_url";
+/** Slack's per-message text limit. Oversized messages are rejected, not sent. */
+const MAX_MESSAGE_LENGTH = 4000;
+
+type AuthMode = "bot" | "webhook";
+
+interface EntryInput {
+  /** The message text to post. Required (unless `dryRun`, which uses a stub). */
+  message?: string;
+  /**
+   * Target channel for the `bot` mode — a name (`#general`) or id (`C0123`).
+   * Ignored by `webhook` mode, where the channel is baked into the URL.
+   */
+  channel?: string;
+  /** Which credential to use. Defaults to `bot`. */
+  via?: AuthMode;
+  /** Optional formatting hint: override the bot's display name for this post. */
+  username?: string;
+  /** Skip the real Slack call (network I/O). Set by `run_local`. */
+  dryRun?: boolean;
+}
+
+interface PostResult extends Record<string, unknown> {
+  posted: boolean;
+  /** Why we didn't post, when `posted` is false (dryRun, no-credential, …). */
+  skipped: string | null;
+  via: AuthMode;
+  channel: string | null;
+  /** Slack message timestamp (`bot` mode only); null otherwise. */
+  ts: string | null;
+}
+
+interface Shared extends Record<string, unknown> {
+  dryRun: boolean;
+  via: AuthMode;
+  channel: string | null;
+  message: string;
+  username: string | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ────────────────────────────────────────────────────────────── helpers ──
+
+/**
+ * Post to Slack via `chat.postMessage` with a bot token. Slack's Web API is
+ * form-encoded and signals errors in the JSON body (`{ ok: false, error }`),
+ * not the HTTP status, so we check `ok` explicitly.
+ */
+async function postViaBot(
+  token: string,
+  channel: string,
+  text: string,
+  username: string | null,
+): Promise<{ channel: string | null; ts: string | null }> {
+  const form = new URLSearchParams({
+    channel,
+    text,
+    unfurl_links: "false",
+    unfurl_media: "false",
+  });
+  if (username) form.set("username", username);
+  const res = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+      Authorization: `Bearer ${token}`,
+    },
+    body: form,
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!json.ok) {
+    throw new Error(`slack chat.postMessage failed: ${String(json.error)}`);
+  }
+  return {
+    channel: (json.channel as string) ?? channel,
+    ts: (json.ts as string) ?? null,
+  };
+}
+
+/**
+ * Post to Slack via an incoming-webhook URL. The channel is fixed by the URL,
+ * so there is no channel/ts to return. A webhook answers `ok` (plain text), not
+ * JSON, so we check the HTTP status.
+ */
+async function postViaWebhook(
+  url: string,
+  text: string,
+  username: string | null,
+): Promise<void> {
+  const body: Record<string, unknown> = { text };
+  if (username) body.username = username;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => res.statusText);
+    throw new Error(`slack webhook failed: ${res.status} ${detail}`);
+  }
+}
+
+// ──────────────────────────────────────────────────────────────── steps ──
+
+/** Validate inputs and resolve config before any network call. */
+const validate = defineStep({
+  name: "validate",
+  next: ["post", "rejected"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const dryRun = input?.dryRun === true;
+    const via: AuthMode = input?.via === "webhook" ? "webhook" : "bot";
+    const message = (input?.message ?? "").trim();
+    const channel = (input?.channel ?? "").trim() || null;
+    const username = (input?.username ?? "").trim() || null;
+
+    if (!message) {
+      return goto("rejected", { reason: "message is required" });
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return goto("rejected", {
+        reason: `message length ${message.length} exceeds cap ${MAX_MESSAGE_LENGTH}`,
+      });
+    }
+    // Bot mode needs a channel; webhook mode carries it in the URL.
+    if (via === "bot" && !channel && !dryRun) {
+      return goto("rejected", {
+        reason:
+          "channel is required for `bot` mode (e.g. '#general' or 'C0123')",
+      });
+    }
+
+    ctx.shared.set("dryRun", dryRun);
+    ctx.shared.set("via", via);
+    ctx.shared.set("channel", channel);
+    ctx.shared.set("message", message);
+    ctx.shared.set("username", username);
+
+    ctx.logger.info("validated slack post", { via, channel, dryRun });
+    return goto("post", {});
+  },
+});
+
+/** Read the credential from the Vault and post to Slack. */
+const post = defineStep({
+  name: "post",
+  next: ["posted", "failed"],
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") ?? false;
+    const via = ctx.shared.get("via") ?? "bot";
+    const channel = ctx.shared.get("channel") ?? null;
+    const message = ctx.shared.get("message")!;
+    const username = ctx.shared.get("username") ?? null;
+
+    // dryRun (run_local): skip the network, synthesize a plausible result so the
+    // full graph runs offline for free.
+    if (dryRun) {
+      ctx.logger.info("dryRun — skipping Slack post", { via, channel });
+      return goto("posted", {
+        posted: false,
+        skipped: "dryRun",
+        via,
+        channel,
+        ts: null,
+      } satisfies PostResult);
+    }
+
+    // Read the credential at runtime — never baked into code.
+    const secretKey = via === "webhook" ? WEBHOOK_KEY : BOT_TOKEN_KEY;
+    let secret: string | null = null;
+    try {
+      secret = await ctx.sapiom.vault.get(VAULT_REF, secretKey);
+    } catch (err) {
+      ctx.logger.warn("vault: no slack credential", { err: String(err) });
+    }
+    // No-key guard: behave like dryRun so a fresh fork traces end to end before
+    // you have set a token.
+    if (!secret) {
+      ctx.logger.warn("no slack credential in vault — skipping post", {
+        ref: VAULT_REF,
+        key: secretKey,
+      });
+      return goto("posted", {
+        posted: false,
+        skipped: "no-credential",
+        via,
+        channel,
+        ts: null,
+      } satisfies PostResult);
+    }
+
+    try {
+      if (via === "webhook") {
+        await postViaWebhook(secret, message, username);
+        ctx.logger.info("posted to slack via webhook");
+        return goto("posted", {
+          posted: true,
+          skipped: null,
+          via,
+          channel: null,
+          ts: null,
+        } satisfies PostResult);
+      }
+      const resolved = await postViaBot(secret, channel!, message, username);
+      ctx.logger.info("posted to slack via bot token", resolved);
+      return goto("posted", {
+        posted: true,
+        skipped: null,
+        via,
+        channel: resolved.channel,
+        ts: resolved.ts,
+      } satisfies PostResult);
+    } catch (err) {
+      ctx.logger.error("slack post failed", { err: String(err) });
+      return goto("failed", { error: String(err) });
+    }
+  },
+});
+
+const posted = defineStep({
+  name: "posted",
+  next: [],
+  terminal: true,
+  async run(input: PostResult) {
+    return terminate(input);
+  },
+});
+
+const failed = defineStep({
+  name: "failed",
+  next: [],
+  terminal: true,
+  async run(input: { error: string }) {
+    return terminate({
+      posted: false,
+      failed: true,
+      error: input?.error ?? "unknown error",
+    });
+  },
+});
+
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason: string }) {
+    return terminate({
+      posted: false,
+      rejected: true,
+      reason: input?.reason ?? "rejected",
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "slack-notifier",
+  entry: "validate",
+  steps: { validate, post, posted, failed, rejected },
+});

--- a/examples/slack-notifier/package.json
+++ b/examples/slack-notifier/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-slack-notifier",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: post a message to Slack using your own credential stored in the Vault — the 'bring your own API' on-ramp (vault).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/slack-notifier/template.json
+++ b/examples/slack-notifier/template.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Post a message to Slack using **your own** credential, stored in the Sapiom Vault — the teaching template for connecting an external service. Slack is just the hook; the whole point is transferable: store a secret, read it at runtime, call an API. Swap Slack for any API by changing the endpoint and the Vault key.\n\nThe `validate` step checks the message and resolves config; the `post` step reads the credential with `ctx.sapiom.vault.get(\"slack\", ...)` and calls Slack directly via `fetch` — either `chat.postMessage` with a bot token (returns the channel + message `ts`) or an incoming-webhook URL. No secret is ever baked into code.\n\nA `dryRun` / no-credential guard lets `run_local` exercise the full graph (validate → post) offline, so you can trace it before you have set a token.",
+  "useCases": [
+    "Send a Slack notification from a workflow — a deploy finished, a run failed, a threshold was crossed.",
+    "Learn the 'bring your own API' pattern: put a credential in the Vault, then call any external API with it.",
+    "Fork it and repoint the endpoint + Vault key to notify Discord, PagerDuty, or your own webhook instead."
+  ],
+  "notes": "**Where the key lives:** after `deploy`, set your token in the Vault under the ref `slack` — key `bot_token` for the default `bot` mode (a Slack bot token with `chat:write`), or `webhook_url` for `webhook` mode (an incoming-webhook URL). Use `POST /workflows/definitions/:id/secrets` until the in-UI 'set a secret at creation' flow lands. The secret is scoped to this workflow and read at runtime — never committed.\n\n`run_local` stubs the Vault (and `dryRun` skips the network), so the agent runs end to end for free and returns `posted: false, skipped: \"dryRun\"`. A real `deploy` + `run` with a stored token posts to Slack for real.\n\n**To generalize:** change the `fetch` URL and the `VAULT_REF` / secret key in `index.ts`, and store your API's key in the Vault under that ref. `AGENTS.md` has the authoring loop.",
+  "examples": [
+    {
+      "title": "Post to a channel with a bot token",
+      "input": {
+        "message": "Deploy finished :rocket:",
+        "channel": "#general"
+      },
+      "output": {
+        "posted": true,
+        "skipped": null,
+        "via": "bot",
+        "channel": "C0123456789",
+        "ts": "1700000000.000100"
+      }
+    },
+    {
+      "title": "Local trace with no token set (dryRun)",
+      "input": {
+        "message": "hello from slack-notifier",
+        "channel": "#general",
+        "dryRun": true
+      },
+      "output": {
+        "posted": false,
+        "skipped": "dryRun",
+        "via": "bot",
+        "channel": "#general",
+        "ts": null
+      }
+    }
+  ]
+}

--- a/examples/slack-notifier/tsconfig.json
+++ b/examples/slack-notifier/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Re-land of #344 onto `main` (was mistakenly merged to `studio-phase2`). One template = one PR.

Adds the **Slack Notifier** onboarding template — the teaching template for connecting an external service: store your own credential in the Vault, then call an API with it at runtime. Slack (`chat.postMessage` bot token or an incoming-webhook URL) is the hook; the shape is transferable — repoint the `fetch` endpoint + Vault key to call any API. No secret is baked into code; it is read via `ctx.sapiom.vault.get(...)` at runtime, and a `dryRun` / no-credential guard lets `run_local` trace the graph (`validate → post`) offline.

Closes SAP-1828.

## Diff
- `examples/slack-notifier/` — `index.ts`, `package.json`, `tsconfig.json`, `template.json`, `README.md`, `AGENTS.md`, `.gitignore` (mirrors `examples/web-research-digest/`).
- `examples/registry.json` — new gallery entry (`capabilities: ["vault"]`, `tags: ["integration","starter","slack"]`, full step graph) — required for the template to appear in the gallery.

## SDK pins
`@sapiom/agent ^0.6.5` / `@sapiom/tools ^0.20.0` — the `vault` namespace landed in `@sapiom/tools@0.18.0`, so the `^0.16` pin older examples use lacks it. Matches the SAP-1824 sibling bump.

## Validation
`npm run typecheck` ✅ · `prettier --check` ✅ · offline graph walk of all paths (dryRun, no-credential, empty message, missing channel) ✅ · registry + manifest validated against their JSON schemas ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)