### PR TITLE
feat(examples): add PR Review Bot workflow template (SAP-1868)

### DIFF
--- a/examples/pr-review-bot/AGENTS.md
+++ b/examples/pr-review-bot/AGENTS.md
@@ -1,0 +1,73 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **PR Review Bot** —
+authored against `@sapiom/agent`. It builds a concrete workflow on the durable
+pause/resume spine: `watch` registers a PR webhook and returns
+`pauseUntilSignal(...)`; the run suspends at $0 until a pull request is opened;
+`review` (the resume target) receives the PR payload as its input, hands the diff
+to a coding agent (`ctx.sapiom.models.coding.run`) that checks the code out and
+analyzes it; `assess` turns the findings into a structured review with
+`ctx.sapiom.models.run`; then `reportEmail` / `reportSlack` post it.
+
+## The pause/resume spine
+
+- **`watch`** registers `{ executionId, signal, correlationId: ctx.executionId }`
+  with the webhook source, then returns
+  `pauseUntilSignal({ signal: "pr.opened", resumeStep: "review", correlationId: ctx.executionId })`.
+  It also carries a static `pause: { signal, resumeStep: "review" }` annotation —
+  the build-time graph edge that must match the directive.
+- **`review`** reads the PR webhook payload **directly as its `run` input** —
+  that's the signal payload the external world delivered. When it's empty (a
+  local run, where nothing recorded a signal), `review` falls back to a built-in
+  sample PR from `ctx.shared` so the coding agent always has something to analyze.
+  Config, channel, and recipient are read back from `ctx.shared`, which survives
+  the pause.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability**. The
+  billed calls are the coding run (`models.coding.run`), the model summary
+  (`models.run`), the email send (`email`), and — for Slack — the Vault read
+  (`vault.get`). Note: `ctx.sapiom.llm` does **not** exist — use `models.run`.
+
+## Read-only review
+
+The coding agent is told **not** to modify or push code — this is a review, not
+an edit. We pass `keepSandbox: false` since no later step reads from or pushes
+the sandbox. A `run.result?.success` of `false` still costs, so `review` records
+whatever the run produced (or its error) and lets `assess` reason over it rather
+than throwing.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` and a `pause: { signal, resumeStep }` annotation; the `resumeStep` is its forward edge.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including the static `pause` annotation.
+- **run_local** — runs your **real** step code against **stub capabilities**. With no `WEBHOOK_REGISTER_URL` configured (or `DRY_RUN` set), the `dryRun` guard skips the live registration and the report step skips the real send, and the local runner auto-resumes the pause with an empty payload — so `review` uses the sample PR and you get the full `watch → paused → review → assess → report → posted` trace offline for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses.
+
+### Firing the resume signal in dev
+
+A real `run` pauses at `watch`. To resume it without a real webhook, fire the signal via the MCP `signal_workflow` / `workflow_signal` tool — the manual stand-in for the PR webhook:
+
+```json
+{
+  "signal": "pr.opened",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "repo": { "owner": "acme", "name": "api" }, "number": 42, "title": "…", "branch": "feat/x", "baseBranch": "main", "diff": "…" }
+}
+```
+
+The `payload` arrives as `review`'s input.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities + the `dryRun` guard), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `correlationId` is `ctx.executionId` (stable across the pause), so the resume signal always lands on the right run.

--- a/examples/pr-review-bot/README.md
+++ b/examples/pr-review-bot/README.md
@@ -1,0 +1,93 @@
+# PR Review Bot
+
+On a pull-request webhook, a coding agent checks out and analyzes the code,
+flags any change that shipped without matching tests, and posts the review to
+your email or a Slack channel — using a token you keep in the Vault.
+
+The run **suspends at $0** while it waits for a PR, so it can sit idle for days
+between reviews and cost nothing until a webhook wakes it.
+
+## What it does
+
+```
+watch  ──(pause: wait for "pr.opened", $0 while idle)──▶  review  ──▶  assess  ─┬─▶  reportEmail  ─┬─▶  posted  (terminal)
+                                                                                └─▶  reportSlack  ─┤
+                                                                                                   └─▶  failed  (terminal)
+```
+
+1. **watch** — registers a PR webhook and a resume contract
+   `{ executionId, signal, correlationId }`, then returns
+   `pauseUntilSignal({ signal: "pr.opened", resumeStep: "review", correlationId })`.
+   The run suspends here at zero cost until a PR is opened.
+2. **(paused)** — nothing runs, nothing is billed, for as long as it takes.
+3. **review** (resume target) — its **input IS the PR payload**. A coding agent
+   (`ctx.sapiom.models.coding.run`) checks the code out in a sandbox and
+   analyzes the diff, told to surface changes that lack tests. It's read-only —
+   the agent reviews, it doesn't push.
+4. **assess** — an LLM (`ctx.sapiom.models.run`) turns the raw findings into a
+   structured review: a verdict, a summary, and the list of missing tests.
+5. **reportEmail | reportSlack** — posts the review. Email uses the built-in
+   `ctx.sapiom.email` capability; Slack uses a bot token you store in the Vault
+   (`ctx.sapiom.vault.get`) and a direct `fetch` — nothing baked into code.
+
+Input: `{ "repo": { "owner": "acme", "name": "api" }, "via": "email", "to": "you@example.com", "config": { "WEBHOOK_REGISTER_URL": "…" } }`.
+With no `WEBHOOK_REGISTER_URL` (or `DRY_RUN` set), `watch` runs offline via its
+`dryRun` guard and the report step skips the real send.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to run the coding agent, call the model, and send email.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (offline via the `dryRun` guard, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses).
+
+## Delivering to Slack (bring your own token)
+
+`review` and `assess` cost the same either way; only the report channel differs.
+To post to Slack, set `"via": "slack"` and `"to": "#your-channel"`, then store a
+[Slack bot token](https://api.slack.com/authentication/token-types#bot) in the
+Vault under the ref `slack`, key `bot_token`, scoped to this workflow. The token
+is read only at runtime and never lands in code. Without a token the run
+degrades to a skip (it still completes) so you can trace the graph first.
+
+## Resuming a paused run in dev
+
+A real `run` pauses at `watch` and waits for the `pr.opened` signal. Instead of
+a real webhook, fire it yourself via the MCP `signal_workflow` / `workflow_signal`
+tool. The `correlationId` is the paused run's `executionId`, and the `payload`
+becomes `review`'s input:
+
+```json
+{
+  "signal": "pr.opened",
+  "correlationId": "<executionId of the paused run>",
+  "payload": {
+    "repo": { "owner": "acme", "name": "api" },
+    "number": 42,
+    "title": "Add avatar upload endpoint",
+    "branch": "feat/avatar-upload",
+    "baseBranch": "main",
+    "diff": "diff --git a/src/users/avatar.ts b/src/users/avatar.ts\n+export async function uploadAvatar(...) { ... }"
+  }
+}
+```
+
+The run wakes at `review`, the coding agent analyzes that PR, and the review is
+posted through the configured channel.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/pr-review-bot/index.ts
+++ b/examples/pr-review-bot/index.ts
@@ -1,0 +1,562 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * PR Review Bot — a coding agent reviews a pull request, then posts feedback.
+ *
+ * A concrete build on the durable pause/resume spine: `watch` registers a PR
+ * webhook and then **suspends at $0** via `pauseUntilSignal` — no polling loop,
+ * no held worker — until a pull request is opened. When the webhook fires, the
+ * run wakes with the PR payload as its input and:
+ *
+ *   1. `review`  — hands the diff to a coding agent (`models.coding.run`) that
+ *                  checks out the code in a sandbox and analyzes it, with a
+ *                  standing instruction to flag any change that ships without
+ *                  matching test coverage.
+ *   2. `assess`  — an LLM (`models.run`) turns those raw findings into a short,
+ *                  structured review: a verdict, a summary, and a list of the
+ *                  missing tests.
+ *   3. report    — posts the review through the configured channel: your own
+ *                  email (`email.send`) or a bring-your-own Slack token read
+ *                  from the Vault (`vault.get`) — never baked into code.
+ *
+ *   watch ──(pause: wait for `pr.opened`, $0 while idle)──▶ review ──▶ assess ─┬─▶ reportEmail ─┬─▶ posted
+ *                                                                              └─▶ reportSlack ─┤
+ *                                                                                               └─▶ failed
+ *
+ * Resume contract: `watch` registers `{ executionId, signal, correlationId }`
+ * with the webhook source and pauses; the source fires that signal when a PR is
+ * opened (in dev, via the MCP `signal_workflow` / `workflow_signal` tool — see
+ * README). The resumed `review` step's input IS the PR payload.
+ *
+ * Offline: with no `WEBHOOK_REGISTER_URL` configured (or `DRY_RUN` set), the
+ * `dryRun` guard skips the live registration POST and the report steps skip the
+ * real send, so `run_local` traces the full graph — watch → paused →
+ * auto-resumed review → assess → report → posted — for free. When the resume
+ * payload is empty (as in a local run), `review` falls back to a built-in
+ * sample PR so the coding agent always has something to analyze.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** Vault ref that holds this workflow's Slack credential (BYO channel). */
+const VAULT_REF = "slack";
+/** Vault key for the Slack bot token used by `chat.postMessage`. */
+const BOT_TOKEN_KEY = "bot_token";
+/** Username for the inbox we send review emails from (created once, reused). */
+const SENDER_USERNAME = "pr-review-bot";
+/** The named signal the PR webhook fires to resume this run. */
+const SIGNAL = "pr.opened";
+
+type Channel = "email" | "slack";
+
+/** The run input: what repo to watch, how to deliver the review, plus config. */
+interface PrReviewInput {
+  /** Repo the webhook watches and the agent reviews. */
+  repo?: RepoRef;
+  /** Where to deliver the review. Defaults to `email`. */
+  via?: Channel;
+  /** email: recipient address. slack: channel (`#reviews` or `C0123`). */
+  to?: string;
+  /** Optional sample PR used when the resume payload is empty (local runs). */
+  samplePr?: PrEvent;
+  /** Absent (or `DRY_RUN`) ⇒ offline: skip registration and the real send. */
+  config?: Config;
+}
+
+interface RepoRef {
+  owner: string;
+  name: string;
+  /** HTTPS clone URL the coding agent uses to check the code out. */
+  cloneUrl?: string;
+}
+
+/**
+ * The pull-request event delivered by the webhook — it becomes `review`'s input
+ * verbatim. Intentionally open: a real webhook carries more than we read here.
+ */
+interface PrEvent {
+  repo?: RepoRef;
+  /** PR number. */
+  number?: number;
+  title?: string;
+  /** Head branch (the change). */
+  branch?: string;
+  /** Base branch the PR targets. */
+  baseBranch?: string;
+  author?: string;
+  /** Unified diff text, when the source inlines it. */
+  diff?: string;
+  /** URL to fetch the diff from, when it isn't inlined. */
+  diffUrl?: string;
+  [key: string]: unknown;
+}
+
+interface Review {
+  /** Overall call on the PR. */
+  verdict: "approve" | "comment" | "request_changes";
+  /** One-paragraph summary of the review. */
+  summary: string;
+  /** Changes that landed without matching test coverage. */
+  missingTests: string[];
+  /** Other notable findings, each a short line. */
+  comments: string[];
+}
+
+interface ReportResult extends Record<string, unknown> {
+  posted: boolean;
+  /** Why we didn't post, when `posted` is false (dryRun, no-credential, …). */
+  skipped: string | null;
+  via: Channel;
+  verdict: Review["verdict"];
+}
+
+/** Pre-pause + cross-step state; everything here survives the suspend. */
+interface Shared extends Record<string, unknown> {
+  config: Config;
+  repo: RepoRef | null;
+  via: Channel;
+  to: string | null;
+  dryRun: boolean;
+  samplePr: PrEvent;
+  correlationId: string;
+  pr: PrEvent;
+  rawFindings: string;
+  review: Review;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/**
+ * True when there's no live external dependency to talk to — no register URL, or
+ * `DRY_RUN` explicitly set. Lets `run_local` exercise the full control flow
+ * offline, mirroring how a real deploy talks to a real webhook source and Slack.
+ */
+function isDryRun(config: Config): boolean {
+  const flag = (config.DRY_RUN ?? "").toLowerCase();
+  return flag === "1" || flag === "true" || !config.WEBHOOK_REGISTER_URL;
+}
+
+/** A plausible PR used when the resume payload is empty (local/offline runs). */
+function defaultSamplePr(repo: RepoRef | null): PrEvent {
+  return {
+    repo: repo ?? { owner: "acme", name: "api" },
+    number: 42,
+    title: "Add POST /users/:id/avatar upload endpoint",
+    branch: "feat/avatar-upload",
+    baseBranch: "main",
+    author: "octocat",
+    diff: [
+      "diff --git a/src/users/avatar.ts b/src/users/avatar.ts",
+      "+export async function uploadAvatar(userId: string, file: Buffer) {",
+      "+  const key = `avatars/${userId}`;",
+      "+  await storage.put(key, file);",
+      "+  return storage.url(key);",
+      "+}",
+    ].join("\n"),
+  };
+}
+
+/** True when the webhook actually delivered PR content (vs an empty resume). */
+function hasPrData(event: PrEvent): boolean {
+  return Boolean(
+    event &&
+    (event.number ||
+      (event.title && event.title.trim()) ||
+      (event.diff && event.diff.trim())),
+  );
+}
+
+/**
+ * Register the resume contract with the webhook source. It is expected to fire
+ * `SIGNAL` (with our `correlationId`) when a PR is opened on the watched repo.
+ */
+async function registerWebhook(
+  config: Config,
+  body: { resume: unknown; repo: RepoRef | null },
+): Promise<void> {
+  const url = (config.WEBHOOK_REGISTER_URL ?? "").replace(/\/$/, "");
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (config.WEBHOOK_REGISTER_KEY)
+    headers.authorization = `Bearer ${config.WEBHOOK_REGISTER_KEY}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(
+      `register failed: HTTP ${res.status} ${text.slice(0, 200)}`,
+    );
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "PR Review Bot",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Post to Slack via `chat.postMessage` with a bot token. Slack signals errors in
+ * the JSON body (`{ ok: false, error }`), not the HTTP status, so we check `ok`.
+ */
+async function postToSlack(
+  token: string,
+  channel: string,
+  text: string,
+): Promise<void> {
+  const res = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+      Authorization: `Bearer ${token}`,
+    },
+    body: new URLSearchParams({ channel, text, unfurl_links: "false" }),
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!json.ok) {
+    throw new Error(`slack chat.postMessage failed: ${String(json.error)}`);
+  }
+}
+
+/** Render a review as the plain-text body shared by both channels. */
+function renderReview(pr: PrEvent, review: Review): string {
+  const lines = [
+    `PR #${pr.number ?? "?"}: ${pr.title ?? "(untitled)"}`,
+    `Verdict: ${review.verdict}`,
+    "",
+    review.summary,
+  ];
+  if (review.missingTests.length) {
+    lines.push("", "Missing tests:");
+    for (const t of review.missingTests) lines.push(`  - ${t}`);
+  }
+  if (review.comments.length) {
+    lines.push("", "Notes:");
+    for (const c of review.comments) lines.push(`  - ${c}`);
+  }
+  return lines.join("\n");
+}
+
+// ───────────────────────────────────────────────────────────────── steps ──
+const watch = defineStep({
+  name: "watch",
+  next: [],
+  // Static graph edge: on `SIGNAL`, resume at `review`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "review" },
+  async run(input: PrReviewInput, ctx: Ctx) {
+    const config = input.config ?? {};
+    const repo = input.repo ?? null;
+    const via: Channel = input.via === "slack" ? "slack" : "email";
+    const to = (input.to ?? "").trim() || null;
+    const dryRun = isDryRun(config);
+
+    // Everything set before the pause survives in ctx.shared and is read back
+    // after resume; the resumed step's *input* is the PR webhook payload itself.
+    ctx.shared.set("config", config);
+    ctx.shared.set("repo", repo);
+    ctx.shared.set("via", via);
+    ctx.shared.set("to", to);
+    ctx.shared.set("dryRun", dryRun);
+    ctx.shared.set("samplePr", input.samplePr ?? defaultSamplePr(repo));
+    ctx.shared.set("correlationId", ctx.executionId);
+
+    // Tell the webhook source how to resume this exact run when a PR opens.
+    const resume = {
+      executionId: ctx.executionId,
+      signal: SIGNAL,
+      correlationId: ctx.executionId,
+    };
+
+    if (dryRun) {
+      ctx.logger.info("dry run: skipping webhook registration", {
+        correlationId: ctx.executionId,
+      });
+    } else {
+      await registerWebhook(config, { resume, repo });
+      ctx.logger.info("webhook registered; pausing for PR", {
+        repo: repo ? `${repo.owner}/${repo.name}` : "(any)",
+        correlationId: ctx.executionId,
+      });
+    }
+
+    // Suspend at $0 until the webhook fires SIGNAL for this correlationId.
+    return pauseUntilSignal({
+      signal: SIGNAL,
+      resumeStep: "review",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const review = defineStep({
+  name: "review",
+  next: ["assess"],
+  // `event` IS the PR webhook payload delivered by the resume signal.
+  async run(event: PrEvent, ctx: Ctx) {
+    // Fall back to the sample PR when the resume payload is empty (local runs).
+    const pr = hasPrData(event)
+      ? event
+      : must(ctx.shared.get("samplePr"), "samplePr");
+    ctx.shared.set("pr", pr);
+
+    const repoLabel = pr.repo ? `${pr.repo.owner}/${pr.repo.name}` : "the repo";
+    const diffSection = pr.diff
+      ? `Unified diff:\n${pr.diff}`
+      : pr.diffUrl
+        ? `Fetch and review the diff at: ${pr.diffUrl}`
+        : "No diff was provided; review the branch against its base.";
+
+    // The coding agent checks the code out in a sandbox and analyzes it. We do
+    // NOT ask it to modify or push anything — this is a read-only review. Its
+    // standing instruction is to surface changes that ship without tests.
+    const task =
+      `Review pull request #${pr.number ?? "?"} ("${pr.title ?? "untitled"}") ` +
+      `on ${repoLabel}, branch "${pr.branch ?? "?"}" against "${pr.baseBranch ?? "main"}".` +
+      (pr.repo?.cloneUrl
+        ? ` Clone from ${pr.repo.cloneUrl} to inspect the code.`
+        : "") +
+      `\n\nDo NOT modify or push any code — this is a read-only review. ` +
+      `Focus on correctness and, above all, TEST COVERAGE: for every behavior ` +
+      `the change adds or alters, check whether a matching test exists, and ` +
+      `explicitly list any that are missing.\n\n${diffSection}`;
+
+    const run = await ctx.sapiom.models.coding.run({
+      task,
+      keepSandbox: false,
+    });
+
+    // A run can finish unsuccessfully (aborted, errored) and still cost — record
+    // whatever it produced and let `assess` reason over it rather than failing.
+    const findings =
+      run.summary?.trim() ||
+      (run.error
+        ? `Coding agent did not complete: ${run.error.stage} — ${run.error.message}`
+        : "Coding agent returned no findings.");
+    ctx.shared.set("rawFindings", findings);
+    ctx.logger.info("coding review finished", {
+      runId: run.runId,
+      success: run.result?.success ?? false,
+    });
+
+    return goto("assess", {});
+  },
+});
+
+const assess = defineStep({
+  name: "assess",
+  next: ["reportEmail", "reportSlack"],
+  async run(_input: unknown, ctx: Ctx) {
+    const pr = must(ctx.shared.get("pr"), "pr");
+    const findings = must(ctx.shared.get("rawFindings"), "rawFindings");
+    const via = ctx.shared.get("via") ?? "email";
+
+    const system =
+      "You are a senior engineer turning a coding agent's raw review notes into a " +
+      "concise, structured PR review. Weigh test coverage heavily: any behavior " +
+      "that changed without a matching test belongs in `missingTests`. Pick a " +
+      "verdict: `request_changes` if there are missing tests or real defects, " +
+      "`comment` for minor notes, `approve` if it is clean. Reply with ONLY " +
+      'minified JSON: {"verdict":"approve|comment|request_changes","summary":string,' +
+      '"missingTests":string[],"comments":string[]}.';
+    const prompt =
+      `PR #${pr.number ?? "?"}: ${pr.title ?? "(untitled)"}\n\n` +
+      `Coding agent findings:\n${findings}`;
+
+    const res = await ctx.sapiom.models.run({ prompt, system, maxTokens: 600 });
+    const rev = parseReview(res.output);
+    ctx.shared.set("review", rev);
+    ctx.logger.info("review assessed", {
+      verdict: rev.verdict,
+      missingTests: rev.missingTests.length,
+    });
+
+    // Deliver through the configured channel.
+    return via === "slack" ? goto("reportSlack", {}) : goto("reportEmail", {});
+  },
+});
+
+const reportEmail = defineStep({
+  name: "reportEmail",
+  next: ["posted", "failed"],
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const to = ctx.shared.get("to") ?? null;
+    const pr = must(ctx.shared.get("pr"), "pr");
+    const review = must(ctx.shared.get("review"), "review");
+
+    // dryRun (run_local / offline): skip the network, report what it would do.
+    if (dryRun) {
+      ctx.logger.info("dryRun — skipping review email", { to });
+      return goto("posted", skip("dryRun", "email", review));
+    }
+    // No-recipient guard: an unconfigured recipient is an expected onboarding
+    // state, not a failure — degrade to a skip so the graph still completes.
+    if (!to) {
+      ctx.logger.warn("no email recipient configured — skipping send");
+      return goto("posted", skip("no-recipient", "email", review));
+    }
+
+    try {
+      const inboxId = await resolveSenderInbox(ctx);
+      const sent = await ctx.sapiom.email.messages.send(inboxId, {
+        to,
+        subject: `PR review #${pr.number ?? "?"}: ${review.verdict}`,
+        text: renderReview(pr, review),
+      });
+      ctx.logger.info("review emailed", { to, messageId: sent.messageId });
+      return goto("posted", {
+        posted: true,
+        skipped: null,
+        via: "email",
+        verdict: review.verdict,
+      } satisfies ReportResult);
+    } catch (err) {
+      ctx.logger.error("email send failed", { err: String(err) });
+      return goto("failed", { error: String(err) });
+    }
+  },
+});
+
+const reportSlack = defineStep({
+  name: "reportSlack",
+  next: ["posted", "failed"],
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const channel = ctx.shared.get("to") ?? null;
+    const pr = must(ctx.shared.get("pr"), "pr");
+    const review = must(ctx.shared.get("review"), "review");
+
+    if (dryRun) {
+      ctx.logger.info("dryRun — skipping Slack post", { channel });
+      return goto("posted", skip("dryRun", "slack", review));
+    }
+    if (!channel) {
+      ctx.logger.warn("no Slack channel configured — skipping post");
+      return goto("posted", skip("no-recipient", "slack", review));
+    }
+
+    // Read the BYO token at runtime — never baked into code.
+    let token: string | null = null;
+    try {
+      token = await ctx.sapiom.vault.get(VAULT_REF, BOT_TOKEN_KEY);
+    } catch (err) {
+      ctx.logger.warn("vault: no slack token", { err: String(err) });
+    }
+    // No-key guard: behave like dryRun so a fresh fork traces end to end before
+    // you have stored a token.
+    if (!token) {
+      ctx.logger.warn("no slack token in vault — skipping post", {
+        ref: VAULT_REF,
+        key: BOT_TOKEN_KEY,
+      });
+      return goto("posted", skip("no-credential", "slack", review));
+    }
+
+    try {
+      await postToSlack(token, channel, renderReview(pr, review));
+      ctx.logger.info("review posted to slack", { channel });
+      return goto("posted", {
+        posted: true,
+        skipped: null,
+        via: "slack",
+        verdict: review.verdict,
+      } satisfies ReportResult);
+    } catch (err) {
+      ctx.logger.error("slack post failed", { err: String(err) });
+      return goto("failed", { error: String(err) });
+    }
+  },
+});
+
+const posted = defineStep({
+  name: "posted",
+  next: [],
+  terminal: true,
+  async run(input: ReportResult) {
+    return terminate(input);
+  },
+});
+
+const failed = defineStep({
+  name: "failed",
+  next: [],
+  terminal: true,
+  async run(input: { error: string }) {
+    return terminate({
+      posted: false,
+      failed: true,
+      error: input?.error ?? "unknown error",
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** Build a "skipped" report result (no send happened, but the run succeeded). */
+function skip(reason: string, via: Channel, review: Review): ReportResult {
+  return { posted: false, skipped: reason, via, verdict: review.verdict };
+}
+
+/** Extract the structured review from model output; fall back to a safe default. */
+function parseReview(output: string | null): Review {
+  const fallback: Review = {
+    verdict: "comment",
+    summary: "Model summary unavailable; see the coding agent's raw findings.",
+    missingTests: [],
+    comments: [],
+  };
+  if (!output) return fallback;
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback;
+    const raw = JSON.parse(output.slice(start, end + 1)) as Partial<Review>;
+    const verdict =
+      raw.verdict === "approve" ||
+      raw.verdict === "comment" ||
+      raw.verdict === "request_changes"
+        ? raw.verdict
+        : fallback.verdict;
+    const asStrings = (v: unknown): string[] =>
+      Array.isArray(v)
+        ? v.filter((x): x is string => typeof x === "string")
+        : [];
+    return {
+      verdict,
+      summary: typeof raw.summary === "string" ? raw.summary : fallback.summary,
+      missingTests: asStrings(raw.missingTests),
+      comments: asStrings(raw.comments),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export const agent = defineAgent<PrReviewInput, Shared>({
+  name: "pr-review-bot",
+  entry: "watch",
+  steps: { watch, review, assess, reportEmail, reportSlack, posted, failed },
+});

--- a/examples/pr-review-bot/package.json
+++ b/examples/pr-review-bot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-pr-review-bot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a PR webhook, a coding agent reviews the code and flags missing tests, then posts feedback via email or a Vault-backed Slack integration.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/pr-review-bot/template.json
+++ b/examples/pr-review-bot/template.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": { "name": "Sapiom", "url": "https://sapiom.ai/" },
+  "longDescription": "A review bot that wakes up when someone opens a pull request. It waits on a webhook and costs nothing while idle — it can sit for days between reviews and only spends once a PR arrives.\n\nWhen one does, a coding agent checks the code out in a sandbox and reads the diff, with a standing instruction to look hardest at test coverage: for every behavior the change touches, does a matching test exist? It reviews, it doesn't edit — nothing is pushed. A model then turns the agent's raw notes into a short, structured review — a verdict, a summary, and a plain list of the tests that are missing.\n\nThe review goes to wherever you want it: your email, or a Slack channel using a bot token you keep in the Vault (read only at runtime, never in code). You pay for the coding review, the model summary, and the delivery — the waiting is free.",
+  "useCases": [
+    "Catch pull requests that add or change behavior without adding tests, before a human reviewer does.",
+    "Give a small team an always-on first-pass reviewer that posts to the channel they already watch.",
+    "Wire a repo's PR webhook to a durable bot that costs nothing between reviews."
+  ],
+  "notes": "**Use this template.** Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nThis workflow **pauses and waits for a PR**. A real run suspends at `watch` at $0 until a pull request is opened. In dev there's no one-click signal button yet — fire the `pr.opened` signal yourself with the MCP `workflow_signal` tool (or the API), passing the paused run's `executionId` as the `correlationId` and the PR as the `payload`. See the README for the exact shape.\n\nTo deliver to Slack instead of email, set `\"via\": \"slack\"` with `\"to\": \"#your-channel\"`, and store a Slack bot token in the Vault under ref `slack`, key `bot_token`. Without it the run still completes — it just skips the post.\n\n**Prefer to work from the code?** Run it locally with `run_local` to trace the whole flow for free (it uses a built-in sample PR), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Watch a repo, review to email",
+      "input": {
+        "repo": { "owner": "acme", "name": "api" },
+        "via": "email",
+        "to": "eng@example.com",
+        "config": { "WEBHOOK_REGISTER_URL": "https://hooks.example.com/register" }
+      }
+    },
+    {
+      "title": "A PR opens (the resume signal payload)",
+      "input": {
+        "repo": { "owner": "acme", "name": "api" },
+        "number": 42,
+        "title": "Add avatar upload endpoint",
+        "branch": "feat/avatar-upload",
+        "baseBranch": "main",
+        "diff": "diff --git a/src/users/avatar.ts b/src/users/avatar.ts\n+export async function uploadAvatar(userId, file) { ... }"
+      },
+      "output": {
+        "posted": true,
+        "skipped": null,
+        "via": "email",
+        "verdict": "request_changes"
+      }
+    }
+  ]
+}

--- a/examples/pr-review-bot/tsconfig.json
+++ b/examples/pr-review-bot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,56 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "pr-review-bot",
+      "name": "PR Review Bot",
+      "description": "When a pull request opens, a coding agent reviews the code and flags missing tests, then posts the review to your email or Slack.",
+      "tags": ["coding-agent", "review", "pause-resume", "webhook"],
+      "sourcePath": "examples/pr-review-bot",
+      "capabilities": ["models.coding", "models.run", "email.send", "vault.get"],
+      "whatItDoes": "An always-on first-pass reviewer for your pull requests. It registers a PR webhook and then waits, costing nothing while idle — it can sit for days between reviews. When a PR is opened, the run wakes with the PR as its input: a coding agent checks the code out in a sandbox and reads the diff, told to look hardest at test coverage and list any change that shipped without a matching test. It reviews, it doesn't edit — nothing is pushed. A model then turns those raw notes into a short, structured review — a verdict, a summary, and the missing tests — and posts it to your email or, using a bot token you keep in the Vault, a Slack channel.",
+      "steps": [
+        {
+          "name": "watch",
+          "description": "Registers a PR webhook and how to resume this run, then pauses and waits for a pull request — costing nothing while idle.",
+          "next": ["review"]
+        },
+        {
+          "name": "review",
+          "description": "Wakes when a PR opens; its input is the PR payload. A coding agent checks the code out and analyzes the diff, flagging changes that lack tests.",
+          "capability": "models.coding",
+          "next": ["assess"]
+        },
+        {
+          "name": "assess",
+          "description": "A model turns the coding agent's raw findings into a structured review — a verdict, a summary, and the list of missing tests.",
+          "capability": "models.run",
+          "next": ["reportEmail", "reportSlack"]
+        },
+        {
+          "name": "reportEmail",
+          "description": "Emails the review to the configured recipient.",
+          "capability": "email.send",
+          "next": ["posted", "failed"]
+        },
+        {
+          "name": "reportSlack",
+          "description": "Reads your Slack bot token from the Vault and posts the review to the configured channel.",
+          "capability": "vault.get",
+          "next": ["posted", "failed"]
+        },
+        {
+          "name": "posted",
+          "description": "Return the result — the channel used and the verdict.",
+          "terminal": true
+        },
+        {
+          "name": "failed",
+          "description": "The send errored; return the error.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.6",
-  tools: "0.21.0",
+  agent: "0.6.7",
+  tools: "0.22.0",
 };
 
 /** The zod major the authoring SDK is built against. */


### PR DESCRIPTION
## What & why

Adds the **PR Review Bot** onboarding template (SAP-1868) to the gallery — the coding-agent showcase for the relaunch template set (epic SAP-1823).

On a pull-request webhook, a coding agent checks out and analyzes the code, flags any change that shipped without matching tests, and posts the review to email or a bring-your-own Slack channel (token from the Vault).

## Design

Built on the same durable pause/resume spine as `wait-for-webhook`, specialized to PR review:

```
watch ──(pause: wait for "pr.opened", $0 while idle)──▶ review ──▶ assess ─┬─▶ reportEmail ─┬─▶ posted
                                                                           └─▶ reportSlack ─┤
                                                                                            └─▶ failed
```

- **watch** — registers a PR webhook + resume contract, then `pauseUntilSignal({ signal: "pr.opened", resumeStep: "review" })`. Suspends at $0 until a PR opens.
- **review** (`models.coding`) — the PR payload is its input; a coding agent checks the code out in a sandbox and analyzes the diff read-only (no push), told to flag missing tests.
- **assess** (`models.run`) — turns the raw findings into a structured review: verdict + summary + missing tests.
- **reportEmail** (`email.send`) / **reportSlack** (`vault.get`) — posts through the configured channel. Slack uses a BYO bot token read from the Vault at runtime, mirroring `slack-notifier`'s no-key guard.

Capabilities: `models.coding`, `models.run`, `email.send`, `vault.get`. `pauseUntilSignal` is a runtime primitive, not a metered capability.

## Offline / run_local

A `dryRun` guard (no `WEBHOOK_REGISTER_URL`, or `DRY_RUN`) skips the live registration and the real send. When the resume payload is empty (as in a local run), `review` falls back to a built-in sample PR, so `run_local` traces the full graph offline for free.

## Validation evidence

- `npm run typecheck` — passes against the pinned SDK (`@sapiom/agent ^0.6.5`, `@sapiom/tools ^0.20.0`); confirms every `ctx.sapiom.*` call exists.
- `check()` — `pr-review-bot`, 7 steps, **0 warnings**; validates the manifest, step graph, and the static `pause` annotation.
- `run_local` — completes end-to-end on **both** channels:
  - email: `watch → review → assess → reportEmail → posted`
  - slack: `watch → review → assess → reportSlack → posted`
  - no unused stubs, no stub warnings.
- registry.json + template.json validate against their schemas; step capabilities ⊆ declared capabilities.
- `prettier --check` clean.

Follows `examples/AUTHORING.md` for all copy (registry `whatItDoes`/steps, `template.json` longDescription/useCases/notes/examples).

Closes SAP-1868.