### PR TITLE
fix(agent-core): default local-run input to {} for prod parity

### DIFF
--- a/packages/agent-core/src/local/run-local.spec.ts
+++ b/packages/agent-core/src/local/run-local.spec.ts
@@ -568,4 +568,41 @@ describe("runLocal", () => {
     expect(result.outcome).toBe("failed");
     expect(runs).toBe(2);
   });
+
+  // Prod parity: the server-side run defaults an absent input to {} (run.ts:63
+  // `const { definitionId, input = {} } = opts`). Local must match — an absent
+  // input must NOT reach the first step as undefined. A step that reads
+  // `input.topic?.trim()` would throw `Cannot read properties of undefined
+  // (reading 'topic')` if input is undefined.
+  it("defaults an absent input to {} so the first step never receives undefined", async () => {
+    let capturedInput: unknown;
+    const entry = defineStep({
+      name: "entry",
+      next: [],
+      terminal: true,
+      async run(input: { topic?: string } | undefined) {
+        capturedInput = input;
+        // mirrors the real failure mode: reading a property of what could be
+        // undefined if the default is missing
+        const trimmed = (input as { topic?: string })?.topic?.trim() ?? "(none)";
+        return terminate({ trimmed });
+      },
+    });
+    const def = defineAgent({
+      name: "no-input",
+      entry: "entry",
+      steps: { entry },
+    });
+
+    // NOTE: `input` is intentionally omitted — this is the scenario that
+    // previously crashed (undefined → Cannot read properties of undefined).
+    const result = await runLocal({
+      definition: def,
+      manifest: manifestFor(def),
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(capturedInput).toEqual({});
+    expect(result.output).toEqual({ trimmed: "(none)" });
+  });
 });

--- a/packages/agent-core/src/local/run-local.ts
+++ b/packages/agent-core/src/local/run-local.ts
@@ -118,7 +118,7 @@ export async function runLocal(opts: RunLocalOptions): Promise<LocalRunResult> {
   const executionId = await core.createExecution(
     opts.definition.name,
     opts.definition.entry,
-    opts.input,
+    opts.input ?? {},
     {
       manifest: opts.manifest,
     },


### PR DESCRIPTION
## Summary

- `run.ts` (prod path) defaults absent input to `{}` via `const { definitionId, input = {} } = opts`. Local `runLocal` was passing `opts.input` directly to `createExecution` with no default, leaving it `undefined` when omitted.
- A step reading `input.topic?.trim()` on an undefined input throws `Cannot read properties of undefined (reading 'topic')`, crashing Local Run while Prod Run silently worked.
- Fix: apply `opts.input ?? {}` at the `createExecution` call site in `run-local.ts` (line 121) to mirror prod's contract at the single entry seam that covers all callers (Studio button, CLI, MCP).

## Test plan

- [ ] New test in `run-local.spec.ts`: `runLocal` called with no `input` property → entry step receives `{}` → property access `input.topic?.trim()` does not throw → run completes with `outcome: "completed"`
- [ ] Confirmed test fails against the unfixed code (undefined → crash) and passes after the `?? {}` fix
- [ ] `pnpm --filter @sapiom/agent-core test`: 127 passed, 1 pre-existing scaffold version-mismatch failure (unrelated)
- [ ] `pnpm --filter @sapiom/harness test`: 1247 passed, 0 failed
- [ ] `pnpm --filter "@sapiom/harness..." build`: clean build