### PR TITLE
fix(harness): remove internal templates-pin roadmap footer

### DIFF
--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -31,7 +31,7 @@ test.describe("templates journey v0 (from the welcome panel)", () => {
     await expect(page.getByTestId("templates-dialog")).toBeVisible();
   });
 
-  test("browse: the two clonable gallery ids, the two bundled starters, and the honest pin note", async ({
+  test("browse: the two clonable gallery ids and the two bundled starters", async ({
     page,
   }) => {
     // Exactly the real clonable slugs — nothing invented.
@@ -39,8 +39,6 @@ test.describe("templates journey v0 (from the welcome panel)", () => {
     await expect(page.getByTestId("template-row-hello-agent")).toBeVisible();
     await expect(page.getByTestId("template-row-default")).toBeVisible();
     await expect(page.getByTestId("template-row-coding-pause")).toBeVisible();
-    // Browse is server-gated (no listing API): the list says it's a pin.
-    await expect(page.getByTestId("templates-pin-note")).toContainText("harness 0.1.4");
 
     await page.screenshot({ path: "web/e2e/screenshots/templates-dialog.png", fullPage: true });
   });

--- a/packages/harness/web/src/components/TemplatesDialog.tsx
+++ b/packages/harness/web/src/components/TemplatesDialog.tsx
@@ -4,7 +4,6 @@ import type { JSX, RefObject } from "react";
 import {
   GALLERY_TEMPLATES,
   STARTER_TEMPLATES,
-  TEMPLATES_PIN,
   templateDirSuggestion,
   type StudioTemplate,
 } from "../lib/templates";
@@ -129,12 +128,6 @@ export function TemplatesDialog({ launchDir, onClose, onUse, triggerRef }: Templ
                 onSelect={select}
               />
             ))}
-            {/* Honest curation: no listing API exists yet, so
-                this index is a pin, and the note says which one. */}
-            <p className="templates-pin-note" data-testid="templates-pin-note">
-              Pinned from the harness {TEMPLATES_PIN.harnessVersion} gallery. Live browse is
-              dashboard only until a listing API ships.
-            </p>
           </div>
 
           <TemplateDetail template={selected} />

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -6110,15 +6110,6 @@ input {
   color: var(--accent-foreground);
 }
 
-/* Honest curation note: the list is a pin, not a live gallery. */
-.templates-pin-note {
-  margin: auto 0 0;
-  padding: var(--sp3) var(--sp2) var(--sp1);
-  font-size: var(--type-micro);
-  color: var(--text-faint);
-  line-height: 1.5;
-}
-
 /* ── Preview pane: real manifest fields only ── */
 .template-detail {
   display: flex;


### PR DESCRIPTION
## Summary

- Removes the `<p class="templates-pin-note">` paragraph from the "Start from a template" panel that leaked internal roadmap copy ("Pinned from the harness 0.1.4 gallery. Live browse is dashboard only until a listing API ships.")
- Drops the now-unused `TEMPLATES_PIN` import from `TemplatesDialog.tsx` (the export in `lib/templates.ts` is left in place)
- Removes the dead `.templates-pin-note` CSS rule from `styles.css`
- Retargets the E2E `browse` test that was asserting the removed element — row-visibility assertions kept, pin-note assertion removed, test title updated

## Test plan

- [x] `pnpm --filter "@sapiom/harness..." build` — clean build, no type errors
- [x] `pnpm --filter @sapiom/harness typecheck` — passes
- [x] `pnpm --filter @sapiom/harness test` — 1204 passed, 6 pre-existing pty-sandbox failures in `transcript-replay.test.ts` (unrelated to this change)
- [x] `CI=1 E2E_PORT=5541 pnpm --filter @sapiom/harness test:ui` — 231 passed, 0 failed
- [x] All templates E2E tests green including the retargeted browse test

🤖 Generated with [Claude Code](https://claude.com/claude-code)