### PR TITLE
feat(examples): Cold Outreach Personalization Engine workflow template (SAP-1855)

### DIFF
--- a/examples/cold-outreach-engine/.gitignore
+++ b/examples/cold-outreach-engine/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/cold-outreach-engine/AGENTS.md
+++ b/examples/cold-outreach-engine/AGENTS.md
@@ -1,0 +1,33 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Cold Outreach Personalization Engine** — authored against `@sapiom/agent`. It has eight steps: `enrich` (Hunter contact lookup) → `scrape` (`web.scrape`) → `personalize` (`models.run`) → `verify` (Hunter deliverability) → `launch` (`database`) → `send` (`email`) ⇄ `advance` → `done`. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.search.emailSearch.findEmail(...)`, `ctx.sapiom.search.scrape(...)`, `ctx.sapiom.models.run(...)`, `ctx.sapiom.search.emailSearch.verifyEmail(...)`, `ctx.sapiom.database.get(...)`, `ctx.sapiom.email.messages.send(...)`).
+
+`send` and `advance` form a drip **loop**: `send` delivers a touch and then pauses until the drip interval elapses or a prospect replies; `advance` wakes, removes anyone who replied, and either loops back to `send` for the next touch or ends the run. The loop is bounded by the number of touches in the sequence.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **The pause is a static edge.** `send` declares `pause: { signal: "reply.received", resumeStep: "advance" }` and returns `pauseUntilSignal({ signal, resumeStep, correlationId, timeoutMs })` — the two must match. The resumed `advance` step's _input_ is the signal payload (`{ email }`); everything else survives the suspend in `ctx.shared`.
+- **The timeout IS the drip cadence.** `pauseUntilSignal`'s `timeoutMs` (from `dripIntervalDays`) is what wakes the run to send the next touch when nobody replies. A reply signal wakes it sooner and drops that prospect.
+- **Keep the edges slim.** The scraped company bodies are bounded (truncated) before the model sees them and are handed only to `personalize` keyed by domain — they never enter `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** `launch` returns the plan and terminates when `dryRun` is set — no send, no DB, no drip. Keep new external side effects behind the same guard.
+- **Degrade, don't abort.** Enrichment, scraping, verification, and sends are all wrapped per-item: a failure skips that lead/domain/contact and logs a warning rather than throwing the whole run. Verification failures keep the contact flagged `unverified` rather than silently dropping a lead.
+- **The opener parse must tolerate junk.** `personalize` parses a JSON array from the model but falls back to a safe generic opener per contact when parsing fails — so the `run_local` stub's non-JSON placeholder still traces end to end.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so Hunter / `models.run` / `database` / `email` return built-in defaults and the agent runs offline for free. Pass `dryRun: true` so `launch` returns the plan and skips the (stubbed) send, DB, and drip. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed run that enriches, personalizes, verifies, and sends. Fire the `reply.received` signal to end the drip early, or attach the `schedule` as a cron trigger.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Every timestamp — contact creation, touch sends, reply time — is captured at the DB boundary via Postgres `now()`, not a per-row JS clock, so retries don't skew the campaign log.

