### PR TITLE
feat(harness): formalize the intelligence spine — streaming contract + named-workflow dispatcher (SAP-1807)

### DIFF
--- a/packages/harness/src/core/assistant-messages.test.ts
+++ b/packages/harness/src/core/assistant-messages.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  describeStep,
+  errorMessage,
+  toolCall,
+  toolResult,
+  turnCompleted,
+  turnDelta,
+  turnStarted,
+} from "./assistant-messages.js";
+import type { StepView } from "../shared/types.js";
+
+function step(overrides: Partial<StepView> = {}): StepView {
+  return { id: "s0", name: "enrich", status: "running", ...overrides };
+}
+
+describe("assistant-messages — pure shaping", () => {
+  it("toolCall carries the tool name and input verbatim", () => {
+    expect(toolCall("d1", "explain-agent", { agentId: "a1" })).toEqual({
+      type: "assistant.tool_call",
+      dispatchId: "d1",
+      tool: "explain-agent",
+      input: { agentId: "a1" },
+    });
+  });
+
+  it("turnStarted omits text when none is given (a streamed turn)", () => {
+    expect(turnStarted("d1", "t1", "assistant")).toEqual({
+      type: "assistant.turn",
+      dispatchId: "d1",
+      turnId: "t1",
+      frame: { kind: "started", role: "assistant" },
+    });
+  });
+
+  it("turnStarted seeds text when a whole turn arrives", () => {
+    expect(turnStarted("d1", "t1", "user", "hi")).toEqual({
+      type: "assistant.turn",
+      dispatchId: "d1",
+      turnId: "t1",
+      frame: { kind: "started", role: "user", text: "hi" },
+    });
+  });
+
+  it("turnDelta appends text under the same turn id", () => {
+    expect(turnDelta("d1", "t1", "more")).toEqual({
+      type: "assistant.turn",
+      dispatchId: "d1",
+      turnId: "t1",
+      frame: { kind: "delta", text: "more" },
+    });
+  });
+
+  it("turnCompleted closes the turn", () => {
+    expect(turnCompleted("d1", "t1")).toEqual({
+      type: "assistant.turn",
+      dispatchId: "d1",
+      turnId: "t1",
+      frame: { kind: "completed" },
+    });
+  });
+
+  it("toolResult threads executionId + status when observed", () => {
+    expect(
+      toolResult("d1", "explain-agent", {
+        ok: true,
+        executionId: "exec_1",
+        status: "completed",
+      }),
+    ).toEqual({
+      type: "assistant.tool_result",
+      dispatchId: "d1",
+      tool: "explain-agent",
+      ok: true,
+      executionId: "exec_1",
+      status: "completed",
+    });
+  });
+
+  it("toolResult omits executionId/status on a start failure (honest absence)", () => {
+    const message = toolResult("d1", "explain-agent", { ok: false });
+    expect(message).toEqual({
+      type: "assistant.tool_result",
+      dispatchId: "d1",
+      tool: "explain-agent",
+      ok: false,
+    });
+    // Not present at all — never a fake id or a null placeholder.
+    expect("executionId" in message).toBe(false);
+    expect("status" in message).toBe(false);
+  });
+
+  it("errorMessage carries the reason", () => {
+    expect(errorMessage("d1", "boom")).toEqual({
+      type: "assistant.error",
+      dispatchId: "d1",
+      error: "boom",
+    });
+  });
+
+  describe("describeStep", () => {
+    it("narrates each status honestly from the StepView", () => {
+      expect(describeStep(step({ status: "pending" }))).toBe("enrich: queued\n");
+      expect(describeStep(step({ status: "running" }))).toBe("enrich: running…\n");
+      expect(describeStep(step({ status: "passed" }))).toBe("enrich: done\n");
+    });
+
+    it("includes a recorded error on a failed step", () => {
+      expect(describeStep(step({ status: "failed", error: "timeout" }))).toBe(
+        "enrich: failed — timeout\n",
+      );
+    });
+
+    it("omits the dash when a failed step recorded no error", () => {
+      expect(describeStep(step({ status: "failed" }))).toBe("enrich: failed\n");
+    });
+  });
+});

