### PR TITLE
feat(examples): Meeting-Notes to CRM Updater workflow template (SAP-1859)

### DIFF
--- a/examples/meeting-notes-crm/.gitignore
+++ b/examples/meeting-notes-crm/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/meeting-notes-crm/AGENTS.md
+++ b/examples/meeting-notes-crm/AGENTS.md
@@ -1,0 +1,46 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Meeting Notes → CRM Updater** — authored against `@sapiom/agent`. It has four steps: `intake` (pause/take the transcript) → `extract` (calls `models.run`, the live LLM) → `upsert` (calls `database`) → `summary` (emails the result). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.models.run(...)`, `ctx.sapiom.database.get(...)`, `ctx.sapiom.email.messages.send(...)`, `ctx.sapiom.vault.get(...)`).
+
+It combines a durability primitive with a real store: it can **pause at $0** for a pushed transcript (`pauseUntilSignal`) or take one directly, and it keeps a **Postgres CRM store** of contacts and action items so a re-processed transcript updates the record instead of duplicating it.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **The pause is a static edge.** `intake` declares `pause: { signal: "transcript.ready", resumeStep: "extract" }` and returns `pauseUntilSignal({ signal, resumeStep, correlationId })` — the two must match. The resumed `extract` step's _input_ is the signal payload (`{ transcript: "..." }`); everything else survives the suspend in `ctx.shared`.
+- **Keep the edges slim.** The transcript is bounded (truncated to `MAX_TRANSCRIPT_CHARS`) before the model sees it, and only the small extracted object crosses the later edges — the raw transcript doesn't linger in `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** `upsert` skips the database and `summary` skips the send when `dryRun` is set (or no recipient resolves), returning the computed recap as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient is read from the vault (`ctx.sapiom.vault.get("meeting-notes-crm", "RECIPIENT")`) inside `summary`, not carried through `ctx.shared`.
+- **Key stability is the contract.** The contact key (email → company → name) and each action item's `stableId` must resolve the same across runs, so a re-processed transcript updates the same contact row and records each item once. If dedup looks wrong, `resolveContactKey` / `normalizeText` are the first place to look.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `models.run` / `database` / `email` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `upsert` skips the (stubbed) DB and `summary` skips the (stubbed) send and returns the recap. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed LLM extraction that writes to the CRM store and emails the summary. Push a transcript with the `transcript.ready` signal.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`). To deliver into Sapiom **memory** instead — a searchable long-term store rather than an inbox — swap the send in `summary` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: deliverTo ?? "meeting-notes-crm",
+  metadata: { newCount, existingCount },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipient, so you can drop the vault lookup — or keep it to override the scope.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Row timestamps are captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `updated_at` / `last_meeting_at`.

