### PR TITLE
feat(examples): add Newsletter Autopilot workflow template (SAP-1854)

### DIFF
--- a/examples/newsletter-autopilot/.gitignore
+++ b/examples/newsletter-autopilot/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json*

--- a/examples/newsletter-autopilot/AGENTS.md
+++ b/examples/newsletter-autopilot/AGENTS.md
@@ -1,0 +1,55 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Newsletter
+Autopilot** — authored against `@sapiom/agent`. It has five steps: `search`
+(calls `web.search`) → `scrape` (calls `web.scrape`) → `write` (calls
+`models.run`, the live LLM) → `header` (calls `contentGeneration.images`) →
+`deliver` (emails the issue to a list). Inside a step's `run`, Sapiom
+capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.search.webSearch(...)`,
+`ctx.sapiom.models.run(...)`, `ctx.sapiom.contentGeneration.images.create(...)`,
+`ctx.sapiom.email.messages.send(...)`).
+
+It is the published-newsletter evolution of `scheduled-research-brief`. That
+template curates a private one-recipient brief with no image; this one has the
+LLM write a full issue (subject + body + image prompt), generates a header
+image, and emails it to a whole subscriber list on a cadence.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **Keep the edges slim.** The scraped article bodies are the only large data here; they stay bounded (truncated, capped count) and die at the `write` boundary — they never enter `ctx.shared`. Large shared state stalls transitions on the cloud engine (the `backlog-nudge` boundary lesson).
+- **Gate real side effects behind `dryRun`.** `deliver` sends email only on a live run with `dryRun` off and subscribers resolved; otherwise it returns the finished issue as a preview. Keep new external side effects behind the same guard.
+- **Keep best-effort steps best-effort.** `header` never throws — a missing image is a warning, not a failed run. This is also what lets `run_local` (which stubs image generation) trace the full graph.
+- **Read secrets/config at runtime, never persist them.** The subscriber list falls back to the vault (`ctx.sapiom.vault.get("newsletter-autopilot", "SUBSCRIBERS")`) inside `deliver`, not carried through `ctx.shared`.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `web.search` / `web.scrape` / `models.run` / `images.create` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `deliver` skips the (stubbed) send and returns the preview. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed search + scrape + LLM write + header image, and deliver the issue. Attach the `schedule` as a cron trigger to run it weekly.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`) to a list. To fan the issue into Sapiom **memory** instead — a searchable long-term archive of past issues — swap the per-subscriber send in `deliver` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: "newsletter-autopilot",
+  metadata: { niche, subject, sources },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipients, so you can drop the vault lookup. Recall past issues later with `ctx.sapiom.memory.recall({ query, scope })`.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/newsletter-autopilot/README.md
+++ b/examples/newsletter-autopilot/README.md
@@ -1,0 +1,69 @@
+# Newsletter Autopilot
+
+Research a niche, write the issue, illustrate it, and email it to your
+subscribers — on a weekly cadence. The published-newsletter sibling of
+[`scheduled-research-brief`](../scheduled-research-brief).
+
+## What it does
+
+```
+search  ──▶  scrape  ──▶  write  ──▶  header  ──▶  deliver  (terminal)
+(web.search)  (web.scrape)  (models.run)  (images)   (email)
+```
+
+1. **search** — takes a `niche`, calls `ctx.sapiom.search.webSearch` for
+   candidate results.
+2. **scrape** — reads the top candidates for full article text
+   (`ctx.sapiom.search.scrape`), degrading per-item on failure. Bodies are
+   truncated and stay bounded — they never enter shared state.
+3. **write** — hands the ranked, scraped sources to an LLM
+   (`ctx.sapiom.models.run` — the live x402-served model) to curate and write
+   this week's issue: a subject, a markdown body, and a header-image prompt.
+4. **header** — generates a header image for the issue
+   (`ctx.sapiom.contentGeneration.images.create`). Best-effort: if nothing comes
+   back, the issue still goes out without it.
+5. **deliver** — emails each subscriber their own copy. A `dryRun` guard writes
+   and renders the full issue but skips the real send; the subscriber list is
+   read from the Sapiom vault at runtime, never persisted.
+
+Input: `{ "niche": "indie game development", "newsletterName": "Pixel Weekly", "schedule": "0 8 * * 1", "subscribers": ["you@example.com"] }`.
+
+- `niche` and `newsletterName` set what it writes about and the masthead.
+- `schedule` is the cron cadence — it defaults to Mondays at 08:00.
+- `subscribers` is the recipient list; omit it to use the vault-configured list.
+- `dryRun: true` returns the finished issue as a preview without emailing anyone.
+
+### `scheduled-research-brief` vs. this
+
+Fork [`scheduled-research-brief`](../scheduled-research-brief) for a **private,
+one-recipient brief** — search → scrape → curate → email, no image. Fork **this**
+when the deliverable is a **published-feeling newsletter**: an LLM writes the
+issue with a subject and a header image, and it goes out to a whole list.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` to skip delivery, free) → `sapiom_dev_agents_link`
+   → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real, billed
+   search + scrape + LLM write + header image, and a delivered issue).
+
+4. To run it weekly, attach the `schedule` as a cron trigger on the deployed
+   agent.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/newsletter-autopilot/index.ts
+++ b/examples/newsletter-autopilot/index.ts
@@ -1,0 +1,498 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Newsletter Autopilot — a standing, self-writing newsletter.
+ *
+ * On each tick (built to run weekly) it searches a `niche`, scrapes the top
+ * results for full text, asks an LLM (`ctx.sapiom.models.run` — the live
+ * x402-served model, NOT a hardcoded formatter) to curate and WRITE the issue,
+ * generates a header image for it, and emails the finished issue to a subscriber
+ * list.
+ *
+ * Composition, in one legible graph:
+ *   search    →   scrape    →   write      →   header               →   deliver
+ *  (web.search)  (web.scrape)  (models.run)  (contentGeneration.images)  (email)
+ *
+ * vs. `scheduled-research-brief`: fork THAT for a private, one-recipient brief
+ * (search → scrape → curate → email). Fork THIS when the deliverable is a
+ * published-feeling newsletter — an LLM writes the issue with a subject line and
+ * an image prompt, a header image is generated, and it goes out to a whole list.
+ *
+ * Side-effect discipline (copied from `scheduled-research-brief`):
+ *   - `dryRun` gates the real send: it still searches, writes, and generates the
+ *     header image, then returns the finished issue as a preview WITHOUT emailing
+ *     anyone. `run_local` uses this to trace the whole graph offline (capabilities
+ *     stubbed) for free before a billed, delivering deploy + run.
+ *   - The subscriber list falls back to the Sapiom vault at runtime and is never
+ *     baked into the code — the same seam you'd read any delivery config from.
+ *   - The header image is best-effort: if generation returns nothing (e.g. a
+ *     stubbed `run_local`), the issue still goes out without it rather than
+ *     aborting the run.
+ *   - Each edge carries a slim payload; the large scraped bodies stay bounded and
+ *     die at the `write` boundary — they never enter `ctx.shared` (big shared
+ *     state stalls transitions, per the `backlog-nudge` boundary lesson).
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Default cadence when the caller doesn't pass one: 08:00 every Monday. */
+const DEFAULT_SCHEDULE = "0 8 * * 1";
+/** Default masthead when the caller doesn't name the newsletter. */
+const DEFAULT_NEWSLETTER_NAME = "Weekly Autopilot";
+/** How many search hits to consider as scrape candidates. */
+const MAX_CANDIDATES = 6;
+/** How many candidates to actually scrape (keeps latency + cost bounded). */
+const MAX_SCRAPES = 4;
+/** Truncate each scraped body — the ONLY large data on the search→write path. */
+const MAX_BODY_CHARS = 1200;
+/** Cap the fan-out of per-subscriber sends (keeps a run's cost bounded). */
+const MAX_RECIPIENTS = 50;
+/** Vault ref holding delivery config (a default SUBSCRIBERS list). Read at runtime. */
+const DELIVERY_VAULT_REF = "newsletter-autopilot";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "newsletter";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** The niche / topic to research and write about on each tick. */
+  niche: string;
+  /** Masthead shown in the subject and header (defaults to a generic name). */
+  newsletterName?: string;
+  /** Cron cadence this newsletter is meant to run on (default weekly Monday 08:00). */
+  schedule?: string;
+  /** Subscriber emails; falls back to the vault-configured list when omitted. */
+  subscribers?: string[];
+  /** Write + render the issue but skip the real send. `run_local` passes this. */
+  dryRun?: boolean;
+}
+
+/** Slim search hit carried across the search → scrape boundary. */
+interface Candidate {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/** A candidate plus its (bounded) scraped body — the scrape → write payload. */
+interface ScrapedSource extends Candidate {
+  /** Extracted article text (markdown, truncated); absent when scraping failed. */
+  content?: string;
+}
+
+/** The slim source reference that crosses write → deliver and lands in output. */
+interface Source {
+  title: string;
+  url: string;
+}
+
+/** The LLM's written issue: a subject, a markdown body, and a header image prompt. */
+interface Issue {
+  subject: string;
+  body: string;
+  imagePrompt: string;
+}
+
+interface Shared extends Record<string, unknown> {
+  niche: string;
+  newsletterName: string;
+  schedule: string;
+  subscribers: string[];
+  dryRun: boolean;
+  subject: string;
+  body: string;
+  imagePrompt: string;
+  headerImageUrl: string | null;
+  headerImageFileId: string | null;
+  sources: Source[];
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/**
+ * Resolve the subscriber list from the vault at runtime. The stored value is a
+ * comma- or newline-separated list of emails. A missing ref/key is an expected
+ * outcome (`vault.get` returns null), not an error — the caller then falls back
+ * to a dry-run preview. Never persisted in execution state.
+ */
+async function subscribersFromVault(ctx: Ctx): Promise<string[]> {
+  try {
+    const raw = await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "SUBSCRIBERS");
+    return parseRecipients(raw);
+  } catch (err) {
+    ctx.logger.warn("vault: no subscriber list configured", {
+      err: String(err),
+    });
+    return [];
+  }
+}
+
+/** Split a raw address list (commas or newlines) into de-duped, trimmed emails. */
+function parseRecipients(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  for (const part of raw.split(/[,\n]/)) {
+    const email = part.trim();
+    if (email && email.includes("@")) seen.add(email);
+  }
+  return [...seen];
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Newsletter Autopilot",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Parse the LLM's minified-JSON issue defensively. A model may wrap the JSON in
+ * prose or fences, so we slice to the outermost object before parsing and fall
+ * back to a plain issue built from the sources when anything is off — the
+ * newsletter still goes out rather than failing on a malformed reply. Mirrors
+ * `scene-to-video`'s `parsePlan`.
+ */
+function parseIssue(
+  output: string | null,
+  niche: string,
+  newsletterName: string,
+  sources: Source[],
+): Issue {
+  const fallbackSubject = `${newsletterName}: ${niche || "this week"}`;
+  const fallbackBody =
+    `# ${fallbackSubject}\n\n` +
+    (sources.length > 0
+      ? `This week in ${niche}:\n\n` +
+        sources.map((s) => `- [${s.title}](${s.url})`).join("\n")
+      : `_No sources were found for this topic this week._`);
+  const fallback: Issue = {
+    subject: fallbackSubject,
+    body: fallbackBody,
+    imagePrompt:
+      `Editorial header illustration for a newsletter about ${niche || newsletterName}. ` +
+      `Clean, modern, magazine cover style. No text.`,
+  };
+  if (!output) return fallback;
+  try {
+    const json = output.slice(output.indexOf("{"), output.lastIndexOf("}") + 1);
+    const raw = JSON.parse(json) as Partial<Issue>;
+    return {
+      subject:
+        typeof raw.subject === "string" && raw.subject.trim()
+          ? raw.subject.trim()
+          : fallback.subject,
+      body:
+        typeof raw.body === "string" && raw.body.trim()
+          ? raw.body
+          : fallback.body,
+      imagePrompt:
+        typeof raw.imagePrompt === "string" && raw.imagePrompt.trim()
+          ? raw.imagePrompt
+          : fallback.imagePrompt,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/** Escape the small set of characters that would break out of HTML text. */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render the issue as a minimal HTML email: the header image (when present) on
+ * top, then the markdown body as pre-wrapped text. Kept deliberately small — a
+ * real newsletter would use a templating layer, but this shows the shape.
+ */
+function renderHtml(issue: Issue, headerImageUrl: string | null): string {
+  const header = headerImageUrl
+    ? `<img src="${escapeHtml(headerImageUrl)}" alt="${escapeHtml(issue.subject)}" style="max-width:100%;border-radius:8px;" />`
+    : "";
+  return (
+    `<div style="font-family:system-ui,sans-serif;max-width:640px;margin:0 auto;">` +
+    header +
+    `<div style="white-space:pre-wrap;line-height:1.5;">${escapeHtml(issue.body)}</div>` +
+    `</div>`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const search = defineStep({
+  name: "search",
+  next: ["scrape"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const niche = input.niche?.trim() ?? "";
+    ctx.shared.set("niche", niche);
+    ctx.shared.set(
+      "newsletterName",
+      input.newsletterName?.trim() || DEFAULT_NEWSLETTER_NAME,
+    );
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set(
+      "subscribers",
+      Array.isArray(input.subscribers)
+        ? parseRecipients(input.subscribers.join(","))
+        : [],
+    );
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    if (!niche) {
+      // Nothing to research — hand an empty candidate list forward so the graph
+      // still traces end to end.
+      return goto("scrape", { candidates: [] as Candidate[] });
+    }
+
+    ctx.logger.info("searching the web", { niche });
+    const hits = await ctx.sapiom.search.webSearch({
+      query: niche,
+      intent: "links",
+    });
+    const candidates: Candidate[] = hits.results
+      .slice(0, MAX_CANDIDATES)
+      .map((r) => ({ title: r.title, url: r.url, snippet: r.snippet }));
+    ctx.logger.info("search returned candidates", { count: candidates.length });
+    return goto("scrape", { candidates });
+  },
+});
+
+const scrape = defineStep({
+  name: "scrape",
+  next: ["write"],
+  async run(input: { candidates: Candidate[] }, ctx: Ctx) {
+    const candidates = input.candidates ?? [];
+    const sources: ScrapedSource[] = [];
+    let scraped = 0;
+    for (const c of candidates) {
+      // Beyond the scrape budget we still forward the candidate — the snippet
+      // alone is useful writing context.
+      if (scraped >= MAX_SCRAPES) {
+        sources.push(c);
+        continue;
+      }
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: c.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        scraped += 1;
+        sources.push({
+          title: page.metadata?.title || c.title,
+          url: c.url,
+          snippet: c.snippet,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Scrapes fail routinely (paywalls, timeouts); degrade per-item, never
+        // throw — an issue written from the survivors beats an aborted run.
+        ctx.logger.warn("scrape failed; keeping snippet only", {
+          url: c.url,
+          err: String(err),
+        });
+        sources.push(c);
+      }
+    }
+    ctx.logger.info("scraped candidates", { scraped, total: sources.length });
+    return goto("write", { sources });
+  },
+});
+
+const write = defineStep({
+  name: "write",
+  next: ["header"],
+  async run(input: { sources: ScrapedSource[] }, ctx: Ctx) {
+    const niche = ctx.shared.get("niche") || "your niche";
+    const newsletterName =
+      ctx.shared.get("newsletterName") || DEFAULT_NEWSLETTER_NAME;
+    const sources = input.sources ?? [];
+    // Slim references only — the scraped bodies stop here and never reach shared
+    // state or the deliver boundary.
+    const slimSources: Source[] = sources.map((s) => ({
+      title: s.title,
+      url: s.url,
+    }));
+
+    let issue: Issue;
+    if (sources.length === 0) {
+      issue = parseIssue(null, niche, newsletterName, slimSources);
+    } else {
+      const research = sources
+        .map(
+          (s, i) =>
+            `[${i + 1}] ${s.title} (${s.url})\n${(s.content || s.snippet).slice(0, MAX_BODY_CHARS)}`,
+        )
+        .join("\n\n");
+      // The live, x402-served model curates AND writes the issue — ranking the
+      // sources, dropping the weak ones, and producing a subject, a markdown
+      // body, and a header-image prompt in one structured reply.
+      const res = await ctx.sapiom.models.run({
+        system:
+          `You are the editor of a newsletter called "${newsletterName}". Given a ` +
+          "NICHE and a set of web SOURCES (each: [n] title, url, extracted text), " +
+          "curate the strongest items, drop thin or duplicate ones, and write this " +
+          "week's issue. The body is markdown: an engaging '# ' subject headline, a " +
+          "2-3 sentence intro, then 3-5 short sections that each summarize a story " +
+          "and link it as a [n] reference, then a '## Sources' list mapping each [n] " +
+          "to its title and url. Also write a vivid header-image prompt (no text in " +
+          "the image). Reply with ONLY minified JSON: " +
+          '{"subject":string,"body":string,"imagePrompt":string}.',
+        prompt: `NICHE: ${niche}\n\nSOURCES:\n${research}`,
+        maxTokens: 1200,
+      });
+      issue = parseIssue(res.output, niche, newsletterName, slimSources);
+    }
+
+    ctx.shared.set("subject", issue.subject);
+    ctx.shared.set("body", issue.body);
+    ctx.shared.set("imagePrompt", issue.imagePrompt);
+    ctx.shared.set("sources", slimSources);
+    ctx.logger.info("wrote issue", {
+      subject: issue.subject,
+      chars: issue.body.length,
+      sources: slimSources.length,
+    });
+    return goto("header", { imagePrompt: issue.imagePrompt });
+  },
+});
+
+const header = defineStep({
+  name: "header",
+  next: ["deliver"],
+  async run(input: { imagePrompt: string }, ctx: Ctx) {
+    const imagePrompt =
+      input.imagePrompt || ctx.shared.get("imagePrompt") || "";
+    let headerImageUrl: string | null = null;
+    let headerImageFileId: string | null = null;
+
+    // Best-effort: a header image is a nice-to-have, not a gate. If generation
+    // returns nothing (e.g. a stubbed `run_local`) or errors, the issue still
+    // goes out without it.
+    try {
+      const result = await ctx.sapiom.contentGeneration.images.create({
+        prompt: imagePrompt,
+        numImages: 1,
+        storage: { visibility: "public" },
+      });
+      const img = result.images?.[0];
+      if (img) {
+        headerImageUrl = img.downloadUrl ?? img.url;
+        headerImageFileId = img.fileId ?? null;
+      } else {
+        ctx.logger.warn("header image returned no output; sending without it");
+      }
+    } catch (err) {
+      ctx.logger.warn("header image generation failed; sending without it", {
+        err: String(err),
+      });
+    }
+
+    ctx.shared.set("headerImageUrl", headerImageUrl);
+    ctx.shared.set("headerImageFileId", headerImageFileId);
+    ctx.logger.info("header ready", { hasImage: Boolean(headerImageUrl) });
+    return goto("deliver", {});
+  },
+});
+
+const deliver = defineStep({
+  name: "deliver",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const niche = ctx.shared.get("niche") || "your niche";
+    const schedule = ctx.shared.get("schedule") || DEFAULT_SCHEDULE;
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const subject = ctx.shared.get("subject") || `Newsletter: ${niche}`;
+    const body = ctx.shared.get("body") || "";
+    const sources = ctx.shared.get("sources") ?? [];
+    const headerImageUrl = ctx.shared.get("headerImageUrl") ?? null;
+    const issue: Issue = {
+      subject,
+      body,
+      imagePrompt: ctx.shared.get("imagePrompt") || "",
+    };
+    const html = renderHtml(issue, headerImageUrl);
+
+    // Explicit input list wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state), capped to bound the fan-out.
+    const configured = ctx.shared.get("subscribers") ?? [];
+    const subscribers = (
+      configured.length > 0 ? configured : await subscribersFromVault(ctx)
+    ).slice(0, MAX_RECIPIENTS);
+
+    // The safe path: a dry run — or a live run with no subscribers configured yet —
+    // returns the finished issue without sending anything.
+    if (dryRun || subscribers.length === 0) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        subscribers: subscribers.length,
+      });
+      return terminate({
+        niche,
+        schedule,
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-subscribers",
+        recipients: 0,
+        subject,
+        headerImageUrl,
+        body,
+        sources,
+      });
+    }
+
+    // Send each subscriber their own copy so the list is never exposed across
+    // recipients. Degrade per-item — one bad address shouldn't sink the issue.
+    const inboxId = await resolveSenderInbox(ctx);
+    const messageIds: string[] = [];
+    let failed = 0;
+    for (const to of subscribers) {
+      try {
+        const sent = await ctx.sapiom.email.messages.send(inboxId, {
+          to,
+          subject,
+          text: body,
+          html,
+        });
+        messageIds.push(sent.messageId);
+      } catch (err) {
+        failed += 1;
+        ctx.logger.warn("send failed for one subscriber", {
+          to,
+          err: String(err),
+        });
+      }
+    }
+    ctx.logger.info("issue delivered", {
+      recipients: messageIds.length,
+      failed,
+    });
+    return terminate({
+      niche,
+      schedule,
+      delivered: messageIds.length > 0,
+      dryRun: false,
+      recipients: messageIds.length,
+      failed,
+      subject,
+      headerImageUrl,
+      messageIds,
+      sources,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "newsletter-autopilot",
+  entry: "search",
+  steps: { search, scrape, write, header, deliver },
+});

--- a/examples/newsletter-autopilot/package.json
+++ b/examples/newsletter-autopilot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-newsletter-autopilot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a weekly cron, search + scrape a niche, curate and write a newsletter issue with an LLM (models.run), generate a header image, and email it to your subscriber list.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/newsletter-autopilot/template.json
+++ b/examples/newsletter-autopilot/template.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a niche and a subscriber list. Every week it searches the web, reads the top results, and writes that week's issue — a subject line, a short intro, a few curated sections that link back to their sources, and a header image to go with it. Then it emails the issue to your list.\n\nThe graph is five steps: `search` (web.search) finds candidates, `scrape` reads them for full text, `write` (`models.run`, the live x402-served model) curates and writes the issue plus a header-image prompt, `header` (`contentGeneration.images`) generates the image, and `deliver` emails each subscriber their own copy. Scrapes fail routinely on paywalls and timeouts — when one does, it keeps the search snippet and writes from the survivors. The header image is best-effort: if it doesn't come back, the issue goes out without it. A `dryRun` flag writes and renders the full issue and returns it as a preview without emailing anyone, and the subscriber list is read from the Sapiom vault at runtime rather than stored in the run.\n\nIts simpler sibling is `scheduled-research-brief`: fork that for a private, one-recipient brief with no image. Fork this one when the deliverable is a published-feeling newsletter that goes out to a whole list on a cadence.\n\nYou pay for the web search, the scrapes, the model writing the issue, and the header image on each run — the emails are cheap, and a dry run still writes and illustrates the issue but sends nothing.",
+  "useCases": [
+    "Run a niche newsletter on autopilot — it researches, writes, and illustrates each issue so you only review and hit send.",
+    "Turn a topic you follow into a weekly email your subscribers get without you drafting anything by hand.",
+    "See how web search, scraping, LLM writing, image generation, and list email compose in one agent, with a safe dry-run preview."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `niche` (what to write about) and a `newsletterName`. Set who receives it with the `subscribers` input (a list of emails), or store a default list under the `newsletter-autopilot` vault ref (key `SUBSCRIBERS`, comma- or newline-separated) — it's read at runtime, never saved into the run. Pass `dryRun: true` to write and illustrate the issue and get it back without emailing anyone. To run it weekly, attach the `schedule` as a cron trigger on the deployed workflow (it defaults to Mondays at 08:00).\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole search → scrape → write → header → deliver flow for free (capabilities stubbed, delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A weekly issue on indie game development",
+      "input": {
+        "niche": "indie game development",
+        "newsletterName": "Pixel Weekly",
+        "schedule": "0 8 * * 1",
+        "dryRun": true
+      },
+      "output": {
+        "niche": "indie game development",
+        "schedule": "0 8 * * 1",
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "recipients": 0,
+        "subject": "Pixel Weekly: what shipped in indie games this week",
+        "headerImageUrl": "https://files.sapiom.ai/…/header.png",
+        "body": "# Pixel Weekly: what shipped in indie games this week\n\nA quieter week for launches, but two engine updates worth your time...\n\n## A solo dev's roguelike hits 1.0 [1]\n...\n\n## Sources\n1. [Roguelike 1.0 launch](https://example.com/launch)\n2. [Engine 5.4 release notes](https://example.com/engine)",
+        "sources": [
+          {
+            "title": "Roguelike 1.0 launch",
+            "url": "https://example.com/launch"
+          },
+          {
+            "title": "Engine 5.4 release notes",
+            "url": "https://example.com/engine"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/newsletter-autopilot/tsconfig.json
+++ b/examples/newsletter-autopilot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,46 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "newsletter-autopilot",
+      "name": "Newsletter Autopilot",
+      "description": "On a weekly schedule, it researches a niche, writes and illustrates the issue, and emails it to your subscriber list.",
+      "tags": ["newsletter", "scheduled", "llm", "email"],
+      "sourcePath": "examples/newsletter-autopilot",
+      "capabilities": ["web.search", "models.run", "contentGeneration.images"],
+      "whatItDoes": "For running a niche newsletter without drafting each issue by hand. It searches the web for your niche, then reads the top results for their full text. It hands those sources to an LLM (models.run) to curate the strongest items and write the issue — a subject line, an intro, a few sections that cite their sources, and a header-image prompt. It generates that header image, then emails each subscriber their own copy. Give it a cron schedule and it publishes on its own, defaulting to Mondays at 08:00. A dryRun flag writes and illustrates the full issue and returns it without emailing anyone, so you can review before it goes out.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Search the web for the niche and collect candidate sources.",
+          "capability": "web.search",
+          "next": ["scrape"]
+        },
+        {
+          "name": "scrape",
+          "description": "Read the top candidates for their full article text, keeping just the snippet when a page won't load.",
+          "capability": "web.search",
+          "next": ["write"]
+        },
+        {
+          "name": "write",
+          "description": "Hand the sources to an LLM to curate them and write this week's issue: a subject, a body that cites each source, and a header-image prompt.",
+          "capability": "models.run",
+          "next": ["header"]
+        },
+        {
+          "name": "header",
+          "description": "Generate a header image for the issue; if none comes back, the issue still goes out without it.",
+          "capability": "contentGeneration.images",
+          "next": ["deliver"]
+        },
+        {
+          "name": "deliver",
+          "description": "Email each subscriber their own copy; a dry run, or a run with no subscribers set, returns the issue without sending.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a new **Newsletter Autopilot** onboarding gallery template under `examples/newsletter-autopilot/`, plus its `examples/registry.json` entry. Grows the relaunch template gallery (epic **SAP-1823**).

Closes SAP-1854.

## The template

The published-newsletter sibling of `scheduled-research-brief`. On a weekly cron it:

```
search  ──▶  scrape  ──▶  write  ──▶  header  ──▶  deliver  (terminal)
(web.search)  (web.scrape)  (models.run)  (images)   (email)
```

1. **search** — web search for the `niche`.
2. **scrape** — read the top candidates for full text; degrade per-item on failure.
3. **write** — an LLM (`models.run`) curates the sources and writes the issue: a subject, a markdown body that cites each source, and a header-image prompt.
4. **header** — generate a header image (`contentGeneration.images`). Best-effort — a missing image never sinks the run.
5. **deliver** — email each subscriber their own copy (privacy: the list is never exposed across recipients). Capped at 50 recipients.

## Design choices

- **`dryRun` guards only the irreversible send.** Search / write / image generation still run, so the preview is complete; `run_local` traces the whole graph for free.
- **`header` is best-effort** (never throws) so a stubbed `run_local` or a failed generation still yields a sendable issue.
- **Runtime config, not persisted.** The subscriber list falls back to the Vault (`newsletter-autopilot` ref, `SUBSCRIBERS` key) at runtime; scraped bodies stay bounded and die at the `write` boundary (never enter shared state).
- **Declared `capabilities`** are the cost-driving ids the source actually calls — `web.search`, `models.run`, `contentGeneration.images`. The cheap email step carries no `capability`, matching the `scheduled-research-brief` convention.
- Pins `@sapiom/agent ^0.6.0` / `@sapiom/tools ^0.20.0` (needed for the email + image caps), per the SDK pin trap.

## Validation

- `npm run typecheck` ✓
- `npx prettier --check "**/*.ts"` ✓ (and JSON files against repo prettier config)
- Offline `buildManifest` + `assertValidGraph` (the MCP `check` step-graph validation) ✓ — entry `search`, `search → scrape → write → header → deliver`, no graph errors.
- Registry `capabilities` cross-checked against `ctx.sapiom.*` calls in source.

The full deployed path (`run_local` → `deploy` → `run` → `inspect`) requires the local Studio stack (`pnpm studio up --full`) and is not exercised here, consistent with how the merged sibling template PRs (#343–349, #356–358) were gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpNN13zXGZ184D6GBQRURW