### PR TITLE
feat(examples): Research → Micro-Site Publisher workflow template (SAP-1873)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,75 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "research-to-microsite",
+      "name": "Research → Micro-Site Publisher",
+      "description": "Research a topic across the web, then build and deploy a shareable live report site — not just a document.",
+      "tags": ["research", "coding-agent", "sandbox", "publish"],
+      "sourcePath": "examples/research-to-microsite",
+      "capabilities": [
+        "web.search",
+        "web.scrape",
+        "models.run",
+        "models.coding",
+        "sandboxes.deployPreview",
+        "domains.dns.create"
+      ],
+      "whatItDoes": "For when you want research to end in something you can link to, not a doc. It searches the web for your topic and reads the top sources for their full text. An LLM (models.run) turns those into a structured, cited report — a title, a summary, and a few sections that reference where each claim came from. Then a coding agent (models.coding) builds a self-contained static site from that report, and the run deploys it to a public URL (sandboxes.deployPreview). Point a domain you own at it and it adds a free CNAME so the site answers on your subdomain; skip the domain and the preview URL is the deliverable. The coding build can take minutes, so build launches it and the run pauses until it's ready — costing nothing while it works. Pass dryRun to get the report back without building or deploying anything.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Take the topic and run one web search for candidate sources.",
+          "capability": "web.search",
+          "next": ["scrape"]
+        },
+        {
+          "name": "scrape",
+          "description": "Read the top candidates for their full article text, keeping just the snippet when a page won't load.",
+          "capability": "web.scrape",
+          "next": ["synthesize"]
+        },
+        {
+          "name": "synthesize",
+          "description": "Hand the sources to an LLM to write a structured, cited report. A dry run stops here and returns the report.",
+          "capability": "models.run",
+          "next": ["build", "drafted"]
+        },
+        {
+          "name": "build",
+          "description": "Launch a coding agent to build a self-contained static site from the report, then pause until it finishes — costing nothing while it works.",
+          "capability": "models.coding",
+          "next": ["publish"]
+        },
+        {
+          "name": "publish",
+          "description": "Re-attach the coding agent's sandbox and deploy the site to a stable public URL.",
+          "capability": "sandboxes.deployPreview",
+          "next": ["mapDomain", "live", "failed"]
+        },
+        {
+          "name": "mapDomain",
+          "description": "If a domain you own is configured, point a subdomain at the live site with a free CNAME; otherwise this is skipped.",
+          "capability": "domains.dns.create",
+          "next": ["live"]
+        },
+        {
+          "name": "live",
+          "description": "Return the live URL, the custom URL when one was mapped, the report title, and the sources.",
+          "terminal": true
+        },
+        {
+          "name": "failed",
+          "description": "The build or the deploy failed; return the stage and the logs.",
+          "terminal": true
+        },
+        {
+          "name": "drafted",
+          "description": "The dry-run off-ramp: the report was computed but nothing was built or deployed.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/research-to-microsite/.gitignore
+++ b/examples/research-to-microsite/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.log

--- a/examples/research-to-microsite/AGENTS.md
+++ b/examples/research-to-microsite/AGENTS.md
@@ -1,0 +1,63 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Research →
+Micro-Site Publisher** — authored against `@sapiom/agent`. It researches a topic,
+synthesizes a cited report, then builds and deploys a live site from it:
+`search` → `scrape` → `synthesize` → `build` → `publish` → `mapDomain` → `live`,
+with `drafted` (dry-run) and `failed` off-ramps. Inside a step's `run`, Sapiom
+capabilities are pre-auth'd on `ctx.sapiom` (here: `ctx.sapiom.search.webSearch`,
+`ctx.sapiom.search.scrape`, `ctx.sapiom.models.run`,
+`ctx.sapiom.models.coding.launch`, `ctx.sapiom.sandboxes.attach` +
+`box.deployPreview`, `ctx.sapiom.domains.dns.create`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **The coding run is async.** `build` LAUNCHES the coding agent
+  (`models.coding.launch`) and returns `pauseUntilSignal(handle, { resumeStep:
+  "publish" })`; `publish` resumes with a `CodingResultPayload`. The run costs
+  nothing while the agent works. Don't turn it into a blocking `run(...)` — the
+  pause is what keeps a minutes-long build durable and free while idle.
+- **The site must self-serve.** The coding task asks for `index.html` (inline CSS,
+  no CDNs) and a zero-dependency `server.js`, so `deployPreview` needs no build
+  step (`start: node server.js`). Keep that contract if you edit the task.
+- **The custom domain is optional and assumed owned.** `mapDomain` creates a free
+  CNAME on a domain you already own in `ctx.sapiom.domains`. With no `customDomain`
+  set, the step is skipped and the preview URL is the deliverable.
+- **`dryRun` gates every billed step after research.** It returns the report via
+  `drafted` without building, deploying, or touching DNS.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point
+you'd run tests in any project — reach for the local suite. You don't need to run
+it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full
+  local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**. Pass
+  `{ "topic": "...", "dryRun": true }`: it traces `search → scrape → synthesize`
+  and returns the computed report via `drafted` **without** building or deploying
+  — so the graph traces offline, free. The coding build, the sandbox deploy, and
+  their cost are only exercised on the deployed path.
+- **deploy**, then **run** — ship it, then perform a real research → build →
+  deploy and get back a live URL.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/research-to-microsite/README.md
+++ b/examples/research-to-microsite/README.md
@@ -1,0 +1,71 @@
+# Research → Micro-Site Publisher
+
+Research a topic across the web, synthesize a cited report, then build and deploy
+a shareable **live site** for it — not just a document.
+
+## What it does
+
+```
+search  ─▶  scrape  ─▶  synthesize  ─▶  build  ─▶  publish  ─▶  mapDomain  ─▶  live
+(web.search) (web.scrape) (models.run) (models.coding) (deployPreview) (domains.dns)  (terminal)
+```
+
+1. **search** — takes a `topic`, calls `ctx.sapiom.search.webSearch` for candidate
+   sources.
+2. **scrape** — reads the top candidates for full article text
+   (`ctx.sapiom.search.scrape`), degrading per-item on failure. Bodies are
+   truncated and stay bounded — they never enter shared state.
+3. **synthesize** — hands the sources to an LLM (`ctx.sapiom.models.run`, the live
+   x402-served model) to write a structured, cited report (title, tagline,
+   summary, sections). `dryRun` stops here and returns the report via `drafted`.
+4. **build** — launches a coding agent (`ctx.sapiom.models.coding`) that turns the
+   report into a self-contained static site (`index.html` + a zero-dependency
+   `server.js`), then pauses until it finishes — costing nothing while it works.
+5. **publish** — re-attaches the coding agent's sandbox and deploys the site
+   (`box.deployPreview`), exposing it at a stable public URL.
+6. **mapDomain** — if you set a `customDomain` you own in Sapiom, points
+   `<subdomain>.<domain>` at the preview host with a free CNAME
+   (`ctx.sapiom.domains.dns`). Skipped when no domain is set.
+7. **live** — terminal; returns the live URL, the custom URL (if mapped), the
+   report title, and the sources.
+
+Input:
+`{ "topic": "the state of on-device AI", "audience": "developers", "customDomain": "your-domain.dev", "subdomain": "report" }`.
+
+- `topic` and `audience` are the two content knobs — what to research, and who
+  it's for.
+- `customDomain` (optional) maps the site onto a domain you already own; omit it
+  to publish at the preview URL only. `subdomain` defaults to `www`.
+- `dryRun: true` returns the report as a preview without building or deploying.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `{ "topic": "...", "dryRun": true }` to trace
+   search → scrape → synthesize and get the report back, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real research → build → deploy that returns a live URL).
+
+4. To map a custom domain, first register/own it in Sapiom
+   (`ctx.sapiom.domains`), then pass `customDomain` (and optionally `subdomain`)
+   on the run.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+- `template.json` — gallery detail (manifest v1).
+- `AGENTS.md` — the authoring loop.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/research-to-microsite/index.ts
+++ b/examples/research-to-microsite/index.ts
@@ -1,0 +1,551 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+/**
+ * Research → Micro-Site Publisher — deep multi-source research that ends in a
+ * shareable LIVE site, not a document.
+ *
+ * It searches the web for a topic, reads the top sources for full text, has an
+ * LLM synthesize them into a structured, cited report, then hands that report to
+ * a coding agent that builds a self-contained static site. The site is deployed
+ * to a public preview URL, and — if you point a Sapiom-owned domain at it — mapped
+ * onto a custom subdomain. The output is a URL you can send someone.
+ *
+ * The graph, one legible line per capability:
+ *   search (web.search) ─▶ scrape (web.scrape) ─▶ synthesize (models.run)
+ *     ─▶ build (models.coding) ─▶ publish (sandboxes.deployPreview)
+ *     ─▶ mapDomain (domains.dns) ─▶ live
+ *
+ * Async pause/resume: `build` LAUNCHES the coding agent and suspends on its result
+ * signal (a coding run takes minutes), so the run costs nothing while the agent
+ * works and resumes at `publish` when it finishes — the same durable machinery
+ * `scene-to-video` uses for video jobs.
+ *
+ * Side-effect discipline:
+ *   - `dryRun` gates every irreversible/billed step after research: it computes
+ *     the report and returns it via the `drafted` off-ramp WITHOUT building,
+ *     deploying, or touching DNS. `run_local` uses this to trace
+ *     search → scrape → synthesize offline (capabilities stubbed) for free before
+ *     a billed deploy. The coding-agent build, the sandbox deploy, and their cost
+ *     are only exercised on the deployed path.
+ *   - The custom domain is optional. With none set, the preview URL IS the
+ *     deliverable; `mapDomain` is skipped. Mapping assumes you already OWN the
+ *     domain in Sapiom (`ctx.sapiom.domains`); DNS record creation is free.
+ *   - Scraped bodies are bounded and die at the `synthesize` boundary — only slim
+ *     report metadata (title, sources) rides shared state to the terminal.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** How many search hits to consider as scrape candidates. */
+const MAX_CANDIDATES = 6;
+/** How many candidates to actually scrape (keeps latency + cost bounded). */
+const MAX_SCRAPES = 5;
+/** Truncate each scraped body — the ONLY large data on the search→synthesize path. */
+const MAX_BODY_CHARS = 1500;
+/** Cap sections the report (and thus the built site) carries. */
+const MAX_SECTIONS = 6;
+/** Truncate each section body handed to the coding agent, to bound the task size. */
+const MAX_SECTION_CHARS = 1200;
+/** Default host on the custom domain when the caller doesn't pass one. */
+const DEFAULT_SUBDOMAIN = "www";
+/** Build/start config for the static site the coding agent produces. */
+const SITE_PORT = 3000;
+const SITE_START = "node server.js";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** What to research and publish a site about. */
+  topic: string;
+  /** Who the site is for — tunes the report's tone (e.g. "investors", "developers"). */
+  audience?: string;
+  /**
+   * A domain you already OWN in Sapiom (`ctx.sapiom.domains`) to map the site
+   * onto. Omit to publish at the preview URL only.
+   */
+  customDomain?: string;
+  /** Host on the custom domain (default "www"), e.g. "report" → report.your.dev. */
+  subdomain?: string;
+  /**
+   * Compute the report and return it as a preview, skipping the build, deploy,
+   * and DNS. `run_local` passes this to trace the graph offline for free.
+   */
+  dryRun?: boolean;
+}
+
+/** Slim search hit carried across the search → scrape boundary. */
+interface Candidate {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/** A candidate plus its (bounded) scraped body — the scrape → synthesize payload. */
+interface ScrapedSource extends Candidate {
+  /** Extracted article text (markdown, truncated); absent when scraping failed. */
+  content?: string;
+}
+
+/** The slim source reference that lands in the report and the output. */
+interface Source {
+  title: string;
+  url: string;
+}
+
+/** One thematic block of the report, rendered as its own section on the site. */
+interface ReportSection {
+  heading: string;
+  /** Markdown body; cites sources as [n] references. */
+  body: string;
+}
+
+/** The structured report the coding agent turns into a site. */
+interface Report {
+  title: string;
+  tagline: string;
+  summary: string;
+  sections: ReportSection[];
+  sources: Source[];
+}
+
+interface Shared extends Record<string, unknown> {
+  topic: string;
+  audience: string;
+  customDomain: string | null;
+  subdomain: string;
+  dryRun: boolean;
+  /** Slim report metadata for the terminal to report (bodies stay off shared state). */
+  reportTitle: string;
+  reportTagline: string;
+  sources: Source[];
+  /** The sandbox the coding agent built in, captured on resume for the terminal. */
+  sandboxName: string | null;
+  /** The live preview URL, once deployed. */
+  liveUrl: string | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/**
+ * Parse the model's JSON report defensively. The model is asked for raw JSON, but
+ * models wrap output in fences or prose often enough that a strict parse would
+ * fail a real run — so strip fences, extract the outermost object, and fall back
+ * to a minimal report built from the sources rather than throwing.
+ */
+function parseReport(raw: string, topic: string, sources: Source[]): Report {
+  const fallback: Report = {
+    title: topic || "Research report",
+    tagline: "",
+    summary: "",
+    sections: [],
+    sources,
+  };
+  const text = (raw ?? "").trim();
+  if (!text) return fallback;
+  // Strip a leading ```json / ``` fence and trailing ``` if present.
+  const unfenced = text
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+  const start = unfenced.indexOf("{");
+  const end = unfenced.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return fallback;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(unfenced.slice(start, end + 1));
+  } catch {
+    return fallback;
+  }
+  if (typeof parsed !== "object" || parsed === null) return fallback;
+  const obj = parsed as Record<string, unknown>;
+  const sections = Array.isArray(obj.sections)
+    ? obj.sections
+        .filter(
+          (s): s is Record<string, unknown> =>
+            typeof s === "object" && s !== null,
+        )
+        .slice(0, MAX_SECTIONS)
+        .map((s) => ({
+          heading: typeof s.heading === "string" ? s.heading : "",
+          body:
+            typeof s.body === "string"
+              ? s.body.slice(0, MAX_SECTION_CHARS)
+              : "",
+        }))
+        .filter((s) => s.heading || s.body)
+    : [];
+  return {
+    title:
+      typeof obj.title === "string" && obj.title ? obj.title : fallback.title,
+    tagline: typeof obj.tagline === "string" ? obj.tagline : "",
+    summary: typeof obj.summary === "string" ? obj.summary : "",
+    sections,
+    // Sources are authoritative from the scrape set — never trust the model to
+    // echo URLs back correctly.
+    sources,
+  };
+}
+
+/**
+ * The coding-agent instruction: build a self-contained static site from the
+ * report. It asks for exactly two files at the workspace root — `index.html`
+ * (inline CSS, no external assets) and a zero-dependency `server.js` — so the
+ * deploy needs no build step and `node server.js` serves the site as-is.
+ */
+function buildSiteTask(report: Report): string {
+  return [
+    "Build a single-page static website that presents the research report below as a polished, shareable micro-site.",
+    "",
+    "Create exactly these two files at the workspace root:",
+    "- `index.html`: a self-contained page (all CSS inline in a <style> tag, NO external stylesheets, fonts, scripts, or CDNs). Render a hero with the report title and tagline, then the summary, then each section as its own block, then a 'Sources' list whose entries are clickable links. Make it clean, readable, and responsive; use a system-font stack and generous spacing.",
+    "- `server.js`: a zero-dependency Node HTTP server (only the built-in `http`/`fs`/`path` modules) that serves files from its own directory, defaults to `index.html`, sets a sensible Content-Type, and listens on `process.env.PORT || 3000` bound to host `0.0.0.0`.",
+    "",
+    "Do NOT create a package.json, add dependencies, or introduce a build step — `node server.js` must start the finished site directly.",
+    "",
+    "REPORT (JSON — title, tagline, summary, sections[{heading, body}], sources[{title, url}]):",
+    "```json",
+    JSON.stringify(report),
+    "```",
+  ].join("\n");
+}
+
+/** Extract the hostname from a URL for a CNAME target; null when unparseable. */
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const search = defineStep({
+  name: "search",
+  next: ["scrape"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const topic = input.topic?.trim() ?? "";
+    ctx.shared.set("topic", topic);
+    ctx.shared.set("audience", input.audience?.trim() || "a general audience");
+    ctx.shared.set("customDomain", input.customDomain?.trim() || null);
+    ctx.shared.set("subdomain", input.subdomain?.trim() || DEFAULT_SUBDOMAIN);
+    ctx.shared.set("dryRun", input.dryRun === true);
+    ctx.shared.set("sandboxName", null);
+    ctx.shared.set("liveUrl", null);
+
+    if (!topic) {
+      // Nothing to research — forward an empty candidate list so the graph still
+      // traces end to end (and `synthesize` yields an empty report).
+      return goto("scrape", { candidates: [] as Candidate[] });
+    }
+
+    ctx.logger.info("searching the web", { topic });
+    const hits = await ctx.sapiom.search.webSearch({
+      query: topic,
+      intent: "links",
+    });
+    const candidates: Candidate[] = (hits?.results ?? [])
+      .slice(0, MAX_CANDIDATES)
+      .map((r) => ({ title: r.title, url: r.url, snippet: r.snippet }));
+    ctx.logger.info("search returned candidates", { count: candidates.length });
+    return goto("scrape", { candidates });
+  },
+});
+
+const scrape = defineStep({
+  name: "scrape",
+  next: ["synthesize"],
+  async run(input: { candidates: Candidate[] }, ctx: Ctx) {
+    const candidates = input.candidates ?? [];
+    const sources: ScrapedSource[] = [];
+    let scraped = 0;
+    for (const c of candidates) {
+      // Beyond the scrape budget we still forward the candidate — the snippet
+      // alone is useful synthesis context.
+      if (scraped >= MAX_SCRAPES) {
+        sources.push(c);
+        continue;
+      }
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: c.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        scraped += 1;
+        sources.push({
+          title: page.metadata?.title || c.title,
+          url: c.url,
+          snippet: c.snippet,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Scrapes fail routinely (paywalls, timeouts); degrade per-item, never
+        // throw — a report from the survivors beats an aborted run.
+        ctx.logger.warn("scrape failed; keeping snippet only", {
+          url: c.url,
+          err: String(err),
+        });
+        sources.push(c);
+      }
+    }
+    ctx.logger.info("scraped candidates", { scraped, total: sources.length });
+    return goto("synthesize", { sources });
+  },
+});
+
+const synthesize = defineStep({
+  name: "synthesize",
+  next: ["build", "drafted"],
+  async run(input: { sources: ScrapedSource[] }, ctx: Ctx) {
+    const topic = ctx.shared.get("topic") || "your topic";
+    const audience = ctx.shared.get("audience") || "a general audience";
+    const scraped = input.sources ?? [];
+    // Slim references only — the scraped bodies stop here and never reach shared
+    // state or the coding agent's task beyond the synthesis prompt.
+    const sources: Source[] = scraped.map((s) => ({
+      title: s.title,
+      url: s.url,
+    }));
+
+    let report: Report;
+    if (scraped.length === 0) {
+      report = {
+        title: `${topic}`,
+        tagline: "",
+        summary: `No sources were found for "${topic}".`,
+        sections: [],
+        sources,
+      };
+    } else {
+      const research = scraped
+        .map(
+          (s, i) =>
+            `[${i + 1}] ${s.title} (${s.url})\n${(s.content || s.snippet).slice(0, MAX_BODY_CHARS)}`,
+        )
+        .join("\n\n");
+      // The live, x402-served model turns the raw sources into a structured,
+      // cited report — the content the site renders.
+      const res = await ctx.sapiom.models.run({
+        system:
+          "You are a research analyst producing a structured report for a web " +
+          "micro-site. Given a TOPIC, an AUDIENCE, and numbered web SOURCES " +
+          "(each: [n] title, url, extracted text), write a report and output " +
+          "ONLY a JSON object (no prose, no code fences) with this shape: " +
+          '{ "title": string, "tagline": string (one line), "summary": string ' +
+          '(2-4 sentences), "sections": [{ "heading": string, "body": string }] }. ' +
+          `Use 3 to ${MAX_SECTIONS} sections. Each section body is markdown and ` +
+          "cites the sources it draws on as [n] references. Rank by relevance and " +
+          "credibility; drop thin or duplicate material. Tune the tone for the AUDIENCE.",
+        prompt: `TOPIC: ${topic}\nAUDIENCE: ${audience}\n\nSOURCES:\n${research}`,
+        maxTokens: 1500,
+      });
+      report = parseReport(res?.output ?? "", topic, sources);
+    }
+
+    // Slim report metadata rides shared state to the terminal; the full section
+    // bodies travel to the coding agent via the goto payload only.
+    ctx.shared.set("reportTitle", report.title);
+    ctx.shared.set("reportTagline", report.tagline);
+    ctx.shared.set("sources", report.sources);
+    ctx.logger.info("synthesized report", {
+      title: report.title,
+      sections: report.sections.length,
+      sources: report.sources.length,
+    });
+
+    // Dry run (and `run_local`): return the report as a preview without building
+    // or deploying anything.
+    if (ctx.shared.get("dryRun") === true) {
+      return goto("drafted", { report });
+    }
+    return goto("build", { report });
+  },
+});
+
+const build = defineStep({
+  name: "build",
+  next: [],
+  // Async pause/resume: the launched coding run fires CODING_RESULT_SIGNAL when it
+  // reaches a terminal state, resuming `publish` with the run's result. The run
+  // costs nothing while the agent works.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "publish" },
+  async run(input: { report: Report }, ctx: Ctx) {
+    const report = input.report;
+    ctx.logger.info("launching coding agent to build the site", {
+      title: report.title,
+      sections: report.sections.length,
+    });
+    // Launch without a repo or sandbox: the run provisions a fresh sandbox and
+    // writes the site into it. `publish` re-attaches that sandbox on resume.
+    const handle = await ctx.sapiom.models.coding.launch({
+      task: buildSiteTask(report),
+    });
+    return await pauseUntilSignal(handle, { resumeStep: "publish" });
+  },
+});
+
+const publish = defineStep({
+  name: "publish",
+  next: ["mapDomain", "live", "failed"],
+  async run(result: CodingResultPayload, ctx: Ctx) {
+    // The coding run must have finished cleanly and left a sandbox to deploy from.
+    if (result.status !== "completed" || !result.executionEnvironment) {
+      ctx.logger.warn("coding run did not complete", {
+        status: result.status,
+        error: result.error?.message ?? null,
+      });
+      return goto("failed", {
+        stage: "build",
+        logs:
+          result.error?.message ??
+          `coding run ended in status "${result.status}"`,
+      });
+    }
+
+    const sandboxName = result.executionEnvironment.id;
+    ctx.shared.set("sandboxName", sandboxName);
+    ctx.logger.info("deploying the built site", { sandbox: sandboxName });
+
+    let deploy: { url: string | null; status: string; logs: string };
+    try {
+      const box = ctx.sapiom.sandboxes.attach(sandboxName);
+      deploy = await box.deployPreview({
+        // source defaults to { kind: "fs" } — the files the coding agent wrote.
+        start: SITE_START,
+        port: SITE_PORT,
+      });
+    } catch (err) {
+      ctx.logger.error("deployPreview threw", {
+        sandbox: sandboxName,
+        err: String(err),
+      });
+      return goto("failed", { stage: "deploy", logs: String(err) });
+    }
+
+    if (deploy.status === "failed" || !deploy.url) {
+      return goto("failed", { stage: "deploy", logs: deploy.logs });
+    }
+    ctx.shared.set("liveUrl", deploy.url);
+    ctx.logger.info("site is live", { url: deploy.url, status: deploy.status });
+
+    // Map a custom domain onto it when one is configured; otherwise the preview
+    // URL is the deliverable.
+    const customDomain = ctx.shared.get("customDomain");
+    if (customDomain) {
+      return goto("mapDomain", { liveUrl: deploy.url });
+    }
+    return goto("live", { liveUrl: deploy.url, customUrl: null });
+  },
+});
+
+const mapDomain = defineStep({
+  name: "mapDomain",
+  next: ["live"],
+  async run(input: { liveUrl: string }, ctx: Ctx) {
+    const domainName = ctx.shared.get("customDomain");
+    const subdomain = ctx.shared.get("subdomain") || DEFAULT_SUBDOMAIN;
+    const liveUrl = input.liveUrl;
+    const target = hostOf(liveUrl);
+
+    // No owned domain, or an unparseable preview host: nothing to map. Fall
+    // through to live with just the preview URL.
+    if (!domainName || !target) {
+      return goto("live", { liveUrl, customUrl: null });
+    }
+
+    // Point <subdomain>.<domain> at the preview host with a CNAME. DNS record
+    // creation is free; assumes you already own the domain in Sapiom. On any
+    // error the preview URL still works, so we log and continue rather than fail.
+    const customUrl = `https://${subdomain}.${domainName}`;
+    try {
+      await ctx.sapiom.domains.dns.create({
+        domainName,
+        type: "CNAME",
+        host: subdomain,
+        value: target,
+      });
+      ctx.logger.info("mapped custom domain", { customUrl, target });
+      return goto("live", { liveUrl, customUrl });
+    } catch (err) {
+      ctx.logger.warn("could not create DNS record; serving preview URL only", {
+        domainName,
+        subdomain,
+        err: String(err),
+      });
+      return goto("live", { liveUrl, customUrl: null });
+    }
+  },
+});
+
+const live = defineStep({
+  name: "live",
+  next: [],
+  terminal: true,
+  async run(input: { liveUrl: string; customUrl: string | null }, ctx: Ctx) {
+    const topic = ctx.shared.get("topic") || "";
+    return terminate({
+      published: true,
+      topic,
+      title: ctx.shared.get("reportTitle") ?? topic,
+      tagline: ctx.shared.get("reportTagline") ?? "",
+      liveUrl: input.liveUrl,
+      customUrl: input.customUrl ?? null,
+      sandboxName: ctx.shared.get("sandboxName") ?? null,
+      sources: ctx.shared.get("sources") ?? [],
+    });
+  },
+});
+
+const failed = defineStep({
+  name: "failed",
+  next: [],
+  terminal: true,
+  async run(input: { stage: string; logs: string | null }, ctx: Ctx) {
+    return terminate({
+      published: false,
+      stage: input?.stage ?? null,
+      logs: input?.logs ?? null,
+      sandboxName: ctx.shared.get("sandboxName") ?? null,
+      title: ctx.shared.get("reportTitle") ?? null,
+    });
+  },
+});
+
+const drafted = defineStep({
+  name: "drafted",
+  next: [],
+  terminal: true,
+  async run(input: { report: Report }, ctx: Ctx) {
+    // The dry-run / run_local off-ramp: the report was computed but nothing was
+    // built, deployed, or mapped.
+    return terminate({
+      published: false,
+      dryRun: true,
+      topic: ctx.shared.get("topic") || "",
+      report: input.report,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "research-to-microsite",
+  entry: "search",
+  steps: {
+    search,
+    scrape,
+    synthesize,
+    build,
+    publish,
+    mapDomain,
+    live,
+    failed,
+    drafted,
+  },
+});

--- a/examples/research-to-microsite/package.json
+++ b/examples/research-to-microsite/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-research-to-microsite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: research a topic across the web, synthesize a cited report with an LLM, then have a coding agent build and deploy a shareable live micro-site — with an optional custom domain.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/research-to-microsite/template.json
+++ b/examples/research-to-microsite/template.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a topic. It searches the web, reads the top sources for full text, and has an LLM write a structured, cited report — a title, a summary, and a handful of sections that reference where each claim came from. Then it does the part a research tool usually leaves to you: it hands the report to a coding agent that builds a self-contained static site, deploys it, and gives you back a URL you can send someone.\n\nThe build is a real coding-agent run, so it can take minutes. The `build` step launches it and pauses on its result — the run costs nothing while the agent works and wakes up at `publish` when the site is ready. `publish` re-attaches the sandbox the agent built in and deploys it to a stable preview URL. If you point a domain you own at it, `mapDomain` adds a free CNAME so the site answers at `report.your-domain.dev` instead; skip the domain and the preview URL is the deliverable.\n\nSet `dryRun: true` and it stops after writing the report and returns it — no build, no deploy, no DNS. That's the free path `run_local` traces end to end before you spend anything.\n\nYou pay for the web search, the scrapes, the model that writes the report, and the coding agent that builds the site — the pause while the build runs, and the DNS record, are free. A dry run costs only the search, scrape, and report.",
+  "useCases": [
+    "Turn a research question into a live, linkable report site — for a market, a competitor, or a technology — instead of a doc.",
+    "Publish a sourced explainer your team or customers can open in a browser, complete with clickable citations.",
+    "Stand up a one-page micro-site on a topic and, optionally, map it onto a subdomain you own."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `topic` (what to research) and, optionally, an `audience` to tune the tone. To publish under your own domain, register/own the domain in Sapiom first, then pass `customDomain` (a domain you own) and an optional `subdomain` (defaults to `www`) — it adds a free CNAME to the live site. Leave the domain off and you still get a shareable preview URL. Pass `dryRun: true` to get the report back without building or deploying anything.\n\nPrefer to work from the code? Run it locally with `run_local` and `{ \"topic\": \"...\", \"dryRun\": true }` to trace search → scrape → synthesize and read the report for free (capabilities stubbed, nothing built), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Preview the report before publishing",
+      "input": {
+        "topic": "the state of on-device AI in 2026",
+        "audience": "developers",
+        "dryRun": true
+      },
+      "output": {
+        "published": false,
+        "dryRun": true,
+        "topic": "the state of on-device AI in 2026",
+        "report": {
+          "title": "On-Device AI in 2026",
+          "tagline": "Smaller models, bigger reach — inference moves to the edge.",
+          "summary": "On-device inference has crossed from demo to default for a growing class of apps...",
+          "sections": [
+            {
+              "heading": "What changed",
+              "body": "Quantized small models now run acceptably on consumer hardware [1], and toolchains ship first-class on-device runtimes [2]."
+            }
+          ],
+          "sources": [
+            {
+              "title": "Small models on the edge",
+              "url": "https://example.com/edge"
+            },
+            {
+              "title": "On-device runtimes",
+              "url": "https://example.com/runtimes"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "title": "Publish a live site under a custom domain",
+      "input": {
+        "topic": "the state of on-device AI in 2026",
+        "audience": "developers",
+        "customDomain": "your-domain.dev",
+        "subdomain": "report"
+      },
+      "output": {
+        "published": true,
+        "topic": "the state of on-device AI in 2026",
+        "title": "On-Device AI in 2026",
+        "tagline": "Smaller models, bigger reach — inference moves to the edge.",
+        "liveUrl": "https://research-to-microsite-abc123.preview.sapiom.ai",
+        "customUrl": "https://report.your-domain.dev",
+        "sandboxName": "research-to-microsite-abc123",
+        "sources": [
+          {
+            "title": "Small models on the edge",
+            "url": "https://example.com/edge"
+          },
+          {
+            "title": "On-device runtimes",
+            "url": "https://example.com/runtimes"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/research-to-microsite/tsconfig.json
+++ b/examples/research-to-microsite/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds a new onboarding gallery template — **Research → Micro-Site Publisher** — under `examples/research-to-microsite/`, plus its `examples/registry.json` entry. Closes SAP-1873 (part of epic SAP-1823, grow the gallery to 8+).

It runs deep multi-source research and ends in a **shareable live site, not a document**:

```
search (web.search) ─▶ scrape (web.scrape) ─▶ synthesize (models.run)
  ─▶ build (models.coding) ─▶ publish (sandboxes.deployPreview)
  ─▶ mapDomain (domains.dns) ─▶ live
```

1. **search / scrape** — web search + full-text scrape of the top sources (bounded, per-item degradation).
2. **synthesize** — an LLM writes a structured, cited report (`models.run`).
3. **build** — a coding agent turns the report into a self-contained static site (`index.html` + a zero-dep `server.js`); the step **launches and pauses** on the coding-run signal, so a minutes-long build costs nothing while idle (same durable pattern as `scene-to-video`).
4. **publish** — re-attaches the coding agent's sandbox and deploys it (`sandboxes.deployPreview`) to a public URL.
5. **mapDomain** — optional: points `<subdomain>.<domain>` at the site with a free CNAME on a domain you already own (`domains.dns`). Skipped when no domain is set.

This is the first gallery entry that composes the coding agent, sandbox deploy, and domains/DNS capabilities end to end — exactly the capability set the ticket calls for (search, scrape, LLM, coding agent, sandbox + preview, domains/DNS).

## Capability ids
`web.search`, `web.scrape`, `models.run`, `models.coding`, `sandboxes.deployPreview`, `domains.dns.create` — matching the `ctx.sapiom.*` calls in `index.ts`, per `examples/AUTHORING.md`. Est-cost card populates via `web.search` (the per-call-priced capability the estimator resolves).

## Safe / offline path
`dryRun` gates every billed step after research: it returns the report via the `drafted` off-ramp without building, deploying, or touching DNS — so `run_local` traces `search → scrape → synthesize` offline for free. The coding build, sandbox deploy, and their cost are exercised only on the deployed path (per the ticket's local-testing notes).

## Files
- `examples/research-to-microsite/{index.ts,template.json,package.json,tsconfig.json,AGENTS.md,README.md,.gitignore}`
- `examples/registry.json` (one new entry)

SDK pins `@sapiom/agent ^0.6.5` / `@sapiom/tools ^0.20.0` (both `models.coding` and `domains` present since 0.20.x), matching the most recent flagship siblings. No `package-lock.json` committed (consistent with siblings).

## Validation
- `npm run typecheck` — passes (confirms every `ctx.sapiom.*` call exists in the pinned SDK).
- `prettier --check` on TS + JSON — passes.
- Offline graph validation (`buildManifest` + `validateGraph`) — **0 errors, 0 warnings**; the `build → publish` pause/resume edge and all terminals validate.
- `run_local`/`deploy`/`run` against a live local stack require `pnpm studio up --full` (out of scope for this headless session); the deployed billed run is the manual verification step the ticket assigns.

Linear: SAP-1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)