### PR TITLE
feat(harness): auto-bind session to workflow on rescan (SAP-1897)

### DIFF
--- a/packages/harness/src/server/auto-bind-rescan.test.ts
+++ b/packages/harness/src/server/auto-bind-rescan.test.ts
@@ -328,7 +328,7 @@ describe("auto-bind on rescan (SAP-1897)", () => {
 
   it(
     "is idempotent — a second rescan does not re-bind or emit redundant events",
-    { retry: 1, timeout: 20_000 },
+    { retry: 1, timeout: 25_000 },
     async () => {
       const port = await startTestServer();
       const session = await server!.sessionManager.create({
@@ -338,41 +338,71 @@ describe("auto-bind on rescan (SAP-1897)", () => {
 
       events = await collectEvents(port);
 
-      // Scaffold the workflow at cwd.
-      await scaffoldWorkflow(cwd);
+      // Scaffold the first workflow as a SUBDIRECTORY of cwd (not at cwd itself).
+      // This is deliberate: when the first workflow lives at `cwd/first-agent`,
+      // the watcher's fingerprint is "cwd/first-agent".  Adding a sibling
+      // `cwd/second-agent` later changes the fingerprint to
+      // "cwd/first-agent|cwd/second-agent", which fires a real onChange.
+      // (If the workflow were at cwd itself, the fingerprint walk stops there
+      // and never descends into any sub-directory, so adding a nested entry
+      // would NOT change the fingerprint and the watcher would never fire.)
+      const firstWorkflow = join(cwd, "first-agent");
+      await scaffoldWorkflow(firstWorkflow);
 
-      // Wait for the initial auto-bind to land.
+      // Wait for the initial auto-bind to land (session binds to firstWorkflow).
       await vi.waitFor(
         async () => {
           const s = await listSessions(port);
           expect(s.find((x) => x.id === session.id)?.boundWorkflowPath).toBe(
-            cwd,
+            firstWorkflow,
           );
         },
         { timeout: 8_000, interval: 150 },
       );
 
-      // Count session.status frames for our session.
+      // Count session.status frames after the first (real) bind.
       const framesAfterBind = events.messages.filter(
         (m) => m.type === "session.status" && m.session.id === session.id,
       ).length;
       expect(framesAfterBind).toBeGreaterThan(0);
 
-      // Touch the workspace to force another rescan.
-      await writeFile(join(cwd, "dummy.txt"), "touch");
-      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+      // Force a REAL second rescan: scaffold a second (peer) workflow directory
+      // under cwd.  The workspace watcher is fingerprint-based — it fires
+      // onChange only when the SET of sapiom.json-bearing directories changes.
+      // Adding a sibling directory changes the fingerprint and guarantees a
+      // rescan fires; the `!session.boundWorkflowPath` guard is now false, so
+      // the auto-bind code runs but does NOT re-bind.
+      const secondWorkflow = join(cwd, "second-agent");
+      await scaffoldWorkflow(secondWorkflow);
 
-      // Verify the binding is unchanged and no NEW session.status frame was emitted
-      // for the already-bound session on account of a second bind attempt.
+      // Wait for the second workflow to appear in the registry — this confirms
+      // the workspace watcher detected the structural change, fired onChange,
+      // and `rescanWorkspaceForSession` completed.
+      await vi.waitFor(
+        async () => {
+          const res = await fetch(
+            `http://127.0.0.1:${port}/api/workflows`,
+            { headers: { "X-Harness-Token": "test-token" } },
+          );
+          const workflows = (await res.json()) as Array<{ path: string }>;
+          expect(workflows.some((w) => w.path === secondWorkflow)).toBe(true);
+        },
+        { timeout: 10_000, interval: 200 },
+      );
+
+      // The binding must remain on the FIRST workflow — the
+      // `!session.boundWorkflowPath` guard (now false) prevented any re-bind.
+      const sessions = await listSessions(port);
+      expect(
+        sessions.find((x) => x.id === session.id)?.boundWorkflowPath,
+      ).toBe(firstWorkflow);
+
+      // No NEW session.status frames should have been emitted for a bind
+      // attempt on account of the second rescan (the guard prevented it).
       const framesAfterSecondRescan = events.messages.filter(
         (m) => m.type === "session.status" && m.session.id === session.id,
       ).length;
       expect(framesAfterSecondRescan).toBe(framesAfterBind);
-
-      const sessions = await listSessions(port);
-      expect(
-        sessions.find((x) => x.id === session.id)?.boundWorkflowPath,
-      ).toBe(cwd);
     },
   );
 });

--- a/packages/harness/src/server/auto-bind-rescan.test.ts
+++ b/packages/harness/src/server/auto-bind-rescan.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Auto-bind (SAP-1897): when a session is unbound and a rescan discovers a
+ * workflow at/under the session's cwd, the session must be bound to that
+ * workflow automatically — using the same setBoundWorkflowPath mechanism that
+ * PATCH /api/sessions/:id/workflow uses.
+ *
+ * Guardrails:
+ *  - Only fires when unbound (never overrides an explicit binding).
+ *  - Only binds workflows at or strictly under the session's cwd.
+ *  - Idempotent: a second rescan does not re-bind or churn.
+ *  - Prefers the workflow at exactly cwd; falls back to the nearest under cwd.
+ *  - Propagates the new binding live via the existing session.status broadcast.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WebSocket } from "ws";
+
+import { startServer, type HarnessServer } from "./index.js";
+import type {
+  BusMessage,
+  HarnessAdapter,
+  HarnessSession,
+  LaunchOpts,
+  SpawnSpec,
+} from "../shared/types.js";
+
+/** Adapter that spawns bash so the pty reaches "running". */
+function fakeClaudeAdapter(): HarnessAdapter {
+  const spec = (opts: LaunchOpts): SpawnSpec => ({
+    command: "bash",
+    args: [],
+    env: {},
+    cwd: opts.cwd,
+  });
+  return {
+    id: "claude-code",
+    eventSource: "hooks",
+    doctor: async () => [],
+    launch: spec,
+    resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec =>
+      spec(opts),
+    listPastSessions: async () => [],
+  };
+}
+
+/** Write a minimal sapiom.json into `dir`, creating the directory first. */
+async function scaffoldWorkflow(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "sapiom.json"),
+    JSON.stringify({ definitionId: null }),
+  );
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({ name: dir.split("/").pop() }),
+  );
+}
+
+/** Fetch the session list from a running server. */
+async function listSessions(port: number): Promise<HarnessSession[]> {
+  const res = await fetch(`http://127.0.0.1:${port}/api/sessions`, {
+    headers: { "X-Harness-Token": "test-token" },
+  });
+  return (await res.json()) as HarnessSession[];
+}
+
+/** Open the /ws/events WebSocket and return a collector of received messages. */
+async function collectEvents(
+  port: number,
+): Promise<{ messages: BusMessage[]; close: () => void }> {
+  const messages: BusMessage[] = [];
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}/ws/events?token=test-token`,
+  );
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  ws.on("message", (raw) => {
+    messages.push(JSON.parse(raw.toString()) as BusMessage);
+  });
+  return {
+    messages,
+    close: () => ws.close(),
+  };
+}
+
+describe("auto-bind on rescan (SAP-1897)", () => {
+  let dir: string;
+  let cwd: string;
+  let server: HarnessServer | undefined;
+  let events: { messages: BusMessage[]; close: () => void } | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-autobind-"));
+    cwd = join(dir, "project");
+    await mkdir(cwd, { recursive: true });
+  });
+
+  afterEach(async () => {
+    events?.close();
+    await server?.sessionManager.flush();
+    await server?.close();
+    server = undefined;
+    // maxRetries guards against macOS's occasional ENOTEMPTY on temp-dir
+    // removal when a watcher handle releases slightly after close().
+    await rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  async function startTestServer(): Promise<number> {
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      adapters: { "claude-code": fakeClaudeAdapter() },
+      stateRoot: dir,
+      launchDir: cwd,
+      autoCreateSession: false,
+    });
+    return server.port;
+  }
+
+  it(
+    "binds an unbound session when a workflow appears at exactly session.cwd",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+      // Create a session in cwd — starts unbound.
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+      expect(session.boundWorkflowPath).toBeNull();
+
+      events = await collectEvents(port);
+
+      // Scaffold a workflow at exactly cwd — the workspace watcher fires a
+      // rescan, which should auto-bind.
+      await scaffoldWorkflow(cwd);
+
+      await vi.waitFor(
+        async () => {
+          const sessions = await listSessions(port);
+          const s = sessions.find((x) => x.id === session.id);
+          expect(s?.boundWorkflowPath).toBe(cwd);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      // The binding must have been broadcast as a session.status frame.
+      expect(
+        events.messages.some(
+          (m) =>
+            m.type === "session.status" &&
+            m.session.id === session.id &&
+            m.session.boundWorkflowPath === cwd,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it(
+    "binds an unbound session when a workflow appears under session.cwd (nested)",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+      expect(session.boundWorkflowPath).toBeNull();
+
+      // Scaffold a workflow under a sub-directory of cwd.
+      const wfDir = join(cwd, "my-agent");
+      await scaffoldWorkflow(wfDir);
+
+      await vi.waitFor(
+        async () => {
+          const sessions = await listSessions(port);
+          const s = sessions.find((x) => x.id === session.id);
+          expect(s?.boundWorkflowPath).toBe(wfDir);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+    },
+  );
+
+  it(
+    "prefers workflow at cwd over a nested one",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+
+      // Scaffold a nested workflow first (to register it), then the one at cwd.
+      const nested = join(cwd, "nested-agent");
+      await scaffoldWorkflow(nested);
+
+      // Wait for nested to appear so both are present when we add the cwd one.
+      await vi.waitFor(
+        async () => {
+          const s = await listSessions(port);
+          expect(s.find((x) => x.id === session.id)?.boundWorkflowPath).toBe(
+            nested,
+          );
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      // Now manually unbind (simulate the user not having an explicit binding)
+      // and scaffold at cwd.  The test validates preference logic directly by
+      // calling the PATCH route.
+      const patchRes = await fetch(
+        `http://127.0.0.1:${port}/api/sessions/${session.id}/workflow`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Harness-Token": "test-token",
+          },
+          body: JSON.stringify({ workflowPath: null }),
+        },
+      );
+      expect(patchRes.status).toBe(200);
+
+      // Scaffold a workflow at exactly cwd — next rescan should prefer it.
+      await scaffoldWorkflow(cwd);
+
+      await vi.waitFor(
+        async () => {
+          const s = await listSessions(port);
+          expect(s.find((x) => x.id === session.id)?.boundWorkflowPath).toBe(
+            cwd,
+          );
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+    },
+  );
+
+  it(
+    "does not auto-bind when the session already has an explicit binding",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+
+      // Pre-register a workflow so we can bind to it.
+      const preexisting = join(dir, "other-agent");
+      await scaffoldWorkflow(preexisting);
+      // Connect it via the API so the registry knows it.
+      const connectRes = await fetch(
+        `http://127.0.0.1:${port}/api/workflows/connect`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Harness-Token": "test-token",
+          },
+          body: JSON.stringify({ path: preexisting }),
+        },
+      );
+      expect(connectRes.status).toBe(200);
+
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+
+      // Explicitly bind to the pre-existing workflow.
+      const patchRes = await fetch(
+        `http://127.0.0.1:${port}/api/sessions/${session.id}/workflow`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Harness-Token": "test-token",
+          },
+          body: JSON.stringify({ workflowPath: preexisting }),
+        },
+      );
+      expect(patchRes.status).toBe(200);
+
+      // Now scaffold a workflow at cwd — a rescan should NOT override the
+      // explicit binding.
+      await scaffoldWorkflow(cwd);
+
+      // Wait long enough for a rescan to have fired; binding must stay.
+      await new Promise<void>((resolve) => setTimeout(resolve, 3_000));
+      const sessions = await listSessions(port);
+      const s = sessions.find((x) => x.id === session.id);
+      expect(s?.boundWorkflowPath).toBe(preexisting);
+    },
+  );
+
+  it(
+    "does not auto-bind when no workflow exists at or under session.cwd",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+
+      // Scaffold a workflow OUTSIDE the session's cwd — must not trigger bind.
+      const outside = join(dir, "unrelated-agent");
+      await scaffoldWorkflow(outside);
+      await fetch(`http://127.0.0.1:${port}/api/workflows/connect`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Harness-Token": "test-token",
+        },
+        body: JSON.stringify({ path: outside }),
+      });
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+      const sessions = await listSessions(port);
+      const s = sessions.find((x) => x.id === session.id);
+      expect(s?.boundWorkflowPath).toBeNull();
+    },
+  );
+
+  it(
+    "is idempotent — a second rescan does not re-bind or emit redundant events",
+    { retry: 1, timeout: 20_000 },
+    async () => {
+      const port = await startTestServer();
+      const session = await server!.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+      });
+
+      events = await collectEvents(port);
+
+      // Scaffold the workflow at cwd.
+      await scaffoldWorkflow(cwd);
+
+      // Wait for the initial auto-bind to land.
+      await vi.waitFor(
+        async () => {
+          const s = await listSessions(port);
+          expect(s.find((x) => x.id === session.id)?.boundWorkflowPath).toBe(
+            cwd,
+          );
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      // Count session.status frames for our session.
+      const framesAfterBind = events.messages.filter(
+        (m) => m.type === "session.status" && m.session.id === session.id,
+      ).length;
+      expect(framesAfterBind).toBeGreaterThan(0);
+
+      // Touch the workspace to force another rescan.
+      await writeFile(join(cwd, "dummy.txt"), "touch");
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+
+      // Verify the binding is unchanged and no NEW session.status frame was emitted
+      // for the already-bound session on account of a second bind attempt.
+      const framesAfterSecondRescan = events.messages.filter(
+        (m) => m.type === "session.status" && m.session.id === session.id,
+      ).length;
+      expect(framesAfterSecondRescan).toBe(framesAfterBind);
+
+      const sessions = await listSessions(port);
+      expect(
+        sessions.find((x) => x.id === session.id)?.boundWorkflowPath,
+      ).toBe(cwd);
+    },
+  );
+});

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -12,7 +12,7 @@ import {
   type Server as HttpServer,
 } from "node:http";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import express, { type Express } from "express";
 import { WebSocketServer } from "ws";
