### PR TITLE
feat(examples): add dependency-upgrade workflow template (SAP-1872)

### DIFF
--- a/examples/dependency-upgrade/.gitignore
+++ b/examples/dependency-upgrade/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/dependency-upgrade/AGENTS.md
+++ b/examples/dependency-upgrade/AGENTS.md
@@ -1,0 +1,60 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` —
+**dependency-upgrade** — authored against `@sapiom/agent`. It is a scheduled
+Dependabot triage: `bump` runs a coding agent to upgrade a repo's dependencies in
+a sandbox, `verify` runs the real test suite in that sandbox, `assess` rates the
+risk, and only a green build within the risk bar reaches `publish` (which pushes).
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here:
+`ctx.sapiom.repositories.get`, `ctx.sapiom.models.coding.launch`,
+`ctx.sapiom.sandboxes.attach` + `box.exec`, `ctx.sapiom.models.run`,
+`ctx.sapiom.fileStorage.upload`, and `repo.pushFromSandbox`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **The coding run is async.** `bump` calls `models.coding.launch(...)` and
+  returns `pauseUntilSignal(handle, { resumeStep: "verify" })`; the step's static
+  `pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "verify" }` annotation must
+  match. `verify`'s input is the `CodingResultPayload` — re-attach the sandbox
+  from `result.executionEnvironment.id`; live handles don't cross the pause.
+- **Green gates the push.** `verify` routes to `rejected` on a failed coding run,
+  a failed install, or a non-zero test exit — a push only happens after a green
+  build. Don't remove that gate.
+- **Never push on a dry run.** The push and the report upload are guarded on
+  `dryRun` so `run_local` traces the whole graph offline with no side effects.
+  Keep the guard.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point
+you'd run tests in any project — reach for the local suite. You don't need to run
+it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation (including the
+  static `pause` annotation). The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**.
+  Pass `{ "repoSlug": "my-app", "dryRun": true }`: the coding launch is stubbed
+  and its pause auto-resumes, `verify` synthesizes a green result (no real
+  sandbox), and `publish` skips the push + upload — so the full graph traces
+  offline, free, with no real repo.
+- **deploy**, then **run** — ship it, then perform a real upgrade + test + push.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/dependency-upgrade/README.md
+++ b/examples/dependency-upgrade/README.md
@@ -1,0 +1,93 @@
+# Dependency Upgrade
+
+A scheduled "Dependabot triage" that only opens a PR when the build is green. A
+coding agent bumps a repo's dependencies in a sandbox, the real test suite runs
+there, a model risk-assesses the diff, and it pushes only when the tests pass and
+the risk is within your bar.
+
+## What it does
+
+```
+plan ─▶ bump ──(pause: models.coding.result → verify)──▶ verify ─┬─▶ assess ─┬─▶ publish  (terminal)
+                                                                 │           └─▶ held     (terminal)
+                                                                 └─▶ rejected (terminal)
+```
+
+1. **plan** — resolves the repo slug and the install/test commands, and validates
+   the input. No `repoSlug` → straight to `rejected`.
+2. **bump** — launches a coding agent (`models.coding`) on the repo; it clones
+   into a fresh sandbox at `/workspace/<slug>` and bumps the dependencies. Coding
+   runs are long, so the workflow **suspends at $0** and resumes at `verify` when
+   the run finishes.
+3. **verify** — re-attaches the coding run's sandbox, runs `git diff --stat`, then
+   installs and runs the test suite (`sandboxes.exec`). A failed coding run, a
+   failed install, or a non-zero test exit all route to `rejected`.
+4. **assess** — a model (`models.run`) rates the upgrade `low`/`medium`/`high`
+   from the dependency diff. Above `maxAutoRisk` (default `medium`) → `held`.
+5. **publish** — pushes the bumped branch from the sandbox and archives the
+   triage report. **held** / **rejected** archive the report but never push.
+
+Every outcome writes a markdown triage report to file storage
+(`fileStorage.upload`) — a durable record of what changed and why it shipped or
+didn't.
+
+## Inputs
+
+```json
+{
+  "repoSlug": "my-app",
+  "task": "Upgrade dependencies to latest compatible versions and update the lockfile.",
+  "installCommand": "npm install",
+  "testCommand": "npm test",
+  "workingDirectory": "my-app",
+  "maxAutoRisk": "medium",
+  "allowRisky": false,
+  "dryRun": false,
+  "schedule": "0 6 * * 1"
+}
+```
+
+- `repoSlug` (required) — an in-network repo the coding agent clones and upgrades.
+- `installCommand` / `testCommand` — how to build and test the checkout (defaults
+  `npm install` / `npm test`).
+- `workingDirectory` — the checkout subdirectory to run tests in, relative to the
+  sandbox workspace (default: the repo slug).
+- `maxAutoRisk` — `low` \| `medium` \| `high`; risk above this is held for a human.
+  Set `allowRisky: true` to push anyway.
+- `dryRun` — assemble everything but skip the push and the report upload, so a
+  local run makes no network calls.
+- `schedule` — documentation for the cron cadence; the trigger carries the real
+  schedule when you deploy.
+
+## The dry-run guard
+
+The push is the one irreversible action, so it (and the report upload) are gated
+on `dryRun`. With `dryRun: true`, `verify` synthesizes a green result when no real
+sandbox is present, so `run_local` traces `plan → bump → verify → assess →
+publish` end to end — free, with nothing pushed.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to run the coding agent, attach the sandbox, and archive the
+   report.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (pass `{ "repoSlug": "my-app", "dryRun": true }` to trace the whole graph
+   offline, free) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real upgrade + test + push).
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/dependency-upgrade/index.ts
+++ b/examples/dependency-upgrade/index.ts
@@ -1,0 +1,554 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+/**
+ * dependency-upgrade — a scheduled "Dependabot triage" that only opens a PR when
+ * the build is green.
+ *
+ * Point it at an in-network repo and put it on a cron. Each run hands a coding
+ * agent the job of bumping the project's dependencies inside a fresh sandbox
+ * (`models.coding`), then does the part a plain bump bot skips: it re-attaches
+ * that sandbox, runs the real test suite there (`sandboxes.exec`), and gates
+ * everything on the result. Green builds get a model risk assessment of the
+ * changed dependencies (`models.run`); red builds never push. Every run — green,
+ * held, or red — archives a triage report to file storage (`fileStorage.upload`)
+ * so you have a durable record of what changed and why it was or wasn't shipped.
+ *
+ *   plan ─▶ bump ──(pause: models.coding.result → verify)──▶ verify ─┬─▶ assess ─┬─▶ publish
+ *                                                                    │           └─▶ held
+ *                                                                    └─▶ rejected
+ *
+ *   - plan     resolves the repo + commands and validates the input.
+ *   - bump     launches the coding agent on the repo, then SUSPENDS at $0 until
+ *              the run finishes — coding runs are long, so the workflow pauses
+ *              rather than holding a worker.
+ *   - verify   re-attaches the coding run's sandbox, installs, and runs the test
+ *              suite. A non-zero exit (or a failed coding run) routes to rejected.
+ *   - assess   asks a model to rate the upgrade's risk from the dependency diff.
+ *   - publish  pushes the bumped branch from the sandbox and archives the report.
+ *   - held     risk above your auto-merge threshold — archived, not pushed.
+ *   - rejected coding failed or the build is red — archived, not pushed.
+ *
+ * The push is the one irreversible action, so it sits behind a `dryRun` guard:
+ * with `dryRun: true`, every step runs but the push and the report upload are
+ * skipped, so `run_local` traces the whole graph offline for free.
+ */
+
+type RiskLevel = "low" | "medium" | "high";
+
+/** Higher = riskier. Used to compare an assessed risk against the auto-merge bar. */
+const RISK_ORDER: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2 };
+
+const DEFAULT_TASK =
+  "Upgrade this project's dependencies to their latest compatible versions and " +
+  "update the lockfile. Change application code only where an upgrade strictly " +
+  "requires it. Keep the diff minimal and focused on the dependency bumps.";
+
+// ──────────────────────────────────────────────────────────────── input ──
+interface DependencyUpgradeInput {
+  /** In-network repo slug the coding agent clones and upgrades. Required. */
+  repoSlug?: string;
+  /** Plain-words upgrade instruction for the coding agent (default: bump all + lockfile). */
+  task?: string;
+  /** Command that installs dependencies in the checkout (default `npm install`). */
+  installCommand?: string;
+  /** Command that runs the test suite in the checkout (default `npm test`). */
+  testCommand?: string;
+  /** Checkout subdirectory (relative to the sandbox workspace) to run tests in. Default: the slug. */
+  workingDirectory?: string;
+  /** Risk at/below which a green build auto-pushes; anything above is held. Default `medium`. */
+  maxAutoRisk?: RiskLevel;
+  /** Push even when the risk is above `maxAutoRisk` (skip the human hold). Default false. */
+  allowRisky?: boolean;
+  /** Assemble everything but skip the push + report upload, so run_local is free. */
+  dryRun?: boolean;
+  /** Cron cadence when deployed as a schedule — documentation only; the trigger carries it. */
+  schedule?: string;
+}
+
+/** Run-scoped state; the values before the pause survive the suspend. */
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+  task: string;
+  installCommand: string;
+  testCommand: string;
+  workingDirectory: string;
+  maxAutoRisk: RiskLevel;
+  allowRisky: boolean;
+  dryRun: boolean;
+  /** Sandbox the coding run left behind (captured after resume, needed to push). */
+  sandboxName: string | null;
+  /** Captured in `verify`, read by `assess`, `publish`, and the report. */
+  codingSummary: string | null;
+  diffStat: string | null;
+  testTail: string | null;
+  assessment: Assessment | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+interface Assessment {
+  risk: RiskLevel;
+  summary: string;
+  notes: string[];
+}
+
+// ──────────────────────────────────────────────────────────────── steps ──
+
+/** Resolve the repo + commands into shared and validate the input. */
+const plan = defineStep({
+  name: "plan",
+  next: ["bump", "rejected"],
+  async run(input: DependencyUpgradeInput, ctx: Ctx) {
+    const repoSlug = (input?.repoSlug ?? "").trim();
+    ctx.shared.set("repoSlug", repoSlug);
+    ctx.shared.set("task", input?.task?.trim() || DEFAULT_TASK);
+    ctx.shared.set(
+      "installCommand",
+      input?.installCommand?.trim() || "npm install",
+    );
+    ctx.shared.set("testCommand", input?.testCommand?.trim() || "npm test");
+    ctx.shared.set(
+      "workingDirectory",
+      input?.workingDirectory?.trim() || repoSlug,
+    );
+    ctx.shared.set(
+      "maxAutoRisk",
+      normalizeRisk(input?.maxAutoRisk) ?? "medium",
+    );
+    ctx.shared.set("allowRisky", input?.allowRisky === true);
+    ctx.shared.set("dryRun", input?.dryRun === true);
+    ctx.shared.set("sandboxName", null);
+    ctx.shared.set("codingSummary", null);
+    ctx.shared.set("diffStat", null);
+    ctx.shared.set("testTail", null);
+    ctx.shared.set("assessment", null);
+
+    if (!repoSlug) {
+      return goto("rejected", {
+        reason: "no-repo",
+        detail:
+          "repoSlug is required — the coding agent needs a repository to upgrade.",
+      });
+    }
+    ctx.logger.info("planning dependency upgrade", { repoSlug });
+    return goto("bump", {});
+  },
+});
+
+/**
+ * Launch the coding agent on the repo and suspend until it finishes. The agent
+ * clones the repo into a fresh sandbox at `/workspace/<slug>`, bumps the deps,
+ * and leaves the checkout in the sandbox for `verify` to test.
+ */
+const bump = defineStep({
+  name: "bump",
+  next: [],
+  // Async pause/resume: the launched coding run fires CODING_RESULT_SIGNAL on
+  // completion (or failure), resuming this workflow at `verify` with the result.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "verify" },
+  async run(_input: unknown, ctx: Ctx) {
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const task = ctx.shared.get("task") ?? DEFAULT_TASK;
+    const repo = await ctx.sapiom.repositories.get(repoSlug);
+    ctx.logger.info("launching coding agent to bump dependencies", {
+      repoSlug,
+    });
+
+    const handle = await ctx.sapiom.models.coding.launch({
+      task,
+      gitRepository: repo,
+    });
+    // Suspend at $0 until the coding run reaches a terminal state; the resumed
+    // `verify` step receives the CodingResultPayload as its input.
+    return await pauseUntilSignal(handle, { resumeStep: "verify" });
+  },
+});
+
+/**
+ * Re-attach the coding run's sandbox and run the real test suite in it. A failed
+ * coding run, a failed install, or a non-zero test exit all route to `rejected`
+ * — only a green build reaches `assess`.
+ */
+const verify = defineStep({
+  name: "verify",
+  next: ["assess", "rejected"],
+  timeoutMs: 900_000,
+  async run(result: CodingResultPayload, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    ctx.shared.set("codingSummary", result?.summary ?? null);
+
+    // The coding agent itself failed — there's nothing to verify.
+    if (result?.status === "failed" || result?.error) {
+      return goto("rejected", {
+        reason: "coding-run-failed",
+        detail:
+          result?.error?.message ?? result?.summary ?? "coding run failed",
+      });
+    }
+
+    const sandboxName = result?.executionEnvironment?.id ?? null;
+    ctx.shared.set("sandboxName", sandboxName);
+
+    if (!sandboxName) {
+      // No sandbox to run tests in. Under a stubbed/dry run this is expected, so
+      // synthesize a pass to trace assess → publish offline; otherwise reject.
+      if (dryRun) {
+        ctx.shared.set("diffStat", "(dry-run) dependency changes not computed");
+        ctx.shared.set("testTail", "(dry-run) test suite not executed");
+        ctx.logger.info("dry run — skipping sandbox verification");
+        return goto("assess", {});
+      }
+      return goto("rejected", {
+        reason: "no-sandbox",
+        detail: "the coding run provisioned no sandbox to verify in",
+      });
+    }
+
+    const installCommand = ctx.shared.get("installCommand") ?? "npm install";
+    const testCommand = ctx.shared.get("testCommand") ?? "npm test";
+    const cwd = ctx.shared.get("workingDirectory") ?? "";
+    const box = ctx.sapiom.sandboxes.attach(sandboxName);
+
+    // Capture what changed, for the risk assessment and the report.
+    try {
+      const diff = await box.exec("git --no-pager diff --stat", {
+        cwd,
+        timeout: 30_000,
+      });
+      ctx.shared.set(
+        "diffStat",
+        (diff.stdout || diff.stderr || "").slice(0, 4000),
+      );
+    } catch (err) {
+      ctx.shared.set("diffStat", `diff unavailable: ${String(err)}`);
+    }
+
+    const install = await box.exec(installCommand, { cwd, timeout: 300_000 });
+    if (install.exitCode !== 0) {
+      ctx.shared.set("testTail", tail(install.stdout, install.stderr));
+      return goto("rejected", {
+        reason: "install-failed",
+        detail: `\`${installCommand}\` exited ${install.exitCode}`,
+      });
+    }
+
+    const test = await box.exec(testCommand, { cwd, timeout: 600_000 });
+    ctx.shared.set("testTail", tail(test.stdout, test.stderr));
+    if (test.exitCode !== 0) {
+      return goto("rejected", {
+        reason: "tests-failed",
+        detail: `\`${testCommand}\` exited ${test.exitCode}`,
+      });
+    }
+
+    ctx.logger.info("build green", { testCommand });
+    return goto("assess", {});
+  },
+});
+
+/**
+ * Rate the upgrade's risk from the dependency diff and the coding summary. The
+ * tests already passed; this catches the "green but scary" upgrades (a major
+ * bump, a broad blast radius) and holds them for a human when they exceed your
+ * auto-merge bar.
+ */
+const assess = defineStep({
+  name: "assess",
+  next: ["publish", "held"],
+  timeoutMs: 60_000,
+  async run(_input: unknown, ctx: Ctx) {
+    const codingSummary = ctx.shared.get("codingSummary") ?? "";
+    const diffStat = ctx.shared.get("diffStat") ?? "";
+    const testTail = ctx.shared.get("testTail") ?? "";
+    const maxAutoRisk = ctx.shared.get("maxAutoRisk") ?? "medium";
+    const allowRisky = ctx.shared.get("allowRisky") === true;
+
+    const system =
+      "You are a release-risk reviewer for a dependency upgrade whose test suite ALREADY PASSED. " +
+      "Judge the risk of merging it from the changed dependencies and the coding agent's summary — " +
+      "weigh major-version bumps, historically breaking packages, and how broad the change is. " +
+      'Reply with ONLY minified JSON: {"risk":"low|medium|high","summary":string,"notes":string[]}.';
+    const prompt =
+      `Coding agent summary:\n${codingSummary}\n\n` +
+      `Dependency changes (git diff --stat):\n${diffStat}\n\n` +
+      `Test output (tail):\n${testTail}`;
+
+    const res = await ctx.sapiom.models.run({ prompt, system, maxTokens: 500 });
+    const assessment = parseAssessment(res.output);
+    ctx.shared.set("assessment", assessment);
+
+    const held =
+      RISK_ORDER[assessment.risk] > RISK_ORDER[maxAutoRisk] && !allowRisky;
+    ctx.logger.info("assessed upgrade risk", {
+      risk: assessment.risk,
+      maxAutoRisk,
+      held,
+    });
+    return held ? goto("held", {}) : goto("publish", {});
+  },
+});
+
+/** Green + within the risk bar: push the bumped branch and archive the report. */
+const publish = defineStep({
+  name: "publish",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const assessment = ctx.shared.get("assessment");
+    const report = buildReport("published", ctx);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+
+    // The push is the one irreversible action — skip it (and the upload) on a dry run.
+    if (dryRun) {
+      ctx.logger.info("dry run — skipping push", { repoSlug });
+      return terminate({
+        decision: "publish",
+        pushed: false,
+        dryRun: true,
+        risk: assessment?.risk ?? null,
+        reportFileId: archived.fileId,
+        summary: assessment?.summary ?? null,
+      });
+    }
+
+    const sandboxName = ctx.shared.get("sandboxName");
+    if (!sandboxName) {
+      return terminate({
+        decision: "publish",
+        pushed: false,
+        risk: assessment?.risk ?? null,
+        reportFileId: archived.fileId,
+        summary: assessment?.summary ?? null,
+        note: "no sandbox available to push from",
+      });
+    }
+
+    const repo = await ctx.sapiom.repositories.get(repoSlug);
+    const box = ctx.sapiom.sandboxes.attach(sandboxName);
+    const message = truncate(
+      `build(deps): ${assessment?.summary ?? "dependency upgrade"}`,
+      72,
+    );
+    const push = await repo.pushFromSandbox(box, { message });
+    ctx.logger.info("pushed dependency upgrade", {
+      sha: push.sha,
+      branch: push.branch,
+    });
+    return terminate({
+      decision: "publish",
+      pushed: push.pushed,
+      sha: push.sha,
+      branch: push.branch ?? null,
+      risk: assessment?.risk ?? null,
+      reportFileId: archived.fileId,
+      summary: assessment?.summary ?? null,
+    });
+  },
+});
+
+/** Green build but the risk exceeded your auto-merge bar: archive, don't push. */
+const held = defineStep({
+  name: "held",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const assessment = ctx.shared.get("assessment");
+    const report = buildReport("held", ctx);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+    ctx.logger.info("upgrade held for human review", {
+      risk: assessment?.risk,
+    });
+    return terminate({
+      decision: "hold",
+      pushed: false,
+      risk: assessment?.risk ?? null,
+      reason: "risk above the auto-merge threshold — held for human review",
+      reportFileId: archived.fileId,
+      summary: assessment?.summary ?? null,
+    });
+  },
+});
+
+/** Coding run failed or the build is red: archive the failure, never push. */
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason: string; detail?: string }, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "unknown";
+    const report = buildReport("rejected", ctx, input);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+    ctx.logger.info("upgrade rejected", { reason: input?.reason });
+    return terminate({
+      decision: "reject",
+      pushed: false,
+      reason: input?.reason ?? "unknown",
+      detail: input?.detail ?? null,
+      reportFileId: archived.fileId,
+      testTail: ctx.shared.get("testTail") ?? null,
+    });
+  },
+});
+
+// ────────────────────────────────────────────────────────────── helpers ──
+
+function normalizeRisk(value: unknown): RiskLevel | null {
+  return value === "low" || value === "medium" || value === "high"
+    ? value
+    : null;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Last `max` chars of the combined stdout/stderr — enough to see a failure. */
+function tail(stdout: string, stderr: string, max = 2000): string {
+  const combined = [stdout, stderr].filter(Boolean).join("\n");
+  return combined.length > max ? combined.slice(-max) : combined;
+}
+
+/** Extract the risk assessment from the model output; default to medium on any miss. */
+function parseAssessment(output: string | null): Assessment {
+  const fallback: Assessment = {
+    risk: "medium",
+    summary: "Risk assessment unavailable; defaulted to medium.",
+    notes: [],
+  };
+  if (!output) return fallback;
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback;
+    const raw = JSON.parse(output.slice(start, end + 1)) as Partial<Assessment>;
+    const risk = normalizeRisk(raw.risk) ?? fallback.risk;
+    return {
+      risk,
+      summary: typeof raw.summary === "string" ? raw.summary : fallback.summary,
+      notes: Array.isArray(raw.notes)
+        ? raw.notes.filter((n): n is string => typeof n === "string")
+        : [],
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/** Render the triage report as markdown from the run's shared state. */
+function buildReport(
+  outcome: "published" | "held" | "rejected",
+  ctx: Ctx,
+  extra?: { reason?: string; detail?: string },
+): string {
+  const repoSlug = ctx.shared.get("repoSlug") ?? "unknown";
+  const assessment = ctx.shared.get("assessment");
+  const diffStat = ctx.shared.get("diffStat");
+  const testTail = ctx.shared.get("testTail");
+  const codingSummary = ctx.shared.get("codingSummary");
+
+  const lines: string[] = [
+    `# Dependency upgrade triage — ${repoSlug}`,
+    "",
+    `**Outcome:** ${outcome}`,
+  ];
+  if (assessment) lines.push(`**Risk:** ${assessment.risk}`);
+  if (extra?.reason) {
+    lines.push(
+      `**Reason:** ${extra.reason}${extra.detail ? ` — ${extra.detail}` : ""}`,
+    );
+  }
+  lines.push(
+    "",
+    "## What the agent changed",
+    codingSummary || "(none reported)",
+    "",
+    "## Dependency diff",
+    "```",
+    diffStat || "(none)",
+    "```",
+    "",
+    "## Test output (tail)",
+    "```",
+    testTail || "(not run)",
+    "```",
+  );
+  if (assessment) {
+    lines.push(
+      "",
+      "## Risk assessment",
+      assessment.summary,
+      ...assessment.notes.map((n) => `- ${n}`),
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Archive the triage report to file storage: presign an upload URL, then PUT the
+ * bytes. Skipped on a dry run so `run_local` makes no network calls; failures are
+ * non-fatal (the run's decision still stands).
+ */
+async function archiveReport(
+  ctx: Ctx,
+  name: string,
+  markdown: string,
+  dryRun: boolean,
+): Promise<{ fileId: string | null }> {
+  if (dryRun) {
+    ctx.logger.info("dry run — skipping report archive", { name });
+    return { fileId: null };
+  }
+  try {
+    const bytes = new TextEncoder().encode(markdown);
+    const upload = await ctx.sapiom.fileStorage.upload({
+      contentType: "text/markdown",
+      fileName: `${name}.md`,
+      fileSize: bytes.byteLength,
+      visibility: "private",
+    });
+    await fetch(upload.uploadUrl, {
+      method: "PUT",
+      headers: upload.requiredHeaders,
+      body: bytes,
+    });
+    ctx.logger.info("archived triage report", { fileId: upload.fileId });
+    return { fileId: upload.fileId };
+  } catch (err) {
+    ctx.logger.warn("report archive failed", { err: String(err) });
+    return { fileId: null };
+  }
+}
+
+export const agent = defineAgent<DependencyUpgradeInput, Shared>({
+  name: "dependency-upgrade",
+  entry: "plan",
+  steps: { plan, bump, verify, assess, publish, held, rejected },
+});

--- a/examples/dependency-upgrade/package.json
+++ b/examples/dependency-upgrade/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-dependency-upgrade",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: a scheduled dependency-upgrade triage — a coding agent bumps deps in a sandbox, the real test suite runs there, a model risk-assesses the diff, and it only pushes when the build is green. Every run archives a triage report to file storage.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/dependency-upgrade/template.json
+++ b/examples/dependency-upgrade/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a repo and a schedule. On each tick a coding agent clones the repo into a fresh sandbox and bumps its dependencies, then the workflow re-attaches that same sandbox and runs your real test suite in it. What happens next depends entirely on the result: a red build is archived and dropped, a green build gets a model risk assessment of the changed dependencies, and only a green build within your risk bar gets pushed.\n\nThe graph is `plan → bump → verify → assess → publish | held | rejected`. `bump` (`models.coding`) is a long-running coding agent, so the workflow suspends at $0 while it works and resumes only when it finishes. `verify` (`sandboxes.exec`) installs and tests in the sandbox — a non-zero exit routes straight to `rejected`. `assess` (`models.run`) rates the upgrade low/medium/high; anything above `maxAutoRisk` is `held` for a human instead of pushed. Every outcome — published, held, or rejected — writes a triage report to file storage (`fileStorage.upload`), so you keep a durable record of what changed and why it did or didn't ship.\n\nThe push is the only irreversible step, so it sits behind a `dryRun` guard: with `dryRun: true` every step runs but the push and the report upload are skipped, so you can trace the whole flow for free.\n\nYou pay for the coding agent's run, the sandbox time your tests take, and the one risk-assessment model call — a dry run costs nothing beyond the coding run it still performs.",
+  "useCases": [
+    "Keep a repo's dependencies current on a cron without a human babysitting each bump.",
+    "Gate every automated upgrade on your real test suite, so nothing lands on a red build.",
+    "Hold major or broad upgrades for review while low-risk bumps push on their own."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `repoSlug` (an in-network repo the coding agent clones and upgrades). Set `testCommand` (default `npm test`) and `installCommand` (default `npm install`) to match the project, and `maxAutoRisk` (default `medium`) to control what pushes on its own versus what waits for you. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed workflow. Pass `dryRun: true` to trace the whole graph without pushing or uploading anything.\n\nPrefer to work from the code? Run it locally with `run_local` (pass `{ \"repoSlug\": \"my-app\", \"dryRun\": true }`) to trace plan → bump → verify → assess → publish for free — capabilities are stubbed and the push is skipped — or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A dry-run triage of a repo's upgrade",
+      "input": {
+        "repoSlug": "my-app",
+        "testCommand": "npm test",
+        "maxAutoRisk": "medium",
+        "dryRun": true
+      },
+      "output": {
+        "decision": "publish",
+        "pushed": false,
+        "dryRun": true,
+        "risk": "low",
+        "reportFileId": null,
+        "summary": "Patch and minor bumps across dev dependencies; no major versions, narrow blast radius."
+      }
+    }
+  ]
+}

--- a/examples/dependency-upgrade/tsconfig.json
+++ b/examples/dependency-upgrade/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,63 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "dependency-upgrade",
+      "name": "Dependency Upgrade",
+      "description": "On a schedule, a coding agent bumps a repo's dependencies in a sandbox, runs the tests, and pushes only when the build is green.",
+      "tags": ["dependencies", "coding-agent", "scheduled", "ci"],
+      "sourcePath": "examples/dependency-upgrade",
+      "capabilities": [
+        "models.coding",
+        "sandboxes.exec",
+        "models.run",
+        "fileStorage.upload",
+        "repositories.pushFromSandbox"
+      ],
+      "whatItDoes": "For keeping a project's dependencies current without a human driving each bump. On each scheduled run a coding agent (`models.coding`) clones your repo into a sandbox and upgrades its dependencies, and because that run is long the workflow pauses at $0 until it finishes. It then re-attaches the same sandbox and runs your real test suite there (`sandboxes.exec`) — a red build is dropped, never pushed. A green build gets a model risk rating of the changed dependencies (`models.run`); anything above your risk bar is held for a person instead of pushed. When it does push, it commits the bumped branch straight from the sandbox. Every run — pushed, held, or dropped — archives a triage report to file storage (`fileStorage.upload`) so you can see what changed and why it did or didn't ship.",
+      "steps": [
+        {
+          "name": "plan",
+          "description": "Resolves the repo and the install and test commands and checks the input; with no repo it stops right away.",
+          "next": ["bump", "rejected"]
+        },
+        {
+          "name": "bump",
+          "description": "Launches a coding agent to bump the repo's dependencies in a sandbox, then pauses until the run finishes.",
+          "capability": "models.coding",
+          "next": ["verify"]
+        },
+        {
+          "name": "verify",
+          "description": "Re-attaches that sandbox and runs the install and test suite there; a failed run or a red build is rejected.",
+          "capability": "sandboxes.exec",
+          "next": ["assess", "rejected"]
+        },
+        {
+          "name": "assess",
+          "description": "Asks a model to rate the upgrade's risk from the dependency diff, holding anything above your bar.",
+          "capability": "models.run",
+          "next": ["publish", "held"]
+        },
+        {
+          "name": "publish",
+          "description": "Pushes the bumped branch from the sandbox and archives the triage report.",
+          "capability": "repositories.pushFromSandbox",
+          "terminal": true
+        },
+        {
+          "name": "held",
+          "description": "The build was green but the risk was too high, so it archives the report and waits for a human.",
+          "capability": "fileStorage.upload",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "The coding run failed or the tests were red, so it archives the report and pushes nothing.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a new onboarding workflow template — **Dependency Upgrade** — to the gallery (`examples/dependency-upgrade/` + one `examples/registry.json` entry). Closes SAP-1872.

A scheduled "Dependabot triage": on a cron, a coding agent bumps a repo's dependencies in a sandbox, the real test suite runs there, a model risk-assesses the diff, and the bumped branch is pushed only when the build is green **and** within your risk bar.

```
plan ─▶ bump ──(pause: models.coding.result → verify)──▶ verify ─┬─▶ assess ─┬─▶ publish
                                                                 │           └─▶ held
                                                                 └─▶ rejected
```

- **bump** — `models.coding.launch` on the repo, then `pauseUntilSignal` at $0 while the (long) coding run works.
- **verify** — re-attaches the coding run's sandbox and runs install + tests via `sandboxes.exec`; a failed run / red build → `rejected`.
- **assess** — `models.run` rates the upgrade `low`/`medium`/`high`; above `maxAutoRisk` → `held` for a human.
- **publish** — `repo.pushFromSandbox` + archives the triage report to `fileStorage.upload`. `held`/`rejected` archive but never push.

## Capabilities

`models.coding`, `sandboxes.exec`, `models.run`, `fileStorage.upload`, `repositories.pushFromSandbox` — matching the ticket's Cron (schedule) + Coding agent + Sandbox + LLM + File storage set. First template to exercise the async coding-agent launch + durable pause/resume pattern.

## Safety

The push is the only irreversible action, gated behind a `dryRun` guard: with `dryRun: true`, `verify` synthesizes a green result when no real sandbox is present, so `run_local` traces the whole graph offline for free — nothing pushed, nothing uploaded.

## Validation

- `npm run typecheck` — clean
- `prettier --check` — clean (index.ts, json, registry.json)
- offline graph validation (`buildManifest` + `assertValidGraph`) — no errors, no warnings; entry `plan`, 7 steps, pause annotation valid
- Pins `@sapiom/agent ^0.6.0` / `@sapiom/tools ^0.20.0` (same as the sandbox/vault siblings; these versions carry `coding`, `repositories`, `sandboxes`, `fileStorage`). No `package-lock.json` (matches siblings).

Follows `examples/AUTHORING.md` for all gallery/detail copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)