--- a/packages/harness/src/core/assistant-messages.ts
+++ b/packages/harness/src/core/assistant-messages.ts
@@ -1,0 +1,136 @@
+/**
+ * assistant-messages — the pure message-shaping half of the intelligence spine
+ * (SAP-1807).
+ *
+ * The dispatcher (./tool-dispatcher.ts) owns the I/O: it runs a named Sapiom
+ * workflow on our account and forwards frames onto the event bus. This module
+ * owns the SHAPE of what it forwards — a set of clock-free, I/O-free builders
+ * that turn dispatch state into the typed `assistant.*` {@link BusMessage}
+ * variants. Keeping the shaping pure means the wire contract can be unit-tested
+ * on its own (assistant-messages.test.ts), the same tier as the SPA's other
+ * pure logic, and the dispatcher's own test only has to prove it calls these in
+ * the right order with the right arguments.
+ *
+ * Honest by construction: `toolResult` omits `executionId`/`status` when the
+ * cloud run never materialized rather than emitting a fake id or a `$0`-style
+ * placeholder, matching the run viewer's honest-absence invariant.
+ */
+
+import type {
+  AssistantTurnRole,
+  BusMessage,
+  RunView,
+  StepView,
+} from "../shared/types.js";
+
+/** `assistant.tool_call` — the assistant is invoking `tool` with `input`. */
+export function toolCall(
+  dispatchId: string,
+  tool: string,
+  input: Record<string, unknown>,
+): BusMessage {
+  return { type: "assistant.tool_call", dispatchId, tool, input };
+}
+
+/** `assistant.turn` opening frame — seeds a turn (optionally whole, via `text`). */
+export function turnStarted(
+  dispatchId: string,
+  turnId: string,
+  role: AssistantTurnRole,
+  text?: string,
+): BusMessage {
+  return {
+    type: "assistant.turn",
+    dispatchId,
+    turnId,
+    frame: text === undefined ? { kind: "started", role } : { kind: "started", role, text },
+  };
+}
+
+/** `assistant.turn` delta — appends `text` to the open turn. */
+export function turnDelta(
+  dispatchId: string,
+  turnId: string,
+  text: string,
+): BusMessage {
+  return {
+    type: "assistant.turn",
+    dispatchId,
+    turnId,
+    frame: { kind: "delta", text },
+  };
+}
+
+/** `assistant.turn` closing frame — the turn is done streaming. */
+export function turnCompleted(dispatchId: string, turnId: string): BusMessage {
+  return {
+    type: "assistant.turn",
+    dispatchId,
+    turnId,
+    frame: { kind: "completed" },
+  };
+}
+
+/** Outcome of a dispatch, folded into `assistant.tool_result`. */
+export interface ToolOutcome {
+  ok: boolean;
+  /** Present only once the cloud run materialized; omitted otherwise. */
+  executionId?: string;
+  /** Terminal run status; omitted when the run never materialized. */
+  status?: RunView["status"];
+}
+
+/**
+ * `assistant.tool_result` — the tool run's terminal outcome. `executionId` and
+ * `status` are threaded through only when observed (honest absence): a dispatch
+ * that failed before enqueue carries neither.
+ */
+export function toolResult(
+  dispatchId: string,
+  tool: string,
+  outcome: ToolOutcome,
+): BusMessage {
+  const message: Extract<BusMessage, { type: "assistant.tool_result" }> = {
+    type: "assistant.tool_result",
+    dispatchId,
+    tool,
+    ok: outcome.ok,
+  };
+  if (outcome.executionId !== undefined) message.executionId = outcome.executionId;
+  if (outcome.status !== undefined) message.status = outcome.status;
+  return message;
+}
+
+/** `assistant.error` — the dispatch could not complete; the app degrades. */
+export function errorMessage(dispatchId: string, error: string): BusMessage {
+  return { type: "assistant.error", dispatchId, error };
+}
+
+/**
+ * A concise, factual one-line reflection of a step transition, used as the text
+ * of a streamed assistant-turn delta. Derived entirely from the observed
+ * {@link StepView} — never fabricated prose — so the assistant's live turn is an
+ * honest narration of what the workflow is actually doing:
+ *
+ *   pending  → `enrich: queued`
+ *   running  → `enrich: running…`
+ *   passed   → `enrich: done`
+ *   failed   → `enrich: failed — <error>` (only when the step recorded one)
+ *
+ * A trailing newline keeps successive deltas on their own lines in the pane's
+ * Markdown render.
+ */
+export function describeStep(step: StepView): string {
+  switch (step.status) {
+    case "pending":
+      return `${step.name}: queued\n`;
+    case "running":
+      return `${step.name}: running…\n`;
+    case "passed":
+      return `${step.name}: done\n`;
+    case "failed":
+      return step.error
+        ? `${step.name}: failed — ${step.error}\n`
+        : `${step.name}: failed\n`;
+  }
+}

