### PR TITLE
feat(harness): Tier-2 canvas enrichment via Sapiom workflow (SAP-1800)

### DIFF
--- a/examples/enrich-canvas/README.md
+++ b/examples/enrich-canvas/README.md
@@ -1,0 +1,50 @@
+# enrich-canvas (internal Sapiom workflow)
+
+The studio's **Tier-2 canvas enrichment**, run on **Sapiom's own account**.
+
+The harness renders a deterministic **Tier-1** structure diagram for a bound
+workflow entirely offline — no LLM, unkillable, free. `enrich-canvas` is the
+**opt-in Tier-2 overlay**: given the already-extracted graph plus the workflow's
+source bodies, one LLM step (`ctx.sapiom.models.run`) returns short text
+annotations — a summary, per-node sublabels/descriptions, edge labels, and a few
+notes — as a single JSON object matching the harness's `CanvasEnrichment`
+contract (`packages/harness/src/core/canvas-enrichment.ts`).
+
+## Why this exists
+
+It replaces the old headless-`claude` enrichment the studio spawned on the
+**user's** Claude Code tokens. Running the enrichment as a Sapiom workflow on our
+account means:
+
+- **0 user Claude tokens** — the enrichment is metered by us, not the user.
+- **Harness-agnostic** — it works for any session (claude-code, codex, …) because
+  it no longer depends on a local headless agent.
+- **Silent degrade** — the harness validates the returned object; on any failure
+  (or if this workflow isn't deployed/configured) the Tier-1 render simply
+  stands. There is no "Visualize failed" state.
+
+## Not a public template
+
+This is an internal workflow — it is intentionally **not** listed in
+`examples/registry.json`, so it never appears in the "Use this template" catalog.
+
+## Input / output
+
+- **Input:** `{ graph, stepBodies }` — the extracted `CanvasGraph` and a map of
+  the workflow's source files (workflow-relative path → contents). The harness
+  supplies both, so this workflow needs no filesystem access.
+- **Output:** one JSON object (`terminate(...)`) matching `CanvasEnrichment`.
+  Unparseable model output degrades to `{}` (an empty overlay), never a failure.
+
+## Deploy
+
+Deployed to Sapiom's account and wired into the harness by definition id:
+
+```bash
+cd examples/enrich-canvas
+sapiom agents deploy        # record the returned definitionId
+```
+
+Set the recorded id on the harness server via
+`SAPIOM_HARNESS_ENRICH_CANVAS_DEFINITION_ID`. When it is unset, the harness skips
+enrichment and renders Tier-1 only.

--- a/examples/enrich-canvas/index.ts
+++ b/examples/enrich-canvas/index.ts
@@ -1,0 +1,173 @@
+import {
+  defineAgent,
+  defineStep,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * enrich-canvas — the harness's Tier-2 canvas enrichment, run on OUR account.
+ *
+ * This is the Sapiom-owned replacement for the token-burning headless-`claude`
+ * enrichment the studio used to spawn on the user's own Claude Code tokens. The
+ * harness renders a deterministic Tier-1 structure diagram offline (zero LLM,
+ * unkillable); this workflow is the opt-in Tier-2 overlay: given the already
+ * extracted graph plus the workflow's source bodies, one LLM step returns short
+ * text annotations (labels / summary / notes) as a single JSON object. It runs
+ * on Sapiom's account, so it is metered by us — the user spends 0 Claude tokens.
+ *
+ * Contract — the returned object is validated by the harness against
+ * `CanvasEnrichment` (packages/harness/src/core/canvas-enrichment.ts). The
+ * harness discards the whole thing on any schema violation and the Tier-1 base
+ * render stands, so this step never needs to be strict: it returns its best
+ * effort and lets the harness be the hard line. Invalid / unparseable model
+ * output degrades to an empty enrichment (`{}`), never a failure the pane shows.
+ *
+ * WHY graph + bodies come in as INPUT (not read from disk): the harness has the
+ * filesystem, this workflow does not. The harness extracts the graph and reads
+ * the step source bodies, then passes both as the run input — this workflow
+ * needs no filesystem access at all.
+ */
+
+/**
+ * Enrichment length caps. These MUST stay in sync with `ENRICHMENT_LIMITS` in
+ * packages/harness/src/core/canvas-enrichment.ts — the harness re-validates
+ * against those exact caps and clamps a few-words-over string rather than
+ * rejecting, but stating them here keeps a well-behaved run comfortably inside
+ * the schema so nothing gets truncated mid-sentence.
+ */
+const LIMITS = {
+  summary: 160,
+  sublabel: 48,
+  description: 120,
+  edgeLabel: 32,
+  noteCount: 3,
+  note: 140,
+  groupLabel: 48,
+  crossWorkflow: 160,
+} as const;
+
+/** Ceiling on the model's output — the contract is a handful of short strings,
+ *  so a small budget is plenty and keeps a runaway answer bounded. */
+const MAX_OUTPUT_TOKENS = 1500;
+
+/** The run input: the extracted graph and the workflow's own source bodies,
+ *  keyed by workflow-relative file path (the step `run()` bodies live here). */
+interface EnrichCanvasInput extends Record<string, unknown> {
+  graph: unknown;
+  stepBodies?: Record<string, string>;
+}
+
+/**
+ * Build the one-shot enrichment prompt: the extracted graph inline (the model
+ * annotates THIS structure — it never invents nodes) plus the workflow's source
+ * bodies for semantics, with the JSON contract and its hard limits stated
+ * verbatim so a well-behaved run needs no retry. Mirrors the prompt the
+ * headless enrichment used, minus the "read files / don't write files"
+ * filesystem language — this workflow has neither the files nor the ability to
+ * write them.
+ */
+function buildEnrichmentPrompt(
+  graph: unknown,
+  stepBodies: Record<string, string>,
+): string {
+  const bodies = Object.entries(stepBodies);
+  const sources =
+    bodies.length > 0
+      ? bodies
+          .map(([file, body]) => `--- ${file} ---\n${body}`)
+          .join("\n\n")
+      : "(no source bodies were provided — annotate from the graph alone)";
+
+  return `You are annotating an already-rendered workflow diagram. The diagram's structure below is fixed — you only supply short text annotations, as one JSON object.
+
+Extracted workflow graph:
+${JSON.stringify(graph, null, 2)}
+
+The workflow's source (read the step run() bodies to understand what each step actually does — what it calls, what it decides, why it branches):
+${sources}
+
+RETURN ONLY a JSON object matching this schema — no prose before or after, no markdown required:
+
+{
+  "summary": "what this workflow does, one line (max ${LIMITS.summary} chars)",
+  "nodeDetails": { "<nodeId>": { "sublabel": "short annotation shown in the node (max ${LIMITS.sublabel} chars)", "description": "one sentence, shown on hover (max ${LIMITS.description} chars)" } },
+  "edgeLabels": { "<fromNodeId>-><toNodeId>": "intent/condition name (max ${LIMITS.edgeLabel} chars)" },
+  "notes": ["up to ${LIMITS.noteCount} facts worth knowing, each max ${LIMITS.note} chars"],
+  "layoutHints": { "groups": [{ "label": "group name (max ${LIMITS.groupLabel} chars)", "nodeIds": ["..."] }], "laneOrder": { "<layerIndex>": ["nodeId", "..."] } },
+  "crossWorkflow": "how this workflow ties into the project's other workflows, if it does (max ${LIMITS.crossWorkflow} chars)"
+}
+
+Rules:
+- Every field is optional — omit what you have nothing useful for (omit, don't write null). Empty strings are worse than omissions.
+- Use ONLY node ids that appear in the graph above.
+- Length limits are hard caps and oversize strings get truncated mid-sentence — aim comfortably under each limit.
+- Your final message must be exactly the JSON object.`;
+}
+
+/**
+ * Pull the JSON object out of the model's final text — fenced (\`\`\`json … \`\`\`)
+ * or raw, tolerating prose around it by falling back to the outermost {…} span.
+ * Null when nothing parses. Mirrors `extractEnrichmentJson` on the harness side;
+ * the harness re-validates, so this only has to get the object out.
+ */
+function extractEnrichmentJson(text: string): Record<string, unknown> | null {
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(text);
+  const candidates: (string | undefined)[] = [fenced?.[1], text];
+  const first = text.indexOf("{");
+  const last = text.lastIndexOf("}");
+  if (first !== -1 && last > first) candidates.push(text.slice(first, last + 1));
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const parsed: unknown = JSON.parse(candidate.trim());
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Try the next candidate shape.
+    }
+  }
+  return null;
+}
+
+const enrich = defineStep({
+  name: "enrich",
+  next: [],
+  terminal: true,
+  async run(
+    input: EnrichCanvasInput,
+    ctx: AgentExecutionContext<EnrichCanvasInput>,
+  ) {
+    const graph = input.graph ?? {};
+    const stepBodies = input.stepBodies ?? {};
+    ctx.logger.info("enriching canvas", {
+      sourceFiles: Object.keys(stepBodies).length,
+    });
+
+    // One metered LLM call on OUR account (models.run → llm.generate). The
+    // result's `output` is the model's final text; we parse the JSON object out
+    // and hand it back as the run output for the harness to validate.
+    const result = await ctx.sapiom.models.run({
+      prompt: buildEnrichmentPrompt(graph, stepBodies),
+      system:
+        "You annotate workflow diagrams. You reply with exactly one JSON object and nothing else.",
+      maxTokens: MAX_OUTPUT_TOKENS,
+    });
+
+    const enrichment = result.output ? extractEnrichmentJson(result.output) : null;
+    if (!enrichment) {
+      // Honest empty overlay — the harness keeps the Tier-1 render; the user
+      // sees the structure, just no annotations. Never a failure state.
+      ctx.logger.info("no parseable enrichment — returning empty overlay");
+      return terminate({});
+    }
+    return terminate(enrichment);
+  },
+});
+
+export const agent = defineAgent<EnrichCanvasInput, EnrichCanvasInput>({
+  name: "enrich-canvas",
+  entry: "enrich",
+  steps: { enrich },
+});