--- a/examples/cold-outreach-engine/README.md
+++ b/examples/cold-outreach-engine/README.md
@@ -1,0 +1,78 @@
+# Cold Outreach Personalization Engine
+
+Enrich a lead list with Hunter, scrape each company site, write a personalized
+first line for every prospect, verify deliverability, then drip touches with
+durable, $0 waits between them — stopping the moment someone replies.
+
+## What it does
+
+```
+enrich ──▶ scrape ──▶ personalize ──▶ verify ──▶ launch ──▶ send ⇄ advance ──▶ done
+(Hunter)   (web)      (models.run)     (Hunter)   (database)  (email)          (terminal)
+```
+
+1. **enrich** — for each lead (`{ domain, company?, fullName? }`), resolve a real
+   contact with Hunter: `findEmail` when you name the person, `domainSearch` to
+   surface a decision-maker when you only have the company. Per-lead failures are
+   skipped, never fatal.
+2. **scrape** — read each unique company site (`ctx.sapiom.search.scrape`) for a
+   few lines of context. Bodies are bounded and die at the next step — they never
+   enter shared state.
+3. **personalize** — hand the snippets to the live model
+   (`ctx.sapiom.models.run`) for one concrete opener per prospect, falling back to
+   a safe generic line when the model returns nothing usable.
+4. **verify** — check each address for deliverability
+   (`ctx.sapiom.search.emailSearch.verifyEmail`) and drop the ones that would
+   bounce before anything sends.
+5. **launch** — persist the campaign roster to a Postgres store the engine owns
+   (`ctx.sapiom.database`), then start the drip. A `dryRun` stops here and returns
+   the full plan — every opener — without sending or persisting.
+6. **send** — deliver the current touch to everyone still active
+   (`ctx.sapiom.email`), log it, then **pause at $0** until the drip interval
+   elapses or a reply lands.
+7. **advance** — wakes on that reply-or-timeout, marks anyone who replied as done,
+   and either loops back for the next touch or ends the run.
+
+Input: `{ "leads": [{ "domain": "acme.com", "fullName": "Jordan Rivera" }], "senderName": "Dana", "dripIntervalDays": 3, "dryRun": true }`.
+
+- `leads` supplies the list; a `domain` is enough, a `fullName` sharpens the match.
+- `sequence` overrides the default three touches; `senderName` signs the mail.
+- `dripIntervalDays` sets the gap between touches (default 3).
+- `dryRun: true` returns the plan and openers without sending, persisting, or waiting.
+
+### The durable wait
+
+Between touches the run suspends via `pauseUntilSignal` with a timeout: it costs
+nothing while idle, resumes on its own when the interval passes, and
+short-circuits the instant a `reply.received` signal arrives — so a prospect who
+answers never gets the next follow-up.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` so the send, DB, and drip are skipped, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed run that enriches, personalizes, verifies, and sends).
+
+4. To end the drip early when a prospect replies, fire the `reply.received`
+   signal with the `workflow_signal` MCP tool, passing `{ "email": "..." }` and
+   the run's `executionId` as the `correlationId`. To run it on a cadence, attach
+   the `schedule` as a cron trigger on the deployed agent.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/cold-outreach-engine/index.ts
+++ b/examples/cold-outreach-engine/index.ts
@@ -1,0 +1,783 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Cold Outreach Personalization Engine — turn a raw lead list into a
+ * personalized, deliverability-checked drip sequence that runs itself.
+ *
+ * On each run it enriches your leads, researches each company, writes a
+ * specific opener for every prospect, drops the addresses that would bounce,
+ * and then sends the sequence one touch at a time — pausing at $0 between
+ * touches and stopping the moment someone replies.
+ *
+ *   enrich (Hunter) ─▶ scrape (web) ─▶ personalize (models.run) ─▶ verify (Hunter)
+ *      └─▶ launch (database) ─▶ send (email) ⇄ advance ─▶ done
+ *
+ *   - **enrich** takes a lead list — a company domain, optionally a person —
+ *     and resolves a real contact with Hunter: `findEmail` when you name the
+ *     person, `domainSearch` to surface a decision-maker when you only have the
+ *     company. Per-lead failures are skipped, never fatal.
+ *   - **scrape** reads each company's site (`web.scrape`) for a few lines of
+ *     context. The bodies are bounded and die here — they never enter shared
+ *     state or cross the drip edges.
+ *   - **personalize** hands those snippets to the live model (`models.run`) and
+ *     gets back one concrete first line per prospect, falling back to a safe
+ *     generic opener when the model returns nothing usable.
+ *   - **verify** checks each address for deliverability (Hunter `verifyEmail`)
+ *     and drops the ones that would bounce before a single email goes out.
+ *   - **launch** persists the campaign and its contacts to a Postgres store the
+ *     engine owns, then hands off to the drip. A `dryRun` stops here and returns
+ *     the full plan — openers and all — without sending or persisting anything.
+ *   - **send** delivers the current touch to everyone still active and logs it,
+ *     then pauses until either the drip interval elapses or a prospect replies.
+ *   - **advance** wakes on that reply-or-timeout, marks anyone who replied as
+ *     done, and either loops back for the next touch or ends the run.
+ *
+ * Durability: the wait between touches is a `pauseUntilSignal` with a timeout —
+ * it costs nothing while idle, resumes on its own when the interval passes, and
+ * short-circuits the instant a `reply.received` signal arrives. Determinism:
+ * each step body runs once on the happy path (again only on retry), and every
+ * timestamp is captured server-side via Postgres `now()`.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the engine owns — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "cold-outreach-engine";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "cold-outreach";
+/** The named signal a reply-webhook fires to end the drip early. */
+const REPLY_SIGNAL = "reply.received";
+/** Cap the lead list so cost + latency stay bounded. */
+const MAX_LEADS = 25;
+/** Truncate each scraped body — the ONLY large data on the scrape→personalize path. */
+const MAX_CONTEXT_CHARS = 1500;
+/** Days between drip touches when the caller doesn't pass one. */
+const DEFAULT_DRIP_DAYS = 3;
+/** Below this Hunter confidence score, treat an address as undeliverable. */
+const VERIFY_MIN_SCORE = 50;
+/** Default cadence documented for the cron trigger: 09:00 on weekdays. */
+const DEFAULT_SCHEDULE = "0 9 * * 1-5";
+/** Milliseconds in a day — drip interval math. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** One row of the lead list. A domain is enough; a name sharpens the match. */
+interface Lead {
+  /** Company domain, e.g. `"example.com"`. Provide this or `company`. */
+  domain?: string;
+  /** Company name, as an alternative to `domain`. */
+  company?: string;
+  /** Prospect's full name — when set, we look up their exact address. */
+  fullName?: string;
+  /** Prospect's first name (pair with `lastName`, or use `fullName`). */
+  firstName?: string;
+  /** Prospect's last name (pair with `firstName`, or use `fullName`). */
+  lastName?: string;
+}
+
+/** One touch in the drip sequence. Tokens: {firstName} {company} {sender}. */
+interface Touch {
+  subject: string;
+  body: string;
+}
+
+interface EntryInput {
+  /** The leads to work through on this run. */
+  leads?: Lead[];
+  /** Campaign name — also the key for the dedup/log store. */
+  campaign?: string;
+  /** The drip sequence; defaults to a three-touch sequence. */
+  sequence?: Touch[];
+  /** Days to wait between touches (default 3). */
+  dripIntervalDays?: number;
+  /** Display name signed on the outgoing mail. */
+  senderName?: string;
+  /** Cron cadence this engine is meant to run on (documentation only). */
+  schedule?: string;
+  /** Postgres handle for the campaign store; defaults to the template handle. */
+  dbHandle?: string;
+  /** Compute the plan and openers but skip the send, the DB, and the drip. */
+  dryRun?: boolean;
+}
+
+/** A resolved, workable contact — grows a first line and a verdict downstream. */
+interface Contact {
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  fullName?: string;
+  position?: string;
+  company?: string;
+  domain?: string;
+  /** The personalized opener (added by `personalize`). */
+  firstLine?: string;
+  /** Whether the address cleared verification (added by `verify`). */
+  deliverable?: boolean;
+  /** Hunter's verification verdict, for the summary (added by `verify`). */
+  verifyStatus?: string;
+  /** Drip state: "active" until it replies or the sequence ends. */
+  status?: "active" | "replied" | "done";
+}
+
+interface Shared extends Record<string, unknown> {
+  campaign: string;
+  dbHandle: string;
+  dryRun: boolean;
+  schedule: string;
+  senderName: string;
+  dripMs: number;
+  sequence: Touch[];
+  contacts: Contact[];
+  touchIndex: number;
+  sent: number;
+  replied: number;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+/** The three-touch default drip — a personalized open, a bump, and a breakup. */
+const DEFAULT_SEQUENCE: Touch[] = [
+  {
+    subject: "Quick idea for {company}",
+    body: "Worth a short call to dig in? Either way, happy to share a couple of thoughts.\n\nBest,\n{sender}",
+  },
+  {
+    subject: "Re: Quick idea for {company}",
+    body: "Bumping this in case it slipped — inboxes get busy. Still glad to send over a couple of ideas for {company} whenever the timing's right.\n\nBest,\n{sender}",
+  },
+  {
+    subject: "Closing the loop, {firstName}",
+    body: "I'll stop here so I'm not a bother. If growing {company} is on your list this quarter, just reply and I'll pick it back up.\n\nAll the best,\n{sender}",
+  },
+];
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Fill {firstName} / {company} / {sender} tokens with sensible fallbacks. */
+function render(template: string, contact: Contact, sender: string): string {
+  return template
+    .replaceAll("{firstName}", contact.firstName?.trim() || "there")
+    .replaceAll("{lastName}", contact.lastName?.trim() || "")
+    .replaceAll(
+      "{fullName}",
+      contact.fullName?.trim() || contact.firstName?.trim() || "there",
+    )
+    .replaceAll("{company}", contact.company?.trim() || "your team")
+    .replaceAll("{sender}", sender);
+}
+
+/** A benign opener used when the model gives us nothing we can use. */
+function fallbackFirstLine(c: Contact): string {
+  const who = c.firstName?.trim() || "there";
+  const org = c.company?.trim() || "your team";
+  return `Hi ${who} — I've been following what ${org} is building and wanted to reach out.`;
+}
+
+/** Normalize + bound the lead list so downstream cost stays predictable. */
+function normalizeLeads(raw: unknown): Lead[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((l): l is Lead => Boolean(l) && typeof l === "object")
+    .map((l) => ({
+      domain: l.domain?.trim() || undefined,
+      company: l.company?.trim() || undefined,
+      fullName: l.fullName?.trim() || undefined,
+      firstName: l.firstName?.trim() || undefined,
+      lastName: l.lastName?.trim() || undefined,
+    }))
+    .filter((l) => Boolean(l.domain || l.company))
+    .slice(0, MAX_LEADS);
+}
+
+/** True when a lead names a specific person we can look up directly. */
+function hasPerson(l: Lead): boolean {
+  return Boolean(l.fullName || (l.firstName && l.lastName));
+}
+
+/** Open a Postgres client for a live run, or null when unavailable. */
+async function openSql(ctx: Ctx, handle: string): Promise<Sql | null> {
+  try {
+    let db;
+    try {
+      db = await ctx.sapiom.database.get(handle);
+    } catch {
+      db = await ctx.sapiom.database.create({
+        handle,
+        duration: "7d",
+        name: "Cold Outreach Engine",
+        description: "Campaign contacts, drip touches, and reply state",
+      });
+    }
+    const conn = db.connection?.connectionString ?? null;
+    if (!conn) {
+      ctx.logger.warn("database: no connection string", { handle });
+      return null;
+    }
+    return postgres(conn, { ssl: "require", connect_timeout: 10 });
+  } catch (err) {
+    // A stubbed / unreachable DB degrades to "no persistence" rather than
+    // aborting the drip — the working set lives in ctx.shared regardless.
+    ctx.logger.warn("database: unavailable, continuing without persistence", {
+      err: String(err),
+    });
+    return null;
+  }
+}
+
+async function initSchema(sql: Sql): Promise<void> {
+  await sql`
+    create table if not exists outreach_contacts (
+      campaign    text not null,
+      email       text not null,
+      full_name   text,
+      company     text,
+      position    text,
+      first_line  text,
+      status      text not null default 'active',
+      replied_at  timestamptz,
+      created_at  timestamptz not null default now(),
+      primary key (campaign, email)
+    )`;
+  await sql`
+    create table if not exists outreach_touches (
+      id           bigserial primary key,
+      campaign     text not null,
+      email        text not null,
+      touch_index  integer not null,
+      subject      text,
+      message_id   text,
+      sent_at      timestamptz not null default now()
+    )`;
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(
+  ctx: Ctx,
+  displayName: string,
+): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName,
+  });
+  return inbox.inboxId;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const enrich = defineStep({
+  name: "enrich",
+  next: ["scrape"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const leads = normalizeLeads(input.leads);
+    const sequence =
+      Array.isArray(input.sequence) && input.sequence.length > 0
+        ? input.sequence
+        : DEFAULT_SEQUENCE;
+    const dripDays =
+      Number(input.dripIntervalDays) > 0
+        ? Number(input.dripIntervalDays)
+        : DEFAULT_DRIP_DAYS;
+
+    ctx.shared.set("campaign", input.campaign?.trim() || "cold-outreach");
+    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set("dryRun", truthy(input.dryRun));
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set("senderName", input.senderName?.trim() || "The team");
+    ctx.shared.set("dripMs", dripDays * DAY_MS);
+    ctx.shared.set("sequence", sequence);
+    ctx.shared.set("touchIndex", 0);
+    ctx.shared.set("sent", 0);
+    ctx.shared.set("replied", 0);
+
+    const byEmail = new Map<string, Contact>();
+    for (const lead of leads) {
+      try {
+        if (hasPerson(lead)) {
+          // We know who — look up their exact address.
+          const found = await ctx.sapiom.search.emailSearch.findEmail({
+            domain: lead.domain,
+            company: lead.company,
+            fullName: lead.fullName,
+            firstName: lead.firstName,
+            lastName: lead.lastName,
+          });
+          if (found.email) {
+            byEmail.set(found.email.toLowerCase(), {
+              email: found.email,
+              firstName: found.firstName ?? lead.firstName,
+              lastName: found.lastName ?? lead.lastName,
+              fullName: lead.fullName,
+              position: found.position,
+              company: found.company ?? lead.company,
+              domain: lead.domain,
+              status: "active",
+            });
+          }
+        } else if (lead.domain) {
+          // We only have the company — surface a decision-maker.
+          const res = await ctx.sapiom.search.emailSearch.domainSearch({
+            domain: lead.domain,
+            limit: 3,
+            type: "personal",
+            seniority: ["senior", "executive"],
+          });
+          const best = res.emails.find((e) => e.email) ?? res.emails[0];
+          if (best?.email) {
+            byEmail.set(best.email.toLowerCase(), {
+              email: best.email,
+              firstName: best.firstName,
+              lastName: best.lastName,
+              position: best.position,
+              company: res.organization ?? lead.company,
+              domain: lead.domain,
+              status: "active",
+            });
+          }
+        }
+      } catch (err) {
+        // Enrichment fails routinely (no match, rate limit); skip the lead,
+        // never abort the batch.
+        ctx.logger.warn("enrich failed for lead; skipping", {
+          domain: lead.domain,
+          err: String(err),
+        });
+      }
+    }
+
+    const contacts = [...byEmail.values()];
+    ctx.logger.info("enriched leads into contacts", {
+      leads: leads.length,
+      contacts: contacts.length,
+    });
+    return goto("scrape", { contacts });
+  },
+});
+
+const scrape = defineStep({
+  name: "scrape",
+  next: ["personalize"],
+  async run(input: { contacts: Contact[] }, ctx: Ctx) {
+    const contacts = input.contacts ?? [];
+    // One scrape per unique domain — many contacts can share a company.
+    const domains = [
+      ...new Set(contacts.map((c) => c.domain).filter((d): d is string => !!d)),
+    ];
+    const context = new Map<string, string>();
+    for (const domain of domains) {
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: `https://${domain}`,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        const text = (page.markdown ?? "").trim();
+        if (text) context.set(domain, text.slice(0, MAX_CONTEXT_CHARS));
+      } catch (err) {
+        // Paywalls, timeouts, DNS — degrade per-domain; the opener falls back.
+        ctx.logger.warn("scrape failed; no context for domain", {
+          domain,
+          err: String(err),
+        });
+      }
+    }
+    ctx.logger.info("scraped company context", {
+      domains: domains.length,
+      withContext: context.size,
+    });
+    // Carry the context ONLY to the next step, keyed by domain — the bodies
+    // never touch ctx.shared.
+    return goto("personalize", {
+      contacts,
+      context: Object.fromEntries(context),
+    });
+  },
+});
+
+const personalize = defineStep({
+  name: "personalize",
+  next: ["verify"],
+  async run(
+    input: { contacts: Contact[]; context: Record<string, string> },
+    ctx: Ctx,
+  ) {
+    const contacts = input.contacts ?? [];
+    const context = input.context ?? {};
+
+    if (contacts.length === 0) {
+      return goto("verify", { contacts });
+    }
+
+    const prospects = contacts
+      .map((c, i) => {
+        const site = c.domain ? context[c.domain] : "";
+        const who = [c.firstName, c.lastName].filter(Boolean).join(" ") || "—";
+        return (
+          `[${i}] ${who}${c.position ? `, ${c.position}` : ""} at ` +
+          `${c.company || c.domain || "unknown"}\n` +
+          `SITE: ${site ? site.slice(0, 600) : "(no site context)"}`
+        );
+      })
+      .join("\n\n");
+
+    const system =
+      "You write cold-email openers. For each prospect you get an index, their " +
+      "name/role/company, and a snippet of their company website. Write ONE " +
+      "warm, specific first line per prospect that references something concrete " +
+      "about their company — never generic flattery, no more than ~25 words, no " +
+      "greeting line and no signature. Reply with ONLY minified JSON: " +
+      '{"lines":[{"i":number,"firstLine":string}]}.';
+    const prompt = `PROSPECTS (${contacts.length}):\n${prospects}`;
+
+    let lines: Record<number, string> = {};
+    try {
+      const res = await ctx.sapiom.models.run({
+        system,
+        prompt,
+        maxTokens: 700,
+      });
+      lines = parseLines(res.output);
+    } catch (err) {
+      // A model error is not fatal — every contact falls back to a safe opener.
+      ctx.logger.warn("personalize model call failed; using fallbacks", {
+        err: String(err),
+      });
+    }
+
+    const personalized = contacts.map((c, i) => ({
+      ...c,
+      firstLine: lines[i]?.trim() || fallbackFirstLine(c),
+    }));
+    ctx.logger.info("wrote personalized openers", {
+      contacts: personalized.length,
+      fromModel: Object.keys(lines).length,
+    });
+    return goto("verify", { contacts: personalized });
+  },
+});
+
+const verify = defineStep({
+  name: "verify",
+  next: ["launch"],
+  async run(input: { contacts: Contact[] }, ctx: Ctx) {
+    const contacts = input.contacts ?? [];
+    const checked: Contact[] = [];
+    for (const c of contacts) {
+      try {
+        const res = await ctx.sapiom.search.emailSearch.verifyEmail({
+          email: c.email,
+        });
+        const status = (res.status || res.result || "unknown").toLowerCase();
+        const badStatus = status === "invalid" || status === "undeliverable";
+        const lowScore =
+          typeof res.score === "number" && res.score < VERIFY_MIN_SCORE;
+        const deliverable = !badStatus && !res.disposable && !lowScore;
+        checked.push({ ...c, deliverable, verifyStatus: status });
+      } catch (err) {
+        // If verification itself errors, don't silently drop the lead — send
+        // to it but flag the address as unverified.
+        ctx.logger.warn("verify failed; keeping contact as unverified", {
+          email: c.email,
+          err: String(err),
+        });
+        checked.push({ ...c, deliverable: true, verifyStatus: "unverified" });
+      }
+    }
+    const deliverable = checked.filter((c) => c.deliverable).length;
+    ctx.logger.info("verified deliverability", {
+      contacts: checked.length,
+      deliverable,
+    });
+    return goto("launch", { contacts: checked });
+  },
+});
+
+const launch = defineStep({
+  name: "launch",
+  next: ["send"],
+  // Terminal too: a dry run returns the plan and ends here instead of dripping.
+  terminal: true,
+  async run(input: { contacts: Contact[] }, ctx: Ctx) {
+    const contacts = input.contacts ?? [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const campaign = ctx.shared.get("campaign") || "cold-outreach";
+    const sequence = ctx.shared.get("sequence") ?? DEFAULT_SEQUENCE;
+    const deliverable = contacts.filter((c) => c.deliverable);
+
+    ctx.shared.set("contacts", contacts);
+
+    // Safe path: a dry run returns the full plan — every opener — without
+    // sending, persisting, or entering the drip.
+    if (dryRun) {
+      ctx.logger.info("dry run: returning plan without sending", {
+        contacts: contacts.length,
+        deliverable: deliverable.length,
+      });
+      return terminate({
+        campaign,
+        dryRun: true,
+        reason: "dry-run",
+        touches: sequence.length,
+        enriched: contacts.length,
+        deliverable: deliverable.length,
+        plan: contacts.map((c) => ({
+          email: c.email,
+          company: c.company,
+          deliverable: c.deliverable,
+          verifyStatus: c.verifyStatus,
+          firstLine: c.firstLine,
+        })),
+      });
+    }
+
+    // Live path: persist the campaign roster (best-effort), then start the drip.
+    const handle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+    const sql = await openSql(ctx, handle);
+    if (sql) {
+      try {
+        await initSchema(sql);
+        for (const c of deliverable) {
+          await sql`
+            insert into outreach_contacts
+              (campaign, email, full_name, company, position, first_line, status)
+            values
+              (${campaign}, ${c.email}, ${c.fullName ?? null}, ${c.company ?? null},
+               ${c.position ?? null}, ${c.firstLine ?? null}, 'active')
+            on conflict (campaign, email) do update set
+              full_name  = excluded.full_name,
+              company    = excluded.company,
+              position   = excluded.position,
+              first_line = excluded.first_line`;
+        }
+      } catch (err) {
+        ctx.logger.warn("launch: persistence failed, continuing", {
+          err: String(err),
+        });
+      } finally {
+        await sql.end({ timeout: 5 });
+      }
+    }
+
+    ctx.shared.set("touchIndex", 0);
+    return goto("send", {});
+  },
+});
+
+const send = defineStep({
+  name: "send",
+  next: ["advance", "done"],
+  // Static graph edge: on REPLY_SIGNAL, resume at `advance`. Matches the directive.
+  pause: { signal: REPLY_SIGNAL, resumeStep: "advance" },
+  async run(_input: unknown, ctx: Ctx) {
+    const campaign = ctx.shared.get("campaign") || "cold-outreach";
+    const sequence = ctx.shared.get("sequence") ?? DEFAULT_SEQUENCE;
+    const senderName = ctx.shared.get("senderName") || "The team";
+    const dbHandle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+    const touchIndex = ctx.shared.get("touchIndex") ?? 0;
+    const contacts = ctx.shared.get("contacts") ?? [];
+    const active = contacts.filter(
+      (c) => c.deliverable && c.status === "active",
+    );
+    const touch = sequence[touchIndex];
+
+    if (active.length === 0 || !touch) {
+      ctx.logger.info("nothing to send", {
+        touchIndex,
+        active: active.length,
+      });
+      return goto("done", {});
+    }
+
+    const inboxId = await resolveSenderInbox(ctx, senderName);
+    const sql = await openSql(ctx, dbHandle);
+    let sentThisTouch = 0;
+    try {
+      for (const c of active) {
+        const subject = render(touch.subject, c, senderName);
+        // The first touch leads with the personalized opener; later touches
+        // reference the thread and skip it.
+        const body =
+          touchIndex === 0
+            ? `${c.firstLine ?? fallbackFirstLine(c)}\n\n${render(touch.body, c, senderName)}`
+            : render(touch.body, c, senderName);
+        try {
+          const sent = await ctx.sapiom.email.messages.send(inboxId, {
+            to: c.email,
+            subject,
+            text: body,
+          });
+          sentThisTouch += 1;
+          if (sql) {
+            await sql`
+              insert into outreach_touches
+                (campaign, email, touch_index, subject, message_id)
+              values
+                (${campaign}, ${c.email}, ${touchIndex}, ${subject}, ${sent.messageId ?? null})`;
+          }
+        } catch (err) {
+          ctx.logger.warn("send failed for contact", {
+            email: c.email,
+            err: String(err),
+          });
+        }
+      }
+    } finally {
+      if (sql) await sql.end({ timeout: 5 });
+    }
+
+    ctx.shared.set("sent", (ctx.shared.get("sent") ?? 0) + sentThisTouch);
+    ctx.logger.info("sent drip touch", {
+      touchIndex,
+      recipients: active.length,
+      sent: sentThisTouch,
+    });
+
+    // Last touch: nothing left to wait for.
+    if (touchIndex >= sequence.length - 1) {
+      return goto("done", {});
+    }
+
+    // Durable wait: idle at $0 until the interval elapses OR a reply lands.
+    const dripMs = ctx.shared.get("dripMs") ?? DEFAULT_DRIP_DAYS * DAY_MS;
+    ctx.logger.info("pausing between touches", {
+      nextTouch: touchIndex + 1,
+      dripMs,
+    });
+    return pauseUntilSignal({
+      signal: REPLY_SIGNAL,
+      resumeStep: "advance",
+      correlationId: ctx.executionId,
+      timeoutMs: dripMs,
+    });
+  },
+});
+
+const advance = defineStep({
+  name: "advance",
+  next: ["send", "done"],
+  // Input is the reply-signal payload (`{ email }`) or empty on timeout.
+  async run(input: { email?: string } | undefined, ctx: Ctx) {
+    const campaign = ctx.shared.get("campaign") || "cold-outreach";
+    const dbHandle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+    const sequence = ctx.shared.get("sequence") ?? DEFAULT_SEQUENCE;
+    const contacts = ctx.shared.get("contacts") ?? [];
+    const replyEmail = input?.email?.trim().toLowerCase();
+
+    // A reply short-circuits the drip for that prospect.
+    if (replyEmail) {
+      let replied = false;
+      const updated = contacts.map((c) => {
+        if (c.email.toLowerCase() === replyEmail && c.status === "active") {
+          replied = true;
+          return { ...c, status: "replied" as const };
+        }
+        return c;
+      });
+      ctx.shared.set("contacts", updated);
+      if (replied) {
+        ctx.shared.set("replied", (ctx.shared.get("replied") ?? 0) + 1);
+        const sql = await openSql(ctx, dbHandle);
+        if (sql) {
+          try {
+            await sql`
+              update outreach_contacts set status = 'replied', replied_at = now()
+              where campaign = ${campaign} and email = ${replyEmail}`;
+          } catch (err) {
+            ctx.logger.warn("advance: reply persist failed", {
+              err: String(err),
+            });
+          } finally {
+            await sql.end({ timeout: 5 });
+          }
+        }
+        ctx.logger.info("prospect replied; removed from drip", {
+          email: replyEmail,
+        });
+      }
+    }
+
+    const touchIndex = (ctx.shared.get("touchIndex") ?? 0) + 1;
+    ctx.shared.set("touchIndex", touchIndex);
+    const stillActive = (ctx.shared.get("contacts") ?? []).filter(
+      (c) => c.deliverable && c.status === "active",
+    );
+
+    if (stillActive.length > 0 && touchIndex < sequence.length) {
+      return goto("send", {});
+    }
+    return goto("done", {});
+  },
+});
+
+const done = defineStep({
+  name: "done",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const contacts = ctx.shared.get("contacts") ?? [];
+    const campaign = ctx.shared.get("campaign") || "cold-outreach";
+    const summary = {
+      campaign,
+      dryRun: false,
+      touchesSent: ctx.shared.get("touchIndex") ?? 0,
+      enriched: contacts.length,
+      deliverable: contacts.filter((c) => c.deliverable).length,
+      sent: ctx.shared.get("sent") ?? 0,
+      replied: ctx.shared.get("replied") ?? 0,
+      contacts: contacts.map((c) => ({
+        email: c.email,
+        company: c.company,
+        deliverable: c.deliverable,
+        status: c.status,
+      })),
+    };
+    ctx.logger.info("outreach run complete", {
+      sent: summary.sent,
+      replied: summary.replied,
+    });
+    return terminate(summary);
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** Extract `{ i, firstLine }` pairs from the model output; empty on failure. */
+function parseLines(output: string | null): Record<number, string> {
+  const out: Record<number, string> = {};
+  if (!output) return out;
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return out;
+    const parsed = JSON.parse(output.slice(start, end + 1)) as {
+      lines?: unknown;
+    };
+    if (!Array.isArray(parsed.lines)) return out;
+    for (const raw of parsed.lines) {
+      if (!raw || typeof raw !== "object") continue;
+      const r = raw as Record<string, unknown>;
+      const i = Number(r.i);
+      const firstLine = String(r.firstLine ?? "").trim();
+      if (Number.isInteger(i) && i >= 0 && firstLine) out[i] = firstLine;
+    }
+  } catch {
+    // Non-JSON (e.g. the run_local stub placeholder) → every contact falls back.
+  }
+  return out;
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "cold-outreach-engine",
+  entry: "enrich",
+  steps: { enrich, scrape, personalize, verify, launch, send, advance, done },
+});

--- a/examples/cold-outreach-engine/package.json
+++ b/examples/cold-outreach-engine/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-cold-outreach-engine",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: enrich a lead list with Hunter, scrape each company site, write personalized first lines (models.run), verify deliverability, then drip touches with durable waits between them.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/cold-outreach-engine/template.json
+++ b/examples/cold-outreach-engine/template.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You hand it a list of companies — a domain each, optionally a person — and it does the whole cold-outreach prep and follow-up for you. It finds a real contact at each company with Hunter (`findEmail` when you name the person, `domainSearch` for a decision-maker when you don't), reads each company's website for a few lines of context, and asks the live model (`models.run`) to write one specific opener per prospect. Before anything sends, it checks each address for deliverability and drops the ones that would bounce.\n\nThen it runs the sequence itself. It sends the first touch — the personalized opener plus your ask — and pauses. The wait between touches is durable: the run idles at $0 for the drip interval and wakes on its own to send the next touch, but the moment a prospect replies it drops them from the sequence so they never get a follow-up meant for someone who ignored you. A short default sequence ships in the box — an opener, a bump, and a breakup — and you can pass your own.\n\nEverything it does is logged to a small Postgres store the engine owns, so the campaign roster, every touch, and who replied outlive the run. A `dryRun` does all the research and writes every opener, then returns the plan without sending, persisting, or waiting — so you can read the openers before a single email goes out.\n\nYou pay for the enrichment, one scrape per company, one model call, and the emails — the waiting between touches is free.",
+  "useCases": [
+    "Turn a raw list of target companies into personalized, deliverability-checked first emails.",
+    "Run a multi-touch drip that follows up on its own cadence and stops the instant someone replies.",
+    "Keep a durable log of who you contacted, what you sent, and who answered — across runs."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it `leads` — an array of `{ domain, company?, fullName? }` — and it enriches, personalizes, verifies, and starts the drip. Set `senderName` for the signature, `sequence` to override the default three touches, and `dripIntervalDays` for the gap between them (default 3). Pass `dryRun: true` to research and write every opener and get the plan back **without sending, persisting, or waiting** — the best first run.\n\nThis template **pauses between touches** and resumes on its own when the interval passes. To end the drip early when a prospect replies, fire the `reply.received` signal with the MCP `workflow_signal` tool (or the API), passing `{ \"email\": \"prospect@their-co.com\" }` and the run's `executionId` as the `correlationId` — there is no one-click signal button yet. To run it on a cadence over a fresh lead batch, attach the `schedule` as a cron trigger on the deployed workflow.\n\nPrefer to work from the code? Run it locally with `run_local` and `dryRun: true` to trace enrich → scrape → personalize → verify for free (capabilities stubbed), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Research + personalize one lead, preview only (dry run)",
+      "input": {
+        "dryRun": true,
+        "senderName": "Dana",
+        "leads": [
+          {
+            "domain": "acme.com",
+            "company": "Acme",
+            "fullName": "Jordan Rivera"
+          }
+        ]
+      },
+      "output": {
+        "campaign": "cold-outreach",
+        "dryRun": true,
+        "reason": "dry-run",
+        "touches": 3,
+        "enriched": 1,
+        "deliverable": 1,
+        "plan": [
+          {
+            "email": "jordan@acme.com",
+            "company": "Acme",
+            "deliverable": true,
+            "verifyStatus": "valid",
+            "firstLine": "Saw Acme just opened its platform API — the kind of move that usually means outreach volume is about to jump."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/cold-outreach-engine/tsconfig.json
+++ b/examples/cold-outreach-engine/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -365,6 +365,72 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "cold-outreach-engine",
+      "name": "Cold Outreach Personalization Engine",
+      "description": "Enrich a lead list, write a personalized first line for each prospect, verify deliverability, then drip follow-ups that stop the moment someone replies.",
+      "tags": ["outreach", "sales", "drip", "personalization"],
+      "sourcePath": "examples/cold-outreach-engine",
+      "capabilities": [
+        "email.domain.search",
+        "email.find",
+        "web.scrape",
+        "models.run",
+        "email.verify",
+        "database.get",
+        "database.create",
+        "email.send"
+      ],
+      "whatItDoes": "For turning a raw list of target companies into personalized outreach that follows up on its own. It finds a real contact at each company with Hunter, reads their website, and asks the live model (`models.run`) to write one specific opener per prospect. It verifies every address and drops the ones that would bounce before anything sends. Then it sends the first touch and pauses — idling at $0 between touches, waking on its own to send the next, but dropping anyone who replies so they never get a follow-up. Everything it sends is logged to a Postgres store it owns, and a `dryRun` returns the plan and every opener without sending a thing.",
+      "steps": [
+        {
+          "name": "enrich",
+          "description": "Resolve a real contact for each lead with Hunter — look up the named person, or surface a decision-maker when you only have the company.",
+          "capability": "email.domain.search",
+          "next": ["scrape"]
+        },
+        {
+          "name": "scrape",
+          "description": "Read each company's website for a few lines of context to personalize with.",
+          "capability": "web.scrape",
+          "next": ["personalize"]
+        },
+        {
+          "name": "personalize",
+          "description": "Ask the live model to write one specific opener per prospect, falling back to a safe generic line when it returns nothing usable.",
+          "capability": "models.run",
+          "next": ["verify"]
+        },
+        {
+          "name": "verify",
+          "description": "Check each address for deliverability and drop the ones that would bounce before anything sends.",
+          "capability": "email.verify",
+          "next": ["launch"]
+        },
+        {
+          "name": "launch",
+          "description": "Persist the campaign roster to a Postgres store the engine owns, then start the drip. A dry run stops here and returns the full plan without sending or persisting.",
+          "capability": "database.create",
+          "next": ["send"]
+        },
+        {
+          "name": "send",
+          "description": "Deliver the current touch to everyone still active and log it, then pause at $0 until the drip interval elapses or a prospect replies.",
+          "capability": "email.send",
+          "next": ["advance", "done"]
+        },
+        {
+          "name": "advance",
+          "description": "Wake on the reply-or-timeout, mark anyone who replied as done, then loop back for the next touch or end the run.",
+          "next": ["send", "done"]
+        },
+        {
+          "name": "done",
+          "description": "Return the campaign summary — who was enriched, how many were deliverable, what was sent, and who replied.",
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What & why

Adds the **Cold Outreach Personalization Engine** to the onboarding template gallery (epic SAP-1823, "grow the gallery to 8+"). Persona: sales / founder.

It turns a raw lead list into personalized, deliverability-checked outreach that follows up on its own:

```
enrich ─▶ scrape ─▶ personalize ─▶ verify ─▶ launch ─▶ send ⇄ advance ─▶ done
(Hunter)  (web)     (models.run)   (Hunter)  (database) (email)         (terminal)
```

- **enrich** — resolve a real contact per lead with Hunter (`findEmail` when a person is named, `domainSearch` for a decision-maker when only the company is known).
- **scrape** — read each company site for a few bounded lines of context (never enters shared state).
- **personalize** — the live model (`models.run`) writes one concrete opener per prospect; falls back to a safe generic line when it returns nothing usable (tolerates the `run_local` stub).
- **verify** — drop addresses that would bounce (`verifyEmail`) before anything sends.
- **launch** — persist the campaign roster to a Postgres store the engine owns; a `dryRun` returns the full plan here without sending, persisting, or waiting.
- **send ⇄ advance** — the drip loop: send a touch, then **pause at \$0** via `pauseUntilSignal` whose `timeoutMs` *is* the drip cadence and whose `reply.received` signal short-circuits it. `advance` drops anyone who replied and loops back or ends.

This template exercises the full capability set the ticket calls for: Hunter enrichment + email verify, scrape, LLM, database, email, `pauseUntilSignal`, and a documented cron cadence.

## Changes
- `examples/cold-outreach-engine/` — `index.ts` + `template.json`, `README.md`, `AGENTS.md`, `package.json`, `tsconfig.json`, `.gitignore`.
- One entry in `examples/registry.json`.
- Pins `@sapiom/agent ^0.6.5` / `@sapiom/tools ^0.20.0` (Hunter `emailSearch` + `email.send`), matching the newest DB+email siblings.

## Validation
- `npm run typecheck` ✅
- `prettier --check` ✅
- offline `buildManifest` + `assertValidGraph` (reproduces MCP \`check\`) ✅ — the static pause edge and the send↔advance cycle validate.

Follows the copy/structure contract in `examples/AUTHORING.md` and the patterns from the merged siblings (scheduled-research-brief, error-triage-digest, human-in-the-loop).

Closes SAP-1855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScwovdEE531oWc37L8fEU6