@@ -574,7 +574,7 @@ export const startServer = async (
     // the session is bound, so this is idempotent and never overrides an
     // explicit/persisted binding.
     if (!session.boundWorkflowPath) {
-      const cwdSep = session.cwd + "/";
+      const cwdSep = session.cwd + sep;
       const candidate =
         after.find((w) => w.path === session.cwd) ??
         after

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -565,6 +565,34 @@ export const startServer = async (
     await workflowRegistry.scan(session.cwd);
     const after = await workflowRegistry.list();
     workflowsCache = after;
+
+    // Auto-bind: if this session is still unbound, find the workflow at or
+    // directly under its cwd and bind it — same mechanism as
+    // PATCH /api/sessions/:id/workflow (setBoundWorkflowPath +
+    // writeSessionContext + renderCanvas). Only runs once: the guard
+    // `!session.boundWorkflowPath` is false on every subsequent rescan once
+    // the session is bound, so this is idempotent and never overrides an
+    // explicit/persisted binding.
+    if (!session.boundWorkflowPath) {
+      const cwdSep = session.cwd + "/";
+      const candidate =
+        after.find((w) => w.path === session.cwd) ??
+        after
+          .filter((w) => w.path.startsWith(cwdSep))
+          .sort((a, b) => a.path.length - b.path.length)[0] ??
+        null;
+      if (candidate) {
+        sessionManager.setBoundWorkflowPath(session.id, candidate.path);
+        // Re-read: setBoundWorkflowPath mutates the session object in place,
+        // so the session reference we already hold already carries the new
+        // binding — pass it directly, same as the PATCH handler does.
+        await writeSessionContext(session);
+        await renderCanvas(session).catch((err: unknown) => {
+          console.error("[harness] auto-bind canvas render failed:", err);
+        });
+      }
+    }
+
     if (workflowListsEqual(before, after)) return;
     await Promise.all(sessionManager.list().map((s) => writeSessionContext(s)));
     bus.publish({ type: "workflows.changed" });


### PR DESCRIPTION
## Summary

- Extends `rescanWorkspaceForSession` (`server/index.ts`) to auto-bind an unbound session to the workflow the agent just built — the same `setBoundWorkflowPath` + `writeSessionContext` + `renderCanvas` path that `PATCH /api/sessions/:id/workflow` uses
- No web layer change needed: `setBoundWorkflowPath` already emits a `session.status` BusMessage; the SPA's existing handler updates `state.sessions` live
- Binding is idempotent (guard: `!session.boundWorkflowPath`), only fires for workflows at/under session cwd, never overrides an explicit/persisted binding

## Bind seam reused

`sessionManager.setBoundWorkflowPath()` (session-manager.ts:830) — identical to the PATCH handler's call site in rest.ts:400. Followed by `writeSessionContext(session)` and `renderCanvas(session)`, matching the PATCH handler exactly.

## Live propagation

No web change was needed. `setBoundWorkflowPath` calls `emitStatus`, which fires the `onStatusChange` callback in `startServer`, which publishes `{ type: "session.status", session }` on the event bus. `use-harness-state.ts` already handles `session.status` by updating `state.sessions` in place (line 507–514) — so `boundWorkflowPath` propagates live to `SessionStepsBar` and Visualize without a refresh.

## Guardrails

- **Only when unbound**: `if (!session.boundWorkflowPath)` — false after first bind, so idempotent
- **Only at/under cwd**: prefers `w.path === session.cwd`; falls back to shortest `w.path.startsWith(cwd + "/")` entry
- **Never overrides explicit binding**: the unbound guard covers this entirely

## Tests

6 integration tests in `auto-bind-rescan.test.ts`:
1. Binds at exactly session.cwd
2. Binds nested workflow under cwd
3. Prefers cwd over nested when both exist
4. Does not override an explicit binding
5. Does not bind a workflow outside cwd
6. Idempotent — second rescan emits no new session.status for the already-bound session

## Test counts

- Unit (vitest): **1216 passed**, 0 failed (90 test files)
- E2E (Playwright): **231 passed**, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)