### PR TITLE
feat(examples): add Durable Backfill / Long-Job Runner workflow template (SAP-1886)

### DIFF
--- a/examples/durable-backfill/.gitignore
+++ b/examples/durable-backfill/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/durable-backfill/AGENTS.md
+++ b/examples/durable-backfill/AGENTS.md
@@ -1,0 +1,51 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Durable Backfill / Long-Job Runner** — authored against `@sapiom/agent`. It processes a large dataset in resumable chunks: `plan` resolves the job and loads any prior checkpoint, `process` handles one chunk (in a sandbox, against a dataset `DATABASE_URL`) and rewrites a durable checkpoint before pausing until a heartbeat, and `finalize` writes a manifest and terminates. The run survives restarts because progress is checkpointed to file storage under a stable `jobId`.
+
+## The chunk loop
+
+- **`process`** is a self-loop. After doing a chunk's work and checkpointing, it returns `pauseUntilSignal({ signal: "backfill.heartbeat", resumeStep: "process", correlationId: ctx.executionId })` when work remains, or `goto("finalize", {})` on the last chunk. Its static `pause: { signal, resumeStep: "process" }` annotation is the build-time graph edge that must match the directive; its `next: ["finalize"]` is the exit edge.
+- The cursor, processed count, chunk index, and checkpoint file id all live in **`ctx.shared`**, which survives every pause. On resume, `process` reads them back — the heartbeat signal payload itself is ignored (it just wakes the step).
+- The **heartbeat** is a cron/schedule firing `backfill.heartbeat` on a cadence. `pauseUntilSignal` is a **runtime primitive, not a metered capability** — a suspended run is not billed while it waits.
+
+## Capabilities
+
+- **`database.get`** resolves the dataset's connection string, which is injected into the chunk sandbox as `DATABASE_URL`.
+- **`sandboxes.create` / `exec`** run the per-chunk `command` in a fresh, short-TTL sandbox (torn down in a `finally`, so nothing lingers between chunks).
+- **`fileStorage.upload` / `getDownloadUrl` / `list` / `delete`** persist the checkpoint (rotated each chunk), the per-chunk result artifacts, and the final manifest — and read the checkpoint back when resuming.
+- **Capabilities come from the types.** What's on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. Note: `ctx.sapiom.llm` does **not** exist; the LLM path (unused here) is `models.run`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares a `pause: { signal, resumeStep }` annotation; a step may both pause and `goto` a `next` target, which is how `process` loops or exits.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including the static `pause` annotation.
+- **run_local** — runs your **real** step code against **stub capabilities**. Leave `dbHandle` unset (or pass `dryRun: true`) so `process` counts each chunk in-process and skips the sandbox / database / file-storage calls; the local runner auto-resumes each heartbeat pause, so you get the full `plan → process → … → finalize` trace offline for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses between chunks.
+
+### Advancing a paused run in dev
+
+A real `run` pauses after each chunk. To advance it without a schedule, fire the heartbeat via the MCP `signal_workflow` / `workflow_signal` tool:
+
+```json
+{
+  "signal": "backfill.heartbeat",
+  "correlationId": "<executionId of the paused run>"
+}
+```
+
+To resume an interrupted job, start a new run with the same `jobId` — `plan` reads the checkpoint from file storage and continues.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities + the offline `dryRun` path), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The `correlationId` is `ctx.executionId` (stable across pauses), so every heartbeat lands on the right run. Progress is advanced in `ctx.shared` and checkpointed to file storage after each chunk, so a resumed or restarted run never reprocesses a completed chunk.