--- a/examples/enrich-canvas/package.json
+++ b/examples/enrich-canvas/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/workflow-enrich-canvas",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Internal Sapiom workflow: Tier-2 canvas enrichment (labels / summary / notes) for the studio, run on Sapiom's account so the user spends 0 Claude tokens.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/enrich-canvas/tsconfig.json
+++ b/examples/enrich-canvas/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/harness/src/core/canvas-enrich.test.ts
+++ b/packages/harness/src/core/canvas-enrich.test.ts
@@ -2,19 +2,16 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { BackgroundTask } from "../shared/types.js";
 import type { CachedExtraction } from "./canvas-cache.js";
 import type { CanvasGraph } from "./canvas-graph.js";
 import { readEnrichmentCacheFile, writeEnrichmentCacheFile } from "./canvas-enrichment.js";
 import { enrichmentCacheFileFor, type RenderableWorkflow } from "./canvas-render.js";
-import { TaskAlreadyRunningError, TaskNotSupportedError, type RunTaskRequest } from "./task-manager.js";
+import { TaskAlreadyRunningError } from "./task-manager.js";
+import type { EnrichCanvasClient, EnrichCanvasRunResult } from "./enrich-canvas-client.js";
 import {
   CanvasEnrichmentCoordinator,
-  buildEnrichmentPrompt,
-  enrichmentModel,
-  extractEnrichmentJson,
+  readWorkflowStepBodies,
   type EnrichmentSession,
-  type EnrichmentTaskRunner,
 } from "./canvas-enrich.js";
 
 const GRAPH: CanvasGraph = {
@@ -28,108 +25,13 @@ const GRAPH: CanvasGraph = {
   edges: [{ from: "intake", to: "route", kind: "sequential" }],
 };
 
-describe("buildEnrichmentPrompt", () => {
-  it("carries the graph inline, points at the workflow dir, and states the JSON-only / no-file-writes contract", () => {
-    const prompt = buildEnrichmentPrompt(GRAPH, "/proj/order-triage");
-    expect(prompt).toContain('"manifestName": "order-triage"');
-    expect(prompt).toContain("run() bodies in /proj/order-triage");
-    expect(prompt).toMatch(/RETURN ONLY a JSON object/);
-    expect(prompt).toMatch(/DO NOT write or modify any files/);
-    // The hard caps ride in the prompt so a well-behaved run needs no retry.
-    expect(prompt).toContain("max 160 chars");
-    expect(prompt).toContain("max 48 chars");
-  });
-});
-
-describe("enrichmentModel", () => {
-  it("defaults to sonnet and honors the env override", () => {
-    expect(enrichmentModel({} as NodeJS.ProcessEnv)).toBe("sonnet");
-    expect(enrichmentModel({ SAPIOM_HARNESS_VISUALIZE_MODEL: "haiku" } as unknown as NodeJS.ProcessEnv)).toBe("haiku");
-  });
-});
-
-describe("extractEnrichmentJson", () => {
-  it("parses a raw JSON object", () => {
-    expect(extractEnrichmentJson('{"summary":"hi"}')).toEqual({ summary: "hi" });
-  });
-  it("parses a fenced block, with or without the json tag", () => {
-    expect(extractEnrichmentJson('```json\n{"summary":"hi"}\n```')).toEqual({ summary: "hi" });
-    expect(extractEnrichmentJson('```\n{"summary":"hi"}\n```')).toEqual({ summary: "hi" });
-  });
-  it("recovers the outermost object from surrounding prose", () => {
-    expect(extractEnrichmentJson('Here you go:\n{"summary":"hi"}\nHope that helps!')).toEqual({ summary: "hi" });
-  });
-  it("returns null for text with no parsable object", () => {
-    expect(extractEnrichmentJson("I could not analyze the workflow.")).toBeNull();
-    expect(extractEnrichmentJson("")).toBeNull();
-  });
-});
+/** The `enrich-canvas` workflow returns the parsed enrichment object directly
+ *  as its run output — the harness only has to validate it. */
+const VALID_OUTPUT = { summary: "routes orders", edgeLabels: { "intake->route": "normalized" } };
 
 // ---------------------------------------------------------------------------
-// Coordinator
+// tmp dir helpers
 // ---------------------------------------------------------------------------
-
-interface FakeRunner extends EnrichmentTaskRunner {
-  requests: RunTaskRequest[];
-  emit(task: BackgroundTask): void;
-  lastTask(): BackgroundTask;
-}
-
-function makeRunner(): FakeRunner {
-  const listeners = new Set<(task: BackgroundTask) => void>();
-  const requests: RunTaskRequest[] = [];
-  const running = new Map<string, BackgroundTask>(); // keyed by task id
-  let n = 0;
-  let last: BackgroundTask | undefined;
-  return {
-    requests,
-    async run(req) {
-      requests.push(req);
-      last = {
-        id: `task-${++n}`,
-        macroId: req.macroId,
-        label: req.label,
-        harnessSessionId: req.harnessSessionId,
-        cwd: req.cwd,
-        workflowPath: req.workflowPath ?? null,
-        status: "running",
-        startedAt: "2026-01-01T00:00:00.000Z",
-        endedAt: null,
-        exitCode: null,
-        statusLines: [],
-        resultText: null,
-        errorTail: null,
-      };
-      running.set(last.id, last);
-      return last;
-    },
-    onStatusChange(listener) {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
-    isRunning(macroId: string, workflowPath: string): boolean {
-      for (const task of running.values()) {
-        if (task.status === "running" && task.macroId === macroId && task.workflowPath === workflowPath) {
-          return true;
-        }
-      }
-      return false;
-    },
-    emit(task) {
-      // Mirror real TaskManager: update status in running map when emitting
-      const existing = running.get(task.id);
-      if (existing) {
-        existing.status = task.status;
-        if (task.status !== "running") running.delete(task.id);
-      }
-      for (const listener of [...listeners]) listener(task);
-    },
-    lastTask() {
-      if (!last) throw new Error("no task spawned");
-      return last;
-    },
-  };
-}
 
 const tmpDirs: string[] = [];
 afterEach(async () => {
@@ -141,171 +43,95 @@ async function tmpCwd(): Promise<string> {
   return dir;
 }
 
+// ---------------------------------------------------------------------------
+// readWorkflowStepBodies
+// ---------------------------------------------------------------------------
+
+describe("readWorkflowStepBodies", () => {
+  it("reads the workflow's source files keyed by workflow-relative path", async () => {
+    const dir = await tmpCwd();
+    await fs.writeFile(path.join(dir, "index.ts"), "export const agent = defineAgent({});\n");
+    const bodies = await readWorkflowStepBodies(dir);
+    expect(bodies["index.ts"]).toContain("export const agent");
+  });
+
+  it("returns an empty map for a directory with no readable sources", async () => {
+    const dir = await tmpCwd();
+    expect(await readWorkflowStepBodies(dir)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coordinator
+// ---------------------------------------------------------------------------
+
 const WORKFLOW: RenderableWorkflow = { path: "/proj/order-triage", name: "order-triage", definitionId: null };
 
 function makeSession(cwd: string): EnrichmentSession {
-  return { id: "sess-1", cwd, harness: "claude-code", boundWorkflowPath: WORKFLOW.path };
+  return { cwd, boundWorkflowPath: WORKFLOW.path };
 }
 
 function extraction(fingerprint: string): (dir: string) => Promise<CachedExtraction> {
   return async () => ({ result: { ok: true, graph: GRAPH }, cached: true, fingerprint });
 }
 
-function makeCoordinator(runner: FakeRunner, cwd: string, overrides: Record<string, unknown> = {}) {
+/** A fake client whose single `run` is a vi.fn — tests set its resolution
+ *  (ok/output, a failure, or a never-settling promise for the in-flight guard). */
+interface FakeClient extends EnrichCanvasClient {
+  run: ReturnType<typeof vi.fn>;
+}
+function makeClient(result: EnrichCanvasRunResult = { ok: true, executionId: "exec_1", output: VALID_OUTPUT }): FakeClient {
+  return { run: vi.fn().mockResolvedValue(result) };
+}
+
+function makeCoordinator(cwd: string, overrides: Record<string, unknown> = {}) {
+  const client = (overrides.client as FakeClient) ?? makeClient();
   const rerender = vi.fn().mockResolvedValue(undefined);
+  const readStepBodies = vi.fn().mockResolvedValue({ "index.ts": "export const agent = defineAgent({});" });
   const onError = vi.fn();
   const coordinator = new CanvasEnrichmentCoordinator({
-    tasks: runner,
+    client,
+    definitionId: "def_enrich",
     rerender,
+    readStepBodies,
     extractCached: extraction("fp-1"),
-    env: {} as NodeJS.ProcessEnv,
     now: () => "2026-01-02T00:00:00.000Z",
     onError,
     ...overrides,
   });
-  return { coordinator, rerender, onError, session: makeSession(cwd) };
+  return { coordinator, client, rerender, readStepBodies, onError, session: makeSession(cwd) };
 }
 
-const VALID_RESULT = '```json\n{"summary":"routes orders","edgeLabels":{"intake->route":"normalized"}}\n```';
-
-describe("CanvasEnrichmentCoordinator.ensureFresh", () => {
-  it("spawns one enrichment task with the visualize macro identity, sonnet, the turn cap and the workflowPath", async () => {
-    const runner = makeRunner();
+describe("CanvasEnrichmentCoordinator.forceRefresh — no auto-fire; the visualize macro is the ONLY trigger", () => {
+  it("runs enrich-canvas on our account with graph + stepBodies, persists the validated output, and re-renders", async () => {
     const cwd = await tmpCwd();
-    const { coordinator, session } = makeCoordinator(runner, cwd);
+    const { coordinator, client, rerender, session } = makeCoordinator(cwd);
 
-    await coordinator.ensureFresh(session, [WORKFLOW]);
+    await coordinator.forceRefresh(session, [WORKFLOW]);
 
-    expect(runner.requests).toHaveLength(1);
-    const req = runner.requests[0];
-    expect(req.macroId).toBe("visualize");
-    expect(req.harnessSessionId).toBe("sess-1");
-    expect(req.workflowPath).toBe(WORKFLOW.path);
-    expect(req.model).toBe("sonnet");
-    expect(req.maxTurns).toBe(8);
-    expect(req.prompt).toContain('"manifestName": "order-triage"');
-  });
-
-  it("persists the validated enrichment to the cache file and re-renders on completion", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
-
-    await coordinator.ensureFresh(session, [WORKFLOW]);
-    runner.emit({ ...runner.lastTask(), status: "completed", resultText: VALID_RESULT });
     await vi.waitFor(async () => {
-      expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW);
+      const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path));
+      expect(entry).toEqual({
+        graph: GRAPH,
+        enrichment: VALID_OUTPUT,
+        sourceFingerprint: "fp-1",
+        enrichedAt: "2026-01-02T00:00:00.000Z",
+      });
     });
-
-    const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path));
-    expect(entry).toEqual({
+    expect(client.run).toHaveBeenCalledWith("def_enrich", {
       graph: GRAPH,
-      enrichment: { summary: "routes orders", edgeLabels: { "intake->route": "normalized" } },
-      sourceFingerprint: "fp-1",
-      enrichedAt: "2026-01-02T00:00:00.000Z",
+      stepBodies: { "index.ts": expect.any(String) },
     });
+    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW);
   });
 
-  it("skips the spawn when the cached enrichment's fingerprint matches the current sources", async () => {
-    const runner = makeRunner();
+  it("drops even a FRESH cache and re-renders the Tier-1 base BEFORE the enrichment lands", async () => {
     const cwd = await tmpCwd();
-    const { coordinator, session } = makeCoordinator(runner, cwd);
-    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
-      graph: GRAPH,
-      enrichment: { summary: "already fresh" },
-      sourceFingerprint: "fp-1",
-      enrichedAt: "2026-01-01T00:00:00.000Z",
-    });
-
-    await coordinator.ensureFresh(session, [WORKFLOW]);
-    expect(runner.requests).toHaveLength(0);
-  });
-
-  it("re-spawns when the cached fingerprint is stale", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, session } = makeCoordinator(runner, cwd, { extractCached: extraction("fp-2") });
-    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
-      graph: GRAPH,
-      enrichment: { summary: "from older sources" },
-      sourceFingerprint: "fp-1",
-      enrichedAt: "2026-01-01T00:00:00.000Z",
-    });
-
-    await coordinator.ensureFresh(session, [WORKFLOW]);
-    expect(runner.requests).toHaveLength(1);
-  });
-
-  it("discards invalid output whole — no cache write, no re-render, base render stands", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, rerender, onError, session } = makeCoordinator(runner, cwd);
-
-    await coordinator.ensureFresh(session, [WORKFLOW]);
-    runner.emit({
-      ...runner.lastTask(),
-      status: "completed",
-      // Valid JSON, structurally invalid enrichment — beyond what the
-      // bounds/nulls normalization repairs.
-      resultText: JSON.stringify({ nodeDetails: "not an object" }),
-    });
-    await vi.waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(expect.stringContaining("invalid output"));
-    });
-
-    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
-    expect(rerender).not.toHaveBeenCalled();
-  });
-
-  it("persists nothing when the task fails — the pane's failure state owns that path", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
-
-    await coordinator.ensureFresh(session, [WORKFLOW]);
-    runner.emit({ ...runner.lastTask(), status: "failed", errorTail: "exploded" });
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
-    expect(rerender).not.toHaveBeenCalled();
-  });
-
-  it("is silent for unbound sessions, failed extractions, and expected spawn refusals", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, onError } = makeCoordinator(runner, cwd);
-
-    await coordinator.ensureFresh({ ...makeSession(cwd), boundWorkflowPath: null }, [WORKFLOW]);
-    expect(runner.requests).toHaveLength(0);
-
-    const failing = makeCoordinator(runner, cwd, {
-      extractCached: async (): Promise<CachedExtraction> => ({
-        result: { ok: false, reason: "run npm install first" },
-        cached: false,
-        fingerprint: "fp-1",
-      }),
-    });
-    await failing.coordinator.ensureFresh(failing.session, [WORKFLOW]);
-    expect(runner.requests).toHaveLength(0);
-
-    for (const refusal of [new TaskAlreadyRunningError("Visualize"), new TaskNotSupportedError("codex", "Visualize")]) {
-      const refusing = makeCoordinator(
-        { ...runner, run: vi.fn().mockRejectedValue(refusal) } as unknown as FakeRunner,
-        cwd,
-      );
-      await expect(refusing.coordinator.ensureFresh(refusing.session, [WORKFLOW])).resolves.toBeUndefined();
-      expect(refusing.onError).not.toHaveBeenCalled();
-    }
-    expect(onError).not.toHaveBeenCalled();
-  });
-});
-
-describe("CanvasEnrichmentCoordinator.forceRefresh", () => {
-  it("drops the enrichment cache, re-renders the base immediately, then re-spawns the task", async () => {
-    const runner = makeRunner();
-    const cwd = await tmpCwd();
-    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
-    await writeEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path), {
+    // A never-settling run: the base re-render must be observable before it.
+    const client = { run: vi.fn().mockReturnValue(new Promise<never>(() => {})) } as unknown as FakeClient;
+    const { coordinator, rerender, session } = makeCoordinator(cwd, { client });
+    const cacheFile = enrichmentCacheFileFor(cwd, WORKFLOW.path);
+    await writeEnrichmentCacheFile(cacheFile, {
       graph: GRAPH,
       enrichment: { summary: "even a FRESH cache is dropped — the user asked for a redo" },
       sourceFingerprint: "fp-1",
@@ -314,69 +140,99 @@ describe("CanvasEnrichmentCoordinator.forceRefresh", () => {
 
     await coordinator.forceRefresh(session, [WORKFLOW]);
 
+    expect(await readEnrichmentCacheFile(cacheFile)).toBeNull();
+    expect(rerender).toHaveBeenCalledTimes(1); // the base render, before any annotations
+    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW);
+    expect(client.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards invalid output whole — logs, no cache write, base render stands", async () => {
+    const cwd = await tmpCwd();
+    // Valid JSON, structurally invalid enrichment (beyond bounds/nulls repair).
+    const client = makeClient({ ok: true, executionId: "exec_1", output: { nodeDetails: "not an object" } });
+    const { coordinator, onError, session } = makeCoordinator(cwd, { client });
+
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("invalid output"));
+    });
     expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
-    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW); // base render, before the task lands
-    expect(runner.requests).toHaveLength(1);
   });
 
-  it("propagates TaskAlreadyRunningError — the macros router turns it into a 409", async () => {
-    const runner = makeRunner();
+  it("degrades silently when the workflow run does not complete — logged, base stands, no cache", async () => {
     const cwd = await tmpCwd();
-    const refusing = { ...runner, run: vi.fn().mockRejectedValue(new TaskAlreadyRunningError("Visualize")) };
-    const { coordinator, session } = makeCoordinator(refusing as unknown as FakeRunner, cwd);
+    const client = makeClient({ ok: false, status: 504, error: "timed out waiting for the run to finish" });
+    const { coordinator, onError, session } = makeCoordinator(cwd, { client });
 
-    await expect(coordinator.forceRefresh(session, [WORKFLOW])).rejects.toBeInstanceOf(TaskAlreadyRunningError);
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("did not complete"));
+    });
+    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
   });
 
-  it("double-click guard: second forceRefresh while a task is running rejects BEFORE touching the cache or re-rendering", async () => {
-    const runner = makeRunner();
+  it("skips the annotation pass entirely when no definition id is configured — Tier-1 renders, workflow never runs", async () => {
     const cwd = await tmpCwd();
-    const { coordinator, rerender, session } = makeCoordinator(runner, cwd);
+    const { coordinator, client, rerender, session } = makeCoordinator(cwd, { definitionId: "" });
 
-    // Write an enrichment cache file that should survive the second call.
-    const cacheFile = enrichmentCacheFileFor(cwd, WORKFLOW.path);
-    await writeEnrichmentCacheFile(cacheFile, {
-      graph: GRAPH,
-      enrichment: { summary: "cached annotations" },
-      sourceFingerprint: "fp-1",
-      enrichedAt: "2026-01-01T00:00:00.000Z",
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+
+    expect(client.run).not.toHaveBeenCalled();
+    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW); // base render still happens
+    expect(await readEnrichmentCacheFile(enrichmentCacheFileFor(cwd, WORKFLOW.path))).toBeNull();
+  });
+
+  it("re-renders the base but does not run the workflow when extraction fails", async () => {
+    const cwd = await tmpCwd();
+    const { coordinator, client, rerender, session } = makeCoordinator(cwd, {
+      extractCached: async (): Promise<CachedExtraction> => ({
+        result: { ok: false, reason: "run npm install first" },
+        cached: false,
+        fingerprint: "fp-1",
+      }),
     });
 
-    // First forceRefresh: starts the task (cache is cleared, rerender called once).
     await coordinator.forceRefresh(session, [WORKFLOW]);
-    expect(runner.requests).toHaveLength(1);
-    // The running task is still in flight (never emitted a terminal status).
 
-    // Write the cache back, simulating the state mid-run where the cache has
-    // been partially repopulated (or was never cleared yet by the second call).
+    expect(rerender).toHaveBeenCalledWith(cwd, WORKFLOW);
+    expect(client.run).not.toHaveBeenCalled();
+  });
+
+  it("double-click guard: a second forceRefresh while one is in flight rejects with TaskAlreadyRunningError before touching the cache or re-rendering", async () => {
+    const cwd = await tmpCwd();
+    // First run never settles, so the workflow stays in flight.
+    const client = { run: vi.fn().mockReturnValue(new Promise<never>(() => {})) } as unknown as FakeClient;
+    const { coordinator, rerender, session } = makeCoordinator(cwd, { client });
+    const cacheFile = enrichmentCacheFileFor(cwd, WORKFLOW.path);
+
+    await coordinator.forceRefresh(session, [WORKFLOW]);
+    expect(client.run).toHaveBeenCalledTimes(1);
+
+    // Simulate the cache present mid-run; the second call must leave it intact.
     await writeEnrichmentCacheFile(cacheFile, {
       graph: GRAPH,
       enrichment: { summary: "mid-run annotations" },
       sourceFingerprint: "fp-1",
       enrichedAt: "2026-01-01T00:00:00.000Z",
     });
-
-    // Second forceRefresh while the task is still running: must reject with
-    // TaskAlreadyRunningError and be a true no-op — cache untouched, no
-    // additional rerender, no additional spawn.
     const rerenderCallsBefore = rerender.mock.calls.length;
+
     await expect(coordinator.forceRefresh(session, [WORKFLOW])).rejects.toBeInstanceOf(TaskAlreadyRunningError);
 
-    // Cache survives the second call (the running enrichment still needs it).
     expect(await readEnrichmentCacheFile(cacheFile)).not.toBeNull();
-    // No additional rerender was triggered.
     expect(rerender.mock.calls.length).toBe(rerenderCallsBefore);
-    // No additional task was spawned.
-    expect(runner.requests).toHaveLength(1);
+    expect(client.run).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op for an unbound session — matching the deterministic render's unbound contract", async () => {
-    const runner = makeRunner();
+  it("is a no-op for an unbound session — no render, no workflow", async () => {
     const cwd = await tmpCwd();
-    const { coordinator, rerender } = makeCoordinator(runner, cwd);
+    const { coordinator, client, rerender } = makeCoordinator(cwd);
 
-    await coordinator.forceRefresh({ ...makeSession(cwd), boundWorkflowPath: null }, [WORKFLOW]);
+    await coordinator.forceRefresh({ cwd, boundWorkflowPath: null }, [WORKFLOW]);
+
     expect(rerender).not.toHaveBeenCalled();
-    expect(runner.requests).toHaveLength(0);
+    expect(client.run).not.toHaveBeenCalled();
   });
 });

--- a/packages/harness/src/core/canvas-enrich.ts
+++ b/packages/harness/src/core/canvas-enrich.ts
@@ -1,35 +1,37 @@
 /**
- * The AI enrichment runner: spawns ONE bounded, headless agent task per
- * workflow (via TaskManager) that reads the workflow's step bodies and
- * returns the JSON `CanvasEnrichment` contract — never HTML, never a file
- * write. On success the validated enrichment is persisted to the workflow's
- * cache file and the render file is rebuilt with it merged in; on any
- * parse/validation failure the enrichment is discarded whole and the base
- * render stands (core/canvas-enrichment.ts's contract). Task-process
- * failures surface through the task record itself (the pane's error state +
- * Retry), never as HTML on disk.
+ * Tier-2 canvas enrichment (SAP-1800): the OPT-IN annotation layer over the
+ * deterministic Tier-1 render.
  *
- * Triggering (see server/index.ts):
- * - bind / session create → `ensureFresh`: spawn only when no cache entry
- *   matches the current source fingerprint; every skip reason is silent.
- * - the visualize macro → `forceRefresh`: drop the extraction + enrichment
- *   caches, re-render the base immediately, re-enrich; refusals propagate
- *   (an already-running enrichment for this workflow → 409 via the macros
- *   router, exactly like any other double-fired background macro).
+ * The producer is the Sapiom `enrich-canvas` workflow, run ON OUR ACCOUNT via
+ * {@link EnrichCanvasClient} — NOT a headless `claude -p` task on the user's
+ * Claude Code tokens. Given the extracted graph plus the workflow's source
+ * bodies, the workflow returns the JSON `CanvasEnrichment` contract
+ * (core/canvas-enrichment.ts); on success the validated enrichment is persisted
+ * to the workflow's cache file and the render file is rebuilt with it merged in
+ * (the write alone hot-reloads any open pane via the canvas watcher).
  *
- * Dedupe is per WORKFLOW, not per session: TaskManager refuses a second
- * running task with the same macroId + workflowPath regardless of which
- * session asked (see TaskAlreadyRunningError) — two panes bound to the same
- * workflow can never race its cache/render files.
+ * Tier-1 is unkillable, so enrichment failure has no total-failure state:
+ * - It NEVER auto-fires. The only trigger is the explicit `visualize` macro
+ *   (`forceRefresh`) — there is no bind/session-create `ensureFresh` anymore.
+ * - On ANY failure — not signed in, workflow not deployed/configured, upstream
+ *   error, timeout, or invalid output — the enrichment is discarded whole and
+ *   the base render already on disk stands. Nothing surfaces as an error to the
+ *   pane; the user sees the honest Tier-1 structure.
+ *
+ * Dedupe is per WORKFLOW: a second force refresh while one is still in flight
+ * for the same workflow rejects with {@link TaskAlreadyRunningError} (→ 409 via
+ * the macros router) before any cache/render mutation, so a double-click
+ * Visualize is a true no-op.
  */
-import type { BackgroundTask, HarnessKind } from "../shared/types.js";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
 import { extractWorkflowGraphCached, invalidateExtractionCache, type CachedExtraction } from "./canvas-cache.js";
+import { listSourceFiles } from "./canvas-interconnections.js";
 import type { CanvasGraph } from "./canvas-graph.js";
 import {
-  ENRICHMENT_LIMITS,
   normalizeCanvasEnrichmentCandidate,
   parseCanvasEnrichment,
-  readEnrichmentCacheFile,
   removeEnrichmentCacheFile,
   writeEnrichmentCacheFile,
 } from "./canvas-enrichment.js";
@@ -38,166 +40,114 @@ import {
   renderWorkflowRenderFile,
   type RenderableWorkflow,
 } from "./canvas-render.js";
-import type { RunTaskRequest } from "./task-manager.js";
-import { TaskAlreadyRunningError, TaskNotSupportedError } from "./task-manager.js";
+import type { EnrichCanvasClient } from "./enrich-canvas-client.js";
+import { TaskAlreadyRunningError } from "./task-manager.js";
 
-/** The macro identity enrichment tasks run under — the pane's Retry re-fires
- *  this macro, which routes back through forceRefresh. */
-export const ENRICHMENT_MACRO_ID = "visualize";
+/** Label the in-flight guard rejects under — surfaced as the 409 message. */
 const ENRICHMENT_TASK_LABEL = "Visualize";
-/** Hard turn cap: read a few step files, answer. A run that needs more than
- *  this is off the rails, not thorough. */
-const ENRICHMENT_MAX_TURNS = 8;
-const DEFAULT_ENRICHMENT_MODEL = "sonnet";
 
-/** Model the enrichment task runs on — overridable per install. */
-export function enrichmentModel(env: NodeJS.ProcessEnv = process.env): string {
-  return env.SAPIOM_HARNESS_VISUALIZE_MODEL || DEFAULT_ENRICHMENT_MODEL;
-}
+/** Per-file cap when reading step bodies to hand the workflow — a source file
+ *  larger than this is skipped rather than blown up into the prompt. */
+const MAX_STEP_BODY_FILE_BYTES = 128 * 1024;
+/** Total cap across all step bodies — bounds the workflow input regardless of
+ *  how many source files the project has. */
+const MAX_STEP_BODY_TOTAL_BYTES = 200 * 1024;
 
 /**
- * Builds the one-shot enrichment prompt: the extracted graph inline (the AI
- * annotates THIS structure — it never invents nodes), pointed at the step
- * sources for semantics, with the JSON contract and its hard limits stated
- * verbatim so a well-behaved run needs no retry.
+ * Reads the workflow's own `.ts`/`.tsx` source bodies (the step `run()` bodies
+ * live here), keyed by workflow-relative path — the material the Sapiom
+ * workflow annotates against. Bounded per-file and in total so a large project
+ * can't produce an unbounded workflow input. Uses the same source walk the
+ * extraction fingerprint uses ({@link listSourceFiles}).
  */
-export function buildEnrichmentPrompt(graph: CanvasGraph, workflowDir: string): string {
-  const L = ENRICHMENT_LIMITS;
-  return `You are annotating an already-rendered workflow diagram. The diagram's structure below is fixed — you only supply short text annotations, as one JSON object.
-
-Extracted workflow graph:
-${JSON.stringify(graph, null, 2)}
-
-Read the step run() bodies in ${workflowDir} to understand what each step actually does (what it calls, what it decides, why it branches), then RETURN ONLY a JSON object matching this schema — no prose before or after, no markdown required, and DO NOT write or modify any files:
-
-{
-  "summary": "what this workflow does, one line (max ${L.summary} chars)",
-  "nodeDetails": { "<nodeId>": { "sublabel": "short annotation shown in the node (max ${L.sublabel} chars)", "description": "one sentence, shown on hover (max ${L.description} chars)" } },
-  "edgeLabels": { "<fromNodeId>-><toNodeId>": "intent/condition name (max ${L.edgeLabel} chars)" },
-  "notes": ["up to ${L.noteCount} facts worth knowing, each max ${L.note} chars"],
-  "layoutHints": { "groups": [{ "label": "group name (max ${L.groupLabel} chars)", "nodeIds": ["..."] }], "laneOrder": { "<layerIndex>": ["nodeId", "..."] } },
-  "crossWorkflow": "how this workflow ties into the project's other workflows, if it does (max ${L.crossWorkflow} chars)"
-}
-
-Rules:
-- Every field is optional — omit what you have nothing useful for (omit, don't write null). Empty strings are worse than omissions.
-- Use ONLY node ids that appear in the graph above.
-- Length limits are hard caps and oversize strings get truncated mid-sentence — aim comfortably under each limit.
-- Your final message must be exactly the JSON object.`;
-}
-
-/**
- * Pulls the JSON object out of a task's final result text — either fenced
- * (\`\`\`json ... \`\`\`) or raw, tolerating prose around it by falling back to
- * the outermost {...} span. Null when nothing parses.
- */
-export function extractEnrichmentJson(text: string): unknown | null {
-  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(text);
-  const candidates = [fenced?.[1], text];
-  const first = text.indexOf("{");
-  const last = text.lastIndexOf("}");
-  if (first !== -1 && last > first) candidates.push(text.slice(first, last + 1));
-  for (const candidate of candidates) {
-    if (!candidate) continue;
+export async function readWorkflowStepBodies(dir: string): Promise<Record<string, string>> {
+  const files = await listSourceFiles(dir);
+  const bodies: Record<string, string> = {};
+  let total = 0;
+  for (const file of files) {
+    if (total >= MAX_STEP_BODY_TOTAL_BYTES) break;
+    let content: string;
     try {
-      const parsed: unknown = JSON.parse(candidate.trim());
-      if (typeof parsed === "object" && parsed !== null) return parsed;
+      const stat = await fs.stat(file);
+      if (stat.size > MAX_STEP_BODY_FILE_BYTES) continue;
+      content = await fs.readFile(file, "utf8");
     } catch {
-      // Try the next candidate shape.
+      continue; // a file that vanished/won't read is just omitted
     }
+    const rel = path.relative(dir, file) || path.basename(file);
+    bodies[rel] = content;
+    total += content.length;
   }
-  return null;
-}
-
-/** The slice of TaskManager the runner uses — injectable for tests. */
-export interface EnrichmentTaskRunner {
-  run(req: RunTaskRequest): Promise<BackgroundTask>;
-  onStatusChange(listener: (task: BackgroundTask) => void): () => void;
-  /** Returns true when an enrichment task for this workflow is currently
-   *  running — checked before cache destruction in forceRefresh so a
-   *  double-click Visualize is a true no-op, not a half-destroyed cache. */
-  isRunning(macroId: string, workflowPath: string): boolean;
+  return bodies;
 }
 
 /** The session shape the coordinator needs — satisfied by HarnessSession. */
 export interface EnrichmentSession {
-  id: string;
   cwd: string;
-  harness: HarnessKind;
   boundWorkflowPath: string | null;
 }
 
 export interface EnrichmentCoordinatorOptions {
-  tasks: EnrichmentTaskRunner;
+  /** Runs the `enrich-canvas` workflow on our account and awaits its output. */
+  client: EnrichCanvasClient;
+  /**
+   * The deployed `enrich-canvas` definition id (env-resolved at the wiring
+   * site). Null/empty disables enrichment entirely — Tier-1 renders and the
+   * force refresh is a base re-render with no annotation pass.
+   */
+  definitionId: string | null;
   /** Rebuilds the workflow's render file (with the just-persisted enrichment
    *  merged) after a successful run — the write alone hot-reloads any open
    *  pane via the canvas watcher. */
   rerender?: (cwd: string, workflow: RenderableWorkflow) => Promise<void>;
+  /** Reads the workflow's step bodies for the workflow input. Injectable for
+   *  tests — defaults to {@link readWorkflowStepBodies}. */
+  readStepBodies?: (dir: string) => Promise<Record<string, string>>;
   /** Injectable for tests — defaults to the real cached extraction. */
   extractCached?: (dir: string) => Promise<CachedExtraction>;
-  env?: NodeJS.ProcessEnv;
   now?: () => string;
   onError?: (message: string) => void;
 }
 
 export class CanvasEnrichmentCoordinator {
-  private readonly tasks: EnrichmentTaskRunner;
+  private readonly client: EnrichCanvasClient;
+  private readonly definitionId: string | null;
   private readonly rerender: (cwd: string, workflow: RenderableWorkflow) => Promise<void>;
+  private readonly readStepBodies: (dir: string) => Promise<Record<string, string>>;
   private readonly extractCached: (dir: string) => Promise<CachedExtraction>;
-  private readonly env: NodeJS.ProcessEnv;
   private readonly now: () => string;
   private readonly onError: (message: string) => void;
+  /** Workflow paths with an enrichment run currently in flight — the per-workflow
+   *  dedupe guard, replacing the TaskManager's cross-session dedupe. */
+  private readonly inFlight = new Set<string>();
 
   constructor(options: EnrichmentCoordinatorOptions) {
-    this.tasks = options.tasks;
+    this.client = options.client;
+    this.definitionId = options.definitionId && options.definitionId.trim() !== "" ? options.definitionId : null;
     this.rerender = options.rerender ?? (async (cwd, workflow) => void (await renderWorkflowRenderFile(cwd, workflow)));
+    this.readStepBodies = options.readStepBodies ?? readWorkflowStepBodies;
     this.extractCached = options.extractCached ?? extractWorkflowGraphCached;
-    this.env = options.env ?? process.env;
     this.now = options.now ?? (() => new Date().toISOString());
     this.onError = options.onError ?? ((message) => console.error(`[harness] ${message}`));
   }
 
   /**
-   * The bind/create trigger: spawn an enrichment task unless a cached
-   * enrichment already matches the workflow's current sources. Silent on
-   * every expected refusal — unbound session, failed extraction, fresh
-   * cache, an enrichment already in flight for this workflow, a harness
-   * with no headless mode, even a spawn failure (logged) — because nothing
-   * here was user-initiated and a bind must never fail on enrichment's
-   * account.
-   */
-  async ensureFresh(session: EnrichmentSession, workflows: readonly RenderableWorkflow[]): Promise<void> {
-    const bound = this.resolveBound(session, workflows);
-    if (!bound) return;
-    try {
-      const { result, fingerprint } = await this.extractCached(bound.path);
-      if (!result.ok) return;
-      const entry = await readEnrichmentCacheFile(enrichmentCacheFileFor(session.cwd, bound.path));
-      if (entry && entry.sourceFingerprint === fingerprint) return;
-      await this.spawn(session, bound, result.graph, fingerprint);
-    } catch (err) {
-      if (err instanceof TaskAlreadyRunningError || err instanceof TaskNotSupportedError) return;
-      this.onError(`canvas enrichment (auto) failed to start: ${(err as Error).message}`);
-    }
-  }
-
-  /**
-   * The visualize macro: invalidate both caches, re-render the base diagram
-   * immediately (instant feedback, honest content — no leftover enrichment
-   * from sources that may have changed), then re-enrich. Refusals propagate
-   * to the macros router (TaskAlreadyRunningError → 409,
-   * TaskNotSupportedError → 400). Unbound session: just a no-op, matching
-   * the deterministic render's own unbound contract.
+   * The visualize macro (the ONLY trigger — enrichment never auto-fires):
+   * invalidate both caches, re-render the base diagram immediately (instant
+   * feedback, honest content), then kick off the Sapiom enrichment in the
+   * background and return. The pane hot-reloads if/when annotations land; a
+   * failure leaves the freshly-rendered Tier-1 base untouched.
    *
-   * The already-running check happens BEFORE any cache destruction so that a
-   * double-click Visualize is a true no-op: the second call rejects with
-   * TaskAlreadyRunningError and the caches and render are left exactly as
-   * the still-running enrichment will need them.
+   * The in-flight check happens BEFORE any cache destruction so a double-click
+   * Visualize is a true no-op: the second call rejects with
+   * {@link TaskAlreadyRunningError} (→ 409) and the caches/render are left
+   * exactly as the still-running enrichment will need them. Unbound session:
+   * a no-op, matching the deterministic render's own unbound contract.
    */
   async forceRefresh(session: EnrichmentSession, workflows: readonly RenderableWorkflow[]): Promise<void> {
     const bound = this.resolveBound(session, workflows);
     if (!bound) return;
-    if (this.tasks.isRunning(ENRICHMENT_MACRO_ID, bound.path)) {
+    if (this.inFlight.has(bound.path)) {
       throw new TaskAlreadyRunningError(ENRICHMENT_TASK_LABEL);
     }
     invalidateExtractionCache(bound.path);
@@ -205,7 +155,14 @@ export class CanvasEnrichmentCoordinator {
     await this.rerender(session.cwd, bound);
     const { result, fingerprint } = await this.extractCached(bound.path);
     if (!result.ok) return;
-    await this.spawn(session, bound, result.graph, fingerprint);
+    // Enrichment not configured (no deployed definition id): Tier-1 stands, no
+    // annotation pass. Silent — an unconfigured install is not an error state.
+    if (!this.definitionId) return;
+
+    this.inFlight.add(bound.path);
+    void this.enrich(session, bound, result.graph, fingerprint).finally(() => {
+      this.inFlight.delete(bound.path);
+    });
   }
 
   private resolveBound(
@@ -215,49 +172,43 @@ export class CanvasEnrichmentCoordinator {
     return session.boundWorkflowPath ? workflows.find((w) => w.path === session.boundWorkflowPath) : undefined;
   }
 
-  private async spawn(
+  /**
+   * Read the step bodies, run `enrich-canvas` on our account, and persist a
+   * valid result. Non-throwing: every failure routes to `onError` (logged) and
+   * leaves the base render standing — there is no pane-visible failure state.
+   */
+  private async enrich(
     session: EnrichmentSession,
     workflow: RenderableWorkflow,
     graph: CanvasGraph,
     fingerprint: string,
   ): Promise<void> {
-    const task = await this.tasks.run({
-      macroId: ENRICHMENT_MACRO_ID,
-      label: ENRICHMENT_TASK_LABEL,
-      harnessSessionId: session.id,
-      harness: session.harness,
-      cwd: session.cwd,
-      prompt: buildEnrichmentPrompt(graph, workflow.path),
-      workflowPath: workflow.path,
-      model: enrichmentModel(this.env),
-      maxTurns: ENRICHMENT_MAX_TURNS,
-    });
-
-    // Subscribed synchronously right after run() resolves — the process's
-    // exit can only arrive via a later event-loop turn, so the terminal
-    // status can't be missed.
-    const unsubscribe = this.tasks.onStatusChange((update) => {
-      if (update.id !== task.id || update.status === "running") return;
-      unsubscribe();
-      if (update.status !== "completed") return; // pane shows the failure; nothing to persist
-      void this.persist(session.cwd, workflow, graph, fingerprint, update.resultText).catch((err: unknown) => {
-        this.onError(`canvas enrichment persist failed: ${(err as Error).message}`);
-      });
-    });
+    try {
+      const stepBodies = await this.readStepBodies(workflow.path);
+      const result = await this.client.run(this.definitionId as string, { graph, stepBodies });
+      if (!result.ok) {
+        this.onError(
+          `canvas enrichment for ${workflow.path} did not complete (${result.status}: ${result.error}) — base render stands`,
+        );
+        return;
+      }
+      await this.persist(session.cwd, workflow, graph, fingerprint, result.output);
+    } catch (err) {
+      this.onError(`canvas enrichment failed: ${(err as Error).message}`);
+    }
   }
 
-  /** Completed task → parse → validate → cache file → re-render. Any parse
-   *  or validation failure discards the enrichment whole; the base render
-   *  already on disk stands untouched. */
+  /** Completed run → normalize → validate → cache file → re-render. Any
+   *  validation failure discards the enrichment whole; the base render already
+   *  on disk stands untouched. */
   private async persist(
     cwd: string,
     workflow: RenderableWorkflow,
     graph: CanvasGraph,
     fingerprint: string,
-    resultText: string | null,
+    output: unknown,
   ): Promise<void> {
-    const candidate = resultText ? extractEnrichmentJson(resultText) : null;
-    const enrichment = candidate ? parseCanvasEnrichment(normalizeCanvasEnrichmentCandidate(candidate)) : null;
+    const enrichment = parseCanvasEnrichment(normalizeCanvasEnrichmentCandidate(output));
     if (!enrichment) {
       this.onError(`canvas enrichment for ${workflow.path} returned invalid output — discarded, base render stands`);
       return;

--- a/packages/harness/src/core/enrich-canvas-client.test.ts
+++ b/packages/harness/src/core/enrich-canvas-client.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEnrichCanvasClient } from "./enrich-canvas-client.js";
+
+// ---------------------------------------------------------------------------
+// fetch fake — branches the START POST vs the poll GET, records every call.
+// ---------------------------------------------------------------------------
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+function res(status: number, body: unknown): MockResponse {
+  return { status, body };
+}
+
+/** A raw execution-projection doc as the agents surface returns it. `output`
+ *  is only populated on a completed run — the field the client reads. */
+function projection(status: string, output: unknown = null): Record<string, unknown> {
+  return { id: "exec_1", status, output, steps: [] };
+}
+
+function makeFetch(startRes: MockResponse, pollResponses: MockResponse[]) {
+  const recorded: { url: string; init?: RequestInit }[] = [];
+  let pollIdx = 0;
+  const fetchImpl = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+    recorded.push({ url, init });
+    const isStart = init?.method === "POST";
+    const picked = isStart
+      ? startRes
+      : (pollResponses[Math.min(pollIdx++, pollResponses.length - 1)] ?? res(404, { error: "not found" }));
+    return Promise.resolve({
+      status: picked.status,
+      ok: picked.status >= 200 && picked.status < 300,
+      json: () => Promise.resolve(picked.body),
+    } as Response);
+  });
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls: () => recorded };
+}
+
+const baseOpts = {
+  coreBaseUrl: "https://core.test",
+  agentsBaseUrl: "https://agents.test",
+  sleep: () => Promise.resolve(),
+};
+
+describe("createEnrichCanvasClient", () => {
+  it("starts the run on our account and returns the completed run's output", async () => {
+    const { fetchImpl, calls } = makeFetch(res(200, { executionId: "exec_1" }), [
+      res(200, projection("running")),
+      res(200, projection("completed", { summary: "routes orders" })),
+    ]);
+    const client = createEnrichCanvasClient({ apiKey: "sk", fetchImpl, ...baseOpts });
+
+    const result = await client.run("def_enrich", { graph: { nodes: [] }, stepBodies: {} });
+
+    expect(result).toEqual({ ok: true, executionId: "exec_1", output: { summary: "routes orders" } });
+
+    const start = calls()[0];
+    expect(start.url).toBe("https://core.test/v1/workflows/executions");
+    expect(start.init?.method).toBe("POST");
+    expect((start.init?.headers as Record<string, string>)["x-api-key"]).toBe("sk");
+    expect(JSON.parse(start.init?.body as string)).toEqual({
+      definitionId: "def_enrich",
+      input: { graph: { nodes: [] }, stepBodies: {} },
+    });
+
+    const poll = calls()[1];
+    expect(poll.url).toBe("https://agents.test/agents/v1/executions/exec_1");
+    expect((poll.init?.headers as Record<string, string>)["x-sapiom-api-key"]).toBe("sk");
+  });
+
+  it("returns 503 and never touches the network without an API key", async () => {
+    const fetchImpl = vi.fn();
+    const client = createEnrichCanvasClient({
+      apiKey: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      ...baseOpts,
+    });
+
+    const result = await client.run("def_enrich", {});
+
+    expect(result).toEqual({ ok: false, status: 503, error: "harness is not signed in to Sapiom" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a start failure without polling", async () => {
+    const { fetchImpl, calls } = makeFetch(res(500, { error: "boom" }), [res(200, projection("completed"))]);
+    const client = createEnrichCanvasClient({ apiKey: "sk", fetchImpl, ...baseOpts });
+
+    const result = await client.run("def_enrich", {});
+
+    expect(result).toEqual({ ok: false, status: 502, error: "gateway responded 500" });
+    expect(calls()).toHaveLength(1); // no poll
+  });
+
+  it("keeps polling through a 404 projection until it materializes", async () => {
+    const { fetchImpl } = makeFetch(res(200, { executionId: "exec_1" }), [
+      res(404, { error: "not found" }),
+      res(200, projection("completed", { summary: "hi" })),
+    ]);
+    const client = createEnrichCanvasClient({ apiKey: "sk", fetchImpl, ...baseOpts });
+
+    const result = await client.run("def_enrich", {});
+
+    expect(result).toEqual({ ok: true, executionId: "exec_1", output: { summary: "hi" } });
+  });
+
+  it("reports a non-completed terminal run as a typed failure", async () => {
+    const { fetchImpl } = makeFetch(res(200, { executionId: "exec_1" }), [res(200, projection("failed"))]);
+    const client = createEnrichCanvasClient({ apiKey: "sk", fetchImpl, ...baseOpts });
+
+    const result = await client.run("def_enrich", {});
+
+    expect(result).toEqual({ ok: false, status: 502, error: "enrich-canvas run ended failed" });
+  });
+
+  it("times out a run that never leaves running", async () => {
+    const { fetchImpl } = makeFetch(res(200, { executionId: "exec_1" }), [res(200, projection("running"))]);
+    let t = 0;
+    const now = (): number => (t += 20); // jumps past the 10ms budget on the 2nd read
+    const client = createEnrichCanvasClient({ apiKey: "sk", fetchImpl, ...baseOpts, timeoutMs: 10, now });
+
+    const result = await client.run("def_enrich", {});
+
+    expect(result).toEqual({ ok: false, status: 504, error: "timed out waiting for the run to finish" });
+  });
+});

--- a/packages/harness/src/core/enrich-canvas-client.ts
+++ b/packages/harness/src/core/enrich-canvas-client.ts
@@ -1,0 +1,205 @@
+/**
+ * enrich-canvas-client — a one-shot run of the Sapiom `enrich-canvas` workflow
+ * ON OUR ACCOUNT that AWAITS the run's final output.
+ *
+ * This is the producer behind Tier-2 canvas enrichment (SAP-1800). Unlike
+ * spine-client.ts — which streams step transitions and returns only the terminal
+ * STATUS — the canvas coordinator needs the workflow's OUTPUT (the
+ * `CanvasEnrichment` JSON the terminal step returns). So this client starts the
+ * run, polls to terminal, and hands back the decoded `ExecutionProjection.output`
+ * for the coordinator to validate.
+ *
+ * Two surfaces, mirroring run-state.ts / spine-client.ts:
+ *   - START on the CORE surface: `POST /v1/workflows/executions` (header
+ *     `x-api-key`). The backend defaults org/tenant from the key, so the run is
+ *     owned + billed by OUR tenant — 0 user Claude tokens, the whole point.
+ *   - POLL the AGENTS surface: `GET /agents/v1/executions/:id` (header
+ *     `x-sapiom-api-key`), decoded with `decodeExecutionProjection` (the same
+ *     decode the run canvas uses), reading `.output` off the terminal projection.
+ *
+ * WHY the key stays server-side: same rationale as run-state.ts / spine-client.ts
+ * — the Sapiom API key is a harness credential that must never reach the browser.
+ * The harness server runs on behalf of the SPA; no key ever leaves the process.
+ *
+ * Intentionally non-throwing: every failure path resolves to a typed
+ * {@link EnrichCanvasRunResult} with `ok: false`, so the coordinator degrades to
+ * the Tier-1 render without a try/catch at the call site.
+ */
+
+import { decodeExecutionProjection, isExecutionTerminal } from "@sapiom/agent-core";
+
+import { resolveAgentsBaseUrl } from "./run-state.js";
+import { resolveCoreBaseUrl } from "./run-spend.js";
+
+/** Default cadence for polling the execution projection while awaiting. */
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Default ceiling on total wait before a still-running enrichment is abandoned.
+ * Generous — a single LLM annotation step — but bounded so a stuck or
+ * never-materializing execution can't poll forever (the Tier-1 render stands).
+ */
+const DEFAULT_TIMEOUT_MS = 2 * 60_000;
+
+/** Terminal outcome of a one-shot enrich-canvas run. */
+export type EnrichCanvasRunResult =
+  | { ok: true; executionId: string; output: unknown }
+  | { ok: false; status: number; error: string };
+
+export interface EnrichCanvasClientOpts {
+  /** Sapiom API key (the held server-side credential); null when not signed in. */
+  apiKey: string | null;
+  /** Override the CORE base URL for the start call (resolved from env by default). Test seam. */
+  coreBaseUrl?: string;
+  /** Override the AGENTS base URL for the poll call (resolved from env by default). Test seam. */
+  agentsBaseUrl?: string;
+  /** Injectable fetch implementation — defaults to global fetch. Test seam. */
+  fetchImpl?: typeof fetch;
+  /** Poll cadence while awaiting; defaults to {@link DEFAULT_POLL_INTERVAL_MS}. */
+  pollIntervalMs?: number;
+  /** Total wait ceiling; defaults to {@link DEFAULT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /**
+   * Sleep implementation between polls. Defaults to a real setTimeout; tests
+   * inject a no-wait stub so the poll loop runs instantly.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /** Clock source (ms). Defaults to Date.now; injectable so tests control the deadline. */
+  now?: () => number;
+}
+
+export interface EnrichCanvasClient {
+  /**
+   * Start `definitionId` on our account with `input`, poll until terminal (or
+   * timeout), and resolve with the run's output on success. `output` is the
+   * raw `terminate(...)` value — the coordinator validates it against the
+   * `CanvasEnrichment` schema.
+   */
+  run(definitionId: string, input: Record<string, unknown>): Promise<EnrichCanvasRunResult>;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Create an enrich-canvas client. See the module header for the two-surface
+ * flow. Non-throwing: all outcomes are typed results.
+ */
+export function createEnrichCanvasClient(opts: EnrichCanvasClientOpts): EnrichCanvasClient {
+  const {
+    apiKey,
+    coreBaseUrl = resolveCoreBaseUrl(),
+    agentsBaseUrl = resolveAgentsBaseUrl(),
+    fetchImpl = fetch,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    sleep = realSleep,
+    now = Date.now,
+  } = opts;
+
+  /** POST the start request; returns the enqueued executionId or a typed error. */
+  async function start(
+    definitionId: string,
+    input: Record<string, unknown>,
+  ): Promise<{ ok: true; executionId: string } | { ok: false; status: number; error: string }> {
+    let res: Response;
+    try {
+      res = await fetchImpl(`${coreBaseUrl}/v1/workflows/executions`, {
+        method: "POST",
+        headers: {
+          "x-api-key": apiKey as string,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ definitionId, input }),
+      });
+    } catch {
+      return { ok: false, status: 502, error: "gateway unreachable" };
+    }
+
+    if (!res.ok) {
+      return { ok: false, status: 502, error: `gateway responded ${res.status}` };
+    }
+
+    try {
+      const body = (await res.json()) as { executionId?: unknown };
+      if (typeof body.executionId !== "string" || body.executionId === "") {
+        return { ok: false, status: 502, error: "start response had no executionId" };
+      }
+      return { ok: true, executionId: body.executionId };
+    } catch {
+      return { ok: false, status: 502, error: "could not decode start response" };
+    }
+  }
+
+  /** GET + decode one projection poll; `output`/`status` off the decoded shape. */
+  async function poll(
+    executionId: string,
+  ): Promise<
+    | { ok: true; status: string; output: unknown }
+    | { ok: false; status: number; error: string }
+  > {
+    let res: Response;
+    try {
+      res = await fetchImpl(
+        `${agentsBaseUrl}/agents/v1/executions/${encodeURIComponent(executionId)}`,
+        { headers: { "x-sapiom-api-key": apiKey as string } },
+      );
+    } catch {
+      return { ok: false, status: 502, error: "gateway unreachable" };
+    }
+
+    if (res.status === 404) {
+      // A freshly enqueued execution's projection can lag the start response.
+      return { ok: false, status: 404, error: "execution not found" };
+    }
+    if (!res.ok) {
+      return { ok: false, status: 502, error: `gateway responded ${res.status}` };
+    }
+
+    try {
+      const raw = (await res.json()) as Record<string, unknown>;
+      const decoded = decodeExecutionProjection(raw);
+      return { ok: true, status: decoded.status, output: decoded.output };
+    } catch {
+      return { ok: false, status: 502, error: "could not decode execution" };
+    }
+  }
+
+  return {
+    async run(definitionId, input): Promise<EnrichCanvasRunResult> {
+      // No API key — never touch the network; the harness is not signed in.
+      if (!apiKey) {
+        return { ok: false, status: 503, error: "harness is not signed in to Sapiom" };
+      }
+
+      const started = await start(definitionId, input);
+      if (!started.ok) return started;
+      const { executionId } = started;
+
+      const deadline = now() + timeoutMs;
+      for (;;) {
+        const result = await poll(executionId);
+
+        if (!result.ok) {
+          // Keep polling through 404 until the projection materializes; any
+          // other upstream error is fatal for this run.
+          if (result.status !== 404) return result;
+        } else if (isExecutionTerminal(result.status)) {
+          if (result.status === "completed") {
+            return { ok: true, executionId, output: result.output };
+          }
+          return {
+            ok: false,
+            status: 502,
+            error: `enrich-canvas run ended ${result.status}`,
+          };
+        }
+
+        if (now() >= deadline) {
+          return { ok: false, status: 504, error: "timed out waiting for the run to finish" };
+        }
+        await sleep(pollIntervalMs);
+      }
+    },
+  };
+}

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -55,12 +55,14 @@ export const DEFAULT_MACROS: MacroDef[] = [
     },
   },
   {
-    // One-click force refresh of the bound workflow's canvas: re-runs the
-    // deterministic, zero-LLM structure render (core/canvas-render.ts —
-    // instant, cache-invalidated) AND re-spawns the bounded AI enrichment
-    // task (core/canvas-enrich.ts, a headless background run that returns
-    // validated JSON annotations, never HTML) — all server-side, without
-    // touching the session's pty. A cheap no-op when the session is unbound.
+    // One-click refresh of the bound workflow's canvas: re-runs the
+    // deterministic, zero-LLM Tier-1 structure render (core/canvas-render.ts —
+    // instant, cache-invalidated) AND kicks off the opt-in Tier-2 enrichment
+    // on our Sapiom account (core/canvas-enrich.ts → the enrich-canvas
+    // workflow, returning validated JSON annotations, 0 user Claude tokens) —
+    // all server-side, without touching the session's pty. A failed or
+    // unconfigured enrichment degrades silently to Tier-1; a cheap no-op when
+    // the session is unbound.
     id: "visualize",
     label: "Visualize",
     icon: "Sparkles",

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -80,6 +80,7 @@ import {
   renderWorkflowRenderFile,
 } from "../core/canvas-render.js";
 import { CanvasEnrichmentCoordinator } from "../core/canvas-enrich.js";
+import { createEnrichCanvasClient } from "../core/enrich-canvas-client.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
 import {
   createDefinitionSlugResolver,
@@ -149,6 +150,17 @@ const NDJSON_RETENTION_SWEEP_MS = 6 * 60 * 60 * 1_000; // every 6 hours
  */
 function resolveSpineWorkflowId(): string {
   return process.env.SAPIOM_SPINE_WORKFLOW_ID ?? "";
+}
+
+/**
+ * The deployed `enrich-canvas` workflow (SAP-1800) run on our account for
+ * Tier-2 canvas enrichment. Env-resolved, not baked in — point it at the
+ * deployed definition via `SAPIOM_HARNESS_ENRICH_CANVAS_DEFINITION_ID`. Absent
+ * an override the coordinator skips the annotation pass entirely and the
+ * deterministic Tier-1 render stands (0 user Claude tokens either way).
+ */
+function resolveEnrichCanvasWorkflowId(): string {
+  return process.env.SAPIOM_HARNESS_ENRICH_CANVAS_DEFINITION_ID ?? "";
 }
 
 export interface HarnessServerOptions {
@@ -647,13 +659,20 @@ export const startServer = async (
     return found;
   };
 
-  // The AI enrichment layer over the deterministic renders: one bounded
-  // headless task per workflow (spawned on bind when no fresh cache exists,
-  // or by the visualize macro's force refresh), whose validated JSON output
-  // is persisted per-workflow and merged into the render on completion —
-  // the render write alone hot-reloads any open pane via the canvas watcher.
+  // Tier-2 canvas enrichment (SAP-1800): the OPT-IN annotation layer over the
+  // deterministic Tier-1 renders. The producer is the Sapiom `enrich-canvas`
+  // workflow run ON OUR ACCOUNT (held key) — never a headless `claude -p` task
+  // on the user's Claude Code tokens. It fires ONLY on the visualize macro
+  // (never on bind); its validated JSON output is persisted per-workflow and
+  // merged into the render (the write alone hot-reloads any open pane), and any
+  // failure degrades silently to the Tier-1 render.
   const enrichment = new CanvasEnrichmentCoordinator({
-    tasks: taskManager,
+    client: createEnrichCanvasClient({
+      apiKey: identity?.apiKey ?? null,
+      coreBaseUrl: resolveCoreBaseUrl(),
+      agentsBaseUrl: resolveAgentsBaseUrl(),
+    }),
+    definitionId: resolveEnrichCanvasWorkflowId(),
     rerender: async (cwd, workflow) => {
       await renderWorkflowRenderFile(cwd, workflow);
     },
@@ -663,21 +682,19 @@ export const startServer = async (
   // always against the live workflowsCache, never an LLM in the render
   // itself; a cheap no-op for an unbound session (the canvas router serves
   // the empty state on its own). Never throws (see core/canvas-render.ts);
-  // best-effort, like every other canvas write here. The bind path
-  // (PATCH /sessions/:id/workflow → rest.ts) and the UNPROMPTED call sites
-  // (session-create/boot auto-render, via autoRenderCanvas — which won't
-  // replace a workflow's existing render with an error panel when its
-  // extraction fails) also kick the enrichment freshness check afterwards:
-  // instant base diagram now, annotations merged in when the task lands.
+  // best-effort, like every other canvas write here. Tier-2 enrichment does
+  // NOT auto-fire on these paths anymore (SAP-1800): bind and the UNPROMPTED
+  // call sites (session-create/boot auto-render — which won't replace a
+  // workflow's existing render with an error panel when its extraction fails)
+  // render only the deterministic Tier-1 structure. Enrichment is opt-in, via
+  // the visualize macro alone.
   const renderCanvas = async (session: HarnessSession): Promise<void> => {
     await renderCanvasForSession(session, workflowsCache);
-    await enrichment.ensureFresh(session, workflowsCache);
   };
   const autoRenderCanvas = async (session: HarnessSession): Promise<void> => {
     await renderCanvasForSession(session, workflowsCache, {
       preserveExistingOnFailure: true,
     });
-    await enrichment.ensureFresh(session, workflowsCache);
   };
 
   const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch(
@@ -865,10 +882,11 @@ export const startServer = async (
       getBoundWorkflowPath: (harnessSessionId) =>
         sessionManager.get(harnessSessionId)?.boundWorkflowPath ?? null,
       // The visualize macro is a FORCE refresh, not a plain re-render:
-      // invalidate the extraction + enrichment caches, re-render the base
-      // instantly, re-spawn the enrichment task. Its refusals map to the
-      // router's existing error handling (already running → 409, codex
-      // session → 400).
+      // invalidate the extraction + enrichment caches, re-render the Tier-1
+      // base instantly, then kick off the opt-in Sapiom enrichment on our
+      // account. A double-fire while one is in flight maps to the router's
+      // existing 409 (already running); the enrichment itself never fails the
+      // pane — it degrades to the Tier-1 render.
       renderCanvas: async (harnessSessionId) => {
         const session = sessionManager.get(harnessSessionId);
         if (session) await enrichment.forceRefresh(session, workflowsCache);

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1239,89 +1239,9 @@ test.describe("background-task canvas states", () => {
     await expect(page.locator(".canvas-iframe")).toBeVisible();
   });
 
-  test("failure view is full-screen (no iframe behind it) — unchanged from before", async ({
-    page,
-  }) => {
-    // Get an iframe up first, then trigger a failure.
-    await page.route("**/canvas/sess-boot/**", async (route) => {
-      await route.fulfill({
-        contentType: "text/html",
-        body: "<html><body>diagram</body></html>",
-      });
-    });
-    await page.evaluate(() => {
-      (
-        window as unknown as {
-          __HARNESS_TEST__: { publish: (message: unknown) => void };
-        }
-      ).__HARNESS_TEST__.publish({
-        type: "canvas.reload",
-        harnessSessionId: "sess-boot",
-      });
-    });
-    await expect(page.locator(".canvas-iframe")).toBeVisible();
-
-    await publish(page, {
-      ...baseTask,
-      status: "failed",
-      endedAt: new Date().toISOString(),
-      exitCode: 1,
-      errorTail: "Connection lost",
-    });
-
-    // Failure state replaces everything — iframe gone, failure panel shown.
-    await expect(page.getByTestId("canvas-task-failed")).toBeVisible();
-    await expect(page.locator(".canvas-iframe")).toHaveCount(0);
-
-    await page.screenshot({
-      path: "web/e2e/screenshots/canvas-failure-fullscreen.png",
-    });
-  });
-
-  test("a failed task shows the error tail with retry and dismiss affordances", async ({
-    page,
-  }) => {
-    await publish(page, {
-      ...baseTask,
-      status: "failed",
-      endedAt: new Date().toISOString(),
-      exitCode: 1,
-      errorTail: "API connection lost",
-    });
-
-    const failed = page.getByTestId("canvas-task-failed");
-    await expect(failed).toBeVisible();
-    await expect(failed).toContainText("Visualize failed");
-    await expect(failed).toContainText("API connection lost");
-    await page.screenshot({
-      path: "web/e2e/screenshots/canvas-task-failed.png",
-    });
-
-    // Retry re-fires the same macro (MockApi records it for us to read back)
-    // — for an enrichment task that's the visualize force refresh.
-    await page.getByTestId("canvas-task-retry").click();
-    await page.waitForFunction(
-      () =>
-        (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } })
-          .__HARNESS_TEST__?.lastMacroRun,
-    );
-    const lastRun = await page.evaluate(
-      () =>
-        (
-          window as unknown as {
-            __HARNESS_TEST__: { lastMacroRun?: { id: string } };
-          }
-        ).__HARNESS_TEST__.lastMacroRun,
-    );
-    expect(lastRun?.id).toBe("visualize");
-
-    // Dismiss hides the failure panel and returns the pane to its usual state.
-    await page.getByTestId("canvas-task-dismiss").click();
-    await expect(page.getByTestId("canvas-task-failed")).toHaveCount(0);
-    await expect(page.locator(".canvas-empty")).toContainText(
-      "Nothing generated yet",
-    );
-  });
+  // NOTE (SAP-1800): the "Visualize failed" total-failure view was removed —
+  // Tier-2 enrichment now runs as a Sapiom workflow that degrades silently to
+  // the Tier-1 render, so there is no canvas-task-failed state to assert.
 });
 
 test.describe("resizable panes", () => {

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -78,11 +78,6 @@ export function CanvasPane({
   // True while the iframe is (re)loading its document — a skeleton overlays
   // it so a load/render in progress never reads as a blank pane.
   const [frameLoading, setFrameLoading] = useState(true);
-  // Failed-task panels the user has explicitly dismissed (client-side only —
-  // the task record itself stays in the server's list).
-  const [dismissedTaskIds, setDismissedTaskIds] = useState<Set<string>>(
-    new Set(),
-  );
 
   // Keep the ref current on every render so onLoad (which captures it by ref)
   // always reads the freshest value.
@@ -222,11 +217,11 @@ export function CanvasPane({
   // Background-task state for THIS session's pane, scoped to the CURRENT
   // binding: a task that carries a workflowPath only surfaces while the pane
   // is showing that workflow — switching the binding mid-run must not bleed
-  // another workflow's activity (or failure) into this one's pane. Tasks
-  // without a workflowPath keep the plain per-session scoping. A running
-  // task shows the live activity view; otherwise the most recently finished
-  // task, if it failed and hasn't been dismissed, shows the failure view
-  // with a retry.
+  // another workflow's activity into this one's pane. Tasks without a
+  // workflowPath keep the plain per-session scoping. A running task shows the
+  // live activity view. There is no failure view: Tier-2 enrichment can't fail
+  // the pane (SAP-1800) — a failed enrichment degrades silently to the Tier-1
+  // render, so the canvas never shows a "Visualize failed" state.
   const sessionTasks = tasks.filter(
     (task) =>
       task.harnessSessionId === sessionId &&
@@ -234,18 +229,6 @@ export function CanvasPane({
   );
   const runningTask =
     sessionTasks.find((task) => task.status === "running") ?? null;
-  const latestFinished = sessionTasks
-    .filter((task) => task.status !== "running")
-    .sort((a, b) => (b.endedAt ?? "").localeCompare(a.endedAt ?? ""))[0];
-  const failedTask =
-    !runningTask &&
-    latestFinished?.status === "failed" &&
-    !dismissedTaskIds.has(latestFinished.id)
-      ? latestFinished
-      : null;
-  const retryMacro = failedTask
-    ? (macros.find((macro) => macro.id === failedTask.macroId) ?? null)
-    : null;
 
   // The header's action IS Visualize now — one click re-fires the same macro
   // that generated what's already on screen; the pane itself swaps in the
@@ -297,39 +280,6 @@ export function CanvasPane({
       {!sessionId ? (
         <div className="canvas-empty">
           Start a session to see its canvas here.
-        </div>
-      ) : failedTask ? (
-        <div className="canvas-task-failed" data-testid="canvas-task-failed">
-          <p className="canvas-task-title">
-            <Icon name="TriangleAlert" size={14} /> {failedTask.label} failed.
-          </p>
-          {failedTask.errorTail && (
-            <pre className="canvas-task-error">{failedTask.errorTail}</pre>
-          )}
-          <div className="canvas-task-actions">
-            {retryMacro && (
-              <button
-                className="btn-primary"
-                data-testid="canvas-task-retry"
-                onClick={() => onRunMacro(retryMacro)}
-              >
-                Retry
-              </button>
-            )}
-            <button
-              className="btn-ghost"
-              data-testid="canvas-task-dismiss"
-              onClick={() =>
-                setDismissedTaskIds((prev) => {
-                  const next = new Set(prev);
-                  next.add(failedTask.id);
-                  return next;
-                })
-              }
-            >
-              Dismiss
-            </button>
-          </div>
         </div>
       ) : runningTask && !hasGeneratedContent ? (
         <div

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1771,8 +1771,7 @@ input {
 
 /* Background-task states (see CanvasPane) ------------------------------- */
 
-.canvas-task-activity,
-.canvas-task-failed {
+.canvas-task-activity {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -1840,31 +1839,6 @@ input {
 /* The newest line is what's happening right now — everything above is history. */
 .canvas-task-lines li:last-child {
   color: var(--text-dim);
-}
-
-.canvas-task-error {
-  max-width: 340px;
-  max-height: 160px;
-  width: 100%;
-  overflow: auto;
-  margin: 0;
-  padding: 8px 10px;
-  text-align: left;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--text-faint);
-  background: var(--bg-inset, rgba(128, 128, 128, 0.08));
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-}
-
-.canvas-task-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 /* Shared buttons ------------------------------------------------------- */


### PR DESCRIPTION
## What

Replaces the token-burning headless-`claude` canvas enrichment with an **opt-in Tier-2 overlay** produced by a **Sapiom-owned `enrich-canvas` workflow run on our account** (0 user Claude tokens). The deterministic **Tier-1** structure render stays the unkillable default; enrichment **degrades silently** on any failure, and the **"Visualize failed" total-failure state is removed**.

Closes SAP-1800 (E5).

## Why

The old path spawned a headless `claude -p` task per workflow on the **user's** Claude Code tokens, and a failed task took over the whole canvas pane. Running enrichment as a workflow on our account:
- meters it to **us** (0 user Claude tokens),
- works for **any** harness kind (no local headless agent required — codex sessions now enrich too),
- makes enrichment failure a **silent no-op** rather than an error, because Tier-1 always renders.

## Changes

- **`examples/enrich-canvas/`** — internal `defineAgent` workflow: one `ctx.sapiom.models.run` step that annotates the extracted graph + the workflow's source bodies and returns the `CanvasEnrichment` JSON contract. Deliberately **not** in `examples/registry.json` (not a public "Use this template" entry). Typechecks against `@sapiom/agent ^0.6` / `@sapiom/tools ^0.20`.
- **`core/enrich-canvas-client.ts`** — one-shot "run on our account" client: starts the workflow (`POST /v1/workflows/executions`, `x-api-key`) and awaits `ExecutionProjection.output` by polling the agents surface (`x-sapiom-api-key`). Mirrors `spine-client.ts` / `run-state.ts`; key held server-side; non-throwing typed results.
- **`core/canvas-enrich.ts`** — `CanvasEnrichmentCoordinator` producer swapped from the TaskManager headless runner to the workflow client. **`ensureFresh` (auto-fire on bind / session-create) removed** — enrichment fires **only** on the explicit `visualize` macro (`forceRefresh`), with a per-workflow in-flight guard (double-click → 409). The `parseCanvasEnrichment` / `normalizeCanvasEnrichmentCandidate` / merge / cache path is unchanged.
- **`server/index.ts`** — coordinator wired with the client + an env-resolved definition id; bind and session-create/boot render **Tier-1 only**.
- **`web/CanvasPane.tsx`** — removed the `canvas-task-failed` view (+ retry/dismiss) and its dead CSS; the e2e failure-state tests are gone.

## Scope note (Tier-2 overlay target)

The ticket's Tier-2 overlay lands on the **studio React FlowGraph** adopted via Launch Epic G (SAP-1766), which is **not on this branch yet** (still the iframe `CanvasPane`). In today's UI the enrichment already flows into the served canvas via the existing cache→re-render "overlay" path, and the opt-in affordance is the existing **Visualize** control. The React FlowGraph overlay proper is deferred to the Epic G rebase (Tasks 1/2/4 are independent; only Task 3's overlay depends on the adopted `web/`).

## Deploy step (manual, requires account access)

Deploy `examples/enrich-canvas` to our Sapiom account and set `SAPIOM_HARNESS_ENRICH_CANVAS_DEFINITION_ID` to its definition id on the harness server. **Unset → enrichment is skipped and Tier-1 renders** (still 0 user Claude tokens). Left as a deploy-time action rather than performed from this automated session.

## Testing

- `pnpm --filter @sapiom/harness typecheck` ✓ (server + web)
- `pnpm --filter @sapiom/harness lint` ✓
- `pnpm --filter @sapiom/harness test` ✓ — 1053 tests, incl. 16 new (client fetch fakes; coordinator no-auto-fire / workflow-producer / silent-degrade / in-flight dedupe / no-op paths)
- `examples/enrich-canvas` typechecks standalone against published `@sapiom/agent` + `@sapiom/tools`
