### PR TITLE
feat(clone): add definitionId clone path for a deployed workflow (SAP-1839)

### DIFF
--- a/packages/agent-core/src/clone.spec.ts
+++ b/packages/agent-core/src/clone.spec.ts
@@ -1,9 +1,11 @@
 /**
- * Unit tests for `clone` (the template-clone handoff, SAP-1357).
+ * Unit tests for `clone` (the template-clone handoff, SAP-1357, and the
+ * definitionId clone-a-deployed-workflow path, SAP-1839).
  *
- * Fully offline: global.fetch is mocked for the fork + clone-token calls, and the
- * git clone is injected as a fake that only records its inputs and materializes an
- * empty target dir. The filesystem (a temp dir) is the only real dependency.
+ * Fully offline: global.fetch is mocked for the fork/clone-token/definitions
+ * calls, and the git clone is injected as a fake that only records its inputs
+ * and materializes an empty target dir. The filesystem (a temp dir) is the
+ * only real dependency.
  */
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -46,6 +48,12 @@ const TOKEN_BODY = {
   repoFullName: 'Sapiom-Platform/sapiom-fork-abc',
   defaultBranch: 'main',
   cloneUrl: 'https://x-access-token:ghs_secretTOKEN@github.com/Sapiom-Platform/sapiom-fork-abc.git',
+  expiresAt: '2026-07-07T01:00:00.000Z',
+};
+const DEFINITION_TOKEN_BODY = {
+  repoFullName: 'Sapiom-Platform/ag-uuid-1',
+  defaultBranch: 'main',
+  cloneUrl: 'https://x-access-token:ghs_secretTOKEN@github.com/Sapiom-Platform/ag-uuid-1.git',
   expiresAt: '2026-07-07T01:00:00.000Z',
 };
 
@@ -134,7 +142,50 @@ describe('clone', () => {
     }
   });
 