--- a/examples/durable-backfill/README.md
+++ b/examples/durable-backfill/README.md
@@ -1,0 +1,83 @@
+# Durable Backfill / Long-Job Runner
+
+Process a huge dataset in resumable chunks, checkpointing progress to durable
+storage and surviving restarts via a cron heartbeat. A pure durability showcase:
+instead of one long-held worker grinding through a million rows (and dying
+halfway with nothing to show), it walks the dataset one bounded chunk at a time,
+writes down where it is after each chunk, and **suspends at $0** between chunks
+until a heartbeat wakes it for the next one.
+
+## What it does
+
+```
+plan  ──▶  process  ──(checkpoint, then pause: wait for "backfill.heartbeat", $0 while idle)──╮
+           ▲                                                                                  │
+           ╰──────────────────────── resume on the heartbeat ─────────────────────────────────╯
+           │
+           ╰─(no work left)─▶  finalize  (terminal)
+```
+
+1. **plan** — resolve the job (dataset `total`, `chunkSize`, a stable `jobId`).
+   If a durable checkpoint already exists for that `jobId`, resume from it;
+   otherwise start at zero.
+2. **process** — handle the current chunk. The real work runs in a sandbox that
+   gets the dataset's `DATABASE_URL` (from the `database` capability) and the
+   chunk range (`CHUNK_OFFSET` / `CHUNK_LIMIT`) injected as env. It saves a
+   per-chunk result file and rewrites the checkpoint (`fileStorage`), advances
+   the cursor, then pauses until the next heartbeat — or, once the last chunk is
+   done, goes straight to `finalize`.
+3. **(paused)** — nothing runs, nothing is billed, until the heartbeat fires.
+4. **finalize** — write a run manifest and terminate with a summary.
+
+Restart survival has two layers. Within one run, the cursor lives in
+`ctx.shared` and survives every pause. Across a full teardown, the checkpoint
+lives in file storage keyed by `jobId`, so a brand-new run started with the same
+`jobId` reads it in `plan` and picks up mid-dataset.
+
+Input: `{ "total": 100000, "chunkSize": 5000, "jobId": "users-backfill", "dbHandle": "users-db", "command": "node backfill.js" }`.
+With no `dbHandle` (or `dryRun` set), `process` counts each chunk in-process and
+skips the sandbox / database / file-storage calls.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the deployed run
+   inherits that authority to provision sandboxes and databases and to read and
+   write file storage.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (offline, free — leave `dbHandle` unset or pass `dryRun: true`) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real run that pauses between chunks).
+
+## Advancing a paused run in dev
+
+A deployed run processes one chunk, then pauses for the `backfill.heartbeat`
+signal. In production a schedule fires that signal on a cadence; in dev, fire it
+yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`:
+
+```json
+{
+  "signal": "backfill.heartbeat",
+  "correlationId": "<executionId of the paused run>"
+}
+```
+
+Each heartbeat processes and checkpoints one more chunk. To resume an
+interrupted job, start a new run with the same `jobId` — `plan` reads the
+checkpoint and continues from the last completed chunk.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/durable-backfill/index.ts
+++ b/examples/durable-backfill/index.ts
@@ -1,0 +1,505 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Durable Backfill / Long-Job Runner — process a huge dataset in resumable
+ * chunks, checkpointing progress to durable storage and surviving restarts.
+ *
+ * A pure durability showcase. Instead of one long-held worker grinding through a
+ * million rows (and dying halfway with nothing to show), this walks the dataset
+ * one bounded chunk at a time. After each chunk it writes a checkpoint, then
+ * **suspends at $0** (`pauseUntilSignal`) until a heartbeat wakes it for the next
+ * chunk — the "heartbeat" is a cron/schedule firing the resume signal on a
+ * cadence. Nothing runs and nothing is billed between chunks.
+ *
+ *   plan ─▶ process ──(checkpoint, then pause: wait for heartbeat, $0)──╮
+ *            ▲                                                          │
+ *            ╰──────────────── resume on `backfill.heartbeat` ──────────╯
+ *            │
+ *            ╰─(no work left)─▶ finalize (terminal)
+ *
+ *   1. plan — resolve the job (dataset size, chunk size, job id). If a durable
+ *      checkpoint already exists for this job id, resume from where it left off;
+ *      otherwise start at zero.
+ *   2. process — handle the current chunk. The real work runs in a sandbox that
+ *      gets the dataset's `DATABASE_URL` (from the `database` capability) and the
+ *      chunk range injected as env. It then persists a per-chunk result artifact
+ *      and rewrites the durable checkpoint (`fileStorage`), advances the cursor,
+ *      and pauses until the next heartbeat — or, when the last chunk is done,
+ *      goes straight to `finalize`.
+ *   3. finalize — write a manifest of the run and terminate with a summary.
+ *
+ * Restart survival has two layers. Within one execution, the cursor lives in
+ * `ctx.shared` and survives every pause. Across a full teardown, the checkpoint
+ * lives in file storage keyed by `jobId`, so a brand-new run started with the
+ * same `jobId` reads it in `plan` and picks up mid-dataset.
+ *
+ * Offline: with no `dbHandle` (or `dryRun` set), `process` handles each chunk
+ * in-process and skips the sandbox / database / file-storage calls, so
+ * `run_local` traces the whole plan → process → … → finalize loop for free. The
+ * local runner auto-resumes each heartbeat pause, so you see every chunk.
+ */
+
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** The run input. Everything is optional and defaults to a small demo job. */
+interface BackfillInput {
+  /** Total items in the dataset to back-fill. */
+  total?: number;
+  /** Items per chunk — the unit of work between heartbeats. */
+  chunkSize?: number;
+  /**
+   * Stable id for this backfill — the checkpoint key. Pass the same `jobId` to a
+   * fresh run to resume an interrupted job. Defaults to the execution id.
+   */
+  jobId?: string;
+  /**
+   * Postgres handle (from the `database` capability) whose connection string is
+   * injected into the chunk processor as `DATABASE_URL`. Absent ⇒ offline.
+   */
+  dbHandle?: string;
+  /**
+   * Shell command run once per chunk inside the sandbox, with `DATABASE_URL`,
+   * `CHUNK_OFFSET`, `CHUNK_LIMIT`, and `JOB_ID` in its env. It should print the
+   * number of items it processed as the last line of stdout. Swap in your real
+   * backfill here; the default just echoes the chunk size.
+   */
+  command?: string;
+  /** Process chunks in-process and skip all external calls. */
+  dryRun?: boolean;
+  /** Reserved for extra string config. */
+  config?: Config;
+}
+
+/** The durable checkpoint — the small JSON that lets a fresh run resume. */
+interface Checkpoint {
+  jobId: string;
+  /** Offset of the next unprocessed item. */
+  cursor: number;
+  /** Items processed so far. */
+  processed: number;
+  /** Chunks completed so far. */
+  chunkIndex: number;
+  /** Dataset size the checkpoint was written against. */
+  total: number;
+}
+
+/** State that survives every pause (and is rebuilt from the checkpoint on resume). */
+interface Shared extends Record<string, unknown> {
+  jobId: string;
+  total: number;
+  chunkSize: number;
+  cursor: number;
+  processed: number;
+  chunkIndex: number;
+  dbHandle: string | null;
+  command: string;
+  dryRun: boolean;
+  /** Latest checkpoint file id, so each write can delete the previous one. */
+  checkpointFileId: string | null;
+  /** Per-chunk result artifact ids, gathered into the final manifest. */
+  resultFileIds: string[];
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+/** The heartbeat signal a cron/schedule fires to advance to the next chunk. */
+const HEARTBEAT = "backfill.heartbeat";
+
+const DEFAULT_TOTAL = 25;
+const DEFAULT_CHUNK_SIZE = 10;
+/** Default chunk command — echoes the chunk size so `parseCount` reads it back. */
+const DEFAULT_COMMAND =
+  'echo "processing $CHUNK_LIMIT items from offset $CHUNK_OFFSET (job $JOB_ID)"; echo "$CHUNK_LIMIT"';
+/** Time-to-live for the per-chunk sandbox — short, since it is torn down each chunk. */
+const CHUNK_SANDBOX_TTL = "15m";
+
+// ---- helpers ---------------------------------------------------------------
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** File name the durable checkpoint is stored under, keyed by job id. */
+function checkpointFileName(jobId: string): string {
+  return `backfill-checkpoint-${jobId}.json`;
+}
+
+/**
+ * A sandbox name is lowercase alphanumeric + hyphens, 2–63 chars. Derive a legal
+ * one from the job id and chunk offset.
+ */
+function sandboxName(jobId: string, offset: number): string {
+  const base = `backfill-${jobId}-c${offset}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return (base || "backfill").slice(0, 63);
+}
+
+/** Read the last integer printed by the chunk command; fall back to the chunk size. */
+function parseCount(stdout: string, fallback: number): number {
+  const matches = stdout.match(/-?\d+/g);
+  if (!matches || matches.length === 0) return fallback;
+  const n = Number(matches[matches.length - 1]);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+/** Upload a small JSON object to file storage; return its file id (or null on failure). */
+async function uploadJson(
+  ctx: Ctx,
+  fileName: string,
+  obj: unknown,
+): Promise<string | null> {
+  try {
+    const bytes = new TextEncoder().encode(JSON.stringify(obj, null, 2));
+    const { fileId, uploadUrl, requiredHeaders } =
+      await ctx.sapiom.fileStorage.upload({
+        contentType: "application/json",
+        fileName,
+        visibility: "private",
+        fileSize: bytes.byteLength,
+      });
+    const put = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: requiredHeaders,
+      body: bytes,
+    });
+    if (!put.ok) {
+      ctx.logger.warn("checkpoint/result upload PUT failed", {
+        fileName,
+        status: put.status,
+      });
+      return null;
+    }
+    return fileId;
+  } catch (err) {
+    ctx.logger.warn("upload failed", { fileName, err: String(err) });
+    return null;
+  }
+}
+
+/** Delete a file id, swallowing errors (rotation is best-effort). */
+async function deleteFile(ctx: Ctx, fileId: string): Promise<void> {
+  try {
+    await ctx.sapiom.fileStorage.delete(fileId);
+  } catch (err) {
+    ctx.logger.warn("checkpoint delete failed", { fileId, err: String(err) });
+  }
+}
+
+/**
+ * Load the durable checkpoint for `jobId` from file storage, if one exists. A
+ * fresh execution started with the same `jobId` uses this to resume mid-dataset.
+ */
+async function readCheckpoint(
+  ctx: Ctx,
+  jobId: string,
+): Promise<Checkpoint | null> {
+  const name = checkpointFileName(jobId);
+  try {
+    const listing = await ctx.sapiom.fileStorage.list({ limit: 100 });
+    const files = listing?.files ?? [];
+    const match = files.find(
+      (f) => f.fileName === name && f.status === "uploaded",
+    );
+    if (!match) return null;
+    const { downloadUrl } = await ctx.sapiom.fileStorage.getDownloadUrl(
+      match.fileId,
+    );
+    const res = await fetch(downloadUrl);
+    if (!res.ok) return null;
+    const cp = (await res.json()) as Partial<Checkpoint>;
+    if (typeof cp.cursor !== "number") return null;
+    ctx.shared.set("checkpointFileId", match.fileId);
+    return {
+      jobId,
+      cursor: cp.cursor,
+      processed: typeof cp.processed === "number" ? cp.processed : 0,
+      chunkIndex: typeof cp.chunkIndex === "number" ? cp.chunkIndex : 0,
+      total: typeof cp.total === "number" ? cp.total : 0,
+    };
+  } catch (err) {
+    ctx.logger.warn("checkpoint read failed", { jobId, err: String(err) });
+    return null;
+  }
+}
+
+/**
+ * Do one chunk's work. Real path: spin up a sandbox with the dataset's
+ * `DATABASE_URL` and the chunk range in its env, run the command, tear the
+ * sandbox down. Offline path (`dryRun`): count the chunk in-process. Returns the
+ * number of items processed.
+ */
+async function processChunk(
+  ctx: Ctx,
+  args: {
+    command: string;
+    dbHandle: string | null;
+    offset: number;
+    limit: number;
+    jobId: string;
+    dryRun: boolean;
+  },
+): Promise<number> {
+  if (args.dryRun) {
+    ctx.logger.info("dry run: processing chunk in-process (no sandbox)", {
+      offset: args.offset,
+      limit: args.limit,
+    });
+    return args.limit;
+  }
+
+  // Resolve the dataset connection string to hand the processor.
+  let databaseUrl: string | undefined;
+  if (args.dbHandle) {
+    try {
+      const db = await ctx.sapiom.database.get(args.dbHandle);
+      databaseUrl = db.connection?.connectionString ?? undefined;
+    } catch (err) {
+      ctx.logger.warn("could not resolve DATABASE_URL from handle", {
+        handle: args.dbHandle,
+        err: String(err),
+      });
+    }
+  }
+
+  const box = await ctx.sapiom.sandboxes.create({
+    name: sandboxName(args.jobId, args.offset),
+    ttl: CHUNK_SANDBOX_TTL,
+    envs: {
+      ...(databaseUrl ? { DATABASE_URL: databaseUrl } : {}),
+      CHUNK_OFFSET: String(args.offset),
+      CHUNK_LIMIT: String(args.limit),
+      JOB_ID: args.jobId,
+    },
+  });
+  try {
+    const res = await box.exec(args.command);
+    if (res.exitCode !== 0) {
+      ctx.logger.warn("chunk command exited non-zero", {
+        exitCode: res.exitCode,
+        stderr: res.stderr.slice(0, 200),
+      });
+    }
+    return parseCount(res.stdout, args.limit);
+  } finally {
+    try {
+      await box.destroy();
+    } catch (err) {
+      ctx.logger.warn("sandbox destroy failed", { err: String(err) });
+    }
+  }
+}
+
+// ---- steps -----------------------------------------------------------------
+const plan = defineStep({
+  name: "plan",
+  next: ["process"],
+  async run(input: BackfillInput, ctx: Ctx) {
+    const total = Math.max(0, Math.floor(input.total ?? DEFAULT_TOTAL));
+    const chunkSize = Math.max(
+      1,
+      Math.floor(input.chunkSize ?? DEFAULT_CHUNK_SIZE),
+    );
+    const jobId = (input.jobId ?? "").trim() || ctx.executionId;
+    const dbHandle = (input.dbHandle ?? "").trim() || null;
+    const command = (input.command ?? "").trim() || DEFAULT_COMMAND;
+    // No dataset handle (or explicit dryRun) ⇒ run offline: no sandbox, DB, or
+    // file storage, so run_local traces the whole loop for free.
+    const dryRun = input.dryRun === true || !dbHandle;
+
+    let cursor = 0;
+    let processed = 0;
+    let chunkIndex = 0;
+    if (!dryRun) {
+      const prior = await readCheckpoint(ctx, jobId);
+      if (prior) {
+        cursor = Math.min(prior.cursor, total);
+        processed = prior.processed;
+        chunkIndex = prior.chunkIndex;
+        ctx.logger.info("resuming from checkpoint", {
+          jobId,
+          cursor,
+          processed,
+          chunkIndex,
+        });
+      }
+    }
+
+    ctx.shared.set("jobId", jobId);
+    ctx.shared.set("total", total);
+    ctx.shared.set("chunkSize", chunkSize);
+    ctx.shared.set("cursor", cursor);
+    ctx.shared.set("processed", processed);
+    ctx.shared.set("chunkIndex", chunkIndex);
+    ctx.shared.set("dbHandle", dbHandle);
+    ctx.shared.set("command", command);
+    ctx.shared.set("dryRun", dryRun);
+    ctx.shared.set("resultFileIds", []);
+    if (ctx.shared.get("checkpointFileId") === undefined) {
+      ctx.shared.set("checkpointFileId", null);
+    }
+
+    ctx.logger.info("backfill planned", {
+      jobId,
+      total,
+      chunkSize,
+      cursor,
+      dryRun,
+    });
+    return goto("process", {});
+  },
+});
+
+const processStep = defineStep({
+  name: "process",
+  next: ["finalize"],
+  // Self-loop: after checkpointing a chunk, pause until the heartbeat fires and
+  // resume this same step for the next chunk.
+  pause: { signal: HEARTBEAT, resumeStep: "process" },
+  async run(_input: unknown, ctx: Ctx) {
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    const total = must(ctx.shared.get("total"), "total");
+    const chunkSize = must(ctx.shared.get("chunkSize"), "chunkSize");
+    const cursor = must(ctx.shared.get("cursor"), "cursor");
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const dbHandle = (ctx.shared.get("dbHandle") as string | null) ?? null;
+    const command = must(ctx.shared.get("command"), "command");
+
+    // Nothing left to do — finalize. (Also the safe landing if woken with no work.)
+    if (cursor >= total) return goto("finalize", {});
+
+    const offset = cursor;
+    const limit = Math.min(chunkSize, total - cursor);
+    const chunkIndex = must(ctx.shared.get("chunkIndex"), "chunkIndex");
+    ctx.logger.info("processing chunk", {
+      jobId,
+      chunkIndex,
+      offset,
+      limit,
+      total,
+    });
+
+    const done = await processChunk(ctx, {
+      command,
+      dbHandle,
+      offset,
+      limit,
+      jobId,
+      dryRun,
+    });
+
+    // Persist a per-chunk result artifact (deployed path only).
+    const resultFileIds = [
+      ...((ctx.shared.get("resultFileIds") as string[] | undefined) ?? []),
+    ];
+    if (!dryRun) {
+      const rid = await uploadJson(
+        ctx,
+        `backfill-${jobId}-chunk-${chunkIndex}.json`,
+        { jobId, chunkIndex, offset, limit, processed: done },
+      );
+      if (rid) resultFileIds.push(rid);
+    }
+
+    // Advance the cursor and record progress.
+    const nextCursor = offset + limit;
+    const nextProcessed = must(ctx.shared.get("processed"), "processed") + done;
+    const nextChunkIndex = chunkIndex + 1;
+    ctx.shared.set("cursor", nextCursor);
+    ctx.shared.set("processed", nextProcessed);
+    ctx.shared.set("chunkIndex", nextChunkIndex);
+    ctx.shared.set("resultFileIds", resultFileIds);
+
+    // Rewrite the durable checkpoint, rotating out the previous file.
+    if (!dryRun) {
+      const prevCheckpoint = ctx.shared.get("checkpointFileId") as
+        | string
+        | null;
+      const cpId = await uploadJson(ctx, checkpointFileName(jobId), {
+        jobId,
+        cursor: nextCursor,
+        processed: nextProcessed,
+        chunkIndex: nextChunkIndex,
+        total,
+      } satisfies Checkpoint);
+      if (cpId) {
+        if (prevCheckpoint && prevCheckpoint !== cpId) {
+          await deleteFile(ctx, prevCheckpoint);
+        }
+        ctx.shared.set("checkpointFileId", cpId);
+      }
+    }
+    ctx.logger.info("chunk checkpointed", {
+      jobId,
+      cursor: nextCursor,
+      processed: nextProcessed,
+    });
+
+    // Last chunk done? Finalize now. Otherwise wait for the next heartbeat.
+    if (nextCursor >= total) return goto("finalize", {});
+    return pauseUntilSignal({
+      signal: HEARTBEAT,
+      resumeStep: "process",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const finalize = defineStep({
+  name: "finalize",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    const total = must(ctx.shared.get("total"), "total");
+    const processed = must(ctx.shared.get("processed"), "processed");
+    const chunkIndex = must(ctx.shared.get("chunkIndex"), "chunkIndex");
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const checkpointFileId =
+      (ctx.shared.get("checkpointFileId") as string | null) ?? null;
+    const resultFileIds =
+      (ctx.shared.get("resultFileIds") as string[] | undefined) ?? [];
+
+    let manifestFileId: string | null = null;
+    if (!dryRun) {
+      manifestFileId = await uploadJson(
+        ctx,
+        `backfill-${jobId}-manifest.json`,
+        { jobId, total, processed, chunks: chunkIndex, resultFileIds },
+      );
+    }
+
+    ctx.logger.info("backfill complete", {
+      jobId,
+      total,
+      processed,
+      chunks: chunkIndex,
+    });
+    return terminate({
+      jobId,
+      total,
+      processed,
+      chunks: chunkIndex,
+      complete: total === 0 || processed >= total,
+      checkpointFileId,
+      manifestFileId,
+      resultFileIds,
+    });
+  },
+});
+
+export const agent = defineAgent<BackfillInput, Shared>({
+  name: "durable-backfill",
+  entry: "plan",
+  steps: { plan, process: processStep, finalize },
+});

--- a/examples/durable-backfill/package.json
+++ b/examples/durable-backfill/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-durable-backfill",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: process a huge dataset in resumable chunks, checkpoint progress to durable storage, and survive restarts via a cron heartbeat.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/durable-backfill/template.json
+++ b/examples/durable-backfill/template.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Some jobs are too big for one pass — backfill a column across a million rows, reprocess a year of records, migrate a table. Run it as one long worker and a restart halfway through loses everything. This template walks the dataset one chunk at a time instead, and writes down where it is after every chunk.\n\n`plan` works out the job — how big the dataset is, how large each chunk is, and a `jobId` that names the run. `process` handles the current chunk: it hands the dataset's connection string and the chunk's range to a fresh sandbox, runs your command there, saves a small result file, and rewrites a checkpoint. Then it pauses until a heartbeat wakes it for the next chunk. The heartbeat is just a schedule firing a signal on a cadence — so between chunks nothing runs and nothing is billed.\n\nRestarts survive on two levels. Inside one run, the cursor rides along in `ctx.shared` through every pause. If the whole run is torn down, the checkpoint is still in file storage under the `jobId` — start a fresh run with the same `jobId` and `plan` reads it back and picks up mid-dataset.\n\nYou pay for the chunk work — the sandbox while it runs, plus the small checkpoint and result files. The waiting between chunks is free.",
+  "useCases": [
+    "Backfill or reprocess a large table in resumable chunks, checkpointing after each one.",
+    "Run a long batch job on a cron heartbeat so it survives restarts and never holds a worker open.",
+    "Resume an interrupted job from its last checkpoint by starting a fresh run with the same job id."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `total` (dataset size), a `chunkSize`, and a `dbHandle` for the Postgres database holding the data; the chunk's `DATABASE_URL`, `CHUNK_OFFSET`, `CHUNK_LIMIT`, and `JOB_ID` are injected into the `command` you run per chunk (it should print the number of items it processed as its last line). A deployed run processes one chunk, then pauses for the heartbeat. Advance it by firing the signal — on a schedule for a real cadence, or by hand with the MCP `workflow_signal` tool: `{ \"signal\": \"backfill.heartbeat\", \"correlationId\": \"<executionId of the paused run>\" }`. To resume an interrupted job, start a new run with the same `jobId` — it reads the checkpoint and continues.\n\nPrefer to work from the code? Run it locally with `run_local` (leave `dbHandle` unset, or pass `dryRun: true`) to trace the whole plan → process → finalize loop for free — it counts each chunk in-process and auto-resumes every heartbeat. Or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Trace the full loop offline (run_local)",
+      "input": {
+        "total": 25,
+        "chunkSize": 10,
+        "jobId": "demo",
+        "dryRun": true
+      },
+      "output": {
+        "jobId": "demo",
+        "total": 25,
+        "processed": 25,
+        "chunks": 3,
+        "complete": true,
+        "checkpointFileId": null,
+        "manifestFileId": null,
+        "resultFileIds": []
+      }
+    },
+    {
+      "title": "Backfill a real dataset in chunks (deployed)",
+      "input": {
+        "total": 100000,
+        "chunkSize": 5000,
+        "jobId": "users-email-backfill",
+        "dbHandle": "users-db",
+        "command": "node backfill.js"
+      },
+      "output": {
+        "jobId": "users-email-backfill",
+        "total": 100000,
+        "processed": 100000,
+        "chunks": 20,
+        "complete": true,
+        "checkpointFileId": "file_abc123",
+        "manifestFileId": "file_def456",
+        "resultFileIds": ["file_chunk0", "file_chunk1"]
+      }
+    }
+  ]
+}

--- a/examples/durable-backfill/tsconfig.json
+++ b/examples/durable-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,41 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "durable-backfill",
+      "name": "Durable Backfill / Long-Job Runner",
+      "description": "Process a huge dataset in resumable chunks, checkpointing progress so the job survives restarts and picks up where it left off.",
+      "tags": ["durable", "backfill", "batch", "cron"],
+      "sourcePath": "examples/durable-backfill",
+      "capabilities": [
+        "database.get",
+        "sandboxes.create",
+        "sandboxes.exec",
+        "fileStorage.upload",
+        "fileStorage.getDownloadUrl",
+        "fileStorage.list",
+        "fileStorage.delete"
+      ],
+      "whatItDoes": "For long jobs that are too big for one pass — a backfill, a migration, a reprocess. It walks the dataset one chunk at a time. Each chunk's work runs in a sandbox that gets the dataset's connection string and the chunk's range, and after every chunk it writes a checkpoint to file storage and pauses until a heartbeat wakes it for the next one — so nothing runs and nothing is billed while it waits. Progress survives restarts: start a fresh run with the same job id and it reads the checkpoint and resumes mid-dataset. Leave the database handle unset (or pass dryRun) and it counts each chunk in-process, so you can trace the whole loop for free.",
+      "steps": [
+        {
+          "name": "plan",
+          "description": "Works out the job — dataset size, chunk size, and a stable job id — then resumes from a saved checkpoint if one exists for that id.",
+          "next": ["process"]
+        },
+        {
+          "name": "process",
+          "description": "Processes the current chunk in a sandbox, saves a result file and rewrites the checkpoint, then pauses for the next heartbeat — or finishes once the last chunk is done.",
+          "capability": "sandboxes.exec",
+          "next": ["finalize"]
+        },
+        {
+          "name": "finalize",
+          "description": "Writes a manifest of the run and returns a summary.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What & why

Adds the **Durable Backfill / Long-Job Runner** onboarding gallery template (SAP-1886, epic SAP-1823) — a pure durability showcase. It processes a huge dataset in resumable chunks, checkpointing progress so the job survives restarts and picks up where it left off. This is the direct answer to "a long job is too expensive / too fragile to run as an agent."

Closes SAP-1886.

## Shape

```
plan  ──▶  process  ──(checkpoint, then pause: wait for "backfill.heartbeat", $0 idle)──╮
           ▲                                                                            │
           ╰───────────────────────── resume on the heartbeat ───────────────────────────╯
           │
           ╰─(no work left)─▶  finalize  (terminal)
```

- **plan** — resolve the job (dataset size, chunk size, stable `jobId`); resume from a saved checkpoint if one exists for that id.
- **process** — a self-loop. Do one bounded chunk's work in a short-lived sandbox (fed the dataset's `DATABASE_URL` from `database.get` + the chunk range as env), save a per-chunk result file, rewrite the durable checkpoint (`fileStorage`, rotated each chunk), advance the cursor, then `pauseUntilSignal` on `backfill.heartbeat` — or `goto finalize` on the last chunk.
- **finalize** — write a run manifest and terminate with a summary.

Restart survival is two-layered: the cursor rides in `ctx.shared` across every pause within a run, and the checkpoint lives in file storage keyed by `jobId`, so a fresh run started with the same id resumes mid-dataset. The heartbeat is a cron/schedule firing the resume signal on a cadence — nothing runs and nothing is billed between chunks.

## Capabilities

Exercises the five the ticket calls for: **cron** (heartbeat), **pauseUntilSignal** (resumable chunking), **database** (`database.get` → dataset connection string), **sandbox** (`sandboxes.create` / `exec` per-chunk processing), and **file storage** (checkpoint + per-chunk results + manifest).

## Offline / run_local

With no `dbHandle` (or `dryRun: true`), `process` counts each chunk in-process and skips the sandbox / database / file-storage calls, so `run_local` traces the whole `plan → process → … → finalize` loop for free (the local runner auto-resumes each heartbeat pause). Real capability cost is verified only on the deployed path, per the template test loop.

## Verification

- `npm run typecheck` — passes (validated against published `@sapiom/agent` 0.6.6 / `@sapiom/tools` 0.20.1; confirms every `ctx.sapiom.*` call).
- `prettier --check` — clean on all new files + `registry.json`.
- Ran the SDK's `buildManifest` + `validateGraph` on the agent: **0 errors, 0 warnings** — the self-loop heartbeat edge and terminal reachability check out.
- Copy follows `examples/AUTHORING.md`; `registry.json` capability ids match the source (`models.run` is not used here).

## Files

`examples/durable-backfill/` (index.ts, package.json, tsconfig.json, template.json, README.md, AGENTS.md, .gitignore) + one entry in `examples/registry.json`. No `package-lock.json` (matches sibling templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)