### PR TITLE
feat(examples): add eval-gate LLM-judge quality gate template (SAP-1830)

### DIFF
--- a/examples/eval-gate/.gitignore
+++ b/examples/eval-gate/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/eval-gate/AGENTS.md
+++ b/examples/eval-gate/AGENTS.md
@@ -1,0 +1,98 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Eval Gate** —
+authored against `@sapiom/agent`. It's an LLM-judge quality gate: `judge` scores
+an output against **your** rubric with one `ctx.sapiom.models.run` call and parses
+a `[0,1]` score; `gate` branches `publish` vs `revise` on `score >= threshold`;
+the terminal steps return `{ decision, score, threshold, rationale }`. The only
+genuinely new code is `judge.ts` (`buildJudgePrompt` + `parseScore`).
+
+## The judge is a metered `models.run` call
+
+- The judge LLM call goes through `ctx.sapiom.models.run({ prompt, model?, maxTokens })`
+  — the real, deploy-injected, **metered** LLM path (x402 at
+  `tools.sapiom.ai/models/v1`). It returns `{ output: string | null, … }`.
+- **`ctx.sapiom.llm` does not exist** — use `models.run`. Do not read `LLM_GATEWAY_*`
+  env vars or POST `/v1/messages` directly; those are not injected on deploy.
+- The judge rides the same step→gateway path as everything else, so the engine's
+  routing / capacity / load-balancing sit in front of it for free — no
+  evals-specific execution path.
+
+## The rubric is yours; the harness is ours
+
+- We ship one generic default judge prompt (`buildJudgePrompt`) and a tolerant
+  score parser (`parseScore`). Override the **rubric** (the `rubric` input), not
+  this scaffolding.
+- `parseScore` prefers a JSON `{score, rationale}`, falls back to the first bare
+  number, clamps to `[0,1]`, and tolerates a 0–100 answer. It **throws** when no
+  number can be parsed — a malformed reply is transient, so the engine retries.
+- Building your own eval = editing three inputs: the **rubric**, the **threshold**
+  (default `0.7`), and the judge **model**. See `README.md`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- The input contract is enforced by a zod schema (`inputSchema`) on the entry
+  `judge` step, with an `examples` block the gallery renders.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` method you
+  used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation.
+- **run_local** — runs your **real** step code against **stub capabilities**.
+  The _default_ `models.run` stub returns a non-numeric placeholder, and
+  `parseScore` throws on a reply with no number (by design — a malformed judge
+  reply is transient), so you **must supply a stub score** to trace the graph.
+  Pass a stub whose `models.run` response carries a numeric `output`, and flip it
+  to verify **both** branches:
+
+  ```jsonc
+  // high score → publish
+  { "version": 1, "steps": { "judge": {
+    "models.run": { "output": "{\"score\":0.9,\"rationale\":\"meets the rubric\"}" }
+  } } }
+
+  // low score → revise
+  { "version": 1, "steps": { "judge": {
+    "models.run": { "output": "{\"score\":0.4,\"rationale\":\"misses the rubric\"}" }
+  } } }
+  ```
+
+  The stub value is returned verbatim as the `models.run` result; `parseScore`
+  reads its `output`. A bare number (`"output": "0.9"`) works too.
+
+- **deploy**, then **run** — ship it, then perform a real, **billed** judge call
+  that meters `models.run` and returns the decision from a real score.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities), not the other way around — never weaken or drop real
+> logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Composition — self-grading with the eval-gate as a child
+
+A parent workflow can grade its own output by launching the deployed eval-gate as
+a **child** and branching on the returned decision. The parent POSTs to
+`https://api.sapiom.ai/v1/workflows/executions` with
+`{ definitionId, input, idempotencyKey }` using `process.env.SAPIOM_API_KEY` (a
+raw HTTP call — **not** a capability namespace, and **not**
+`ctx.sapiom.agents.launch`, which 404s in prod), then `pauseUntilSignal(...)` at
+$0 until the child's decision arrives as a signal, and branches ship/regenerate.
+Guard the outbound POST behind a `dryRun` flag so `run_local` stays offline and
+free. Full parent sketch + the dev resume signal are in `README.md`.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/eval-gate/README.md
+++ b/examples/eval-gate/README.md
@@ -1,0 +1,262 @@
+# Eval Gate
+
+An **LLM-judge quality gate**. Score an output against **your** rubric, then gate
+the next step on the score. This is the template for **building your own evals** —
+you bring the rubric, we own the harness.
+
+The eval-gate is **not a capability**. Decomposed, it's a reference agent built
+from primitives you already have:
+
+| Piece                  | What it is                                             | Primitive                      |
+| ---------------------- | ------------------------------------------------------ | ------------------------------ |
+| Score an output        | one LLM call with a judge prompt → a number            | `ctx.sapiom.models.run`        |
+| Branch on the score    | `score >= threshold ? publish : revise`                | engine control flow            |
+| Build the judge prompt | string templating from **your** rubric + a score parse | `judge.ts` (the only new code) |
+
+## What it does
+
+```
+judge ─▶ gate ─┬─▶ publish   (score >= threshold)
+               └─▶ revise    (score <  threshold)
+```
+
+1. **judge** (entry) — validates input against a zod schema, builds the judge
+   prompt from **your** rubric, calls the LLM via `ctx.sapiom.models.run`, and
+   parses a `[0,1]` score from the reply. A malformed reply throws, so the engine
+   retries.
+2. **gate** — pure branch, no capability call: `score >= threshold` ⇒ `publish`,
+   else `revise`.
+3. **publish** / **revise** (terminal) — return `{ decision, score, threshold,
+rationale }`. **You** decide what "publish" and "revise" mean.
+
+Input contract: `{ input, output, rubric, threshold=0.7, model? }`.
+
+- `input` — the case the output was produced from (task, prompt, question).
+- `output` — the thing being graded.
+- `rubric` — **your** criteria string. The judge scores against this.
+- `threshold` — the pass bar in `[0,1]` (default `0.7`).
+- `model` — optional judge-model alias.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the `judge` step
+   inherits that authority to call the model.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (the `models.run`
+   capability is stubbed, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real, **billed** judge
+   call that meters `models.run`).
+
+### Tracing both branches offline (run_local)
+
+`run_local` resolves `ctx.sapiom.models.run` from a stub. The _default_ stub
+returns a non-numeric placeholder, and `parseScore` throws on a reply with no
+number (by design), so supply a **stub score** to trace the graph — and flip it
+to see each branch:
+
+```jsonc
+// high score → gate → publish
+{ "version": 1, "steps": { "judge": {
+  "models.run": { "output": "{\"score\":0.9,\"rationale\":\"meets the rubric\"}" }
+} } }
+
+// low score → gate → revise
+{ "version": 1, "steps": { "judge": {
+  "models.run": { "output": "{\"score\":0.4,\"rationale\":\"misses the rubric\"}" }
+} } }
+```
+
+Run `npm run typecheck` to confirm it compiles (and that every `ctx.sapiom.*`
+method you used exists).
+
+## Build your own eval
+
+The rubric is yours; everything else is scaffolding. To adapt this into a real
+eval, change three things:
+
+- **The rubric** — the criteria the judge scores against. Pass it as the `rubric`
+  input. This is where all your opinion about "quality" lives; we ship none.
+  Example: `"Cites at least one source, no unsupported claims, under 200 words."`
+- **The threshold** — the pass bar in `[0,1]` (default `0.7`). Raise it to be
+  stricter about what reaches `publish`; lower it to let more through.
+- **The judge model** — pass `model` (a models alias the gateway knows) to pick a
+  cheaper/stronger judge. Leave it unset for the configured default.
+
+The judge prompt and score parser live in `judge.ts` (`buildJudgePrompt` +
+`parseScore`) — the only genuinely new code. `parseScore` prefers a JSON
+`{score, rationale}`, falls back to a bare number, clamps to `[0,1]`, and
+tolerates a model that answered on a 0–100 scale. Override the **rubric**, not
+this scaffolding.
+
+## Self-grading composition (call it as a child)
+
+Because the eval-gate is a deployable agent, a **parent** workflow can grade its
+own output by launching the eval-gate as a **child** and branching on the
+returned decision — the canonical self-grading-workflow pattern:
+
+```
+parent.produce ─▶ parent.grade ─(POST /v1/workflows/executions)─▶ eval-gate child
+                                ─(pauseUntilSignal, $0 while idle)─▶ decision ─┬─▶ ship
+                                                                              └─▶ regenerate
+```
+
+The parent produces an output, POSTs a child eval-gate execution, then **pauses
+at $0** until the child's decision arrives as a signal. A `dryRun` guard keeps
+`run_local` offline and free. Sketch of the parent (a separate agent you'd
+author alongside your workflow):
+
+```ts
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/** The signal the child's decision is delivered on, correlated by executionId. */
+const CHILD_DONE = "eval.child.done";
+
+interface Shared extends Record<string, unknown> {
+  output: string;
+}
+
+/** The eval-gate child's terminal output — what the resumed step receives. */
+interface EvalDecision {
+  decision: "publish" | "revise";
+  score: number;
+  threshold: number;
+  rationale: string;
+}
+
+const produce = defineStep({
+  name: "produce",
+  next: ["grade"],
+  async run(input: { brief: string }, ctx: AgentExecutionContext<Shared>) {
+    const res = await ctx.sapiom.models.run({
+      prompt: input.brief,
+      maxTokens: 400,
+    });
+    const output = res.output ?? "";
+    ctx.shared.set("output", output);
+    return goto("grade", { brief: input.brief, output });
+  },
+});
+
+const grade = defineStep({
+  name: "grade",
+  next: [],
+  // Static graph edge: on CHILD_DONE, resume at `decision`.
+  pause: { signal: CHILD_DONE, resumeStep: "decision" },
+  async run(
+    input: { brief: string; output: string },
+    ctx: AgentExecutionContext<Shared>,
+  ) {
+    // Offline unless there's a real API key (or DRY_RUN forces it off).
+    const dryRun = !process.env.SAPIOM_API_KEY || process.env.DRY_RUN === "1";
+    const childInput = {
+      input: input.brief,
+      output: input.output,
+      rubric: "Accurate, on-brief, and free of unsupported claims.",
+      threshold: 0.7,
+    };
+    if (!dryRun) {
+      // Launch the deployed eval-gate as a child. Raw HTTP — NOT a capability
+      // namespace, and NOT ctx.sapiom.agents.launch (which 404s in prod).
+      await fetch("https://api.sapiom.ai/v1/workflows/executions", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${process.env.SAPIOM_API_KEY}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          definitionId: process.env.EVAL_GATE_DEFINITION_ID,
+          input: childInput,
+          idempotencyKey: ctx.executionId,
+        }),
+      });
+    }
+    // Suspend at $0 until the child's decision fires CHILD_DONE for this run.
+    return pauseUntilSignal({
+      signal: CHILD_DONE,
+      resumeStep: "decision",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const decision = defineStep({
+  name: "decision",
+  next: ["ship", "regenerate"],
+  // The signal payload IS the eval-gate child's terminal output.
+  async run(child: EvalDecision, ctx: AgentExecutionContext<Shared>) {
+    ctx.logger.info("child graded", {
+      decision: child.decision,
+      score: child.score,
+    });
+    return child.decision === "publish"
+      ? goto("ship", {})
+      : goto("regenerate", {});
+  },
+});
+
+const ship = defineStep({
+  name: "ship",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
+    return terminate({ shipped: ctx.shared.get("output") });
+  },
+});
+
+const regenerate = defineStep({
+  name: "regenerate",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, _ctx: AgentExecutionContext<Shared>) {
+    // ...loop back to produce with the rationale, or hand off for human review.
+    return terminate({ shipped: null, action: "regenerate" });
+  },
+});
+
+export const agent = defineAgent<{ brief: string }, Shared>({
+  name: "self-grading-writer",
+  entry: "produce",
+  steps: { produce, grade, decision, ship, regenerate },
+});
+```
+
+The child's terminal output (`{ decision, score, threshold, rationale }`) is
+delivered as `decision`'s input via the `CHILD_DONE` signal, correlated by the
+parent's `executionId`. In dev you fire that signal yourself via the MCP
+`signal_workflow` / `workflow_signal` tool once the child run finishes — the same
+manual stand-in the Wait-for-Webhook template uses:
+
+```json
+{
+  "signal": "eval.child.done",
+  "correlationId": "<parent executionId>",
+  "payload": {
+    "decision": "publish",
+    "score": 0.9,
+    "threshold": 0.7,
+    "rationale": "…"
+  }
+}
+```
+
+## Files
+
+- `index.ts` — the eval-gate agent (edit this).
+- `judge.ts` — `buildJudgePrompt` + `parseScore`, the only new logic.
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+- `AGENTS.md` — the authoring loop and the composition contract.

