### PR TITLE
feat(examples): scheduled compliance audit + attestation workflow template (SAP-1878)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,55 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "scheduled-compliance-audit",
+      "name": "Scheduled Compliance Audit + Attestation",
+      "description": "On a schedule, it audits your resources against a policy, waits for a person to sign off, then archives the signed attestation.",
+      "tags": ["compliance", "scheduled", "human-in-the-loop", "attestation"],
+      "sourcePath": "examples/scheduled-compliance-audit",
+      "capabilities": [
+        "web.scrape",
+        "models.run",
+        "fileStorage.upload",
+        "fileStorage.getDownloadUrl"
+      ],
+      "whatItDoes": "For a recurring policy audit you need a signed record of. On each tick it reads the current state of the resources you point it at — a config page, a status endpoint, a policy doc — and hands that state and your policy to an LLM (models.run) that returns an overall verdict plus one check per requirement, with evidence and a fix for each failure. Then it pauses and waits for a person to sign off, costing nothing while idle. Only an explicit approval archives the signed attestation to durable file storage (fileStorage) and hands back a download link — because an attestation records that a human reviewed and approved, it is never filed automatically. Decline and the findings come back, but nothing is archived. A dryRun flag returns the whole attestation as a preview without archiving.",
+      "steps": [
+        {
+          "name": "collect",
+          "description": "Read the current state of each resource with a scrape, keeping the error as missing evidence when a page won't load.",
+          "capability": "web.scrape",
+          "next": ["audit"]
+        },
+        {
+          "name": "audit",
+          "description": "Hand the collected state and your policy to an LLM to produce a verdict and one evidence-cited check per requirement.",
+          "capability": "models.run",
+          "next": ["review"]
+        },
+        {
+          "name": "review",
+          "description": "Pause and wait for a human sign-off signal, costing nothing while idle (resumes at 'onSignoff').",
+          "next": ["onSignoff"]
+        },
+        {
+          "name": "onSignoff",
+          "description": "Read the sign-off reply: an explicit approve archives the attestation, anything else backs out with nothing filed.",
+          "next": ["archive", "rejected"]
+        },
+        {
+          "name": "archive",
+          "description": "Write the signed attestation to durable file storage and return its file id and download link; a dry run skips the upload.",
+          "capability": "fileStorage.upload",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "Sign-off was declined — return the audit findings, having archived nothing.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/scheduled-compliance-audit/.gitignore
+++ b/examples/scheduled-compliance-audit/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/scheduled-compliance-audit/AGENTS.md
+++ b/examples/scheduled-compliance-audit/AGENTS.md
@@ -1,0 +1,83 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Scheduled
+Compliance Audit + Attestation** — authored against `@sapiom/agent`. It has six
+steps: `collect` (calls `web.scrape`) → `audit` (calls `models.run`, the live
+LLM) → `review` (pauses on the `attestation.signoff` signal) → `onSignoff`
+(reads the decision) → `archive` (calls `fileStorage.upload`) or `rejected`.
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g.
+`ctx.sapiom.search.scrape(...)`, `ctx.sapiom.models.run(...)`,
+`ctx.sapiom.fileStorage.upload(...)`).
+
+It composes the scheduled-collect-and-curate shape of `scheduled-research-brief`
+with the pause-for-a-human gate of `human-in-the-loop`. The gate here protects
+the **attestation archive**: nothing is filed until a person explicitly signs off.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **The durable pause is a primitive, not a capability.** `review` declares a
+  static `pause: { signal, resumeStep }` edge AND returns
+  `pauseUntilSignal({ signal, resumeStep, correlationId: ctx.executionId })`. The
+  resume target (`onSignoff`) receives the signal payload as its `run` input.
+- **Gate real side effects behind `dryRun`.** `archive` uploads the attestation
+  only on a live run with `dryRun` off; otherwise it returns the computed
+  attestation as a preview. The upload's presigned PUT is a raw `fetch` (not a
+  stubbed capability), so it MUST stay behind this guard or it would hit the
+  network during `run_local`.
+- **Safe by default on resume.** Only an explicit `approve` archives; a resume
+  with no decision (what `run_local` sends) takes the `rejected` branch. This is
+  deliberate — an attestation asserts a human reviewed and signed off, so it is
+  never filed without one.
+- **Keep the edges slim.** The scraped bodies are the only large data; they stay
+  bounded (truncated, capped count) and die at the `audit` boundary — they never
+  enter `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full
+  local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so
+  `web.scrape` / `models.run` / `fileStorage.upload` return built-in defaults and
+  the agent runs end-to-end offline for free. The pause is auto-resumed with no
+  decision, so the offline trace lands on `rejected`; pass `dryRun: true` so
+  `archive` would skip the (stubbed) upload if you drive the approve path with a
+  real signal. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed collect + policy
+  check that pauses for sign-off. Fire the `attestation.signoff` signal to resume
+  (see `README.md`). Attach the `schedule` as a cron trigger to run it on a cadence.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities), not the other way around — never weaken or drop real
+> logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Collection channel: scrape vs. sandbox
+
+This template collects state over the network with `web.scrape` — the simplest
+way to read a config page, a status endpoint, or a published policy doc. To audit
+state that only exists inside a running environment — files on disk, a service's
+live config, a command's output — swap the scrape in `collect` for a sandbox
+attach + exec, e.g. `ctx.sapiom.sandboxes.attach(id)` then run a read-only command
+and capture stdout as the collected evidence. Keep the same per-item
+degrade-on-failure loop and the `MAX_BODY_CHARS` bound so a body never lands in
+shared state.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). The audit timestamp is captured once in `collect` and carried forward via
+`ctx.shared` rather than recomputed downstream — do the same for any id or clock
+value a later step depends on.

--- a/examples/scheduled-compliance-audit/README.md
+++ b/examples/scheduled-compliance-audit/README.md
@@ -1,0 +1,105 @@
+# Scheduled Compliance Audit + Attestation
+
+On a cron cadence, collect the current state of your resources, check it against
+your policy with an LLM, **pause for a human sign-off**, and — only once a person
+approves — archive the signed attestation as a durable file.
+
+Nothing is filed until a human signs off: an attestation is a record that a
+person reviewed and approved, so it is never archived automatically.
+
+## What it does
+
+```
+collect ──▶ audit ─(pause: attestation.signoff, $0 while idle)─▶ onSignoff
+(web.scrape)  (models.run)                                          │
+                                             reject ◀────────────────┼─▶ approve
+                                               │                      ▼
+                                           rejected (terminal)   archive (fileStorage, terminal)
+```
+
+1. **collect** — reads each resource's current state with
+   `ctx.sapiom.search.scrape` (a config page, a status endpoint, a policy doc),
+   degrading per-item on failure. Bodies are truncated and stay bounded — they
+   never enter shared state.
+2. **audit** — hands the collected state and your `policy` to an LLM
+   (`ctx.sapiom.models.run` — the live x402-served model) to produce a structured
+   report: an overall verdict plus one check per requirement, each with evidence
+   and a remediation for failures.
+3. **review** — `pauseUntilSignal({ signal: "attestation.signoff", resumeStep: "onSignoff" })`.
+   The run suspends here at $0 until a person signs off.
+4. **onSignoff** (resume target) — its **input is the sign-off payload**. Only an
+   explicit `{ "decision": "approve" }` proceeds to `archive`; anything else takes
+   the safe `rejected` branch, and nothing is archived.
+5. **archive** — writes the signed attestation to `ctx.sapiom.fileStorage` and
+   returns its `fileId` and a download URL. A `dryRun` guard computes the
+   attestation and returns it as a preview without uploading anything.
+
+Input:
+
+```json
+{
+  "resources": [
+    { "id": "api-config", "url": "https://example.com/security.txt", "label": "API security policy" },
+    { "id": "status", "url": "https://example.com/status", "label": "Service status" }
+  ],
+  "policy": "All services must publish a security contact and enforce TLS. Status page must show 99.9% uptime.",
+  "schedule": "0 6 * * 1",
+  "framework": "SOC 2 CC6",
+  "signOffBy": "compliance@example.com"
+}
+```
+
+- `resources` and `policy` are the two knobs — what to audit, and the rules to
+  audit it against.
+- `schedule` is the cron cadence; `framework` and `signOffBy` are recorded in the
+  attestation.
+- `dryRun: true` returns the attestation as a preview without archiving anything.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed, the pause auto-resumed, free — pass `dryRun: true` so `archive` skips
+   the upload) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real, billed collect + policy check that pauses for
+   sign-off).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the
+   deployed agent.
+
+## Resuming a paused run in dev
+
+A real `run` pauses at `review`. Instead of a real approver, fire the sign-off
+signal yourself via the MCP `workflow_signal` / `signal_workflow` tool. The
+`correlationId` is the paused run's `executionId`, and the `payload` becomes
+`onSignoff`'s input.
+
+**Approve** (resumes `onSignoff` → `archive`):
+
+```json
+{
+  "signal": "attestation.signoff",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve", "signer": "compliance@example.com" }
+}
+```
+
+Send `{ "decision": "reject" }` instead to see the safe `rejected` path, where
+the audit findings come back but nothing is archived.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/scheduled-compliance-audit/index.ts
+++ b/examples/scheduled-compliance-audit/index.ts
@@ -1,0 +1,566 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Scheduled Compliance Audit + Attestation — the recurring "prove we're still
+ * compliant" pattern.
+ *
+ * On each tick it collects the current state of the resources you point it at
+ * (config pages, status endpoints, policy docs — read with `web.scrape`), asks
+ * an LLM (`ctx.sapiom.models.run` — the live x402 path) to check that state
+ * against your `policy` and produce a structured finding, then **pauses for a
+ * human sign-off**. Only after a person explicitly approves does it archive the
+ * signed attestation as a durable file (`fileStorage.upload`) — because an
+ * attestation is a record that a human reviewed and signed off, auto-archiving
+ * one without a real sign-off would be a lie.
+ *
+ *   collect (web.scrape) → audit (models.run) ─(pause: attestation.signoff, $0)─▶ onSignoff
+ *                                                                                    │
+ *                                              reject ◀───────────────────────────────┼─▶ approve
+ *                                                │                                     ▼
+ *                                            rejected (terminal)                  archive (fileStorage, terminal)
+ *
+ * The durable pause (`pauseUntilSignal`) suspends the run at $0 until a person
+ * fires the sign-off signal — it is a runtime primitive, not a metered
+ * capability. The billed calls are the scrapes (`web.scrape`), the model
+ * reasoning (`ctx.sapiom.models.run` — `ctx.sapiom.llm` does NOT exist), and the
+ * attestation upload (`fileStorage.upload`).
+ *
+ * Side-effect discipline (copied from `scheduled-research-brief` /
+ * `human-in-the-loop`):
+ *   - `dryRun` gates the one irreversible action: `archive` computes the
+ *     attestation and returns it as a preview WITHOUT uploading anything. The
+ *     upload's presigned PUT is a raw `fetch` (not a stubbed capability), so it
+ *     must stay behind this guard or it would hit the network offline.
+ *   - A resume with no explicit `approve` takes the SAFE branch (`rejected`,
+ *     nothing archived). `run_local` auto-resumes the pause, so the offline trace
+ *     lands on `rejected` by default; fire a real `attestation.signoff` signal
+ *     with `{ "decision": "approve" }` to drive the archive path (see README).
+ *   - The scraped bodies are the only large data; they stay bounded (truncated,
+ *     capped count) and die at the `audit` boundary — they never enter
+ *     `ctx.shared` (large shared state stalls transitions on the cloud engine).
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Default cadence when the caller doesn't pass one: 06:00 every Monday. */
+const DEFAULT_SCHEDULE = "0 6 * * 1";
+/** Cap on how many resources we scrape per run (keeps latency + cost bounded). */
+const MAX_RESOURCES = 8;
+/** Truncate each scraped body — the ONLY large data on the collect→audit path. */
+const MAX_BODY_CHARS = 2000;
+/** The signal a human fires to approve or reject the attestation. */
+const SIGNOFF_SIGNAL = "attestation.signoff";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** A resource whose current state should be audited against the policy. */
+interface ResourceRef {
+  /** Stable id echoed into findings so a check maps back to its resource. */
+  id: string;
+  /** Where to read the resource's current config/state from. */
+  url: string;
+  /** Human-readable label shown in the attestation. Falls back to `id`. */
+  label?: string;
+}
+
+interface EntryInput {
+  /** The resources/config to collect and audit on each tick. */
+  resources: ResourceRef[];
+  /** The policy the collected state is checked against (free text or rules). */
+  policy: string;
+  /** Cron cadence this audit is meant to run on (e.g. "0 6 * * 1"). */
+  schedule?: string;
+  /** Compliance framework label for the attestation title (e.g. "SOC 2 CC6"). */
+  framework?: string;
+  /** Who is expected to sign off; recorded in the attestation. Informational. */
+  signOffBy?: string;
+  /** Compute + pause but never perform the real archive upload. `run_local` sets this. */
+  dryRun?: boolean;
+}
+
+/** A resource plus its (bounded) collected content — the collect→audit payload. */
+interface CollectedResource extends ResourceRef {
+  /** Extracted current state (markdown, truncated); absent when collection failed. */
+  content?: string;
+  /** Why collection failed, when it did — surfaced to the audit as missing evidence. */
+  error?: string;
+}
+
+/** One requirement check the model produced against the policy. */
+interface CheckFinding {
+  /** Resource id this check concerns, or a policy-level id. */
+  id: string;
+  /** The requirement being checked, in plain words. */
+  requirement: string;
+  /** Verdict for this requirement. */
+  status: "pass" | "fail" | "unknown";
+  /** What in the collected state supports the verdict. */
+  evidence: string;
+  /** Suggested fix when the verdict is `fail`. */
+  remediation?: string;
+}
+
+/** Overall verdict of the audit. */
+type AuditStatus = "compliant" | "non_compliant" | "needs_review";
+
+/** The structured audit report, computed by `audit` and stored in shared. */
+interface ComplianceReport {
+  status: AuditStatus;
+  summary: string;
+  checks: CheckFinding[];
+}
+
+/** The payload a human delivers on the `attestation.signoff` signal. */
+interface SignoffDecision {
+  /** `approve` archives the attestation; anything else takes the safe reject branch. */
+  decision?: "approve" | "reject";
+  /** Who signed off; recorded in the archived attestation. */
+  signer?: string;
+  /** Optional free-text rationale carried through to the outcome. */
+  notes?: string;
+}
+
+interface Shared extends Record<string, unknown> {
+  policy: string;
+  schedule: string;
+  framework: string;
+  signOffBy: string | null;
+  dryRun: boolean;
+  collectedAt: string;
+  report: ComplianceReport;
+  /** Slim resource references for the attestation; scraped bodies do NOT live here. */
+  resources: Array<{ id: string; label: string; url: string; error?: string }>;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** Status glyph for the attestation checklist. */
+function glyph(status: CheckFinding["status"]): string {
+  return status === "pass" ? "✓" : status === "fail" ? "✗" : "?";
+}
+
+// ─────────────────────────────────────────────────────── model reasoning ──
+/**
+ * Ask the model to check the collected state against the policy and return a
+ * structured report. Parsed defensively — a malformed reply degrades to a
+ * `needs_review` verdict rather than throwing, so the sign-off gate still runs.
+ */
+async function runPolicyCheck(
+  ctx: Ctx,
+  policy: string,
+  collected: CollectedResource[],
+): Promise<ComplianceReport> {
+  if (collected.length === 0) {
+    return {
+      status: "needs_review",
+      summary: "No resources were collected, so nothing could be audited.",
+      checks: [],
+    };
+  }
+  const evidence = collected
+    .map((r, i) => {
+      const head = `[${i + 1}] ${r.label ?? r.id} (${r.url})`;
+      if (r.error) return `${head}\n(collection failed: ${r.error})`;
+      return `${head}\n${(r.content ?? "").slice(0, MAX_BODY_CHARS)}`;
+    })
+    .join("\n\n");
+  const system =
+    "You are a compliance auditor. Given a POLICY and the current STATE of a set " +
+    "of resources (each: [n] label, url, then its collected text or a collection " +
+    "error), check the state against the policy. Produce one check per distinct " +
+    "requirement, cite the evidence you relied on, and suggest a remediation for " +
+    "each failure. A requirement you cannot evaluate from the evidence is " +
+    '"unknown", not "pass". Set the overall status to "compliant" only if every ' +
+    'check passes, "non_compliant" if any check fails, else "needs_review". ' +
+    "Reply with ONLY minified JSON: " +
+    '{"status":"compliant|non_compliant|needs_review","summary":string,' +
+    '"checks":[{"id":string,"requirement":string,"status":"pass|fail|unknown",' +
+    '"evidence":string,"remediation":string}]}.';
+  const res = await ctx.sapiom.models.run({
+    system,
+    prompt: `POLICY:\n${policy}\n\nSTATE:\n${evidence}`,
+    maxTokens: 900,
+  });
+  return coerceReport(res.output);
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const collect = defineStep({
+  name: "collect",
+  next: ["audit"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const policy = input.policy?.trim() ?? "";
+    ctx.shared.set("policy", policy);
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set("framework", input.framework?.trim() || "General policy");
+    ctx.shared.set("signOffBy", input.signOffBy?.trim() || null);
+    ctx.shared.set("dryRun", input.dryRun === true);
+    // Capture the audit timestamp once; steps re-run only on retry, so pin it
+    // here and carry it forward rather than recomputing downstream.
+    ctx.shared.set("collectedAt", new Date().toISOString());
+
+    const resources = (input.resources ?? []).slice(0, MAX_RESOURCES);
+    const collected: CollectedResource[] = [];
+    for (const r of resources) {
+      const base: ResourceRef = { id: r.id, url: r.url };
+      if (r.label !== undefined) base.label = r.label;
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: r.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        collected.push({
+          ...base,
+          label: r.label || page.metadata?.title || r.id,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Collection fails routinely (auth walls, timeouts, dead endpoints).
+        // Degrade per-item and forward the error as missing evidence — the audit
+        // then marks that requirement "unknown" rather than the run aborting.
+        ctx.logger.warn("collection failed; forwarding as missing evidence", {
+          url: r.url,
+          err: String(err),
+        });
+        collected.push({ ...base, error: String(err) });
+      }
+    }
+
+    // Slim references for the attestation — the scraped bodies stop here.
+    ctx.shared.set(
+      "resources",
+      collected.map((r) => ({
+        id: r.id,
+        label: r.label ?? r.id,
+        url: r.url,
+        ...(r.error !== undefined && { error: r.error }),
+      })),
+    );
+    ctx.logger.info("collected resources", {
+      total: collected.length,
+      failed: collected.filter((r) => r.error).length,
+    });
+    return goto("audit", { collected });
+  },
+});
+
+const audit = defineStep({
+  name: "audit",
+  next: ["review"],
+  async run(input: { collected: CollectedResource[] }, ctx: Ctx) {
+    const policy = must(ctx.shared.get("policy"), "policy");
+    const report = await runPolicyCheck(ctx, policy, input.collected ?? []);
+    ctx.shared.set("report", report);
+    ctx.logger.info("policy check complete", {
+      status: report.status,
+      checks: report.checks.length,
+      failing: report.checks.filter((c) => c.status === "fail").length,
+    });
+    return goto("review", {});
+  },
+});
+
+const review = defineStep({
+  name: "review",
+  next: [],
+  // Static graph edge: on the sign-off signal, resume at `onSignoff`. Must match
+  // the `pauseUntilSignal` directive below.
+  pause: { signal: SIGNOFF_SIGNAL, resumeStep: "onSignoff" },
+  async run(_input: unknown, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    const framework = ctx.shared.get("framework") ?? "General policy";
+    const signOffBy = ctx.shared.get("signOffBy") ?? null;
+
+    // No notification capability here (by design — this template's surface is
+    // cron + scrape + LLM + pause + file storage). The pending attestation is in
+    // the run's output/logs; the reviewer reads it there and fires the signal.
+    ctx.logger.info("attestation ready for sign-off; pausing", {
+      framework,
+      status: report.status,
+      signOffBy,
+      checks: report.checks.length,
+    });
+
+    // Suspend at $0 until a human fires the sign-off signal for this run.
+    return pauseUntilSignal({
+      signal: SIGNOFF_SIGNAL,
+      resumeStep: "onSignoff",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const onSignoff = defineStep({
+  name: "onSignoff",
+  next: ["archive", "rejected"],
+  // `payload` IS the sign-off signal body.
+  async run(payload: SignoffDecision, ctx: Ctx) {
+    // Safe default: only an explicit `approve` archives — the whole point of the
+    // gate is that no attestation is filed without a deliberate human sign-off.
+    const approved = payload?.decision === "approve";
+    ctx.logger.info("sign-off decision", {
+      decision: payload?.decision ?? "(none)",
+      approved,
+      signer: payload?.signer ?? null,
+    });
+    if (!approved) {
+      return goto("rejected", {
+        reason: payload?.notes ?? "not-approved",
+      });
+    }
+    return goto("archive", {
+      signer: payload?.signer ?? null,
+      notes: payload?.notes ?? null,
+    });
+  },
+});
+
+const archive = defineStep({
+  name: "archive",
+  next: [],
+  terminal: true,
+  async run(input: { signer: string | null; notes: string | null }, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    const framework = ctx.shared.get("framework") ?? "General policy";
+    const schedule = ctx.shared.get("schedule") ?? DEFAULT_SCHEDULE;
+    const collectedAt = ctx.shared.get("collectedAt") ?? "";
+    const resources = ctx.shared.get("resources") ?? [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const signer = input?.signer ?? ctx.shared.get("signOffBy") ?? null;
+    const signedAt = new Date().toISOString();
+
+    const attestation = buildAttestation({
+      framework,
+      schedule,
+      collectedAt,
+      signedAt,
+      signer,
+      notes: input?.notes ?? null,
+      report,
+      resources,
+    });
+    const fileName = `attestation-${collectedAt.slice(0, 10) || "latest"}.md`;
+
+    if (dryRun) {
+      // Offline / preview: the single irreversible action (the upload PUT, a raw
+      // fetch that is NOT a stubbed capability) is skipped. Everything up to here
+      // — collect, audit, the sign-off gate — already ran for real.
+      ctx.logger.info("dry run: skipping the attestation upload", {
+        status: report.status,
+        fileName,
+      });
+      return terminate({
+        archived: false,
+        dryRun: true,
+        status: report.status,
+        framework,
+        signer,
+        signedAt,
+        fileName,
+        attestation,
+        fileId: null,
+        downloadUrl: null,
+      });
+    }
+
+    // ── The single billed/irreversible action ──────────────────────────────
+    // Reached ONLY after a human approved. Persist the signed attestation as a
+    // durable, private file and hand back a download URL for the archive.
+    const bytes = new TextEncoder().encode(attestation);
+    const { fileId, uploadUrl, requiredHeaders } =
+      await ctx.sapiom.fileStorage.upload({
+        contentType: "text/markdown",
+        fileName,
+        fileSize: bytes.byteLength,
+        visibility: "private",
+      });
+    // You own the bytes transfer: PUT them to the presigned URL yourself.
+    const put = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: requiredHeaders,
+      body: bytes,
+    });
+    if (!put.ok) {
+      const detail = await put.text().catch(() => put.statusText);
+      throw new Error(`attestation upload failed: ${put.status} ${detail}`);
+    }
+    const { downloadUrl } = await ctx.sapiom.fileStorage.getDownloadUrl(fileId);
+
+    ctx.logger.info("attestation archived", {
+      fileId,
+      status: report.status,
+      signer,
+    });
+    return terminate({
+      archived: true,
+      dryRun: false,
+      status: report.status,
+      framework,
+      signer,
+      signedAt,
+      fileName,
+      fileId,
+      downloadUrl,
+    });
+  },
+});
+
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason?: string }, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    // Nothing was archived — the sign-off was declined (or absent). The audit
+    // findings are still returned so a reviewer can act on them.
+    ctx.logger.info("sign-off declined — nothing archived", {
+      status: report.status,
+      reason: input?.reason ?? "not-approved",
+    });
+    return terminate({
+      archived: false,
+      outcome: "rejected",
+      status: report.status,
+      reason: input?.reason ?? "not-approved",
+      summary: report.summary,
+      checks: report.checks,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── attestation body ──
+function buildAttestation(a: {
+  framework: string;
+  schedule: string;
+  collectedAt: string;
+  signedAt: string;
+  signer: string | null;
+  notes: string | null;
+  report: ComplianceReport;
+  resources: Array<{ id: string; label: string; url: string; error?: string }>;
+}): string {
+  const checks =
+    a.report.checks.length > 0
+      ? a.report.checks
+          .map((c) => {
+            const remediation =
+              c.status === "fail" && c.remediation
+                ? `\n  - Remediation: ${c.remediation}`
+                : "";
+            return `- [${glyph(c.status)}] ${c.requirement} — ${c.status}: ${c.evidence}${remediation}`;
+          })
+          .join("\n")
+      : "_No checks were produced._";
+  const sources =
+    a.resources.length > 0
+      ? a.resources
+          .map(
+            (r) =>
+              `- ${r.label} (${r.url})${r.error ? ` — collection failed: ${r.error}` : ""}`,
+          )
+          .join("\n")
+      : "_No resources were collected._";
+  return [
+    `# Compliance Attestation — ${a.framework}`,
+    "",
+    `- **Overall status:** ${a.report.status}`,
+    `- **Audited at:** ${a.collectedAt || "(unknown)"}`,
+    `- **Cadence:** ${a.schedule}`,
+    `- **Resources audited:** ${a.resources.length}`,
+    "",
+    "## Summary",
+    a.report.summary || "_No summary._",
+    "",
+    "## Checks",
+    checks,
+    "",
+    "## Sign-off",
+    `- **Decision:** approved`,
+    `- **Signed by:** ${a.signer ?? "(unspecified)"}`,
+    `- **Signed at:** ${a.signedAt}`,
+    ...(a.notes ? [`- **Notes:** ${a.notes}`] : []),
+    "",
+    "## Sources",
+    sources,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────── output parsing ──
+/** Coerce the audit-step model output into a `ComplianceReport`, with fallbacks. */
+function coerceReport(output: string | null): ComplianceReport {
+  const fallback: ComplianceReport = {
+    status: "needs_review",
+    summary: "The auditor returned no usable report; a human should review.",
+    checks: [],
+  };
+  const obj = extractJson(output);
+  if (!obj) return fallback;
+
+  const status = coerceStatus(obj.status);
+  const summary =
+    typeof obj.summary === "string" && obj.summary.trim()
+      ? obj.summary.trim()
+      : fallback.summary;
+  const checks = Array.isArray(obj.checks)
+    ? obj.checks.map(coerceCheck).filter((c): c is CheckFinding => c !== null)
+    : [];
+  return { status, summary, checks };
+}
+
+function coerceStatus(value: unknown): AuditStatus {
+  return value === "compliant" || value === "non_compliant"
+    ? value
+    : "needs_review";
+}
+
+function coerceCheck(entry: unknown): CheckFinding | null {
+  if (!entry || typeof entry !== "object") return null;
+  const e = entry as Record<string, unknown>;
+  const requirement =
+    typeof e.requirement === "string" ? e.requirement.trim() : "";
+  if (!requirement) return null;
+  const status: CheckFinding["status"] =
+    e.status === "pass" || e.status === "fail" ? e.status : "unknown";
+  const check: CheckFinding = {
+    id: typeof e.id === "string" ? e.id : requirement.slice(0, 40),
+    requirement,
+    status,
+    evidence:
+      typeof e.evidence === "string" ? e.evidence : "(no evidence cited)",
+  };
+  if (status === "fail" && typeof e.remediation === "string" && e.remediation) {
+    check.remediation = e.remediation;
+  }
+  return check;
+}
+
+/** Best-effort extraction of a single JSON object from model output. */
+function extractJson(output: string | null): Record<string, unknown> | null {
+  if (!output) return null;
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < 0 || end < start) return null;
+  try {
+    return JSON.parse(output.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "scheduled-compliance-audit",
+  entry: "collect",
+  steps: { collect, audit, review, onSignoff, archive, rejected },
+});