--- a/packages/harness/src/core/tool-dispatcher.test.ts
+++ b/packages/harness/src/core/tool-dispatcher.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  createToolDispatcher,
+  createToolRegistry,
+  type ToolRegistry,
+} from "./tool-dispatcher.js";
+import type { SpineClient, SpineRunResult } from "./spine-client.js";
+import type { BusMessage, StepView } from "../shared/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Collects every published BusMessage for order/shape assertions. */
+function fakeBus(): { publish: (m: BusMessage) => void; messages: BusMessage[] } {
+  const messages: BusMessage[] = [];
+  return { publish: (m) => messages.push(m), messages };
+}
+
+interface FakeClientScript {
+  /** Frames to replay via onFrame before resolving. */
+  frames?: StepView[];
+  /** The terminal result run() resolves with. */
+  result: SpineRunResult;
+  /** When set, run() rejects with this instead of resolving. */
+  throwWith?: Error;
+}
+
+/** A SpineClient that replays a fixed script and records how it was called. */
+function fakeClient(
+  script: FakeClientScript,
+): { client: SpineClient; calls: () => { definitionId: string; input: unknown }[] } {
+  const calls: { definitionId: string; input: unknown }[] = [];
+  const client: SpineClient = {
+    async run(definitionId, input, handlers) {
+      calls.push({ definitionId, input });
+      if (script.throwWith) throw script.throwWith;
+      for (const step of script.frames ?? []) handlers?.onFrame?.({ step });
+      return script.result;
+    },
+  };
+  return { client, calls: () => calls };
+}
+
+const REGISTRY: ToolRegistry = createToolRegistry([
+  { name: "explain-agent", definitionId: "def_explain" },
+  { name: "debug-step", definitionId: "def_debug" },
+]);
+
+const ids = () => {
+  let d = 0;
+  let t = 0;
+  return {
+    generateDispatchId: () => `d${++d}`,
+    generateTurnId: () => `t${++t}`,
+  };
+};
+
+function step(overrides: Partial<StepView> = {}): StepView {
+  return { id: "s0", name: "explain", status: "passed", ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createToolRegistry", () => {
+  it("rejects duplicate tool names", () => {
+    expect(() =>
+      createToolRegistry([
+        { name: "dup", definitionId: "a" },
+        { name: "dup", definitionId: "b" },
+      ]),
+    ).toThrow(/duplicate tool name/);
+  });
+});
+
+describe("createToolDispatcher", () => {
+  it("resolves a named tool to its workflow and streams the full exchange", async () => {
+    const bus = fakeBus();
+    const { client, calls } = fakeClient({
+      frames: [step({ name: "explain", status: "running" }), step({ name: "explain", status: "passed" })],
+      result: { ok: true, executionId: "exec_1", status: "completed" },
+    });
+
+    const dispatcher = createToolDispatcher({
+      registry: REGISTRY,
+      bus,
+      spineClient: client,
+      ...ids(),
+    });
+
+    const result = await dispatcher.dispatch("explain-agent", { agentId: "a1" });
+
+    // Named tool → the registry's definition id, with input forwarded.
+    expect(calls()).toEqual([{ definitionId: "def_explain", input: { agentId: "a1" } }]);
+    expect(result).toEqual({
+      ok: true,
+      dispatchId: "d1",
+      executionId: "exec_1",
+      status: "completed",
+    });
+
+    // Exact wire sequence: call → turn open → one delta per frame → turn close → result.
+    expect(bus.messages).toEqual([
+      { type: "assistant.tool_call", dispatchId: "d1", tool: "explain-agent", input: { agentId: "a1" } },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "started", role: "assistant" } },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "delta", text: "explain: running…\n" } },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "delta", text: "explain: done\n" } },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "completed" } },
+      { type: "assistant.tool_result", dispatchId: "d1", tool: "explain-agent", ok: true, executionId: "exec_1", status: "completed" },
+    ]);
+  });
+
+  it("defaults input to an empty object when none is given", async () => {
+    const bus = fakeBus();
+    const { client, calls } = fakeClient({
+      result: { ok: true, executionId: "exec_1", status: "completed" },
+    });
+    const dispatcher = createToolDispatcher({ registry: REGISTRY, bus, spineClient: client, ...ids() });
+
+    await dispatcher.dispatch("debug-step");
+
+    expect(calls()).toEqual([{ definitionId: "def_debug", input: {} }]);
+  });
+
+  it("degrades on an unknown tool without calling the spine", async () => {
+    const bus = fakeBus();
+    const { client, calls } = fakeClient({
+      result: { ok: true, executionId: "exec_1", status: "completed" },
+    });
+    const dispatcher = createToolDispatcher({ registry: REGISTRY, bus, spineClient: client, ...ids() });
+
+    const result = await dispatcher.dispatch("nope");
+
+    expect(calls()).toEqual([]); // never touched the workflow
+    expect(result).toEqual({ ok: false, dispatchId: "d1", error: 'unknown tool: "nope"' });
+    // Only an error turn — no tool_call/result for a call that never happened.
+    expect(bus.messages).toEqual([
+      { type: "assistant.error", dispatchId: "d1", error: 'unknown tool: "nope"' },
+    ]);
+  });
+
+  it("surfaces a run failure as an error turn and a failed result", async () => {
+    const bus = fakeBus();
+    const { client } = fakeClient({
+      result: { ok: false, status: 502, error: "gateway responded 500" },
+    });
+    const dispatcher = createToolDispatcher({ registry: REGISTRY, bus, spineClient: client, ...ids() });
+
+    const result = await dispatcher.dispatch("explain-agent");
+
+    expect(result).toEqual({ ok: false, dispatchId: "d1", error: "gateway responded 500" });
+    expect(bus.messages).toEqual([
+      { type: "assistant.tool_call", dispatchId: "d1", tool: "explain-agent", input: {} },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "started", role: "assistant" } },
+      // The open turn is closed so the pane never hangs on a streaming caret.
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "completed" } },
+      { type: "assistant.error", dispatchId: "d1", error: "gateway responded 500" },
+      // tool_result omits executionId/status — the run never materialized.
+      { type: "assistant.tool_result", dispatchId: "d1", tool: "explain-agent", ok: false },
+    ]);
+  });
+
+  it("treats a signed-out spine (503) as a graceful error, not a crash", async () => {
+    const bus = fakeBus();
+    const { client } = fakeClient({
+      result: { ok: false, status: 503, error: "harness is not signed in to Sapiom" },
+    });
+    const dispatcher = createToolDispatcher({ registry: REGISTRY, bus, spineClient: client, ...ids() });
+
+    const result = await dispatcher.dispatch("explain-agent");
+
+    expect(result.ok).toBe(false);
+    expect(bus.messages.at(-2)).toEqual({
+      type: "assistant.error",
+      dispatchId: "d1",
+      error: "harness is not signed in to Sapiom",
+    });
+  });
+
+  it("never throws even if the spine client rejects unexpectedly", async () => {
+    const bus = fakeBus();
+    const { client } = fakeClient({
+      result: { ok: true, executionId: "exec_1", status: "completed" },
+      throwWith: new Error("kaboom"),
+    });
+    const dispatcher = createToolDispatcher({ registry: REGISTRY, bus, spineClient: client, ...ids() });
+
+    const result = await dispatcher.dispatch("explain-agent");
+
+    expect(result).toEqual({ ok: false, dispatchId: "d1", error: "kaboom" });
+    expect(bus.messages).toEqual([
+      { type: "assistant.tool_call", dispatchId: "d1", tool: "explain-agent", input: {} },
+      { type: "assistant.turn", dispatchId: "d1", turnId: "t1", frame: { kind: "started", role: "assistant" } },
+      { type: "assistant.error", dispatchId: "d1", error: "kaboom" },
+      { type: "assistant.tool_result", dispatchId: "d1", tool: "explain-agent", ok: false },
+    ]);
+  });
+
+  it("lets a renderFrame override shape the streamed turn text", async () => {
+    const bus = fakeBus();
+    const { client } = fakeClient({
+      frames: [step({ name: "explain", status: "passed" })],
+      result: { ok: true, executionId: "exec_1", status: "completed" },
+    });
+    const dispatcher = createToolDispatcher({
+      registry: REGISTRY,
+      bus,
+      spineClient: client,
+      renderFrame: (s) => `<<${s.name}>>`,
+      ...ids(),
+    });
+
+    await dispatcher.dispatch("explain-agent");
+
+    const deltas = bus.messages.filter(
+      (m): m is Extract<BusMessage, { type: "assistant.turn" }> =>
+        m.type === "assistant.turn" && m.frame.kind === "delta",
+    );
+    expect(deltas.map((m) => (m.frame.kind === "delta" ? m.frame.text : ""))).toEqual(["<<explain>>"]);
+  });
+});

