### PR TITLE
feat(examples): Error / Log Triage Digest workflow template (SAP-1883)

### DIFF
--- a/examples/error-triage-digest/.gitignore
+++ b/examples/error-triage-digest/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/error-triage-digest/AGENTS.md
+++ b/examples/error-triage-digest/AGENTS.md
@@ -1,0 +1,46 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Error / Log Triage Digest** — authored against `@sapiom/agent`. It has four steps: `collect` (pause/pull the batch) → `triage` (calls `models.run`, the live LLM) → `dedupe` (calls `database`) → `digest` (emails the result). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.models.run(...)`, `ctx.sapiom.database.get(...)`, `ctx.sapiom.email.messages.send(...)`, `ctx.sapiom.vault.get(...)`).
+
+It combines two durability primitives with real fan-in: it can **pause at $0** for a pushed webhook batch (`pauseUntilSignal`) or run on a **cron** with a pulled batch, and it keeps a **Postgres dedup store** so a daily digest surfaces new issues instead of re-alerting on known ones.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **The pause is a static edge.** `collect` declares `pause: { signal: "errors.pushed", resumeStep: "triage" }` and returns `pauseUntilSignal({ signal, resumeStep, correlationId })` — the two must match. The resumed `triage` step's _input_ is the signal payload (`{ errors: [...] }`); everything else survives the suspend in `ctx.shared`.
+- **Keep the edges slim.** The raw error bodies are bounded (truncated, capped count) before the model sees them and don't linger in `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** `dedupe` skips the database and `digest` skips the send when `dryRun` is set (or no recipient resolves), returning the computed digest as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient is read from the vault (`ctx.sapiom.vault.get("error-triage-digest", "RECIPIENT")`) inside `digest`, not carried through `ctx.shared`.
+- **Fingerprint stability is the contract.** The model is asked to derive a fingerprint from an error's invariant parts and strip volatile bits, so the same recurring error keys the same row across runs. If dedup looks wrong, that prompt is the first place to look.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `models.run` / `database` / `email` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `dedupe` skips the (stubbed) DB and `digest` skips the (stubbed) send and returns the preview. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed LLM triage that writes to the dedup store and delivers the digest. Attach the `schedule` as a cron trigger, or push a batch with the `errors.pushed` signal.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`). To deliver into Sapiom **memory** instead — a searchable long-term store rather than an inbox — swap the send in `digest` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: deliverTo ?? "error-triage-digest",
+  metadata: { newCount, recurringCount },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipient, so you can drop the vault lookup — or keep it to override the scope.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The dedup timestamp is captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `last_seen`.

