### PR TITLE
chore(release): add missing changesets (agent-core deploy hardening + harness E2E fixes)

### DIFF
--- a/.changeset/agent-core-deploy-hardening.md
+++ b/.changeset/agent-core-deploy-hardening.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Harden deploy and local-run input handling:
+
+- Redact credentials from git error output, so a push URL's embedded token can never leak into an error hint or the deploy stream.
+- On an auth-class deploy-push failure, mint a fresh push credential and retry the push once.
+- Report a superseded build as a distinct, non-alarming outcome (a newer deploy replaced this build) instead of a generic build failure.
+- Default an absent local-run input to `{}`, so a step that reads its input behaves the same locally as it does in a production run.

--- a/.changeset/harness-e2e-hardening.md
+++ b/.changeset/harness-e2e-hardening.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio run and step-inspection hardening:
+
+- Auto-bind a session to the workflow in its folder the moment the session starts, not only when a file later changes — so the canvas and Run actions light up immediately for an existing workflow.
+- Animate the canvas board (per-step running / passed / failed status) during both local and production runs.
+- Never let a direct action (Local Run / Prod Run / Deploy) fail silently: surface the reason on a blocked click, clear the in-flight indicator when the action settles, and distinguish "deploy failed — retry" from "not deployed yet".
+- Enrich the step inspector: per-step input/output and logs, the capability calls a step made (with the served stub values on offline runs), and clickable preview / download / research links found in a step's output — all shown when you click into a step.


### PR DESCRIPTION
The E2E-fix PRs (#395-#401) merged **without changesets**.

**The important gap:** there was no `@sapiom/agent-core` changeset, but **#400** (token-leak redaction + push retry) and **#401** (local-run input parity) live in `@sapiom/agent-core`. The harness depends on it via `"@sapiom/agent-core": "workspace:^"` — a **runtime dependency, not bundled** (`tsc` doesn't inline it). So without an agent-core changeset, agent-core wouldn't version-bump/publish, and the new `@sapiom/harness` would ship depending on the **old** agent-core — meaning **the security fix wouldn't actually reach users**.

This adds:
- `@sapiom/agent-core: patch` — deploy hardening (credential redaction, push retry, superseded messaging) + local-run input parity.
- `@sapiom/harness: patch` — E2E hardening (auto-bind on start, canvas animation, non-silent actions, rich step detail) for changelog completeness.

Both `patch` per the repo's patch-only changeset policy. No code changes — release metadata only.