--- a/packages/harness/src/core/tool-dispatcher.ts
+++ b/packages/harness/src/core/tool-dispatcher.ts
@@ -1,0 +1,182 @@
+/**
+ * tool-dispatcher — the named-workflow dispatcher of the intelligence spine
+ * (SAP-1807), generalizing the S1 spike (SAP-1804).
+ *
+ * The Studio Assistant's tools ARE Sapiom workflows we author/deploy/run on our
+ * account (§2 of the app-experience design). Where the spike ran ONE hardcoded
+ * workflow id, this dispatcher maps a NAMED tool (`explain-agent`, `debug-step`,
+ * …) to its deployed workflow and runs it via the {@link SpineClient} — still
+ * on our account, still metered by us, never the user's Claude Code tokens.
+ *
+ * It shapes the run's lifecycle into the typed `assistant.*` bus contract:
+ *   - one `assistant.tool_call` when a known tool is invoked,
+ *   - one `assistant.turn` (started → deltas → completed) narrating the run,
+ *   - one `assistant.tool_result` with the terminal outcome,
+ *   - an `assistant.error` on any failure.
+ * All message SHAPING lives in ./assistant-messages.ts (pure, unit-tested);
+ * this file owns only the ordering and the I/O (running the workflow, publishing
+ * to the bus).
+ *
+ * Graceful degradation is the load-bearing invariant: `dispatch` NEVER throws
+ * and never rejects. An unknown tool, a signed-out harness, an upstream failure,
+ * or even an unexpected bug all resolve to an error turn on the bus and a typed
+ * `{ ok: false }` result — the spine can degrade, but it can never crash or lock
+ * the Studio.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { EventBus } from "./event-bus.js";
+import type { SpineClient } from "./spine-client.js";
+import type { RunView, StepView } from "../shared/types.js";
+import {
+  describeStep,
+  errorMessage,
+  toolCall,
+  toolResult,
+  turnCompleted,
+  turnDelta,
+  turnStarted,
+} from "./assistant-messages.js";
+
+/** A named Assistant tool bound to the Sapiom workflow that backs it. */
+export interface ToolDefinition {
+  /** The name the assistant / UI dispatches by (e.g. "explain-agent"). */
+  name: string;
+  /** The deployed workflow definition id it runs on our account. */
+  definitionId: string;
+}
+
+/** Tool lookup by name. Built with {@link createToolRegistry}. */
+export type ToolRegistry = ReadonlyMap<string, ToolDefinition>;
+
+/**
+ * Build a name→definition registry, rejecting duplicate names so a
+ * misconfigured tool set fails loudly at wiring time rather than silently
+ * shadowing one tool with another.
+ */
+export function createToolRegistry(
+  definitions: readonly ToolDefinition[],
+): ToolRegistry {
+  const registry = new Map<string, ToolDefinition>();
+  for (const definition of definitions) {
+    if (registry.has(definition.name)) {
+      throw new Error(`duplicate tool name in registry: "${definition.name}"`);
+    }
+    registry.set(definition.name, definition);
+  }
+  return registry;
+}
+
+/** Terminal outcome of a dispatch. Mirrors the `assistant.tool_result` shape. */
+export type DispatchResult =
+  | { ok: true; dispatchId: string; executionId: string; status: RunView["status"] }
+  | { ok: false; dispatchId: string; error: string };
+
+export interface ToolDispatcherOpts {
+  /** The tools this dispatcher can run, keyed by name. */
+  registry: ToolRegistry;
+  /** The bus every `assistant.*` message is published onto (forwarded to /ws/events). */
+  bus: Pick<EventBus, "publish">;
+  /**
+   * The spine client that runs a workflow on our account. Injected (built once
+   * at the wiring site from the held api key) so the dispatcher owns no
+   * credentials and tests can drive it with a fake client.
+   */
+  spineClient: SpineClient;
+  /**
+   * Render a step transition into the text of a streamed turn delta. Defaults to
+   * {@link describeStep} (an honest progress narration). The extension point for
+   * S5: a tool whose value is textual output can swap in a renderer that surfaces
+   * the workflow's own output instead of step progress.
+   */
+  renderFrame?: (step: StepView) => string;
+  /** Dispatch-correlation id generator; defaults to crypto.randomUUID. Test seam. */
+  generateDispatchId?: () => string;
+  /** Turn id generator; defaults to crypto.randomUUID. Test seam. */
+  generateTurnId?: () => string;
+}
+
+export interface ToolDispatcher {
+  /**
+   * Run the named `tool` with `input` on our account, streaming the exchange
+   * over the bus. Resolves with the terminal {@link DispatchResult} once
+   * streaming ends. Never throws.
+   */
+  dispatch(tool: string, input?: Record<string, unknown>): Promise<DispatchResult>;
+}
+
+/**
+ * Create a tool dispatcher. See the module header for the lifecycle and the
+ * graceful-degradation invariant.
+ */
+export function createToolDispatcher(opts: ToolDispatcherOpts): ToolDispatcher {
+  const {
+    registry,
+    bus,
+    spineClient,
+    renderFrame = describeStep,
+    generateDispatchId = randomUUID,
+    generateTurnId = randomUUID,
+  } = opts;
+
+  return {
+    async dispatch(tool, input = {}): Promise<DispatchResult> {
+      const dispatchId = generateDispatchId();
+
+      // Unknown tool: nothing was called, so emit only an error turn (no
+      // tool_call / tool_result for a call that never happened) and degrade.
+      const definition = registry.get(tool);
+      if (!definition) {
+        const error = `unknown tool: "${tool}"`;
+        bus.publish(errorMessage(dispatchId, error));
+        return { ok: false, dispatchId, error };
+      }
+
+      // Everything past here is guarded: the spine client is non-throwing, but a
+      // renderFrame override or a bus listener could still throw, and the spine
+      // must never surface as an unhandled rejection that locks the Studio.
+      try {
+        bus.publish(toolCall(dispatchId, tool, input));
+
+        const turnId = generateTurnId();
+        bus.publish(turnStarted(dispatchId, turnId, "assistant"));
+
+        const result = await spineClient.run(definition.definitionId, input, {
+          onFrame: (frame) => {
+            bus.publish(turnDelta(dispatchId, turnId, renderFrame(frame.step)));
+          },
+        });
+
+        // Close the open turn either way so the pane never hangs on a streaming
+        // caret, then report the terminal outcome.
+        bus.publish(turnCompleted(dispatchId, turnId));
+
+        if (result.ok) {
+          bus.publish(
+            toolResult(dispatchId, tool, {
+              ok: true,
+              executionId: result.executionId,
+              status: result.status,
+            }),
+          );
+          return {
+            ok: true,
+            dispatchId,
+            executionId: result.executionId,
+            status: result.status,
+          };
+        }
+
+        bus.publish(errorMessage(dispatchId, result.error));
+        bus.publish(toolResult(dispatchId, tool, { ok: false }));
+        return { ok: false, dispatchId, error: result.error };
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : "tool dispatch failed";
+        bus.publish(errorMessage(dispatchId, error));
+        bus.publish(toolResult(dispatchId, tool, { ok: false }));
+        return { ok: false, dispatchId, error };
+      }
+    },
+  };
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -412,7 +412,79 @@ export type BusMessage =
       status: RunView["status"];
     }
   /** The run could not be started or streamed (auth, upstream, or decode). */