--- a/examples/error-triage-digest/README.md
+++ b/examples/error-triage-digest/README.md
@@ -1,0 +1,73 @@
+# Error / Log Triage Digest
+
+Ingest a stream of errors, cluster and summarize them with an LLM, dedupe against
+a database so you only hear about what's new, and email a daily digest. The
+scheduled-or-pushed, deduped sibling of a plain alert forwarder.
+
+## What it does
+
+```
+collect  ──▶  triage  ──▶  dedupe  ──▶  digest  (terminal)
+(pause/pull)   (models.run)  (database)   (email)
+```
+
+1. **collect** — gathers the error batch. It takes one directly as `errors`, GETs
+   one from a `pullUrl`, or — with `webhook: true` and no batch yet — **pauses at
+   $0** via `pauseUntilSignal` until your pipeline pushes one as the
+   `errors.pushed` signal. No polling loop, no billed idle.
+2. **triage** — hands the raw errors to an LLM (`ctx.sapiom.models.run` — the
+   live x402-served model) to cluster them into a handful of distinct issues,
+   each with a **stable fingerprint** (volatile ids, timestamps, and line numbers
+   stripped), a title, a severity, and an occurrence count.
+3. **dedupe** — looks each fingerprint up in a Postgres table the digest owns
+   (`ctx.sapiom.database`). Never-seen fingerprints are **new**; the rest are
+   **recurring**, with their running totals updated. This is what stops a daily
+   digest from re-alerting on the same known error every morning.
+4. **digest** — writes a markdown digest (new issues first, recurring below) and
+   emails it. A `dryRun` computes the digest but skips the DB writes and the real
+   send; the recipient is read from the Sapiom vault at runtime, never persisted.
+
+Input: `{ "errors": [{ "message": "...", "level": "error", "service": "checkout" }], "deliverTo": "you@example.com", "schedule": "0 8 * * *" }`.
+
+- `errors` (or `pullUrl`, or the `errors.pushed` webhook) supplies the batch.
+- `deliverTo` sets the recipient; omit it to use the vault-configured default.
+- `dryRun: true` returns the digest as a preview without writing or sending.
+
+### Two ways in
+
+- **Scheduled pull** — attach `schedule` as a cron trigger; the run pulls a batch
+  from `pullUrl` (or is handed one directly) and digests it.
+- **Webhook push** — run with `webhook: true`; the run suspends until your
+  pipeline pushes a batch with the `errors.pushed` signal, then resumes and
+  digests it.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` so the DB and delivery are skipped, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed LLM triage that writes to the dedup store and delivers the
+   digest).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the
+   deployed agent. To push errors in instead, run with `webhook: true` and fire
+   the `errors.pushed` signal with the `workflow_signal` MCP tool, passing
+   `{ "errors": [ ... ] }`.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/error-triage-digest/index.ts
+++ b/examples/error-triage-digest/index.ts
@@ -1,0 +1,580 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Error / Log Triage Digest — turn a noisy stream of errors into one daily
+ * digest that separates what's new from what you already know about.
+ *
+ * It ingests a batch of errors two ways, from the same entry step:
+ *   - **Scheduled pull** — a cron-triggered run passes the batch in as `errors`,
+ *     or hands it a `pullUrl` to GET the batch from your log store.
+ *   - **Webhook push** — with `webhook: true` and no batch yet, the run
+ *     **suspends at $0** via `pauseUntilSignal` until your error pipeline pushes
+ *     a batch as the `errors.pushed` signal. No polling loop, no billed idle.
+ *
+ * Then, in one legible graph:
+ *   collect ──▶ triage (models.run) ──▶ dedupe (database) ──▶ digest (email)
+ *
+ *   - **triage** hands the raw errors to an LLM (`ctx.sapiom.models.run` — the
+ *     live x402-served model) to cluster them into a handful of issues, each
+ *     with a stable `fingerprint`, a title, a severity, and an occurrence count.
+ *   - **dedupe** looks each fingerprint up in a Postgres table the digest owns.
+ *     Clusters it has never seen are **new**; the rest are **recurring**, and it
+ *     updates their running totals and last-seen time. This is what stops the
+ *     digest from re-alerting on the same known error every single day.
+ *   - **digest** writes a markdown digest — new issues first, recurring below —
+ *     and emails it. A `dryRun` (or a run with no recipient) returns the digest
+ *     as a preview without sending, so `run_local` traces the whole graph for
+ *     free (capabilities stubbed, DB and delivery skipped).
+ *
+ * Determinism: each step body runs once on the happy path (again only on retry).
+ * Non-deterministic values — the dedup timestamp — are captured once at the DB
+ * boundary via Postgres `now()`, not recomputed per row.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the digest owns — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "error-triage-digest";
+/** Vault ref holding delivery config (e.g. a default RECIPIENT). Read at runtime. */
+const DELIVERY_VAULT_REF = "error-triage-digest";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "error-triage";
+/** The named signal an external error pipeline fires to push a batch in. */
+const SIGNAL = "errors.pushed";
+/** Cap the batch handed to the model so cost + latency stay bounded. */
+const MAX_ERRORS = 200;
+/** Cap each error message the model sees — stacks can be enormous. */
+const MAX_MESSAGE_CHARS = 800;
+/** Default cadence documented for the cron trigger: 08:00 every day. */
+const DEFAULT_SCHEDULE = "0 8 * * *";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** A raw error/log entry. Open-ended — a real source returns what it returns. */
+interface RawError {
+  /** The error message or log line. The only field we require. */
+  message: string;
+  /** Severity as the source labels it, e.g. "error" / "warning". */
+  level?: string;
+  /** Which service/component emitted it. */
+  service?: string;
+  /** Stack trace, if any. Truncated before the model sees it. */
+  stack?: string;
+  /** When it happened (ISO). */
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+interface EntryInput {
+  /** The error batch to triage (the "scheduled pull" / direct path). */
+  errors?: RawError[];
+  /** Optional URL to GET the batch from (JSON array, or `{ errors: [] }`). */
+  pullUrl?: string;
+  /** Wait for a webhook to push the batch instead of pulling one. */
+  webhook?: boolean;
+  /** Cron cadence this digest is meant to run on (documentation only). */
+  schedule?: string;
+  /** Postgres handle for the dedup store; defaults to the template handle. */
+  dbHandle?: string;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Compute the digest but skip the DB writes and the real send. */
+  dryRun?: boolean;
+}
+
+/** A batch of errors — the shape that crosses collect → triage, either path. */
+interface Batch {
+  errors: RawError[];
+}
+
+/** One clustered issue as the model returns it. */
+interface Cluster {
+  /** Stable key for dedup — same recurring issue must yield the same value. */
+  fingerprint: string;
+  title: string;
+  summary: string;
+  severity: "critical" | "high" | "medium" | "low";
+  /** A representative raw message for the issue. */
+  sampleMessage: string;
+  /** Occurrences of this issue in THIS batch. */
+  count: number;
+}
+
+/** A recurring cluster enriched with what the DB already knew about it. */
+interface RecurringCluster extends Cluster {
+  /** When this fingerprint was first seen, across all prior runs (ISO). */
+  firstSeen: string;
+  /** Total occurrences recorded before this batch. */
+  priorTotal: number;
+}
+
+interface Shared extends Record<string, unknown> {
+  dbHandle: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  schedule: string;
+  batchSize: number;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Normalize + bound a raw batch so downstream cost stays predictable. */
+function normalizeErrors(raw: unknown): RawError[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((e): e is RawError => Boolean(e) && typeof e === "object")
+    .map((e) => {
+      const message = String(
+        (e as RawError).message ?? (e as { msg?: unknown }).msg ?? "",
+      ).trim();
+      return { ...(e as RawError), message } as RawError;
+    })
+    .filter((e) => e.message.length > 0)
+    .slice(0, MAX_ERRORS);
+}
+
+/** GET a batch from a log store. Accepts a bare array or `{ errors: [] }`. */
+async function pullErrors(url: string): Promise<RawError[]> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`pull failed: HTTP ${res.status}`);
+  const body = (await res.json()) as unknown;
+  const arr = Array.isArray(body)
+    ? body
+    : ((body as { errors?: unknown }).errors ?? []);
+  return normalizeErrors(arr);
+}
+
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (returns null), not an error — the caller then falls back to
+ * a preview. Never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Error Triage Digest",
+  });
+  return inbox.inboxId;
+}
+
+/** Open a Postgres client for a live run, or null in dryRun / when unavailable. */
+async function openSql(ctx: Ctx, handle: string): Promise<Sql | null> {
+  let db;
+  try {
+    db = await ctx.sapiom.database.get(handle);
+  } catch {
+    db = await ctx.sapiom.database.create({
+      handle,
+      duration: "7d",
+      name: "Error Triage Digest",
+      description: "Seen-error fingerprints + running counts for the digest",
+    });
+  }
+  // `db` may be a stub (undefined) under run_local — stay null-safe and degrade.
+  const conn = db?.connection?.connectionString ?? null;
+  if (!conn) {
+    ctx.logger.warn("database: no connection string", { handle });
+    return null;
+  }
+  return postgres(conn, { ssl: "require" });
+}
+
+async function initSchema(sql: Sql): Promise<void> {
+  await sql`
+    create table if not exists error_clusters (
+      fingerprint     text primary key,
+      title           text,
+      severity        text,
+      first_seen      timestamptz not null default now(),
+      last_seen       timestamptz not null default now(),
+      total_count     bigint not null default 0,
+      times_reported  bigint not null default 0
+    )`;
+}
+
+/** ISO-string a value the pg driver may hand back as a Date or a string. */
+function toIso(v: unknown): string {
+  if (v instanceof Date) return v.toISOString();
+  return String(v ?? "");
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const collect = defineStep({
+  name: "collect",
+  next: ["triage"],
+  // Static graph edge: on SIGNAL, resume at `triage`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "triage" },
+  async run(input: EntryInput, ctx: Ctx) {
+    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", truthy(input.dryRun));
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+
+    let errors = normalizeErrors(input.errors);
+
+    // Nothing passed in, but a pull URL is configured: fetch the batch now
+    // (the "scheduled pull" path a cron trigger would take).
+    if (errors.length === 0 && input.pullUrl && !truthy(input.dryRun)) {
+      try {
+        errors = await pullErrors(input.pullUrl.trim());
+        ctx.logger.info("pulled error batch", { count: errors.length });
+      } catch (err) {
+        ctx.logger.warn("pull failed; continuing with empty batch", {
+          err: String(err),
+        });
+      }
+    }
+
+    // Still nothing and asked to wait: suspend at $0 until the pipeline pushes a
+    // batch. The resumed `triage` step's input IS the signal payload.
+    if (errors.length === 0 && truthy(input.webhook)) {
+      ctx.shared.set("batchSize", 0);
+      ctx.logger.info("no batch yet; pausing for the errors.pushed signal", {
+        correlationId: ctx.executionId,
+      });
+      return pauseUntilSignal({
+        signal: SIGNAL,
+        resumeStep: "triage",
+        correlationId: ctx.executionId,
+      });
+    }
+
+    ctx.shared.set("batchSize", errors.length);
+    return goto("triage", { errors });
+  },
+});
+
+const triage = defineStep({
+  name: "triage",
+  next: ["dedupe"],
+  // `input` is either collect's goto payload or the resumed signal payload.
+  async run(input: Batch, ctx: Ctx) {
+    const errors = normalizeErrors(input?.errors);
+    ctx.shared.set("batchSize", errors.length);
+
+    if (errors.length === 0) {
+      ctx.logger.info("empty batch; nothing to cluster");
+      return goto("dedupe", { clusters: [] as Cluster[] });
+    }
+
+    const rendered = errors
+      .map((e, i) => {
+        const head = [e.level, e.service].filter(Boolean).join("/");
+        const body = `${e.message}${e.stack ? `\n${e.stack}` : ""}`.slice(
+          0,
+          MAX_MESSAGE_CHARS,
+        );
+        return `[${i + 1}]${head ? ` (${head})` : ""} ${body}`;
+      })
+      .join("\n\n");
+
+    const system =
+      "You are an on-call engineer triaging a batch of error/log entries. " +
+      "Group them into a small set of distinct issues (usually 1-8). For each " +
+      "issue produce a STABLE fingerprint: a short lowercase slug derived from " +
+      "the error's invariant parts (error type, module, message template) with " +
+      "volatile bits — ids, timestamps, hostnames, line numbers — stripped, so " +
+      "the same recurring issue always yields the same fingerprint. Rank by " +
+      'severity. Reply with ONLY minified JSON: {"clusters":[{"fingerprint":' +
+      'string,"title":string,"summary":string,"severity":"critical|high|medium|' +
+      'low","sampleMessage":string,"count":number}]}.';
+    const prompt = `ERROR BATCH (${errors.length} entries):\n${rendered}`;
+
+    const res = await ctx.sapiom.models.run({ system, prompt, maxTokens: 900 });
+    const clusters = parseClusters(res.output, errors);
+    ctx.logger.info("triaged batch into clusters", {
+      errors: errors.length,
+      clusters: clusters.length,
+    });
+    return goto("dedupe", { clusters });
+  },
+});
+
+const dedupe = defineStep({
+  name: "dedupe",
+  next: ["digest"],
+  async run(input: { clusters: Cluster[] }, ctx: Ctx) {
+    const clusters = Array.isArray(input?.clusters) ? input.clusters : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const handle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+
+    // Dry run (or run_local's stubbed DB): treat everything as new so the graph
+    // traces end to end without touching a real database.
+    if (dryRun || clusters.length === 0) {
+      ctx.logger.info("skipping dedup store", {
+        dryRun,
+        clusters: clusters.length,
+      });
+      return goto("digest", {
+        newClusters: clusters,
+        recurringClusters: [] as RecurringCluster[],
+      });
+    }
+
+    const sql = await openSql(ctx, handle);
+    if (!sql) {
+      // No DB available — degrade to "everything new" rather than abort.
+      return goto("digest", {
+        newClusters: clusters,
+        recurringClusters: [] as RecurringCluster[],
+      });
+    }
+
+    try {
+      await initSchema(sql);
+      const newClusters: Cluster[] = [];
+      const recurringClusters: RecurringCluster[] = [];
+
+      for (const c of clusters) {
+        const prior = await sql<
+          { first_seen: unknown; total_count: string }[]
+        >`select first_seen, total_count from error_clusters
+            where fingerprint = ${c.fingerprint}`;
+        if (prior.length === 0) {
+          newClusters.push(c);
+        } else {
+          recurringClusters.push({
+            ...c,
+            firstSeen: toIso(prior[0].first_seen),
+            priorTotal: Number(prior[0].total_count),
+          });
+        }
+        // Upsert running state — server-side now() keeps last_seen deterministic
+        // regardless of retries.
+        await sql`
+          insert into error_clusters
+            (fingerprint, title, severity, total_count, times_reported)
+          values
+            (${c.fingerprint}, ${c.title}, ${c.severity}, ${c.count}, 1)
+          on conflict (fingerprint) do update set
+            title          = excluded.title,
+            severity       = excluded.severity,
+            last_seen      = now(),
+            total_count    = error_clusters.total_count + ${c.count},
+            times_reported = error_clusters.times_reported + 1`;
+      }
+
+      ctx.logger.info("deduped clusters", {
+        new: newClusters.length,
+        recurring: recurringClusters.length,
+      });
+      return goto("digest", { newClusters, recurringClusters });
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  },
+});
+
+const digest = defineStep({
+  name: "digest",
+  next: [],
+  terminal: true,
+  async run(
+    input: { newClusters: Cluster[]; recurringClusters: RecurringCluster[] },
+    ctx: Ctx,
+  ) {
+    const newClusters = Array.isArray(input?.newClusters)
+      ? input.newClusters
+      : [];
+    const recurringClusters = Array.isArray(input?.recurringClusters)
+      ? input.recurringClusters
+      : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const batchSize = ctx.shared.get("batchSize") ?? 0;
+    const total = newClusters.length + recurringClusters.length;
+
+    const body = renderDigest(newClusters, recurringClusters, batchSize);
+    const subject =
+      total === 0
+        ? "Error triage digest: all clear"
+        : `Error triage digest: ${newClusters.length} new, ${recurringClusters.length} recurring`;
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // Safe path: a dry run, or a live run with no recipient, returns the digest
+    // without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        digest: body,
+        newCount: newClusters.length,
+        recurringCount: recurringClusters.length,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: body,
+    });
+    ctx.logger.info("digest delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      messageId: sent.messageId,
+      newCount: newClusters.length,
+      recurringCount: recurringClusters.length,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── render ──
+const SEVERITY_ORDER: Record<Cluster["severity"], number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function bySeverity(a: Cluster, b: Cluster): number {
+  return SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+}
+
+function renderCluster(c: Cluster, extra = ""): string {
+  return (
+    `- **[${c.severity}] ${c.title}** — ${c.summary} ` +
+    `(${c.count} this batch${extra})\n  \`${c.sampleMessage.slice(0, 200)}\``
+  );
+}
+
+function renderDigest(
+  newClusters: Cluster[],
+  recurringClusters: RecurringCluster[],
+  batchSize: number,
+): string {
+  if (newClusters.length === 0 && recurringClusters.length === 0) {
+    return `# Error triage digest\n\nNo errors in this batch — all clear.`;
+  }
+  const lines = [
+    `# Error triage digest`,
+    ``,
+    `Triaged **${batchSize}** entries into ` +
+      `**${newClusters.length}** new and **${recurringClusters.length}** recurring issue(s).`,
+    ``,
+  ];
+  lines.push(`## 🔴 New issues (${newClusters.length})`);
+  lines.push(
+    newClusters.length === 0
+      ? `_None — nothing here we haven't already seen._`
+      : [...newClusters]
+          .sort(bySeverity)
+          .map((c) => renderCluster(c))
+          .join("\n"),
+  );
+  lines.push(``);
+  lines.push(`## 🔁 Recurring issues (${recurringClusters.length})`);
+  lines.push(
+    recurringClusters.length === 0
+      ? `_None._`
+      : [...recurringClusters]
+          .sort(bySeverity)
+          .map((c) =>
+            renderCluster(
+              c,
+              `, ${c.priorTotal + c.count} total, first seen ${c.firstSeen.slice(0, 10)}`,
+            ),
+          )
+          .join("\n"),
+  );
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** Extract clusters from the model output; fall back to one catch-all cluster. */
+function parseClusters(output: string | null, errors: RawError[]): Cluster[] {
+  const fallback = (): Cluster[] => [
+    {
+      fingerprint: "untriaged-batch",
+      title: "Untriaged errors",
+      summary: "The model returned no usable clustering for this batch.",
+      severity: "medium",
+      sampleMessage: errors[0]?.message ?? "",
+      count: errors.length,
+    },
+  ];
+  if (!output) return fallback();
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback();
+    const parsed = JSON.parse(output.slice(start, end + 1)) as {
+      clusters?: unknown;
+    };
+    if (!Array.isArray(parsed.clusters)) return fallback();
+    const clusters = parsed.clusters
+      .map(coerceCluster)
+      .filter((c): c is Cluster => c !== null);
+    return clusters.length > 0 ? clusters : fallback();
+  } catch {
+    return fallback();
+  }
+}
+
+function coerceCluster(raw: unknown): Cluster | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const fingerprint = String(r.fingerprint ?? "").trim();
+  const title = String(r.title ?? "").trim();
+  if (!fingerprint || !title) return null;
+  const severity = (["critical", "high", "medium", "low"] as const).includes(
+    r.severity as Cluster["severity"],
+  )
+    ? (r.severity as Cluster["severity"])
+    : "medium";
+  const count = Number(r.count);
+  return {
+    fingerprint,
+    title,
+    summary: String(r.summary ?? "").trim(),
+    severity,
+    sampleMessage: String(r.sampleMessage ?? "").trim(),
+    count: Number.isFinite(count) && count > 0 ? Math.floor(count) : 1,
+  };
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "error-triage-digest",
+  entry: "collect",
+  steps: { collect, triage, dedupe, digest },
+});

