### PR TITLE
fix(harness): inject window.__HARNESS__ boot token into SPA HTML (SAP-1898)

### DIFF
--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1118,7 +1118,7 @@ export const startServer = async (
   // NOTE: mount additional routers above this line — the static/SPA fallback
   // below is a catch-all and must stay last.
   const webDir = options.webDir ?? join(packageRoot(), "dist", "web");
-  app.use(createStaticRouter(webDir));
+  app.use(createStaticRouter(webDir, options.bootToken));
 
   app.use(
     (

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -129,8 +129,14 @@ describe("createStaticRouter", () => {
       const html = await res.text();
       // The raw string must NOT appear verbatim — it must be JSON-escaped.
       expect(html).not.toContain(weirdToken);
-      // The JSON-encoded form must be present.
-      expect(html).toContain(JSON.stringify(weirdToken));
+      // The safe (< → <) encoded form must be present in the page.
+      const safeJson = JSON.stringify({ token: weirdToken }).replace(/</g, "\\u003c");
+      expect(html).toContain(safeJson);
+      // The </script> breakout sequence from the token must not appear literally
+      // — it would terminate the injected script block early and allow XSS.
+      // The < is Unicode-escaped to < (inert to JSON.parse, opaque to
+      // the HTML parser), so the raw sequence can never appear verbatim.
+      expect(html).not.toContain("</script><script>evil");
     });
   });
 

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -15,16 +15,22 @@ import { createStaticRouter } from "./static.js";
 // deep-route fallback), and an unbuilt tree degrades to the placeholder rather
 // than 404ing — so the launch-critical `build → serve → npx` path can't
 // silently regress.
+//
+// SAP-1898: the router also bakes `window.__HARNESS__ = { token }` into every
+// HTML response so the SPA can always read the boot token without depending on
+// the `?token=` query param (which is lost on navigation/reload).
 // ---------------------------------------------------------------------------
+
+const TEST_BOOT_TOKEN = "test-boot-token-abc123";
 
 describe("createStaticRouter", () => {
   let server: ReturnType<express.Express["listen"]>;
   let baseUrl: string;
   const tmpDirs: string[] = [];
 
-  function start(webDir: string): void {
+  function start(webDir: string, bootToken = TEST_BOOT_TOKEN): void {
     const app = express();
-    app.use(createStaticRouter(webDir));
+    app.use(createStaticRouter(webDir, bootToken));
     server = app.listen(0);
     const address = server.address() as AddressInfo;
     baseUrl = `http://127.0.0.1:${address.port}`;
@@ -83,6 +89,48 @@ describe("createStaticRouter", () => {
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain("<title>Sapiom Studio</title>");
+    });
+
+    // SAP-1898: boot-token injection
+    it("injects window.__HARNESS__ script with the boot token before </head>", async () => {
+      start(makeBuiltWebDir(), TEST_BOOT_TOKEN);
+
+      const res = await fetch(`${baseUrl}/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+
+      // The script must be present and contain the token JSON-encoded.
+      expect(html).toContain("window.__HARNESS__");
+      expect(html).toContain(JSON.stringify(TEST_BOOT_TOKEN));
+      // The script must appear before </head> so it runs before SPA modules load.
+      const scriptPos = html.indexOf("window.__HARNESS__");
+      const headClosePos = html.indexOf("</head>");
+      expect(scriptPos).toBeGreaterThan(-1);
+      expect(headClosePos).toBeGreaterThan(-1);
+      expect(scriptPos).toBeLessThan(headClosePos);
+    });
+
+    it("injects window.__HARNESS__ on deep SPA routes too (navigation/reload safety)", async () => {
+      start(makeBuiltWebDir(), TEST_BOOT_TOKEN);
+
+      const res = await fetch(`${baseUrl}/some/client/route`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("window.__HARNESS__");
+      expect(html).toContain(JSON.stringify(TEST_BOOT_TOKEN));
+    });
+
+    it("JSON-escapes the boot token so special characters cannot break the script block", async () => {
+      // A token containing characters that could break a bare string interpolation.
+      const weirdToken = 'tok"en</script><script>evil';
+      start(makeBuiltWebDir(), weirdToken);
+
+      const res = await fetch(`${baseUrl}/`);
+      const html = await res.text();
+      // The raw string must NOT appear verbatim — it must be JSON-escaped.
+      expect(html).not.toContain(weirdToken);
+      // The JSON-encoded form must be present.
+      expect(html).toContain(JSON.stringify(weirdToken));
     });
   });
 

--- a/packages/harness/src/server/static.ts
+++ b/packages/harness/src/server/static.ts
@@ -2,11 +2,25 @@
  * Serves the built Vite SPA from dist/web. Falls back to a placeholder page
  * when the web bundle hasn't been built yet (e.g. `pnpm dev` without a prior
  * `pnpm build:web`), so the server is still useful for API/WS-only testing.
+ *
+ * Boot-token injection: every HTML response has a `<script>` block baked in
+ * before `</head>` that sets `window.__HARNESS__ = { token: "<bootToken>" }`.
+ * This lets `getBootToken()` (web/src/lib/api.ts) resolve the token without
+ * relying on the `?token=` query param — which is lost on navigation/reload
+ * and caused every /api POST to 401 after the first page load (SAP-1898).
+ *
+ * Implementation note: `express.static` serves index.html directly on `/`
+ * requests, bypassing any downstream handlers. To guarantee injection we:
+ *   1. Use `express.static` with `index: false` so it never auto-serves
+ *      index.html itself.
+ *   2. Add a catch-all `GET *` that serves the pre-injected HTML string for
+ *      any route that `express.static` didn't match (SPA deep-route fallback
+ *      AND the root `/`).
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import express, { Router } from "express";
+import express, { Router, type Request, type Response } from "express";
 
 const PLACEHOLDER_HTML = `<!doctype html>
 <html>
@@ -20,17 +34,56 @@ const PLACEHOLDER_HTML = `<!doctype html>
 </html>
 `;
 
-export function createStaticRouter(webDir: string): Router {
+/**
+ * Builds the inline `<script>` that bakes the boot token into the page before
+ * any SPA JS runs. JSON.stringify ensures the token is safely escaped even if
+ * it contains characters that could break a bare string interpolation.
+ */
+function buildTokenScript(bootToken: string): string {
+  return `<script>window.__HARNESS__ = ${JSON.stringify({ token: bootToken })};</script>`;
+}
+
+/**
+ * Injects the boot-token `<script>` block into raw HTML. The block is
+ * inserted immediately before `</head>` so it executes before any SPA modules
+ * load. Falls back to prepending to `<body>` if `</head>` is absent (shouldn't
+ * happen with our Vite output, but keeps the injection unconditional).
+ */
+function injectTokenScript(html: string, bootToken: string): string {
+  const script = buildTokenScript(bootToken);
+  if (html.includes("</head>")) {
+    return html.replace("</head>", `${script}</head>`);
+  }
+  // Fallback: inject at the very start of <body> if </head> is missing.
+  if (html.includes("<body>")) {
+    return html.replace("<body>", `<body>${script}`);
+  }
+  // Last resort: prepend to the document.
+  return script + html;
+}
+
+export function createStaticRouter(webDir: string, bootToken: string): Router {
   const router = Router();
   const indexPath = join(webDir, "index.html");
 
   if (existsSync(indexPath)) {
-    router.use(express.static(webDir));
-    router.get("*", (_req, res) => {
-      res.sendFile(indexPath);
+    // Read index.html once at startup. The file doesn't change at runtime
+    // (it's a Vite build output), so a single read is fine and avoids
+    // repeated disk I/O for every page navigation request.
+    const rawHtml = readFileSync(indexPath, "utf-8");
+    const injectedHtml = injectTokenScript(rawHtml, bootToken);
+
+    // Serve hashed assets (JS, CSS, images) via express.static.
+    // `index: false` prevents express.static from auto-serving index.html
+    // on GET / — we handle that (and all SPA deep routes) in the catch-all
+    // below so every HTML response always carries the injected token script.
+    router.use(express.static(webDir, { index: false }));
+
+    router.get("*", (_req: Request, res: Response) => {
+      res.status(200).set("Content-Type", "text/html").send(injectedHtml);
     });
   } else {
-    router.get("*", (_req, res) => {
+    router.get("*", (_req: Request, res: Response) => {
       res.status(200).set("Content-Type", "text/html").send(PLACEHOLDER_HTML);
     });
   }

--- a/packages/harness/src/server/static.ts
+++ b/packages/harness/src/server/static.ts
@@ -4,7 +4,7 @@
  * `pnpm build:web`), so the server is still useful for API/WS-only testing.
  *
  * Boot-token injection: every HTML response has a `<script>` block baked in
- * before `</head>` that sets `window.__HARNESS__ = { token: "<bootToken>" }`.
+ * before `</head>` that sets `window.__HARNESS__ = { token: ${bootToken} }`.
  * This lets `getBootToken()` (web/src/lib/api.ts) resolve the token without
  * relying on the `?token=` query param — which is lost on navigation/reload
  * and caused every /api POST to 401 after the first page load (SAP-1898).
@@ -40,7 +40,8 @@ const PLACEHOLDER_HTML = `<!doctype html>
  * it contains characters that could break a bare string interpolation.
  */
 function buildTokenScript(bootToken: string): string {
-  return `<script>window.__HARNESS__ = ${JSON.stringify({ token: bootToken })};</script>`;
+  const safeJson = JSON.stringify({ token: bootToken }).replace(/</g, "\\u003c");
+  return `<script>window.__HARNESS__ = ${safeJson};</script>`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `src/server/static.ts`: `createStaticRouter` now accepts a `bootToken` parameter and bakes `<script>window.__HARNESS__ = {"token":"..."}</script>` before `</head>` in every HTML response, using `JSON.stringify` for safe escaping. `express.static` is mounted with `index: false` to prevent it intercepting `GET /` before the injected catch-all.
- `src/server/index.ts`: threads `options.bootToken` through to `createStaticRouter`.
- `src/server/static.test.ts`: adds 3 new tests — injection present before `</head>`, injection on deep SPA routes, and JSON-escaped special characters.

**Result:** `getBootToken()` reads `window.__HARNESS__.token` on every load, never falls through to `?token=` in the URL. Every `/api` POST (template session-create, Local Run, Prod Run) gets a valid `X-Harness-Token` header regardless of navigation or reload. The boot-token gate is unchanged.

## Test plan

- [x] `pnpm --filter "@sapiom/harness..." build` — green
- [x] `pnpm --filter @sapiom/harness exec tsc --noEmit` — green  
- [x] `pnpm --filter @sapiom/harness test` — 1196 passed (0 failed)
- [x] `CI=1 E2E_PORT=5557 pnpm --filter @sapiom/harness test:ui` — 206 passed (0 failed)

Fixes SAP-1898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)