-  | { type: "spine.error"; spineRunId: string; error: string };
+  | { type: "spine.error"; spineRunId: string; error: string }
+  // -------------------------------------------------------------------------
+  // Assistant streaming contract (SAP-1807) — the formalized layer over the
+  // spine spike. The Assistant's tools ARE named Sapiom workflows; dispatching
+  // one runs it ON OUR ACCOUNT and streams the exchange over this bus. Where
+  // `spine.*` carries a raw run's step transitions, `assistant.*` carries the
+  // conversation the pane renders: a tool call, the assistant turn it streams,
+  // its terminal result, and graceful errors. `dispatchId` correlates every
+  // message of one dispatch and — like `spineRunId` — is minted BEFORE the
+  // cloud run exists, so a start failure still routes to the right listener.
+  // The contract S4 (pane) and S5 (tool wiring) build against.
+  // -------------------------------------------------------------------------
+  /**
+   * The assistant is invoking a named tool (a Sapiom workflow) with `input`.
+   * Emitted once per dispatch, before the run is enqueued.
+   */
+  | {
+      type: "assistant.tool_call";
+      dispatchId: string;
+      tool: string;
+      input: Record<string, unknown>;
+    }
+  /**
+   * One incremental frame of an assistant turn, scoped by `turnId` within the
+   * dispatch. Folds onto the pane's turn reducer with no translation (see
+   * {@link AssistantTurnFrame}).
+   */
+  | {
+      type: "assistant.turn";
+      dispatchId: string;
+      turnId: string;
+      frame: AssistantTurnFrame;
+    }
+  /**
+   * The tool run reached a terminal state. `ok` is the dispatch outcome;
+   * `executionId`/`status` are present once the cloud run materialized (absent
+   * on a start failure — honest absence, never a fake id).
+   */
+  | {
+      type: "assistant.tool_result";
+      dispatchId: string;
+      tool: string;
+      ok: boolean;
+      executionId?: string;
+      status?: RunView["status"];
+    }
+  /**
+   * The dispatch could not complete (unknown tool, not signed in, upstream, or
+   * decode). The app surfaces it as an error turn and stays usable — the spine
+   * never blocks the Studio.
+   */
+  | { type: "assistant.error"; dispatchId: string; error: string };
+
+// ---------------------------------------------------------------------------
+// Assistant streaming contract — turn shape (see BusMessage assistant.* above)
+// ---------------------------------------------------------------------------
+
+/** Who authored an assistant-conversation turn. `user` is the person;
+ *  `assistant` is the Sapiom-run helper. */
+export type AssistantTurnRole = "user" | "assistant";
+
+/**
+ * One incremental frame of an assistant turn. A turn opens with `started`,
+ * grows via zero or more `delta`s, and closes with `completed`. Deliberately
+ * mirrors the pane's turn reducer (`web/src/lib/assistant-stream.ts`) so a bus
+ * turn folds onto the rendered conversation with a source change only — the
+ * `turnId` on the bus message is that reducer's join `id`, and `started`'s
+ * `text` seeds a turn that arrives whole (e.g. the user's own prompt).
+ */
+export type AssistantTurnFrame =
+  | { kind: "started"; role: AssistantTurnRole; text?: string }
+  | { kind: "delta"; text: string }
+  | { kind: "completed" };
 
 // ---------------------------------------------------------------------------
 // Intelligence spine — streamed frame shape (see BusMessage spine.* above)