--- a/examples/error-triage-digest/package.json
+++ b/examples/error-triage-digest/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-error-triage-digest",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: ingest errors via webhook or a scheduled pull, cluster + summarize them with an LLM (models.run), dedupe against a Postgres store, and email a daily digest.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/error-triage-digest/template.json
+++ b/examples/error-triage-digest/template.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You point it at your errors and it turns the noise into one readable digest. It takes them either way: a cron-triggered run hands it a batch (or a URL to pull one from), or you set `webhook: true` and it waits for your error pipeline to push a batch in.\n\nThe graph is four steps. `collect` gathers the batch — and when it's told to wait for a webhook, it pauses and costs nothing until one arrives. `triage` (`models.run`, the live x402-served model) clusters the raw entries into a handful of distinct issues, each with a stable fingerprint that strips out volatile bits like ids and line numbers, so the same recurring error always lands on the same key. `dedupe` looks each fingerprint up in a small Postgres store the digest owns: ones it has never seen are new, the rest are recurring, and it updates their running totals. `digest` writes the markdown — new issues first, recurring below — and emails it.\n\nThe dedup store is the point. Without it, a daily digest re-alerts on the same known error every morning; with it, new problems stand out and the familiar ones fade into a counted summary. A `dryRun` computes the digest and returns it without touching the database or sending mail, so you can trace the whole flow for free before it writes or delivers anything.\n\nYou pay for the model reasoning on each run and a small database footprint — the waiting is free, and the emails are cheap.",
+  "useCases": [
+    "Wake up to one triaged digest of overnight errors instead of a thousand raw alerts.",
+    "Surface only genuinely new failures — let recurring, already-known errors collapse into a counted summary.",
+    "Ingest errors either way: push them in from a webhook, or pull a batch on a schedule."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nFeed it a batch as `errors` (an array of `{ message, level?, service?, stack? }`), or a `pullUrl` it GETs the batch from on each run. Set who gets the digest with `deliverTo`, or store a default under the `error-triage-digest` vault ref (key `RECIPIENT`) — it's read at runtime, never saved into the run. Pass `dryRun: true` to compute the digest and get it back without writing to the database or sending mail. To run it daily, attach the `schedule` as a cron trigger on the deployed workflow.\n\nThis template can also **pause and wait for a webhook**: run it with `webhook: true` and no batch, and it suspends at $0 until your pipeline pushes one. Send the batch with the MCP `workflow_signal` tool (or the API) using the signal name `errors.pushed` and a payload of `{ \"errors\": [ ... ] }` — there is no one-click signal button yet.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole collect → triage → dedupe → digest flow for free (capabilities stubbed, database and delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Triage a small batch, preview only (dry run)",
+      "input": {
+        "dryRun": true,
+        "errors": [
+          {
+            "message": "TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42",
+            "level": "error",
+            "service": "checkout"
+          },
+          {
+            "message": "TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42",
+            "level": "error",
+            "service": "checkout"
+          },
+          {
+            "message": "Timeout after 30000ms calling payments.charge",
+            "level": "error",
+            "service": "payments"
+          }
+        ]
+      },
+      "output": {
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "Error triage digest: 2 new, 0 recurring",
+        "newCount": 2,
+        "recurringCount": 0,
+        "digest": "# Error triage digest\n\nTriaged **3** entries into **2** new and **0** recurring issue(s).\n\n## 🔴 New issues (2)\n- **[high] Undefined read in checkout** — Reading `id` off an undefined object in checkout.js. (2 this batch)\n  `TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42`\n- **[medium] Payment charge timeout** — payments.charge exceeds its 30s timeout. (1 this batch)\n  `Timeout after 30000ms calling payments.charge`\n\n## 🔁 Recurring issues (0)\n_None._"
+      }
+    }
+  ]
+}

