### PR TITLE
feat(examples): add proposal / quote generator workflow template

### DIFF
--- a/examples/proposal-generator/.gitignore
+++ b/examples/proposal-generator/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/proposal-generator/AGENTS.md
+++ b/examples/proposal-generator/AGENTS.md
@@ -1,0 +1,90 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Proposal / Quote
+Generator** — authored against `@sapiom/agent`. From a free-text requirement it
+drafts a proposal with an LLM, renders it to a PDF in a sandbox, persists the file,
+pauses for a human to sign off, and only then emails the proposal to the client.
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom`
+(`ctx.sapiom.models.run`, `ctx.sapiom.sandboxes`, `ctx.sapiom.fileStorage`,
+`ctx.sapiom.email`).
+
+## The spine
+
+- **`draft`** calls `ctx.sapiom.models.run` for a structured proposal, then totals
+  the line items **in code** — the money is never trusted from the model.
+- **`render`** creates a sandbox, `writeFile`s `proposal.json` + a `pdf-lib` layout
+  script (`RENDER_SCRIPT`), `exec`s the render, reads the PDF back as base64, and
+  PUTs the bytes to the presigned URL from `ctx.sapiom.fileStorage.upload`. The
+  sandbox is destroyed in a `finally`. Under `run_local` the sandbox exec is
+  stubbed (empty output) — the step detects the empty render and skips the real
+  byte PUT while still walking the upload shape, so the offline trace stays whole.
+- **`review`** emails the approver, then returns
+  `pauseUntilSignal({ signal: "proposal.decision", resumeStep: "onDecision", correlationId: ctx.executionId })`.
+  It carries a static `pause: { signal, resumeStep: "onDecision" }` annotation —
+  the build-time graph edge that must match the directive.
+- **`onDecision`** reads the approval payload **directly as its `run` input**. Safe
+  default: only `{ decision: "approve" }` proceeds to `send`; anything else
+  (including a `run_local` resume with no payload) routes to `rejected` — nothing
+  reaches the client without a deliberate yes.
+- **`send`** holds the one outward action (the client email), reached only after
+  approval. A `dryRun` guard makes it a no-op.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability** — don't
+  list it in `capabilities`. The billed calls are `ctx.sapiom.models.run` (the
+  live x402 path — note `ctx.sapiom.llm` does **not** exist), the sandbox render,
+  the file upload, and `ctx.sapiom.email`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` (its forward edge is the pause
+  `resumeStep`) and a `pause: { signal, resumeStep }` annotation.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined
+  by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A
+  wrong capability or method name fails typecheck.
+- The PDF layout is intentionally dependency-light (`pdf-lib`, standard Helvetica,
+  no browser). It lives in `RENDER_SCRIPT`; edit that string to change the document.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including the
+  static `pause` annotation.
+- **run_local** — runs your **real** step code against **stub capabilities** and
+  auto-resumes the pause. With no payload injected, the approval resume takes the
+  safe reject branch, so you get a full offline trace for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses.
+
+### Firing the resume signal in dev
+
+A real `run` pauses once, at `review`. To resume without a real approver, fire the
+signal via the MCP `signal_workflow` / `workflow_signal` tool — the manual
+stand-in:
+
+```json
+{ "signal": "proposal.decision", "correlationId": "<executionId>", "payload": { "decision": "approve" } }
+```
+
+Send `{ "decision": "reject" }` to walk the reject path. The `payload` arrives as
+`onDecision`'s input.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values once and pass them forward via the
+`goto(...)` input or `ctx.shared` rather than recomputing them. The quote number
+is derived from `ctx.executionId` (stable across retries and the pause), and
+`correlationId` is `ctx.executionId`, so a resume signal always lands on the right
+run.

