### PR TITLE
feat(examples): add preview-keep-alive workflow template (SAP-1824)

### DIFF
--- a/examples/preview-keep-alive/.gitignore
+++ b/examples/preview-keep-alive/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/preview-keep-alive/AGENTS.md
+++ b/examples/preview-keep-alive/AGENTS.md
@@ -1,0 +1,57 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Preview
+Keep-Alive** — authored against `@sapiom/agent`. It is a self-healing cron
+heartbeat: `check` probes a preview's health; if it is down, `heal` re-attaches
+the sandbox and calls `deployPreview` (source `fs`) to rebuild + restart the
+uploaded code at the same stable URL. Inside a step's `run`, Sapiom capabilities
+are pre-auth'd on `ctx.sapiom` (here: `ctx.sapiom.sandboxes.attach`,
+`box.deployPreview`, `ctx.sapiom.database.get`, `ctx.sapiom.vault.get`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **Heal only on failure.** `check` routes to `heal` only when the probe fails;
+  the healthy path is a terminal no-op. Relaunching a live app would stack a
+  second process and EADDRINUSE the port — don't remove that guard.
+- **Never bake secrets into the schedule.** A secret the app needs at start is
+  named in `vaultInject` (`ENV_VAR -> vaultKey`) and read from the vault at
+  runtime via `ctx.sapiom.vault.get(vaultRef, key)`. The schedule input carries
+  the reference, never the value.
+- **One definition, many previews.** The target is per-run via the schedule
+  input (`sandboxName`, `url`, `start`, …), so one deploy keeps N previews alive.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point
+you'd run tests in any project — reach for the local suite. You don't need to run
+it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full
+  local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**.
+  Pass `{ "dryRun": true, "sandboxName": "my-app", "url": "https://…", "start": "node server.js" }`:
+  `check` skips the network probe and `heal` assembles the relaunch env, then
+  reports the injected env keys (names only) **without** calling `deployPreview`
+  — so the full heal branch traces offline, free, with no real key.
+- **deploy**, then **run** — ship it, then perform a real relaunch against a down
+  sandbox.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/preview-keep-alive/README.md
+++ b/examples/preview-keep-alive/README.md
@@ -1,0 +1,82 @@
+# Preview Keep-Alive
+
+A durable cron heartbeat that **relaunches** a dead sandbox preview — not just
+observes it. The missing actuator for Sapiom sandbox previews.
+
+Sapiom sandbox previews are NOT durable always-on hosts: Blaxel recycles the app
+process while the sandbox stays "running", so the preview URL 502s until a human
+redeploys. A plain `GET /health` cron only observes. This agent redeploys on
+failure, entirely on Sapiom's durable cron.
+
+## What it does
+
+```
+        ┌──────────▶ healthy  (terminal, no-op)
+check ──┤
+        └──────────▶ heal ──┬──▶ healed       (terminal)
+(fetch probe)               └──▶ heal_failed  (terminal)
+                    (sandboxes.attach + sandboxes.deployPreview,
+                     env from database.get + vault.get)
+```
+
+1. **check** — probes `<url><healthPath>` (default `/health`, 8s timeout). Healthy
+   → `healthy` (no-op, so it never stacks a second process onto a live one).
+   Down → `heal`.
+2. **heal** — re-attaches the sandbox and calls `deployPreview` with source `fs`
+   (rebuild + restart the code already uploaded there, same stable URL). The
+   relaunch env is `{ PORT, ...env }` plus an optional `DATABASE_URL` from a
+   Postgres handle and any `vaultInject` secrets read at runtime.
+3. **healed** / **heal_failed** — terminal; report the URL/status or surface the
+   `deployPreview` logs.
+
+Heals only a sandbox that still **exists** — its uploaded code is the `fs` that
+`deployPreview` rebuilds. A fully deleted sandbox must first be re-created with a
+full upload deploy; after that, this keeps it up.
+
+## Multi-target
+
+The target is supplied per-run via the schedule input, so **one** deployed
+definition keeps **N** previews alive — one schedule each:
+
+```json
+{
+  "sandboxName": "my-app",
+  "url": "https://your-preview-hash.preview.bl.run",
+  "start": "node server.js",
+  "port": 3000,
+  "dbHandle": "my-app-db",
+  "vaultRef": "my-app",
+  "vaultInject": { "SAPIOM_API_KEY": "sapiom_api_key" }
+}
+```
+
+`healthPath` (default `/health`), `build` (default `npm install`), `start`
+(default `node server.js`), and `port` (default 3000) fall back to generic
+defaults. Secrets named in `vaultInject` are read from the vault at runtime via
+`vault.get` — never baked into the schedule or source.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the `heal` step
+   inherits that authority to attach the sandbox and read the DB handle / vault.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (pass `{ "dryRun": true, "sandboxName": "my-app", "url": "https://…", "start": "node server.js" }`
+   to trace the heal branch offline, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real relaunch against
+   a down sandbox).
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/preview-keep-alive/index.ts
+++ b/examples/preview-keep-alive/index.ts
@@ -1,0 +1,315 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Preview Keep-Alive — a durable cron heartbeat that RELAUNCHES a dead sandbox
+ * preview, not just observes it.
+ *
+ * Sapiom sandbox previews are NOT durable always-on hosts: Blaxel recycles the
+ * app process while the sandbox stays "running", so the preview URL 502s until a
+ * human redeploys. A plain `GET /health` cron only *observes* — it never restarts
+ * anything. This agent is the missing actuator: a cloud-side heartbeat that
+ * actually redeploys on failure, entirely on Sapiom's durable cron.
+ *
+ * On each scheduled run it probes `<url><healthPath>`. If healthy, it is a
+ * terminal no-op — so it never stacks a second process onto a live one (which
+ * would EADDRINUSE the port). If down, it re-attaches the target sandbox and
+ * calls `deployPreview` with source `fs` — rebuild + restart the code ALREADY
+ * uploaded there, re-exposed at the same stable URL, no human.
+ *
+ * NOTE: this heals only a sandbox that still EXISTS (its uploaded code is the
+ * `fs` that `deployPreview` rebuilds). A fully deleted sandbox must first be
+ * re-created with a full upload deploy; after that, this keeps it up.
+ *
+ * ── Multi-target ──────────────────────────────────────────────────────────────
+ * The target is supplied per-run via the schedule input, so ONE deployed
+ * definition keeps N previews alive — one schedule each.
+ *
+ * Some apps need env at relaunch or they come up misconfigured (e.g. the server
+ * reads DATABASE_URL/PORT). Pass literal `env`, and/or a `dbHandle` to inject
+ * DATABASE_URL from a Sapiom-managed Postgres, and/or `vaultInject` to read
+ * secrets from the vault at runtime — never baked into the schedule.
+ */
+
+// ─────────────────────────────────────────────────────────── target config ──
+interface Target {
+  /** Sandbox name to attach + relaunch. */
+  sandboxName: string;
+  /** Base URL of the preview (health is probed at url + healthPath). */
+  url: string;
+  /** Health path to probe (default `/health`). */
+  healthPath: string;
+  /** Build command for deployPreview (default `npm install`). */
+  build: string;
+  /** Command that (re)starts the long-running server (default `node server.js`). */
+  start: string;
+  /** Port the app listens on (default 3000). */
+  port: number;
+  /** Literal env injected into the relaunched process. */
+  env?: Record<string, string>;
+  /** If set, inject DATABASE_URL from this Sapiom Postgres handle. */
+  dbHandle?: string;
+  /** Vault ref to read injected secrets from (paired with vaultInject). */
+  vaultRef?: string;
+  /**
+   * Map of ENV_VAR -> vault key name. Each value is read from `vaultRef` at heal
+   * time and injected into the relaunched process — so a secret the app needs
+   * (e.g. its bootstrap SAPIOM_API_KEY) lives in the vault, never in the schedule.
+   */
+  vaultInject?: Record<string, string>;
+}
+
+const HEALTH_TIMEOUT_MS = 8000;
+
+interface EntryInput extends Partial<Target> {
+  /** Skip the probe and go straight to heal — for manual repair. */
+  forceHeal?: boolean;
+  /**
+   * Assemble the relaunch env but do NOT call deployPreview — so `run_local`
+   * traces the full heal branch offline, with no real key or network call.
+   */
+  dryRun?: boolean;
+}
+
+interface Shared extends Record<string, unknown> {
+  target: Target;
+  dryRun: boolean;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+/**
+ * Resolve the run input into a fully-specified target. `sandboxName`, `url`, and
+ * `start` come from the schedule; the rest fall back to generic defaults
+ * (`/health`, `npm install`, `node server.js`, port 3000).
+ */
+function resolveTarget(input: EntryInput | undefined): Target {
+  return {
+    sandboxName: input?.sandboxName ?? "",
+    url: input?.url ?? "",
+    healthPath: input?.healthPath ?? "/health",
+    build: input?.build ?? "npm install",
+    start: input?.start ?? "node server.js",
+    port: input?.port ?? 3000,
+    env: input?.env,
+    dbHandle: input?.dbHandle,
+    vaultRef: input?.vaultRef,
+    vaultInject: input?.vaultInject,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────── steps ──
+
+/** Probe the app; route to heal only when it is actually down. */
+const check = defineStep({
+  name: "check",
+  next: ["healthy", "heal"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const target = resolveTarget(input);
+    ctx.shared.set("target", target);
+    ctx.shared.set("dryRun", input?.dryRun === true);
+
+    if (input?.forceHeal || input?.dryRun) {
+      ctx.logger.info("skipping probe — healing", {
+        sandbox: target.sandboxName,
+        reason: input?.dryRun ? "dryRun" : "forceHeal",
+      });
+      return goto("heal", { reason: input?.dryRun ? "dry-run" : "forced" });
+    }
+
+    const probeUrl = `${target.url}${target.healthPath}`;
+    try {
+      const res = await fetch(probeUrl, {
+        signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+      });
+      if (res.ok) {
+        ctx.logger.info("app healthy", {
+          sandbox: target.sandboxName,
+          status: res.status,
+        });
+        return goto("healthy", { status: res.status });
+      }
+      ctx.logger.warn("app unhealthy", {
+        sandbox: target.sandboxName,
+        status: res.status,
+      });
+      return goto("heal", { reason: `status ${res.status}` });
+    } catch (err) {
+      // Network error / timeout == down.
+      ctx.logger.warn("app probe failed", {
+        sandbox: target.sandboxName,
+        err: String(err),
+      });
+      return goto("heal", { reason: String(err) });
+    }
+  },
+});
+
+/** Nothing to do — the app is serving. Terminal. */
+const healthy = defineStep({
+  name: "healthy",
+  next: [],
+  terminal: true,
+  async run(input: { status: number }) {
+    return terminate({
+      healed: false,
+      healthy: true,
+      status: input?.status ?? null,
+    });
+  },
+});
+
+/**
+ * Relaunch the app in the existing sandbox. deployPreview with source `fs`
+ * rebuilds + (re)starts the code already uploaded there and re-exposes the same
+ * URL — so a redeploy of the app itself never has to re-run here.
+ */
+const heal = defineStep({
+  name: "heal",
+  next: ["healed", "heal_failed"],
+  async run(input: { reason: string }, ctx: Ctx) {
+    const target = ctx.shared.get("target");
+    if (!target) {
+      return goto("heal_failed", {
+        status: "error",
+        logs: "no target resolved",
+      });
+    }
+    const dryRun = ctx.shared.get("dryRun") === true;
+    ctx.logger.info("healing app", {
+      sandbox: target.sandboxName,
+      reason: input?.reason,
+    });
+
+    // Assemble relaunch env: PORT + literal env, optional DATABASE_URL from a
+    // handle, plus any vault-injected secrets — all read at runtime.
+    const env: Record<string, string> = {
+      PORT: String(target.port),
+      ...(target.env ?? {}),
+    };
+    if (target.dbHandle) {
+      try {
+        const db = await ctx.sapiom.database.get(target.dbHandle);
+        const connectionString = db.connection?.connectionString ?? null;
+        if (connectionString) env.DATABASE_URL = connectionString;
+      } catch (err) {
+        ctx.logger.warn("could not read db connection string", {
+          handle: target.dbHandle,
+          err: String(err),
+        });
+      }
+    }
+    // Inject secrets from the vault (value fetched at runtime — never stored in
+    // the schedule or source).
+    if (target.vaultRef && target.vaultInject) {
+      for (const [envVar, vaultKey] of Object.entries(target.vaultInject)) {
+        try {
+          const secret = await ctx.sapiom.vault.get(target.vaultRef, vaultKey);
+          if (secret) env[envVar] = secret;
+          else
+            ctx.logger.warn("vault key missing/empty", {
+              ref: target.vaultRef,
+              key: vaultKey,
+            });
+        } catch (err) {
+          ctx.logger.warn("vault read failed", {
+            ref: target.vaultRef,
+            key: vaultKey,
+            err: String(err),
+          });
+        }
+      }
+    }
+
+    // Dry run: report the assembled env keys (names only, never values) and stop
+    // before any real actuation — so run_local traces this branch for free.
+    if (dryRun) {
+      ctx.logger.info("dry run — skipping deployPreview", {
+        sandbox: target.sandboxName,
+        envKeys: Object.keys(env),
+      });
+      return goto("healed", {
+        status: "dry-run",
+        url: target.url || null,
+        dryRun: true,
+        envKeys: Object.keys(env),
+      });
+    }
+
+    try {
+      const box = ctx.sapiom.sandboxes.attach(target.sandboxName);
+      const res = await box.deployPreview({
+        // source defaults to { kind: "fs" } — rebuild/restart the uploaded code.
+        build: target.build,
+        start: target.start,
+        port: target.port,
+        env,
+      });
+      ctx.logger.info("deployPreview result", {
+        sandbox: target.sandboxName,
+        status: res.status,
+        url: res.url,
+      });
+      if (res.status === "failed") {
+        return goto("heal_failed", { status: res.status, logs: res.logs });
+      }
+      return goto("healed", {
+        status: res.status,
+        url: res.url ?? target.url,
+      });
+    } catch (err) {
+      ctx.logger.error("deployPreview threw", {
+        sandbox: target.sandboxName,
+        err: String(err),
+      });
+      return goto("heal_failed", { status: "error", logs: String(err) });
+    }
+  },
+});
+
+/** Relaunch succeeded (or is unverified but exposed). Terminal. */
+const healed = defineStep({
+  name: "healed",
+  next: [],
+  terminal: true,
+  async run(input: {
+    status: string;
+    url: string | null;
+    dryRun?: boolean;
+    envKeys?: string[];
+  }) {
+    return terminate({
+      healed: true,
+      dryRun: input?.dryRun ?? false,
+      status: input?.status ?? null,
+      url: input?.url ?? null,
+      envKeys: input?.envKeys ?? null,
+    });
+  },
+});
+
+/** Relaunch failed — surface it so a run/schedule inspection shows the problem. */
+const heal_failed = defineStep({
+  name: "heal_failed",
+  next: [],
+  terminal: true,
+  async run(input: { status: string; logs: string | null }) {
+    return terminate({
+      healed: false,
+      failed: true,
+      status: input?.status ?? null,
+      logs: input?.logs ?? null,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "preview-keep-alive",
+  entry: "check",
+  steps: { check, healthy, heal, healed, heal_failed },
+});

--- a/examples/preview-keep-alive/package.json
+++ b/examples/preview-keep-alive/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-preview-keep-alive",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: a durable cron heartbeat that relaunches a dead sandbox preview — self-healing on sandbox lifecycle, DB-handle env, and runtime vault secrets.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/preview-keep-alive/template.json
+++ b/examples/preview-keep-alive/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "A durable cron template that heals a dead sandbox preview by relaunching it — a self-healing \"keep my app up\" utility.\n\nSapiom sandbox previews are NOT durable always-on hosts: Blaxel recycles the app process while the sandbox stays \"running\", so the preview URL 502s until a human redeploys. A plain `GET /health` heartbeat only *observes* — it never restarts anything. This template is the missing **actuator**: a cloud-side heartbeat that actually redeploys on failure, entirely on Sapiom's durable cron.\n\nOn each scheduled run, `check` probes `<url><healthPath>` (default `/health`, 8s timeout). If healthy, it is a terminal no-op — so it never stacks a second process onto a live one (which would EADDRINUSE the port). If down, `heal` re-attaches the target sandbox and calls `deployPreview` with source `fs` — rebuild + restart the code already uploaded there, re-exposed at the same stable URL, no human.\n\nThe target is supplied per-run via the schedule input, so ONE deployed definition keeps N previews alive — one schedule each. At heal time the relaunch env is assembled from `{ PORT, ...literal env }`, an optional `DATABASE_URL` resolved from a Sapiom-managed Postgres handle (`database.get`), and any `vaultInject` secrets read from the vault at runtime (`vault.get`) — never baked into the schedule.",
+  "useCases": [
+    "Keep a sandbox-hosted preview app reachable across Blaxel process recycles, with no human redeploy.",
+    "Run one deployed definition as the self-healing heartbeat for many previews — one schedule per app.",
+    "Relaunch an app that needs DATABASE_URL and a bootstrap secret at start, injected from a DB handle and the vault at runtime."
+  ],
+  "notes": "Heals only a sandbox that still EXISTS — its uploaded code is the `fs` that `deployPreview` rebuilds. A fully deleted sandbox must first be re-created with a full upload deploy; after that, this keeps it up.\n\n`run_local` with `{ \"dryRun\": true }` (or `{ \"forceHeal\": true }`) traces the full heal branch offline: `check` skips the network probe, `heal` assembles the relaunch env and — under `dryRun` — reports the injected env keys (names only, never values) without calling `deployPreview`, so no real key or network call is needed. A real `deploy` + `run` against a down sandbox actually relaunches it.\n\nSecrets are read from the vault at runtime via `vault.get(vaultRef, key)`, so a value like a bootstrap `SAPIOM_API_KEY` lives in the vault and never in the schedule input or source. See `AGENTS.md` for the authoring loop.",
+  "examples": [
+    {
+      "title": "Keep a preview alive (real relaunch on failure)",
+      "input": {
+        "sandboxName": "my-app",
+        "url": "https://your-preview-hash.preview.bl.run",
+        "start": "node server.js",
+        "port": 3000,
+        "dbHandle": "my-app-db",
+        "vaultRef": "my-app",
+        "vaultInject": { "SAPIOM_API_KEY": "sapiom_api_key" }
+      },
+      "output": {
+        "healed": true,
+        "dryRun": false,
+        "status": "deployed",
+        "url": "https://your-preview-hash.preview.bl.run",
+        "envKeys": null
+      }
+    },
+    {
+      "title": "Trace the heal branch offline (run_local)",
+      "input": {
+        "sandboxName": "my-app",
+        "url": "https://your-preview-hash.preview.bl.run",
+        "start": "node server.js",
+        "dryRun": true
+      },
+      "output": {
+        "healed": true,
+        "dryRun": true,
+        "status": "dry-run",
+        "url": "https://your-preview-hash.preview.bl.run",
+        "envKeys": ["PORT"]
+      }
+    }
+  ]
+}

--- a/examples/preview-keep-alive/tsconfig.json
+++ b/examples/preview-keep-alive/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,48 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "preview-keep-alive",
+      "name": "Preview Keep-Alive",
+      "description": "A durable cron heartbeat that relaunches a dead sandbox preview — self-healing, no human redeploy.",
+      "tags": ["sandbox", "self-healing", "cron"],
+      "sourcePath": "examples/preview-keep-alive",
+      "capabilities": [
+        "sandboxes.deployPreview",
+        "sandboxes.attach",
+        "database.get",
+        "vault.get"
+      ],
+      "whatItDoes": "On each scheduled run, probes a preview's health path. If healthy, it's a terminal no-op — so it never stacks a second process onto a live one. If down, it re-attaches the target sandbox and calls deployPreview (source fs) to rebuild + restart the uploaded code at the same stable URL, with env assembled from a Postgres handle and vault secrets read at runtime. One deployed definition keeps N previews alive — one schedule each.",
+      "steps": [
+        {
+          "name": "check",
+          "description": "Probe the preview's health path; route to heal only when it's down.",
+          "next": ["healthy", "heal"]
+        },
+        {
+          "name": "healthy",
+          "description": "App is serving — terminal no-op.",
+          "terminal": true
+        },
+        {
+          "name": "heal",
+          "description": "Re-attach the sandbox and redeploy the fs source; assemble env from database.get + vault.get.",
+          "capability": "sandboxes.deployPreview",
+          "next": ["healed", "heal_failed"]
+        },
+        {
+          "name": "healed",
+          "description": "Relaunch succeeded — report url/status.",
+          "terminal": true
+        },
+        {
+          "name": "heal_failed",
+          "description": "Relaunch failed — surface the deployPreview logs.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Re-land of #343 onto `main` (was mistakenly merged to `studio-phase2`). One template = one PR.

## What & why

Adds the **Preview Keep-Alive** onboarding workflow template (SAP-1824, epic SAP-1823 — grow the gallery to 8+).

Sapiom sandbox previews are **not** durable always-on hosts: Blaxel recycles the app process while the sandbox stays `running`, so the preview URL 502s until a human redeploys. A plain `GET /health` cron only *observes* — this template is the missing **actuator**: a cloud-side heartbeat that actually redeploys on failure, entirely on Sapiom's durable cron.

## Behavior

```
        ┌─▶ healthy  (terminal no-op)
check ──┤
        └─▶ heal ──┬─▶ healed       (terminal)
                   └─▶ heal_failed  (terminal)
```

- **check** — probes `<url><healthPath>` (default `/health`, 8s). Healthy → no-op (never double-processes → no EADDRINUSE). Down → `heal`.
- **heal** — `sandboxes.attach` + `deployPreview` source `fs` (rebuild + restart uploaded code, same stable URL). Env = `{ PORT, ...env }` + `DATABASE_URL` from `database.get(dbHandle)` + `vaultInject` secrets read at runtime via `vault.get`.
- **healed / heal_failed** — terminal; report url/status or surface deployPreview logs.

Target is per-run via the schedule input, so **one deployed definition keeps N previews alive**. Secrets read from the vault at runtime, never baked into the schedule or source.

## Files

`examples/preview-keep-alive/` — `index.ts`, `package.json`, `tsconfig.json`, `template.json` (manifestVersion 1), `README.md`, `AGENTS.md` (+ `.gitignore`). One `registry.json` gallery entry (slug = dir = `preview-keep-alive`; caps `sandboxes.deployPreview/attach`, `database.get`, `vault.get`; tags `sandbox`/`self-healing`/`cron`).

> **SDK pins** `@sapiom/agent ^0.6.0` / `@sapiom/tools ^0.20.0` — `deployPreview`/`vault` don't exist until tools 0.19/0.20 (the `^0.16.0` siblings predate them).

## Validation

- ✅ `npm run typecheck` passes
- ✅ `prettier --check` clean; both JSON files valid & schema-conformant
- ✅ `run_local` with `{ "dryRun": true }` traces the full `check → heal → healed` graph offline — no real key, no network

Closes SAP-1824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6aAnXvEAcKD5J1cAUfcJn