--- a/examples/error-triage-digest/tsconfig.json
+++ b/examples/error-triage-digest/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,45 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "error-triage-digest",
+      "name": "Error / Log Triage Digest",
+      "description": "Ingest errors by webhook or a scheduled pull, cluster and summarize them with an LLM, dedupe against a database, and email a daily digest.",
+      "tags": ["errors", "triage", "digest", "dedupe", "scheduled"],
+      "sourcePath": "examples/error-triage-digest",
+      "capabilities": [
+        "models.run",
+        "database.get",
+        "database.create",
+        "email.send"
+      ],
+      "whatItDoes": "For turning a noisy error stream into one digest that tells you what's actually new. It takes a batch of errors two ways from the same entry: a cron-triggered run pulls one in (or is handed one), or with `webhook: true` it pauses at $0 until your pipeline pushes one as the `errors.pushed` signal. An LLM (`models.run`) clusters the raw entries into a handful of issues, each with a stable fingerprint that strips out volatile ids and line numbers. It looks each fingerprint up in a Postgres store it owns (`database`): unseen ones are new, the rest are recurring with their running totals updated — so the daily digest surfaces new problems instead of re-alerting on known ones. Then it emails a markdown digest, new issues first. A dryRun computes the digest without touching the database or sending mail.",
+      "steps": [
+        {
+          "name": "collect",
+          "description": "Gather the error batch — take it directly, GET it from a pull URL, or pause at $0 until a webhook pushes one via the errors.pushed signal.",
+          "next": ["triage"]
+        },
+        {
+          "name": "triage",
+          "description": "Hand the raw errors to an LLM to cluster them into distinct issues, each with a stable fingerprint, a severity, and an occurrence count.",
+          "capability": "models.run",
+          "next": ["dedupe"]
+        },
+        {
+          "name": "dedupe",
+          "description": "Look each fingerprint up in a Postgres store: never-seen ones are new, the rest are recurring, and their running totals are updated. Skipped on a dry run.",
+          "capability": "database.get",
+          "next": ["digest"]
+        },
+        {
+          "name": "digest",
+          "description": "Write a markdown digest — new issues first, recurring below — and email it. A dry run, or a run with no recipient, returns it without sending.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What & why

Adds the **Error / Log Triage Digest** onboarding template to the gallery. Part of SAP-1823 (grow the onboarding gallery to 8+ templates); this is the **Developer / SRE** persona entry.

It's the only template so far that composes all four of the ticket's capabilities in one legible graph — **Cron / pauseUntilSignal + LLM + Database + Email** — and shows the durable-pause and dedup patterns together.

## What it does

```
collect  ──▶  triage  ──▶  dedupe  ──▶  digest  (terminal)
(pause/pull)   (models.run)  (database)   (email)
```

- **collect** — takes the error batch directly (`errors`), GETs it from a `pullUrl`, or — with `webhook: true` and no batch — **pauses at \$0** via `pauseUntilSignal` until the pipeline pushes one as the `errors.pushed` signal.
- **triage** — an LLM (`models.run`) clusters raw errors into distinct issues, each with a **stable fingerprint** (volatile ids / line numbers stripped), a severity, and a count.
- **dedupe** — looks each fingerprint up in a Postgres store it owns (`database`): unseen → new, otherwise recurring with running totals updated. This is what stops a daily digest from re-alerting on the same known error every morning.
- **digest** — writes a markdown digest (new first, recurring below) and emails it. Terminal.

A `dryRun` computes the digest without touching the database or sending mail, so `run_local` traces the whole graph for free.

## Files

- `examples/error-triage-digest/` — `index.ts`, `package.json`, `tsconfig.json`, `template.json`, `README.md`, `AGENTS.md`, `.gitignore`
- `examples/registry.json` — new gallery entry

## Patterns followed

- Mirrors the merged siblings **scheduled-research-brief** (SAP-1827: cron + `models.run` + email, `dryRun` guard, vault-at-runtime recipient), **wait-for-webhook** (SAP-1829: static `pause` edge + `pauseUntilSignal`), and **the-brain** (SAP-1825: `ctx.sapiom.database` + `postgres`).
- SDK pins `@sapiom/agent ^0.6.5` / `@sapiom/tools ^0.20.0` / `postgres ^3.4.5` (database + vault caps need ≥0.20).
- `registry.json` `capabilities` list exactly the `ctx.sapiom.*` ids the source calls (`models.run`, `database.get`, `database.create`, `email.send`).

## Verification

- `npm install && npm run typecheck` — clean
- `npx prettier --check "**/*.ts"` and md/json — clean
- `registry.json` + `template.json` parse as valid JSON

Closes SAP-1883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTG53baMTJoBg9NsiZXKrq