--- a/examples/eval-gate/index.ts
+++ b/examples/eval-gate/index.ts
@@ -1,0 +1,208 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { z } from "zod/v4";
+
+import { buildJudgePrompt, parseScore } from "./judge.js";
+
+/**
+ * eval-gate
+ * ---------
+ * An LLM-judge quality gate. Score an output against YOUR rubric, then gate the
+ * next step on the score — a deployable Sapiom agent built from primitives you
+ * already have: one metered LLM call (the judge, via `ctx.sapiom.models.run`),
+ * the engine's branch control flow (the gate), and two terminal outcomes
+ * (publish / revise).
+ *
+ * We own the harness (a default judge prompt + a score parser, see `judge.ts`)
+ * and the pattern. The RUBRIC is yours — we ship one generic default judge prompt
+ * you override, never an opinion about what "quality" means.
+ *
+ *   judge ─▶ gate ─┬─▶ publish   (score >= threshold)
+ *                  └─▶ revise    (score <  threshold)
+ *
+ * The judge is an ordinary `models.run` call, so it rides the same step→gateway
+ * path as everything else and inherits the engine's routing / capacity / load
+ * balancing for free — no evals-specific execution path is created.
+ *
+ * Shape: `(input, output, rubric, threshold) → { decision, score, threshold,
+ * rationale }`. Copy this as a starter, or call it as a CHILD from a parent
+ * workflow that produced `output` and branch on the returned decision — see the
+ * "self-grading workflow" composition pattern in `README.md`.
+ */
+
+/** Run-scoped values stashed in `ctx.shared` so later steps can read them. */
+interface EvalShared extends Record<string, unknown> {
+  /** The pass bar, stashed by `judge` so `gate` can branch on it. */
+  threshold: number;
+}
+
+const judgeInputSchema = z
+  .object({
+    input: z
+      .unknown()
+      .describe(
+        "The case the output was produced from (task, prompt, question…).",
+      ),
+    output: z.unknown().describe("The produced output to grade."),
+    rubric: z
+      .string()
+      .min(1)
+      .describe(
+        "YOUR criteria. The judge scores the output against this — we ship no scorer taxonomy.",
+      ),
+    threshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.7)
+      .describe(
+        "Pass bar in [0,1]. score >= threshold ⇒ publish, else revise.",
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Judge-model alias the models capability knows (default: the configured judge model).",
+      ),
+  })
+  .meta({
+    examples: [
+      {
+        input:
+          "Write a one-line product tagline for a privacy-first email app.",
+        output: "Inbox peace, finally — email that never reads your mail.",
+        rubric:
+          "Concise (<= 12 words), mentions privacy, no jargon, reads naturally.",
+        threshold: 0.7,
+      },
+    ],
+  });
+
+/** What the workflow is kicked off with. */
+export type EvalGateInput = z.infer<typeof judgeInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Step 1 — judge: build the prompt from YOUR rubric, call models.run, parse score
+// ---------------------------------------------------------------------------
+
+const judge = defineStep({
+  name: "judge",
+  next: ["gate"],
+  timeoutMs: 60_000,
+  inputSchema: judgeInputSchema,
+  async run(input: EvalGateInput, ctx: AgentExecutionContext<EvalShared>) {
+    ctx.shared.set("threshold", input.threshold);
+    const prompt = buildJudgePrompt({
+      input: input.input,
+      output: input.output,
+      rubric: input.rubric,
+    });
+    // The load-bearing seam: the judge is an ordinary metered LLM call. A
+    // malformed reply (or none) makes `parseScore` throw, so the engine retries.
+    const res = await ctx.sapiom.models.run({
+      prompt,
+      model: input.model,
+      maxTokens: 256,
+    });
+    const { score, rationale } = parseScore(res.output ?? "");
+    ctx.logger.info("judge: scored output against rubric", {
+      score,
+      threshold: input.threshold,
+    });
+    return goto("gate", { score, rationale });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 2 — gate: the branch the whole template turns on (pure logic, no call)
+// ---------------------------------------------------------------------------
+
+interface GateInput {
+  score: number;
+  rationale: string;
+}
+
+interface GateOutcome {
+  score: number;
+  threshold: number;
+  rationale: string;
+}
+
+const gate = defineStep({
+  name: "gate",
+  next: ["publish", "revise"],
+  async run(input: GateInput, ctx: AgentExecutionContext<EvalShared>) {
+    const threshold = ctx.shared.get("threshold") ?? 0.7;
+    const passed = input.score >= threshold;
+    ctx.logger.info(
+      `gate: score ${passed ? "met" : "below"} threshold → ${passed ? "publish" : "revise"}`,
+      { score: input.score, threshold },
+    );
+    const outcome: GateOutcome = {
+      score: input.score,
+      threshold,
+      rationale: input.rationale,
+    };
+    return passed ? goto("publish", outcome) : goto("revise", outcome);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 — terminal outcomes. The caller decides what publish/revise MEAN.
+// ---------------------------------------------------------------------------
+
+const publish = defineStep({
+  name: "publish",
+  next: [],
+  terminal: true,
+  async run(input: GateOutcome, ctx: AgentExecutionContext<EvalShared>) {
+    ctx.logger.info("publish: output passed the eval-gate", {
+      score: input.score,
+    });
+    return terminate(
+      {
+        decision: "publish",
+        score: input.score,
+        threshold: input.threshold,
+        rationale: input.rationale,
+      },
+      { reason: "score met threshold" },
+    );
+  },
+});
+
+const revise = defineStep({
+  name: "revise",
+  next: [],
+  terminal: true,
+  async run(input: GateOutcome, ctx: AgentExecutionContext<EvalShared>) {
+    ctx.logger.info("revise: output failed the eval-gate", {
+      score: input.score,
+    });
+    return terminate(
+      {
+        decision: "revise",
+        score: input.score,
+        threshold: input.threshold,
+        rationale: input.rationale,
+      },
+      { reason: "score below threshold" },
+    );
+  },
+});
+
+/**
+ * The agent. The engine imports THIS `agent` export, bundles it, and walks these
+ * step bodies inside a sandbox. Exactly ONE `defineAgent` is exported from this
+ * module — the loader requires precisely one.
+ */
+export const agent = defineAgent<EvalGateInput, EvalShared>({
+  name: "eval-gate",
+  entry: "judge",
+  steps: { judge, gate, publish, revise },
+});

--- a/examples/eval-gate/judge.ts
+++ b/examples/eval-gate/judge.ts
@@ -1,0 +1,91 @@
+/**
+ * judge.ts — the eval-gate's only genuinely new code.
+ *
+ * Two small pieces: a default judge prompt builder and a text score parser. The
+ * RUBRIC is the caller's — we own the harness, not an opinion about what
+ * "quality" means. These are factored out (not inlined in the steps) so the same
+ * judge scaffolding is reusable if you compose the eval-gate as a child of your
+ * own workflow.
+ *
+ * There is NO gateway call in this file. The judge LLM call lives in the `judge`
+ * step in `index.ts` and goes through `ctx.sapiom.models.run` — the real,
+ * deploy-injected, metered LLM path (x402 at `tools.sapiom.ai/models/v1`). This
+ * file only builds the prompt string and parses the score out of the reply.
+ */
+
+export interface JudgeResult {
+  /** Score in [0,1]: 1.0 fully satisfies the rubric, 0.0 not at all. */
+  score: number;
+  /** Best-effort one-line model explanation (empty when the reply carried none). */
+  rationale: string;
+}
+
+/**
+ * Build the single default judge prompt from the caller's rubric. This is the
+ * unopinionated default — override the RUBRIC, not this scaffolding. We ask for a
+ * JSON object so the parse is robust, but `parseScore` tolerates a bare number
+ * too.
+ */
+export function buildJudgePrompt(args: {
+  input: unknown;
+  output: unknown;
+  rubric: string;
+}): string {
+  const { input, output, rubric } = args;
+  const render = (v: unknown): string =>
+    typeof v === "string" ? v : JSON.stringify(v, null, 2);
+  return [
+    "You are an impartial evaluator. Score the OUTPUT from 0.0 to 1.0 on how well it",
+    "satisfies the CRITERIA — 1.0 = fully satisfies, 0.0 = does not satisfy at all.",
+    'Respond with ONLY a JSON object: {"score": <number 0..1>, "rationale": "<one sentence>"}.',
+    "",
+    "CRITERIA (the rubric — supplied by the caller):",
+    rubric,
+    "",
+    "INPUT (what the output was produced from):",
+    render(input),
+    "",
+    "OUTPUT (the thing you are grading):",
+    render(output),
+  ].join("\n");
+}
+
+/** Clamp to [0,1], tolerating a model that answered on a 0–100 scale. */
+function clamp01(n: number): number {
+  const v = n > 1 && n <= 100 ? n / 100 : n;
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * Parse a [0,1] score (and best-effort rationale) out of the model's text reply.
+ * Prefers the JSON object the prompt asked for; falls back to the first bare
+ * number in the text. Throws when no number can be found at all — a malformed
+ * reply is treated as transient, so the engine retries the step up to its cap.
+ */
+export function parseScore(reply: string): JudgeResult {
+  const json = reply.match(/\{[\s\S]*\}/);
+  if (json) {
+    try {
+      const obj = JSON.parse(json[0]) as {
+        score?: unknown;
+        rationale?: unknown;
+      };
+      const n = Number(obj.score);
+      if (Number.isFinite(n)) {
+        return {
+          score: clamp01(n),
+          rationale: typeof obj.rationale === "string" ? obj.rationale : "",
+        };
+      }
+    } catch {
+      // Not valid JSON — fall through to the bare-number path.
+    }
+  }
+  const m = reply.match(/-?\d+(?:\.\d+)?/);
+  if (!m) {
+    throw new Error(
+      `eval-gate judge: could not parse a score from reply: ${reply.slice(0, 200)}`,
+    );
+  }
+  return { score: clamp01(Number(m[0])), rationale: "" };
+}

--- a/examples/eval-gate/package.json
+++ b/examples/eval-gate/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-eval-gate",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: an LLM-judge quality gate — score an output against YOUR rubric with one metered models.run judge call, then branch publish/revise on a threshold. Composes as a child to self-grade a parent workflow.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.5.0",
+    "@sapiom/tools": "^0.16.0",
+    "zod": "^3.25.76 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/eval-gate/template.json
+++ b/examples/eval-gate/template.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "An LLM-judge quality gate — score an output against **your** rubric, then branch the next step on the score. The template for building your own evals.\n\nThe `judge` step renders a prompt from your rubric, calls an LLM via `ctx.sapiom.models.run` (the metered x402 models path), and parses a `[0,1]` score from the reply (prefers a JSON `{score, rationale}`, falls back to a bare number, clamps to `[0,1]`, tolerates a 0–100 answer). A pure `gate` step then branches `publish` vs `revise` on `score >= threshold`. The terminal steps return `{ decision, score, threshold, rationale }` — you decide what publish/revise *mean*.\n\nWe own the harness (the default judge prompt + the score parser); the rubric is yours. Swap the rubric, tune the threshold, pick a judge model — that's the whole authoring loop for a custom eval.\n\n**Self-grading composition.** Because the eval-gate is a deployable agent, a parent workflow can launch it as a **child** on its own output (POST `/v1/workflows/executions`), pause at $0 for the returned decision, and branch ship/regenerate — the canonical self-grading-workflow pattern. See the README.",
+  "useCases": [
+    "Gate an LLM-generated draft on a quality bar before it's published or sent.",
+    "Build your own eval: write a rubric, tune a threshold, pick a judge model — no scorer framework to learn.",
+    "Self-grade a workflow's output by calling the eval-gate as a child and branching on the decision."
+  ],
+  "notes": "`run_local` stubs the `llm.generate` (`models.run`) capability, so you can trace the full graph offline for free. The default stub reply carries no number and `parseScore` throws on that (by design), so supply a stub score to trace the graph — a high `output` score → `publish`, a low one → `revise`. See `AGENTS.md`/`README.md` for the exact stub. A real `deploy` + `run` performs a billed judge call and returns the decision from a real score.\n\nTo build your own eval, edit three things in `index.ts`: the **rubric** (the criteria the judge scores against — passed as input), the **threshold** (the pass bar, default 0.7), and the **model** (the judge-model alias). To self-grade, wire the eval-gate as a child of your workflow — the composition snippet in `README.md`/`AGENTS.md` POSTs to `/v1/workflows/executions` and pauses for the child's decision, guarded by a `dryRun` flag so `run_local` stays offline.",
+  "examples": [
+    {
+      "title": "High score → publish",
+      "input": {
+        "input": "Write a one-line product tagline for a privacy-first email app.",
+        "output": "Inbox peace, finally — email that never reads your mail.",
+        "rubric": "Concise (<= 12 words), mentions privacy, no jargon, reads naturally.",
+        "threshold": 0.7
+      },
+      "output": {
+        "decision": "publish",
+        "score": 0.9,
+        "threshold": 0.7,
+        "rationale": "Concise, mentions privacy, reads naturally."
+      }
+    },
+    {
+      "title": "Low score → revise",
+      "input": {
+        "input": "Write a one-line product tagline for a privacy-first email app.",
+        "output": "The best email application in the entire world for everyone everywhere.",
+        "rubric": "Concise (<= 12 words), mentions privacy, no jargon, reads naturally.",
+        "threshold": 0.7
+      },
+      "output": {
+        "decision": "revise",
+        "score": 0.3,
+        "threshold": 0.7,
+        "rationale": "Does not mention privacy and reads as generic hype."
+      }
+    }
+  ]
+}

--- a/examples/eval-gate/tsconfig.json
+++ b/examples/eval-gate/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -39,6 +39,38 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "eval-gate",
+      "name": "Eval Gate",
+      "description": "An LLM-judge quality gate — score an output against your rubric, then branch publish/revise on a threshold.",
+      "tags": ["evals", "quality-gate", "llm-judge", "composition"],
+      "sourcePath": "examples/eval-gate",
+      "capabilities": ["llm.generate"],
+      "whatItDoes": "Renders a judge prompt from YOUR rubric, calls an LLM via ctx.sapiom.models.run, and parses a [0,1] score. A pure gate step branches publish vs revise on score >= threshold; the terminal steps return { decision, score, threshold, rationale } — you decide what publish/revise mean. We own the harness (default judge prompt + score parser); the rubric is yours, so it doubles as an eval-authoring on-ramp. Because it's a deployable agent, a parent workflow can launch it as a child to self-grade its own output and branch on the returned decision.",
+      "steps": [
+        {
+          "name": "judge",
+          "description": "Build the judge prompt from your rubric, call the LLM (models.run), parse the score.",
+          "capability": "llm.generate",
+          "next": ["gate"]
+        },
+        {
+          "name": "gate",
+          "description": "Pure branch: score >= threshold ⇒ publish, else revise. No capability call.",
+          "next": ["publish", "revise"]
+        },
+        {
+          "name": "publish",
+          "description": "Terminal: output met the threshold. Return { decision: 'publish', score, … }.",
+          "terminal": true
+        },
+        {
+          "name": "revise",
+          "description": "Terminal: output below the threshold. Return { decision: 'revise', score, … }.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ships an **Eval Gate** workflow template into the single-sourced `examples/` registry: an **LLM-judge quality gate** that scores an output against *your* rubric and branches `publish` vs `revise` on a threshold, plus a documented **self-grading composition** variant where a parent workflow calls the eval-gate as a **child** to grade its own output.

This is a rebuild of the deploy-broken [SAP-1183](https://linear.app/sapiom/issue/SAP-1183) eval-gate.

Closes SAP-1830.

## The fix that motivated the rebuild

SAP-1183's `judge.ts` read `process.env.LLM_GATEWAY_BASE_URL/API_KEY/MODEL` and POSTed the gateway's `/v1/messages` directly. **Those vars are not injected on deploy** (`resolveSpawnEnv` doesn't add them), so the template only ever worked `run_local` and failed the moment it was deployed. `ctx.sapiom.llm` doesn't exist either.

The judge now routes through **`ctx.sapiom.models.run`** — the real, deploy-injected, metered LLM path (x402 at `tools.sapiom.ai/models/v1`). No `LLM_GATEWAY_*` reads and no raw `/v1/messages` fetch remain.

## What's in it

`examples/eval-gate/` — `index.ts`, `judge.ts`, `package.json`, `tsconfig.json`, `template.json` (`manifestVersion: 1`), `README.md`, `AGENTS.md` — plus one `examples/registry.json` entry.

- **Ported to `defineAgent`/`defineStep`** (`@sapiom/agent`) to match the current template layout, not the old `defineOrchestration`. Exactly one `defineAgent` export. Steps: `judge → gate → publish|revise`.
- **`buildJudgePrompt` + `parseScore` kept as-is** from SAP-1183 (the only genuinely new logic); the raw-fetch `callJudge` is gone — the judge call is inlined in the `judge` step via `ctx.sapiom.models.run`, threading `ctx`.
- **Input contract** `{ input, output, rubric, threshold=0.7, model? }` enforced via a **zod** schema with an `examples` block on the entry step.
- **Composition / self-grading** documented in `README.md` + `AGENTS.md`: a parent `produce → grade → decision → ship|regenerate` that POSTs to `api.sapiom.ai/v1/workflows/executions` `{ definitionId, input, idempotencyKey }` with `process.env.SAPIOM_API_KEY`, then `pauseUntilSignal` for the child decision — guarded by a `dryRun` flag so `run_local` stays offline. Does **not** use `ctx.sapiom.agents.launch` (404s in prod).
- **README teaches building your own eval**: swap the rubric, tune the threshold, pick a judge model.

## One deliberate deviation from the ticket text

The ticket said the registry entry should carry `capabilities: ["models.run"]`. I used **`["llm.generate"]`** instead: the registry `capabilities` field holds **catalog capability ids** that drive per-run cost estimation, and `ctx.sapiom.models.run` invokes the catalog capability `llm.generate`. The merged sibling **wait-for-webhook** (identical `models.run` usage) shipped with `["llm.generate"]`; `["models.run"]` would not resolve to a catalog id and would break cost estimation in the gallery. Happy to switch if the catalog has since gained a `models.run` id.

## Validation

- ✅ `npm run typecheck` passes — confirms every `ctx.sapiom.*` method used exists.
- ✅ `prettier --check` clean on all new files; `registry.json` + `template.json` validate against their schemas.
- ⏳ `run_local` (both branches), a deployed metered `run`, and a real composition child-run are manual steps for review — they need the Sapiom MCP dev environment and bill real capability calls. **Note:** the default `models.run` stub returns a non-numeric placeholder and `parseScore` throws on that by design, so `run_local` needs a stub score (`{ "steps": { "judge": { "models.run": { "output": "{\"score\":0.9}" } } } }`) — documented in `README.md`/`AGENTS.md` with both-branch examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PiTdmGjZ42C9LeQA4zhkX