--- a/examples/proposal-generator/README.md
+++ b/examples/proposal-generator/README.md
@@ -1,0 +1,103 @@
+# Proposal / Quote Generator
+
+Turn a free-text requirement into a client-ready PDF quote — drafted by an LLM,
+rendered in a sandbox, **paused for human sign-off**, then emailed to the client.
+Nothing reaches the client until a person approves it.
+
+## What it does
+
+```
+draft ─▶ render ─▶ review ─(pause: proposal.decision, $0 while idle)─▶ onDecision
+(models.run) (sandbox +                                                 │
+             fileStorage)                              approve ◀─────────┼─▶ reject
+                                                         ▼               ▼
+                                                       send          rejected
+                                                    (terminal)       (terminal)
+```
+
+1. **draft** — an LLM (`ctx.sapiom.models.run`) turns the `request` into a
+   structured proposal: title, summary, scope, and priced line items. Then
+   deterministic code totals the line items (the money is never trusted from the
+   model). Reversible.
+2. **render** — create a sandbox (`ctx.sapiom.sandboxes.create`), lay the proposal
+   out as a PDF with a small self-contained Node script (`pdf-lib`, pure JS), and
+   persist the bytes to file storage (`ctx.sapiom.fileStorage.upload`). The
+   sandbox is torn down before the step returns. Stores the `fileId` + a download
+   link.
+3. **review** — email the approver a summary and the PDF link
+   (`ctx.sapiom.email`), then `pauseUntilSignal({ signal: "proposal.decision", resumeStep: "onDecision" })`.
+   The run suspends here at $0.
+4. **onDecision** (resume target) — its **input is the approval payload**. Only an
+   explicit `{ "decision": "approve" }` proceeds to `send`; anything else takes
+   the safe `rejected` branch — nothing goes to the client.
+5. **send** — the one outward action: email the finished proposal to the client.
+   A `dryRun` guard makes it a no-op so a deployed run can be traced safely.
+6. **rejected** — terminal: nothing was sent; the draft PDF is still in file
+   storage for a human to pick up.
+
+Input:
+
+```json
+{
+  "request": "We need a marketing website: 5 pages, a blog, a contact form, and basic SEO. Launch in 6 weeks.",
+  "client": {
+    "name": "Dana Lee",
+    "company": "Northwind Coffee",
+    "email": "dana@northwind.example.com"
+  },
+  "from": { "company": "Acme Studio" },
+  "currency": "USD",
+  "taxRate": 0.08,
+  "approver": "owner@acme.example.com"
+}
+```
+
+The `approver` and client `email` fall back to `config.APPROVER_EMAIL` /
+`config.CLIENT_EMAIL` when omitted. Pass `dryRun: true` to run everything but skip
+the client email.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to call the model, run the sandbox, store the file, and send
+   the emails.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (capabilities stubbed, pause auto-resumed, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses).
+
+## Resuming a paused run in dev
+
+A real `run` pauses once, at `review`. Instead of a real approver, fire the signal
+yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`, and the `payload` becomes the
+resumed step's input.
+
+**Approve** (resumes `onDecision` → `send`, emailing the client):
+
+```json
+{
+  "signal": "proposal.decision",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve" }
+}
+```
+
+Send `{ "decision": "reject" }` instead to see the `rejected` path — nothing goes
+to the client and the draft PDF stays on file.
+
+## Files
+
+- `index.ts` — the agent (edit this). The PDF layout lives in `RENDER_SCRIPT` at
+  the bottom; change it to make the document your own.
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -1,0 +1,774 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Proposal / Quote Generator — requirements in, a signed-off PDF quote out.
+ *
+ * The "draft → render → get sign-off → send" shape a salesperson or agency runs
+ * by hand for every inbound request, done as one durable workflow:
+ *
+ *   draft ─▶ render ─▶ review ─(pause: proposal.decision, $0 while idle)─▶ onDecision
+ *  (models.run) (sandbox+                                                    │
+ *               fileStorage)                                approve ◀─────────┼─▶ reject
+ *                                                             ▼               ▼
+ *                                                           send          rejected
+ *                                                        (terminal)       (terminal)
+ *
+ *   1. draft — an LLM (`ctx.sapiom.models.run`) turns the free-text requirement
+ *      into a structured proposal: a title, a summary, a scope list, priced line
+ *      items, and terms. Deterministic code then totals the line items.
+ *   2. render — spin up a sandbox (`ctx.sapiom.sandboxes.create`), lay the
+ *      proposal out as a PDF with a tiny self-contained Node script, and persist
+ *      the bytes to file storage (`ctx.sapiom.fileStorage.upload`). The sandbox
+ *      is torn down before the step returns.
+ *   3. review — email the internal approver a summary and the PDF link
+ *      (`ctx.sapiom.email`), then **block on a human approval signal**. The run
+ *      suspends at $0 until someone decides.
+ *   4. onDecision — its input IS the approval payload. Only an explicit
+ *      `{ decision: "approve" }` proceeds; anything else takes the safe reject
+ *      branch — nothing goes out to the client without a deliberate yes.
+ *   5. send — the one outward action: email the finished proposal to the client.
+ *      A `dryRun` guard makes it a no-op so a deployed run can be traced safely.
+ *
+ * Offline: `run_local` stubs the capabilities and auto-resumes the pause. A
+ * resume with no payload takes the safe reject branch, so the whole graph traces
+ * end to end for free. The sandbox exec returns empty output under stubs, so
+ * `render` skips the real byte upload but still walks its full shape. Fire a real
+ * `proposal.decision` signal (in dev, via the MCP `workflow_signal` tool — see
+ * README) to drive the approve → send path.
+ *
+ * `pauseUntilSignal` is a runtime primitive, not a metered capability. The billed
+ * calls are the model reasoning (`ctx.sapiom.models.run` — the live x402 path;
+ * `ctx.sapiom.llm` does NOT exist), the sandbox render, the file upload, and the
+ * emails.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** The signal a human fires to approve or reject the drafted proposal. */
+const DECISION_SIGNAL = "proposal.decision";
+
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "proposals";
+
+/** Package the sandbox installs to lay out the PDF (pure JS, no native deps). */
+const PDF_PACKAGE = "pdf-lib@1.17.1";
+
+/** Bounds so a runaway model output can't produce an unusable quote. */
+const MAX_LINE_ITEMS = 25;
+const MAX_SCOPE_ITEMS = 12;
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** Who the quote is for / from — shown on the PDF and used for delivery. */
+interface Party {
+  name?: string;
+  company?: string;
+  email?: string;
+}
+
+interface EntryInput {
+  /** The free-text requirement / RFP / brief to quote against. */
+  request: string;
+  /** The client the proposal is for. `email` is where the final PDF is sent. */
+  client?: Party;
+  /** Who the proposal is from (your company). Shown on the PDF. */
+  from?: Party;
+  /** ISO 4217 currency code for the quote (default "USD"). */
+  currency?: string;
+  /** Tax rate as a fraction, e.g. 0.08 for 8% (default 0 — no tax line). */
+  taxRate?: number;
+  /** Who signs off before the client sees it. Falls back to `config.APPROVER_EMAIL`. */
+  approver?: string;
+  /** Where to send the approved proposal. Falls back to `client.email` / `config.CLIENT_EMAIL`. */
+  recipientEmail?: string;
+  /** Draft + render + get sign-off, but never send the client email. `run_local` behaviour. */
+  dryRun?: boolean;
+  /** String-only config bag (approver / client fallbacks). */
+  config?: Config;
+}
+
+/** One priced line on the quote, as the model returns it. */
+interface ProposalLine {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+/** The structured proposal the model drafts from the request. */
+interface ProposalDraft {
+  title: string;
+  summary: string;
+  scope: string[];
+  lineItems: ProposalLine[];
+  terms: string;
+}
+
+/** Computed money totals (never trusted from the model). */
+interface Totals {
+  subtotal: number;
+  tax: number;
+  total: number;
+}
+
+/** The payload the human delivers on the `proposal.decision` signal. */
+interface ApprovalDecision {
+  /** `approve` sends to the client; anything else (or absent) rejects safely. */
+  decision?: "approve" | "reject";
+  /** Optional free-text note carried through to the outcome. */
+  notes?: string;
+}
+
+/** State that survives the pause, read back after the resume. */
+interface Shared extends Record<string, unknown> {
+  request: string;
+  currency: string;
+  taxRate: number;
+  client: Party;
+  from: Party;
+  approver: string | null;
+  recipientEmail: string | null;
+  dryRun: boolean;
+  draft: ProposalDraft;
+  totals: Totals;
+  quoteNumber: string;
+  fileId: string | null;
+  downloadUrl: string | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** A stable, human-readable quote id derived from the run (survives retries). */
+function quoteNumberFor(executionId: string): string {
+  const tail = executionId
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .slice(-6)
+    .toUpperCase();
+  return `Q-${tail || "000000"}`;
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Proposals",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Send a notification, degrading gracefully when there's no recipient. A missing
+ * address is an expected outcome (no approver configured, no client email) — log
+ * and skip rather than failing the run.
+ */
+async function notify(
+  ctx: Ctx,
+  to: string | null | undefined,
+  subject: string,
+  text: string,
+): Promise<boolean> {
+  if (!to) {
+    ctx.logger.warn("notify skipped: no recipient", { subject });
+    return false;
+  }
+  const inboxId = await resolveSenderInbox(ctx);
+  const sent = await ctx.sapiom.email.messages.send(inboxId, {
+    to,
+    subject,
+    text,
+  });
+  ctx.logger.info("notified", { to, subject, messageId: sent.messageId });
+  return true;
+}
+
+/** Sum the priced line items — the total is computed here, never from the model. */
+function computeTotals(lineItems: ProposalLine[], taxRate: number): Totals {
+  const subtotal = lineItems.reduce(
+    (sum, li) => sum + li.quantity * li.unitPrice,
+    0,
+  );
+  const tax = subtotal * taxRate;
+  return {
+    subtotal: round2(subtotal),
+    tax: round2(tax),
+    total: round2(subtotal + tax),
+  };
+}
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function money(amount: number, currency: string): string {
+  return `${currency} ${amount.toFixed(2)}`;
+}
+
+// ─────────────────────────────────────────────────────── model reasoning ──
+/** Draft the proposal from the free-text request (reversible prep). */
+async function draftProposal(
+  ctx: Ctx,
+  request: string,
+  currency: string,
+): Promise<ProposalDraft> {
+  const system =
+    "You are a solutions consultant drafting a client proposal and price quote " +
+    "from a request. Produce a short title, a one-paragraph summary, a scope " +
+    "list of what's included, and priced line items (a clear deliverable, a " +
+    `quantity, and a unit price as a plain number in ${currency}). Price the ` +
+    "work realistically for the request. Add brief terms (validity + payment). " +
+    "Reply with ONLY minified JSON: " +
+    '{"title":string,"summary":string,"scope":string[],' +
+    '"lineItems":[{"description":string,"quantity":number,"unitPrice":number}],' +
+    '"terms":string}.';
+  const res = await ctx.sapiom.models.run({
+    prompt: request,
+    system,
+    maxTokens: 900,
+  });
+  return coerceDraft(res.output, request);
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const draft = defineStep({
+  name: "draft",
+  next: ["render"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const request = input.request?.trim() ?? "";
+    if (!request) throw new Error("`request` is required");
+    const config = input.config ?? {};
+    const currency = (input.currency?.trim() || "USD").toUpperCase();
+    const taxRate =
+      typeof input.taxRate === "number" && Number.isFinite(input.taxRate)
+        ? Math.max(0, input.taxRate)
+        : 0;
+
+    ctx.shared.set("request", request);
+    ctx.shared.set("currency", currency);
+    ctx.shared.set("taxRate", taxRate);
+    ctx.shared.set("client", input.client ?? {});
+    ctx.shared.set("from", input.from ?? {});
+    ctx.shared.set(
+      "approver",
+      input.approver?.trim() || config.APPROVER_EMAIL || null,
+    );
+    ctx.shared.set(
+      "recipientEmail",
+      input.recipientEmail?.trim() ||
+        input.client?.email?.trim() ||
+        config.CLIENT_EMAIL ||
+        null,
+    );
+    ctx.shared.set("dryRun", input.dryRun === true);
+    ctx.shared.set("quoteNumber", quoteNumberFor(ctx.executionId));
+
+    // Reversible prep: draft the proposal, then total the line items in code.
+    const proposal = await draftProposal(ctx, request, currency);
+    const totals = computeTotals(proposal.lineItems, taxRate);
+    ctx.shared.set("draft", proposal);
+    ctx.shared.set("totals", totals);
+    ctx.logger.info("drafted proposal", {
+      title: proposal.title,
+      lineItems: proposal.lineItems.length,
+      total: totals.total,
+    });
+    return goto("render", {});
+  },
+});
+
+const render = defineStep({
+  name: "render",
+  next: ["review"],
+  async run(_input: unknown, ctx: Ctx) {
+    const draftDoc = must(ctx.shared.get("draft"), "draft");
+    const totals = must(ctx.shared.get("totals"), "totals");
+    const currency = must(ctx.shared.get("currency"), "currency");
+    const quoteNumber = must(ctx.shared.get("quoteNumber"), "quoteNumber");
+    const from = ctx.shared.get("from") ?? {};
+    const client = ctx.shared.get("client") ?? {};
+
+    const fileName = `${quoteNumber}.pdf`;
+    const boxName = `proposal-${quoteNumber.toLowerCase()}`;
+    const proposalJson = JSON.stringify({
+      quoteNumber,
+      currency,
+      from,
+      client,
+      draft: draftDoc,
+      totals,
+    });
+
+    // Lay out the PDF in a throwaway sandbox, then read the bytes back as base64.
+    // A sandbox is torn down in `finally` so a render failure never leaks compute.
+    let pdfBase64 = "";
+    const box = await ctx.sapiom.sandboxes.create({ name: boxName });
+    try {
+      await box.writeFile("proposal.json", proposalJson);
+      await box.writeFile("render.mjs", RENDER_SCRIPT);
+      // Install the (pure-JS) PDF library and render. `--no-save` keeps it out of
+      // a package.json we don't ship; errors surface via a non-zero exit below.
+      const built = await box.exec(
+        `npm install --no-save --no-audit --no-fund --loglevel=error ${PDF_PACKAGE} && node render.mjs`,
+        { timeout: 180_000 },
+      );
+      if (built.exitCode !== 0) {
+        ctx.logger.error("pdf render failed", {
+          exitCode: built.exitCode,
+          stderr: built.stderr.slice(-500),
+        });
+        throw new Error(`PDF render failed (exit ${built.exitCode})`);
+      }
+      // Read the PDF as base64 so binary bytes survive the text-only exec channel.
+      const read = await box.exec(
+        `base64 -w0 ${fileName} || base64 ${fileName}`,
+      );
+      pdfBase64 = read.stdout.replace(/\s+/g, "");
+    } finally {
+      await box.destroy().catch((err) => {
+        ctx.logger.warn("sandbox destroy failed", { err: String(err) });
+      });
+    }
+
+    // Persist the bytes to file storage. `upload` hands back a presigned URL we
+    // PUT the bytes to ourselves. Under `run_local` the sandbox exec is stubbed
+    // (empty output), so there are no bytes to PUT — we still walk the upload
+    // shape and return a (stub) fileId, keeping the offline trace complete.
+    const bytes = Buffer.from(pdfBase64, "base64");
+    const upload = await ctx.sapiom.fileStorage.upload({
+      contentType: "application/pdf",
+      fileName,
+      fileSize: bytes.length,
+      visibility: "private",
+    });
+    if (bytes.length > 0) {
+      const res = await fetch(upload.uploadUrl, {
+        method: "PUT",
+        headers: upload.requiredHeaders,
+        body: bytes,
+      });
+      if (!res.ok) {
+        throw new Error(
+          `file upload PUT failed: ${res.status} ${res.statusText}`,
+        );
+      }
+    } else {
+      ctx.logger.warn(
+        "no PDF bytes rendered — skipping upload PUT (local/stub)",
+      );
+    }
+    const link = await ctx.sapiom.fileStorage.getDownloadUrl(upload.fileId);
+    ctx.shared.set("fileId", upload.fileId);
+    ctx.shared.set("downloadUrl", link.downloadUrl);
+    ctx.logger.info("proposal rendered", {
+      fileId: upload.fileId,
+      bytes: bytes.length,
+    });
+    return goto("review", {});
+  },
+});
+
+const review = defineStep({
+  name: "review",
+  next: [],
+  // Static graph edge: on the decision signal, resume at `onDecision`. Must match
+  // the `pauseUntilSignal` directive below.
+  pause: { signal: DECISION_SIGNAL, resumeStep: "onDecision" },
+  async run(_input: unknown, ctx: Ctx) {
+    const draftDoc = must(ctx.shared.get("draft"), "draft");
+    const totals = must(ctx.shared.get("totals"), "totals");
+    const currency = must(ctx.shared.get("currency"), "currency");
+    const quoteNumber = must(ctx.shared.get("quoteNumber"), "quoteNumber");
+    const approver = ctx.shared.get("approver") ?? null;
+    const downloadUrl = ctx.shared.get("downloadUrl") ?? null;
+
+    // Email the internal approver a summary + the PDF link before anything goes
+    // to the client.
+    await notify(
+      ctx,
+      approver,
+      `Approval needed: ${draftDoc.title} (${quoteNumber})`,
+      buildApproverEmail(
+        draftDoc,
+        totals,
+        currency,
+        downloadUrl,
+        ctx.executionId,
+      ),
+    );
+
+    ctx.logger.info("approver notified; pausing for decision", {
+      approver,
+      quoteNumber,
+    });
+
+    // Suspend at $0 until a human fires the approval signal for this run.
+    return pauseUntilSignal({
+      signal: DECISION_SIGNAL,
+      resumeStep: "onDecision",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const onDecision = defineStep({
+  name: "onDecision",
+  next: ["send", "rejected"],
+  // `payload` IS the approval signal body.
+  async run(payload: ApprovalDecision, ctx: Ctx) {
+    // Safe default: only an explicit `approve` sends the proposal to the client.
+    const approved = payload?.decision === "approve";
+    ctx.logger.info("approval decision", {
+      decision: payload?.decision ?? "(none)",
+      approved,
+    });
+    if (!approved) return goto("rejected", { notes: payload?.notes });
+    return goto("send", { notes: payload?.notes });
+  },
+});
+
+const send = defineStep({
+  name: "send",
+  next: [],
+  terminal: true,
+  async run(input: { notes?: string }, ctx: Ctx) {
+    const draftDoc = must(ctx.shared.get("draft"), "draft");
+    const totals = must(ctx.shared.get("totals"), "totals");
+    const currency = must(ctx.shared.get("currency"), "currency");
+    const quoteNumber = must(ctx.shared.get("quoteNumber"), "quoteNumber");
+    const client = ctx.shared.get("client") ?? {};
+    const recipient = ctx.shared.get("recipientEmail") ?? null;
+    const downloadUrl = ctx.shared.get("downloadUrl") ?? null;
+    const fileId = ctx.shared.get("fileId") ?? null;
+    const dryRun = ctx.shared.get("dryRun") ?? false;
+
+    if (dryRun) {
+      // Deployed preview: skip the one outward action. Everything up to here
+      // (draft, render, approval) already ran for real.
+      ctx.logger.info("dry run — skipping client email", { quoteNumber });
+      return terminate({
+        sent: false,
+        dryRun: true,
+        outcome: "approved-dry-run",
+        quoteNumber,
+        fileId,
+        downloadUrl,
+        total: totals.total,
+      });
+    }
+
+    // ── The one outward action ─────────────────────────────────────────────
+    const sent = await notify(
+      ctx,
+      recipient,
+      `Your proposal: ${draftDoc.title} (${quoteNumber})`,
+      buildClientEmail(draftDoc, totals, currency, downloadUrl, client),
+    );
+
+    ctx.logger.info("proposal sent", { recipient, quoteNumber, sent });
+    return terminate({
+      sent,
+      dryRun: false,
+      outcome: sent ? "sent" : "approved-no-recipient",
+      quoteNumber,
+      fileId,
+      downloadUrl,
+      total: totals.total,
+      notes: input?.notes ?? null,
+    });
+  },
+});
+
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { notes?: string }, ctx: Ctx) {
+    const quoteNumber = ctx.shared.get("quoteNumber") ?? null;
+    const fileId = ctx.shared.get("fileId") ?? null;
+    // Nothing went to the client, so rejecting is a clean stop: the draft PDF is
+    // still in file storage for a human to pick up or revise.
+    ctx.logger.info("rejected — nothing sent to the client", { quoteNumber });
+    return terminate({
+      sent: false,
+      outcome: "rejected",
+      quoteNumber,
+      fileId,
+      notes: input?.notes ?? null,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── email bodies ──
+function buildApproverEmail(
+  d: ProposalDraft,
+  totals: Totals,
+  currency: string,
+  downloadUrl: string | null,
+  executionId: string,
+): string {
+  return [
+    `Proposal drafted for approval: ${d.title}`,
+    "",
+    d.summary,
+    "",
+    "Line items:",
+    ...d.lineItems.map(
+      (li) =>
+        `- ${li.description} — ${li.quantity} × ${money(li.unitPrice, currency)} = ${money(li.quantity * li.unitPrice, currency)}`,
+    ),
+    "",
+    `Subtotal: ${money(totals.subtotal, currency)}`,
+    ...(totals.tax > 0 ? [`Tax: ${money(totals.tax, currency)}`] : []),
+    `Total: ${money(totals.total, currency)}`,
+    "",
+    downloadUrl ? `PDF: ${downloadUrl}` : "(PDF link unavailable)",
+    "",
+    "Nothing has been sent to the client. Fire the `proposal.decision` signal",
+    'with {"decision":"approve"} to send it, or {"decision":"reject"} to stop.',
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildClientEmail(
+  d: ProposalDraft,
+  totals: Totals,
+  currency: string,
+  downloadUrl: string | null,
+  client: Party,
+): string {
+  return [
+    `Hi ${client.name ?? "there"},`,
+    "",
+    `Please find our proposal, ${d.title}, attached below.`,
+    "",
+    d.summary,
+    "",
+    `Total: ${money(totals.total, currency)}`,
+    "",
+    downloadUrl
+      ? `View the full proposal (PDF): ${downloadUrl}`
+      : "(PDF link unavailable — we'll follow up shortly.)",
+    "",
+    d.terms,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────── output parsing ──
+/**
+ * Coerce the draft-step model output into a `ProposalDraft`, defensively. A model
+ * may wrap the JSON in prose or fences, so we slice to the outermost object and
+ * fall back to a minimal single-line quote when anything is off — the pipeline
+ * still renders and runs end to end rather than failing on a malformed draft.
+ */
+function coerceDraft(output: string | null, request: string): ProposalDraft {
+  const fallback: ProposalDraft = {
+    title: "Proposal",
+    summary: request.slice(0, 200) || "(no request supplied)",
+    scope: [],
+    lineItems: [
+      { description: "Professional services", quantity: 1, unitPrice: 0 },
+    ],
+    terms: "Valid for 30 days. Payment due within 30 days of acceptance.",
+  };
+  const obj = extractJson(output);
+  if (!obj) return fallback;
+
+  const title =
+    typeof obj.title === "string" && obj.title.trim()
+      ? obj.title.trim()
+      : fallback.title;
+  const summary =
+    typeof obj.summary === "string" && obj.summary.trim()
+      ? obj.summary.trim()
+      : fallback.summary;
+  const scope = Array.isArray(obj.scope)
+    ? obj.scope
+        .filter(
+          (s): s is string => typeof s === "string" && s.trim().length > 0,
+        )
+        .slice(0, MAX_SCOPE_ITEMS)
+    : [];
+  const lineItems = Array.isArray(obj.lineItems)
+    ? obj.lineItems
+        .map(coerceLine)
+        .filter((li): li is ProposalLine => li !== null)
+        .slice(0, MAX_LINE_ITEMS)
+    : [];
+  const terms =
+    typeof obj.terms === "string" && obj.terms.trim()
+      ? obj.terms.trim()
+      : fallback.terms;
+
+  return {
+    title,
+    summary,
+    scope,
+    lineItems: lineItems.length > 0 ? lineItems : fallback.lineItems,
+    terms,
+  };
+}
+
+/** Coerce one raw line item; drop anything without a usable description. */
+function coerceLine(raw: unknown): ProposalLine | null {
+  if (!raw || typeof raw !== "object") return null;
+  const e = raw as Record<string, unknown>;
+  const description =
+    typeof e.description === "string" ? e.description.trim() : "";
+  if (!description) return null;
+  const quantity =
+    typeof e.quantity === "number" &&
+    Number.isFinite(e.quantity) &&
+    e.quantity > 0
+      ? e.quantity
+      : 1;
+  const unitPrice =
+    typeof e.unitPrice === "number" &&
+    Number.isFinite(e.unitPrice) &&
+    e.unitPrice >= 0
+      ? e.unitPrice
+      : 0;
+  return { description, quantity, unitPrice };
+}
+
+/** Best-effort extraction of a single JSON object from model output. */
+function extractJson(output: string | null): Record<string, unknown> | null {
+  if (!output) return null;
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < 0 || end < start) return null;
+  try {
+    return JSON.parse(output.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The PDF layout script, written into the sandbox and run with Node. Reads
+ * `proposal.json`, lays the quote out with `pdf-lib` (pure JS, standard Helvetica
+ * — no browser, no native deps), and writes `<quoteNumber>.pdf`. Kept dependency-
+ * light on purpose: the point is to show a real render in a sandbox, not to be a
+ * document-design system — fork it and make the layout your own.
+ */
+const RENDER_SCRIPT = `import { readFileSync, writeFileSync } from "node:fs";
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+const data = JSON.parse(readFileSync("proposal.json", "utf8"));
+const { quoteNumber, currency, from = {}, client = {}, draft, totals } = data;
+
+const money = (n) => \`\${currency} \${Number(n).toFixed(2)}\`;
+const MARGIN = 56;
+const PAGE = [612, 792]; // US Letter
+const WIDTH = PAGE[0] - MARGIN * 2;
+
+const pdf = await PDFDocument.create();
+const font = await pdf.embedFont(StandardFonts.Helvetica);
+const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+let page = pdf.addPage(PAGE);
+let y = PAGE[1] - MARGIN;
+
+function newPage() {
+  page = pdf.addPage(PAGE);
+  y = PAGE[1] - MARGIN;
+}
+function ensure(space) {
+  if (y - space < MARGIN) newPage();
+}
+// Greedy word-wrap to the content width at the given size.
+function wrap(text, f, size) {
+  const words = String(text).split(/\\s+/).filter(Boolean);
+  const lines = [];
+  let line = "";
+  for (const w of words) {
+    const next = line ? line + " " + w : w;
+    if (f.widthOfTextAtSize(next, size) > WIDTH && line) {
+      lines.push(line);
+      line = w;
+    } else {
+      line = next;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.length ? lines : [""];
+}
+function text(str, { f = font, size = 11, gap = 4, color = rgb(0.1, 0.1, 0.1) } = {}) {
+  for (const line of wrap(str, f, size)) {
+    ensure(size + gap);
+    page.drawText(line, { x: MARGIN, y, size, font: f, color });
+    y -= size + gap;
+  }
+}
+// A right-aligned amount on the same row as a left label.
+function row(label, amount, { f = font, size = 11 } = {}) {
+  ensure(size + 6);
+  page.drawText(label, { x: MARGIN, y, size, font: f, color: rgb(0.1, 0.1, 0.1) });
+  const w = f.widthOfTextAtSize(amount, size);
+  page.drawText(amount, { x: MARGIN + WIDTH - w, y, size, font: f, color: rgb(0.1, 0.1, 0.1) });
+  y -= size + 6;
+}
+
+// Header: title + quote meta.
+text(draft.title || "Proposal", { f: bold, size: 22, gap: 8 });
+text(\`Quote \${quoteNumber}\`, { f: bold, size: 11, gap: 2, color: rgb(0.4, 0.4, 0.4) });
+if (from.company || from.name) text(\`From: \${[from.company, from.name].filter(Boolean).join(" · ")}\`, { size: 10, color: rgb(0.4, 0.4, 0.4) });
+if (client.company || client.name) text(\`For: \${[client.company, client.name].filter(Boolean).join(" · ")}\`, { size: 10, color: rgb(0.4, 0.4, 0.4) });
+y -= 10;
+
+// Summary.
+if (draft.summary) { text(draft.summary); y -= 6; }
+
+// Scope.
+if (Array.isArray(draft.scope) && draft.scope.length) {
+  text("Scope", { f: bold, size: 13, gap: 6 });
+  for (const s of draft.scope) text("•  " + s);
+  y -= 6;
+}
+
+// Line items.
+text("Line items", { f: bold, size: 13, gap: 8 });
+for (const li of draft.lineItems || []) {
+  const amount = money((li.quantity || 0) * (li.unitPrice || 0));
+  const label = \`\${li.description}  (\${li.quantity} × \${money(li.unitPrice)})\`;
+  // Wrap the label but keep the amount pinned to the last line.
+  const lines = wrap(label, font, 11);
+  for (let i = 0; i < lines.length; i++) {
+    ensure(11 + 6);
+    page.drawText(lines[i], { x: MARGIN, y, size: 11, font, color: rgb(0.1, 0.1, 0.1) });
+    if (i === lines.length - 1) {
+      const w = font.widthOfTextAtSize(amount, 11);
+      page.drawText(amount, { x: MARGIN + WIDTH - w, y, size: 11, font, color: rgb(0.1, 0.1, 0.1) });
+    }
+    y -= 11 + 6;
+  }
+}
+y -= 8;
+row("Subtotal", money(totals.subtotal));
+if (totals.tax > 0) row("Tax", money(totals.tax));
+row("Total", money(totals.total), { f: bold, size: 13 });
+
+// Terms.
+if (draft.terms) { y -= 12; text("Terms", { f: bold, size: 13, gap: 6 }); text(draft.terms, { size: 10, color: rgb(0.4, 0.4, 0.4) }); }
+
+writeFileSync(\`\${quoteNumber}.pdf\`, await pdf.save());
+`;
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "proposal-generator",
+  entry: "draft",
+  steps: { draft, render, review, onDecision, send, rejected },
+});

