### PR TITLE
feat(examples): Multi-Party Approval Chain (Saga) workflow template (SAP-1882)

### DIFF
--- a/examples/approval-chain/.gitignore
+++ b/examples/approval-chain/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json

--- a/examples/approval-chain/AGENTS.md
+++ b/examples/approval-chain/AGENTS.md
@@ -1,0 +1,105 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Multi-Party
+Approval Chain (Saga)** — authored against `@sapiom/agent`. It runs an ordered
+list of approvers through sequential, durable sign-off gates
+(`present` ⇄ `remind` → `decide`), advancing one gate at a time, and terminates in
+`finalize` (all approved), `compensate` (someone rejected), or `escalate` (a gate
+went silent). Inside a step's `run`, Sapiom capabilities are pre-auth'd on
+`ctx.sapiom` (here, `ctx.sapiom.email` and `ctx.sapiom.database`).
+
+## The sign-off spine
+
+- **`present`** records the current gate as `pending`, emails the approver, then
+  returns `pauseUntilSignal({ signal: "approval.decision", resumeStep: "decide", correlationId: ctx.executionId, timeoutMs })`.
+  It carries a static `pause: { signal, resumeStep: "decide" }` annotation — the
+  build-time graph edge that must match the directive.
+- **`decide`** reads the approval payload **directly as its `run` input**. Safe
+  default: only an explicit `{ decision: "approve" }` advances; `reject`
+  compensates; `timeout` escalates; anything else (including a `run_local` resume
+  with no payload, or the engine firing the pause `timeoutMs`) is a **reminder
+  tick**. The gate index, reminder count, recorded approvals, and audit trail all
+  live in `ctx.shared` and survive every pause.
+- **`remind`** re-notifies the current approver and re-pauses on the same gate
+  (`resumeStep: "decide"`), so `present → decide → remind → decide → …` is a
+  legal cycle bounded by `maxReminders`.
+- **`finalize`** holds the single irreversible action, reached only after EVERY
+  gate approved. A `dryRun` guard makes it a no-op offline.
+- **`compensate`** is the saga's rollback: notify everyone who already approved
+  that the chain was cancelled. Nothing irreversible ran before a rejection, so
+  the compensation is a set of notifications, not an undo of committed work.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability** — don't
+  list it in `capabilities`. The billed calls are `ctx.sapiom.email` and, when a
+  `ledgerHandle` is set, the `ctx.sapiom.database` the ledger lives in.
+
+## Chain state & the ledger
+
+The canonical state is `ctx.shared`. The `database` capability is an **optional,
+best-effort** durable copy: `recordTransition` appends every transition to
+`ctx.shared.trail` and, when a `ledgerHandle` is configured and it's not a
+`dryRun`, also to a Postgres `approval_chain_ledger` table (via a `pg` client on
+the provisioned connection string). A missing handle, a `dryRun`, or any DB error
+degrades to shared + logs and never fails the chain. Rows are keyed on
+`(execution_id, seq)` with `ON CONFLICT DO NOTHING`, so a step retry is idempotent.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` (its forward edge is the pause
+  `resumeStep`) and a `pause: { signal, resumeStep }` annotation.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including
+  the static `pause` annotations (the cycle through `remind` is legal).
+- **run_local** — runs your **real** step code against **stub capabilities** and
+  auto-resumes each pause with no payload, so the default trace walks
+  `present → reminder(s) → escalate` to a terminal for free. With no
+  `ledgerHandle`, no live Postgres is touched.
+- **deploy**, then **run** — ship it, then perform a real run that pauses at each
+  gate.
+
+### Firing the resume signals in dev
+
+A real `run` pauses at every gate. To resume without a real approver, fire the
+signals via the MCP `signal_workflow` / `workflow_signal` tool — the manual
+stand-in. The `correlationId` is the paused run's `executionId`, and each
+`payload` arrives as `decide`'s input.
+
+```json
+{
+  "signal": "approval.decision",
+  "correlationId": "<executionId>",
+  "payload": { "decision": "approve" }
+}
+```
+
+Fire one `approve` per approver to reach `finalize`. Send `{ "decision": "reject" }`
+to walk `compensate`, or `{ "decision": "remind" }` / `{ "decision": "timeout" }`
+to exercise the reminder / escalation branches.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them —
+the ledger uses DB-side `now()` for timestamps to stay deterministic across
+retries. The `correlationId` is `ctx.executionId` (stable across every gate), so a
+resume signal always lands on the right run.

--- a/examples/approval-chain/README.md
+++ b/examples/approval-chain/README.md
@@ -1,0 +1,133 @@
+# Multi-Party Approval Chain (Saga)
+
+A durable, sequential multi-party sign-off flow. An ordered chain of approvers
+(e.g. legal → finance → the CEO) must each approve a subject — a contract, a
+budget, a policy change — **in order**, with reminders and timeout escalation
+between gates, and **compensation** if anyone rejects.
+
+Each gate is a durable `pauseUntilSignal`: the run suspends at **$0** until the
+current party decides, then advances to the next gate. Nothing irreversible
+happens until every party has signed off.
+
+## What it does
+
+```
+start → present ─(pause: approval.decision, $0 while idle)─▶ decide
+          ▲                                                    │
+          │ approve & more gates                              │
+          └────────────────────────────────────────────────── ┤
+        remind ─(pause: approval.decision)────────────────────┤ reminder tick (budget left)
+          ▲                                                     │
+          └───────────────────────── reminder tick ─────────────┤
+                                                                 │
+     reject │              approve & last gate │        timeout / no-response │
+            ▼                                  ▼                              ▼
+       compensate                          finalize                       escalate
+       (terminal)                          (terminal)                      (terminal)
+```
+
+1. **start** — resolve the `subject`, the ordered `approvers`, and the
+   escalation / ledger / reminder settings; initialise the chain state. Empty
+   chain → `escalate`.
+2. **present** — record the gate as `pending` and email the current approver
+   (`ctx.sapiom.email`), then `pauseUntilSignal({ signal: "approval.decision", resumeStep: "decide" })`.
+   The run suspends here at $0.
+3. **decide** (resume target) — its **input is the approval payload**.
+   - `{ "decision": "approve" }` → record it and advance to the next gate
+     (`present`), or `finalize` on the last gate.
+   - `{ "decision": "reject" }` → `compensate`.
+   - `{ "decision": "timeout" }` → `escalate` immediately.
+   - anything else (no decision, `remind`, or a pause-timeout / `run_local`
+     auto-resume) → a reminder tick: `remind` while the reminder budget lasts,
+     else `escalate`.
+4. **remind** — email a reminder to the current approver, then pause again on the
+   same gate (`resumeStep: "decide"`).
+5. **finalize** — the single irreversible action, reached **only after every party
+   approved**. A `dryRun` guard makes it a no-op offline.
+6. **compensate** — saga rollback: notify everyone who already approved that the
+   chain was cancelled.
+7. **escalate** — a gate went silent (or timed out): notify the escalation channel.
+
+The canonical chain state lives in `ctx.shared` (it survives every pause). When a
+`ledgerHandle` is configured, each transition is also appended to a durable
+Postgres table (`approval_chain_ledger`) via `ctx.sapiom.database` — a best-effort
+external audit copy that never blocks the chain.
+
+Input:
+
+```json
+{
+  "subject": "Master Services Agreement v3",
+  "approvers": [
+    { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+    { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+  ],
+  "escalateTo": "ops@example.com",
+  "maxReminders": 2,
+  "ledgerHandle": "approvals-ledger"
+}
+```
+
+`escalateTo` and `ledgerHandle` fall back to `config.ESCALATION_EMAIL` /
+`config.LEDGER_HANDLE` when omitted. Omit `ledgerHandle` to keep the audit trail
+in `ctx.shared` only (no Postgres touched).
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to send notifications and provision the ledger database.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed, pauses auto-resumed, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses
+   at each gate).
+
+Offline, the default `run_local` trace walks `present → reminder(s) → escalate` —
+with no `ledgerHandle` no live Postgres is touched, so it's free. Keep
+`maxReminders` small so it terminates quickly.
+
+## Resuming a paused run in dev
+
+A real `run` pauses at each gate. Instead of a real approver, fire the signals
+yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`, and each `payload` becomes the
+resumed `decide` step's input.
+
+**Approve** the current gate (advances to the next, or finalises on the last):
+
+```json
+{
+  "signal": "approval.decision",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve" }
+}
+```
+
+Fire one `approve` per approver to reach `finalize`. To walk the other branches:
+
+- `{ "decision": "reject" }` → `compensate` (notifies prior approvers).
+- `{ "decision": "remind" }` → a reminder tick (re-notifies, re-pauses).
+- `{ "decision": "timeout" }` → `escalate`.
+
+## Persisting the audit ledger
+
+Pass a `ledgerHandle` (or `config.LEDGER_HANDLE`) and run **deployed** with
+`dryRun: false`. Each transition is appended to the `approval_chain_ledger` table
+of a Postgres provisioned on demand (`ctx.sapiom.database`), keyed on
+`(execution_id, seq)` so step retries are idempotent. `run_local` stubs the
+database, so verify the rows on the deployed path.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -1,0 +1,776 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { Client } from "pg";
+
+/**
+ * Multi-Party Approval Chain (Saga) — a durable, sequential sign-off flow.
+ *
+ * An ordered list of approvers (e.g. legal → finance → the CEO) must each sign
+ * off on a subject — a contract, a budget, a policy change — **in order**. The
+ * run presents to one approver, then **suspends at $0 via `pauseUntilSignal`**
+ * until that party decides; only then does it advance to the next gate. Between
+ * gates it nudges the current approver (reminders) and, if they never respond,
+ * escalates to a human channel (timeout). If any approver rejects, the run walks
+ * a **saga compensation** — notifying everyone who already approved that the
+ * chain was cancelled — instead of leaving a half-signed contract behind.
+ *
+ *   start → present ─(pause: approval.decision, $0 while idle)─▶ decide
+ *             ▲                                                    │
+ *             │ approve & more gates                              │
+ *             └──────────────────────────────────────────────────┤
+ *             remind ─(pause: approval.decision)──────────────────┤ reminder tick
+ *             ▲                                                    │
+ *             └──────────────── reminder tick (budget left) ───────┤
+ *                                                                  │
+ *        reject │        approve & last gate │        timeout / no-response │
+ *               ▼                            ▼                              ▼
+ *          compensate                    finalize                       escalate
+ *          (terminal)                    (terminal)                      (terminal)
+ *
+ * Every gate is a durable `pauseUntilSignal`: the run survives the wait with no
+ * compute burning, resuming only when a party fires `approval.decision` for this
+ * run. `pauseUntilSignal` is a runtime primitive, not a metered capability — so
+ * it is NOT listed in `capabilities`. The billed calls are the notifications
+ * (`ctx.sapiom.email`); the optional durable audit **ledger** persists each
+ * transition to a Postgres provisioned via `ctx.sapiom.database`.
+ *
+ * ── Reminders & timeout ────────────────────────────────────────────────────────
+ * A resume with an explicit `{ decision: "approve" | "reject" }` drives the saga.
+ * A resume with NO decision — the engine firing the pause `timeoutMs`, a
+ * `run_local` auto-resume, or an explicit `{ decision: "remind" }` — counts as a
+ * reminder tick: re-notify the current approver and re-pause, up to
+ * `maxReminders`, after which the gate escalates. An explicit
+ * `{ decision: "timeout" }` escalates immediately. This mirrors the "a timeout
+ * fires the signal" convention — wire a cron to fire `remind`/`timeout` on a
+ * schedule, or rely on the pause `timeoutMs` where the engine supports it.
+ *
+ * ── Chain state ────────────────────────────────────────────────────────────────
+ * The canonical chain state — which gate we're on, who has approved, the full
+ * transition trail — lives in `ctx.shared`, which survives every pause. When a
+ * `ledgerHandle` is configured, each transition is ALSO appended to a durable
+ * Postgres table (`database` capability) so the sign-off record outlives the run
+ * and is queryable by the ops/legal owner. The ledger is best-effort: a missing
+ * handle, a `dryRun`, or an unreachable DB degrades to `ctx.shared` + logs and
+ * never fails the chain.
+ *
+ * Offline: `run_local` stubs the capabilities and auto-resumes each pause with no
+ * payload — so the default trace walks present → reminder(s) → escalate for free
+ * (no `ledgerHandle` ⇒ no live Postgres). Fire real `approval.decision` signals
+ * (in dev, via the MCP `signal_workflow` / `workflow_signal` tool — see README)
+ * to drive the approve → next-gate → finalize and reject → compensate paths.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** The signal a party fires to approve / reject (or nudge / time out) a gate. */
+const APPROVAL_SIGNAL = "approval.decision";
+
+/** Username for the inbox we send notifications from (created once, then reused). */
+const SENDER_USERNAME = "approvals";
+
+/** Reminders sent before a silent gate escalates. */
+const DEFAULT_MAX_REMINDERS = 2;
+
+/** Default pause timeout per gate (best-effort auto-reminder): 24 hours. */
+const DEFAULT_REMINDER_MS = 24 * 60 * 60 * 1000;
+
+/** Postgres table the durable ledger appends to. */
+const LEDGER_TABLE = "approval_chain_ledger";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** One party in the ordered sign-off chain. */
+interface Approver {
+  /** Stable id used in the audit trail and compensation. */
+  id: string;
+  /** Human-readable name shown in notifications. */
+  name: string;
+  /** Where to send the sign-off request. Absent ⇒ can't be contacted (logged, skipped). */
+  email?: string;
+}
+
+/** The payload a party delivers on the `approval.decision` signal. */
+interface ApprovalDecision {
+  /**
+   * `approve` advances to the next gate (or finalizes on the last); `reject`
+   * compensates; `timeout` escalates immediately; `remind` (or anything absent)
+   * is a reminder tick. Safe default: only an explicit `approve` advances.
+   */
+  decision?: "approve" | "reject" | "timeout" | "remind";
+  /** Optional free-text note carried into the trail / outcome. */
+  notes?: string;
+}
+
+/** A gate a party has signed off, in order. */
+interface RecordedApproval {
+  id: string;
+  name: string;
+  notes: string | null;
+}
+
+/** One immutable row in the sign-off audit trail. */
+interface Transition {
+  /** Monotonic index within this run — the ledger's per-run primary key. */
+  seq: number;
+  /** Which gate the transition belongs to. */
+  gateIndex: number;
+  /** The gate's approver id, or `null` for chain-level transitions. */
+  approverId: string | null;
+  /** What happened: `pending` | `reminder` | `approved` | `rejected` | `timeout` | `completed` | `cancelled` | `escalated` | `chain-started`. */
+  phase: string;
+  /** Optional free-text detail. */
+  note: string | null;
+}
+
+interface EntryInput {
+  /** What is being signed off (contract, budget, policy…). */
+  subject?: string;
+  /** The ordered chain of approvers — each must approve before the next is asked. */
+  approvers?: Approver[];
+  /** Human channel to escalate to on timeout. Falls back to `config.ESCALATION_EMAIL`. */
+  escalateTo?: string;
+  /**
+   * Handle of a durable Postgres to append the audit trail to (`database`
+   * capability). Falls back to `config.LEDGER_HANDLE`. Absent ⇒ ledger kept in
+   * `ctx.shared` only.
+   */
+  ledgerHandle?: string;
+  /** Pause timeout per gate in ms (best-effort auto-reminder). Default 24h. */
+  reminderMs?: number;
+  /** Reminders before a silent gate escalates. Default 2. */
+  maxReminders?: number;
+  /** Skip the irreversible finalize action and live DB writes. `run_local` sets this. */
+  dryRun?: boolean;
+  /** String-only config bag (escalation / ledger fallbacks). */
+  config?: Config;
+}
+
+/** State that survives the pauses, read back after each resume. */
+interface Shared extends Record<string, unknown> {
+  subject: string;
+  approvers: Approver[];
+  gateIndex: number;
+  reminders: number;
+  approvals: RecordedApproval[];
+  trail: Transition[];
+  escalateTo: string | null;
+  ledgerHandle: string | null;
+  reminderMs: number;
+  maxReminders: number;
+  dryRun: boolean;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** Normalise the input chain: guarantee an id + name for every approver. */
+function normalizeApprovers(raw: Approver[]): Approver[] {
+  return raw.map((a, i) => ({
+    id: a.id?.trim() || `approver-${i + 1}`,
+    name: a.name?.trim() || a.id?.trim() || `Approver ${i + 1}`,
+    email: a.email?.trim() || undefined,
+  }));
+}
+
+/** Clamp a caller-supplied reminder interval to a sane positive value. */
+function clampReminderMs(ms: number | undefined): number {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) {
+    return DEFAULT_REMINDER_MS;
+  }
+  return Math.floor(ms);
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Approvals",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Send a notification, degrading gracefully when there's no recipient. A missing
+ * address is an expected outcome (an approver with no email, no escalation
+ * channel configured) — log and skip rather than failing the run.
+ */
+async function notify(
+  ctx: Ctx,
+  to: string | null | undefined,
+  subject: string,
+  text: string,
+): Promise<boolean> {
+  if (!to) {
+    ctx.logger.warn("notify skipped: no recipient", { subject });
+    return false;
+  }
+  const inboxId = await resolveSenderInbox(ctx);
+  const sent = await ctx.sapiom.email.messages.send(inboxId, {
+    to,
+    subject,
+    text,
+  });
+  ctx.logger.info("notified", { to, subject, messageId: sent.messageId });
+  return true;
+}
+
+/**
+ * Append a transition to the canonical trail in `ctx.shared`, and — best-effort —
+ * to the durable Postgres ledger. The ledger is an external audit copy, never the
+ * source of truth: no `ledgerHandle`, a `dryRun`, or any DB error degrades to
+ * `ctx.shared` + logs so an unreachable ledger can't break the sign-off flow.
+ *
+ * The write is keyed on `(execution_id, seq)` with `ON CONFLICT DO NOTHING`, so a
+ * step retry (which re-runs the body) is idempotent.
+ */
+async function recordTransition(
+  ctx: Ctx,
+  phase: string,
+  note?: string | null,
+): Promise<void> {
+  const approvers = ctx.shared.get("approvers") ?? [];
+  const gateIndex = ctx.shared.get("gateIndex") ?? 0;
+  const trail = ctx.shared.get("trail") ?? [];
+  const transition: Transition = {
+    seq: trail.length,
+    gateIndex,
+    approverId: approvers[gateIndex]?.id ?? null,
+    phase,
+    note: note ?? null,
+  };
+  ctx.shared.set("trail", [...trail, transition]);
+  ctx.logger.info("ledger: transition", {
+    seq: transition.seq,
+    phase,
+    gateIndex,
+    approverId: transition.approverId,
+  });
+
+  const handle = ctx.shared.get("ledgerHandle");
+  if (ctx.shared.get("dryRun") || !handle) return;
+  await persistTransition(ctx, handle, transition).catch((err) => {
+    // Audit persistence is best-effort; a broken ledger must not stop the chain.
+    ctx.logger.warn("ledger: persist failed (kept in shared)", {
+      seq: transition.seq,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
+/** Resolve (or provision) the ledger DB and append one transition row. */
+async function persistTransition(
+  ctx: Ctx,
+  handle: string,
+  transition: Transition,
+): Promise<void> {
+  const db = await ctx.sapiom.database
+    .get(handle)
+    .catch(() => ctx.sapiom.database.create({ duration: "7d", handle }));
+  const connectionString = db.connection?.connectionString;
+  if (!connectionString) {
+    ctx.logger.warn("ledger: database has no connection string yet", {
+      handle,
+    });
+    return;
+  }
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS ${LEDGER_TABLE} (
+         execution_id text NOT NULL,
+         seq          integer NOT NULL,
+         subject      text,
+         gate_index   integer,
+         approver_id  text,
+         phase        text NOT NULL,
+         note         text,
+         recorded_at  timestamptz NOT NULL DEFAULT now(),
+         PRIMARY KEY (execution_id, seq)
+       )`,
+    );
+    await client.query(
+      `INSERT INTO ${LEDGER_TABLE}
+         (execution_id, seq, subject, gate_index, approver_id, phase, note)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (execution_id, seq) DO NOTHING`,
+      [
+        ctx.executionId,
+        transition.seq,
+        ctx.shared.get("subject") ?? null,
+        transition.gateIndex,
+        transition.approverId,
+        transition.phase,
+        transition.note,
+      ],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const start = defineStep({
+  name: "start",
+  next: ["present", "escalate"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const config = input.config ?? {};
+    const subject = input.subject?.trim() || "(untitled approval)";
+    const approvers = normalizeApprovers(input.approvers ?? []);
+    ctx.shared.set("subject", subject);
+    ctx.shared.set("approvers", approvers);
+    ctx.shared.set("gateIndex", 0);
+    ctx.shared.set("reminders", 0);
+    ctx.shared.set("approvals", []);
+    ctx.shared.set("trail", []);
+    ctx.shared.set(
+      "escalateTo",
+      input.escalateTo?.trim() || config.ESCALATION_EMAIL || null,
+    );
+    ctx.shared.set(
+      "ledgerHandle",
+      input.ledgerHandle?.trim() || config.LEDGER_HANDLE || null,
+    );
+    ctx.shared.set("reminderMs", clampReminderMs(input.reminderMs));
+    ctx.shared.set("maxReminders", input.maxReminders ?? DEFAULT_MAX_REMINDERS);
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    await recordTransition(ctx, "chain-started", subject);
+
+    if (approvers.length === 0) {
+      // Nothing to sign off — escalate rather than pausing on a gate that doesn't exist.
+      ctx.logger.warn("no approvers supplied — escalating");
+      return goto("escalate", { reason: "no-approvers" });
+    }
+
+    ctx.logger.info("approval chain started", {
+      subject,
+      gates: approvers.length,
+    });
+    return goto("present", {});
+  },
+});
+
+const present = defineStep({
+  name: "present",
+  next: [],
+  // Static graph edge: on the approval signal, resume at `decide`.
+  pause: { signal: APPROVAL_SIGNAL, resumeStep: "decide" },
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const reminderMs = must(ctx.shared.get("reminderMs"), "reminderMs");
+    const current = approvers[gateIndex];
+    if (!current) {
+      // Invariant guard — callers only route here with a valid gate.
+      throw new Error(
+        `no approver at gate ${gateIndex} of ${approvers.length}`,
+      );
+    }
+
+    // A fresh gate: reset the reminder budget and record the pending sign-off.
+    ctx.shared.set("reminders", 0);
+    await recordTransition(ctx, "pending");
+    await notify(
+      ctx,
+      current.email,
+      `Sign-off needed (${gateIndex + 1}/${approvers.length}): ${subject}`,
+      buildRequestEmail(
+        subject,
+        current,
+        gateIndex,
+        approvers.length,
+        ctx.executionId,
+      ),
+    );
+
+    ctx.logger.info("presented gate; pausing for decision", {
+      gate: gateIndex + 1,
+      approver: current.id,
+    });
+
+    // Suspend at $0 until this party fires the approval signal for this run. The
+    // `timeoutMs` is a best-effort auto-reminder where the engine supports it.
+    return pauseUntilSignal({
+      signal: APPROVAL_SIGNAL,
+      resumeStep: "decide",
+      correlationId: ctx.executionId,
+      timeoutMs: reminderMs,
+    });
+  },
+});
+
+const decide = defineStep({
+  name: "decide",
+  next: ["present", "remind", "finalize", "compensate", "escalate"],
+  // `payload` IS the approval signal body (or empty on a pause timeout / auto-resume).
+  async run(payload: ApprovalDecision, ctx: Ctx) {
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const current = approvers[gateIndex];
+    const decision = payload?.decision;
+    ctx.logger.info("gate decision", {
+      gate: gateIndex + 1,
+      approver: current?.id,
+      decision: decision ?? "(none)",
+    });
+
+    if (decision === "approve") {
+      await recordTransition(ctx, "approved", payload?.notes);
+      const approvals = ctx.shared.get("approvals") ?? [];
+      ctx.shared.set("approvals", [
+        ...approvals,
+        {
+          id: current?.id ?? `approver-${gateIndex + 1}`,
+          name: current?.name ?? "(unknown)",
+          notes: payload?.notes ?? null,
+        },
+      ]);
+      const nextIndex = gateIndex + 1;
+      if (nextIndex < approvers.length) {
+        // Advance to the next gate in the chain.
+        ctx.shared.set("gateIndex", nextIndex);
+        return goto("present", {});
+      }
+      // Every party has signed off.
+      return goto("finalize", {});
+    }
+
+    if (decision === "reject") {
+      await recordTransition(ctx, "rejected", payload?.notes);
+      return goto("compensate", {
+        rejectedBy: current?.id ?? null,
+        notes: payload?.notes ?? null,
+      });
+    }
+
+    if (decision === "timeout") {
+      await recordTransition(ctx, "timeout", payload?.notes);
+      return goto("escalate", { reason: "timeout" });
+    }
+
+    // No explicit decision → a reminder tick (pause timeout / auto-resume / "remind").
+    const reminders = (ctx.shared.get("reminders") ?? 0) + 1;
+    ctx.shared.set("reminders", reminders);
+    const maxReminders =
+      ctx.shared.get("maxReminders") ?? DEFAULT_MAX_REMINDERS;
+    if (reminders > maxReminders) {
+      // Out of reminders and still no response — escalate the silent gate.
+      await recordTransition(
+        ctx,
+        "timeout",
+        `no response after ${maxReminders} reminders`,
+      );
+      return goto("escalate", { reason: "no-response" });
+    }
+    return goto("remind", {});
+  },
+});
+
+const remind = defineStep({
+  name: "remind",
+  next: [],
+  // Static graph edge: on the approval signal, resume at `decide` (same as present).
+  pause: { signal: APPROVAL_SIGNAL, resumeStep: "decide" },
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const reminderMs = must(ctx.shared.get("reminderMs"), "reminderMs");
+    const reminders = ctx.shared.get("reminders") ?? 1;
+    const current = approvers[gateIndex];
+    if (!current) {
+      throw new Error(
+        `no approver at gate ${gateIndex} of ${approvers.length}`,
+      );
+    }
+
+    await recordTransition(ctx, "reminder", `reminder ${reminders}`);
+    await notify(
+      ctx,
+      current.email,
+      `Reminder ${reminders}: sign-off still needed — ${subject}`,
+      buildReminderEmail(subject, current, reminders, ctx.executionId),
+    );
+
+    ctx.logger.info("reminder sent; pausing again for decision", {
+      gate: gateIndex + 1,
+      approver: current.id,
+      reminders,
+    });
+
+    // Re-suspend on the same gate until a decision (or the next reminder tick).
+    return pauseUntilSignal({
+      signal: APPROVAL_SIGNAL,
+      resumeStep: "decide",
+      correlationId: ctx.executionId,
+      timeoutMs: reminderMs,
+    });
+  },
+});
+
+const finalize = defineStep({
+  name: "finalize",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvals = ctx.shared.get("approvals") ?? [];
+    const dryRun = ctx.shared.get("dryRun") ?? false;
+
+    await recordTransition(ctx, "completed");
+
+    if (dryRun) {
+      // Offline / preview: the single irreversible action is a no-op. Every gate,
+      // notification, and ledger row up to here already ran (or was traced) for real.
+      ctx.logger.info("dry run: skipping the irreversible finalize action", {
+        subject,
+        approvals: approvals.length,
+      });
+      return terminate({
+        committed: false,
+        dryRun: true,
+        outcome: "dry-run",
+        subject,
+        approvals,
+      });
+    }
+
+    // ── The single irreversible action ─────────────────────────────────────
+    // Reached ONLY after EVERY party in the chain approved. In a real fork,
+    // replace this completion notice with the action the sign-off authorises —
+    // countersign + release the contract, disburse the budget, publish the policy.
+    let notified = 0;
+    for (const approver of ctx.shared.get("approvers") ?? []) {
+      const email = approver.email;
+      if (
+        await notify(
+          ctx,
+          email,
+          `Approved & finalised: ${subject}`,
+          buildCompletedEmail(subject, approvals, ctx.executionId),
+        )
+      ) {
+        notified += 1;
+      }
+    }
+
+    ctx.logger.info("chain finalised", {
+      subject,
+      approvals: approvals.length,
+    });
+    return terminate({
+      committed: true,
+      dryRun: false,
+      outcome: "completed",
+      subject,
+      approvals,
+      notified,
+    });
+  },
+});
+
+const compensate = defineStep({
+  name: "compensate",
+  next: [],
+  terminal: true,
+  async run(
+    input: { rejectedBy?: string | null; notes?: string | null },
+    ctx: Ctx,
+  ) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvals = ctx.shared.get("approvals") ?? [];
+    const approvers = ctx.shared.get("approvers") ?? [];
+    const rejectedBy = input?.rejectedBy ?? null;
+
+    await recordTransition(ctx, "cancelled", input?.notes);
+
+    // Saga compensation: everyone who already approved acted on the assumption
+    // the chain would complete. Notify them it was cancelled so downstream
+    // effects of their sign-off can be unwound. Nothing irreversible ran, so the
+    // compensation is a set of notifications, not a rollback of committed work.
+    let compensated = 0;
+    for (const approved of approvals) {
+      const contact = approvers.find((a) => a.id === approved.id)?.email;
+      if (
+        await notify(
+          ctx,
+          contact,
+          `Cancelled: ${subject}`,
+          buildCancelledEmail(subject, approved, rejectedBy),
+        )
+      ) {
+        compensated += 1;
+      }
+    }
+
+    ctx.logger.info("chain rejected — compensated prior approvals", {
+      subject,
+      rejectedBy,
+      compensated,
+    });
+    return terminate({
+      committed: false,
+      outcome: "rejected",
+      subject,
+      rejectedBy,
+      approved: approvals,
+      compensated,
+    });
+  },
+});
+
+const escalate = defineStep({
+  name: "escalate",
+  next: [],
+  terminal: true,
+  async run(input: { reason?: string }, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = ctx.shared.get("approvers") ?? [];
+    const gateIndex = ctx.shared.get("gateIndex") ?? 0;
+    const escalateTo = ctx.shared.get("escalateTo") ?? null;
+    const reason = input?.reason ?? "no-response";
+    const stalledAt = approvers[gateIndex] ?? null;
+
+    await recordTransition(ctx, "escalated", reason);
+    await notify(
+      ctx,
+      escalateTo,
+      `Escalation: approval chain stalled — ${subject}`,
+      buildEscalationEmail(subject, stalledAt, gateIndex, reason),
+    );
+
+    ctx.logger.info("escalated to human channel", {
+      subject,
+      escalateTo,
+      reason,
+      gate: gateIndex + 1,
+    });
+    return terminate({
+      committed: false,
+      outcome: "escalated",
+      reason,
+      subject,
+      stalledAtGate: approvers.length > 0 ? gateIndex + 1 : 0,
+      stalledApprover: stalledAt
+        ? { id: stalledAt.id, name: stalledAt.name }
+        : null,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── email bodies ──
+function buildRequestEmail(
+  subject: string,
+  approver: Approver,
+  gateIndex: number,
+  total: number,
+  executionId: string,
+): string {
+  return [
+    `Hi ${approver.name},`,
+    "",
+    `Your sign-off is needed on: ${subject}`,
+    `You are approver ${gateIndex + 1} of ${total} in the chain.`,
+    "",
+    "Fire the `approval.decision` signal with",
+    '{"decision":"approve"} to sign off, or {"decision":"reject"} to stop the chain.',
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildReminderEmail(
+  subject: string,
+  approver: Approver,
+  reminders: number,
+  executionId: string,
+): string {
+  return [
+    `Hi ${approver.name},`,
+    "",
+    `Reminder #${reminders}: we're still waiting on your sign-off for: ${subject}`,
+    "",
+    "Fire the `approval.decision` signal with",
+    '{"decision":"approve"} or {"decision":"reject"}. If we don\'t hear back,',
+    "the request will be escalated.",
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildCompletedEmail(
+  subject: string,
+  approvals: RecordedApproval[],
+  executionId: string,
+): string {
+  return [
+    `The approval chain for "${subject}" is complete — every party signed off.`,
+    "",
+    "Sign-off order:",
+    ...approvals.map((a, i) => `${i + 1}. ${a.name}`),
+    "",
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildCancelledEmail(
+  subject: string,
+  approved: RecordedApproval,
+  rejectedBy: string | null,
+): string {
+  return [
+    `Hi ${approved.name},`,
+    "",
+    `The approval chain for "${subject}" was cancelled${
+      rejectedBy ? ` (rejected by ${rejectedBy})` : ""
+    }.`,
+    "You approved an earlier gate — no further action is needed, and any",
+    "downstream effect of your sign-off should be treated as void.",
+  ].join("\n");
+}
+
+function buildEscalationEmail(
+  subject: string,
+  stalledAt: Approver | null,
+  gateIndex: number,
+  reason: string,
+): string {
+  return [
+    `Escalation: the approval chain for "${subject}" stalled.`,
+    "",
+    `Reason: ${reason}.`,
+    stalledAt
+      ? `Waiting on gate ${gateIndex + 1}: ${stalledAt.name} (${stalledAt.id}).`
+      : "No approvers were supplied to the chain.",
+    "",
+    "Human intervention needed to unblock or cancel the sign-off.",
+  ].join("\n");
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "approval-chain",
+  entry: "start",
+  steps: {
+    start,
+    present,
+    decide,
+    remind,
+    finalize,
+    compensate,
+    escalate,
+  },
+});

--- a/examples/approval-chain/package.json
+++ b/examples/approval-chain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sapiom/example-approval-chain",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: a durable multi-party sign-off saga — sequential pauseUntilSignal approval gates with reminders, timeout escalation, and compensation on rejection, with an optional Postgres audit ledger.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0",
+    "pg": "^8.11.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/pg": "^8.11.5",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/approval-chain/template.json
+++ b/examples/approval-chain/template.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "A durable, sequential multi-party sign-off **saga**: an ordered chain of approvers (e.g. legal → finance → the CEO) must each approve a subject — a contract, a budget, a policy change — **in order**, with reminders and timeout escalation between gates, and compensation if anyone rejects.\n\nEach gate is a durable `pauseUntilSignal`: the run presents the request to the current approver (`ctx.sapiom.email`), then **suspends at $0** until that party fires `approval.decision`. An `approve` advances to the next gate (or finalises on the last); a `reject` walks a **saga compensation** — notifying everyone who already signed off that the chain was cancelled — so a half-signed contract is never left behind.\n\nBetween gates, a resume with no decision (the pause `timeoutMs`, an auto-resume, or an explicit `{ decision: 'remind' }`) is a reminder tick: re-notify the current approver and re-pause, up to `maxReminders`, after which the silent gate escalates to a human channel. An explicit `{ decision: 'timeout' }` escalates immediately.\n\nThe canonical chain state — the current gate, who has approved, the full transition trail — lives in `ctx.shared`, which survives every pause. When a `ledgerHandle` is set, each transition is ALSO appended to a durable Postgres table via the `database` capability, so the sign-off record outlives the run and stays queryable. The ledger is best-effort: no handle, a `dryRun`, or an unreachable DB degrades to `ctx.shared` + logs and never breaks the chain. `pauseUntilSignal` is a runtime primitive, not a metered capability; the billed calls are the notifications and the ledger's database.",
+  "useCases": [
+    "Route a contract, budget, or policy change through a fixed sequence of sign-offs, one party at a time.",
+    "Nudge a slow approver on a schedule and escalate to a human when a gate goes silent, instead of stalling forever.",
+    "Unwind a partially-approved chain safely (saga compensation) the moment any party rejects.",
+    "Keep a durable, queryable audit trail of who approved what, and when, in your own Postgres."
+  ],
+  "notes": "`run_local` stubs the capabilities and auto-resumes each pause with no payload, so the default offline trace walks present → reminder(s) → escalate to a terminal for free — with no `ledgerHandle`, no live Postgres is touched. Set a small `maxReminders` (default 2) so the offline trace terminates quickly.\n\nA real `deploy` + `run` pauses for real at each gate. To drive it in dev, fire the signals via the MCP `signal_workflow` / `workflow_signal` tool with `correlationId` = the paused run's `executionId`. Approve a gate: `{ \"signal\": \"approval.decision\", \"correlationId\": \"<executionId>\", \"payload\": { \"decision\": \"approve\" } }` — repeat once per approver to reach `finalize`. Send `{ \"decision\": \"reject\" }` to walk the compensation path, or `{ \"decision\": \"remind\" }` / `{ \"decision\": \"timeout\" }` to exercise the reminder / escalation branches.\n\nTo persist the audit trail to Postgres, pass a `ledgerHandle` (or `config.LEDGER_HANDLE`) and run deployed with `dryRun: false`; verify the rows land in the `approval_chain_ledger` table. See `README.md` and `AGENTS.md`.",
+  "examples": [
+    {
+      "title": "Two-party contract sign-off, both approve",
+      "input": {
+        "subject": "Master Services Agreement v3",
+        "approvers": [
+          { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+          { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+        ],
+        "escalateTo": "ops@example.com",
+        "maxReminders": 2
+      },
+      "output": {
+        "committed": true,
+        "dryRun": false,
+        "outcome": "completed",
+        "subject": "Master Services Agreement v3",
+        "notified": 2
+      }
+    },
+    {
+      "title": "Finance rejects after legal approved — compensate",
+      "input": {
+        "subject": "Q3 marketing budget increase",
+        "approvers": [
+          { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+          { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+        ],
+        "escalateTo": "ops@example.com"
+      },
+      "output": {
+        "committed": false,
+        "outcome": "rejected",
+        "subject": "Q3 marketing budget increase",
+        "rejectedBy": "finance",
+        "compensated": 1
+      }
+    }
+  ]
+}

--- a/examples/approval-chain/tsconfig.json
+++ b/examples/approval-chain/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,58 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "approval-chain",
+      "name": "Multi-Party Approval Chain (Saga)",
+      "description": "A durable sequential sign-off chain — pause-per-gate approvals with reminders, timeout escalation, and compensation on rejection.",
+      "tags": ["approval", "saga", "pause-resume", "durable"],
+      "sourcePath": "examples/approval-chain",
+      "capabilities": ["email.send", "database.create"],
+      "whatItDoes": "Routes a subject — a contract, a budget, a policy change — through an ordered chain of approvers (e.g. legal → finance → the CEO) who must each sign off IN ORDER. Every gate is a durable pauseUntilSignal: the run emails the current approver and suspends at $0 until they fire approval.decision, then advances to the next gate. A reject walks a saga compensation — notifying everyone who already approved that the chain was cancelled — so a half-signed contract is never left behind. Between gates, a resume with no decision (the pause timeoutMs, an auto-resume, or an explicit remind) is a reminder tick that re-notifies and re-pauses, up to maxReminders, after which a silent gate escalates to a human channel. The canonical chain state lives in ctx.shared and survives every pause; when a ledgerHandle is set, each transition is also appended to a durable Postgres table (the database capability) as a best-effort, queryable audit trail. pauseUntilSignal is a runtime primitive, not a metered capability — the billed calls are the notifications and the ledger database.",
+      "steps": [
+        {
+          "name": "start",
+          "description": "Resolve the subject, the ordered approvers, and the escalation / ledger / reminder settings; initialise the chain state. An empty chain escalates.",
+          "capability": "database.create",
+          "next": ["present", "escalate"]
+        },
+        {
+          "name": "present",
+          "description": "Record the gate as pending and email the current approver, then pause until the approval signal (resumes at 'decide').",
+          "capability": "email.send",
+          "next": ["decide"]
+        },
+        {
+          "name": "decide",
+          "description": "Resume target — its input is the approval payload; approve advances to the next gate or finalises, reject compensates, timeout/no-response escalates, and any other resume is a reminder tick.",
+          "next": ["present", "remind", "finalize", "compensate", "escalate"]
+        },
+        {
+          "name": "remind",
+          "description": "Email a reminder to the current approver, then pause again on the same gate (resumes at 'decide').",
+          "capability": "email.send",
+          "next": ["decide"]
+        },
+        {
+          "name": "finalize",
+          "description": "The single irreversible action — reached only after every party approved; a dryRun guard makes it a no-op offline.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "compensate",
+          "description": "Saga rollback: someone rejected — notify everyone who already approved that the chain was cancelled.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "escalate",
+          "description": "Terminal branch: a gate went silent or timed out — escalate to a human channel.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the **`approval-chain`** onboarding template — a durable, sequential multi-party sign-off **saga** — to the relaunch gallery (epic SAP-1823, closes SAP-1882).

An ordered chain of approvers (e.g. legal → finance → the CEO) must each approve a subject **in order**. Every gate is a durable `pauseUntilSignal`: the run emails the current approver and **suspends at $0** until they fire `approval.decision`, then advances to the next gate.

```
start → present ─(pause: approval.decision, $0 while idle)─▶ decide
          ▲ approve & more gates          │ reminder tick
          └── remind ─(pause)── decide ────┤
   reject │        approve & last gate │        timeout / no-response │
          ▼                            ▼                              ▼
     compensate                    finalize                       escalate
```

- **Reminders + timeout** — a resume with no decision (pause `timeoutMs`, auto-resume, or explicit `remind`) is a reminder tick that re-notifies and re-pauses, up to `maxReminders`, after which a silent gate escalates. `timeout` escalates immediately.
- **Saga compensation** — a `reject` notifies everyone who already approved that the chain was cancelled, so a half-signed contract is never left behind.
- **Chain state** — canonical state lives in `ctx.shared` (survives every pause); each transition is *also* appended, best-effort, to a durable Postgres audit ledger via the `database` capability. A missing handle, a `dryRun`, or a DB error degrades to shared + logs and never breaks the chain.
- `pauseUntilSignal` + `timeoutMs` are runtime primitives, not metered capabilities. Billed calls: `email` notifications + the optional ledger `database`.

Follows the `human-in-the-loop` sibling's structure (six files + one `registry.json` entry), pins `@sapiom/agent ^0.6.0` / `@sapiom/tools ^0.20.0` (needed for `email`).

## Capabilities (per ticket)
`pauseUntilSignal` (sequential gates) · cron / `timeoutMs` (reminders / timeout) · `email` (notifications) · `database` (chain-state ledger).

## Testing
- `npm run typecheck` — clean.
- Offline graph validation (`buildManifest` + `assertValidGraph`) — 7 steps, no errors/warnings; the `remind` cycle is accepted.
- `prettier --check` — clean.
- Stubbed-context drive across all three terminals: approve×2 → `finalize`, approve→reject → `compensate` (prior approver notified), silent → 2 reminders → `escalate` (reminder budget respected). Matches the free default `run_local` trace.
- Deployed path (real pauses, live ledger, billed) to be verified via the MCP dev tools per the ticket's local-testing loop.

Linear: SAP-1882