### PR TITLE
fix(harness): open Sapiom dashboard at /workflows, not the onboarding redirect

### DIFF
--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -25,7 +25,7 @@ import { HARNESS_LABELS, historyRowMeta } from "../lib/history-meta";
 import { loadUiPrefs, saveUiPrefs } from "../lib/ui-prefs";
 import { buildWorkspaceTree } from "../lib/workspace-tree";
 
-const SAPIOM_DASHBOARD_URL = "https://app.sapiom.ai";
+const SAPIOM_DASHBOARD_URL = "https://app.sapiom.ai/workflows";
 
 interface WorkflowsRailProps {
   /** Resizable width (px) — the rail can shrink to minWidth under pressure. */


### PR DESCRIPTION
## Summary

- Changes `SAPIOM_DASHBOARD_URL` in `WorkflowsRail.tsx` from `https://app.sapiom.ai` to `https://app.sapiom.ai/workflows`
- Both call sites (account menu "Open Sapiom dashboard" button at line 783, and the profile section shortcut at line 834) inherit the fix from the single constant

## Test plan

- [x] Build: `pnpm --filter "@sapiom/harness..." build` — clean
- [x] Typecheck: `pnpm --filter "@sapiom/harness" typecheck` — clean
- [x] Unit tests: 1187 passed (vitest) — no failures attributable to this change
- [x] E2E tests: `CI=1 E2E_PORT=5555 pnpm --filter @sapiom/harness test:ui` — 206 passed
- No test updated: the existing `smoke.spec.ts` only asserts visibility of `profile-open-dashboard`, not the URL it opens; no test asserted the old bare-root URL

## Follow-up note (not changed in this PR)

`SAPIOM_DASHBOARD_URL` is hardcoded to `app.sapiom.ai` (prod) and is not environment-aware — under `SAPIOM_ENVIRONMENT=dev`/staging it still points at prod. This is a pre-existing condition and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)