--- a/examples/scheduled-compliance-audit/package.json
+++ b/examples/scheduled-compliance-audit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-scheduled-compliance-audit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a cron cadence, collect resource/config state (web.scrape), run an LLM policy check (models.run), pause for human sign-off, then archive the signed attestation (fileStorage).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/scheduled-compliance-audit/template.json
+++ b/examples/scheduled-compliance-audit/template.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You point it at the resources that prove you're compliant — a config page, a status endpoint, a published policy doc — and give it the policy to hold them to. On each tick it reads the current state of each resource, hands that state and your policy to an LLM (`models.run`), and gets back a structured report: an overall verdict, plus one check per requirement with the evidence it relied on and a fix for anything that failed.\n\nThen it stops and waits for a person. The run pauses on a sign-off signal, costing nothing while idle, and only an explicit approval moves it forward. That gate is the point: an attestation is a record that a human reviewed and signed off, so it is never filed automatically. Approve, and it writes the signed attestation — verdict, checks, sources, signer, and timestamp — to durable file storage and hands back a download link. Decline, and the findings come back but nothing is archived.\n\nCollection fails routinely on auth walls and dead endpoints — when a resource won't load, the auditor sees it as missing evidence and marks that requirement unknown rather than the run aborting. A `dryRun` flag computes the whole attestation and returns it as a preview without archiving anything.\n\nYou pay for the scrapes, the model reasoning, and the one attestation upload on each run — the waiting is free, and a dry run costs only the collect and the check it still performs.",
+  "useCases": [
+    "Run a recurring policy audit — SOC 2, an internal security baseline, a data-retention rule — and keep a signed record each time.",
+    "Require a human sign-off before an attestation is filed, so no compliance record is ever created without a real review.",
+    "Archive every audit's signed attestation to durable storage, building an evidence trail you can hand an auditor later."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it `resources` (the config/status/policy URLs to audit) and a `policy` (the rules to hold them to). Set the `schedule` cron cadence, and optionally a `framework` label and `signOffBy` address, both recorded in the attestation. This template **pauses for a human sign-off**: a real run stops after the policy check and waits. Resume it by firing the `attestation.signoff` signal with `{ \"decision\": \"approve\" }` (today via the MCP `workflow_signal` tool / the API — there is no one-click sign-off button yet); the `correlationId` is the paused run's `executionId`. Only an explicit approval archives the attestation — anything else returns the findings without filing anything. Pass `dryRun: true` to compute the attestation and get it back without archiving.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole collect → audit → sign-off → archive flow for free (capabilities stubbed, the pause auto-resumed, the archive skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A weekly SOC 2 access-control audit (dry-run preview)",
+      "input": {
+        "resources": [
+          {
+            "id": "api-config",
+            "url": "https://example.com/.well-known/security.txt",
+            "label": "API security policy"
+          }
+        ],
+        "policy": "Every service must publish a security contact and enforce TLS 1.2+.",
+        "schedule": "0 6 * * 1",
+        "framework": "SOC 2 CC6",
+        "signOffBy": "compliance@example.com",
+        "dryRun": true
+      },
+      "output": {
+        "archived": false,
+        "dryRun": true,
+        "status": "needs_review",
+        "framework": "SOC 2 CC6",
+        "signer": "compliance@example.com",
+        "signedAt": "2026-01-05T06:00:12.000Z",
+        "fileName": "attestation-2026-01-05.md",
+        "attestation": "# Compliance Attestation — SOC 2 CC6\n\n- **Overall status:** needs_review\n- **Audited at:** 2026-01-05T06:00:00.000Z\n- **Cadence:** 0 6 * * 1\n- **Resources audited:** 1\n\n## Summary\nA security contact is published, but TLS version enforcement could not be confirmed from the collected state.\n\n## Checks\n- [✓] A security contact is published — pass: security.txt lists a Contact field.\n- [?] TLS 1.2+ is enforced — unknown: the collected page does not state the TLS policy.\n\n## Sign-off\n- **Decision:** approved\n- **Signed by:** compliance@example.com\n- **Signed at:** 2026-01-05T06:00:12.000Z\n\n## Sources\n- API security policy (https://example.com/.well-known/security.txt)",
+        "fileId": null,
+        "downloadUrl": null
+      }
+    }
+  ]
+}

