### PR TITLE
feat(examples): add a news-roundup template

### DIFF
--- a/examples/news-roundup/.gitignore
+++ b/examples/news-roundup/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.tsbuildinfo
+sapiom.json

--- a/examples/news-roundup/.sapiom-dev/stubs.json
+++ b/examples/news-roundup/.sapiom-dev/stubs.json
@@ -1,0 +1,58 @@
+{
+  "version": 1,
+  "steps": {
+    "search": {
+      "search.webSearch": {
+        "query": "stub",
+        "results": [
+          { "title": "Polsia raises Series A", "url": "https://news.example/polsia-a", "snippet": "Polsia announced a funding round..." },
+          { "title": "Polsia launches product", "url": "https://news.example/polsia-b", "snippet": "The company launched..." },
+          { "title": "Polsia bakery Berlin", "url": "https://blog.example/bakery", "snippet": "Unrelated bakery blog..." },
+          { "title": "Polsia hires CTO", "url": "https://news.example/polsia-c", "snippet": "Polsia announced a new CTO..." }
+        ]
+      }
+    },
+    "select": {
+      "models.run": {
+        "runId": "r1",
+        "status": "completed",
+        "output": "[{\"title\":\"Polsia raises Series A\",\"url\":\"https://news.example/polsia-a\",\"summary\":\"Polsia raised new funding. This gives the company money to grow.\",\"imagePrompt\":\"A friendly illustration of a growing plant in a pot of coins\"},{\"title\":\"Polsia launches product\",\"url\":\"https://news.example/polsia-b\",\"summary\":\"Polsia released a new product. Customers can use it today.\",\"imagePrompt\":\"A gift box opening with light rays\"},{\"title\":\"Polsia hires CTO\",\"url\":\"https://news.example/polsia-c\",\"summary\":\"Polsia hired a new technology chief. They will lead the engineering team.\",\"imagePrompt\":\"A person joining a team around a table, flat illustration\"}]",
+        "result": null,
+        "error": null
+      }
+    },
+    "illustrate": {
+      "contentGeneration.images.create": {
+        "images": [{ "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" }]
+      },
+      "fileStorage.upload": {
+        "fileId": "img-stub",
+        "uploadUrl": "http://127.0.0.1:4599/put",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "requiredHeaders": { "content-type": "image/png" }
+      }
+    },
+    "publish": {
+      "fileStorage.upload": {
+        "fileId": "page-stub",
+        "uploadUrl": "http://127.0.0.1:4599/put",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "requiredHeaders": { "content-type": "text/html" }
+      },
+      "fileStorage.list": {
+        "files": [
+          { "fileId": "page-stub", "fileName": "news-roundup/polsia/pages/2026-07-22.html", "contentType": "text/html", "visibility": "public", "status": "uploaded", "fileSize": "1000", "createdAt": "2026-07-22T00:00:00Z", "downloadRequestCount": 0 },
+          { "fileId": "img-stub", "fileName": "news-roundup/polsia/images/2026-07-22-1.png", "contentType": "image/png", "visibility": "public", "status": "uploaded", "fileSize": "100", "createdAt": "2026-07-22T00:00:00Z", "downloadRequestCount": 0 }
+        ],
+        "limit": 100, "offset": 0, "hasMore": false
+      },
+      "fileStorage.getDownloadUrl": {
+        "downloadUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "expiresAt": "2099-01-01T00:00:00Z"
+      },
+      "sandboxes.get": { "name": "news-roundup-polsia", "source": "agent", "status": "running", "tier": "s", "url": null, "workspaceRoot": "/workspace", "expiresAt": null, "createdAt": "2026-07-22T00:00:00Z", "updatedAt": "2026-07-22T00:00:00Z" },
+      "sandbox.uploadFile": null,
+      "sandbox.deployPreview": { "url": "https://news-roundup-polsia.preview.example", "status": "deployed", "logs": "" }
+    }
+  }
+}

--- a/examples/news-roundup/AGENTS.md
+++ b/examples/news-roundup/AGENTS.md
@@ -1,0 +1,50 @@
+# Working in this agent project
+
+This project defines exactly one Sapiom agent in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+
+The full authoring guide is the `sapiom-agent-authoring` skill — it auto-loads in Claude Code via the Sapiom plugin (the scaffolder also drops it into new projects). Read it for the step model, directives, failure patterns, pause/resume, and stub rules.
+
+## Authoring
+
+- An orchestration is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — this project ships a near-complete local suite. Reach for it then; you don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so a workflow runs end-to-end with zero setup. Returns a per-step trace.
+- **deploy** — ship it.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+## Stubs (overrides)
+
+`run_local` works with **no stubs** — capabilities return sensible defaults. Add an override only when a step's logic branches on a specific result (e.g. "if `repositories.list()` already contains my repo, skip create"). Put overrides in `.sapiom-dev/stubs.json` (committed and human-reviewable); `run_local` reads it automatically. Shape:
+
+```jsonc
+{ "version": 1, "steps": { "<stepName>": { "<capability.path>": <response> } } }
+```
+
+- Capability paths are namespace methods (`repositories.list`, `repositories.create`, `models.coding.run`) or handle methods, which use the **singular** handle type (`repository.pushFromSandbox`, `sandbox.exec`) — not the plural namespace.
+- `<response>` is returned **verbatim** — it is the value that call would return, so match its real shape. `repositories.list` takes the array `list()` returns: `[{ "slug": "...", "cloneUrl": "..." }]` (each element a repository — *not* `[[ … ]]`). `repositories.create`/`get`/`attach` take a single `{ "slug", "cloneUrl" }`.
+- `run_local` reports **`unusedStubs`** (a key that matched no call — usually a typo or the plural/singular mistake) and **`stubWarnings`** (a key matched but the value was the wrong shape). A green run with either non-empty means a stub silently didn't take effect — check them.
+
+## Dispatched runs: pause & resume
+
+A long-running capability (today the coding agent) is launched fire-and-forget and the workflow suspends until it finishes:
+
+```ts
+const run = await ctx.sapiom.models.coding.launch({ task, gitRepository: repo }); // returns a handle, not a result
+return pauseUntilSignal(run, { resumeStep: "finalize" });                         // suspend on the run's result signal
+```
+
+- **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
+- That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
+- **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` *in the launching step* — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Don't rely on a value being recomputed identically across a pause/resume — capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared`.