--- a/examples/meeting-notes-crm/README.md
+++ b/examples/meeting-notes-crm/README.md
@@ -1,0 +1,74 @@
+# Meeting Notes → CRM Updater
+
+Take a meeting transcript, extract the contact, the CRM fields to update, and the
+action items with an LLM, write them to a database, and email a summary. The
+transcript arrives directly or by a durable webhook pause.
+
+## What it does
+
+```
+intake  ──▶  extract  ──▶  upsert  ──▶  summary  (terminal)
+(pause/take)  (models.run)  (database)   (email)
+```
+
+1. **intake** — takes the transcript. It reads one directly as `transcript`, or —
+   with `webhook: true` and no transcript yet — **pauses at $0** via
+   `pauseUntilSignal` until your note-taker pushes one as the `transcript.ready`
+   signal. No polling loop, no billed idle.
+2. **extract** — hands the transcript to an LLM (`ctx.sapiom.models.run` — the
+   live x402-served model) to pull structured data: the **contact** the call was
+   with, the **CRM fields** to change (deal stage, next step), and the **action
+   items**, each with an owner and due date when the call named them.
+3. **upsert** — writes to a Postgres CRM store the template owns
+   (`ctx.sapiom.database`). It updates the contact's row (keyed by email, falling
+   back to company) with `coalesce`, so a partial call never wipes a field, and
+   records each action item under a **stable id** so a re-run logs it once.
+4. **summary** — writes a markdown recap (fields updated, action items new vs.
+   already tracked) and emails it. A `dryRun` computes the recap but skips the DB
+   writes and the real send; the recipient is read from the Sapiom vault at
+   runtime, never persisted.
+
+Input: `{ "transcript": "Call with Dana Ruiz, VP Eng at Northwind. ...", "deliverTo": "you@example.com", "meetingDate": "2026-07-22" }`.
+
+- `transcript` (or the `transcript.ready` webhook) supplies the notes.
+- `deliverTo` sets the recipient; omit it to use the vault-configured default.
+- `meetingDate` (ISO) stamps the contact's last-meeting time.
+- `dryRun: true` returns the recap as a preview without writing or sending.
+
+### Two ways in
+
+- **Direct / scheduled** — pass the notes as `transcript` (e.g. a nightly job over
+  yesterday's calls).
+- **Webhook push** — run with `webhook: true`; the run suspends until your
+  note-taker pushes a transcript with the `transcript.ready` signal, then resumes
+  and processes it.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` so the DB and delivery are skipped, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed LLM extraction that writes to the CRM store and emails the
+   summary).
+
+4. To push transcripts in, run with `webhook: true` and fire the
+   `transcript.ready` signal with the `workflow_signal` MCP tool, passing
+   `{ "transcript": "..." }`.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/meeting-notes-crm/index.ts
+++ b/examples/meeting-notes-crm/index.ts
@@ -1,0 +1,605 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Meeting-Notes → CRM Updater — turn a raw meeting transcript into a clean CRM
+ * update: the fields to change on the contact, and the action items that came
+ * out of the call.
+ *
+ * A transcript arrives two ways, from the same entry step:
+ *   - **Direct / scheduled** — a run passes the notes in as `transcript` (e.g. a
+ *     nightly job that hands over yesterday's calls).
+ *   - **Webhook push** — with `webhook: true` and no transcript yet, the run
+ *     **suspends at $0** via `pauseUntilSignal` until your note-taker (Otter,
+ *     Fireflies, a Zoom hook) pushes one as the `transcript.ready` signal. No
+ *     polling loop, no billed idle.
+ *
+ * Then, in one legible graph:
+ *   intake ──▶ extract (models.run) ──▶ upsert (database) ──▶ summary (email)
+ *
+ *   - **extract** hands the transcript to an LLM (`ctx.sapiom.models.run` — the
+ *     live x402-served model) to pull the contact it's about, the CRM fields to
+ *     change (deal stage, next step), and the action items, as structured JSON.
+ *   - **upsert** writes to a small Postgres CRM store the template owns. It
+ *     upserts the contact row (keyed by email, falling back to company) and
+ *     inserts each action item under a stable id, so the same item from a
+ *     re-processed transcript is recorded once, not twice.
+ *   - **summary** writes a markdown recap — fields updated, action items new vs.
+ *     already tracked — and emails it to the rep. A `dryRun` (or a run with no
+ *     recipient) returns the recap as a preview without touching the database or
+ *     sending, so `run_local` traces the whole graph for free.
+ *
+ * Determinism: each step body runs once on the happy path (again only on retry).
+ * Non-deterministic values — the row timestamps — are captured once at the DB
+ * boundary via Postgres `now()`, not recomputed per row.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the CRM store lives under — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "meeting-notes-crm";
+/** Vault ref holding delivery config (e.g. a default RECIPIENT). Read at runtime. */
+const DELIVERY_VAULT_REF = "meeting-notes-crm";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "meeting-crm";
+/** The named signal a note-taker fires to push a finished transcript in. */
+const SIGNAL = "transcript.ready";
+/** Cap the transcript the model sees — full-call transcripts can be enormous. */
+const MAX_TRANSCRIPT_CHARS = 16000;
+/** Cap the action items pulled from one call so cost + storage stay bounded. */
+const MAX_ACTION_ITEMS = 50;
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** The meeting transcript / notes to process (the direct path). */
+  transcript?: string;
+  /** Wait for a note-taker to push the transcript instead of passing one. */
+  webhook?: boolean;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Postgres handle for the CRM store; defaults to the template handle. */
+  dbHandle?: string;
+  /** When the meeting happened (ISO); defaults to now on the DB side. */
+  meetingDate?: string;
+  /** Compute the update but skip the DB writes and the real send. */
+  dryRun?: boolean;
+}
+
+/** The transcript payload that crosses intake → extract, either path. */
+interface Transcript {
+  transcript: string;
+}
+
+/** Who the meeting was about, as the model returns it. */
+interface Contact {
+  name: string;
+  email: string | null;
+  company: string | null;
+  title: string | null;
+}
+
+/** The CRM fields to change on the contact, as the model returns them. */
+interface CrmUpdate {
+  dealStage: string | null;
+  nextStep: string | null;
+  /** A one- or two-sentence recap of the call. */
+  summary: string;
+}
+
+/** One action item as the model returns it — no id yet (derived in code). */
+interface ExtractedActionItem {
+  description: string;
+  owner: string | null;
+  dueDate: string | null;
+}
+
+/** An action item enriched with the stable id used to dedup it in the store. */
+interface ActionItem extends ExtractedActionItem {
+  /** Stable key for dedup — same item from a re-run must yield the same value. */
+  id: string;
+}
+
+/** Everything the model pulled out of one transcript. */
+interface Extraction {
+  contact: Contact;
+  update: CrmUpdate;
+  actionItems: ExtractedActionItem[];
+}
+
+interface Shared extends Record<string, unknown> {
+  dbHandle: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  /** ISO meeting date, or null to let the DB default it to now(). */
+  meetingDate: string | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Trim + bound the transcript so downstream cost stays predictable. */
+function normalizeTranscript(raw: unknown): string {
+  return String(raw ?? "")
+    .trim()
+    .slice(0, MAX_TRANSCRIPT_CHARS);
+}
+
+/** Collapse a description to a stable form for dedup (case/space-insensitive). */
+function normalizeText(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.\s]+$/, "")
+    .trim();
+}
+
+/**
+ * Resolve the natural CRM key for the contact — email if we have one, else a
+ * company slug, else a name slug. The same contact must resolve to the same key
+ * across runs so their row is updated, not duplicated.
+ */
+function resolveContactKey(contact: Contact): string {
+  const email = contact.email?.trim().toLowerCase();
+  if (email) return email;
+  const slug = (contact.company || contact.name || "").trim().toLowerCase();
+  const cleaned = slug.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown-contact";
+}
+
+/** Deterministic djb2 hash → hex, so an action item keys the same row every run. */
+function stableId(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) >>> 0;
+  }
+  return `ai_${h.toString(16)}`;
+}
+
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (returns null), not an error — the caller then falls back to
+ * a preview. Never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Meeting Notes CRM",
+  });
+  return inbox.inboxId;
+}
+
+/** Open a Postgres client for a live run, or null in dryRun / when unavailable. */
+async function openSql(ctx: Ctx, handle: string): Promise<Sql | null> {
+  let db;
+  try {
+    db = await ctx.sapiom.database.get(handle);
+  } catch {
+    db = await ctx.sapiom.database.create({
+      handle,
+      duration: "7d",
+      name: "Meeting Notes CRM",
+      description: "Contacts + action items extracted from meeting transcripts",
+    });
+  }
+  // `db` may be a stub (undefined) under run_local — stay null-safe and degrade.
+  const conn = db?.connection?.connectionString ?? null;
+  if (!conn) {
+    ctx.logger.warn("database: no connection string", { handle });
+    return null;
+  }
+  return postgres(conn, { ssl: "require" });
+}
+
+async function initSchema(sql: Sql): Promise<void> {
+  await sql`
+    create table if not exists crm_contacts (
+      contact_key     text primary key,
+      name            text,
+      email           text,
+      company         text,
+      title           text,
+      deal_stage      text,
+      next_step       text,
+      last_meeting_at timestamptz,
+      first_seen      timestamptz not null default now(),
+      updated_at      timestamptz not null default now()
+    )`;
+  await sql`
+    create table if not exists crm_action_items (
+      id           text primary key,
+      contact_key  text not null,
+      description  text not null,
+      owner        text,
+      due_date     text,
+      status       text not null default 'open',
+      created_at   timestamptz not null default now()
+    )`;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const intake = defineStep({
+  name: "intake",
+  next: ["extract"],
+  // Static graph edge: on SIGNAL, resume at `extract`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "extract" },
+  async run(input: EntryInput, ctx: Ctx) {
+    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", truthy(input.dryRun));
+    ctx.shared.set("meetingDate", input.meetingDate?.trim() || null);
+
+    const transcript = normalizeTranscript(input.transcript);
+
+    // Nothing passed in and asked to wait: suspend at $0 until a note-taker
+    // pushes a transcript. The resumed `extract` step's input IS the payload.
+    if (transcript.length === 0 && truthy(input.webhook)) {
+      ctx.logger.info(
+        "no transcript yet; pausing for the transcript.ready signal",
+        {
+          correlationId: ctx.executionId,
+        },
+      );
+      return pauseUntilSignal({
+        signal: SIGNAL,
+        resumeStep: "extract",
+        correlationId: ctx.executionId,
+      });
+    }
+
+    return goto("extract", { transcript });
+  },
+});
+
+const extract = defineStep({
+  name: "extract",
+  next: ["upsert"],
+  // `input` is either intake's goto payload or the resumed signal payload.
+  async run(input: Transcript, ctx: Ctx) {
+    const transcript = normalizeTranscript(input?.transcript);
+
+    if (transcript.length === 0) {
+      ctx.logger.info("empty transcript; nothing to extract");
+      return goto("upsert", { extraction: emptyExtraction() });
+    }
+
+    const system =
+      "You are a sales-ops assistant reading a single meeting transcript. " +
+      "Extract, as data, (1) the primary external contact the meeting was with, " +
+      "(2) the CRM fields to update on them, and (3) the concrete action items " +
+      "that came out of the call. Use null for anything the transcript does not " +
+      "state — never guess an email or a company. Keep each action item to one " +
+      "clear sentence, with an owner and a due date only when explicitly said. " +
+      'Reply with ONLY minified JSON: {"contact":{"name":string,"email":string|' +
+      'null,"company":string|null,"title":string|null},"update":{"dealStage":' +
+      'string|null,"nextStep":string|null,"summary":string},"actionItems":' +
+      '[{"description":string,"owner":string|null,"dueDate":string|null}]}.';
+    const prompt = `MEETING TRANSCRIPT:\n${transcript}`;
+
+    const res = await ctx.sapiom.models.run({ system, prompt, maxTokens: 900 });
+    const extraction = parseExtraction(res.output);
+    ctx.logger.info("extracted meeting notes", {
+      contact: extraction.contact.name,
+      actionItems: extraction.actionItems.length,
+    });
+    return goto("upsert", { extraction });
+  },
+});
+
+const upsert = defineStep({
+  name: "upsert",
+  next: ["summary"],
+  async run(input: { extraction: Extraction }, ctx: Ctx) {
+    const extraction = input?.extraction ?? emptyExtraction();
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const handle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+    const meetingDate = ctx.shared.get("meetingDate") ?? null;
+
+    const contactKey = resolveContactKey(extraction.contact);
+    const items: ActionItem[] = extraction.actionItems
+      .slice(0, MAX_ACTION_ITEMS)
+      .map((a) => ({
+        ...a,
+        id: stableId(`${contactKey}|${normalizeText(a.description)}`),
+      }));
+
+    // Dry run (or run_local's stubbed DB): treat every item as new so the graph
+    // traces end to end without touching a real database.
+    if (dryRun) {
+      ctx.logger.info("skipping CRM store", { dryRun, items: items.length });
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems: items,
+        existingItems: [] as ActionItem[],
+      });
+    }
+
+    const sql = await openSql(ctx, handle);
+    if (!sql) {
+      // No DB available — degrade to "everything new" rather than abort.
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems: items,
+        existingItems: [] as ActionItem[],
+      });
+    }
+
+    try {
+      await initSchema(sql);
+      const { contact, update } = extraction;
+
+      // Upsert the contact — coalesce keeps a prior non-null value when this
+      // transcript didn't restate it, so a partial call never wipes a field.
+      await sql`
+        insert into crm_contacts
+          (contact_key, name, email, company, title, deal_stage, next_step, last_meeting_at)
+        values
+          (${contactKey}, ${contact.name}, ${contact.email}, ${contact.company},
+           ${contact.title}, ${update.dealStage}, ${update.nextStep},
+           coalesce(${meetingDate}::timestamptz, now()))
+        on conflict (contact_key) do update set
+          name            = coalesce(excluded.name, crm_contacts.name),
+          email           = coalesce(excluded.email, crm_contacts.email),
+          company         = coalesce(excluded.company, crm_contacts.company),
+          title           = coalesce(excluded.title, crm_contacts.title),
+          deal_stage      = coalesce(excluded.deal_stage, crm_contacts.deal_stage),
+          next_step       = coalesce(excluded.next_step, crm_contacts.next_step),
+          last_meeting_at = excluded.last_meeting_at,
+          updated_at      = now()`;
+
+      const newItems: ActionItem[] = [];
+      const existingItems: ActionItem[] = [];
+      for (const item of items) {
+        const prior = await sql<{ id: string }[]>`
+          select id from crm_action_items where id = ${item.id}`;
+        if (prior.length === 0) {
+          newItems.push(item);
+        } else {
+          existingItems.push(item);
+        }
+        await sql`
+          insert into crm_action_items (id, contact_key, description, owner, due_date)
+          values (${item.id}, ${contactKey}, ${item.description}, ${item.owner}, ${item.dueDate})
+          on conflict (id) do nothing`;
+      }
+
+      ctx.logger.info("wrote CRM update", {
+        contactKey,
+        new: newItems.length,
+        existing: existingItems.length,
+      });
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems,
+        existingItems,
+      });
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  },
+});
+
+const summary = defineStep({
+  name: "summary",
+  next: [],
+  terminal: true,
+  async run(
+    input: {
+      contactKey: string;
+      extraction: Extraction;
+      newItems: ActionItem[];
+      existingItems: ActionItem[];
+    },
+    ctx: Ctx,
+  ) {
+    const extraction = input?.extraction ?? emptyExtraction();
+    const newItems = Array.isArray(input?.newItems) ? input.newItems : [];
+    const existingItems = Array.isArray(input?.existingItems)
+      ? input.existingItems
+      : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+
+    const body = renderSummary(extraction, newItems, existingItems);
+    const who =
+      extraction.contact.company || extraction.contact.name || "the contact";
+    const subject = `CRM updated: ${who} — ${newItems.length} new action item(s)`;
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // Safe path: a dry run, or a live run with no recipient, returns the recap
+    // without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        summary: body,
+        contact: extraction.contact,
+        newCount: newItems.length,
+        existingCount: existingItems.length,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: body,
+    });
+    ctx.logger.info("summary delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      messageId: sent.messageId,
+      contact: extraction.contact,
+      newCount: newItems.length,
+      existingCount: existingItems.length,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── render ──
+function renderItem(item: ActionItem): string {
+  const meta = [item.owner, item.dueDate ? `due ${item.dueDate}` : null]
+    .filter(Boolean)
+    .join(", ");
+  return `- ${item.description}${meta ? ` _(${meta})_` : ""}`;
+}
+
+function renderSummary(
+  extraction: Extraction,
+  newItems: ActionItem[],
+  existingItems: ActionItem[],
+): string {
+  const { contact, update } = extraction;
+  const heading = [contact.title, contact.company].filter(Boolean).join(", ");
+  const lines = [
+    `# Meeting notes → CRM`,
+    ``,
+    `**Contact:** ${contact.name}${heading ? ` — ${heading}` : ""}` +
+      `${contact.email ? ` <${contact.email}>` : ""}`,
+    `**Deal stage:** ${update.dealStage ?? "_unchanged_"}`,
+    `**Next step:** ${update.nextStep ?? "_none noted_"}`,
+    ``,
+    update.summary || "_No recap produced._",
+    ``,
+    `## Action items (${newItems.length} new, ${existingItems.length} already tracked)`,
+  ];
+  lines.push(`### New (${newItems.length})`);
+  lines.push(
+    newItems.length === 0
+      ? `_None — nothing new from this call._`
+      : newItems.map(renderItem).join("\n"),
+  );
+  lines.push(``);
+  lines.push(`### Already tracked (${existingItems.length})`);
+  lines.push(
+    existingItems.length === 0
+      ? `_None._`
+      : existingItems.map(renderItem).join("\n"),
+  );
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** A minimal, valid extraction for the empty / unparseable path. */
+function emptyExtraction(): Extraction {
+  return {
+    contact: {
+      name: "Unknown contact",
+      email: null,
+      company: null,
+      title: null,
+    },
+    update: { dealStage: null, nextStep: null, summary: "" },
+    actionItems: [],
+  };
+}
+
+/** Extract the structured update from model output; fall back to empty. */
+function parseExtraction(output: string | null): Extraction {
+  if (!output) return emptyExtraction();
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return emptyExtraction();
+    const parsed = JSON.parse(output.slice(start, end + 1)) as {
+      contact?: unknown;
+      update?: unknown;
+      actionItems?: unknown;
+    };
+    return {
+      contact: coerceContact(parsed.contact),
+      update: coerceUpdate(parsed.update),
+      actionItems: Array.isArray(parsed.actionItems)
+        ? parsed.actionItems
+            .map(coerceActionItem)
+            .filter((a): a is ExtractedActionItem => a !== null)
+        : [],
+    };
+  } catch {
+    return emptyExtraction();
+  }
+}
+
+/** null-safe string: trims and returns null for empty/absent values. */
+function nullableStr(v: unknown): string | null {
+  const s = String(v ?? "").trim();
+  return s.length > 0 ? s : null;
+}
+
+function coerceContact(raw: unknown): Contact {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    name: nullableStr(r.name) ?? "Unknown contact",
+    email: nullableStr(r.email),
+    company: nullableStr(r.company),
+    title: nullableStr(r.title),
+  };
+}
+
+function coerceUpdate(raw: unknown): CrmUpdate {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    dealStage: nullableStr(r.dealStage),
+    nextStep: nullableStr(r.nextStep),
+    summary: nullableStr(r.summary) ?? "",
+  };
+}
+
+function coerceActionItem(raw: unknown): ExtractedActionItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const description = nullableStr(r.description);
+  if (!description) return null;
+  return {
+    description,
+    owner: nullableStr(r.owner),
+    dueDate: nullableStr(r.dueDate),
+  };
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "meeting-notes-crm",
+  entry: "intake",
+  steps: { intake, extract, upsert, summary },
+});

