### PR TITLE
fix(harness): write NUL key-delimiters as escape sequences

### DIFF
--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -242,7 +242,7 @@ function workflowListsEqual(
 ): boolean {
   if (a.length !== b.length) return false;
   const key = (w: WorkflowInfo): string =>
-    `${w.path} ${w.name} ${w.definitionId ?? ""} ${w.source}`;
+    `${w.path}\u0000${w.name}\u0000${w.definitionId ?? ""}\u0000${w.source}`;
   const setA = new Set(a.map(key));
   return b.every((w) => setA.has(key(w)));
 }


### PR DESCRIPTION
## What and why

Raw NUL bytes (U+0000) committed in TypeScript source make the file appear binary to `grep`, `git diff`, and most editors -- unacceptable in a public open-source repo.

`packages/harness/src/server/index.ts` contains a composite dedup-Set key that intentionally uses NUL as a collision-safe field delimiter.

**Before:** Three raw NUL bytes used as delimiters inside a template literal key expression (line 245).

**After (pure-text source, identical runtime behaviour):** the same template literal with the three raw bytes replaced by their source-level \u0000 escape sequences.

The \u0000 escape sequences produce char code 0 at runtime -- the collision-safe delimiter semantics are fully preserved.

## Scope

Server-side only. `packages/harness/web/` is untouched (PR #394 owns that path).

## Verification

- Zero raw NUL bytes remain in server-side harness source after the fix.
- Build: `pnpm --filter "@sapiom/harness..." build` -- clean.
- Unit tests: **1196 passed**.
- E2E tests: **206 passed**.
- Runtime sanity: `"a\u0000b".charCodeAt(1) === 0` evaluates to `true`.
- `git diff` shows exactly one line changed (line 245), no other modifications.

## Files changed

- `packages/harness/src/server/index.ts` -- line 245: 3 raw NUL bytes replaced with 3 \u0000 escapes.

Generated with [Claude Code](https://claude.ai/claude-code)