--- a/examples/news-roundup/README.md
+++ b/examples/news-roundup/README.md
@@ -1,0 +1,95 @@
+# news-roundup
+
+A Sapiom agent, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent), that builds a small news-roundup website for a company. Given a company name, it searches the web for recent news, asks a model to pick the 3–5 most relevant articles and write a plain-language summary and an illustration prompt for each, generates one image per article, and publishes a dated roundup page to a per-company site. Each run adds a new dated page to that company's site without touching prior runs.
+
+## Steps
+
+`search` → `select` → `illustrate` → `publish` (defined in `index.ts`, backed by `lib/`):
+
+1. **search** — `ctx.sapiom.search.webSearch` for `"<companyName>" company news from the last 7 days`. If nothing comes back, the agent terminates gracefully (see "No news" below) instead of failing.
+2. **select** — `ctx.sapiom.models.run` picks 3–5 articles from the search results and returns, per article, a title/url/summary/imagePrompt.
+3. **illustrate** — `ctx.sapiom.contentGeneration.images.create` generates one image per selected article; each image is uploaded public to Sapiom file storage. A failed generation degrades that article to a text-only card (two attempts, then move on) rather than failing the run.
+4. **publish** — renders the dated HTML page, uploads it to file storage, then rebuilds the company's sandbox site entirely from what's in storage (see "Storage" and "Serving" below) and returns the live URLs.
+
+## Entry input
+
+```json
+{ "companyName": "Polsia" }
+```
+
+`companyName` is the only input; it's slugified (e.g. `Polsia` → `polsia`) to key storage paths and the sandbox name.
+
+## Output
+
+On success (`publish` terminates with):
+
+```json
+{
+  "status": "published",
+  "siteUrl": "https://news-roundup-polsia-<id>.sandbox.sapiom.ai",
+  "pageUrl": "https://news-roundup-polsia-<id>.sandbox.sapiom.ai/pages/2026-07-22.html",
+  "articles": [
+    { "title": "...", "sourceUrl": "...", "summary": "...", "imageUrl": "https://.../images/2026-07-22-1.png" }
+  ]
+}
+```
+
+`imageUrl` is `null` for an article whose illustration generation failed — the site still renders it as a text-only card.
+
+### No news
+
+If `search` finds zero results for the company, the agent terminates early with:
+
+```json
+{ "status": "no-news", "companyName": "Polsia" }
+```
+
+No page is published and the sandbox is left untouched for that run.
+
+## Storage layout
+
+Everything durable lives in Sapiom file storage under a per-company prefix, uploaded with `visibility: "public"`:
+
+```
+news-roundup/<companySlug>/
+  pages/<runDate>.html        # one dated roundup page per run
+  images/<runDate>-<n>.png    # one image per illustrated article that run
+```
+
+This is the source of truth. The sandbox (below) is a disposable, rebuildable view over it — losing the sandbox loses nothing; the next run (or a manual `deployPreview`) reconstructs the whole site from these files.
+
+## Sandbox naming & serving
+
+- Sandbox name: `news-roundup-<companySlug>` (find-or-create — reused across runs for the same company).
+- `ttl: "24h"`, `tier: "xs"`.
+- **Stateless**: on every `publish`, the agent lists all files under the company's storage prefix, mirrors them into the sandbox as `site/pages/...` and `site/images/...`, writes a generated `site/index.html` (links to every dated page) and `site/server.mjs` (a tiny static file server), then calls `deployPreview({ start: "node site/server.mjs", port: 3000 })`.
+- Because the TTL is 24h, the sandbox — and its preview URL — disappear roughly a day after the last run and get recreated (with a **new** preview URL) on the next run. Don't hardcode or bookmark a `siteUrl`/`pageUrl` long-term; re-run or check the latest execution's output for the current one.
+
+## Testing locally (free — no real capability calls)
+
+```sh
+npm run typecheck && npm test
+```
+
+Then validate the step graph and bundle offline:
+
+- MCP `sapiom_dev_agents_check` — bundles `index.ts`, derives the manifest, checks the step graph. Offline, instant.
+
+To exercise the real step code end-to-end against stubs:
+
+1. Start the local upload sink (services the presigned-PUT calls `uploadPublicFile` makes): `node test/upload-sink.mjs`
+2. In another terminal, MCP `sapiom_dev_agents_run_local` with input `{"companyName": "Polsia"}`. It reads the committed `.sapiom-dev/stubs.json` (stubbed search results, model selection output, image generation, and file-storage/sandbox responses for a `polsia` run) and runs every step's real code against those stubs — zero spend, no live Sapiom calls.
+
+## Running for real
+
+MCP `sapiom_dev_agents_run` with input `{ "companyName": "Polsia" }` runs the deployed agent (slug `news-roundup`) live: real web search, real model call, real image generation, and a real sandbox rebuild/deploy. Inspect the execution's output for the current `siteUrl`/`pageUrl`.
+
+## Schedule
+
+A weekly cron schedule is active for this agent: **every Monday at 08:00 UTC**, input `{ "companyName": "Polsia" }` (schedule id `78`, `definition` slug `news-roundup`). Inspect or manage it with `sapiom_dev_agents_schedule_inspect` / `sapiom_dev_agents_schedule_cancel`.
+
+## Authoring
+
+The orchestration is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`. No credentials to wire — a per-execution tenant credential is injected when the orchestration runs.
+
+See `AGENTS.md` for the full authoring loop (`check` → `run_local` → `deploy`).

--- a/examples/news-roundup/index.ts
+++ b/examples/news-roundup/index.ts
@@ -1,0 +1,207 @@
+import {
+  defineAgent,
+  defineStep,
+  fail,
+  goto,
+  retry,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { z } from "zod/v4";
+import {
+  buildIndexPage,
+  buildRoundupPage,
+  imageStorageName,
+  pageStorageName,
+  roundupDatesFromFileNames,
+  SERVER_JS,
+} from "./lib/html.js";
+import { buildSelectionPrompt, parseSelection } from "./lib/select.js";
+import { downloadFileBytes, listFilesByPrefix, uploadPublicFile } from "./lib/storage.js";
+import type {
+  IllustratedArticle,
+  RawArticle,
+  RoundupShared,
+  SelectedArticle,
+} from "./lib/types.js";
+import { slugify, todayIso } from "./lib/util.js";
+
+const entryInput = z.object({ companyName: z.string().min(1) });
+const SITE_PORT = 3000;
+
+const search = defineStep({
+  name: "search",
+  next: ["select"],
+  terminal: true,
+  canFail: true,
+  inputSchema: entryInput,
+  async run(input: { companyName: string }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = input.companyName.trim();
+    const companySlug = slugify(companyName);
+    ctx.shared.set("companyName", companyName);
+    ctx.shared.set("companySlug", companySlug);
+    ctx.shared.set("runDate", todayIso());
+    ctx.shared.set("storagePrefix", `news-roundup/${companySlug}/`);
+    try {
+      const res = await ctx.sapiom.search.webSearch({
+        query: `"${companyName}" company news from the last 7 days`,
+        intent: "links",
+      });
+      const articles: RawArticle[] = res.results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.snippet,
+      }));
+      if (articles.length === 0) {
+        ctx.logger.info("no news found", { companyName });
+        return terminate({ status: "no-news", companyName });
+      }
+      ctx.logger.info("search done", { count: articles.length });
+      return goto("select", { articles });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`search failed: ${String(err)}`);
+    }
+  },
+});
+
+const select = defineStep({
+  name: "select",
+  next: ["illustrate"],
+  canFail: true,
+  async run(input: { articles: RawArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = ctx.shared.get("companyName") ?? "";
+    const runDate = ctx.shared.get("runDate") ?? "";
+    try {
+      const res = await ctx.sapiom.models.run({
+        prompt: buildSelectionPrompt(companyName, runDate, input.articles),
+        maxTokens: 2000,
+      });
+      if (res.status !== "completed" || !res.output) {
+        throw new Error(res.error?.message ?? `model run ended as ${res.status}`);
+      }
+      const selected = parseSelection(res.output);
+      ctx.logger.info("selection done", { count: selected.length });
+      return goto("illustrate", { selected });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`select failed: ${String(err)}`);
+    }
+  },
+});
+
+const illustrate = defineStep({
+  name: "illustrate",
+  next: ["publish"],
+  canFail: true,
+  async run(input: { selected: SelectedArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const prefix = ctx.shared.get("storagePrefix") ?? "news-roundup/company/";
+    const runDate = ctx.shared.get("runDate") ?? todayIso();
+    try {
+      const articles: IllustratedArticle[] = [];
+      for (const [i, art] of input.selected.entries()) {
+        let imageFileName: string | null = null;
+        // Per-article: one inline retry (two attempts), then degrade to a text-only card.
+        for (let attempt = 0; attempt < 2 && imageFileName === null; attempt++) {
+          try {
+            const gen = await ctx.sapiom.contentGeneration.images.create({ prompt: art.imagePrompt });
+            const url = gen.images?.[0]?.url;
+            if (!url) throw new Error("no image in generation result");
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`image fetch failed: ${res.status}`);
+            const bytes = new Uint8Array(await res.arrayBuffer());
+            const fileName = imageStorageName(prefix, runDate, i + 1);
+            await uploadPublicFile(ctx.sapiom, { fileName, contentType: "image/png", bytes });
+            imageFileName = fileName;
+          } catch (err) {
+            ctx.logger.warn("image failed", { article: art.title, attempt, err: String(err) });
+          }
+        }
+        articles.push({ title: art.title, sourceUrl: art.url, summary: art.summary, imageFileName });
+      }
+      ctx.logger.info("illustrations done", {
+        withImage: articles.filter((a) => a.imageFileName !== null).length,
+        total: articles.length,
+      });
+      return goto("publish", { articles });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`illustrate failed: ${String(err)}`);
+    }
+  },
+});
+
+const publish = defineStep({
+  name: "publish",
+  next: [],
+  terminal: true,
+  canFail: true,
+  async run(input: { articles: IllustratedArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = ctx.shared.get("companyName") ?? "";
+    const companySlug = ctx.shared.get("companySlug") ?? "company";
+    const runDate = ctx.shared.get("runDate") ?? todayIso();
+    const prefix = ctx.shared.get("storagePrefix") ?? `news-roundup/${companySlug}/`;
+    try {
+      // 1. Durable copy of the dated page.
+      const pageHtml = buildRoundupPage({ companyName, runDate, articles: input.articles });
+      await uploadPublicFile(ctx.sapiom, {
+        fileName: pageStorageName(prefix, runDate),
+        contentType: "text/html",
+        bytes: new TextEncoder().encode(pageHtml),
+      });
+      // 2. Full inventory — the sandbox is rebuilt from storage every run.
+      const stored = await listFilesByPrefix(ctx.sapiom, prefix);
+      // 3. Find-or-create the site sandbox.
+      const sandboxName = `news-roundup-${companySlug}`;
+      let sandbox;
+      try {
+        const info = await ctx.sapiom.sandboxes.get(sandboxName);
+        ctx.logger.info("sandbox found", { name: sandboxName, status: info.status });
+        if (info.status !== "running") throw new Error(`sandbox status ${info.status}`);
+        sandbox = ctx.sapiom.sandboxes.attach(sandboxName);
+      } catch (err) {
+        // Expired/missing sandbox is the normal weekly path; the reason distinguishes
+        // not-found from auth/network failures in the execution logs.
+        ctx.logger.warn("creating sandbox", { name: sandboxName, reason: String(err) });
+        sandbox = await ctx.sapiom.sandboxes.create({ name: sandboxName, ttl: "24h", tier: "xs", port: SITE_PORT });
+      }
+      // 4. Mirror storage into site/ (pages/... and images/...).
+      for (const f of stored) {
+        const rel = f.fileName.slice(prefix.length);
+        const bytes = await downloadFileBytes(ctx.sapiom, f.fileId);
+        await sandbox.uploadFile(`site/${rel}`, bytes);
+      }
+      // 5. Index + server, then (re)start.
+      const dates = roundupDatesFromFileNames(stored.map((f) => f.fileName), prefix);
+      await sandbox.uploadFile("site/index.html", buildIndexPage(companyName, dates));
+      await sandbox.uploadFile("site/server.mjs", SERVER_JS);
+      const deploy = await sandbox.deployPreview({ start: "node site/server.mjs", port: SITE_PORT });
+      if (!deploy.url || deploy.status !== "deployed") {
+        throw new Error(`deployPreview ${deploy.status}: ${deploy.logs.slice(-500)}`);
+      }
+      const siteUrl = deploy.url.replace(/\/+$/, "");
+      const imagesPrefix = `${prefix}images/`;
+      ctx.logger.info("published", { siteUrl, files: stored.length });
+      return terminate({
+        status: "published",
+        siteUrl,
+        pageUrl: `${siteUrl}/pages/${runDate}.html`,
+        articles: input.articles.map((a) => ({
+          title: a.title,
+          sourceUrl: a.sourceUrl,
+          summary: a.summary,
+          imageUrl: a.imageFileName ? `${siteUrl}/images/${a.imageFileName.slice(imagesPrefix.length)}` : null,
+        })),
+      });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 2000 });
+      return fail(`publish failed: ${String(err)}`);
+    }
+  },
+});
+
+export const agent = defineAgent<{ companyName: string }, RoundupShared>({
+  name: "news-roundup",
+  entry: "search",
+  steps: { search, select, illustrate, publish },
+});

--- a/examples/news-roundup/lib/html.test.ts
+++ b/examples/news-roundup/lib/html.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIndexPage,
+  buildRoundupPage,
+  imageStorageName,
+  pageStorageName,
+  roundupDatesFromFileNames,
+} from "./html.js";
+
+const PREFIX = "news-roundup/polsia/";
+
+describe("storage names", () => {
+  it("builds page and image names", () => {
+    expect(pageStorageName(PREFIX, "2026-07-22")).toBe("news-roundup/polsia/pages/2026-07-22.html");
+    expect(imageStorageName(PREFIX, "2026-07-22", 1)).toBe("news-roundup/polsia/images/2026-07-22-1.png");
+  });
+});
+
+describe("buildRoundupPage", () => {
+  const page = buildRoundupPage({
+    companyName: "Polsia",
+    runDate: "2026-07-22",
+    articles: [
+      { title: "Big <news>", sourceUrl: "https://a.example/1", summary: "Short & sweet.", imageFileName: `${PREFIX}images/2026-07-22-1.png` },
+      { title: "No image story", sourceUrl: "https://a.example/2", summary: "Text only.", imageFileName: null },
+    ],
+  });
+  it("references images relative to /pages/", () => {
+    expect(page).toContain('src="../images/2026-07-22-1.png"');
+  });
+  it("escapes HTML in article fields", () => {
+    expect(page).toContain("Big &lt;news&gt;");
+    expect(page).toContain("Short &amp; sweet.");
+    expect(page).not.toContain("Big <news>");
+  });
+  it("renders a text-only card when imageFileName is null", () => {
+    expect(page).toContain("No image story");
+    const imgCount = (page.match(/<img /g) ?? []).length;
+    expect(imgCount).toBe(1);
+  });
+  it("links each source", () => {
+    expect(page).toContain('href="https://a.example/1"');
+  });
+  it("does not link non-http(s) source URLs", () => {
+    const p = buildRoundupPage({
+      companyName: "Polsia",
+      runDate: "2026-07-22",
+      articles: [
+        { title: "Evil", sourceUrl: "javascript:alert(1)", summary: "x", imageFileName: null },
+      ],
+    });
+    expect(p).not.toContain("javascript:");
+    expect(p).toContain("Evil");
+  });
+});
+
+describe("roundupDatesFromFileNames", () => {
+  it("extracts unique page dates sorted descending, ignoring other files", () => {
+    const dates = roundupDatesFromFileNames(
+      [
+        `${PREFIX}pages/2026-07-15.html`,
+        `${PREFIX}pages/2026-07-22.html`,
+        `${PREFIX}pages/2026-07-22.html`,
+        `${PREFIX}images/2026-07-22-1.png`,
+        "other/pages/2026-01-01.html",
+      ],
+      PREFIX,
+    );
+    expect(dates).toEqual(["2026-07-22", "2026-07-15"]);
+  });
+});
+
+describe("buildIndexPage", () => {
+  it("links every date page", () => {
+    const html = buildIndexPage("Polsia", ["2026-07-22", "2026-07-15"]);
+    expect(html).toContain('href="pages/2026-07-22.html"');
+    expect(html).toContain('href="pages/2026-07-15.html"');
+    expect(html).toContain("Polsia");
+  });
+});

--- a/examples/news-roundup/lib/html.ts
+++ b/examples/news-roundup/lib/html.ts
@@ -1,0 +1,119 @@
+import type { IllustratedArticle } from "./types.js";
+
+export function pageStorageName(prefix: string, runDate: string): string {
+  return `${prefix}pages/${runDate}.html`;
+}
+
+export function imageStorageName(prefix: string, runDate: string, n: number): string {
+  return `${prefix}images/${runDate}-${n}.png`;
+}
+
+function esc(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const STYLE = `<style>
+  body { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f7; color: #1c1c1e; }
+  main { max-width: 720px; margin: 0 auto; padding: 2rem 1rem; }
+  h1 { font-size: 1.6rem; }
+  .card { background: #fff; border-radius: 12px; padding: 1.25rem; margin: 1rem 0; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+  .card img { max-width: 100%; border-radius: 8px; }
+  .card h2 { font-size: 1.15rem; margin: .75rem 0 .5rem; }
+  .card p { line-height: 1.5; margin: 0 0 .5rem; }
+  a { color: #0a5dc2; }
+  ul.dates { list-style: none; padding: 0; } ul.dates li { margin: .5rem 0; }
+</style>`;
+
+export function buildRoundupPage(opts: {
+  companyName: string;
+  runDate: string;
+  articles: IllustratedArticle[];
+}): string {
+  const cards = opts.articles
+    .map((a) => {
+      const base = a.imageFileName ? a.imageFileName.split("/").pop() : null;
+      const img = base ? `<img src="../images/${esc(base)}" alt="${esc(a.title)}">` : "";
+      const safeHref = /^https?:\/\//i.test(a.sourceUrl) ? a.sourceUrl : null;
+      return `<article class="card">
+${img}
+<h2>${esc(a.title)}</h2>
+<p>${esc(a.summary)}</p>
+${safeHref ? `<p><a href="${esc(safeHref)}">Read the full article</a></p>` : ""}
+</article>`;
+    })
+    .join("\n");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(opts.companyName)} news roundup — ${opts.runDate}</title>${STYLE}</head>
+<body><main>
+<p><a href="../index.html">← All roundups</a></p>
+<h1>${esc(opts.companyName)} news roundup — ${opts.runDate}</h1>
+${cards}
+</main></body></html>`;
+}
+
+export function roundupDatesFromFileNames(fileNames: string[], prefix: string): string[] {
+  const pagePrefix = `${prefix}pages/`;
+  const dates = new Set<string>();
+  for (const name of fileNames) {
+    if (name.startsWith(pagePrefix) && name.endsWith(".html")) {
+      dates.add(name.slice(pagePrefix.length, -".html".length));
+    }
+  }
+  return [...dates].sort().reverse();
+}
+
+export function buildIndexPage(companyName: string, dates: string[]): string {
+  const items = dates
+    .map((d) => `<li class="card"><a href="pages/${esc(d)}.html">Roundup of ${esc(d)}</a></li>`)
+    .join("\n");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(companyName)} news roundups</title>${STYLE}</head>
+<body><main>
+<h1>${esc(companyName)} news roundups</h1>
+<ul class="dates">
+${items}
+</ul>
+</main></body></html>`;
+}
+
+/** Dependency-free static server, written into the sandbox as site/server.js. */
+export const SERVER_JS = `import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const port = Number(process.env.PORT ?? 3000);
+const types = {
+  ".html": "text/html; charset=utf-8",
+  ".png": "image/png",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+};
+
+createServer(async (req, res) => {
+  try {
+    const urlPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+    let rel = normalize(urlPath).replace(/^[/\\\\]+/, "");
+    if (rel === "" || rel === ".") rel = "index.html";
+    const file = resolve(join(root, rel));
+    if (file !== root && !file.startsWith(root + "/")) {
+      res.writeHead(403, { "content-type": "text/plain" });
+      res.end("forbidden");
+      return;
+    }
+    const body = await readFile(file);
+    res.writeHead(200, { "content-type": types[extname(file)] ?? "application/octet-stream" });
+    res.end(body);
+  } catch {
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  }
+}).listen(port, () => console.log("serving on " + port));
+`;

--- a/examples/news-roundup/lib/select.test.ts
+++ b/examples/news-roundup/lib/select.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildSelectionPrompt, parseSelection } from "./select.js";
+
+const articles = [
+  { title: "Polsia raises funds", url: "https://a.example/1", snippet: "Polsia announced..." },
+  { title: "Unrelated Polsia GmbH", url: "https://b.example/2", snippet: "A German bakery..." },
+];
+
+describe("buildSelectionPrompt", () => {
+  it("mentions company, date, and every article", () => {
+    const p = buildSelectionPrompt("Polsia", "2026-07-22", articles);
+    expect(p).toContain("Polsia");
+    expect(p).toContain("2026-07-22");
+    expect(p).toContain("https://a.example/1");
+    expect(p).toContain("https://b.example/2");
+    expect(p).toContain("imagePrompt");
+  });
+});
+
+describe("parseSelection", () => {
+  const good = JSON.stringify([
+    { title: "T", url: "https://a.example/1", summary: "S.", imagePrompt: "P" },
+  ]);
+  it("parses a bare JSON array", () => {
+    expect(parseSelection(good)).toHaveLength(1);
+  });
+  it("parses an array wrapped in prose/code fences", () => {
+    expect(parseSelection("Here you go:\n```json\n" + good + "\n```")).toHaveLength(1);
+  });
+  it("rejects output without a JSON array", () => {
+    expect(() => parseSelection("no json here")).toThrow();
+  });
+  it("rejects items missing required keys", () => {
+    expect(() => parseSelection('[{"title":"T"}]')).toThrow();
+  });
+  it("rejects more than 5 items", () => {
+    const six = JSON.stringify(Array.from({ length: 6 }, () => JSON.parse(good)[0]));
+    expect(() => parseSelection(six)).toThrow();
+  });
+});

--- a/examples/news-roundup/lib/select.ts
+++ b/examples/news-roundup/lib/select.ts
@@ -1,0 +1,45 @@
+import { z } from "zod/v4";
+import type { RawArticle, SelectedArticle } from "./types.js";
+
+const selectionSchema = z
+  .array(
+    z.object({
+      title: z.string().min(1),
+      url: z.string().min(1),
+      summary: z.string().min(1),
+      imagePrompt: z.string().min(1),
+    }),
+  )
+  .min(1)
+  .max(5);
+
+export function buildSelectionPrompt(
+  companyName: string,
+  runDate: string,
+  articles: RawArticle[],
+): string {
+  const list = articles
+    .map((a, i) => `${i + 1}. ${a.title}\n   URL: ${a.url}\n   Excerpt: ${a.snippet}`)
+    .join("\n");
+  return `Today is ${runDate}. Below are web search results for news about the company "${companyName}".
+
+Select the 3 to 5 results that are genuinely recent news (roughly the last 7 days) about this specific company. Drop results about unrelated companies or people with similar names, duplicates, and pages that are not news articles. If fewer than 3 qualify, select only those that do (minimum 1).
+
+For each selected article provide:
+- "title": the article title
+- "url": the article URL, copied exactly as given
+- "summary": 2-3 plain-language sentences a non-expert understands (no jargon)
+- "imagePrompt": one sentence describing a simple, friendly illustration of the story (no text or logos in the image)
+
+Respond with ONLY a JSON array of objects with keys "title", "url", "summary", "imagePrompt".
+
+Search results:
+${list}`;
+}
+
+export function parseSelection(output: string): SelectedArticle[] {
+  const start = output.indexOf("[");
+  const end = output.lastIndexOf("]");
+  if (start === -1 || end <= start) throw new Error("no JSON array found in model output");
+  return selectionSchema.parse(JSON.parse(output.slice(start, end + 1)));
+}

--- a/examples/news-roundup/lib/server.test.ts
+++ b/examples/news-roundup/lib/server.test.ts
@@ -1,0 +1,50 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SERVER_JS } from "./html.js";
+
+const PORT = 4712;
+let child: ChildProcess;
+
+beforeAll(async () => {
+  const dir = await mkdtemp(join(tmpdir(), "roundup-server-"));
+  await writeFile(join(dir, "server.js"), SERVER_JS);
+  await writeFile(join(dir, "index.html"), "<h1>idx</h1>");
+  child = spawn(process.execPath, [join(dir, "server.js")], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: "ignore",
+  });
+  // wait for the server to accept connections
+  for (let i = 0; i < 50; i++) {
+    try {
+      await fetch(`http://127.0.0.1:${PORT}/`);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error("server never came up");
+}, 15000);
+
+afterAll(() => {
+  child?.kill();
+});
+
+describe("SERVER_JS", () => {
+  it("serves index.html at / with html content type", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("idx");
+  });
+  it("404s missing files", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/nope.html`);
+    expect(res.status).toBe(404);
+  });
+  it("refuses path traversal", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/%2e%2e/%2e%2e/etc/passwd`);
+    expect([403, 404]).toContain(res.status);
+  });
+});

