### PR TITLE
feat(examples): Human-in-the-Loop Approval workflow template (SAP-1831)

### DIFF
--- a/examples/human-in-the-loop/.gitignore
+++ b/examples/human-in-the-loop/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/human-in-the-loop/AGENTS.md
+++ b/examples/human-in-the-loop/AGENTS.md
@@ -1,0 +1,88 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Human-in-the-Loop
+Approval** — authored against `@sapiom/agent`. It demonstrates the "ask before you
+commit/spend" pattern: reversible prep (`parse` → `rank` → `notifyApprover`), a
+durable pause on a human approval signal, and — once approved — a ranked
+sequential-fallback loop (`offer` ⇄ `resolve`) that commits only when a candidate
+accepts and escalates when the list is exhausted. Inside a step's `run`, Sapiom
+capabilities are pre-auth'd on `ctx.sapiom` (here, `ctx.sapiom.models.run` and
+`ctx.sapiom.email`).
+
+## The approval + fallback spine
+
+- **`notifyApprover`** emails the ranked recommendation, then returns
+  `pauseUntilSignal({ signal: "approval.decision", resumeStep: "onDecision", correlationId: ctx.executionId })`.
+  It carries a static `pause: { signal, resumeStep: "onDecision" }` annotation —
+  the build-time graph edge that must match the directive.
+- **`onDecision`** reads the approval payload **directly as its `run` input**.
+  Safe default: only `{ decision: "approve" }` proceeds; anything else (including
+  a `run_local` resume with no payload) routes to `revert` — nothing commits
+  without a deliberate human yes.
+- **`offer`** makes a *provisional, non-committing* offer to `ranked[index]` and
+  pauses on `candidate.confirm`, resuming at `resolve`.
+- **`resolve`** reads the confirm payload as its input. `accept` → `commit`;
+  `decline`/`timeout`/absent → `index + 1` and loop back to `offer` while
+  candidates remain, else `escalate`. The loop edge is `resolve → offer`; the
+  loop counter (`index`) lives in `ctx.shared` and survives every pause.
+- **`commit`** holds the single irreversible/expensive action, reached only after
+  approval AND an accept. A `dryRun` guard makes it a no-op offline.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability** — don't
+  list it in `capabilities`. The billed calls are `ctx.sapiom.models.run` (the
+  live x402 path — note `ctx.sapiom.llm` does **not** exist) and `ctx.sapiom.email`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` (its forward edge is the pause
+  `resumeStep`) and a `pause: { signal, resumeStep }` annotation.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including
+  the static `pause` annotations.
+- **run_local** — runs your **real** step code against **stub capabilities** and
+  auto-resumes both pauses. With no payload injected, the approval resume takes
+  the safe branch and the `dryRun` guard keeps `commit` a no-op, so you get a full
+  offline trace for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses.
+
+### Firing the resume signals in dev
+
+A real `run` pauses twice. To resume without a real approver/candidate, fire the
+signals via the MCP `signal_workflow` / `workflow_signal` tool — the manual
+stand-in. Approve, then accept:
+
+```json
+{ "signal": "approval.decision", "correlationId": "<executionId>", "payload": { "decision": "approve" } }
+{ "signal": "candidate.confirm", "correlationId": "<executionId>", "payload": { "decision": "accept" } }
+```
+
+Send `{ "decision": "decline" }` on `candidate.confirm` to walk the fallback to
+the next candidate; `{ "decision": "reject" }` on `approval.decision` to walk the
+revert path. Each `payload` arrives as the resumed step's input.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+The `correlationId` is `ctx.executionId` (stable across both pauses), so a resume
+signal always lands on the right run.

--- a/examples/human-in-the-loop/README.md
+++ b/examples/human-in-the-loop/README.md
@@ -1,0 +1,117 @@
+# Human-in-the-Loop Approval
+
+The "ask before you commit/spend" pattern: do some reversible work, then **pause
+for a human approval signal** before committing an irreversible or expensive
+action — and once approved, act via a **ranked sequential-fallback loop** (try
+candidates in order until one accepts, escalating if the list runs out).
+
+Nothing irreversible or billed happens until a human approves **and** a candidate
+accepts.
+
+## What it does
+
+```
+parse → rank → notifyApprover ─(pause: approval.decision, $0 while idle)─▶ onDecision
+                                                                             │
+                       reject ◀─────────────────────────────────────────────┼─▶ approve
+                         │                                                    ▼
+                       revert (terminal)                  offer ─(pause: candidate.confirm)─▶ resolve
+                                                            ▲                                   │
+                                    decline/timeout & more ─┘      accept │ exhausted │         │
+                                                                          ▼           ▼
+                                                                      commit       escalate
+                                                                     (terminal)    (terminal)
+```
+
+1. **parse** — parse the free-text `request` into structured intent with an LLM
+   (`ctx.sapiom.models.run`). Reversible.
+2. **rank** — rank the `candidates` by fit (not just cost) with the LLM;
+   every candidate is returned exactly once. Reversible.
+3. **notifyApprover** — email the approver the ranked recommendation
+   (`ctx.sapiom.email`), then `pauseUntilSignal({ signal: "approval.decision", resumeStep: "onDecision" })`.
+   The run suspends here at $0.
+4. **onDecision** (resume target) — its **input is the approval payload**. Only
+   an explicit `{ "decision": "approve" }` proceeds; anything else takes the safe
+   `revert` branch (nothing committed).
+5. **offer** — provisional, non-committing offer to the current top candidate,
+   then `pauseUntilSignal({ signal: "candidate.confirm", resumeStep: "resolve" })`.
+6. **resolve** (resume target) — its **input is the confirm payload**. `accept`
+   → `commit`; `decline`/`timeout` → advance to the next candidate (loop back to
+   `offer`) or `escalate` once the list is exhausted.
+7. **commit** — the single irreversible/expensive action, reached only after
+   approval **and** an accept. A `dryRun` guard makes it a no-op offline.
+8. **revert / escalate** — terminal branches: revert to a safe state, or escalate
+   to a human channel.
+
+Input:
+
+```json
+{
+  "request": "Find someone to repaint the lobby by Friday, quality over price.",
+  "candidates": [
+    { "id": "a", "name": "Acme Painting", "email": "acme@example.com" },
+    { "id": "b", "name": "Budget Coats", "email": "budget@example.com" }
+  ],
+  "approver": "approver@example.com",
+  "escalateTo": "ops@example.com"
+}
+```
+
+The `approver` and `escalateTo` addresses fall back to `config.APPROVER_EMAIL` /
+`config.ESCALATION_EMAIL` when omitted.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to call the model and send notifications.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (capabilities stubbed, pauses auto-resumed, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses).
+
+## Resuming a paused run in dev
+
+A real `run` pauses twice. Instead of a real approver / candidate, fire the
+signals yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`, and each `payload` becomes the
+resumed step's input.
+
+**Approve** (resumes `onDecision`):
+
+```json
+{
+  "signal": "approval.decision",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve" }
+}
+```
+
+**Accept** the provisional offer (resumes `resolve` → `commit`):
+
+```json
+{
+  "signal": "candidate.confirm",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "accept" }
+}
+```
+
+Exercise the fallback by sending `{ "decision": "decline" }` (or `"timeout"`) on
+`candidate.confirm` instead — the run advances to the next candidate and offers
+again; decline every candidate to see it `escalate`. Send
+`{ "decision": "reject" }` on `approval.decision` to see the `revert` path.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -1,0 +1,652 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Human-in-the-Loop Approval — the "ask before you commit/spend" pattern.
+ *
+ * Do the reversible work first (parse the request, rank the candidates by fit,
+ * notify the approver), then **block on a human approval signal** before anything
+ * irreversible or billed happens. On approve, run a **ranked sequential-fallback
+ * loop**: make a provisional offer to the top candidate, wait for their confirm,
+ * and advance to the next on decline/timeout — committing the single irreversible
+ * action only when a candidate accepts, and escalating to a human if the ranked
+ * list is exhausted.
+ *
+ *   parse → rank → notifyApprover ─(pause: approval.decision, $0 while idle)─▶ onDecision
+ *                                                                                │
+ *                          reject ◀──────────────────────────────────────────────┼─▶ approve
+ *                            │                                                     ▼
+ *                          revert (terminal)                     offer ─(pause: candidate.confirm)─▶ resolve
+ *                                                                  ▲                                    │
+ *                                        decline/timeout & more ───┘        accept │ exhausted │        │
+ *                                                                                  ▼           ▼
+ *                                                                             commit       escalate
+ *                                                                            (terminal)    (terminal)
+ *
+ * Two durable pauses (`pauseUntilSignal`) suspend the run at $0: the approval
+ * gate, and each turn of the confirmation loop. `pauseUntilSignal` is a runtime
+ * primitive, not a metered capability. The billed calls are the model reasoning
+ * (`ctx.sapiom.models.run` — the live x402 path; `ctx.sapiom.llm` does NOT exist)
+ * and the notifications (`ctx.sapiom.email`).
+ *
+ * Offline: `run_local` stubs the capabilities and auto-resumes the pauses. A
+ * resume with no explicit decision takes the SAFE branch (nothing commits), and
+ * the `dryRun` guard makes `commit`'s irreversible action a no-op — so the whole
+ * graph traces end to end for free. Fire real `approval.decision` / `candidate.confirm`
+ * signals (in dev, via the MCP `workflow_signal` tool — see README) to drive the
+ * approve → accept → commit path and the fallback loop.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** How many top-ranked candidates to describe in the approver notification. */
+const APPROVER_PREVIEW = 5;
+
+/** The signal a human fires to approve or reject the recommendation. */
+const APPROVAL_SIGNAL = "approval.decision";
+/** The signal a candidate fires to accept or decline a provisional offer. */
+const CONFIRM_SIGNAL = "candidate.confirm";
+
+/** Username for the inbox we send notifications from (created once, then reused). */
+const SENDER_USERNAME = "approvals";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** A candidate the request could be fulfilled by, in any order. */
+interface Candidate {
+  /** Stable id, echoed back by the ranking model to preserve contact info. */
+  id: string;
+  /** Human-readable name shown in notifications. */
+  name: string;
+  /** Where to send the provisional offer / result. Absent ⇒ can't be contacted. */
+  email?: string;
+  /** Freeform attributes the ranking model can weigh (fit, price, availability…). */
+  attributes?: Record<string, unknown>;
+}
+
+/** A candidate plus the model's fit assessment. */
+interface RankedCandidate extends Candidate {
+  /** Fit score the model assigned (higher = better fit), for display/ordering. */
+  score: number;
+  /** Why the model ranked it here. */
+  rationale: string;
+}
+
+/** Structured intent extracted from the free-text request. */
+interface ParsedRequest {
+  /** One-line summary of what's being requested. */
+  summary: string;
+  /** Criteria the ranking should optimise for (fit, not just cost). */
+  criteria: string[];
+}
+
+interface EntryInput {
+  /** The natural-language request to fulfil (parsed by the model). */
+  request: string;
+  /** The pool of candidates to rank and offer to, in any order. */
+  candidates: Candidate[];
+  /** Who approves before anything commits. Falls back to `config.APPROVER_EMAIL`. */
+  approver?: string;
+  /** Human channel to escalate to when the ranked list is exhausted. Falls back to `config.ESCALATION_EMAIL`. */
+  escalateTo?: string;
+  /** Compute + notify but never perform the irreversible commit. `run_local` sets this. */
+  dryRun?: boolean;
+  /** String-only config bag (approver / escalation fallbacks). */
+  config?: Config;
+}
+
+/** The payload the human delivers on the `approval.decision` signal. */
+interface ApprovalDecision {
+  /** `approve` proceeds; anything else (or absent) takes the safe reject branch. */
+  decision?: "approve" | "reject";
+  /** Optional free-text rationale carried through to the outcome. */
+  notes?: string;
+}
+
+/** The payload a candidate delivers on the `candidate.confirm` signal. */
+interface ConfirmDecision {
+  /** `accept` commits; `decline`/`timeout` (or absent) advance to the next candidate. */
+  decision?: "accept" | "decline" | "timeout";
+  /** Optional free-text note carried through to the outcome. */
+  notes?: string;
+}
+
+/** State that survives the pauses, read back after each resume. */
+interface Shared extends Record<string, unknown> {
+  request: string;
+  parsed: ParsedRequest;
+  ranked: RankedCandidate[];
+  index: number;
+  approver: string | null;
+  escalateTo: string | null;
+  dryRun: boolean;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Approvals",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Send a notification, degrading gracefully when there's no recipient. A missing
+ * address is an expected outcome (a candidate with no email, no approver
+ * configured yet) — log and skip rather than failing the run.
+ */
+async function notify(
+  ctx: Ctx,
+  to: string | null | undefined,
+  subject: string,
+  text: string,
+): Promise<boolean> {
+  if (!to) {
+    ctx.logger.warn("notify skipped: no recipient", { subject });
+    return false;
+  }
+  const inboxId = await resolveSenderInbox(ctx);
+  const sent = await ctx.sapiom.email.messages.send(inboxId, {
+    to,
+    subject,
+    text,
+  });
+  ctx.logger.info("notified", { to, subject, messageId: sent.messageId });
+  return true;
+}
+
+// ─────────────────────────────────────────────────────── model reasoning ──
+/** Parse the free-text request into structured intent (reversible prep). */
+async function parseRequest(ctx: Ctx, request: string): Promise<ParsedRequest> {
+  if (!request) return { summary: "(empty request)", criteria: [] };
+  const system =
+    "You extract structured intent from a request that will be fulfilled by " +
+    "selecting one of several candidates. Identify what is being asked for and " +
+    "the criteria that should drive the choice (weigh fit, not just cost). " +
+    'Reply with ONLY minified JSON: {"summary":string,"criteria":string[]}.';
+  const res = await ctx.sapiom.models.run({
+    prompt: request,
+    system,
+    maxTokens: 300,
+  });
+  return coerceParsed(res.output, request);
+}
+
+/**
+ * Rank the candidates by fit to the parsed criteria. Every input candidate is
+ * returned exactly once (contact info preserved); the model only reorders + scores.
+ */
+async function rankCandidates(
+  ctx: Ctx,
+  parsed: ParsedRequest,
+  candidates: Candidate[],
+): Promise<RankedCandidate[]> {
+  if (candidates.length === 0) return [];
+  const system =
+    "You rank candidates by how well they FIT the criteria — not by cost alone. " +
+    "Return every candidate exactly once, best first, each with a 0-100 fit " +
+    "score and a one-line rationale. Use the candidate `id` values verbatim. " +
+    'Reply with ONLY minified JSON: {"ranking":[{"id":string,"score":number,"rationale":string}]}.';
+  const prompt =
+    `CRITERIA:\n${parsed.criteria.map((c) => `- ${c}`).join("\n") || "- (none)"}\n\n` +
+    `CANDIDATES:\n${JSON.stringify(candidates)}`;
+  const res = await ctx.sapiom.models.run({ prompt, system, maxTokens: 600 });
+  return applyRanking(res.output, candidates);
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const parse = defineStep({
+  name: "parse",
+  next: ["rank"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const request = input.request?.trim() ?? "";
+    const config = input.config ?? {};
+    ctx.shared.set("request", request);
+    ctx.shared.set("index", 0);
+    ctx.shared.set(
+      "approver",
+      input.approver?.trim() || config.APPROVER_EMAIL || null,
+    );
+    ctx.shared.set(
+      "escalateTo",
+      input.escalateTo?.trim() || config.ESCALATION_EMAIL || null,
+    );
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    // Reversible prep: understand the request before touching any candidate.
+    const parsed = await parseRequest(ctx, request);
+    ctx.shared.set("parsed", parsed);
+    ctx.logger.info("parsed request", {
+      summary: parsed.summary,
+      criteria: parsed.criteria.length,
+    });
+    return goto("rank", { candidates: input.candidates ?? [] });
+  },
+});
+
+const rank = defineStep({
+  name: "rank",
+  next: ["notifyApprover"],
+  async run(input: { candidates: Candidate[] }, ctx: Ctx) {
+    const parsed = must(ctx.shared.get("parsed"), "parsed");
+    const ranked = await rankCandidates(ctx, parsed, input.candidates ?? []);
+    ctx.shared.set("ranked", ranked);
+    ctx.logger.info("ranked candidates", {
+      count: ranked.length,
+      top: ranked[0]?.id ?? null,
+    });
+    return goto("notifyApprover", {});
+  },
+});
+
+const notifyApprover = defineStep({
+  name: "notifyApprover",
+  next: [],
+  // Static graph edge: on the approval signal, resume at `onDecision`. Must match
+  // the `pauseUntilSignal` directive below.
+  pause: { signal: APPROVAL_SIGNAL, resumeStep: "onDecision" },
+  async run(_input: unknown, ctx: Ctx) {
+    const parsed = must(ctx.shared.get("parsed"), "parsed");
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    const approver = ctx.shared.get("approver") ?? null;
+
+    // Reversible prep: notify the approver with the ranked recommendation.
+    await notify(
+      ctx,
+      approver,
+      `Approval needed: ${parsed.summary}`,
+      buildApproverEmail(parsed, ranked, ctx.executionId),
+    );
+
+    ctx.logger.info("approver notified; pausing for decision", {
+      approver,
+      ranked: ranked.length,
+    });
+
+    // Suspend at $0 until a human fires the approval signal for this run.
+    return pauseUntilSignal({
+      signal: APPROVAL_SIGNAL,
+      resumeStep: "onDecision",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const onDecision = defineStep({
+  name: "onDecision",
+  next: ["offer", "escalate", "revert"],
+  // `payload` IS the approval signal body.
+  async run(payload: ApprovalDecision, ctx: Ctx) {
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    // Safe default: only an explicit `approve` proceeds — the whole point of the
+    // gate is that nothing commits without a deliberate human yes.
+    const approved = payload?.decision === "approve";
+    ctx.logger.info("approval decision", {
+      decision: payload?.decision ?? "(none)",
+      approved,
+    });
+    if (!approved) return goto("revert", { notes: payload?.notes });
+    // Approved but nobody to offer to → escalate rather than pause forever.
+    if (ranked.length === 0)
+      return goto("escalate", { reason: "no-candidates" });
+    return goto("offer", {});
+  },
+});
+
+const revert = defineStep({
+  name: "revert",
+  next: [],
+  terminal: true,
+  async run(input: { notes?: string }, ctx: Ctx) {
+    // Nothing irreversible happened before the approval gate, so reverting to a
+    // safe state is a clean no-op: log the rejection and terminate.
+    ctx.logger.info("rejected — reverting to safe state, nothing committed");
+    return terminate({
+      committed: false,
+      outcome: "rejected",
+      notes: input?.notes ?? null,
+    });
+  },
+});
+
+const offer = defineStep({
+  name: "offer",
+  next: [],
+  // Static graph edge: on a candidate's confirm, resume at `resolve`.
+  pause: { signal: CONFIRM_SIGNAL, resumeStep: "resolve" },
+  async run(_input: unknown, ctx: Ctx) {
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    const index = must(ctx.shared.get("index"), "index");
+    const candidate = ranked[index];
+    if (!candidate) {
+      // Invariant guard — callers only route here with a valid index.
+      throw new Error(`no candidate at index ${index} of ${ranked.length}`);
+    }
+
+    // Provisional, NON-committing offer to the current top-ranked candidate.
+    await notify(
+      ctx,
+      candidate.email,
+      `Provisional offer (please confirm)`,
+      buildOfferEmail(candidate, index, ctx.executionId),
+    );
+
+    ctx.logger.info("provisional offer sent; pausing for confirm", {
+      candidate: candidate.id,
+      index,
+    });
+
+    // Suspend at $0 until this candidate confirms (or a timeout fires the signal).
+    return pauseUntilSignal({
+      signal: CONFIRM_SIGNAL,
+      resumeStep: "resolve",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const resolve = defineStep({
+  name: "resolve",
+  next: ["commit", "offer", "escalate"],
+  // `payload` IS the candidate confirm signal body.
+  async run(payload: ConfirmDecision, ctx: Ctx) {
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    const index = must(ctx.shared.get("index"), "index");
+    // Safe default: only an explicit `accept` commits.
+    const accepted = payload?.decision === "accept";
+    ctx.logger.info("candidate confirm", {
+      decision: payload?.decision ?? "(none)",
+      index,
+      accepted,
+    });
+    if (accepted) return goto("commit", {});
+
+    // decline / timeout / anything else → advance to the next ranked candidate.
+    const nextIndex = index + 1;
+    ctx.shared.set("index", nextIndex);
+    if (nextIndex < ranked.length) return goto("offer", {});
+    // Ranked list exhausted — escalate instead of silently failing.
+    return goto("escalate", { reason: "exhausted" });
+  },
+});
+
+const commit = defineStep({
+  name: "commit",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    const index = must(ctx.shared.get("index"), "index");
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const selected = ranked[index];
+    const others = ranked.filter((_, i) => i !== index);
+    const selectedRef = selected
+      ? { id: selected.id, name: selected.name }
+      : null;
+
+    if (dryRun) {
+      // Offline / preview: the single irreversible action is a no-op. Everything
+      // up to here (parse, rank, notify, provisional offer) already ran for real.
+      ctx.logger.info("dry run: skipping the irreversible commit", {
+        selected: selected?.id,
+      });
+      return terminate({
+        committed: false,
+        dryRun: true,
+        outcome: "dry-run",
+        selected: selectedRef,
+      });
+    }
+
+    // ── The single irreversible / expensive action ─────────────────────────
+    // Reached ONLY after a human approved AND a candidate accepted. In a real
+    // fork, replace this binding confirmation with your irreversible action —
+    // charge a card, book a resource, sign a contract, provision infra.
+    await notify(
+      ctx,
+      selected?.email,
+      `Confirmed — you're selected`,
+      buildCommitEmail(selected, ctx.executionId),
+    );
+    // Courtesy notification to the candidates who weren't selected (reversible).
+    let notified = 0;
+    for (const other of others) {
+      if (
+        await notify(
+          ctx,
+          other.email,
+          `Update on your offer`,
+          buildNotSelectedEmail(other),
+        )
+      )
+        notified += 1;
+    }
+
+    ctx.logger.info("committed", { selected: selected?.id, notified });
+    return terminate({
+      committed: true,
+      dryRun: false,
+      outcome: "committed",
+      selected: selectedRef,
+      notified,
+    });
+  },
+});
+
+const escalate = defineStep({
+  name: "escalate",
+  next: [],
+  terminal: true,
+  async run(input: { reason?: string }, ctx: Ctx) {
+    const parsed = must(ctx.shared.get("parsed"), "parsed");
+    const ranked = must(ctx.shared.get("ranked"), "ranked");
+    const escalateTo = ctx.shared.get("escalateTo") ?? null;
+    const reason = input?.reason ?? "exhausted";
+
+    await notify(
+      ctx,
+      escalateTo,
+      `Escalation: no candidate accepted`,
+      buildEscalationEmail(parsed, ranked, reason),
+    );
+
+    ctx.logger.info("escalated to human channel", { escalateTo, reason });
+    return terminate({
+      committed: false,
+      outcome: "escalated",
+      reason,
+      considered: ranked.length,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── email bodies ──
+function buildApproverEmail(
+  parsed: ParsedRequest,
+  ranked: RankedCandidate[],
+  executionId: string,
+): string {
+  const list =
+    ranked.length > 0
+      ? ranked
+          .slice(0, APPROVER_PREVIEW)
+          .map(
+            (c, i) => `${i + 1}. ${c.name} (score ${c.score}) — ${c.rationale}`,
+          )
+          .join("\n")
+      : "(no candidates supplied)";
+  return [
+    `Approval requested for: ${parsed.summary}`,
+    "",
+    "Criteria:",
+    ...(parsed.criteria.length > 0
+      ? parsed.criteria.map((c) => `- ${c}`)
+      : ["- (none)"]),
+    "",
+    `Recommended order (top ${Math.min(APPROVER_PREVIEW, ranked.length)}):`,
+    list,
+    "",
+    "Nothing has been committed. Fire the `approval.decision` signal with",
+    '{"decision":"approve"} to proceed, or {"decision":"reject"} to stop.',
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildOfferEmail(
+  candidate: RankedCandidate,
+  index: number,
+  executionId: string,
+): string {
+  return [
+    `Hi ${candidate.name},`,
+    "",
+    "You're our top pick (this offer is provisional and not yet binding).",
+    `Rank: #${index + 1} — ${candidate.rationale}`,
+    "",
+    "Confirm by firing the `candidate.confirm` signal with",
+    '{"decision":"accept"} to accept, or {"decision":"decline"} to pass.',
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildCommitEmail(
+  candidate: RankedCandidate | undefined,
+  executionId: string,
+): string {
+  return [
+    `Hi ${candidate?.name ?? "there"},`,
+    "",
+    "This confirms you've been selected — the commitment is now final.",
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildNotSelectedEmail(candidate: RankedCandidate): string {
+  return [
+    `Hi ${candidate.name},`,
+    "",
+    "Thanks for your interest — another candidate was selected this time.",
+  ].join("\n");
+}
+
+function buildEscalationEmail(
+  parsed: ParsedRequest,
+  ranked: RankedCandidate[],
+  reason: string,
+): string {
+  return [
+    `Escalation: could not fulfil "${parsed.summary}" automatically.`,
+    "",
+    `Reason: ${reason}.`,
+    `Candidates considered: ${ranked.length}.`,
+    "",
+    reason === "exhausted"
+      ? "Every ranked candidate declined or timed out. Human intervention needed."
+      : "No candidates were available to offer to. Human intervention needed.",
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────── output parsing ──
+/** Coerce the parse-step model output into a `ParsedRequest`, with a fallback. */
+function coerceParsed(output: string | null, request: string): ParsedRequest {
+  const fallback: ParsedRequest = {
+    summary: request.slice(0, 120) || "(empty request)",
+    criteria: [],
+  };
+  const obj = extractJson(output);
+  if (!obj) return fallback;
+  const summary =
+    typeof obj.summary === "string" && obj.summary.trim()
+      ? obj.summary.trim()
+      : fallback.summary;
+  const criteria = Array.isArray(obj.criteria)
+    ? obj.criteria.filter((c): c is string => typeof c === "string")
+    : [];
+  return { summary, criteria };
+}
+
+/**
+ * Apply the ranking-model output to the candidate pool: reorder by the model's
+ * ranking, attach score + rationale, and guarantee every candidate appears
+ * exactly once (falling back to input order for anything the model dropped).
+ */
+function applyRanking(
+  output: string | null,
+  candidates: Candidate[],
+): RankedCandidate[] {
+  const byId = new Map(candidates.map((c) => [c.id, c]));
+  const obj = extractJson(output);
+  const rawRanking = obj && Array.isArray(obj.ranking) ? obj.ranking : [];
+
+  const ranked: RankedCandidate[] = [];
+  const seen = new Set<string>();
+  for (const entry of rawRanking) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const id = typeof e.id === "string" ? e.id : undefined;
+    if (!id || seen.has(id)) continue;
+    const candidate = byId.get(id);
+    if (!candidate) continue;
+    seen.add(id);
+    ranked.push({
+      ...candidate,
+      score: typeof e.score === "number" ? e.score : 0,
+      rationale:
+        typeof e.rationale === "string" ? e.rationale : "(no rationale)",
+    });
+  }
+
+  // Append any candidate the model omitted, preserving input order.
+  for (const candidate of candidates) {
+    if (seen.has(candidate.id)) continue;
+    ranked.push({ ...candidate, score: 0, rationale: "(unranked)" });
+  }
+  return ranked;
+}
+
+/** Best-effort extraction of a single JSON object from model output. */
+function extractJson(output: string | null): Record<string, unknown> | null {
+  if (!output) return null;
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < 0 || end < start) return null;
+  try {
+    return JSON.parse(output.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "human-in-the-loop",
+  entry: "parse",
+  steps: {
+    parse,
+    rank,
+    notifyApprover,
+    onDecision,
+    revert,
+    offer,
+    resolve,
+    commit,
+    escalate,
+  },
+});

--- a/examples/human-in-the-loop/package.json
+++ b/examples/human-in-the-loop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-human-in-the-loop",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: do reversible work, pause for a human approval signal before anything commits, then commit via a ranked sequential-fallback loop (try candidates in order, escalate if exhausted).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/human-in-the-loop/template.json
+++ b/examples/human-in-the-loop/template.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "The \"ask before you commit/spend\" pattern: do some reversible work, then **pause for a human approval signal** before committing an irreversible or expensive action — and once approved, act via a **ranked sequential-fallback loop** (try candidates in order until one accepts, escalating if the list runs out).\n\nThe agent does its reversible prep first — parse the request (`ctx.sapiom.models.run`), rank the candidates by fit (not just cost), and notify the approver (`ctx.sapiom.email`) with the recommendation — then blocks on `pauseUntilSignal({ signal: 'approval.decision' })`, suspending the run at $0 with no compute burning. A `reject` reverts to a safe state and terminates; an `approve` enters the confirmation loop.\n\nIn the loop, the agent makes a *provisional* (non-committing) offer to the top candidate and pauses on `candidate.confirm`. An `accept` performs the single irreversible action (`commit`) and notifies the non-selected; a `decline`/`timeout` advances to the next candidate. Exhausting the ranked list escalates to a human channel instead of silently failing.\n\nNothing irreversible or billed happens until a human approves AND a candidate accepts. `pauseUntilSignal` is a runtime primitive, not a metered capability; the billed calls are the model reasoning and the notifications.",
+  "useCases": [
+    "Gate an expensive or irreversible action (a spend, a booking, a contract) on explicit human approval before it runs.",
+    "Fill a request from a ranked shortlist — offer to the best fit first and fall back down the list until someone accepts.",
+    "Escalate to a human when automation can't close the loop, instead of failing silently."
+  ],
+  "notes": "`run_local` stubs the capabilities and auto-resumes both pauses. A resume with no explicit decision takes the SAFE branch (nothing commits), and the `dryRun` guard makes `commit`'s irreversible action a no-op — so the whole graph traces end to end for free before a billed deploy.\n\nA real `deploy` + `run` pauses for real. To drive it in dev, fire the signals via the MCP `signal_workflow` / `workflow_signal` tool. Approve: `{ \"signal\": \"approval.decision\", \"correlationId\": \"<executionId>\", \"payload\": { \"decision\": \"approve\" } }`. Then accept: `{ \"signal\": \"candidate.confirm\", \"correlationId\": \"<executionId>\", \"payload\": { \"decision\": \"accept\" } }`. Send `{ \"decision\": \"decline\" }` on `candidate.confirm` to exercise the fallback to the next candidate. See `README.md` and `AGENTS.md`.",
+  "examples": [
+    {
+      "title": "Rank, approve, and commit to the top candidate",
+      "input": {
+        "request": "Find someone to repaint the lobby by Friday, quality over price.",
+        "candidates": [
+          {
+            "id": "a",
+            "name": "Acme Painting",
+            "email": "acme@example.com",
+            "attributes": { "rating": 4.8, "price": 1200, "availability": "Thu" }
+          },
+          {
+            "id": "b",
+            "name": "Budget Coats",
+            "email": "budget@example.com",
+            "attributes": { "rating": 3.9, "price": 700, "availability": "Fri" }
+          }
+        ],
+        "approver": "approver@example.com",
+        "escalateTo": "ops@example.com"
+      },
+      "output": {
+        "committed": true,
+        "dryRun": false,
+        "outcome": "committed",
+        "selected": { "id": "a", "name": "Acme Painting" },
+        "notified": 1
+      }
+    },
+    {
+      "title": "Approved, but every candidate declined — escalate",
+      "input": {
+        "request": "Find someone to repaint the lobby by Friday.",
+        "candidates": [
+          { "id": "a", "name": "Acme Painting", "email": "acme@example.com" }
+        ],
+        "approver": "approver@example.com",
+        "escalateTo": "ops@example.com"
+      },
+      "output": {
+        "committed": false,
+        "outcome": "escalated",
+        "reason": "exhausted",
+        "considered": 1
+      }
+    }
+  ]
+}

--- a/examples/human-in-the-loop/tsconfig.json
+++ b/examples/human-in-the-loop/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,68 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "human-in-the-loop",
+      "name": "Human-in-the-Loop Approval",
+      "description": "Do reversible work, pause for a human approval signal before committing, then commit via a ranked sequential-fallback loop.",
+      "tags": ["approval", "human-in-the-loop", "hitl", "fallback"],
+      "sourcePath": "examples/human-in-the-loop",
+      "capabilities": ["llm.generate", "email.send"],
+      "whatItDoes": "The \"ask before you commit/spend\" pattern. The agent does reversible prep — parse the request (models.run), rank the candidates by fit, and notify the approver (email) — then blocks on a durable pauseUntilSignal so the run survives the wait at $0. A reject reverts to a safe state and terminates. An approve enters a ranked sequential-fallback loop: a provisional (non-committing) offer to the top candidate, a pause for their confirm, and on decline/timeout it advances to the next candidate. The single irreversible/expensive action lands in commit only after a human approved AND a candidate accepted; exhausting the ranked list escalates to a human instead of silently failing.",
+      "steps": [
+        {
+          "name": "parse",
+          "description": "Parse the free-text request into structured intent with an LLM.",
+          "capability": "llm.generate",
+          "next": ["rank"]
+        },
+        {
+          "name": "rank",
+          "description": "Rank the candidates by fit (not just cost) with an LLM.",
+          "capability": "llm.generate",
+          "next": ["notifyApprover"]
+        },
+        {
+          "name": "notifyApprover",
+          "description": "Email the approver the ranked recommendation, then pause until the approval signal (resumes at 'onDecision').",
+          "capability": "email.send",
+          "next": ["onDecision"]
+        },
+        {
+          "name": "onDecision",
+          "description": "Resume target — its input is the approval payload; approve enters the offer loop, reject reverts, no candidates escalates.",
+          "next": ["offer", "escalate", "revert"]
+        },
+        {
+          "name": "revert",
+          "description": "Terminal branch: rejected — revert to a safe state, nothing committed.",
+          "terminal": true
+        },
+        {
+          "name": "offer",
+          "description": "Provisional (non-committing) offer to the top-ranked candidate, then pause until their confirm (resumes at 'resolve').",
+          "capability": "email.send",
+          "next": ["resolve"]
+        },
+        {
+          "name": "resolve",
+          "description": "Resume target — its input is the confirm payload; accept commits, decline/timeout advances to the next candidate or escalates when exhausted.",
+          "next": ["commit", "offer", "escalate"]
+        },
+        {
+          "name": "commit",
+          "description": "The single irreversible/expensive action — reached only after approval AND a candidate accept; a dryRun guard makes it a no-op offline.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "escalate",
+          "description": "Terminal branch: ranked list exhausted (or no candidates) — escalate to a human channel.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a generic **Human-in-the-Loop Approval** agent template to the onboarding gallery — the "ask before you commit/spend" pattern.

The agent does its reversible prep first, then **blocks on a durable human approval signal** before anything irreversible or billed happens. Once approved, it commits via a **ranked sequential-fallback loop**: try candidates in order until one accepts, escalating to a human if the list is exhausted.

```
parse → rank → notifyApprover ─(pause: approval.decision)─▶ onDecision
                                                              │
                       reject ◀──────────────────────────────┼─▶ approve
                         │                                    ▼
                       revert (terminal)      offer ─(pause: candidate.confirm)─▶ resolve
                                                ▲                                   │
                                decline/timeout ┘   accept │ exhausted │           │
                                                           ▼           ▼
                                                       commit       escalate
                                                      (terminal)    (terminal)
```

## Highlights

- **Two `pauseUntilSignal` pauses** — the approval gate and each turn of the confirmation loop; the run suspends at \$0 and resumes on signal. Resumed steps (`onDecision`, `resolve`) consume the signal payload as their `run` input.
- **Ranked sequential fallback** — provisional (non-committing) offer to the top candidate; `decline`/`timeout` advances to the next; the ranked list living in `ctx.shared` survives every pause; exhaustion escalates instead of silently failing.
- **Commit is the only irreversible action**, reached only after a human approves **and** a candidate accepts. A `dryRun` guard makes it a no-op offline.
- **Safe defaults** — only an explicit `approve`/`accept` proceeds; anything else takes the safe branch, so an offline resume with no payload can't commit.
- LLM parse + fit-ranking via `ctx.sapiom.models.run`; approver/offer/escalation notifications via `ctx.sapiom.email`.
- One `examples/registry.json` entry with `capabilities` + `tags`; six template files mirroring the existing examples.

## Validation

- `npm run typecheck` ✅ (confirms every `ctx.sapiom.*` capability/method exists at the pinned SDK versions)
- `prettier --check` ✅
- Offline step-graph validation (`buildManifest` + `validateGraph` + `assertValidGraph`, the `check` equivalent) ✅ — both pause annotations and the `resolve → offer` loop edge validate with no errors/warnings.

Resolves SAP-1831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)