--- a/examples/proposal-generator/package.json
+++ b/examples/proposal-generator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-proposal-generator",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: draft a client proposal from a request with an LLM, render it to a PDF in a sandbox, pause for human sign-off, then email the approved quote to the client.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/proposal-generator/template.json
+++ b/examples/proposal-generator/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Turn an inbound request into a client-ready quote without the copy-paste. You give it the requirement — a brief, an RFP, a description of what the client wants — and an LLM (`models.run`) drafts a proposal: a title, a summary, a scope list, and priced line items. Your code, not the model, totals the numbers.\n\nIt then renders that draft into a real PDF. A throwaway sandbox (`ctx.sapiom.sandboxes`) lays the quote out with a small Node script and the file lands in your file storage (`ctx.sapiom.fileStorage`), so you get a durable link you can share. The sandbox is torn down as soon as the render is done.\n\nBefore anything reaches the client, it pauses. It emails your approver a summary and the PDF link, then waits on a real approval signal (`pauseUntilSignal`) — the run costs nothing while it sits idle, for minutes or days. Approve it and it emails the finished proposal to the client; reject it and it stops with the draft still on file. The one outward action — the client email — only happens after a person says yes.\n\nYou pay for the model reasoning, the sandbox render, the file storage, and the emails. The waiting is free.",
+  "useCases": [
+    "Answer an inbound RFP or brief with a priced, formatted PDF quote instead of a hand-built doc.",
+    "Keep a human in the loop — review and approve every proposal before it goes to the client.",
+    "Give sales or an agency a repeatable quote flow: same structure, same sign-off, every time."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page with your request. Your $5 signup credit covers first runs.\n\nThis workflow pauses once and waits for a real approval, so you drive it as it runs. It drafts the proposal, renders the PDF, emails your approver, then pauses. Send the decision with the MCP `workflow_signal` tool: signal `proposal.decision`, `correlationId` set to the run's executionId, payload `{ \"decision\": \"approve\" }` to email the client (or `{ \"decision\": \"reject\" }` to stop). Set an `approver` and a client `email` (or pass `config.APPROVER_EMAIL` / `config.CLIENT_EMAIL`) so the notifications have somewhere to go; pass `dryRun: true` to run the whole thing but skip the client email.\n\nPrefer to work from the code? Run it locally with `run_local` — it stubs the capabilities and auto-resumes the pause (a resume with no decision takes the safe reject branch, and the stubbed sandbox skips the real byte upload), so the whole graph traces end to end for free. Then edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Draft, render, approve, and send a quote",
+      "input": {
+        "request": "We need a marketing website: 5 pages, a blog, a contact form, and basic SEO. Launch in 6 weeks.",
+        "client": {
+          "name": "Dana Lee",
+          "company": "Northwind Coffee",
+          "email": "dana@northwind.example.com"
+        },
+        "from": { "company": "Acme Studio" },
+        "currency": "USD",
+        "taxRate": 0.08,
+        "approver": "owner@acme.example.com"
+      },
+      "output": {
+        "sent": true,
+        "dryRun": false,
+        "outcome": "sent",
+        "quoteNumber": "Q-3F9A2C",
+        "total": 12960
+      }
+    },
+    {
+      "title": "Rejected at review — nothing goes to the client",
+      "input": {
+        "request": "Quote a one-day logo refresh.",
+        "client": { "name": "Sam", "email": "sam@example.com" },
+        "approver": "owner@acme.example.com"
+      },
+      "output": {
+        "sent": false,
+        "outcome": "rejected",
+        "quoteNumber": "Q-8B1D40"
+      }
+    }
+  ]
+}

