### PR TITLE
fix(examples): correct registry capability llm.generate → models.run (3 templates)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -83,7 +83,7 @@
       "description": "Durable pause/resume — start a slow external job, suspend at $0 until a webhook callback fires, then decide.",
       "tags": ["durable", "pause-resume", "webhook", "async"],
       "sourcePath": "examples/wait-for-webhook",
-      "capabilities": ["llm.generate"],
+      "capabilities": ["models.run"],
       "whatItDoes": "Starts a slow external async job and registers a resume contract, then suspends the run indefinitely at $0 via pauseUntilSignal — no polling, no held worker, no billed idle time. When an external webhook/callback fires the signal, the run resumes exactly where it left off: the callback payload becomes the resumed step's input, an LLM summarizes it, and the run branches to accept or reject. The sharpest showcase of the platform's durability differentiator.",
       "steps": [
         {
@@ -94,7 +94,7 @@
         {
           "name": "decide",
           "description": "Resume target — its input is the callback payload; summarize it with an LLM and branch.",
-          "capability": "llm.generate",
+          "capability": "models.run",
           "next": ["accept", "reject"]
         },
         {
@@ -240,19 +240,19 @@
       "description": "Do reversible work, pause for a human approval signal before committing, then commit via a ranked sequential-fallback loop.",
       "tags": ["approval", "human-in-the-loop", "hitl", "fallback"],
       "sourcePath": "examples/human-in-the-loop",
-      "capabilities": ["llm.generate", "email.send"],
+      "capabilities": ["models.run", "email.send"],
       "whatItDoes": "The \"ask before you commit/spend\" pattern. The agent does reversible prep — parse the request (models.run), rank the candidates by fit, and notify the approver (email) — then blocks on a durable pauseUntilSignal so the run survives the wait at $0. A reject reverts to a safe state and terminates. An approve enters a ranked sequential-fallback loop: a provisional (non-committing) offer to the top candidate, a pause for their confirm, and on decline/timeout it advances to the next candidate. The single irreversible/expensive action lands in commit only after a human approved AND a candidate accepted; exhausting the ranked list escalates to a human instead of silently failing.",
       "steps": [
         {
           "name": "parse",
           "description": "Parse the free-text request into structured intent with an LLM.",
-          "capability": "llm.generate",
+          "capability": "models.run",
           "next": ["rank"]
         },
         {
           "name": "rank",
           "description": "Rank the candidates by fit (not just cost) with an LLM.",
-          "capability": "llm.generate",
+          "capability": "models.run",
           "next": ["notifyApprover"]
         },
         {
@@ -302,13 +302,13 @@
       "description": "An LLM-judge quality gate — score an output against your rubric, then branch publish/revise on a threshold.",
       "tags": ["evals", "quality-gate", "llm-judge", "composition"],
       "sourcePath": "examples/eval-gate",
-      "capabilities": ["llm.generate"],
+      "capabilities": ["models.run"],
       "whatItDoes": "Renders a judge prompt from YOUR rubric, calls an LLM via ctx.sapiom.models.run, and parses a [0,1] score. A pure gate step branches publish vs revise on score >= threshold; the terminal steps return { decision, score, threshold, rationale } — you decide what publish/revise mean. We own the harness (default judge prompt + score parser); the rubric is yours, so it doubles as an eval-authoring on-ramp. Because it's a deployable agent, a parent workflow can launch it as a child to self-grade its own output and branch on the returned decision.",
       "steps": [
         {
           "name": "judge",
           "description": "Build the judge prompt from your rubric, call the LLM (models.run), parse the score.",
-          "capability": "llm.generate",
+          "capability": "models.run",
           "next": ["gate"]
         },
         {


### PR DESCRIPTION
## What

Three templates declared their LLM step capability as `llm.generate` in `registry.json`, but all three call `ctx.sapiom.models.run` in source:

| Template | Steps fixed | Source call |
|---|---|---|
| `wait-for-webhook` | `decide` | `index.ts:183` |
| `human-in-the-loop` | `parse`, `rank` | `models.run` |
| `eval-gate` | `judge` | `models.run` |

`llm.generate` is a Core-catalog id that reads `coming_soon` and is **not** the runtime LLM path (`models.run` is). The mismatch made the gallery **estimated cost** and the **definition graph** advertise a capability the deployed runs never call. (All three were authored on the older `@sapiom/agent ^0.5.0` pins.)

## Fix

Point each template's `capabilities` array and its LLM step(s) at `models.run`.

## Test

- Diff is exactly the 6 `llm.generate` → `models.run` lines; no other content changed.
- Zero `llm.generate` occurrences remain in `registry.json`; file stays valid + prettier-clean.
- Verified against each source (all call `ctx.sapiom.models.run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)