-  it('rejects when neither templateId nor forkId is given', async () => {
+  it('clones by definitionId directly (no fork step), and pre-links sapiom.json', async () => {
+    const spy = mockFetch([{ status: 200, body: DEFINITION_TOKEN_BODY }]);
+    const base = makeTmp();
+    const target = path.join(base, 'project');
+    const rec = recordingClone();
+    try {
+      const result = await clone(
+        { definitionId: '253', targetDir: target, cloneRepo: rec.fn },
+        client,
+      );
+
+      // Hits the definitions clone-token endpoint directly — no fork call.
+      const urls = spy.mock.calls.map((c) => (c as [string])[0]);
+      expect(urls).toEqual(['https://example.com/v1/workflows/definitions/253/clone-token']);
+
+      expect(rec.calls).toHaveLength(1);
+      expect(rec.calls[0].cloneUrl).toBe(DEFINITION_TOKEN_BODY.cloneUrl);
+      expect(rec.calls[0].branch).toBe('main');
+
+      // Result carries the definitionId, no forkId/templateId, no credential.
+      expect(result).toMatchObject({
+        definitionId: '253',
+        repoFullName: 'Sapiom-Platform/ag-uuid-1',
+        defaultBranch: 'main',
+        targetDir: target,
+      });
+      expect(result.forkId).toBeUndefined();
+      expect(result.templateId).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('ghs_secretTOKEN');
+
+      // sapiom.json is pre-linked: definitionId present, no forkId, no token.
+      const cfg = JSON.parse(readFileSync(path.join(target, CONFIG_FILE), 'utf8'));
+      expect(cfg).toEqual({
+        repoFullName: 'Sapiom-Platform/ag-uuid-1',
+        defaultBranch: 'main',
+        definitionId: '253',
+      });
+      expect(JSON.stringify(cfg)).not.toContain('ghs_secretTOKEN');
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects when none of templateId, forkId, or definitionId is given', async () => {
     const spy = mockFetch([{ status: 200, body: {} }]);
     await expect(clone({ targetDir: '/tmp/whatever', cloneRepo: () => {} }, client)).rejects.toMatchObject({
       code: 'BAD_INPUT',
@@ -142,9 +193,21 @@ describe('clone', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('rejects when both templateId and forkId are given', async () => {
+  it('rejects when more than one of templateId, forkId, or definitionId is given', async () => {
     await expect(
       clone({ templateId: 't', forkId: 'f', targetDir: '/tmp/whatever', cloneRepo: () => {} }, client),
+    ).rejects.toMatchObject({ code: 'BAD_INPUT' });
+    await expect(
+      clone(
+        { templateId: 't', definitionId: '1', targetDir: '/tmp/whatever', cloneRepo: () => {} },
+        client,
+      ),
+    ).rejects.toMatchObject({ code: 'BAD_INPUT' });
+    await expect(
+      clone(
+        { forkId: 'f', definitionId: '1', targetDir: '/tmp/whatever', cloneRepo: () => {} },
+        client,
+      ),
     ).rejects.toMatchObject({ code: 'BAD_INPUT' });
   });
 

--- a/packages/agent-core/src/clone.ts
+++ b/packages/agent-core/src/clone.ts
@@ -1,21 +1,38 @@
 /**
- * clone — materialize a Sapiom workflow template as a local, deployable project
- * (SAP-1357). The client half of the template handoff (design D5, "MCP is the run
- * surface"): closes browse → fork → clone → deploy → run.
+ * clone — materialize a Sapiom workflow locally, either as a fresh template/fork
+ * checkout (SAP-1357) or by pulling an already-deployed workflow's live source by
+ * `definitionId` (SAP-1839). The client half of two handoffs that share one flow:
+ *   - templateId/forkId: browse → fork → clone → deploy → run.
+ *   - definitionId: an existing deployed workflow → clone its current build-repo
+ *     source → edit → redeploy, round-trip-consistently.
  *
- * Given a registry template id (forked here) or an existing fork id, this:
- *   1. forks the template into a per-fork repo the caller owns (if templateId),
- *   2. mints a short-lived, repo-scoped clone credential,
+ * Given exactly one of a registry template id, an existing fork id, or a deployed
+ * definition id, this:
+ *   1. forks the template into a per-fork repo the caller owns (templateId only),
+ *   2. mints a short-lived, repo-scoped clone credential — from the per-fork repo
+ *      (templateId/forkId) or the engine's live `ag-*` build repo (definitionId),
  *   3. `git clone`s the token-bearing URL into a local checkout,
- *   4. writes `sapiom.json` recording the fork provenance,
+ *   4. writes `sapiom.json` recording the provenance,
  * so the standard `link → deploy → run` lifecycle then operates on the checkout.
+ * The definitionId path writes `definitionId` directly, pre-linking the checkout
+ * so `link` is never required before the first `deploy`.
  *
- * No engine definition is created here — that happens at `deploy` (D6). A fork is
- * just seeded, cloneable source until then.
+ * No engine definition is created by the templateId/forkId path — that happens at
+ * `deploy` (D6). A fork is just seeded, cloneable source until then. The
+ * definitionId path is the opposite: the definition already exists, and cloning
+ * it never creates or changes one.
  *
  * Networked operation: requires a GatewayClient. Security: the minted clone URL
  * embeds a live credential and is treated as a secret — it is never returned,
  * logged, or written to `sapiom.json` (see git.ts `cloneRepo`).
+ *
+ * `definitionId` representation: the engine id is a bigint. The harness surfaces
+ * it as a `number` (`workspace-context.ts`); the rest of agent-core (`config.ts`,
+ * `link.ts`, `deploy.ts`, `types.ts`) uniformly treats definition ids as opaque
+ * `string`s to avoid float precision loss on large bigints. This module keeps
+ * that convention — `CloneOptions.definitionId` is a `string` — and callers that
+ * only have a `number` (e.g. the MCP tool, on behalf of the harness) normalize at
+ * that boundary with `String(definitionId)` before calling in.
  */
 import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import path from 'node:path';
@@ -33,7 +50,11 @@ interface ForkTemplateResponse {
   defaultBranch: string;
 }
 
-/** Response of `POST /v1/workflows/forks/:id/clone-token`. */
+/**
+ * Response of `POST /v1/workflows/forks/:id/clone-token` and
+ * `POST /v1/workflows/definitions/:id/clone-token` — identical shape
+ * (`CloneTokenResponseDto` on the backend).
+ */
 interface CloneTokenResponse {
   repoFullName: string;
   defaultBranch: string;
@@ -44,13 +65,23 @@ interface CloneTokenResponse {
 
 export interface CloneOptions {
   /**
-   * Registry template id to fork, then clone. Mutually exclusive with `forkId`:
-   * pass a template id to start from the gallery, or a fork id to re-clone an
-   * existing fork.
+   * Registry template id to fork, then clone. Mutually exclusive with `forkId`
+   * and `definitionId`: pass a template id to start from the gallery, a fork id
+   * to re-clone an existing fork, or a definitionId to pull a deployed
+   * workflow's live source.
    */
   templateId?: string;
   /** Existing fork id (`github_user_repos.id`) to clone — skips the fork step. */
   forkId?: string;
+  /**
+   * Deployed workflow's definition id (engine bigint, as a string — see the
+   * module docstring) to clone. Skips the fork step entirely and clones the
+   * engine's live `ag-*` build-repo source directly, so the checkout always
+   * matches what is actually deployed. Writes `definitionId` into `sapiom.json`,
+   * pre-linking the checkout (`link` is never required before the first
+   * `deploy`). Mutually exclusive with `templateId` and `forkId`.
+   */
+  definitionId?: string;
   /** Absolute path to clone into. Must not exist or must be empty. */
   targetDir: string;
   /**
@@ -61,11 +92,19 @@ export interface CloneOptions {
 }
 
 export interface CloneResult {
-  /** Fork record id — cache it to re-mint a clone token later. */
-  forkId: string;
+  /**
+   * Fork record id — cache it to re-mint a clone token later. Absent for a
+   * definitionId clone (there is no fork; re-mint against `definitionId` instead).
+   */
+  forkId?: string;
   /** Registry template id, when the fork was created from a template here. */
   templateId?: string;
-  /** Full repo name `owner/repo` of the per-fork repo. */
+  /**
+   * Deployed definition id, when cloned by `definitionId` — the checkout is
+   * already pre-linked (see {@link CloneOptions.definitionId}).
+   */
+  definitionId?: string;
+  /** Full repo name `owner/repo` of the cloned repo. */
   repoFullName: string;
   /** Default branch checked out. */
   defaultBranch: string;
@@ -82,20 +121,23 @@ export interface CloneResult {
  * failures (`HTTP_*`, `NETWORK`), or git failures (`GIT_CLONE`).
  */
 export async function clone(opts: CloneOptions, client: GatewayClient): Promise<CloneResult> {
-  const { templateId, forkId, targetDir } = opts;
+  const { templateId, forkId, definitionId, targetDir } = opts;
   const runClone = opts.cloneRepo ?? defaultCloneRepo;
 
-  if (!templateId && !forkId) {
+  const provided = [templateId, forkId, definitionId].filter((v) => v !== undefined).length;
+  if (provided === 0) {
     throw new AgentOperationError({
       code: 'BAD_INPUT',
-      message: 'Provide a templateId (to fork then clone) or a forkId (to clone an existing fork).',
+      message:
+        'Provide a templateId (to fork then clone), a forkId (to clone an existing fork), or a definitionId (to clone a deployed workflow).',
     });
   }
-  if (templateId && forkId) {
+  if (provided > 1) {
     throw new AgentOperationError({
       code: 'BAD_INPUT',
-      message: 'Provide only one of templateId or forkId, not both.',
-      hint: 'Use templateId to start from a gallery template, or forkId to re-clone an existing fork.',
+      message: 'Provide only one of templateId, forkId, or definitionId.',
+      hint:
+        'Use templateId to start from a gallery template, forkId to re-clone an existing fork, or definitionId to pull a deployed workflow local.',
     });
   }
 
@@ -109,8 +151,9 @@ export async function clone(opts: CloneOptions, client: GatewayClient): Promise<
     });
   }
 
-  // 1. Provision the per-fork repo (unless the caller already has a fork id).
-  let resolvedForkId = forkId ?? '';
+  // 1. Provision the per-fork repo (unless the caller already has a fork id, or
+  // is cloning by definitionId, which skips forking entirely).
+  let resolvedForkId = forkId;
   let resolvedTemplateId = templateId;
   if (templateId) {
     const fork = await client.post<ForkTemplateResponse>(
@@ -121,11 +164,17 @@ export async function clone(opts: CloneOptions, client: GatewayClient): Promise<
     resolvedTemplateId = fork.templateId;
   }
 
-  // 2. Mint a short-lived, repo-scoped clone credential.
-  const token = await client.post<CloneTokenResponse>(
-    `/forks/${encodeURIComponent(resolvedForkId)}/clone-token`,
-    {},
-  );
+  // 2. Mint a short-lived, repo-scoped clone credential — from the per-fork
+  // repo (templateId/forkId) or the engine's live build repo (definitionId).
+  const token = definitionId
+    ? await client.post<CloneTokenResponse>(
+        `/definitions/${encodeURIComponent(definitionId)}/clone-token`,
+        {},
+      )
+    : await client.post<CloneTokenResponse>(
+        `/forks/${encodeURIComponent(resolvedForkId as string)}/clone-token`,
+        {},
+      );
 
   // Defense in depth: the clone URL is handed to `git clone` as a positional
   // argument. `cloneRepo` already terminates option parsing with `--`, but also
@@ -149,16 +198,18 @@ export async function clone(opts: CloneOptions, client: GatewayClient): Promise<
     cwd: parent,
   });
 
-  // 4. Record the fork provenance so `link`/`deploy`/`run` know what this is.
+  // 4. Record the provenance so `link`/`deploy`/`run` know what this is. The
+  // definitionId path writes `definitionId` directly — the checkout is
+  // pre-linked, so a subsequent `link` is never required before `deploy`.
   writeConfig(targetDir, {
     repoFullName: token.repoFullName,
     defaultBranch: token.defaultBranch,
-    forkId: resolvedForkId,
+    ...(definitionId ? { definitionId } : { forkId: resolvedForkId as string }),
     ...(resolvedTemplateId ? { templateId: resolvedTemplateId } : {}),
   });
 
   return {
-    forkId: resolvedForkId,
+    ...(definitionId ? { definitionId } : { forkId: resolvedForkId as string }),
     ...(resolvedTemplateId ? { templateId: resolvedTemplateId } : {}),
     repoFullName: token.repoFullName,
     defaultBranch: token.defaultBranch,

--- a/packages/mcp/src/tools/agents.clone.test.ts
+++ b/packages/mcp/src/tools/agents.clone.test.ts
@@ -87,6 +87,7 @@ describe("sapiom_dev_agents_clone tool", () => {
       {
         templateId: "web-research-digest",
         forkId: undefined,
+        definitionId: undefined,
         targetDir: "/tmp/proj",
       },
       expect.anything(),
@@ -96,6 +97,37 @@ describe("sapiom_dev_agents_clone tool", () => {
     expect(out.hint).toContain("sapiom_dev_agents_link");
     // The credential must never surface in the tool output.
     expect(res.content[0].text).not.toContain("x-access-token");
+  });
+
+  it("clones by definitionId, normalizing a number input to a string, and hints no link needed", async () => {
+    vi.mocked(clone).mockResolvedValue({
+      definitionId: "253",
+      repoFullName: "Sapiom-Platform/ag-uuid-1",
+      defaultBranch: "main",
+      targetDir: "/tmp/proj",
+      tokenExpiresAt: "2026-07-07T01:00:00.000Z",
+    });
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_agents_clone")!({
+      dir: "/tmp/proj",
+      definitionId: 253,
+    });
+
+    expect(clone).toHaveBeenCalledWith(
+      {
+        templateId: undefined,
+        forkId: undefined,
+        definitionId: "253",
+        targetDir: "/tmp/proj",
+      },
+      expect.anything(),
+    );
+    const out = parse(res);
+    expect(out.definitionId).toBe("253");
+    expect(out.hint).toContain("no link needed");
+    expect(out.hint).not.toContain("sapiom_dev_agents_link");
   });
 
   it("returns a structured error when not authenticated", async () => {

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -348,9 +348,9 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     server,
     "sapiom_dev_agents_clone",
     [
-      "Materialize a Sapiom workflow template as a local project — the 'use this template' handoff. Given a template id (from the gallery) it forks the template into a repo you own; given an existing fork id it re-clones that fork. Either way it mints a short-lived, repo-scoped clone credential, git-clones the repo into <dir>, and writes sapiom.json recording the fork.",
-      "After cloning: read the project's AGENTS.md, then run sapiom_dev_agents_link (associate/create the tenant definition) → _deploy (creates the engine definition) → _run → _inspect. The clone appears under 'my workflows' in the dashboard immediately; the build shows once you deploy.",
-      "Pass exactly one of templateId or forkId. The clone credential is single-repo, read-only, and ~1h-lived — it is used for the clone and discarded (never stored in sapiom.json).",
+      "Materialize a Sapiom workflow locally. Given a template id (from the gallery) it forks the template into a repo you own; given an existing fork id it re-clones that fork; given a deployed workflow's definitionId it clones the engine's live build-repo source directly (no fork step, always current) and pre-links the checkout. Either way it mints a short-lived, repo-scoped clone credential, git-clones the repo into <dir>, and writes sapiom.json recording the provenance.",
+      "After cloning: read the project's AGENTS.md, then _deploy → _run → _inspect. Run sapiom_dev_agents_link first too, UNLESS you cloned by definitionId — that path already writes sapiom.json's definitionId, so the checkout is pre-linked and link would be redundant. The clone appears under 'my workflows' in the dashboard immediately; the build shows once you deploy.",
+      "Pass exactly one of templateId, forkId, or definitionId. The clone credential is single-repo, read-only, and ~1h-lived — it is used for the clone and discarded (never stored in sapiom.json).",
     ].join("\n"),
     {
       dir: z
@@ -363,27 +363,42 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         .string()
         .optional()
         .describe(
-          "Registry template id to fork then clone (e.g. 'web-research-digest'). Mutually exclusive with forkId.",
+          "Registry template id to fork then clone (e.g. 'web-research-digest'). Mutually exclusive with forkId and definitionId.",
         ),
       forkId: z
         .string()
         .optional()
         .describe(
-          "Existing fork id to clone (skips the fork step). Mutually exclusive with templateId.",
+          "Existing fork id to clone (skips the fork step). Mutually exclusive with templateId and definitionId.",
+        ),
+      definitionId: z
+        .union([z.string(), z.number()])
+        .optional()
+        .describe(
+          "Deployed workflow's definition id to pull local (e.g. from the dashboard URL or a prior link/deploy). Clones the engine's current build-repo source directly, skipping the fork step, and pre-links the checkout (sapiom.json is written with this id, so sapiom_dev_agents_link is not needed before deploy). Accepts a number or string — the engine id is a bigint. Mutually exclusive with templateId and forkId.",
         ),
     },
-    async ({ dir, templateId, forkId }) => {
+    async ({ dir, templateId, forkId, definitionId }) => {
       const client = await gatewayClient(env);
       if (!client) return NOT_AUTHED;
       try {
         const result = await clone(
-          { templateId, forkId, targetDir: dir },
+          {
+            templateId,
+            forkId,
+            // Normalize the harness's number-typed definitionId to agent-core's
+            // string convention at this boundary — see clone.ts's module
+            // docstring for the full drift note (SAP-1839).
+            definitionId:
+              definitionId === undefined ? undefined : String(definitionId),
+            targetDir: dir,
+          },
           client,
         );
-        return ok({
-          ...result,
-          hint: `Cloned into ${result.targetDir}. Next: read its AGENTS.md, then sapiom_dev_agents_link → _deploy → _run → _inspect.`,
-        });
+        const hint = result.definitionId
+          ? `Cloned into ${result.targetDir}. Already linked to definition ${result.definitionId} — read its AGENTS.md, then _deploy → _run → _inspect (no link needed).`
+          : `Cloned into ${result.targetDir}. Next: read its AGENTS.md, then sapiom_dev_agents_link → _deploy → _run → _inspect.`;
+        return ok({ ...result, hint });
       } catch (err) {
         return fail(err);
       }


### PR DESCRIPTION
## Summary
- Adds a `definitionId` clone path to `clone()` (agent-core) and the `sapiom_dev_agents_clone` MCP tool, alongside the existing `templateId`/`forkId` paths — exactly one of the three is required.
- Given `definitionId`, skips the fork step and clones the engine's live build-repo source directly via the new `POST /v1/workflows/definitions/:id/clone-token` endpoint, then writes `definitionId` into `sapiom.json` — pre-linking the checkout so `link` is never required before the first `deploy`.
- This is the client half of "pull a deployed workflow local by definitionId." The server contract is frozen by [#3536](https://github.com/sapiom/Sapiom/pull/3536) (SAP-1837, `apps/workflows-engine` + backend relay), which this PR depends on and does not modify.

## Type drift fix
- The harness represents `definitionId` as a `number`; the rest of agent-core (`config.ts`, `link.ts`, `deploy.ts`, `types.ts`) already treats definition ids as opaque `string`s (bigint-safe — avoids float precision loss).
- Kept `CloneOptions.definitionId: string` to match the existing agent-core convention, and normalized at the boundary: the MCP tool's `definitionId` input accepts `number | string` and converts to `String(definitionId)` before calling `clone()`. Documented the choice in `clone.ts`'s module docstring.

## Test plan
- `packages/agent-core/src/clone.spec.ts`: new tests — clones by `definitionId` directly (asserts the `/definitions/:id/clone-token` URL, no fork call), asserts `sapiom.json` is pre-linked (`definitionId` present, no `forkId`/token), and mutual-exclusivity rejections (none given, more than one of templateId/forkId/definitionId given).
- `packages/mcp/src/tools/agents.clone.test.ts`: new test — MCP tool clones by a numeric `definitionId` input, normalizes it to a string before calling `clone`, and returns a hint noting no `link` step is needed.
- Ran (this repo, off a fresh worktree on `main`): `pnpm build` (full monorepo, clean), `pnpm --filter @sapiom/agent-core test` (119/119 passed), `pnpm --filter @sapiom/mcp test` (71/71 passed), `pnpm --filter @sapiom/agent-core typecheck` (clean), `pnpm --filter @sapiom/mcp build` (clean).

Closes SAP-1839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YdWMzMYEiE8Te1fFsgJX6