--- a/examples/proposal-generator/tsconfig.json
+++ b/examples/proposal-generator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,56 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "proposal-generator",
+      "name": "Proposal / Quote Generator",
+      "description": "Draft a client proposal from a request, render it to a PDF, then wait for a person to approve it before it emails the client.",
+      "tags": ["sales", "pdf", "approval", "human-in-the-loop"],
+      "sourcePath": "examples/proposal-generator",
+      "capabilities": [
+        "models.run",
+        "sandboxes.create",
+        "fileStorage.upload",
+        "email.send"
+      ],
+      "whatItDoes": "For turning an inbound request into a client-ready quote without building the doc by hand. You give it the requirement and an LLM (models.run) drafts a proposal — a title, a summary, a scope list, and priced line items — then your code, not the model, totals the numbers. It renders that draft into a real PDF in a throwaway sandbox and saves the file, so you get a link you can share. Before anything reaches the client it emails your approver a summary and pauses, costing nothing while it waits. Approve it and it emails the finished proposal to the client; reject it and it stops with the draft still on file. The one outward step only runs after a person says yes.",
+      "steps": [
+        {
+          "name": "draft",
+          "description": "An LLM turns the request into a structured proposal — title, summary, scope, and priced line items — then the totals are computed in code, not trusted from the model.",
+          "capability": "models.run",
+          "next": ["render"]
+        },
+        {
+          "name": "render",
+          "description": "Spin up a sandbox, lay the proposal out as a PDF with a small Node script, save the file to storage, then tear the sandbox down.",
+          "capability": "sandboxes.create",
+          "next": ["review"]
+        },
+        {
+          "name": "review",
+          "description": "Email the approver a summary and the PDF link, then pause and wait for their decision — costing nothing while idle (resumes at 'onDecision').",
+          "capability": "email.send",
+          "next": ["onDecision"]
+        },
+        {
+          "name": "onDecision",
+          "description": "Read the approval reply: approve emails the client, anything else stops safely with nothing sent.",
+          "next": ["send", "rejected"]
+        },
+        {
+          "name": "send",
+          "description": "The one outward step — email the approved proposal to the client. A dry run skips the send.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "Rejected at review — nothing goes to the client, and the draft PDF stays on file.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What & why

A new onboarding gallery template for the sales / agency persona: **Proposal / Quote Generator**. It takes an inbound requirement and produces a signed-off, client-ready PDF quote — the copy-paste flow a salesperson runs by hand for every request, done as one durable workflow.

## How it works

```
draft ─▶ render ─▶ review ─(pause: proposal.decision, $0 while idle)─▶ onDecision
(models.run) (sandbox +                                                 │
             fileStorage)                              approve ◀─────────┼─▶ reject
                                                         ▼               ▼
                                                       send          rejected
```

1. **draft** — an LLM (`ctx.sapiom.models.run`) turns the free-text request into a structured proposal (title, summary, scope, priced line items). Totals are computed **in code**, never trusted from the model.
2. **render** — a throwaway sandbox (`ctx.sapiom.sandboxes`) lays the proposal out as a PDF with a small self-contained `pdf-lib` script (pure JS, no browser); the bytes are persisted to file storage (`ctx.sapiom.fileStorage`) and the sandbox is torn down in a `finally`.
3. **review** — email the approver a summary + PDF link (`ctx.sapiom.email`), then block on a durable `pauseUntilSignal`. The run costs nothing while it waits.
4. **onDecision** — its input is the approval payload. Only an explicit `{ "decision": "approve" }` proceeds; anything else (including a `run_local` resume with no payload) takes the safe reject branch.
5. **send** — the one outward action: email the finished proposal to the client. A `dryRun` guard makes it a no-op.

Under `run_local` the capabilities are stubbed and the pause auto-resumes to the safe reject branch, so the whole graph traces end to end for free; the stubbed sandbox produces no bytes, so the real upload PUT is skipped while the upload shape is still walked.

## Changes

- `examples/proposal-generator/` — `index.ts` (the agent), `README.md`, `AGENTS.md`, `template.json` manifest, `package.json`, `tsconfig.json`, `.gitignore`.
- `examples/registry.json` — gallery entry (capabilities: `models.run`, `sandboxes.create`, `fileStorage.upload`, `email.send`).

## Validation

- `npm run typecheck` clean; files pass `prettier --check`.
- `registry.json` + `template.json` parse and validate against their schemas.
- The embedded PDF render script was extracted and run against sample data — emits a valid PDF (v1.7), exercising word-wrap, multi-line line items, totals, and terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)