--- a/examples/meeting-notes-crm/package.json
+++ b/examples/meeting-notes-crm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-meeting-notes-crm",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: take a meeting transcript (directly or via a webhook pause), extract the contact, CRM fields, and action items with an LLM (models.run), write them to a Postgres CRM store, and email a summary.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/meeting-notes-crm/template.json
+++ b/examples/meeting-notes-crm/template.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You hand it a meeting transcript and it does the CRM busywork for you: it works out who the call was with, what to change on their record, and what everyone agreed to do next. It takes the transcript either way — a run passes one in directly (a nightly job over yesterday's calls), or you set `webhook: true` and it waits for your note-taker to push one in.\n\nThe graph is four steps. `intake` takes the transcript — and when it's told to wait for a webhook, it pauses and costs nothing until one arrives. `extract` (`models.run`, the live x402-served model) reads the transcript and returns structured data: the contact, the CRM fields to update (deal stage, next step), and the action items, each with an owner and due date when the call actually named them. `upsert` writes to a small Postgres CRM store the template owns — it updates the contact's row (keyed by email, falling back to company) without wiping fields the call didn't mention, and records each action item under a stable id. `summary` writes a markdown recap — fields updated, action items split into new vs. already tracked — and emails it to the rep.\n\nThe stable id on each action item is the point. Re-process the same transcript, or send a lightly-edited one, and the item is recorded once, not twice — so the CRM store and the recap show what's genuinely new. A `dryRun` computes the recap and returns it without touching the database or sending mail, so you can trace the whole flow for free before it writes or delivers anything.\n\nYou pay for the model reasoning on each run and a small database footprint — the waiting is free, and the email is cheap.",
+  "useCases": [
+    "Turn a sales call transcript into an updated contact record and a clean action-item list, without hand-copying anything.",
+    "Let a note-taker push transcripts in as calls end — the run waits at $0 until one arrives, then processes it.",
+    "Keep a running CRM store of contacts and open action items across every meeting, deduped so nothing is logged twice."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nFeed it the notes as `transcript` (plain text). Set who gets the recap with `deliverTo`, or store a default under the `meeting-notes-crm` vault ref (key `RECIPIENT`) — it's read at runtime, never saved into the run. Pass `meetingDate` (ISO) to stamp the contact's last-meeting time, and `dryRun: true` to compute the recap and get it back without writing to the database or sending mail.\n\nThis template can also **pause and wait for a webhook**: run it with `webhook: true` and no transcript, and it suspends at $0 until your note-taker pushes one. Send the transcript with the MCP `workflow_signal` tool (or the API) using the signal name `transcript.ready` and a payload of `{ \"transcript\": \"...\" }` — there is no one-click signal button yet.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole intake → extract → upsert → summary flow for free (capabilities stubbed, database and delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Extract a short call, preview only (dry run)",
+      "input": {
+        "dryRun": true,
+        "transcript": "Call with Dana Ruiz, VP Eng at Northwind. She confirmed budget for the Q3 rollout and wants a security review before signing. I'll send the SOC 2 report by Friday and Dana will loop in their CISO next week. Deal looks like it's moving to contract stage.",
+        "meetingDate": "2026-07-22"
+      },
+      "output": {
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "CRM updated: Northwind — 2 new action item(s)",
+        "contact": {
+          "name": "Dana Ruiz",
+          "email": null,
+          "company": "Northwind",
+          "title": "VP Eng"
+        },
+        "newCount": 2,
+        "existingCount": 0,
+        "summary": "# Meeting notes → CRM\n\n**Contact:** Dana Ruiz — VP Eng, Northwind\n**Deal stage:** contract\n**Next step:** Send SOC 2 report, then security review before signing\n\nDana confirmed Q3 rollout budget and wants a security review before signing.\n\n## Action items (2 new, 0 already tracked)\n### New (2)\n- Send the SOC 2 report _(me, due Friday)_\n- Loop in the CISO _(Dana, due next week)_\n\n### Already tracked (0)\n_None._"
+      }
+    }
+  ]
+}