--- a/examples/news-roundup/lib/storage.test.ts
+++ b/examples/news-roundup/lib/storage.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Sapiom } from "@sapiom/tools";
+import { downloadFileBytes, listFilesByPrefix, uploadPublicFile } from "./storage.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function fakeSapiom(fileStorage: Record<string, unknown>): Sapiom {
+  return { fileStorage } as unknown as Sapiom;
+}
+
+describe("uploadPublicFile", () => {
+  it("initiates a public upload and PUTs the bytes", async () => {
+    const upload = vi.fn().mockResolvedValue({
+      fileId: "f1",
+      uploadUrl: "https://signed.example/put",
+      expiresAt: "2099-01-01T00:00:00Z",
+      requiredHeaders: { "content-type": "text/html" },
+    });
+    const put = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", put);
+    const id = await uploadPublicFile(fakeSapiom({ upload }), {
+      fileName: "news-roundup/polsia/pages/2026-07-22.html",
+      contentType: "text/html",
+      bytes: new TextEncoder().encode("<p>hi</p>"),
+    });
+    expect(id).toBe("f1");
+    expect(upload).toHaveBeenCalledWith({
+      contentType: "text/html",
+      fileName: "news-roundup/polsia/pages/2026-07-22.html",
+      visibility: "public",
+      fileSize: 9,
+    });
+    expect(put).toHaveBeenCalledWith("https://signed.example/put", expect.objectContaining({ method: "PUT" }));
+  });
+  it("throws when the PUT fails", async () => {
+    const upload = vi.fn().mockResolvedValue({
+      fileId: "f1", uploadUrl: "https://signed.example/put", expiresAt: "x", requiredHeaders: {},
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(
+      uploadPublicFile(fakeSapiom({ upload }), { fileName: "a", contentType: "t", bytes: new Uint8Array(1) }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("listFilesByPrefix", () => {
+  const file = (fileId: string, fileName: string, createdAt: string, status = "uploaded") => ({
+    fileId, fileName, createdAt, status, contentType: "x", visibility: "public", fileSize: "1", downloadRequestCount: 0,
+  });
+  it("paginates, filters by prefix, drops deleted, dedupes keeping newest", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: [
+          file("a", "news-roundup/polsia/pages/2026-07-22.html", "2026-07-22T01:00:00Z"),
+          file("b", "other/x.html", "2026-07-22T01:00:00Z"),
+        ],
+        limit: 100, offset: 0, hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        files: [
+          file("c", "news-roundup/polsia/pages/2026-07-22.html", "2026-07-22T02:00:00Z"),
+          file("d", "news-roundup/polsia/images/2026-07-22-1.png", "2026-07-22T01:00:00Z"),
+          file("e", "news-roundup/polsia/pages/old.html", "2026-01-01T00:00:00Z", "deleted"),
+        ],
+        limit: 100, offset: 100, hasMore: false,
+      });
+    const out = await listFilesByPrefix(fakeSapiom({ list }), "news-roundup/polsia/");
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(out).toEqual(
+      expect.arrayContaining([
+        { fileId: "c", fileName: "news-roundup/polsia/pages/2026-07-22.html" },
+        { fileId: "d", fileName: "news-roundup/polsia/images/2026-07-22-1.png" },
+      ]),
+    );
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("downloadFileBytes", () => {
+  it("resolves a fresh URL and GETs the bytes", async () => {
+    const getDownloadUrl = vi.fn().mockResolvedValue({ downloadUrl: "https://signed.example/get", expiresAt: "x" });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    }));
+    const bytes = await downloadFileBytes(fakeSapiom({ getDownloadUrl }), "f1");
+    expect([...bytes]).toEqual([1, 2, 3]);
+  });
+});

--- a/examples/news-roundup/lib/storage.ts
+++ b/examples/news-roundup/lib/storage.ts
@@ -1,0 +1,51 @@
+import type { Sapiom } from "@sapiom/tools";
+
+/** Upload bytes to Sapiom file storage with public visibility; returns the fileId. */
+export async function uploadPublicFile(
+  sapiom: Sapiom,
+  opts: { fileName: string; contentType: string; bytes: Uint8Array },
+): Promise<string> {
+  const res = await sapiom.fileStorage.upload({
+    contentType: opts.contentType,
+    fileName: opts.fileName,
+    visibility: "public",
+    fileSize: opts.bytes.byteLength,
+  });
+  const put = await fetch(res.uploadUrl, {
+    method: "PUT",
+    headers: res.requiredHeaders,
+    body: opts.bytes as unknown as BodyInit,
+  });
+  if (!put.ok) throw new Error(`upload PUT for ${opts.fileName} failed: ${put.status}`);
+  return res.fileId;
+}
+
+/** All non-deleted files whose fileName starts with prefix, newest per fileName. */
+export async function listFilesByPrefix(
+  sapiom: Sapiom,
+  prefix: string,
+): Promise<Array<{ fileId: string; fileName: string }>> {
+  const newest = new Map<string, { fileId: string; fileName: string; createdAt: string }>();
+  let offset = 0;
+  for (;;) {
+    const page = await sapiom.fileStorage.list({ limit: 100, offset });
+    for (const f of page.files) {
+      if (!f.fileName?.startsWith(prefix) || f.status === "deleted") continue;
+      const prev = newest.get(f.fileName);
+      if (!prev || f.createdAt > prev.createdAt) {
+        newest.set(f.fileName, { fileId: f.fileId, fileName: f.fileName, createdAt: f.createdAt });
+      }
+    }
+    if (!page.hasMore || page.files.length === 0) break;
+    offset += page.limit;
+  }
+  return [...newest.values()].map(({ fileId, fileName }) => ({ fileId, fileName }));
+}
+
+/** Download a stored file's bytes via a fresh presigned URL. */
+export async function downloadFileBytes(sapiom: Sapiom, fileId: string): Promise<Uint8Array> {
+  const { downloadUrl } = await sapiom.fileStorage.getDownloadUrl(fileId);
+  const res = await fetch(downloadUrl);
+  if (!res.ok) throw new Error(`download GET for ${fileId} failed: ${res.status}`);
+  return new Uint8Array(await res.arrayBuffer());
+}

--- a/examples/news-roundup/lib/types.ts
+++ b/examples/news-roundup/lib/types.ts
@@ -1,0 +1,27 @@
+export interface RawArticle {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export interface SelectedArticle {
+  title: string;
+  url: string;
+  summary: string;
+  imagePrompt: string;
+}
+
+export interface IllustratedArticle {
+  title: string;
+  sourceUrl: string;
+  summary: string;
+  /** File-storage fileName of the article image, or null when generation failed. */
+  imageFileName: string | null;
+}
+
+export interface RoundupShared extends Record<string, unknown> {
+  companyName: string;
+  companySlug: string;
+  runDate: string;
+  storagePrefix: string;
+}

--- a/examples/news-roundup/lib/util.test.ts
+++ b/examples/news-roundup/lib/util.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { slugify, todayIso } from "./util.js";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugify("Polsia")).toBe("polsia");
+    expect(slugify("Acme Corp, Inc.")).toBe("acme-corp-inc");
+  });
+  it("strips accents and trims hyphens", () => {
+    expect(slugify("Café Été!")).toBe("cafe-ete");
+  });
+  it("caps length at 40 and never returns empty", () => {
+    expect(slugify("x".repeat(80)).length).toBe(40);
+    expect(slugify("!!!")).toBe("company");
+  });
+});
+
+describe("todayIso", () => {
+  it("returns YYYY-MM-DD", () => {
+    expect(todayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/examples/news-roundup/lib/util.ts
+++ b/examples/news-roundup/lib/util.ts
@@ -1,0 +1,16 @@
+/** Lowercase-ascii-hyphen slug, ≤40 chars so "news-roundup-<slug>" fits sandbox name limits. */
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/, "");
+  return slug || "company";
+}
+
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/examples/news-roundup/package-lock.json
+++ b/examples/news-roundup/package-lock.json
@@ -1,0 +1,1394 @@
+{
+  "name": "news-roundup",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "news-roundup",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sapiom/agent": "0.6.5",
+        "@sapiom/tools": "0.20.1",
+        "zod": "4.1.12"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.2",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sapiom/agent": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@sapiom/agent/-/agent-0.6.5.tgz",
+      "integrity": "sha512-SmEXNtp0ZI6zA3jtUueVx0EBfjnstz9Qh2EPawBqbBRHr7eEvvmVxWzKEKt6njZ2oGg69A0JMOy27qjQHpCJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/tools": "^0.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.0.0"
+      }
+    },
+    "node_modules/@sapiom/analytics-core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/analytics-core/-/analytics-core-0.2.1.tgz",
+      "integrity": "sha512-IZaSdegheySbLxSwmrvcKFKpog3+Ef8IP/hkd7Qjp7uxgo7pfwkmjy9nFH9lXDH4ALeW5+Fhs717+RKwkW1EJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sapiom/tools": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/tools/-/tools-0.20.1.tgz",
+      "integrity": "sha512-Pv2Uy0PdS9bkvEWxitNoGrUXCMlmI7QLUkBlLAxgL89/dXgWfSiD50DP/KUfIlbyFbW+5fWZR7syhpFj1YkpDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/analytics-core": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/news-roundup/package.json
+++ b/examples/news-roundup/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "news-roundup",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\"",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@sapiom/agent": "0.6.5",
+    "@sapiom/tools": "0.20.1",
+    "zod": "4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/examples/news-roundup/template.json
+++ b/examples/news-roundup/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a company name. It searches the web for that company's news from the last week, asks an LLM to pick the three-to-five most relevant articles, and writes a plain-language summary and an illustration prompt for each. It generates one image per article, then publishes a dated roundup page to a small website for that company.\n\nEverything durable lives in file storage under a per-company prefix — one HTML page and its images per run. The website itself is disposable: every run rebuilds it from scratch out of storage, so losing it costs nothing, and each run just adds a new dated page without touching the earlier ones. The site is served from a sandbox that expires after a day and is recreated — with a new URL — on the next run.\n\nIf an image fails to generate, that article still shows up as a text-only card instead of failing the run. If the search turns up nothing for the company, it stops early and tells you rather than publishing an empty page.\n\nYou pay for the web search, the model that picks and summarizes the articles, and the images it generates — plus the short-lived sandbox that serves the site. A run that finds no news costs only the search.",
+  "useCases": [
+    "Keep a shareable news page for a company you track — a competitor, a partner, or a portfolio company — refreshed on a schedule.",
+    "Turn a week of scattered press coverage into one dated, illustrated summary you can send someone.",
+    "Run it for several companies so each gets its own standing news site, built and rebuilt automatically."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `companyName` — that's the only input. Each run adds a new dated page to that company's site and returns the live URL. The site is served from a sandbox with a 24-hour TTL, so its URL changes once the sandbox expires and is recreated on the next run — read the latest run's output for the current link instead of bookmarking one. To keep a company's page fresh, put it on a schedule (the shipped example runs weekly).\n\nPrefer to work from the code? Run it locally with `run_local` and `{ \"companyName\": \"Polsia\" }` to trace search → select → illustrate → publish for free against the committed stubs — nothing generated or deployed. (For a local run that exercises the real uploads, start the bundled upload sink first; see the README.) Or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A published roundup",
+      "input": {
+        "companyName": "Polsia"
+      },
+      "output": {
+        "status": "published",
+        "siteUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai",
+        "pageUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai/pages/2026-07-22.html",
+        "articles": [
+          {
+            "title": "Polsia raises Series B to expand its logistics network",
+            "sourceUrl": "https://example.com/polsia-series-b",
+            "summary": "Polsia closed a Series B this week and says the funding will go toward opening two regional warehouses and doubling its delivery fleet.",
+            "imageUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai/images/2026-07-22-1.png"
+          },
+          {
+            "title": "Polsia partners with a regional grocer on same-day delivery",
+            "sourceUrl": "https://example.com/polsia-grocery-pilot",
+            "summary": "A pilot with a regional grocery chain brings Polsia's same-day delivery to three new cities, its first move into groceries.",
+            "imageUrl": null
+          }
+        ]
+      }
+    },
+    {
+      "title": "No recent news found",
+      "input": {
+        "companyName": "Polsia"
+      },
+      "output": {
+        "status": "no-news",
+        "companyName": "Polsia"
+      }
+    }
+  ]
+}

--- a/examples/news-roundup/test/upload-sink.mjs
+++ b/examples/news-roundup/test/upload-sink.mjs
@@ -1,0 +1,11 @@
+// Local sink for presigned-PUT calls during sapiom_dev_agents_run_local.
+// Accepts any method/path with 200 so uploadPublicFile's fetch succeeds.
+import { createServer } from "node:http";
+const port = Number(process.env.PORT ?? 4599);
+createServer((req, res) => {
+  req.resume();
+  req.on("end", () => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{}");
+  });
+}).listen(port, () => console.log(`upload sink on ${port}`));

--- a/examples/news-roundup/tsconfig.json
+++ b/examples/news-roundup/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -600,6 +600,49 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "news-roundup",
+      "name": "Company News Roundup",
+      "description": "Search the web for a company's recent news, then publish a dated, illustrated roundup page to a small website for that company.",
+      "tags": ["news", "summarize", "images", "publish"],
+      "sourcePath": "examples/news-roundup",
+      "capabilities": [
+        "web.search",
+        "models.run",
+        "contentGeneration.images",
+        "fileStorage.upload",
+        "sandboxes.create",
+        "sandboxes.deployPreview"
+      ],
+      "whatItDoes": "For keeping a shareable news page for a company you care about, refreshed whenever you run it. You give it a company name and it searches the web (web.search) for that company's news from the last week. An LLM (models.run) picks the three-to-five most relevant articles and writes a plain-language summary and an image prompt for each, and it generates one illustration per article (contentGeneration.images). It saves the page and images to file storage, then rebuilds the company's website from storage in a sandbox and deploys it (sandboxes.deployPreview), handing back the live URL. Each run adds a new dated page without touching the earlier ones. If an image fails it becomes a text-only card, and if there's no news the run stops early instead of publishing an empty page.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Search the web for the company's news from the last week. If nothing comes back, stop early and report no news instead of publishing.",
+          "capability": "web.search",
+          "next": ["select"]
+        },
+        {
+          "name": "select",
+          "description": "Ask an LLM to pick the three-to-five most relevant articles and write a plain-language summary and an image prompt for each.",
+          "capability": "models.run",
+          "next": ["illustrate"]
+        },
+        {
+          "name": "illustrate",
+          "description": "Generate one image per selected article and save each to storage; an article whose image fails degrades to a text-only card.",
+          "capability": "contentGeneration.images",
+          "next": ["publish"]
+        },
+        {
+          "name": "publish",
+          "description": "Save the dated page, rebuild the company's site from storage in a sandbox, and deploy it — returning the live site and page URLs.",
+          "capability": "sandboxes.deployPreview",
+          "next": [],
+          "terminal": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the news-roundup example as a gallery template: a Sapiom agent that searches the web for a company's recent news, has an LLM select and summarize the top articles, illustrates each, and publishes a dated roundup page to a per-company sandbox site.

## What's in it
- `template.json` — rich detail manifest (about, use cases, notes, sample I/O), schema-validated
- `registry.json` — gallery entry with capabilities and the `search → select → illustrate → publish` step graph
- The workflow itself (`index.ts`, `lib/`, tests, README, AGENTS.md) plus `.sapiom-dev/stubs.json` for the free `run_local` trace

## Validation
- `npm run typecheck` clean; `npm test` 25/25; `sapiom_dev_agents_check` derives a 4-step manifest with no warnings
- `sapiom_dev_agents_run_local` with `{ "companyName": "Polsia" }` completes end-to-end against the committed stubs — `unusedStubs`/`stubWarnings` both empty
- Declared capabilities match the actual `ctx.sapiom.*` calls in the source

## Notes
- Dev-local `sapiom.json` is gitignored; the duplicated authoring `SKILL.md` was dropped (canonical copy lives in `agent-core`) and `AGENTS.md` repointed at the plugin-loaded skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