### PR DESCRIPTION
## What & why

Closes **SAP-1807** — formalize the intelligence spine into the contract S4 (pane) and S5 (tool wiring) build against. Generalizes the S1 spike (SAP-1804, #337): the spike ran **one hardcoded workflow id** and streamed raw `spine.*` step frames; this adds the **named-workflow dispatcher**, the **assistant streaming contract**, and **graceful degradation**.

Design: `plans/sapiom-studio/modules/app-experience/design.md` §1–2 · interfaces: `plans/sapiom-studio/interfaces.md` (Intelligence spine). Runs still happen **on our account** via the held server-side key — never the user's Claude Code tokens.

## Changes

- **`shared/types.ts`** — typed bus contract: `assistant.tool_call` · `assistant.turn` · `assistant.tool_result` · `assistant.error`, plus `AssistantTurnRole` / `AssistantTurnFrame`. The turn frame mirrors the pane's turn reducer (`web/src/lib/assistant-stream.ts`) so it folds onto the rendered conversation with a source change only. `dispatchId` correlates a dispatch and is minted before the cloud run exists (a start failure still routes). Forwarded to `/ws/events` automatically — the bus has no allowlist.
- **`core/assistant-messages.ts`** — pure, clock-free message-shaping: builders for the four variants + an honest `describeStep` progress narrator. `tool_result` omits `executionId`/`status` when the run never materialized (honest absence — no fake id).
- **`core/tool-dispatcher.ts`** — `createToolRegistry` (name→definitionId, rejects dups) + `createToolDispatcher`: resolves a **named** tool, runs its workflow via the injected spine client, and shapes the lifecycle onto the bus (`tool_call → turn started → deltas → turn completed → tool_result`). `dispatch()` **never throws** — unknown tool, signed-out harness, upstream failure, or an unexpected bug all degrade to an error turn + a typed `{ ok: false }`. `renderFrame` is an injectable seam so S5 can surface real workflow output.

## Acceptance criteria

- [x] A named Sapiom workflow runs on our account and streams via the formalized service with typed bus messages.
- [x] Failures degrade gracefully (error turn, no crash/lock).
- [x] Dispatcher + pure message-shaping unit-tested.

## Testing

- `assistant-messages.test.ts` (11) — every builder, honest-absence, all `describeStep` branches.
- `tool-dispatcher.test.ts` (8) — resolve+stream, empty-input default, unknown tool (spine untouched), run failure, signed-out (503), never-throws on reject, `renderFrame` override.
- `pnpm build && pnpm typecheck && pnpm lint` clean; full harness suite green (**1073 tests**).

## Scope notes

Adds the spine **service + contract** only (ticket's Files/Areas: `core/` + `shared/types.ts`). Populating the registry with real deployed tools and mounting a dispatch route is **S5 (SAP-1808)**; the pane consuming this contract is **S4 (SAP-1806)**. `event-bus.ts` needs no change — it's already generic over `BusMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)