--- a/examples/meeting-notes-crm/tsconfig.json
+++ b/examples/meeting-notes-crm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,40 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "meeting-notes-crm",
+      "name": "Meeting Notes to CRM Updater",
+      "description": "Take a meeting transcript, pull out the contact, the CRM fields to update, and the action items, write them to a database, and email a summary.",
+      "tags": ["crm", "sales", "transcript", "pause-resume"],
+      "sourcePath": "examples/meeting-notes-crm",
+      "capabilities": ["models.run", "database.get", "database.create", "email.send"],
+      "whatItDoes": "For turning what was said on a call into an updated CRM record without hand-copying anything. It takes the transcript either way: a run hands it one directly, or you set `webhook: true` and it pauses at $0 until your note-taker pushes one as the `transcript.ready` signal. An LLM (`models.run`) reads the transcript and returns structured data — the contact the call was with, the fields to change (deal stage, next step), and the action items with owners and due dates. It writes them to a small Postgres store it owns, updating the contact's row without wiping fields the call didn't mention and recording each action item under a stable id so a re-run logs it once. Then it emails a recap that splits action items into new versus already tracked. A dryRun computes the recap and returns it without touching the database or sending mail.",
+      "steps": [
+        {
+          "name": "intake",
+          "description": "Takes the transcript — passed in directly, or, with webhook set, pauses at $0 until a note-taker pushes one via the transcript.ready signal.",
+          "next": ["extract"]
+        },
+        {
+          "name": "extract",
+          "description": "Hands the transcript to an LLM to pull the contact, the CRM fields to update, and the action items as structured JSON.",
+          "capability": "models.run",
+          "next": ["upsert"]
+        },
+        {
+          "name": "upsert",
+          "description": "Writes to a Postgres CRM store: updates the contact's row without wiping unmentioned fields, and records each action item under a stable id. Skipped on a dry run.",
+          "capability": "database.get",
+          "next": ["summary"]
+        },
+        {
+          "name": "summary",
+          "description": "Writes a markdown recap — fields updated, action items new vs. already tracked — and emails it. A dry run, or a run with no recipient, returns it without sending.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a new onboarding gallery template — **Meeting Notes → CRM Updater** — under `examples/meeting-notes-crm/`, and registers it in `examples/registry.json` (11th entry).

Inbound transcript → extract contact + CRM fields + action items → write to a DB → email a summary.

```
intake  ──▶  extract  ──▶  upsert  ──▶  summary  (terminal)
(pause/take)  (models.run)  (database)   (email)
```

- **intake** — takes the transcript directly, or with `webhook: true` **pauses at $0** via `pauseUntilSignal` until a note-taker pushes one as the `transcript.ready` signal.
- **extract** — an LLM (`models.run`) returns structured JSON: the contact, the CRM fields to update (deal stage, next step), and the action items.
- **upsert** — writes to a Postgres CRM store the template owns; `coalesce` keeps prior fields the call didn't restate, and each action item is keyed by a stable id so a re-processed transcript logs it once.
- **summary** — emails a markdown recap (fields updated, action items new vs. already tracked). `dryRun` / no recipient returns the recap as a preview.

Capabilities: `pauseUntilSignal`, `models.run` (LLM), `database`, `email` — exactly as the ticket specifies.

## Why this shape

Mirrors the established `error-triage-digest` / `human-in-the-loop` template pattern so the gallery reads in one consistent voice: `dryRun`-gated side effects, vault-read recipient never persisted through state, deterministic keys for dedup, and bounded edges (the raw transcript is truncated before the model sees it and doesn't linger in `ctx.shared`).

## Verification

- `npm run typecheck` — clean (agent `0.6.6`, tools `0.20.1`, within the `^0.6.5` / `^0.20.0` pins).
- `prettier --check` — clean, house style.
- `registry.json` — valid JSON; entry validated against the backend registry shape (unique step names, all `next` targets resolve). 11 templates total.
- `capabilities` / `steps[].capability` match the real `ctx.sapiom.*` ids the source calls (`models.run`, not `llm.generate`), per `examples/AUTHORING.md`.
- `examples/*` is outside the `packages/*` workspace, so this change is isolated from the CI build/typecheck/test graph.

Closes SAP-1859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd6DFQszNWv7BeMyib1P4N