--- a/examples/scheduled-compliance-audit/tsconfig.json
+++ b/examples/scheduled-compliance-audit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds the **`scheduled-compliance-audit`** onboarding template and registers it in the gallery — growing the relaunch template gallery (epic **SAP-1823**).

A cron-scheduled agent that scans resources/config, runs an LLM policy check, pauses for a human sign-off, then archives the resulting attestation.

Closes **SAP-1878**.

## Graph

```
collect (web.scrape) → audit (models.run) ─(pause: attestation.signoff, $0)─▶ onSignoff
                                                                                 │
                                           reject ◀───────────────────────────────┼─▶ approve
                                             │                                     ▼
                                         rejected (terminal)                  archive (fileStorage, terminal)
```

Maps the ticket's capabilities directly: **cron** (`schedule` input + cron trigger on the deployed workflow) · **scrape** (`web.scrape` resource/config collection; sandbox alternative documented in `AGENTS.md`) · **LLM** (`models.run` policy check) · **pauseUntilSignal** (human sign-off) · **file storage** (`fileStorage.upload` attestation archive).

## Design notes

- **The sign-off gate is the point.** An attestation records that a human reviewed and approved, so it is never filed automatically — the safe default on resume is `rejected` (nothing archived); only an explicit `{ "decision": "approve" }` archives.
- **`dryRun` guards the one billed/irreversible action.** The presigned upload PUT is a raw `fetch` (not a stubbed capability), so it stays behind `dryRun` — `run_local` traces the whole graph offline for free and lands on `rejected` by default.
- Composes the scheduled collect-and-curate shape of `scheduled-research-brief` (SAP-1827) with the human gate of `human-in-the-loop` (SAP-1831). Follows `examples/AUTHORING.md` copy style.
- Bounded scrape bodies die at the `audit` boundary (never enter `ctx.shared`); model output parsed defensively; per-item scrape degrade-on-failure.

## Validation

- `tsc --noEmit` ✅ (against published `@sapiom/agent` 0.6.6 / `@sapiom/tools` 0.20.1 — confirms every `ctx.sapiom.*` call exists)
- `prettier --check` ✅
- Definition import + `buildManifest` graph validation (the `check` equivalent) ✅ — entry + all `next`/`resumeStep` edges resolve

> The stdio dev MCP (`sapiom_dev_agents_*`) is not connected in this session, so `check`/`run_local` weren't driven through it; the equivalent bundle→import→manifest graph validation was run directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzNC6g6TFuYewMsiSt6uKc