### PR TITLE
feat(examples): add 10 workflow templates (batched)

### DIFF
--- a/examples/approval-chain/.gitignore
+++ b/examples/approval-chain/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json

--- a/examples/approval-chain/AGENTS.md
+++ b/examples/approval-chain/AGENTS.md
@@ -1,0 +1,105 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Multi-Party
+Approval Chain (Saga)** — authored against `@sapiom/agent`. It runs an ordered
+list of approvers through sequential, durable sign-off gates
+(`present` ⇄ `remind` → `decide`), advancing one gate at a time, and terminates in
+`finalize` (all approved), `compensate` (someone rejected), or `escalate` (a gate
+went silent). Inside a step's `run`, Sapiom capabilities are pre-auth'd on
+`ctx.sapiom` (here, `ctx.sapiom.email` and `ctx.sapiom.database`).
+
+## The sign-off spine
+
+- **`present`** records the current gate as `pending`, emails the approver, then
+  returns `pauseUntilSignal({ signal: "approval.decision", resumeStep: "decide", correlationId: ctx.executionId, timeoutMs })`.
+  It carries a static `pause: { signal, resumeStep: "decide" }` annotation — the
+  build-time graph edge that must match the directive.
+- **`decide`** reads the approval payload **directly as its `run` input**. Safe
+  default: only an explicit `{ decision: "approve" }` advances; `reject`
+  compensates; `timeout` escalates; anything else (including a `run_local` resume
+  with no payload, or the engine firing the pause `timeoutMs`) is a **reminder
+  tick**. The gate index, reminder count, recorded approvals, and audit trail all
+  live in `ctx.shared` and survive every pause.
+- **`remind`** re-notifies the current approver and re-pauses on the same gate
+  (`resumeStep: "decide"`), so `present → decide → remind → decide → …` is a
+  legal cycle bounded by `maxReminders`.
+- **`finalize`** holds the single irreversible action, reached only after EVERY
+  gate approved. A `dryRun` guard makes it a no-op offline.
+- **`compensate`** is the saga's rollback: notify everyone who already approved
+  that the chain was cancelled. Nothing irreversible ran before a rejection, so
+  the compensation is a set of notifications, not an undo of committed work.
+- `pauseUntilSignal` is a **runtime primitive, not a metered capability** — don't
+  list it in `capabilities`. The billed calls are `ctx.sapiom.email` and, when a
+  `ledgerHandle` is set, the `ctx.sapiom.database` the ledger lives in.
+
+## Chain state & the ledger
+
+The canonical state is `ctx.shared`. The `database` capability is an **optional,
+best-effort** durable copy: `recordTransition` appends every transition to
+`ctx.shared.trail` and, when a `ledgerHandle` is configured and it's not a
+`dryRun`, also to a Postgres `approval_chain_ledger` table (via a `pg` client on
+the provisioned connection string). A missing handle, a `dryRun`, or any DB error
+degrades to shared + logs and never fails the chain. Rows are keyed on
+`(execution_id, seq)` with `ON CONFLICT DO NOTHING`, so a step retry is idempotent.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares `next: []` (its forward edge is the pause
+  `resumeStep`) and a `pause: { signal, resumeStep }` annotation.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including
+  the static `pause` annotations (the cycle through `remind` is legal).
+- **run_local** — runs your **real** step code against **stub capabilities** and
+  auto-resumes each pause with no payload, so the default trace walks
+  `present → reminder(s) → escalate` to a terminal for free. With no
+  `ledgerHandle`, no live Postgres is touched.
+- **deploy**, then **run** — ship it, then perform a real run that pauses at each
+  gate.
+
+### Firing the resume signals in dev
+
+A real `run` pauses at every gate. To resume without a real approver, fire the
+signals via the MCP `signal_workflow` / `workflow_signal` tool — the manual
+stand-in. The `correlationId` is the paused run's `executionId`, and each
+`payload` arrives as `decide`'s input.
+
+```json
+{
+  "signal": "approval.decision",
+  "correlationId": "<executionId>",
+  "payload": { "decision": "approve" }
+}
+```
+
+Fire one `approve` per approver to reach `finalize`. Send `{ "decision": "reject" }`
+to walk `compensate`, or `{ "decision": "remind" }` / `{ "decision": "timeout" }`
+to exercise the reminder / escalation branches.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them —
+the ledger uses DB-side `now()` for timestamps to stay deterministic across
+retries. The `correlationId` is `ctx.executionId` (stable across every gate), so a
+resume signal always lands on the right run.

--- a/examples/approval-chain/README.md
+++ b/examples/approval-chain/README.md
@@ -1,0 +1,133 @@
+# Multi-Party Approval Chain (Saga)
+
+A durable, sequential multi-party sign-off flow. An ordered chain of approvers
+(e.g. legal → finance → the CEO) must each approve a subject — a contract, a
+budget, a policy change — **in order**, with reminders and timeout escalation
+between gates, and **compensation** if anyone rejects.
+
+Each gate is a durable `pauseUntilSignal`: the run suspends at **$0** until the
+current party decides, then advances to the next gate. Nothing irreversible
+happens until every party has signed off.
+
+## What it does
+
+```
+start → present ─(pause: approval.decision, $0 while idle)─▶ decide
+          ▲                                                    │
+          │ approve & more gates                              │
+          └────────────────────────────────────────────────── ┤
+        remind ─(pause: approval.decision)────────────────────┤ reminder tick (budget left)
+          ▲                                                     │
+          └───────────────────────── reminder tick ─────────────┤
+                                                                 │
+     reject │              approve & last gate │        timeout / no-response │
+            ▼                                  ▼                              ▼
+       compensate                          finalize                       escalate
+       (terminal)                          (terminal)                      (terminal)
+```
+
+1. **start** — resolve the `subject`, the ordered `approvers`, and the
+   escalation / ledger / reminder settings; initialise the chain state. Empty
+   chain → `escalate`.
+2. **present** — record the gate as `pending` and email the current approver
+   (`ctx.sapiom.email`), then `pauseUntilSignal({ signal: "approval.decision", resumeStep: "decide" })`.
+   The run suspends here at $0.
+3. **decide** (resume target) — its **input is the approval payload**.
+   - `{ "decision": "approve" }` → record it and advance to the next gate
+     (`present`), or `finalize` on the last gate.
+   - `{ "decision": "reject" }` → `compensate`.
+   - `{ "decision": "timeout" }` → `escalate` immediately.
+   - anything else (no decision, `remind`, or a pause-timeout / `run_local`
+     auto-resume) → a reminder tick: `remind` while the reminder budget lasts,
+     else `escalate`.
+4. **remind** — email a reminder to the current approver, then pause again on the
+   same gate (`resumeStep: "decide"`).
+5. **finalize** — the single irreversible action, reached **only after every party
+   approved**. A `dryRun` guard makes it a no-op offline.
+6. **compensate** — saga rollback: notify everyone who already approved that the
+   chain was cancelled.
+7. **escalate** — a gate went silent (or timed out): notify the escalation channel.
+
+The canonical chain state lives in `ctx.shared` (it survives every pause). When a
+`ledgerHandle` is configured, each transition is also appended to a durable
+Postgres table (`approval_chain_ledger`) via `ctx.sapiom.database` — a best-effort
+external audit copy that never blocks the chain.
+
+Input:
+
+```json
+{
+  "subject": "Master Services Agreement v3",
+  "approvers": [
+    { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+    { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+  ],
+  "escalateTo": "ops@example.com",
+  "maxReminders": 2,
+  "ledgerHandle": "approvals-ledger"
+}
+```
+
+`escalateTo` and `ledgerHandle` fall back to `config.ESCALATION_EMAIL` /
+`config.LEDGER_HANDLE` when omitted. Omit `ledgerHandle` to keep the audit trail
+in `ctx.shared` only (no Postgres touched).
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to send notifications and provision the ledger database.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed, pauses auto-resumed, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real run that pauses
+   at each gate).
+
+Offline, the default `run_local` trace walks `present → reminder(s) → escalate` —
+with no `ledgerHandle` no live Postgres is touched, so it's free. Keep
+`maxReminders` small so it terminates quickly.
+
+## Resuming a paused run in dev
+
+A real `run` pauses at each gate. Instead of a real approver, fire the signals
+yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`, and each `payload` becomes the
+resumed `decide` step's input.
+
+**Approve** the current gate (advances to the next, or finalises on the last):
+
+```json
+{
+  "signal": "approval.decision",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve" }
+}
+```
+
+Fire one `approve` per approver to reach `finalize`. To walk the other branches:
+
+- `{ "decision": "reject" }` → `compensate` (notifies prior approvers).
+- `{ "decision": "remind" }` → a reminder tick (re-notifies, re-pauses).
+- `{ "decision": "timeout" }` → `escalate`.
+
+## Persisting the audit ledger
+
+Pass a `ledgerHandle` (or `config.LEDGER_HANDLE`) and run **deployed** with
+`dryRun: false`. Each transition is appended to the `approval_chain_ledger` table
+of a Postgres provisioned on demand (`ctx.sapiom.database`), keyed on
+`(execution_id, seq)` so step retries are idempotent. `run_local` stubs the
+database, so verify the rows on the deployed path.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -1,0 +1,776 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { Client } from "pg";
+
+/**
+ * Multi-Party Approval Chain (Saga) — a durable, sequential sign-off flow.
+ *
+ * An ordered list of approvers (e.g. legal → finance → the CEO) must each sign
+ * off on a subject — a contract, a budget, a policy change — **in order**. The
+ * run presents to one approver, then **suspends at $0 via `pauseUntilSignal`**
+ * until that party decides; only then does it advance to the next gate. Between
+ * gates it nudges the current approver (reminders) and, if they never respond,
+ * escalates to a human channel (timeout). If any approver rejects, the run walks
+ * a **saga compensation** — notifying everyone who already approved that the
+ * chain was cancelled — instead of leaving a half-signed contract behind.
+ *
+ *   start → present ─(pause: approval.decision, $0 while idle)─▶ decide
+ *             ▲                                                    │
+ *             │ approve & more gates                              │
+ *             └──────────────────────────────────────────────────┤
+ *             remind ─(pause: approval.decision)──────────────────┤ reminder tick
+ *             ▲                                                    │
+ *             └──────────────── reminder tick (budget left) ───────┤
+ *                                                                  │
+ *        reject │        approve & last gate │        timeout / no-response │
+ *               ▼                            ▼                              ▼
+ *          compensate                    finalize                       escalate
+ *          (terminal)                    (terminal)                      (terminal)
+ *
+ * Every gate is a durable `pauseUntilSignal`: the run survives the wait with no
+ * compute burning, resuming only when a party fires `approval.decision` for this
+ * run. `pauseUntilSignal` is a runtime primitive, not a metered capability — so
+ * it is NOT listed in `capabilities`. The billed calls are the notifications
+ * (`ctx.sapiom.email`); the optional durable audit **ledger** persists each
+ * transition to a Postgres provisioned via `ctx.sapiom.database`.
+ *
+ * ── Reminders & timeout ────────────────────────────────────────────────────────
+ * A resume with an explicit `{ decision: "approve" | "reject" }` drives the saga.
+ * A resume with NO decision — the engine firing the pause `timeoutMs`, a
+ * `run_local` auto-resume, or an explicit `{ decision: "remind" }` — counts as a
+ * reminder tick: re-notify the current approver and re-pause, up to
+ * `maxReminders`, after which the gate escalates. An explicit
+ * `{ decision: "timeout" }` escalates immediately. This mirrors the "a timeout
+ * fires the signal" convention — wire a cron to fire `remind`/`timeout` on a
+ * schedule, or rely on the pause `timeoutMs` where the engine supports it.
+ *
+ * ── Chain state ────────────────────────────────────────────────────────────────
+ * The canonical chain state — which gate we're on, who has approved, the full
+ * transition trail — lives in `ctx.shared`, which survives every pause. When a
+ * `ledgerHandle` is configured, each transition is ALSO appended to a durable
+ * Postgres table (`database` capability) so the sign-off record outlives the run
+ * and is queryable by the ops/legal owner. The ledger is best-effort: a missing
+ * handle, a `dryRun`, or an unreachable DB degrades to `ctx.shared` + logs and
+ * never fails the chain.
+ *
+ * Offline: `run_local` stubs the capabilities and auto-resumes each pause with no
+ * payload — so the default trace walks present → reminder(s) → escalate for free
+ * (no `ledgerHandle` ⇒ no live Postgres). Fire real `approval.decision` signals
+ * (in dev, via the MCP `signal_workflow` / `workflow_signal` tool — see README)
+ * to drive the approve → next-gate → finalize and reject → compensate paths.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** The signal a party fires to approve / reject (or nudge / time out) a gate. */
+const APPROVAL_SIGNAL = "approval.decision";
+
+/** Username for the inbox we send notifications from (created once, then reused). */
+const SENDER_USERNAME = "approvals";
+
+/** Reminders sent before a silent gate escalates. */
+const DEFAULT_MAX_REMINDERS = 2;
+
+/** Default pause timeout per gate (best-effort auto-reminder): 24 hours. */
+const DEFAULT_REMINDER_MS = 24 * 60 * 60 * 1000;
+
+/** Postgres table the durable ledger appends to. */
+const LEDGER_TABLE = "approval_chain_ledger";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** One party in the ordered sign-off chain. */
+interface Approver {
+  /** Stable id used in the audit trail and compensation. */
+  id: string;
+  /** Human-readable name shown in notifications. */
+  name: string;
+  /** Where to send the sign-off request. Absent ⇒ can't be contacted (logged, skipped). */
+  email?: string;
+}
+
+/** The payload a party delivers on the `approval.decision` signal. */
+interface ApprovalDecision {
+  /**
+   * `approve` advances to the next gate (or finalizes on the last); `reject`
+   * compensates; `timeout` escalates immediately; `remind` (or anything absent)
+   * is a reminder tick. Safe default: only an explicit `approve` advances.
+   */
+  decision?: "approve" | "reject" | "timeout" | "remind";
+  /** Optional free-text note carried into the trail / outcome. */
+  notes?: string;
+}
+
+/** A gate a party has signed off, in order. */
+interface RecordedApproval {
+  id: string;
+  name: string;
+  notes: string | null;
+}
+
+/** One immutable row in the sign-off audit trail. */
+interface Transition {
+  /** Monotonic index within this run — the ledger's per-run primary key. */
+  seq: number;
+  /** Which gate the transition belongs to. */
+  gateIndex: number;
+  /** The gate's approver id, or `null` for chain-level transitions. */
+  approverId: string | null;
+  /** What happened: `pending` | `reminder` | `approved` | `rejected` | `timeout` | `completed` | `cancelled` | `escalated` | `chain-started`. */
+  phase: string;
+  /** Optional free-text detail. */
+  note: string | null;
+}
+
+interface EntryInput {
+  /** What is being signed off (contract, budget, policy…). */
+  subject?: string;
+  /** The ordered chain of approvers — each must approve before the next is asked. */
+  approvers?: Approver[];
+  /** Human channel to escalate to on timeout. Falls back to `config.ESCALATION_EMAIL`. */
+  escalateTo?: string;
+  /**
+   * Handle of a durable Postgres to append the audit trail to (`database`
+   * capability). Falls back to `config.LEDGER_HANDLE`. Absent ⇒ ledger kept in
+   * `ctx.shared` only.
+   */
+  ledgerHandle?: string;
+  /** Pause timeout per gate in ms (best-effort auto-reminder). Default 24h. */
+  reminderMs?: number;
+  /** Reminders before a silent gate escalates. Default 2. */
+  maxReminders?: number;
+  /** Skip the irreversible finalize action and live DB writes. `run_local` sets this. */
+  dryRun?: boolean;
+  /** String-only config bag (escalation / ledger fallbacks). */
+  config?: Config;
+}
+
+/** State that survives the pauses, read back after each resume. */
+interface Shared extends Record<string, unknown> {
+  subject: string;
+  approvers: Approver[];
+  gateIndex: number;
+  reminders: number;
+  approvals: RecordedApproval[];
+  trail: Transition[];
+  escalateTo: string | null;
+  ledgerHandle: string | null;
+  reminderMs: number;
+  maxReminders: number;
+  dryRun: boolean;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** Normalise the input chain: guarantee an id + name for every approver. */
+function normalizeApprovers(raw: Approver[]): Approver[] {
+  return raw.map((a, i) => ({
+    id: a.id?.trim() || `approver-${i + 1}`,
+    name: a.name?.trim() || a.id?.trim() || `Approver ${i + 1}`,
+    email: a.email?.trim() || undefined,
+  }));
+}
+
+/** Clamp a caller-supplied reminder interval to a sane positive value. */
+function clampReminderMs(ms: number | undefined): number {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) {
+    return DEFAULT_REMINDER_MS;
+  }
+  return Math.floor(ms);
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Approvals",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Send a notification, degrading gracefully when there's no recipient. A missing
+ * address is an expected outcome (an approver with no email, no escalation
+ * channel configured) — log and skip rather than failing the run.
+ */
+async function notify(
+  ctx: Ctx,
+  to: string | null | undefined,
+  subject: string,
+  text: string,
+): Promise<boolean> {
+  if (!to) {
+    ctx.logger.warn("notify skipped: no recipient", { subject });
+    return false;
+  }
+  const inboxId = await resolveSenderInbox(ctx);
+  const sent = await ctx.sapiom.email.messages.send(inboxId, {
+    to,
+    subject,
+    text,
+  });
+  ctx.logger.info("notified", { to, subject, messageId: sent.messageId });
+  return true;
+}
+
+/**
+ * Append a transition to the canonical trail in `ctx.shared`, and — best-effort —
+ * to the durable Postgres ledger. The ledger is an external audit copy, never the
+ * source of truth: no `ledgerHandle`, a `dryRun`, or any DB error degrades to
+ * `ctx.shared` + logs so an unreachable ledger can't break the sign-off flow.
+ *
+ * The write is keyed on `(execution_id, seq)` with `ON CONFLICT DO NOTHING`, so a
+ * step retry (which re-runs the body) is idempotent.
+ */
+async function recordTransition(
+  ctx: Ctx,
+  phase: string,
+  note?: string | null,
+): Promise<void> {
+  const approvers = ctx.shared.get("approvers") ?? [];
+  const gateIndex = ctx.shared.get("gateIndex") ?? 0;
+  const trail = ctx.shared.get("trail") ?? [];
+  const transition: Transition = {
+    seq: trail.length,
+    gateIndex,
+    approverId: approvers[gateIndex]?.id ?? null,
+    phase,
+    note: note ?? null,
+  };
+  ctx.shared.set("trail", [...trail, transition]);
+  ctx.logger.info("ledger: transition", {
+    seq: transition.seq,
+    phase,
+    gateIndex,
+    approverId: transition.approverId,
+  });
+
+  const handle = ctx.shared.get("ledgerHandle");
+  if (ctx.shared.get("dryRun") || !handle) return;
+  await persistTransition(ctx, handle, transition).catch((err) => {
+    // Audit persistence is best-effort; a broken ledger must not stop the chain.
+    ctx.logger.warn("ledger: persist failed (kept in shared)", {
+      seq: transition.seq,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
+/** Resolve (or provision) the ledger DB and append one transition row. */
+async function persistTransition(
+  ctx: Ctx,
+  handle: string,
+  transition: Transition,
+): Promise<void> {
+  const db = await ctx.sapiom.database
+    .get(handle)
+    .catch(() => ctx.sapiom.database.create({ duration: "7d", handle }));
+  const connectionString = db.connection?.connectionString;
+  if (!connectionString) {
+    ctx.logger.warn("ledger: database has no connection string yet", {
+      handle,
+    });
+    return;
+  }
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS ${LEDGER_TABLE} (
+         execution_id text NOT NULL,
+         seq          integer NOT NULL,
+         subject      text,
+         gate_index   integer,
+         approver_id  text,
+         phase        text NOT NULL,
+         note         text,
+         recorded_at  timestamptz NOT NULL DEFAULT now(),
+         PRIMARY KEY (execution_id, seq)
+       )`,
+    );
+    await client.query(
+      `INSERT INTO ${LEDGER_TABLE}
+         (execution_id, seq, subject, gate_index, approver_id, phase, note)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (execution_id, seq) DO NOTHING`,
+      [
+        ctx.executionId,
+        transition.seq,
+        ctx.shared.get("subject") ?? null,
+        transition.gateIndex,
+        transition.approverId,
+        transition.phase,
+        transition.note,
+      ],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const start = defineStep({
+  name: "start",
+  next: ["present", "escalate"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const config = input.config ?? {};
+    const subject = input.subject?.trim() || "(untitled approval)";
+    const approvers = normalizeApprovers(input.approvers ?? []);
+    ctx.shared.set("subject", subject);
+    ctx.shared.set("approvers", approvers);
+    ctx.shared.set("gateIndex", 0);
+    ctx.shared.set("reminders", 0);
+    ctx.shared.set("approvals", []);
+    ctx.shared.set("trail", []);
+    ctx.shared.set(
+      "escalateTo",
+      input.escalateTo?.trim() || config.ESCALATION_EMAIL || null,
+    );
+    ctx.shared.set(
+      "ledgerHandle",
+      input.ledgerHandle?.trim() || config.LEDGER_HANDLE || null,
+    );
+    ctx.shared.set("reminderMs", clampReminderMs(input.reminderMs));
+    ctx.shared.set("maxReminders", input.maxReminders ?? DEFAULT_MAX_REMINDERS);
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    await recordTransition(ctx, "chain-started", subject);
+
+    if (approvers.length === 0) {
+      // Nothing to sign off — escalate rather than pausing on a gate that doesn't exist.
+      ctx.logger.warn("no approvers supplied — escalating");
+      return goto("escalate", { reason: "no-approvers" });
+    }
+
+    ctx.logger.info("approval chain started", {
+      subject,
+      gates: approvers.length,
+    });
+    return goto("present", {});
+  },
+});
+
+const present = defineStep({
+  name: "present",
+  next: [],
+  // Static graph edge: on the approval signal, resume at `decide`.
+  pause: { signal: APPROVAL_SIGNAL, resumeStep: "decide" },
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const reminderMs = must(ctx.shared.get("reminderMs"), "reminderMs");
+    const current = approvers[gateIndex];
+    if (!current) {
+      // Invariant guard — callers only route here with a valid gate.
+      throw new Error(
+        `no approver at gate ${gateIndex} of ${approvers.length}`,
+      );
+    }
+
+    // A fresh gate: reset the reminder budget and record the pending sign-off.
+    ctx.shared.set("reminders", 0);
+    await recordTransition(ctx, "pending");
+    await notify(
+      ctx,
+      current.email,
+      `Sign-off needed (${gateIndex + 1}/${approvers.length}): ${subject}`,
+      buildRequestEmail(
+        subject,
+        current,
+        gateIndex,
+        approvers.length,
+        ctx.executionId,
+      ),
+    );
+
+    ctx.logger.info("presented gate; pausing for decision", {
+      gate: gateIndex + 1,
+      approver: current.id,
+    });
+
+    // Suspend at $0 until this party fires the approval signal for this run. The
+    // `timeoutMs` is a best-effort auto-reminder where the engine supports it.
+    return pauseUntilSignal({
+      signal: APPROVAL_SIGNAL,
+      resumeStep: "decide",
+      correlationId: ctx.executionId,
+      timeoutMs: reminderMs,
+    });
+  },
+});
+
+const decide = defineStep({
+  name: "decide",
+  next: ["present", "remind", "finalize", "compensate", "escalate"],
+  // `payload` IS the approval signal body (or empty on a pause timeout / auto-resume).
+  async run(payload: ApprovalDecision, ctx: Ctx) {
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const current = approvers[gateIndex];
+    const decision = payload?.decision;
+    ctx.logger.info("gate decision", {
+      gate: gateIndex + 1,
+      approver: current?.id,
+      decision: decision ?? "(none)",
+    });
+
+    if (decision === "approve") {
+      await recordTransition(ctx, "approved", payload?.notes);
+      const approvals = ctx.shared.get("approvals") ?? [];
+      ctx.shared.set("approvals", [
+        ...approvals,
+        {
+          id: current?.id ?? `approver-${gateIndex + 1}`,
+          name: current?.name ?? "(unknown)",
+          notes: payload?.notes ?? null,
+        },
+      ]);
+      const nextIndex = gateIndex + 1;
+      if (nextIndex < approvers.length) {
+        // Advance to the next gate in the chain.
+        ctx.shared.set("gateIndex", nextIndex);
+        return goto("present", {});
+      }
+      // Every party has signed off.
+      return goto("finalize", {});
+    }
+
+    if (decision === "reject") {
+      await recordTransition(ctx, "rejected", payload?.notes);
+      return goto("compensate", {
+        rejectedBy: current?.id ?? null,
+        notes: payload?.notes ?? null,
+      });
+    }
+
+    if (decision === "timeout") {
+      await recordTransition(ctx, "timeout", payload?.notes);
+      return goto("escalate", { reason: "timeout" });
+    }
+
+    // No explicit decision → a reminder tick (pause timeout / auto-resume / "remind").
+    const reminders = (ctx.shared.get("reminders") ?? 0) + 1;
+    ctx.shared.set("reminders", reminders);
+    const maxReminders =
+      ctx.shared.get("maxReminders") ?? DEFAULT_MAX_REMINDERS;
+    if (reminders > maxReminders) {
+      // Out of reminders and still no response — escalate the silent gate.
+      await recordTransition(
+        ctx,
+        "timeout",
+        `no response after ${maxReminders} reminders`,
+      );
+      return goto("escalate", { reason: "no-response" });
+    }
+    return goto("remind", {});
+  },
+});
+
+const remind = defineStep({
+  name: "remind",
+  next: [],
+  // Static graph edge: on the approval signal, resume at `decide` (same as present).
+  pause: { signal: APPROVAL_SIGNAL, resumeStep: "decide" },
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = must(ctx.shared.get("approvers"), "approvers");
+    const gateIndex = must(ctx.shared.get("gateIndex"), "gateIndex");
+    const reminderMs = must(ctx.shared.get("reminderMs"), "reminderMs");
+    const reminders = ctx.shared.get("reminders") ?? 1;
+    const current = approvers[gateIndex];
+    if (!current) {
+      throw new Error(
+        `no approver at gate ${gateIndex} of ${approvers.length}`,
+      );
+    }
+
+    await recordTransition(ctx, "reminder", `reminder ${reminders}`);
+    await notify(
+      ctx,
+      current.email,
+      `Reminder ${reminders}: sign-off still needed — ${subject}`,
+      buildReminderEmail(subject, current, reminders, ctx.executionId),
+    );
+
+    ctx.logger.info("reminder sent; pausing again for decision", {
+      gate: gateIndex + 1,
+      approver: current.id,
+      reminders,
+    });
+
+    // Re-suspend on the same gate until a decision (or the next reminder tick).
+    return pauseUntilSignal({
+      signal: APPROVAL_SIGNAL,
+      resumeStep: "decide",
+      correlationId: ctx.executionId,
+      timeoutMs: reminderMs,
+    });
+  },
+});
+
+const finalize = defineStep({
+  name: "finalize",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvals = ctx.shared.get("approvals") ?? [];
+    const dryRun = ctx.shared.get("dryRun") ?? false;
+
+    await recordTransition(ctx, "completed");
+
+    if (dryRun) {
+      // Offline / preview: the single irreversible action is a no-op. Every gate,
+      // notification, and ledger row up to here already ran (or was traced) for real.
+      ctx.logger.info("dry run: skipping the irreversible finalize action", {
+        subject,
+        approvals: approvals.length,
+      });
+      return terminate({
+        committed: false,
+        dryRun: true,
+        outcome: "dry-run",
+        subject,
+        approvals,
+      });
+    }
+
+    // ── The single irreversible action ─────────────────────────────────────
+    // Reached ONLY after EVERY party in the chain approved. In a real fork,
+    // replace this completion notice with the action the sign-off authorises —
+    // countersign + release the contract, disburse the budget, publish the policy.
+    let notified = 0;
+    for (const approver of ctx.shared.get("approvers") ?? []) {
+      const email = approver.email;
+      if (
+        await notify(
+          ctx,
+          email,
+          `Approved & finalised: ${subject}`,
+          buildCompletedEmail(subject, approvals, ctx.executionId),
+        )
+      ) {
+        notified += 1;
+      }
+    }
+
+    ctx.logger.info("chain finalised", {
+      subject,
+      approvals: approvals.length,
+    });
+    return terminate({
+      committed: true,
+      dryRun: false,
+      outcome: "completed",
+      subject,
+      approvals,
+      notified,
+    });
+  },
+});
+
+const compensate = defineStep({
+  name: "compensate",
+  next: [],
+  terminal: true,
+  async run(
+    input: { rejectedBy?: string | null; notes?: string | null },
+    ctx: Ctx,
+  ) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvals = ctx.shared.get("approvals") ?? [];
+    const approvers = ctx.shared.get("approvers") ?? [];
+    const rejectedBy = input?.rejectedBy ?? null;
+
+    await recordTransition(ctx, "cancelled", input?.notes);
+
+    // Saga compensation: everyone who already approved acted on the assumption
+    // the chain would complete. Notify them it was cancelled so downstream
+    // effects of their sign-off can be unwound. Nothing irreversible ran, so the
+    // compensation is a set of notifications, not a rollback of committed work.
+    let compensated = 0;
+    for (const approved of approvals) {
+      const contact = approvers.find((a) => a.id === approved.id)?.email;
+      if (
+        await notify(
+          ctx,
+          contact,
+          `Cancelled: ${subject}`,
+          buildCancelledEmail(subject, approved, rejectedBy),
+        )
+      ) {
+        compensated += 1;
+      }
+    }
+
+    ctx.logger.info("chain rejected — compensated prior approvals", {
+      subject,
+      rejectedBy,
+      compensated,
+    });
+    return terminate({
+      committed: false,
+      outcome: "rejected",
+      subject,
+      rejectedBy,
+      approved: approvals,
+      compensated,
+    });
+  },
+});
+
+const escalate = defineStep({
+  name: "escalate",
+  next: [],
+  terminal: true,
+  async run(input: { reason?: string }, ctx: Ctx) {
+    const subject = must(ctx.shared.get("subject"), "subject");
+    const approvers = ctx.shared.get("approvers") ?? [];
+    const gateIndex = ctx.shared.get("gateIndex") ?? 0;
+    const escalateTo = ctx.shared.get("escalateTo") ?? null;
+    const reason = input?.reason ?? "no-response";
+    const stalledAt = approvers[gateIndex] ?? null;
+
+    await recordTransition(ctx, "escalated", reason);
+    await notify(
+      ctx,
+      escalateTo,
+      `Escalation: approval chain stalled — ${subject}`,
+      buildEscalationEmail(subject, stalledAt, gateIndex, reason),
+    );
+
+    ctx.logger.info("escalated to human channel", {
+      subject,
+      escalateTo,
+      reason,
+      gate: gateIndex + 1,
+    });
+    return terminate({
+      committed: false,
+      outcome: "escalated",
+      reason,
+      subject,
+      stalledAtGate: approvers.length > 0 ? gateIndex + 1 : 0,
+      stalledApprover: stalledAt
+        ? { id: stalledAt.id, name: stalledAt.name }
+        : null,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── email bodies ──
+function buildRequestEmail(
+  subject: string,
+  approver: Approver,
+  gateIndex: number,
+  total: number,
+  executionId: string,
+): string {
+  return [
+    `Hi ${approver.name},`,
+    "",
+    `Your sign-off is needed on: ${subject}`,
+    `You are approver ${gateIndex + 1} of ${total} in the chain.`,
+    "",
+    "Fire the `approval.decision` signal with",
+    '{"decision":"approve"} to sign off, or {"decision":"reject"} to stop the chain.',
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildReminderEmail(
+  subject: string,
+  approver: Approver,
+  reminders: number,
+  executionId: string,
+): string {
+  return [
+    `Hi ${approver.name},`,
+    "",
+    `Reminder #${reminders}: we're still waiting on your sign-off for: ${subject}`,
+    "",
+    "Fire the `approval.decision` signal with",
+    '{"decision":"approve"} or {"decision":"reject"}. If we don\'t hear back,',
+    "the request will be escalated.",
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildCompletedEmail(
+  subject: string,
+  approvals: RecordedApproval[],
+  executionId: string,
+): string {
+  return [
+    `The approval chain for "${subject}" is complete — every party signed off.`,
+    "",
+    "Sign-off order:",
+    ...approvals.map((a, i) => `${i + 1}. ${a.name}`),
+    "",
+    `Run: ${executionId}`,
+  ].join("\n");
+}
+
+function buildCancelledEmail(
+  subject: string,
+  approved: RecordedApproval,
+  rejectedBy: string | null,
+): string {
+  return [
+    `Hi ${approved.name},`,
+    "",
+    `The approval chain for "${subject}" was cancelled${
+      rejectedBy ? ` (rejected by ${rejectedBy})` : ""
+    }.`,
+    "You approved an earlier gate — no further action is needed, and any",
+    "downstream effect of your sign-off should be treated as void.",
+  ].join("\n");
+}
+
+function buildEscalationEmail(
+  subject: string,
+  stalledAt: Approver | null,
+  gateIndex: number,
+  reason: string,
+): string {
+  return [
+    `Escalation: the approval chain for "${subject}" stalled.`,
+    "",
+    `Reason: ${reason}.`,
+    stalledAt
+      ? `Waiting on gate ${gateIndex + 1}: ${stalledAt.name} (${stalledAt.id}).`
+      : "No approvers were supplied to the chain.",
+    "",
+    "Human intervention needed to unblock or cancel the sign-off.",
+  ].join("\n");
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "approval-chain",
+  entry: "start",
+  steps: {
+    start,
+    present,
+    decide,
+    remind,
+    finalize,
+    compensate,
+    escalate,
+  },
+});

--- a/examples/approval-chain/package.json
+++ b/examples/approval-chain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sapiom/example-approval-chain",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: a durable multi-party sign-off saga — sequential pauseUntilSignal approval gates with reminders, timeout escalation, and compensation on rejection, with an optional Postgres audit ledger.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0",
+    "pg": "^8.11.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/pg": "^8.11.5",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/approval-chain/template.json
+++ b/examples/approval-chain/template.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "A durable, sequential multi-party sign-off **saga**: an ordered chain of approvers (e.g. legal → finance → the CEO) must each approve a subject — a contract, a budget, a policy change — **in order**, with reminders and timeout escalation between gates, and compensation if anyone rejects.\n\nEach gate is a durable `pauseUntilSignal`: the run presents the request to the current approver (`ctx.sapiom.email`), then **suspends at $0** until that party fires `approval.decision`. An `approve` advances to the next gate (or finalises on the last); a `reject` walks a **saga compensation** — notifying everyone who already signed off that the chain was cancelled — so a half-signed contract is never left behind.\n\nBetween gates, a resume with no decision (the pause `timeoutMs`, an auto-resume, or an explicit `{ decision: 'remind' }`) is a reminder tick: re-notify the current approver and re-pause, up to `maxReminders`, after which the silent gate escalates to a human channel. An explicit `{ decision: 'timeout' }` escalates immediately.\n\nThe canonical chain state — the current gate, who has approved, the full transition trail — lives in `ctx.shared`, which survives every pause. When a `ledgerHandle` is set, each transition is ALSO appended to a durable Postgres table via the `database` capability, so the sign-off record outlives the run and stays queryable. The ledger is best-effort: no handle, a `dryRun`, or an unreachable DB degrades to `ctx.shared` + logs and never breaks the chain. `pauseUntilSignal` is a runtime primitive, not a metered capability; the billed calls are the notifications and the ledger's database.",
+  "useCases": [
+    "Route a contract, budget, or policy change through a fixed sequence of sign-offs, one party at a time.",
+    "Nudge a slow approver on a schedule and escalate to a human when a gate goes silent, instead of stalling forever.",
+    "Unwind a partially-approved chain safely (saga compensation) the moment any party rejects.",
+    "Keep a durable, queryable audit trail of who approved what, and when, in your own Postgres."
+  ],
+  "notes": "`run_local` stubs the capabilities and auto-resumes each pause with no payload, so the default offline trace walks present → reminder(s) → escalate to a terminal for free — with no `ledgerHandle`, no live Postgres is touched. Set a small `maxReminders` (default 2) so the offline trace terminates quickly.\n\nA real `deploy` + `run` pauses for real at each gate. To drive it in dev, fire the signals via the MCP `signal_workflow` / `workflow_signal` tool with `correlationId` = the paused run's `executionId`. Approve a gate: `{ \"signal\": \"approval.decision\", \"correlationId\": \"<executionId>\", \"payload\": { \"decision\": \"approve\" } }` — repeat once per approver to reach `finalize`. Send `{ \"decision\": \"reject\" }` to walk the compensation path, or `{ \"decision\": \"remind\" }` / `{ \"decision\": \"timeout\" }` to exercise the reminder / escalation branches.\n\nTo persist the audit trail to Postgres, pass a `ledgerHandle` (or `config.LEDGER_HANDLE`) and run deployed with `dryRun: false`; verify the rows land in the `approval_chain_ledger` table. See `README.md` and `AGENTS.md`.",
+  "examples": [
+    {
+      "title": "Two-party contract sign-off, both approve",
+      "input": {
+        "subject": "Master Services Agreement v3",
+        "approvers": [
+          { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+          { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+        ],
+        "escalateTo": "ops@example.com",
+        "maxReminders": 2
+      },
+      "output": {
+        "committed": true,
+        "dryRun": false,
+        "outcome": "completed",
+        "subject": "Master Services Agreement v3",
+        "notified": 2
+      }
+    },
+    {
+      "title": "Finance rejects after legal approved — compensate",
+      "input": {
+        "subject": "Q3 marketing budget increase",
+        "approvers": [
+          { "id": "legal", "name": "Legal", "email": "legal@example.com" },
+          { "id": "finance", "name": "Finance", "email": "finance@example.com" }
+        ],
+        "escalateTo": "ops@example.com"
+      },
+      "output": {
+        "committed": false,
+        "outcome": "rejected",
+        "subject": "Q3 marketing budget increase",
+        "rejectedBy": "finance",
+        "compensated": 1
+      }
+    }
+  ]
+}

--- a/examples/approval-chain/tsconfig.json
+++ b/examples/approval-chain/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/dependency-upgrade/.gitignore
+++ b/examples/dependency-upgrade/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/dependency-upgrade/AGENTS.md
+++ b/examples/dependency-upgrade/AGENTS.md
@@ -1,0 +1,60 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` —
+**dependency-upgrade** — authored against `@sapiom/agent`. It is a scheduled
+Dependabot triage: `bump` runs a coding agent to upgrade a repo's dependencies in
+a sandbox, `verify` runs the real test suite in that sandbox, `assess` rates the
+risk, and only a green build within the risk bar reaches `publish` (which pushes).
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here:
+`ctx.sapiom.repositories.get`, `ctx.sapiom.models.coding.launch`,
+`ctx.sapiom.sandboxes.attach` + `box.exec`, `ctx.sapiom.models.run`,
+`ctx.sapiom.fileStorage.upload`, and `repo.pushFromSandbox`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **The coding run is async.** `bump` calls `models.coding.launch(...)` and
+  returns `pauseUntilSignal(handle, { resumeStep: "verify" })`; the step's static
+  `pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "verify" }` annotation must
+  match. `verify`'s input is the `CodingResultPayload` — re-attach the sandbox
+  from `result.executionEnvironment.id`; live handles don't cross the pause.
+- **Green gates the push.** `verify` routes to `rejected` on a failed coding run,
+  a failed install, or a non-zero test exit — a push only happens after a green
+  build. Don't remove that gate.
+- **Never push on a dry run.** The push and the report upload are guarded on
+  `dryRun` so `run_local` traces the whole graph offline with no side effects.
+  Keep the guard.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point
+you'd run tests in any project — reach for the local suite. You don't need to run
+it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation (including the
+  static `pause` annotation). The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**.
+  Pass `{ "repoSlug": "my-app", "dryRun": true }`: the coding launch is stubbed
+  and its pause auto-resumes, `verify` synthesizes a green result (no real
+  sandbox), and `publish` skips the push + upload — so the full graph traces
+  offline, free, with no real repo.
+- **deploy**, then **run** — ship it, then perform a real upgrade + test + push.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities + the `dryRun` guard), not the other way around — never
+> weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/dependency-upgrade/README.md
+++ b/examples/dependency-upgrade/README.md
@@ -1,0 +1,93 @@
+# Dependency Upgrade
+
+A scheduled "Dependabot triage" that only opens a PR when the build is green. A
+coding agent bumps a repo's dependencies in a sandbox, the real test suite runs
+there, a model risk-assesses the diff, and it pushes only when the tests pass and
+the risk is within your bar.
+
+## What it does
+
+```
+plan ─▶ bump ──(pause: models.coding.result → verify)──▶ verify ─┬─▶ assess ─┬─▶ publish  (terminal)
+                                                                 │           └─▶ held     (terminal)
+                                                                 └─▶ rejected (terminal)
+```
+
+1. **plan** — resolves the repo slug and the install/test commands, and validates
+   the input. No `repoSlug` → straight to `rejected`.
+2. **bump** — launches a coding agent (`models.coding`) on the repo; it clones
+   into a fresh sandbox at `/workspace/<slug>` and bumps the dependencies. Coding
+   runs are long, so the workflow **suspends at $0** and resumes at `verify` when
+   the run finishes.
+3. **verify** — re-attaches the coding run's sandbox, runs `git diff --stat`, then
+   installs and runs the test suite (`sandboxes.exec`). A failed coding run, a
+   failed install, or a non-zero test exit all route to `rejected`.
+4. **assess** — a model (`models.run`) rates the upgrade `low`/`medium`/`high`
+   from the dependency diff. Above `maxAutoRisk` (default `medium`) → `held`.
+5. **publish** — pushes the bumped branch from the sandbox and archives the
+   triage report. **held** / **rejected** archive the report but never push.
+
+Every outcome writes a markdown triage report to file storage
+(`fileStorage.upload`) — a durable record of what changed and why it shipped or
+didn't.
+
+## Inputs
+
+```json
+{
+  "repoSlug": "my-app",
+  "task": "Upgrade dependencies to latest compatible versions and update the lockfile.",
+  "installCommand": "npm install",
+  "testCommand": "npm test",
+  "workingDirectory": "my-app",
+  "maxAutoRisk": "medium",
+  "allowRisky": false,
+  "dryRun": false,
+  "schedule": "0 6 * * 1"
+}
+```
+
+- `repoSlug` (required) — an in-network repo the coding agent clones and upgrades.
+- `installCommand` / `testCommand` — how to build and test the checkout (defaults
+  `npm install` / `npm test`).
+- `workingDirectory` — the checkout subdirectory to run tests in, relative to the
+  sandbox workspace (default: the repo slug).
+- `maxAutoRisk` — `low` \| `medium` \| `high`; risk above this is held for a human.
+  Set `allowRisky: true` to push anyway.
+- `dryRun` — assemble everything but skip the push and the report upload, so a
+  local run makes no network calls.
+- `schedule` — documentation for the cron cadence; the trigger carries the real
+  schedule when you deploy.
+
+## The dry-run guard
+
+The push is the one irreversible action, so it (and the report upload) are gated
+on `dryRun`. With `dryRun: true`, `verify` synthesizes a green result when no real
+sandbox is present, so `run_local` traces `plan → bump → verify → assess →
+publish` end to end — free, with nothing pushed.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit
+   that authority to run the coding agent, attach the sandbox, and archive the
+   report.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (pass `{ "repoSlug": "my-app", "dryRun": true }` to trace the whole graph
+   offline, free) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real upgrade + test + push).
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/dependency-upgrade/index.ts
+++ b/examples/dependency-upgrade/index.ts
@@ -1,0 +1,554 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+
+/**
+ * dependency-upgrade — a scheduled "Dependabot triage" that only opens a PR when
+ * the build is green.
+ *
+ * Point it at an in-network repo and put it on a cron. Each run hands a coding
+ * agent the job of bumping the project's dependencies inside a fresh sandbox
+ * (`models.coding`), then does the part a plain bump bot skips: it re-attaches
+ * that sandbox, runs the real test suite there (`sandboxes.exec`), and gates
+ * everything on the result. Green builds get a model risk assessment of the
+ * changed dependencies (`models.run`); red builds never push. Every run — green,
+ * held, or red — archives a triage report to file storage (`fileStorage.upload`)
+ * so you have a durable record of what changed and why it was or wasn't shipped.
+ *
+ *   plan ─▶ bump ──(pause: models.coding.result → verify)──▶ verify ─┬─▶ assess ─┬─▶ publish
+ *                                                                    │           └─▶ held
+ *                                                                    └─▶ rejected
+ *
+ *   - plan     resolves the repo + commands and validates the input.
+ *   - bump     launches the coding agent on the repo, then SUSPENDS at $0 until
+ *              the run finishes — coding runs are long, so the workflow pauses
+ *              rather than holding a worker.
+ *   - verify   re-attaches the coding run's sandbox, installs, and runs the test
+ *              suite. A non-zero exit (or a failed coding run) routes to rejected.
+ *   - assess   asks a model to rate the upgrade's risk from the dependency diff.
+ *   - publish  pushes the bumped branch from the sandbox and archives the report.
+ *   - held     risk above your auto-merge threshold — archived, not pushed.
+ *   - rejected coding failed or the build is red — archived, not pushed.
+ *
+ * The push is the one irreversible action, so it sits behind a `dryRun` guard:
+ * with `dryRun: true`, every step runs but the push and the report upload are
+ * skipped, so `run_local` traces the whole graph offline for free.
+ */
+
+type RiskLevel = "low" | "medium" | "high";
+
+/** Higher = riskier. Used to compare an assessed risk against the auto-merge bar. */
+const RISK_ORDER: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2 };
+
+const DEFAULT_TASK =
+  "Upgrade this project's dependencies to their latest compatible versions and " +
+  "update the lockfile. Change application code only where an upgrade strictly " +
+  "requires it. Keep the diff minimal and focused on the dependency bumps.";
+
+// ──────────────────────────────────────────────────────────────── input ──
+interface DependencyUpgradeInput {
+  /** In-network repo slug the coding agent clones and upgrades. Required. */
+  repoSlug?: string;
+  /** Plain-words upgrade instruction for the coding agent (default: bump all + lockfile). */
+  task?: string;
+  /** Command that installs dependencies in the checkout (default `npm install`). */
+  installCommand?: string;
+  /** Command that runs the test suite in the checkout (default `npm test`). */
+  testCommand?: string;
+  /** Checkout subdirectory (relative to the sandbox workspace) to run tests in. Default: the slug. */
+  workingDirectory?: string;
+  /** Risk at/below which a green build auto-pushes; anything above is held. Default `medium`. */
+  maxAutoRisk?: RiskLevel;
+  /** Push even when the risk is above `maxAutoRisk` (skip the human hold). Default false. */
+  allowRisky?: boolean;
+  /** Assemble everything but skip the push + report upload, so run_local is free. */
+  dryRun?: boolean;
+  /** Cron cadence when deployed as a schedule — documentation only; the trigger carries it. */
+  schedule?: string;
+}
+
+/** Run-scoped state; the values before the pause survive the suspend. */
+interface Shared extends Record<string, unknown> {
+  repoSlug: string;
+  task: string;
+  installCommand: string;
+  testCommand: string;
+  workingDirectory: string;
+  maxAutoRisk: RiskLevel;
+  allowRisky: boolean;
+  dryRun: boolean;
+  /** Sandbox the coding run left behind (captured after resume, needed to push). */
+  sandboxName: string | null;
+  /** Captured in `verify`, read by `assess`, `publish`, and the report. */
+  codingSummary: string | null;
+  diffStat: string | null;
+  testTail: string | null;
+  assessment: Assessment | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+interface Assessment {
+  risk: RiskLevel;
+  summary: string;
+  notes: string[];
+}
+
+// ──────────────────────────────────────────────────────────────── steps ──
+
+/** Resolve the repo + commands into shared and validate the input. */
+const plan = defineStep({
+  name: "plan",
+  next: ["bump", "rejected"],
+  async run(input: DependencyUpgradeInput, ctx: Ctx) {
+    const repoSlug = (input?.repoSlug ?? "").trim();
+    ctx.shared.set("repoSlug", repoSlug);
+    ctx.shared.set("task", input?.task?.trim() || DEFAULT_TASK);
+    ctx.shared.set(
+      "installCommand",
+      input?.installCommand?.trim() || "npm install",
+    );
+    ctx.shared.set("testCommand", input?.testCommand?.trim() || "npm test");
+    ctx.shared.set(
+      "workingDirectory",
+      input?.workingDirectory?.trim() || repoSlug,
+    );
+    ctx.shared.set(
+      "maxAutoRisk",
+      normalizeRisk(input?.maxAutoRisk) ?? "medium",
+    );
+    ctx.shared.set("allowRisky", input?.allowRisky === true);
+    ctx.shared.set("dryRun", input?.dryRun === true);
+    ctx.shared.set("sandboxName", null);
+    ctx.shared.set("codingSummary", null);
+    ctx.shared.set("diffStat", null);
+    ctx.shared.set("testTail", null);
+    ctx.shared.set("assessment", null);
+
+    if (!repoSlug) {
+      return goto("rejected", {
+        reason: "no-repo",
+        detail:
+          "repoSlug is required — the coding agent needs a repository to upgrade.",
+      });
+    }
+    ctx.logger.info("planning dependency upgrade", { repoSlug });
+    return goto("bump", {});
+  },
+});
+
+/**
+ * Launch the coding agent on the repo and suspend until it finishes. The agent
+ * clones the repo into a fresh sandbox at `/workspace/<slug>`, bumps the deps,
+ * and leaves the checkout in the sandbox for `verify` to test.
+ */
+const bump = defineStep({
+  name: "bump",
+  next: [],
+  // Async pause/resume: the launched coding run fires CODING_RESULT_SIGNAL on
+  // completion (or failure), resuming this workflow at `verify` with the result.
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "verify" },
+  async run(_input: unknown, ctx: Ctx) {
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const task = ctx.shared.get("task") ?? DEFAULT_TASK;
+    const repo = await ctx.sapiom.repositories.get(repoSlug);
+    ctx.logger.info("launching coding agent to bump dependencies", {
+      repoSlug,
+    });
+
+    const handle = await ctx.sapiom.models.coding.launch({
+      task,
+      gitRepository: repo,
+    });
+    // Suspend at $0 until the coding run reaches a terminal state; the resumed
+    // `verify` step receives the CodingResultPayload as its input.
+    return await pauseUntilSignal(handle, { resumeStep: "verify" });
+  },
+});
+
+/**
+ * Re-attach the coding run's sandbox and run the real test suite in it. A failed
+ * coding run, a failed install, or a non-zero test exit all route to `rejected`
+ * — only a green build reaches `assess`.
+ */
+const verify = defineStep({
+  name: "verify",
+  next: ["assess", "rejected"],
+  timeoutMs: 900_000,
+  async run(result: CodingResultPayload, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    ctx.shared.set("codingSummary", result?.summary ?? null);
+
+    // The coding agent itself failed — there's nothing to verify.
+    if (result?.status === "failed" || result?.error) {
+      return goto("rejected", {
+        reason: "coding-run-failed",
+        detail:
+          result?.error?.message ?? result?.summary ?? "coding run failed",
+      });
+    }
+
+    const sandboxName = result?.executionEnvironment?.id ?? null;
+    ctx.shared.set("sandboxName", sandboxName);
+
+    if (!sandboxName) {
+      // No sandbox to run tests in. Under a stubbed/dry run this is expected, so
+      // synthesize a pass to trace assess → publish offline; otherwise reject.
+      if (dryRun) {
+        ctx.shared.set("diffStat", "(dry-run) dependency changes not computed");
+        ctx.shared.set("testTail", "(dry-run) test suite not executed");
+        ctx.logger.info("dry run — skipping sandbox verification");
+        return goto("assess", {});
+      }
+      return goto("rejected", {
+        reason: "no-sandbox",
+        detail: "the coding run provisioned no sandbox to verify in",
+      });
+    }
+
+    const installCommand = ctx.shared.get("installCommand") ?? "npm install";
+    const testCommand = ctx.shared.get("testCommand") ?? "npm test";
+    const cwd = ctx.shared.get("workingDirectory") ?? "";
+    const box = ctx.sapiom.sandboxes.attach(sandboxName);
+
+    // Capture what changed, for the risk assessment and the report.
+    try {
+      const diff = await box.exec("git --no-pager diff --stat", {
+        cwd,
+        timeout: 30_000,
+      });
+      ctx.shared.set(
+        "diffStat",
+        (diff.stdout || diff.stderr || "").slice(0, 4000),
+      );
+    } catch (err) {
+      ctx.shared.set("diffStat", `diff unavailable: ${String(err)}`);
+    }
+
+    const install = await box.exec(installCommand, { cwd, timeout: 300_000 });
+    if (install.exitCode !== 0) {
+      ctx.shared.set("testTail", tail(install.stdout, install.stderr));
+      return goto("rejected", {
+        reason: "install-failed",
+        detail: `\`${installCommand}\` exited ${install.exitCode}`,
+      });
+    }
+
+    const test = await box.exec(testCommand, { cwd, timeout: 600_000 });
+    ctx.shared.set("testTail", tail(test.stdout, test.stderr));
+    if (test.exitCode !== 0) {
+      return goto("rejected", {
+        reason: "tests-failed",
+        detail: `\`${testCommand}\` exited ${test.exitCode}`,
+      });
+    }
+
+    ctx.logger.info("build green", { testCommand });
+    return goto("assess", {});
+  },
+});
+
+/**
+ * Rate the upgrade's risk from the dependency diff and the coding summary. The
+ * tests already passed; this catches the "green but scary" upgrades (a major
+ * bump, a broad blast radius) and holds them for a human when they exceed your
+ * auto-merge bar.
+ */
+const assess = defineStep({
+  name: "assess",
+  next: ["publish", "held"],
+  timeoutMs: 60_000,
+  async run(_input: unknown, ctx: Ctx) {
+    const codingSummary = ctx.shared.get("codingSummary") ?? "";
+    const diffStat = ctx.shared.get("diffStat") ?? "";
+    const testTail = ctx.shared.get("testTail") ?? "";
+    const maxAutoRisk = ctx.shared.get("maxAutoRisk") ?? "medium";
+    const allowRisky = ctx.shared.get("allowRisky") === true;
+
+    const system =
+      "You are a release-risk reviewer for a dependency upgrade whose test suite ALREADY PASSED. " +
+      "Judge the risk of merging it from the changed dependencies and the coding agent's summary — " +
+      "weigh major-version bumps, historically breaking packages, and how broad the change is. " +
+      'Reply with ONLY minified JSON: {"risk":"low|medium|high","summary":string,"notes":string[]}.';
+    const prompt =
+      `Coding agent summary:\n${codingSummary}\n\n` +
+      `Dependency changes (git diff --stat):\n${diffStat}\n\n` +
+      `Test output (tail):\n${testTail}`;
+
+    const res = await ctx.sapiom.models.run({ prompt, system, maxTokens: 500 });
+    const assessment = parseAssessment(res.output);
+    ctx.shared.set("assessment", assessment);
+
+    const held =
+      RISK_ORDER[assessment.risk] > RISK_ORDER[maxAutoRisk] && !allowRisky;
+    ctx.logger.info("assessed upgrade risk", {
+      risk: assessment.risk,
+      maxAutoRisk,
+      held,
+    });
+    return held ? goto("held", {}) : goto("publish", {});
+  },
+});
+
+/** Green + within the risk bar: push the bumped branch and archive the report. */
+const publish = defineStep({
+  name: "publish",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const assessment = ctx.shared.get("assessment");
+    const report = buildReport("published", ctx);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+
+    // The push is the one irreversible action — skip it (and the upload) on a dry run.
+    if (dryRun) {
+      ctx.logger.info("dry run — skipping push", { repoSlug });
+      return terminate({
+        decision: "publish",
+        pushed: false,
+        dryRun: true,
+        risk: assessment?.risk ?? null,
+        reportFileId: archived.fileId,
+        summary: assessment?.summary ?? null,
+      });
+    }
+
+    const sandboxName = ctx.shared.get("sandboxName");
+    if (!sandboxName) {
+      return terminate({
+        decision: "publish",
+        pushed: false,
+        risk: assessment?.risk ?? null,
+        reportFileId: archived.fileId,
+        summary: assessment?.summary ?? null,
+        note: "no sandbox available to push from",
+      });
+    }
+
+    const repo = await ctx.sapiom.repositories.get(repoSlug);
+    const box = ctx.sapiom.sandboxes.attach(sandboxName);
+    const message = truncate(
+      `build(deps): ${assessment?.summary ?? "dependency upgrade"}`,
+      72,
+    );
+    const push = await repo.pushFromSandbox(box, { message });
+    ctx.logger.info("pushed dependency upgrade", {
+      sha: push.sha,
+      branch: push.branch,
+    });
+    return terminate({
+      decision: "publish",
+      pushed: push.pushed,
+      sha: push.sha,
+      branch: push.branch ?? null,
+      risk: assessment?.risk ?? null,
+      reportFileId: archived.fileId,
+      summary: assessment?.summary ?? null,
+    });
+  },
+});
+
+/** Green build but the risk exceeded your auto-merge bar: archive, don't push. */
+const held = defineStep({
+  name: "held",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "";
+    const assessment = ctx.shared.get("assessment");
+    const report = buildReport("held", ctx);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+    ctx.logger.info("upgrade held for human review", {
+      risk: assessment?.risk,
+    });
+    return terminate({
+      decision: "hold",
+      pushed: false,
+      risk: assessment?.risk ?? null,
+      reason: "risk above the auto-merge threshold — held for human review",
+      reportFileId: archived.fileId,
+      summary: assessment?.summary ?? null,
+    });
+  },
+});
+
+/** Coding run failed or the build is red: archive the failure, never push. */
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason: string; detail?: string }, ctx: Ctx) {
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const repoSlug = ctx.shared.get("repoSlug") ?? "unknown";
+    const report = buildReport("rejected", ctx, input);
+    const archived = await archiveReport(
+      ctx,
+      `${repoSlug}-upgrade`,
+      report,
+      dryRun,
+    );
+    ctx.logger.info("upgrade rejected", { reason: input?.reason });
+    return terminate({
+      decision: "reject",
+      pushed: false,
+      reason: input?.reason ?? "unknown",
+      detail: input?.detail ?? null,
+      reportFileId: archived.fileId,
+      testTail: ctx.shared.get("testTail") ?? null,
+    });
+  },
+});
+
+// ────────────────────────────────────────────────────────────── helpers ──
+
+function normalizeRisk(value: unknown): RiskLevel | null {
+  return value === "low" || value === "medium" || value === "high"
+    ? value
+    : null;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Last `max` chars of the combined stdout/stderr — enough to see a failure. */
+function tail(stdout: string, stderr: string, max = 2000): string {
+  const combined = [stdout, stderr].filter(Boolean).join("\n");
+  return combined.length > max ? combined.slice(-max) : combined;
+}
+
+/** Extract the risk assessment from the model output; default to medium on any miss. */
+function parseAssessment(output: string | null): Assessment {
+  const fallback: Assessment = {
+    risk: "medium",
+    summary: "Risk assessment unavailable; defaulted to medium.",
+    notes: [],
+  };
+  if (!output) return fallback;
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback;
+    const raw = JSON.parse(output.slice(start, end + 1)) as Partial<Assessment>;
+    const risk = normalizeRisk(raw.risk) ?? fallback.risk;
+    return {
+      risk,
+      summary: typeof raw.summary === "string" ? raw.summary : fallback.summary,
+      notes: Array.isArray(raw.notes)
+        ? raw.notes.filter((n): n is string => typeof n === "string")
+        : [],
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/** Render the triage report as markdown from the run's shared state. */
+function buildReport(
+  outcome: "published" | "held" | "rejected",
+  ctx: Ctx,
+  extra?: { reason?: string; detail?: string },
+): string {
+  const repoSlug = ctx.shared.get("repoSlug") ?? "unknown";
+  const assessment = ctx.shared.get("assessment");
+  const diffStat = ctx.shared.get("diffStat");
+  const testTail = ctx.shared.get("testTail");
+  const codingSummary = ctx.shared.get("codingSummary");
+
+  const lines: string[] = [
+    `# Dependency upgrade triage — ${repoSlug}`,
+    "",
+    `**Outcome:** ${outcome}`,
+  ];
+  if (assessment) lines.push(`**Risk:** ${assessment.risk}`);
+  if (extra?.reason) {
+    lines.push(
+      `**Reason:** ${extra.reason}${extra.detail ? ` — ${extra.detail}` : ""}`,
+    );
+  }
+  lines.push(
+    "",
+    "## What the agent changed",
+    codingSummary || "(none reported)",
+    "",
+    "## Dependency diff",
+    "```",
+    diffStat || "(none)",
+    "```",
+    "",
+    "## Test output (tail)",
+    "```",
+    testTail || "(not run)",
+    "```",
+  );
+  if (assessment) {
+    lines.push(
+      "",
+      "## Risk assessment",
+      assessment.summary,
+      ...assessment.notes.map((n) => `- ${n}`),
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Archive the triage report to file storage: presign an upload URL, then PUT the
+ * bytes. Skipped on a dry run so `run_local` makes no network calls; failures are
+ * non-fatal (the run's decision still stands).
+ */
+async function archiveReport(
+  ctx: Ctx,
+  name: string,
+  markdown: string,
+  dryRun: boolean,
+): Promise<{ fileId: string | null }> {
+  if (dryRun) {
+    ctx.logger.info("dry run — skipping report archive", { name });
+    return { fileId: null };
+  }
+  try {
+    const bytes = new TextEncoder().encode(markdown);
+    const upload = await ctx.sapiom.fileStorage.upload({
+      contentType: "text/markdown",
+      fileName: `${name}.md`,
+      fileSize: bytes.byteLength,
+      visibility: "private",
+    });
+    await fetch(upload.uploadUrl, {
+      method: "PUT",
+      headers: upload.requiredHeaders,
+      body: bytes,
+    });
+    ctx.logger.info("archived triage report", { fileId: upload.fileId });
+    return { fileId: upload.fileId };
+  } catch (err) {
+    ctx.logger.warn("report archive failed", { err: String(err) });
+    return { fileId: null };
+  }
+}
+
+export const agent = defineAgent<DependencyUpgradeInput, Shared>({
+  name: "dependency-upgrade",
+  entry: "plan",
+  steps: { plan, bump, verify, assess, publish, held, rejected },
+});

--- a/examples/dependency-upgrade/package.json
+++ b/examples/dependency-upgrade/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-dependency-upgrade",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: a scheduled dependency-upgrade triage — a coding agent bumps deps in a sandbox, the real test suite runs there, a model risk-assesses the diff, and it only pushes when the build is green. Every run archives a triage report to file storage.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/dependency-upgrade/template.json
+++ b/examples/dependency-upgrade/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a repo and a schedule. On each tick a coding agent clones the repo into a fresh sandbox and bumps its dependencies, then the workflow re-attaches that same sandbox and runs your real test suite in it. What happens next depends entirely on the result: a red build is archived and dropped, a green build gets a model risk assessment of the changed dependencies, and only a green build within your risk bar gets pushed.\n\nThe graph is `plan → bump → verify → assess → publish | held | rejected`. `bump` (`models.coding`) is a long-running coding agent, so the workflow suspends at $0 while it works and resumes only when it finishes. `verify` (`sandboxes.exec`) installs and tests in the sandbox — a non-zero exit routes straight to `rejected`. `assess` (`models.run`) rates the upgrade low/medium/high; anything above `maxAutoRisk` is `held` for a human instead of pushed. Every outcome — published, held, or rejected — writes a triage report to file storage (`fileStorage.upload`), so you keep a durable record of what changed and why it did or didn't ship.\n\nThe push is the only irreversible step, so it sits behind a `dryRun` guard: with `dryRun: true` every step runs but the push and the report upload are skipped, so you can trace the whole flow for free.\n\nYou pay for the coding agent's run, the sandbox time your tests take, and the one risk-assessment model call — a dry run costs nothing beyond the coding run it still performs.",
+  "useCases": [
+    "Keep a repo's dependencies current on a cron without a human babysitting each bump.",
+    "Gate every automated upgrade on your real test suite, so nothing lands on a red build.",
+    "Hold major or broad upgrades for review while low-risk bumps push on their own."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `repoSlug` (an in-network repo the coding agent clones and upgrades). Set `testCommand` (default `npm test`) and `installCommand` (default `npm install`) to match the project, and `maxAutoRisk` (default `medium`) to control what pushes on its own versus what waits for you. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed workflow. Pass `dryRun: true` to trace the whole graph without pushing or uploading anything.\n\nPrefer to work from the code? Run it locally with `run_local` (pass `{ \"repoSlug\": \"my-app\", \"dryRun\": true }`) to trace plan → bump → verify → assess → publish for free — capabilities are stubbed and the push is skipped — or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A dry-run triage of a repo's upgrade",
+      "input": {
+        "repoSlug": "my-app",
+        "testCommand": "npm test",
+        "maxAutoRisk": "medium",
+        "dryRun": true
+      },
+      "output": {
+        "decision": "publish",
+        "pushed": false,
+        "dryRun": true,
+        "risk": "low",
+        "reportFileId": null,
+        "summary": "Patch and minor bumps across dev dependencies; no major versions, narrow blast radius."
+      }
+    }
+  ]
+}

--- a/examples/dependency-upgrade/tsconfig.json
+++ b/examples/dependency-upgrade/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/durable-backfill/.gitignore
+++ b/examples/durable-backfill/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/durable-backfill/AGENTS.md
+++ b/examples/durable-backfill/AGENTS.md
@@ -1,0 +1,51 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Durable Backfill / Long-Job Runner** — authored against `@sapiom/agent`. It processes a large dataset in resumable chunks: `plan` resolves the job and loads any prior checkpoint, `process` handles one chunk (in a sandbox, against a dataset `DATABASE_URL`) and rewrites a durable checkpoint before pausing until a heartbeat, and `finalize` writes a manifest and terminates. The run survives restarts because progress is checkpointed to file storage under a stable `jobId`.
+
+## The chunk loop
+
+- **`process`** is a self-loop. After doing a chunk's work and checkpointing, it returns `pauseUntilSignal({ signal: "backfill.heartbeat", resumeStep: "process", correlationId: ctx.executionId })` when work remains, or `goto("finalize", {})` on the last chunk. Its static `pause: { signal, resumeStep: "process" }` annotation is the build-time graph edge that must match the directive; its `next: ["finalize"]` is the exit edge.
+- The cursor, processed count, chunk index, and checkpoint file id all live in **`ctx.shared`**, which survives every pause. On resume, `process` reads them back — the heartbeat signal payload itself is ignored (it just wakes the step).
+- The **heartbeat** is a cron/schedule firing `backfill.heartbeat` on a cadence. `pauseUntilSignal` is a **runtime primitive, not a metered capability** — a suspended run is not billed while it waits.
+
+## Capabilities
+
+- **`database.get`** resolves the dataset's connection string, which is injected into the chunk sandbox as `DATABASE_URL`.
+- **`sandboxes.create` / `exec`** run the per-chunk `command` in a fresh, short-TTL sandbox (torn down in a `finally`, so nothing lingers between chunks).
+- **`fileStorage.upload` / `getDownloadUrl` / `list` / `delete`** persist the checkpoint (rotated each chunk), the per-chunk result artifacts, and the final manifest — and read the checkpoint back when resuming.
+- **Capabilities come from the types.** What's on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. Note: `ctx.sapiom.llm` does **not** exist; the LLM path (unused here) is `models.run`.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- A step that pauses declares a `pause: { signal, resumeStep }` annotation; a step may both pause and `goto` a `next` target, which is how `process` loops or exits.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation, including the static `pause` annotation.
+- **run_local** — runs your **real** step code against **stub capabilities**. Leave `dbHandle` unset (or pass `dryRun: true`) so `process` counts each chunk in-process and skips the sandbox / database / file-storage calls; the local runner auto-resumes each heartbeat pause, so you get the full `plan → process → … → finalize` trace offline for free.
+- **deploy**, then **run** — ship it, then perform a real run that pauses between chunks.
+
+### Advancing a paused run in dev
+
+A real `run` pauses after each chunk. To advance it without a schedule, fire the heartbeat via the MCP `signal_workflow` / `workflow_signal` tool:
+
+```json
+{
+  "signal": "backfill.heartbeat",
+  "correlationId": "<executionId of the paused run>"
+}
+```
+
+To resume an interrupted job, start a new run with the same `jobId` — `plan` reads the checkpoint from file storage and continues.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities + the offline `dryRun` path), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The `correlationId` is `ctx.executionId` (stable across pauses), so every heartbeat lands on the right run. Progress is advanced in `ctx.shared` and checkpointed to file storage after each chunk, so a resumed or restarted run never reprocesses a completed chunk.

--- a/examples/durable-backfill/README.md
+++ b/examples/durable-backfill/README.md
@@ -1,0 +1,83 @@
+# Durable Backfill / Long-Job Runner
+
+Process a huge dataset in resumable chunks, checkpointing progress to durable
+storage and surviving restarts via a cron heartbeat. A pure durability showcase:
+instead of one long-held worker grinding through a million rows (and dying
+halfway with nothing to show), it walks the dataset one bounded chunk at a time,
+writes down where it is after each chunk, and **suspends at $0** between chunks
+until a heartbeat wakes it for the next one.
+
+## What it does
+
+```
+plan  ──▶  process  ──(checkpoint, then pause: wait for "backfill.heartbeat", $0 while idle)──╮
+           ▲                                                                                  │
+           ╰──────────────────────── resume on the heartbeat ─────────────────────────────────╯
+           │
+           ╰─(no work left)─▶  finalize  (terminal)
+```
+
+1. **plan** — resolve the job (dataset `total`, `chunkSize`, a stable `jobId`).
+   If a durable checkpoint already exists for that `jobId`, resume from it;
+   otherwise start at zero.
+2. **process** — handle the current chunk. The real work runs in a sandbox that
+   gets the dataset's `DATABASE_URL` (from the `database` capability) and the
+   chunk range (`CHUNK_OFFSET` / `CHUNK_LIMIT`) injected as env. It saves a
+   per-chunk result file and rewrites the checkpoint (`fileStorage`), advances
+   the cursor, then pauses until the next heartbeat — or, once the last chunk is
+   done, goes straight to `finalize`.
+3. **(paused)** — nothing runs, nothing is billed, until the heartbeat fires.
+4. **finalize** — write a run manifest and terminate with a summary.
+
+Restart survival has two layers. Within one run, the cursor lives in
+`ctx.shared` and survives every pause. Across a full teardown, the checkpoint
+lives in file storage keyed by `jobId`, so a brand-new run started with the same
+`jobId` reads it in `plan` and picks up mid-dataset.
+
+Input: `{ "total": 100000, "chunkSize": 5000, "jobId": "users-backfill", "dbHandle": "users-db", "command": "node backfill.js" }`.
+With no `dbHandle` (or `dryRun` set), `process` counts each chunk in-process and
+skips the sandbox / database / file-storage calls.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the deployed run
+   inherits that authority to provision sandboxes and databases and to read and
+   write file storage.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (offline, free — leave `dbHandle` unset or pass `dryRun: true`) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real run that pauses between chunks).
+
+## Advancing a paused run in dev
+
+A deployed run processes one chunk, then pauses for the `backfill.heartbeat`
+signal. In production a schedule fires that signal on a cadence; in dev, fire it
+yourself via the MCP `signal_workflow` / `workflow_signal` tool. The
+`correlationId` is the paused run's `executionId`:
+
+```json
+{
+  "signal": "backfill.heartbeat",
+  "correlationId": "<executionId of the paused run>"
+}
+```
+
+Each heartbeat processes and checkpoints one more chunk. To resume an
+interrupted job, start a new run with the same `jobId` — `plan` reads the
+checkpoint and continues from the last completed chunk.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/durable-backfill/index.ts
+++ b/examples/durable-backfill/index.ts
@@ -1,0 +1,505 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Durable Backfill / Long-Job Runner — process a huge dataset in resumable
+ * chunks, checkpointing progress to durable storage and surviving restarts.
+ *
+ * A pure durability showcase. Instead of one long-held worker grinding through a
+ * million rows (and dying halfway with nothing to show), this walks the dataset
+ * one bounded chunk at a time. After each chunk it writes a checkpoint, then
+ * **suspends at $0** (`pauseUntilSignal`) until a heartbeat wakes it for the next
+ * chunk — the "heartbeat" is a cron/schedule firing the resume signal on a
+ * cadence. Nothing runs and nothing is billed between chunks.
+ *
+ *   plan ─▶ process ──(checkpoint, then pause: wait for heartbeat, $0)──╮
+ *            ▲                                                          │
+ *            ╰──────────────── resume on `backfill.heartbeat` ──────────╯
+ *            │
+ *            ╰─(no work left)─▶ finalize (terminal)
+ *
+ *   1. plan — resolve the job (dataset size, chunk size, job id). If a durable
+ *      checkpoint already exists for this job id, resume from where it left off;
+ *      otherwise start at zero.
+ *   2. process — handle the current chunk. The real work runs in a sandbox that
+ *      gets the dataset's `DATABASE_URL` (from the `database` capability) and the
+ *      chunk range injected as env. It then persists a per-chunk result artifact
+ *      and rewrites the durable checkpoint (`fileStorage`), advances the cursor,
+ *      and pauses until the next heartbeat — or, when the last chunk is done,
+ *      goes straight to `finalize`.
+ *   3. finalize — write a manifest of the run and terminate with a summary.
+ *
+ * Restart survival has two layers. Within one execution, the cursor lives in
+ * `ctx.shared` and survives every pause. Across a full teardown, the checkpoint
+ * lives in file storage keyed by `jobId`, so a brand-new run started with the
+ * same `jobId` reads it in `plan` and picks up mid-dataset.
+ *
+ * Offline: with no `dbHandle` (or `dryRun` set), `process` handles each chunk
+ * in-process and skips the sandbox / database / file-storage calls, so
+ * `run_local` traces the whole plan → process → … → finalize loop for free. The
+ * local runner auto-resumes each heartbeat pause, so you see every chunk.
+ */
+
+/** String-only config bag (matches how templates receive their `config`). */
+type Config = Record<string, string>;
+
+/** The run input. Everything is optional and defaults to a small demo job. */
+interface BackfillInput {
+  /** Total items in the dataset to back-fill. */
+  total?: number;
+  /** Items per chunk — the unit of work between heartbeats. */
+  chunkSize?: number;
+  /**
+   * Stable id for this backfill — the checkpoint key. Pass the same `jobId` to a
+   * fresh run to resume an interrupted job. Defaults to the execution id.
+   */
+  jobId?: string;
+  /**
+   * Postgres handle (from the `database` capability) whose connection string is
+   * injected into the chunk processor as `DATABASE_URL`. Absent ⇒ offline.
+   */
+  dbHandle?: string;
+  /**
+   * Shell command run once per chunk inside the sandbox, with `DATABASE_URL`,
+   * `CHUNK_OFFSET`, `CHUNK_LIMIT`, and `JOB_ID` in its env. It should print the
+   * number of items it processed as the last line of stdout. Swap in your real
+   * backfill here; the default just echoes the chunk size.
+   */
+  command?: string;
+  /** Process chunks in-process and skip all external calls. */
+  dryRun?: boolean;
+  /** Reserved for extra string config. */
+  config?: Config;
+}
+
+/** The durable checkpoint — the small JSON that lets a fresh run resume. */
+interface Checkpoint {
+  jobId: string;
+  /** Offset of the next unprocessed item. */
+  cursor: number;
+  /** Items processed so far. */
+  processed: number;
+  /** Chunks completed so far. */
+  chunkIndex: number;
+  /** Dataset size the checkpoint was written against. */
+  total: number;
+}
+
+/** State that survives every pause (and is rebuilt from the checkpoint on resume). */
+interface Shared extends Record<string, unknown> {
+  jobId: string;
+  total: number;
+  chunkSize: number;
+  cursor: number;
+  processed: number;
+  chunkIndex: number;
+  dbHandle: string | null;
+  command: string;
+  dryRun: boolean;
+  /** Latest checkpoint file id, so each write can delete the previous one. */
+  checkpointFileId: string | null;
+  /** Per-chunk result artifact ids, gathered into the final manifest. */
+  resultFileIds: string[];
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+/** The heartbeat signal a cron/schedule fires to advance to the next chunk. */
+const HEARTBEAT = "backfill.heartbeat";
+
+const DEFAULT_TOTAL = 25;
+const DEFAULT_CHUNK_SIZE = 10;
+/** Default chunk command — echoes the chunk size so `parseCount` reads it back. */
+const DEFAULT_COMMAND =
+  'echo "processing $CHUNK_LIMIT items from offset $CHUNK_OFFSET (job $JOB_ID)"; echo "$CHUNK_LIMIT"';
+/** Time-to-live for the per-chunk sandbox — short, since it is torn down each chunk. */
+const CHUNK_SANDBOX_TTL = "15m";
+
+// ---- helpers ---------------------------------------------------------------
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** File name the durable checkpoint is stored under, keyed by job id. */
+function checkpointFileName(jobId: string): string {
+  return `backfill-checkpoint-${jobId}.json`;
+}
+
+/**
+ * A sandbox name is lowercase alphanumeric + hyphens, 2–63 chars. Derive a legal
+ * one from the job id and chunk offset.
+ */
+function sandboxName(jobId: string, offset: number): string {
+  const base = `backfill-${jobId}-c${offset}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return (base || "backfill").slice(0, 63);
+}
+
+/** Read the last integer printed by the chunk command; fall back to the chunk size. */
+function parseCount(stdout: string, fallback: number): number {
+  const matches = stdout.match(/-?\d+/g);
+  if (!matches || matches.length === 0) return fallback;
+  const n = Number(matches[matches.length - 1]);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+/** Upload a small JSON object to file storage; return its file id (or null on failure). */
+async function uploadJson(
+  ctx: Ctx,
+  fileName: string,
+  obj: unknown,
+): Promise<string | null> {
+  try {
+    const bytes = new TextEncoder().encode(JSON.stringify(obj, null, 2));
+    const { fileId, uploadUrl, requiredHeaders } =
+      await ctx.sapiom.fileStorage.upload({
+        contentType: "application/json",
+        fileName,
+        visibility: "private",
+        fileSize: bytes.byteLength,
+      });
+    const put = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: requiredHeaders,
+      body: bytes,
+    });
+    if (!put.ok) {
+      ctx.logger.warn("checkpoint/result upload PUT failed", {
+        fileName,
+        status: put.status,
+      });
+      return null;
+    }
+    return fileId;
+  } catch (err) {
+    ctx.logger.warn("upload failed", { fileName, err: String(err) });
+    return null;
+  }
+}
+
+/** Delete a file id, swallowing errors (rotation is best-effort). */
+async function deleteFile(ctx: Ctx, fileId: string): Promise<void> {
+  try {
+    await ctx.sapiom.fileStorage.delete(fileId);
+  } catch (err) {
+    ctx.logger.warn("checkpoint delete failed", { fileId, err: String(err) });
+  }
+}
+
+/**
+ * Load the durable checkpoint for `jobId` from file storage, if one exists. A
+ * fresh execution started with the same `jobId` uses this to resume mid-dataset.
+ */
+async function readCheckpoint(
+  ctx: Ctx,
+  jobId: string,
+): Promise<Checkpoint | null> {
+  const name = checkpointFileName(jobId);
+  try {
+    const listing = await ctx.sapiom.fileStorage.list({ limit: 100 });
+    const files = listing?.files ?? [];
+    const match = files.find(
+      (f) => f.fileName === name && f.status === "uploaded",
+    );
+    if (!match) return null;
+    const { downloadUrl } = await ctx.sapiom.fileStorage.getDownloadUrl(
+      match.fileId,
+    );
+    const res = await fetch(downloadUrl);
+    if (!res.ok) return null;
+    const cp = (await res.json()) as Partial<Checkpoint>;
+    if (typeof cp.cursor !== "number") return null;
+    ctx.shared.set("checkpointFileId", match.fileId);
+    return {
+      jobId,
+      cursor: cp.cursor,
+      processed: typeof cp.processed === "number" ? cp.processed : 0,
+      chunkIndex: typeof cp.chunkIndex === "number" ? cp.chunkIndex : 0,
+      total: typeof cp.total === "number" ? cp.total : 0,
+    };
+  } catch (err) {
+    ctx.logger.warn("checkpoint read failed", { jobId, err: String(err) });
+    return null;
+  }
+}
+
+/**
+ * Do one chunk's work. Real path: spin up a sandbox with the dataset's
+ * `DATABASE_URL` and the chunk range in its env, run the command, tear the
+ * sandbox down. Offline path (`dryRun`): count the chunk in-process. Returns the
+ * number of items processed.
+ */
+async function processChunk(
+  ctx: Ctx,
+  args: {
+    command: string;
+    dbHandle: string | null;
+    offset: number;
+    limit: number;
+    jobId: string;
+    dryRun: boolean;
+  },
+): Promise<number> {
+  if (args.dryRun) {
+    ctx.logger.info("dry run: processing chunk in-process (no sandbox)", {
+      offset: args.offset,
+      limit: args.limit,
+    });
+    return args.limit;
+  }
+
+  // Resolve the dataset connection string to hand the processor.
+  let databaseUrl: string | undefined;
+  if (args.dbHandle) {
+    try {
+      const db = await ctx.sapiom.database.get(args.dbHandle);
+      databaseUrl = db.connection?.connectionString ?? undefined;
+    } catch (err) {
+      ctx.logger.warn("could not resolve DATABASE_URL from handle", {
+        handle: args.dbHandle,
+        err: String(err),
+      });
+    }
+  }
+
+  const box = await ctx.sapiom.sandboxes.create({
+    name: sandboxName(args.jobId, args.offset),
+    ttl: CHUNK_SANDBOX_TTL,
+    envs: {
+      ...(databaseUrl ? { DATABASE_URL: databaseUrl } : {}),
+      CHUNK_OFFSET: String(args.offset),
+      CHUNK_LIMIT: String(args.limit),
+      JOB_ID: args.jobId,
+    },
+  });
+  try {
+    const res = await box.exec(args.command);
+    if (res.exitCode !== 0) {
+      ctx.logger.warn("chunk command exited non-zero", {
+        exitCode: res.exitCode,
+        stderr: res.stderr.slice(0, 200),
+      });
+    }
+    return parseCount(res.stdout, args.limit);
+  } finally {
+    try {
+      await box.destroy();
+    } catch (err) {
+      ctx.logger.warn("sandbox destroy failed", { err: String(err) });
+    }
+  }
+}
+
+// ---- steps -----------------------------------------------------------------
+const plan = defineStep({
+  name: "plan",
+  next: ["process"],
+  async run(input: BackfillInput, ctx: Ctx) {
+    const total = Math.max(0, Math.floor(input.total ?? DEFAULT_TOTAL));
+    const chunkSize = Math.max(
+      1,
+      Math.floor(input.chunkSize ?? DEFAULT_CHUNK_SIZE),
+    );
+    const jobId = (input.jobId ?? "").trim() || ctx.executionId;
+    const dbHandle = (input.dbHandle ?? "").trim() || null;
+    const command = (input.command ?? "").trim() || DEFAULT_COMMAND;
+    // No dataset handle (or explicit dryRun) ⇒ run offline: no sandbox, DB, or
+    // file storage, so run_local traces the whole loop for free.
+    const dryRun = input.dryRun === true || !dbHandle;
+
+    let cursor = 0;
+    let processed = 0;
+    let chunkIndex = 0;
+    if (!dryRun) {
+      const prior = await readCheckpoint(ctx, jobId);
+      if (prior) {
+        cursor = Math.min(prior.cursor, total);
+        processed = prior.processed;
+        chunkIndex = prior.chunkIndex;
+        ctx.logger.info("resuming from checkpoint", {
+          jobId,
+          cursor,
+          processed,
+          chunkIndex,
+        });
+      }
+    }
+
+    ctx.shared.set("jobId", jobId);
+    ctx.shared.set("total", total);
+    ctx.shared.set("chunkSize", chunkSize);
+    ctx.shared.set("cursor", cursor);
+    ctx.shared.set("processed", processed);
+    ctx.shared.set("chunkIndex", chunkIndex);
+    ctx.shared.set("dbHandle", dbHandle);
+    ctx.shared.set("command", command);
+    ctx.shared.set("dryRun", dryRun);
+    ctx.shared.set("resultFileIds", []);
+    if (ctx.shared.get("checkpointFileId") === undefined) {
+      ctx.shared.set("checkpointFileId", null);
+    }
+
+    ctx.logger.info("backfill planned", {
+      jobId,
+      total,
+      chunkSize,
+      cursor,
+      dryRun,
+    });
+    return goto("process", {});
+  },
+});
+
+const processStep = defineStep({
+  name: "process",
+  next: ["finalize"],
+  // Self-loop: after checkpointing a chunk, pause until the heartbeat fires and
+  // resume this same step for the next chunk.
+  pause: { signal: HEARTBEAT, resumeStep: "process" },
+  async run(_input: unknown, ctx: Ctx) {
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    const total = must(ctx.shared.get("total"), "total");
+    const chunkSize = must(ctx.shared.get("chunkSize"), "chunkSize");
+    const cursor = must(ctx.shared.get("cursor"), "cursor");
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const dbHandle = (ctx.shared.get("dbHandle") as string | null) ?? null;
+    const command = must(ctx.shared.get("command"), "command");
+
+    // Nothing left to do — finalize. (Also the safe landing if woken with no work.)
+    if (cursor >= total) return goto("finalize", {});
+
+    const offset = cursor;
+    const limit = Math.min(chunkSize, total - cursor);
+    const chunkIndex = must(ctx.shared.get("chunkIndex"), "chunkIndex");
+    ctx.logger.info("processing chunk", {
+      jobId,
+      chunkIndex,
+      offset,
+      limit,
+      total,
+    });
+
+    const done = await processChunk(ctx, {
+      command,
+      dbHandle,
+      offset,
+      limit,
+      jobId,
+      dryRun,
+    });
+
+    // Persist a per-chunk result artifact (deployed path only).
+    const resultFileIds = [
+      ...((ctx.shared.get("resultFileIds") as string[] | undefined) ?? []),
+    ];
+    if (!dryRun) {
+      const rid = await uploadJson(
+        ctx,
+        `backfill-${jobId}-chunk-${chunkIndex}.json`,
+        { jobId, chunkIndex, offset, limit, processed: done },
+      );
+      if (rid) resultFileIds.push(rid);
+    }
+
+    // Advance the cursor and record progress.
+    const nextCursor = offset + limit;
+    const nextProcessed = must(ctx.shared.get("processed"), "processed") + done;
+    const nextChunkIndex = chunkIndex + 1;
+    ctx.shared.set("cursor", nextCursor);
+    ctx.shared.set("processed", nextProcessed);
+    ctx.shared.set("chunkIndex", nextChunkIndex);
+    ctx.shared.set("resultFileIds", resultFileIds);
+
+    // Rewrite the durable checkpoint, rotating out the previous file.
+    if (!dryRun) {
+      const prevCheckpoint = ctx.shared.get("checkpointFileId") as
+        | string
+        | null;
+      const cpId = await uploadJson(ctx, checkpointFileName(jobId), {
+        jobId,
+        cursor: nextCursor,
+        processed: nextProcessed,
+        chunkIndex: nextChunkIndex,
+        total,
+      } satisfies Checkpoint);
+      if (cpId) {
+        if (prevCheckpoint && prevCheckpoint !== cpId) {
+          await deleteFile(ctx, prevCheckpoint);
+        }
+        ctx.shared.set("checkpointFileId", cpId);
+      }
+    }
+    ctx.logger.info("chunk checkpointed", {
+      jobId,
+      cursor: nextCursor,
+      processed: nextProcessed,
+    });
+
+    // Last chunk done? Finalize now. Otherwise wait for the next heartbeat.
+    if (nextCursor >= total) return goto("finalize", {});
+    return pauseUntilSignal({
+      signal: HEARTBEAT,
+      resumeStep: "process",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const finalize = defineStep({
+  name: "finalize",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const jobId = must(ctx.shared.get("jobId"), "jobId");
+    const total = must(ctx.shared.get("total"), "total");
+    const processed = must(ctx.shared.get("processed"), "processed");
+    const chunkIndex = must(ctx.shared.get("chunkIndex"), "chunkIndex");
+    const dryRun = ctx.shared.get("dryRun") === true;
+    const checkpointFileId =
+      (ctx.shared.get("checkpointFileId") as string | null) ?? null;
+    const resultFileIds =
+      (ctx.shared.get("resultFileIds") as string[] | undefined) ?? [];
+
+    let manifestFileId: string | null = null;
+    if (!dryRun) {
+      manifestFileId = await uploadJson(
+        ctx,
+        `backfill-${jobId}-manifest.json`,
+        { jobId, total, processed, chunks: chunkIndex, resultFileIds },
+      );
+    }
+
+    ctx.logger.info("backfill complete", {
+      jobId,
+      total,
+      processed,
+      chunks: chunkIndex,
+    });
+    return terminate({
+      jobId,
+      total,
+      processed,
+      chunks: chunkIndex,
+      complete: total === 0 || processed >= total,
+      checkpointFileId,
+      manifestFileId,
+      resultFileIds,
+    });
+  },
+});
+
+export const agent = defineAgent<BackfillInput, Shared>({
+  name: "durable-backfill",
+  entry: "plan",
+  steps: { plan, process: processStep, finalize },
+});

--- a/examples/durable-backfill/package.json
+++ b/examples/durable-backfill/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-durable-backfill",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: process a huge dataset in resumable chunks, checkpoint progress to durable storage, and survive restarts via a cron heartbeat.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/durable-backfill/template.json
+++ b/examples/durable-backfill/template.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Some jobs are too big for one pass — backfill a column across a million rows, reprocess a year of records, migrate a table. Run it as one long worker and a restart halfway through loses everything. This template walks the dataset one chunk at a time instead, and writes down where it is after every chunk.\n\n`plan` works out the job — how big the dataset is, how large each chunk is, and a `jobId` that names the run. `process` handles the current chunk: it hands the dataset's connection string and the chunk's range to a fresh sandbox, runs your command there, saves a small result file, and rewrites a checkpoint. Then it pauses until a heartbeat wakes it for the next chunk. The heartbeat is just a schedule firing a signal on a cadence — so between chunks nothing runs and nothing is billed.\n\nRestarts survive on two levels. Inside one run, the cursor rides along in `ctx.shared` through every pause. If the whole run is torn down, the checkpoint is still in file storage under the `jobId` — start a fresh run with the same `jobId` and `plan` reads it back and picks up mid-dataset.\n\nYou pay for the chunk work — the sandbox while it runs, plus the small checkpoint and result files. The waiting between chunks is free.",
+  "useCases": [
+    "Backfill or reprocess a large table in resumable chunks, checkpointing after each one.",
+    "Run a long batch job on a cron heartbeat so it survives restarts and never holds a worker open.",
+    "Resume an interrupted job from its last checkpoint by starting a fresh run with the same job id."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `total` (dataset size), a `chunkSize`, and a `dbHandle` for the Postgres database holding the data; the chunk's `DATABASE_URL`, `CHUNK_OFFSET`, `CHUNK_LIMIT`, and `JOB_ID` are injected into the `command` you run per chunk (it should print the number of items it processed as its last line). A deployed run processes one chunk, then pauses for the heartbeat. Advance it by firing the signal — on a schedule for a real cadence, or by hand with the MCP `workflow_signal` tool: `{ \"signal\": \"backfill.heartbeat\", \"correlationId\": \"<executionId of the paused run>\" }`. To resume an interrupted job, start a new run with the same `jobId` — it reads the checkpoint and continues.\n\nPrefer to work from the code? Run it locally with `run_local` (leave `dbHandle` unset, or pass `dryRun: true`) to trace the whole plan → process → finalize loop for free — it counts each chunk in-process and auto-resumes every heartbeat. Or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Trace the full loop offline (run_local)",
+      "input": {
+        "total": 25,
+        "chunkSize": 10,
+        "jobId": "demo",
+        "dryRun": true
+      },
+      "output": {
+        "jobId": "demo",
+        "total": 25,
+        "processed": 25,
+        "chunks": 3,
+        "complete": true,
+        "checkpointFileId": null,
+        "manifestFileId": null,
+        "resultFileIds": []
+      }
+    },
+    {
+      "title": "Backfill a real dataset in chunks (deployed)",
+      "input": {
+        "total": 100000,
+        "chunkSize": 5000,
+        "jobId": "users-email-backfill",
+        "dbHandle": "users-db",
+        "command": "node backfill.js"
+      },
+      "output": {
+        "jobId": "users-email-backfill",
+        "total": 100000,
+        "processed": 100000,
+        "chunks": 20,
+        "complete": true,
+        "checkpointFileId": "file_abc123",
+        "manifestFileId": "file_def456",
+        "resultFileIds": ["file_chunk0", "file_chunk1"]
+      }
+    }
+  ]
+}

--- a/examples/durable-backfill/tsconfig.json
+++ b/examples/durable-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/error-triage-digest/.gitignore
+++ b/examples/error-triage-digest/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/error-triage-digest/AGENTS.md
+++ b/examples/error-triage-digest/AGENTS.md
@@ -1,0 +1,46 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Error / Log Triage Digest** — authored against `@sapiom/agent`. It has four steps: `collect` (pause/pull the batch) → `triage` (calls `models.run`, the live LLM) → `dedupe` (calls `database`) → `digest` (emails the result). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.models.run(...)`, `ctx.sapiom.database.get(...)`, `ctx.sapiom.email.messages.send(...)`, `ctx.sapiom.vault.get(...)`).
+
+It combines two durability primitives with real fan-in: it can **pause at $0** for a pushed webhook batch (`pauseUntilSignal`) or run on a **cron** with a pulled batch, and it keeps a **Postgres dedup store** so a daily digest surfaces new issues instead of re-alerting on known ones.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **The pause is a static edge.** `collect` declares `pause: { signal: "errors.pushed", resumeStep: "triage" }` and returns `pauseUntilSignal({ signal, resumeStep, correlationId })` — the two must match. The resumed `triage` step's _input_ is the signal payload (`{ errors: [...] }`); everything else survives the suspend in `ctx.shared`.
+- **Keep the edges slim.** The raw error bodies are bounded (truncated, capped count) before the model sees them and don't linger in `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** `dedupe` skips the database and `digest` skips the send when `dryRun` is set (or no recipient resolves), returning the computed digest as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient is read from the vault (`ctx.sapiom.vault.get("error-triage-digest", "RECIPIENT")`) inside `digest`, not carried through `ctx.shared`.
+- **Fingerprint stability is the contract.** The model is asked to derive a fingerprint from an error's invariant parts and strip volatile bits, so the same recurring error keys the same row across runs. If dedup looks wrong, that prompt is the first place to look.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `models.run` / `database` / `email` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `dedupe` skips the (stubbed) DB and `digest` skips the (stubbed) send and returns the preview. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed LLM triage that writes to the dedup store and delivers the digest. Attach the `schedule` as a cron trigger, or push a batch with the `errors.pushed` signal.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`). To deliver into Sapiom **memory** instead — a searchable long-term store rather than an inbox — swap the send in `digest` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: deliverTo ?? "error-triage-digest",
+  metadata: { newCount, recurringCount },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipient, so you can drop the vault lookup — or keep it to override the scope.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The dedup timestamp is captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `last_seen`.

--- a/examples/error-triage-digest/README.md
+++ b/examples/error-triage-digest/README.md
@@ -1,0 +1,73 @@
+# Error / Log Triage Digest
+
+Ingest a stream of errors, cluster and summarize them with an LLM, dedupe against
+a database so you only hear about what's new, and email a daily digest. The
+scheduled-or-pushed, deduped sibling of a plain alert forwarder.
+
+## What it does
+
+```
+collect  ──▶  triage  ──▶  dedupe  ──▶  digest  (terminal)
+(pause/pull)   (models.run)  (database)   (email)
+```
+
+1. **collect** — gathers the error batch. It takes one directly as `errors`, GETs
+   one from a `pullUrl`, or — with `webhook: true` and no batch yet — **pauses at
+   $0** via `pauseUntilSignal` until your pipeline pushes one as the
+   `errors.pushed` signal. No polling loop, no billed idle.
+2. **triage** — hands the raw errors to an LLM (`ctx.sapiom.models.run` — the
+   live x402-served model) to cluster them into a handful of distinct issues,
+   each with a **stable fingerprint** (volatile ids, timestamps, and line numbers
+   stripped), a title, a severity, and an occurrence count.
+3. **dedupe** — looks each fingerprint up in a Postgres table the digest owns
+   (`ctx.sapiom.database`). Never-seen fingerprints are **new**; the rest are
+   **recurring**, with their running totals updated. This is what stops a daily
+   digest from re-alerting on the same known error every morning.
+4. **digest** — writes a markdown digest (new issues first, recurring below) and
+   emails it. A `dryRun` computes the digest but skips the DB writes and the real
+   send; the recipient is read from the Sapiom vault at runtime, never persisted.
+
+Input: `{ "errors": [{ "message": "...", "level": "error", "service": "checkout" }], "deliverTo": "you@example.com", "schedule": "0 8 * * *" }`.
+
+- `errors` (or `pullUrl`, or the `errors.pushed` webhook) supplies the batch.
+- `deliverTo` sets the recipient; omit it to use the vault-configured default.
+- `dryRun: true` returns the digest as a preview without writing or sending.
+
+### Two ways in
+
+- **Scheduled pull** — attach `schedule` as a cron trigger; the run pulls a batch
+  from `pullUrl` (or is handed one directly) and digests it.
+- **Webhook push** — run with `webhook: true`; the run suspends until your
+  pipeline pushes a batch with the `errors.pushed` signal, then resumes and
+  digests it.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` so the DB and delivery are skipped, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed LLM triage that writes to the dedup store and delivers the
+   digest).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the
+   deployed agent. To push errors in instead, run with `webhook: true` and fire
+   the `errors.pushed` signal with the `workflow_signal` MCP tool, passing
+   `{ "errors": [ ... ] }`.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/error-triage-digest/index.ts
+++ b/examples/error-triage-digest/index.ts
@@ -1,0 +1,580 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Error / Log Triage Digest — turn a noisy stream of errors into one daily
+ * digest that separates what's new from what you already know about.
+ *
+ * It ingests a batch of errors two ways, from the same entry step:
+ *   - **Scheduled pull** — a cron-triggered run passes the batch in as `errors`,
+ *     or hands it a `pullUrl` to GET the batch from your log store.
+ *   - **Webhook push** — with `webhook: true` and no batch yet, the run
+ *     **suspends at $0** via `pauseUntilSignal` until your error pipeline pushes
+ *     a batch as the `errors.pushed` signal. No polling loop, no billed idle.
+ *
+ * Then, in one legible graph:
+ *   collect ──▶ triage (models.run) ──▶ dedupe (database) ──▶ digest (email)
+ *
+ *   - **triage** hands the raw errors to an LLM (`ctx.sapiom.models.run` — the
+ *     live x402-served model) to cluster them into a handful of issues, each
+ *     with a stable `fingerprint`, a title, a severity, and an occurrence count.
+ *   - **dedupe** looks each fingerprint up in a Postgres table the digest owns.
+ *     Clusters it has never seen are **new**; the rest are **recurring**, and it
+ *     updates their running totals and last-seen time. This is what stops the
+ *     digest from re-alerting on the same known error every single day.
+ *   - **digest** writes a markdown digest — new issues first, recurring below —
+ *     and emails it. A `dryRun` (or a run with no recipient) returns the digest
+ *     as a preview without sending, so `run_local` traces the whole graph for
+ *     free (capabilities stubbed, DB and delivery skipped).
+ *
+ * Determinism: each step body runs once on the happy path (again only on retry).
+ * Non-deterministic values — the dedup timestamp — are captured once at the DB
+ * boundary via Postgres `now()`, not recomputed per row.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the digest owns — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "error-triage-digest";
+/** Vault ref holding delivery config (e.g. a default RECIPIENT). Read at runtime. */
+const DELIVERY_VAULT_REF = "error-triage-digest";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "error-triage";
+/** The named signal an external error pipeline fires to push a batch in. */
+const SIGNAL = "errors.pushed";
+/** Cap the batch handed to the model so cost + latency stay bounded. */
+const MAX_ERRORS = 200;
+/** Cap each error message the model sees — stacks can be enormous. */
+const MAX_MESSAGE_CHARS = 800;
+/** Default cadence documented for the cron trigger: 08:00 every day. */
+const DEFAULT_SCHEDULE = "0 8 * * *";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** A raw error/log entry. Open-ended — a real source returns what it returns. */
+interface RawError {
+  /** The error message or log line. The only field we require. */
+  message: string;
+  /** Severity as the source labels it, e.g. "error" / "warning". */
+  level?: string;
+  /** Which service/component emitted it. */
+  service?: string;
+  /** Stack trace, if any. Truncated before the model sees it. */
+  stack?: string;
+  /** When it happened (ISO). */
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+interface EntryInput {
+  /** The error batch to triage (the "scheduled pull" / direct path). */
+  errors?: RawError[];
+  /** Optional URL to GET the batch from (JSON array, or `{ errors: [] }`). */
+  pullUrl?: string;
+  /** Wait for a webhook to push the batch instead of pulling one. */
+  webhook?: boolean;
+  /** Cron cadence this digest is meant to run on (documentation only). */
+  schedule?: string;
+  /** Postgres handle for the dedup store; defaults to the template handle. */
+  dbHandle?: string;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Compute the digest but skip the DB writes and the real send. */
+  dryRun?: boolean;
+}
+
+/** A batch of errors — the shape that crosses collect → triage, either path. */
+interface Batch {
+  errors: RawError[];
+}
+
+/** One clustered issue as the model returns it. */
+interface Cluster {
+  /** Stable key for dedup — same recurring issue must yield the same value. */
+  fingerprint: string;
+  title: string;
+  summary: string;
+  severity: "critical" | "high" | "medium" | "low";
+  /** A representative raw message for the issue. */
+  sampleMessage: string;
+  /** Occurrences of this issue in THIS batch. */
+  count: number;
+}
+
+/** A recurring cluster enriched with what the DB already knew about it. */
+interface RecurringCluster extends Cluster {
+  /** When this fingerprint was first seen, across all prior runs (ISO). */
+  firstSeen: string;
+  /** Total occurrences recorded before this batch. */
+  priorTotal: number;
+}
+
+interface Shared extends Record<string, unknown> {
+  dbHandle: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  schedule: string;
+  batchSize: number;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Normalize + bound a raw batch so downstream cost stays predictable. */
+function normalizeErrors(raw: unknown): RawError[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((e): e is RawError => Boolean(e) && typeof e === "object")
+    .map((e) => {
+      const message = String(
+        (e as RawError).message ?? (e as { msg?: unknown }).msg ?? "",
+      ).trim();
+      return { ...(e as RawError), message } as RawError;
+    })
+    .filter((e) => e.message.length > 0)
+    .slice(0, MAX_ERRORS);
+}
+
+/** GET a batch from a log store. Accepts a bare array or `{ errors: [] }`. */
+async function pullErrors(url: string): Promise<RawError[]> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`pull failed: HTTP ${res.status}`);
+  const body = (await res.json()) as unknown;
+  const arr = Array.isArray(body)
+    ? body
+    : ((body as { errors?: unknown }).errors ?? []);
+  return normalizeErrors(arr);
+}
+
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (returns null), not an error — the caller then falls back to
+ * a preview. Never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Error Triage Digest",
+  });
+  return inbox.inboxId;
+}
+
+/** Open a Postgres client for a live run, or null in dryRun / when unavailable. */
+async function openSql(ctx: Ctx, handle: string): Promise<Sql | null> {
+  let db;
+  try {
+    db = await ctx.sapiom.database.get(handle);
+  } catch {
+    db = await ctx.sapiom.database.create({
+      handle,
+      duration: "7d",
+      name: "Error Triage Digest",
+      description: "Seen-error fingerprints + running counts for the digest",
+    });
+  }
+  // `db` may be a stub (undefined) under run_local — stay null-safe and degrade.
+  const conn = db?.connection?.connectionString ?? null;
+  if (!conn) {
+    ctx.logger.warn("database: no connection string", { handle });
+    return null;
+  }
+  return postgres(conn, { ssl: "require" });
+}
+
+async function initSchema(sql: Sql): Promise<void> {
+  await sql`
+    create table if not exists error_clusters (
+      fingerprint     text primary key,
+      title           text,
+      severity        text,
+      first_seen      timestamptz not null default now(),
+      last_seen       timestamptz not null default now(),
+      total_count     bigint not null default 0,
+      times_reported  bigint not null default 0
+    )`;
+}
+
+/** ISO-string a value the pg driver may hand back as a Date or a string. */
+function toIso(v: unknown): string {
+  if (v instanceof Date) return v.toISOString();
+  return String(v ?? "");
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const collect = defineStep({
+  name: "collect",
+  next: ["triage"],
+  // Static graph edge: on SIGNAL, resume at `triage`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "triage" },
+  async run(input: EntryInput, ctx: Ctx) {
+    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", truthy(input.dryRun));
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+
+    let errors = normalizeErrors(input.errors);
+
+    // Nothing passed in, but a pull URL is configured: fetch the batch now
+    // (the "scheduled pull" path a cron trigger would take).
+    if (errors.length === 0 && input.pullUrl && !truthy(input.dryRun)) {
+      try {
+        errors = await pullErrors(input.pullUrl.trim());
+        ctx.logger.info("pulled error batch", { count: errors.length });
+      } catch (err) {
+        ctx.logger.warn("pull failed; continuing with empty batch", {
+          err: String(err),
+        });
+      }
+    }
+
+    // Still nothing and asked to wait: suspend at $0 until the pipeline pushes a
+    // batch. The resumed `triage` step's input IS the signal payload.
+    if (errors.length === 0 && truthy(input.webhook)) {
+      ctx.shared.set("batchSize", 0);
+      ctx.logger.info("no batch yet; pausing for the errors.pushed signal", {
+        correlationId: ctx.executionId,
+      });
+      return pauseUntilSignal({
+        signal: SIGNAL,
+        resumeStep: "triage",
+        correlationId: ctx.executionId,
+      });
+    }
+
+    ctx.shared.set("batchSize", errors.length);
+    return goto("triage", { errors });
+  },
+});
+
+const triage = defineStep({
+  name: "triage",
+  next: ["dedupe"],
+  // `input` is either collect's goto payload or the resumed signal payload.
+  async run(input: Batch, ctx: Ctx) {
+    const errors = normalizeErrors(input?.errors);
+    ctx.shared.set("batchSize", errors.length);
+
+    if (errors.length === 0) {
+      ctx.logger.info("empty batch; nothing to cluster");
+      return goto("dedupe", { clusters: [] as Cluster[] });
+    }
+
+    const rendered = errors
+      .map((e, i) => {
+        const head = [e.level, e.service].filter(Boolean).join("/");
+        const body = `${e.message}${e.stack ? `\n${e.stack}` : ""}`.slice(
+          0,
+          MAX_MESSAGE_CHARS,
+        );
+        return `[${i + 1}]${head ? ` (${head})` : ""} ${body}`;
+      })
+      .join("\n\n");
+
+    const system =
+      "You are an on-call engineer triaging a batch of error/log entries. " +
+      "Group them into a small set of distinct issues (usually 1-8). For each " +
+      "issue produce a STABLE fingerprint: a short lowercase slug derived from " +
+      "the error's invariant parts (error type, module, message template) with " +
+      "volatile bits — ids, timestamps, hostnames, line numbers — stripped, so " +
+      "the same recurring issue always yields the same fingerprint. Rank by " +
+      'severity. Reply with ONLY minified JSON: {"clusters":[{"fingerprint":' +
+      'string,"title":string,"summary":string,"severity":"critical|high|medium|' +
+      'low","sampleMessage":string,"count":number}]}.';
+    const prompt = `ERROR BATCH (${errors.length} entries):\n${rendered}`;
+
+    const res = await ctx.sapiom.models.run({ system, prompt, maxTokens: 900 });
+    const clusters = parseClusters(res.output, errors);
+    ctx.logger.info("triaged batch into clusters", {
+      errors: errors.length,
+      clusters: clusters.length,
+    });
+    return goto("dedupe", { clusters });
+  },
+});
+
+const dedupe = defineStep({
+  name: "dedupe",
+  next: ["digest"],
+  async run(input: { clusters: Cluster[] }, ctx: Ctx) {
+    const clusters = Array.isArray(input?.clusters) ? input.clusters : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const handle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+
+    // Dry run (or run_local's stubbed DB): treat everything as new so the graph
+    // traces end to end without touching a real database.
+    if (dryRun || clusters.length === 0) {
+      ctx.logger.info("skipping dedup store", {
+        dryRun,
+        clusters: clusters.length,
+      });
+      return goto("digest", {
+        newClusters: clusters,
+        recurringClusters: [] as RecurringCluster[],
+      });
+    }
+
+    const sql = await openSql(ctx, handle);
+    if (!sql) {
+      // No DB available — degrade to "everything new" rather than abort.
+      return goto("digest", {
+        newClusters: clusters,
+        recurringClusters: [] as RecurringCluster[],
+      });
+    }
+
+    try {
+      await initSchema(sql);
+      const newClusters: Cluster[] = [];
+      const recurringClusters: RecurringCluster[] = [];
+
+      for (const c of clusters) {
+        const prior = await sql<
+          { first_seen: unknown; total_count: string }[]
+        >`select first_seen, total_count from error_clusters
+            where fingerprint = ${c.fingerprint}`;
+        if (prior.length === 0) {
+          newClusters.push(c);
+        } else {
+          recurringClusters.push({
+            ...c,
+            firstSeen: toIso(prior[0].first_seen),
+            priorTotal: Number(prior[0].total_count),
+          });
+        }
+        // Upsert running state — server-side now() keeps last_seen deterministic
+        // regardless of retries.
+        await sql`
+          insert into error_clusters
+            (fingerprint, title, severity, total_count, times_reported)
+          values
+            (${c.fingerprint}, ${c.title}, ${c.severity}, ${c.count}, 1)
+          on conflict (fingerprint) do update set
+            title          = excluded.title,
+            severity       = excluded.severity,
+            last_seen      = now(),
+            total_count    = error_clusters.total_count + ${c.count},
+            times_reported = error_clusters.times_reported + 1`;
+      }
+
+      ctx.logger.info("deduped clusters", {
+        new: newClusters.length,
+        recurring: recurringClusters.length,
+      });
+      return goto("digest", { newClusters, recurringClusters });
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  },
+});
+
+const digest = defineStep({
+  name: "digest",
+  next: [],
+  terminal: true,
+  async run(
+    input: { newClusters: Cluster[]; recurringClusters: RecurringCluster[] },
+    ctx: Ctx,
+  ) {
+    const newClusters = Array.isArray(input?.newClusters)
+      ? input.newClusters
+      : [];
+    const recurringClusters = Array.isArray(input?.recurringClusters)
+      ? input.recurringClusters
+      : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const batchSize = ctx.shared.get("batchSize") ?? 0;
+    const total = newClusters.length + recurringClusters.length;
+
+    const body = renderDigest(newClusters, recurringClusters, batchSize);
+    const subject =
+      total === 0
+        ? "Error triage digest: all clear"
+        : `Error triage digest: ${newClusters.length} new, ${recurringClusters.length} recurring`;
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // Safe path: a dry run, or a live run with no recipient, returns the digest
+    // without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        digest: body,
+        newCount: newClusters.length,
+        recurringCount: recurringClusters.length,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: body,
+    });
+    ctx.logger.info("digest delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      messageId: sent.messageId,
+      newCount: newClusters.length,
+      recurringCount: recurringClusters.length,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── render ──
+const SEVERITY_ORDER: Record<Cluster["severity"], number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function bySeverity(a: Cluster, b: Cluster): number {
+  return SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+}
+
+function renderCluster(c: Cluster, extra = ""): string {
+  return (
+    `- **[${c.severity}] ${c.title}** — ${c.summary} ` +
+    `(${c.count} this batch${extra})\n  \`${c.sampleMessage.slice(0, 200)}\``
+  );
+}
+
+function renderDigest(
+  newClusters: Cluster[],
+  recurringClusters: RecurringCluster[],
+  batchSize: number,
+): string {
+  if (newClusters.length === 0 && recurringClusters.length === 0) {
+    return `# Error triage digest\n\nNo errors in this batch — all clear.`;
+  }
+  const lines = [
+    `# Error triage digest`,
+    ``,
+    `Triaged **${batchSize}** entries into ` +
+      `**${newClusters.length}** new and **${recurringClusters.length}** recurring issue(s).`,
+    ``,
+  ];
+  lines.push(`## 🔴 New issues (${newClusters.length})`);
+  lines.push(
+    newClusters.length === 0
+      ? `_None — nothing here we haven't already seen._`
+      : [...newClusters]
+          .sort(bySeverity)
+          .map((c) => renderCluster(c))
+          .join("\n"),
+  );
+  lines.push(``);
+  lines.push(`## 🔁 Recurring issues (${recurringClusters.length})`);
+  lines.push(
+    recurringClusters.length === 0
+      ? `_None._`
+      : [...recurringClusters]
+          .sort(bySeverity)
+          .map((c) =>
+            renderCluster(
+              c,
+              `, ${c.priorTotal + c.count} total, first seen ${c.firstSeen.slice(0, 10)}`,
+            ),
+          )
+          .join("\n"),
+  );
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** Extract clusters from the model output; fall back to one catch-all cluster. */
+function parseClusters(output: string | null, errors: RawError[]): Cluster[] {
+  const fallback = (): Cluster[] => [
+    {
+      fingerprint: "untriaged-batch",
+      title: "Untriaged errors",
+      summary: "The model returned no usable clustering for this batch.",
+      severity: "medium",
+      sampleMessage: errors[0]?.message ?? "",
+      count: errors.length,
+    },
+  ];
+  if (!output) return fallback();
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return fallback();
+    const parsed = JSON.parse(output.slice(start, end + 1)) as {
+      clusters?: unknown;
+    };
+    if (!Array.isArray(parsed.clusters)) return fallback();
+    const clusters = parsed.clusters
+      .map(coerceCluster)
+      .filter((c): c is Cluster => c !== null);
+    return clusters.length > 0 ? clusters : fallback();
+  } catch {
+    return fallback();
+  }
+}
+
+function coerceCluster(raw: unknown): Cluster | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const fingerprint = String(r.fingerprint ?? "").trim();
+  const title = String(r.title ?? "").trim();
+  if (!fingerprint || !title) return null;
+  const severity = (["critical", "high", "medium", "low"] as const).includes(
+    r.severity as Cluster["severity"],
+  )
+    ? (r.severity as Cluster["severity"])
+    : "medium";
+  const count = Number(r.count);
+  return {
+    fingerprint,
+    title,
+    summary: String(r.summary ?? "").trim(),
+    severity,
+    sampleMessage: String(r.sampleMessage ?? "").trim(),
+    count: Number.isFinite(count) && count > 0 ? Math.floor(count) : 1,
+  };
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "error-triage-digest",
+  entry: "collect",
+  steps: { collect, triage, dedupe, digest },
+});

--- a/examples/error-triage-digest/package.json
+++ b/examples/error-triage-digest/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-error-triage-digest",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: ingest errors via webhook or a scheduled pull, cluster + summarize them with an LLM (models.run), dedupe against a Postgres store, and email a daily digest.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/error-triage-digest/template.json
+++ b/examples/error-triage-digest/template.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You point it at your errors and it turns the noise into one readable digest. It takes them either way: a cron-triggered run hands it a batch (or a URL to pull one from), or you set `webhook: true` and it waits for your error pipeline to push a batch in.\n\nThe graph is four steps. `collect` gathers the batch — and when it's told to wait for a webhook, it pauses and costs nothing until one arrives. `triage` (`models.run`, the live x402-served model) clusters the raw entries into a handful of distinct issues, each with a stable fingerprint that strips out volatile bits like ids and line numbers, so the same recurring error always lands on the same key. `dedupe` looks each fingerprint up in a small Postgres store the digest owns: ones it has never seen are new, the rest are recurring, and it updates their running totals. `digest` writes the markdown — new issues first, recurring below — and emails it.\n\nThe dedup store is the point. Without it, a daily digest re-alerts on the same known error every morning; with it, new problems stand out and the familiar ones fade into a counted summary. A `dryRun` computes the digest and returns it without touching the database or sending mail, so you can trace the whole flow for free before it writes or delivers anything.\n\nYou pay for the model reasoning on each run and a small database footprint — the waiting is free, and the emails are cheap.",
+  "useCases": [
+    "Wake up to one triaged digest of overnight errors instead of a thousand raw alerts.",
+    "Surface only genuinely new failures — let recurring, already-known errors collapse into a counted summary.",
+    "Ingest errors either way: push them in from a webhook, or pull a batch on a schedule."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nFeed it a batch as `errors` (an array of `{ message, level?, service?, stack? }`), or a `pullUrl` it GETs the batch from on each run. Set who gets the digest with `deliverTo`, or store a default under the `error-triage-digest` vault ref (key `RECIPIENT`) — it's read at runtime, never saved into the run. Pass `dryRun: true` to compute the digest and get it back without writing to the database or sending mail. To run it daily, attach the `schedule` as a cron trigger on the deployed workflow.\n\nThis template can also **pause and wait for a webhook**: run it with `webhook: true` and no batch, and it suspends at $0 until your pipeline pushes one. Send the batch with the MCP `workflow_signal` tool (or the API) using the signal name `errors.pushed` and a payload of `{ \"errors\": [ ... ] }` — there is no one-click signal button yet.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole collect → triage → dedupe → digest flow for free (capabilities stubbed, database and delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Triage a small batch, preview only (dry run)",
+      "input": {
+        "dryRun": true,
+        "errors": [
+          {
+            "message": "TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42",
+            "level": "error",
+            "service": "checkout"
+          },
+          {
+            "message": "TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42",
+            "level": "error",
+            "service": "checkout"
+          },
+          {
+            "message": "Timeout after 30000ms calling payments.charge",
+            "level": "error",
+            "service": "payments"
+          }
+        ]
+      },
+      "output": {
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "Error triage digest: 2 new, 0 recurring",
+        "newCount": 2,
+        "recurringCount": 0,
+        "digest": "# Error triage digest\n\nTriaged **3** entries into **2** new and **0** recurring issue(s).\n\n## 🔴 New issues (2)\n- **[high] Undefined read in checkout** — Reading `id` off an undefined object in checkout.js. (2 this batch)\n  `TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42`\n- **[medium] Payment charge timeout** — payments.charge exceeds its 30s timeout. (1 this batch)\n  `Timeout after 30000ms calling payments.charge`\n\n## 🔁 Recurring issues (0)\n_None._"
+      }
+    }
+  ]
+}

--- a/examples/error-triage-digest/tsconfig.json
+++ b/examples/error-triage-digest/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/meeting-notes-crm/.gitignore
+++ b/examples/meeting-notes-crm/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/meeting-notes-crm/AGENTS.md
+++ b/examples/meeting-notes-crm/AGENTS.md
@@ -1,0 +1,46 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Meeting Notes → CRM Updater** — authored against `@sapiom/agent`. It has four steps: `intake` (pause/take the transcript) → `extract` (calls `models.run`, the live LLM) → `upsert` (calls `database`) → `summary` (emails the result). Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.models.run(...)`, `ctx.sapiom.database.get(...)`, `ctx.sapiom.email.messages.send(...)`, `ctx.sapiom.vault.get(...)`).
+
+It combines a durability primitive with a real store: it can **pause at $0** for a pushed transcript (`pauseUntilSignal`) or take one directly, and it keeps a **Postgres CRM store** of contacts and action items so a re-processed transcript updates the record instead of duplicating it.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **The pause is a static edge.** `intake` declares `pause: { signal: "transcript.ready", resumeStep: "extract" }` and returns `pauseUntilSignal({ signal, resumeStep, correlationId })` — the two must match. The resumed `extract` step's _input_ is the signal payload (`{ transcript: "..." }`); everything else survives the suspend in `ctx.shared`.
+- **Keep the edges slim.** The transcript is bounded (truncated to `MAX_TRANSCRIPT_CHARS`) before the model sees it, and only the small extracted object crosses the later edges — the raw transcript doesn't linger in `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** `upsert` skips the database and `summary` skips the send when `dryRun` is set (or no recipient resolves), returning the computed recap as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient is read from the vault (`ctx.sapiom.vault.get("meeting-notes-crm", "RECIPIENT")`) inside `summary`, not carried through `ctx.shared`.
+- **Key stability is the contract.** The contact key (email → company → name) and each action item's `stableId` must resolve the same across runs, so a re-processed transcript updates the same contact row and records each item once. If dedup looks wrong, `resolveContactKey` / `normalizeText` are the first place to look.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `models.run` / `database` / `email` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `upsert` skips the (stubbed) DB and `summary` skips the (stubbed) send and returns the recap. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed LLM extraction that writes to the CRM store and emails the summary. Push a transcript with the `transcript.ready` signal.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`). To deliver into Sapiom **memory** instead — a searchable long-term store rather than an inbox — swap the send in `summary` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: deliverTo ?? "meeting-notes-crm",
+  metadata: { newCount, existingCount },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipient, so you can drop the vault lookup — or keep it to override the scope.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Row timestamps are captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `updated_at` / `last_meeting_at`.

--- a/examples/meeting-notes-crm/README.md
+++ b/examples/meeting-notes-crm/README.md
@@ -1,0 +1,74 @@
+# Meeting Notes → CRM Updater
+
+Take a meeting transcript, extract the contact, the CRM fields to update, and the
+action items with an LLM, write them to a database, and email a summary. The
+transcript arrives directly or by a durable webhook pause.
+
+## What it does
+
+```
+intake  ──▶  extract  ──▶  upsert  ──▶  summary  (terminal)
+(pause/take)  (models.run)  (database)   (email)
+```
+
+1. **intake** — takes the transcript. It reads one directly as `transcript`, or —
+   with `webhook: true` and no transcript yet — **pauses at $0** via
+   `pauseUntilSignal` until your note-taker pushes one as the `transcript.ready`
+   signal. No polling loop, no billed idle.
+2. **extract** — hands the transcript to an LLM (`ctx.sapiom.models.run` — the
+   live x402-served model) to pull structured data: the **contact** the call was
+   with, the **CRM fields** to change (deal stage, next step), and the **action
+   items**, each with an owner and due date when the call named them.
+3. **upsert** — writes to a Postgres CRM store the template owns
+   (`ctx.sapiom.database`). It updates the contact's row (keyed by email, falling
+   back to company) with `coalesce`, so a partial call never wipes a field, and
+   records each action item under a **stable id** so a re-run logs it once.
+4. **summary** — writes a markdown recap (fields updated, action items new vs.
+   already tracked) and emails it. A `dryRun` computes the recap but skips the DB
+   writes and the real send; the recipient is read from the Sapiom vault at
+   runtime, never persisted.
+
+Input: `{ "transcript": "Call with Dana Ruiz, VP Eng at Northwind. ...", "deliverTo": "you@example.com", "meetingDate": "2026-07-22" }`.
+
+- `transcript` (or the `transcript.ready` webhook) supplies the notes.
+- `deliverTo` sets the recipient; omit it to use the vault-configured default.
+- `meetingDate` (ISO) stamps the contact's last-meeting time.
+- `dryRun: true` returns the recap as a preview without writing or sending.
+
+### Two ways in
+
+- **Direct / scheduled** — pass the notes as `transcript` (e.g. a nightly job over
+  yesterday's calls).
+- **Webhook push** — run with `webhook: true`; the run suspends until your
+  note-taker pushes a transcript with the `transcript.ready` signal, then resumes
+  and processes it.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` so the DB and delivery are skipped, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed LLM extraction that writes to the CRM store and emails the
+   summary).
+
+4. To push transcripts in, run with `webhook: true` and fire the
+   `transcript.ready` signal with the `workflow_signal` MCP tool, passing
+   `{ "transcript": "..." }`.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/meeting-notes-crm/index.ts
+++ b/examples/meeting-notes-crm/index.ts
@@ -1,0 +1,605 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Meeting-Notes → CRM Updater — turn a raw meeting transcript into a clean CRM
+ * update: the fields to change on the contact, and the action items that came
+ * out of the call.
+ *
+ * A transcript arrives two ways, from the same entry step:
+ *   - **Direct / scheduled** — a run passes the notes in as `transcript` (e.g. a
+ *     nightly job that hands over yesterday's calls).
+ *   - **Webhook push** — with `webhook: true` and no transcript yet, the run
+ *     **suspends at $0** via `pauseUntilSignal` until your note-taker (Otter,
+ *     Fireflies, a Zoom hook) pushes one as the `transcript.ready` signal. No
+ *     polling loop, no billed idle.
+ *
+ * Then, in one legible graph:
+ *   intake ──▶ extract (models.run) ──▶ upsert (database) ──▶ summary (email)
+ *
+ *   - **extract** hands the transcript to an LLM (`ctx.sapiom.models.run` — the
+ *     live x402-served model) to pull the contact it's about, the CRM fields to
+ *     change (deal stage, next step), and the action items, as structured JSON.
+ *   - **upsert** writes to a small Postgres CRM store the template owns. It
+ *     upserts the contact row (keyed by email, falling back to company) and
+ *     inserts each action item under a stable id, so the same item from a
+ *     re-processed transcript is recorded once, not twice.
+ *   - **summary** writes a markdown recap — fields updated, action items new vs.
+ *     already tracked — and emails it to the rep. A `dryRun` (or a run with no
+ *     recipient) returns the recap as a preview without touching the database or
+ *     sending, so `run_local` traces the whole graph for free.
+ *
+ * Determinism: each step body runs once on the happy path (again only on retry).
+ * Non-deterministic values — the row timestamps — are captured once at the DB
+ * boundary via Postgres `now()`, not recomputed per row.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the CRM store lives under — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "meeting-notes-crm";
+/** Vault ref holding delivery config (e.g. a default RECIPIENT). Read at runtime. */
+const DELIVERY_VAULT_REF = "meeting-notes-crm";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "meeting-crm";
+/** The named signal a note-taker fires to push a finished transcript in. */
+const SIGNAL = "transcript.ready";
+/** Cap the transcript the model sees — full-call transcripts can be enormous. */
+const MAX_TRANSCRIPT_CHARS = 16000;
+/** Cap the action items pulled from one call so cost + storage stay bounded. */
+const MAX_ACTION_ITEMS = 50;
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** The meeting transcript / notes to process (the direct path). */
+  transcript?: string;
+  /** Wait for a note-taker to push the transcript instead of passing one. */
+  webhook?: boolean;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Postgres handle for the CRM store; defaults to the template handle. */
+  dbHandle?: string;
+  /** When the meeting happened (ISO); defaults to now on the DB side. */
+  meetingDate?: string;
+  /** Compute the update but skip the DB writes and the real send. */
+  dryRun?: boolean;
+}
+
+/** The transcript payload that crosses intake → extract, either path. */
+interface Transcript {
+  transcript: string;
+}
+
+/** Who the meeting was about, as the model returns it. */
+interface Contact {
+  name: string;
+  email: string | null;
+  company: string | null;
+  title: string | null;
+}
+
+/** The CRM fields to change on the contact, as the model returns them. */
+interface CrmUpdate {
+  dealStage: string | null;
+  nextStep: string | null;
+  /** A one- or two-sentence recap of the call. */
+  summary: string;
+}
+
+/** One action item as the model returns it — no id yet (derived in code). */
+interface ExtractedActionItem {
+  description: string;
+  owner: string | null;
+  dueDate: string | null;
+}
+
+/** An action item enriched with the stable id used to dedup it in the store. */
+interface ActionItem extends ExtractedActionItem {
+  /** Stable key for dedup — same item from a re-run must yield the same value. */
+  id: string;
+}
+
+/** Everything the model pulled out of one transcript. */
+interface Extraction {
+  contact: Contact;
+  update: CrmUpdate;
+  actionItems: ExtractedActionItem[];
+}
+
+interface Shared extends Record<string, unknown> {
+  dbHandle: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  /** ISO meeting date, or null to let the DB default it to now(). */
+  meetingDate: string | null;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Trim + bound the transcript so downstream cost stays predictable. */
+function normalizeTranscript(raw: unknown): string {
+  return String(raw ?? "")
+    .trim()
+    .slice(0, MAX_TRANSCRIPT_CHARS);
+}
+
+/** Collapse a description to a stable form for dedup (case/space-insensitive). */
+function normalizeText(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.\s]+$/, "")
+    .trim();
+}
+
+/**
+ * Resolve the natural CRM key for the contact — email if we have one, else a
+ * company slug, else a name slug. The same contact must resolve to the same key
+ * across runs so their row is updated, not duplicated.
+ */
+function resolveContactKey(contact: Contact): string {
+  const email = contact.email?.trim().toLowerCase();
+  if (email) return email;
+  const slug = (contact.company || contact.name || "").trim().toLowerCase();
+  const cleaned = slug.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown-contact";
+}
+
+/** Deterministic djb2 hash → hex, so an action item keys the same row every run. */
+function stableId(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) >>> 0;
+  }
+  return `ai_${h.toString(16)}`;
+}
+
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (returns null), not an error — the caller then falls back to
+ * a preview. Never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Meeting Notes CRM",
+  });
+  return inbox.inboxId;
+}
+
+/** Open a Postgres client for a live run, or null in dryRun / when unavailable. */
+async function openSql(ctx: Ctx, handle: string): Promise<Sql | null> {
+  let db;
+  try {
+    db = await ctx.sapiom.database.get(handle);
+  } catch {
+    db = await ctx.sapiom.database.create({
+      handle,
+      duration: "7d",
+      name: "Meeting Notes CRM",
+      description: "Contacts + action items extracted from meeting transcripts",
+    });
+  }
+  // `db` may be a stub (undefined) under run_local — stay null-safe and degrade.
+  const conn = db?.connection?.connectionString ?? null;
+  if (!conn) {
+    ctx.logger.warn("database: no connection string", { handle });
+    return null;
+  }
+  return postgres(conn, { ssl: "require" });
+}
+
+async function initSchema(sql: Sql): Promise<void> {
+  await sql`
+    create table if not exists crm_contacts (
+      contact_key     text primary key,
+      name            text,
+      email           text,
+      company         text,
+      title           text,
+      deal_stage      text,
+      next_step       text,
+      last_meeting_at timestamptz,
+      first_seen      timestamptz not null default now(),
+      updated_at      timestamptz not null default now()
+    )`;
+  await sql`
+    create table if not exists crm_action_items (
+      id           text primary key,
+      contact_key  text not null,
+      description  text not null,
+      owner        text,
+      due_date     text,
+      status       text not null default 'open',
+      created_at   timestamptz not null default now()
+    )`;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const intake = defineStep({
+  name: "intake",
+  next: ["extract"],
+  // Static graph edge: on SIGNAL, resume at `extract`. Must match the directive.
+  pause: { signal: SIGNAL, resumeStep: "extract" },
+  async run(input: EntryInput, ctx: Ctx) {
+    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", truthy(input.dryRun));
+    ctx.shared.set("meetingDate", input.meetingDate?.trim() || null);
+
+    const transcript = normalizeTranscript(input.transcript);
+
+    // Nothing passed in and asked to wait: suspend at $0 until a note-taker
+    // pushes a transcript. The resumed `extract` step's input IS the payload.
+    if (transcript.length === 0 && truthy(input.webhook)) {
+      ctx.logger.info(
+        "no transcript yet; pausing for the transcript.ready signal",
+        {
+          correlationId: ctx.executionId,
+        },
+      );
+      return pauseUntilSignal({
+        signal: SIGNAL,
+        resumeStep: "extract",
+        correlationId: ctx.executionId,
+      });
+    }
+
+    return goto("extract", { transcript });
+  },
+});
+
+const extract = defineStep({
+  name: "extract",
+  next: ["upsert"],
+  // `input` is either intake's goto payload or the resumed signal payload.
+  async run(input: Transcript, ctx: Ctx) {
+    const transcript = normalizeTranscript(input?.transcript);
+
+    if (transcript.length === 0) {
+      ctx.logger.info("empty transcript; nothing to extract");
+      return goto("upsert", { extraction: emptyExtraction() });
+    }
+
+    const system =
+      "You are a sales-ops assistant reading a single meeting transcript. " +
+      "Extract, as data, (1) the primary external contact the meeting was with, " +
+      "(2) the CRM fields to update on them, and (3) the concrete action items " +
+      "that came out of the call. Use null for anything the transcript does not " +
+      "state — never guess an email or a company. Keep each action item to one " +
+      "clear sentence, with an owner and a due date only when explicitly said. " +
+      'Reply with ONLY minified JSON: {"contact":{"name":string,"email":string|' +
+      'null,"company":string|null,"title":string|null},"update":{"dealStage":' +
+      'string|null,"nextStep":string|null,"summary":string},"actionItems":' +
+      '[{"description":string,"owner":string|null,"dueDate":string|null}]}.';
+    const prompt = `MEETING TRANSCRIPT:\n${transcript}`;
+
+    const res = await ctx.sapiom.models.run({ system, prompt, maxTokens: 900 });
+    const extraction = parseExtraction(res.output);
+    ctx.logger.info("extracted meeting notes", {
+      contact: extraction.contact.name,
+      actionItems: extraction.actionItems.length,
+    });
+    return goto("upsert", { extraction });
+  },
+});
+
+const upsert = defineStep({
+  name: "upsert",
+  next: ["summary"],
+  async run(input: { extraction: Extraction }, ctx: Ctx) {
+    const extraction = input?.extraction ?? emptyExtraction();
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const handle = ctx.shared.get("dbHandle") || DEFAULT_DB_HANDLE;
+    const meetingDate = ctx.shared.get("meetingDate") ?? null;
+
+    const contactKey = resolveContactKey(extraction.contact);
+    const items: ActionItem[] = extraction.actionItems
+      .slice(0, MAX_ACTION_ITEMS)
+      .map((a) => ({
+        ...a,
+        id: stableId(`${contactKey}|${normalizeText(a.description)}`),
+      }));
+
+    // Dry run (or run_local's stubbed DB): treat every item as new so the graph
+    // traces end to end without touching a real database.
+    if (dryRun) {
+      ctx.logger.info("skipping CRM store", { dryRun, items: items.length });
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems: items,
+        existingItems: [] as ActionItem[],
+      });
+    }
+
+    const sql = await openSql(ctx, handle);
+    if (!sql) {
+      // No DB available — degrade to "everything new" rather than abort.
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems: items,
+        existingItems: [] as ActionItem[],
+      });
+    }
+
+    try {
+      await initSchema(sql);
+      const { contact, update } = extraction;
+
+      // Upsert the contact — coalesce keeps a prior non-null value when this
+      // transcript didn't restate it, so a partial call never wipes a field.
+      await sql`
+        insert into crm_contacts
+          (contact_key, name, email, company, title, deal_stage, next_step, last_meeting_at)
+        values
+          (${contactKey}, ${contact.name}, ${contact.email}, ${contact.company},
+           ${contact.title}, ${update.dealStage}, ${update.nextStep},
+           coalesce(${meetingDate}::timestamptz, now()))
+        on conflict (contact_key) do update set
+          name            = coalesce(excluded.name, crm_contacts.name),
+          email           = coalesce(excluded.email, crm_contacts.email),
+          company         = coalesce(excluded.company, crm_contacts.company),
+          title           = coalesce(excluded.title, crm_contacts.title),
+          deal_stage      = coalesce(excluded.deal_stage, crm_contacts.deal_stage),
+          next_step       = coalesce(excluded.next_step, crm_contacts.next_step),
+          last_meeting_at = excluded.last_meeting_at,
+          updated_at      = now()`;
+
+      const newItems: ActionItem[] = [];
+      const existingItems: ActionItem[] = [];
+      for (const item of items) {
+        const prior = await sql<{ id: string }[]>`
+          select id from crm_action_items where id = ${item.id}`;
+        if (prior.length === 0) {
+          newItems.push(item);
+        } else {
+          existingItems.push(item);
+        }
+        await sql`
+          insert into crm_action_items (id, contact_key, description, owner, due_date)
+          values (${item.id}, ${contactKey}, ${item.description}, ${item.owner}, ${item.dueDate})
+          on conflict (id) do nothing`;
+      }
+
+      ctx.logger.info("wrote CRM update", {
+        contactKey,
+        new: newItems.length,
+        existing: existingItems.length,
+      });
+      return goto("summary", {
+        contactKey,
+        extraction,
+        newItems,
+        existingItems,
+      });
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  },
+});
+
+const summary = defineStep({
+  name: "summary",
+  next: [],
+  terminal: true,
+  async run(
+    input: {
+      contactKey: string;
+      extraction: Extraction;
+      newItems: ActionItem[];
+      existingItems: ActionItem[];
+    },
+    ctx: Ctx,
+  ) {
+    const extraction = input?.extraction ?? emptyExtraction();
+    const newItems = Array.isArray(input?.newItems) ? input.newItems : [];
+    const existingItems = Array.isArray(input?.existingItems)
+      ? input.existingItems
+      : [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+
+    const body = renderSummary(extraction, newItems, existingItems);
+    const who =
+      extraction.contact.company || extraction.contact.name || "the contact";
+    const subject = `CRM updated: ${who} — ${newItems.length} new action item(s)`;
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // Safe path: a dry run, or a live run with no recipient, returns the recap
+    // without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        summary: body,
+        contact: extraction.contact,
+        newCount: newItems.length,
+        existingCount: existingItems.length,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: body,
+    });
+    ctx.logger.info("summary delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      messageId: sent.messageId,
+      contact: extraction.contact,
+      newCount: newItems.length,
+      existingCount: existingItems.length,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── render ──
+function renderItem(item: ActionItem): string {
+  const meta = [item.owner, item.dueDate ? `due ${item.dueDate}` : null]
+    .filter(Boolean)
+    .join(", ");
+  return `- ${item.description}${meta ? ` _(${meta})_` : ""}`;
+}
+
+function renderSummary(
+  extraction: Extraction,
+  newItems: ActionItem[],
+  existingItems: ActionItem[],
+): string {
+  const { contact, update } = extraction;
+  const heading = [contact.title, contact.company].filter(Boolean).join(", ");
+  const lines = [
+    `# Meeting notes → CRM`,
+    ``,
+    `**Contact:** ${contact.name}${heading ? ` — ${heading}` : ""}` +
+      `${contact.email ? ` <${contact.email}>` : ""}`,
+    `**Deal stage:** ${update.dealStage ?? "_unchanged_"}`,
+    `**Next step:** ${update.nextStep ?? "_none noted_"}`,
+    ``,
+    update.summary || "_No recap produced._",
+    ``,
+    `## Action items (${newItems.length} new, ${existingItems.length} already tracked)`,
+  ];
+  lines.push(`### New (${newItems.length})`);
+  lines.push(
+    newItems.length === 0
+      ? `_None — nothing new from this call._`
+      : newItems.map(renderItem).join("\n"),
+  );
+  lines.push(``);
+  lines.push(`### Already tracked (${existingItems.length})`);
+  lines.push(
+    existingItems.length === 0
+      ? `_None._`
+      : existingItems.map(renderItem).join("\n"),
+  );
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────── parsing ──
+/** A minimal, valid extraction for the empty / unparseable path. */
+function emptyExtraction(): Extraction {
+  return {
+    contact: {
+      name: "Unknown contact",
+      email: null,
+      company: null,
+      title: null,
+    },
+    update: { dealStage: null, nextStep: null, summary: "" },
+    actionItems: [],
+  };
+}
+
+/** Extract the structured update from model output; fall back to empty. */
+function parseExtraction(output: string | null): Extraction {
+  if (!output) return emptyExtraction();
+  try {
+    const start = output.indexOf("{");
+    const end = output.lastIndexOf("}");
+    if (start < 0 || end < 0) return emptyExtraction();
+    const parsed = JSON.parse(output.slice(start, end + 1)) as {
+      contact?: unknown;
+      update?: unknown;
+      actionItems?: unknown;
+    };
+    return {
+      contact: coerceContact(parsed.contact),
+      update: coerceUpdate(parsed.update),
+      actionItems: Array.isArray(parsed.actionItems)
+        ? parsed.actionItems
+            .map(coerceActionItem)
+            .filter((a): a is ExtractedActionItem => a !== null)
+        : [],
+    };
+  } catch {
+    return emptyExtraction();
+  }
+}
+
+/** null-safe string: trims and returns null for empty/absent values. */
+function nullableStr(v: unknown): string | null {
+  const s = String(v ?? "").trim();
+  return s.length > 0 ? s : null;
+}
+
+function coerceContact(raw: unknown): Contact {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    name: nullableStr(r.name) ?? "Unknown contact",
+    email: nullableStr(r.email),
+    company: nullableStr(r.company),
+    title: nullableStr(r.title),
+  };
+}
+
+function coerceUpdate(raw: unknown): CrmUpdate {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    dealStage: nullableStr(r.dealStage),
+    nextStep: nullableStr(r.nextStep),
+    summary: nullableStr(r.summary) ?? "",
+  };
+}
+
+function coerceActionItem(raw: unknown): ExtractedActionItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const description = nullableStr(r.description);
+  if (!description) return null;
+  return {
+    description,
+    owner: nullableStr(r.owner),
+    dueDate: nullableStr(r.dueDate),
+  };
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "meeting-notes-crm",
+  entry: "intake",
+  steps: { intake, extract, upsert, summary },
+});

--- a/examples/meeting-notes-crm/package.json
+++ b/examples/meeting-notes-crm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-meeting-notes-crm",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: take a meeting transcript (directly or via a webhook pause), extract the contact, CRM fields, and action items with an LLM (models.run), write them to a Postgres CRM store, and email a summary.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/meeting-notes-crm/template.json
+++ b/examples/meeting-notes-crm/template.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You hand it a meeting transcript and it does the CRM busywork for you: it works out who the call was with, what to change on their record, and what everyone agreed to do next. It takes the transcript either way — a run passes one in directly (a nightly job over yesterday's calls), or you set `webhook: true` and it waits for your note-taker to push one in.\n\nThe graph is four steps. `intake` takes the transcript — and when it's told to wait for a webhook, it pauses and costs nothing until one arrives. `extract` (`models.run`, the live x402-served model) reads the transcript and returns structured data: the contact, the CRM fields to update (deal stage, next step), and the action items, each with an owner and due date when the call actually named them. `upsert` writes to a small Postgres CRM store the template owns — it updates the contact's row (keyed by email, falling back to company) without wiping fields the call didn't mention, and records each action item under a stable id. `summary` writes a markdown recap — fields updated, action items split into new vs. already tracked — and emails it to the rep.\n\nThe stable id on each action item is the point. Re-process the same transcript, or send a lightly-edited one, and the item is recorded once, not twice — so the CRM store and the recap show what's genuinely new. A `dryRun` computes the recap and returns it without touching the database or sending mail, so you can trace the whole flow for free before it writes or delivers anything.\n\nYou pay for the model reasoning on each run and a small database footprint — the waiting is free, and the email is cheap.",
+  "useCases": [
+    "Turn a sales call transcript into an updated contact record and a clean action-item list, without hand-copying anything.",
+    "Let a note-taker push transcripts in as calls end — the run waits at $0 until one arrives, then processes it.",
+    "Keep a running CRM store of contacts and open action items across every meeting, deduped so nothing is logged twice."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nFeed it the notes as `transcript` (plain text). Set who gets the recap with `deliverTo`, or store a default under the `meeting-notes-crm` vault ref (key `RECIPIENT`) — it's read at runtime, never saved into the run. Pass `meetingDate` (ISO) to stamp the contact's last-meeting time, and `dryRun: true` to compute the recap and get it back without writing to the database or sending mail.\n\nThis template can also **pause and wait for a webhook**: run it with `webhook: true` and no transcript, and it suspends at $0 until your note-taker pushes one. Send the transcript with the MCP `workflow_signal` tool (or the API) using the signal name `transcript.ready` and a payload of `{ \"transcript\": \"...\" }` — there is no one-click signal button yet.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole intake → extract → upsert → summary flow for free (capabilities stubbed, database and delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Extract a short call, preview only (dry run)",
+      "input": {
+        "dryRun": true,
+        "transcript": "Call with Dana Ruiz, VP Eng at Northwind. She confirmed budget for the Q3 rollout and wants a security review before signing. I'll send the SOC 2 report by Friday and Dana will loop in their CISO next week. Deal looks like it's moving to contract stage.",
+        "meetingDate": "2026-07-22"
+      },
+      "output": {
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "CRM updated: Northwind — 2 new action item(s)",
+        "contact": {
+          "name": "Dana Ruiz",
+          "email": null,
+          "company": "Northwind",
+          "title": "VP Eng"
+        },
+        "newCount": 2,
+        "existingCount": 0,
+        "summary": "# Meeting notes → CRM\n\n**Contact:** Dana Ruiz — VP Eng, Northwind\n**Deal stage:** contract\n**Next step:** Send SOC 2 report, then security review before signing\n\nDana confirmed Q3 rollout budget and wants a security review before signing.\n\n## Action items (2 new, 0 already tracked)\n### New (2)\n- Send the SOC 2 report _(me, due Friday)_\n- Loop in the CISO _(Dana, due next week)_\n\n### Already tracked (0)\n_None._"
+      }
+    }
+  ]
+}

--- a/examples/meeting-notes-crm/tsconfig.json
+++ b/examples/meeting-notes-crm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/news-roundup/.gitignore
+++ b/examples/news-roundup/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.tsbuildinfo
+sapiom.json

--- a/examples/news-roundup/.sapiom-dev/stubs.json
+++ b/examples/news-roundup/.sapiom-dev/stubs.json
@@ -1,0 +1,58 @@
+{
+  "version": 1,
+  "steps": {
+    "search": {
+      "search.webSearch": {
+        "query": "stub",
+        "results": [
+          { "title": "Polsia raises Series A", "url": "https://news.example/polsia-a", "snippet": "Polsia announced a funding round..." },
+          { "title": "Polsia launches product", "url": "https://news.example/polsia-b", "snippet": "The company launched..." },
+          { "title": "Polsia bakery Berlin", "url": "https://blog.example/bakery", "snippet": "Unrelated bakery blog..." },
+          { "title": "Polsia hires CTO", "url": "https://news.example/polsia-c", "snippet": "Polsia announced a new CTO..." }
+        ]
+      }
+    },
+    "select": {
+      "models.run": {
+        "runId": "r1",
+        "status": "completed",
+        "output": "[{\"title\":\"Polsia raises Series A\",\"url\":\"https://news.example/polsia-a\",\"summary\":\"Polsia raised new funding. This gives the company money to grow.\",\"imagePrompt\":\"A friendly illustration of a growing plant in a pot of coins\"},{\"title\":\"Polsia launches product\",\"url\":\"https://news.example/polsia-b\",\"summary\":\"Polsia released a new product. Customers can use it today.\",\"imagePrompt\":\"A gift box opening with light rays\"},{\"title\":\"Polsia hires CTO\",\"url\":\"https://news.example/polsia-c\",\"summary\":\"Polsia hired a new technology chief. They will lead the engineering team.\",\"imagePrompt\":\"A person joining a team around a table, flat illustration\"}]",
+        "result": null,
+        "error": null
+      }
+    },
+    "illustrate": {
+      "contentGeneration.images.create": {
+        "images": [{ "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" }]
+      },
+      "fileStorage.upload": {
+        "fileId": "img-stub",
+        "uploadUrl": "http://127.0.0.1:4599/put",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "requiredHeaders": { "content-type": "image/png" }
+      }
+    },
+    "publish": {
+      "fileStorage.upload": {
+        "fileId": "page-stub",
+        "uploadUrl": "http://127.0.0.1:4599/put",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "requiredHeaders": { "content-type": "text/html" }
+      },
+      "fileStorage.list": {
+        "files": [
+          { "fileId": "page-stub", "fileName": "news-roundup/polsia/pages/2026-07-22.html", "contentType": "text/html", "visibility": "public", "status": "uploaded", "fileSize": "1000", "createdAt": "2026-07-22T00:00:00Z", "downloadRequestCount": 0 },
+          { "fileId": "img-stub", "fileName": "news-roundup/polsia/images/2026-07-22-1.png", "contentType": "image/png", "visibility": "public", "status": "uploaded", "fileSize": "100", "createdAt": "2026-07-22T00:00:00Z", "downloadRequestCount": 0 }
+        ],
+        "limit": 100, "offset": 0, "hasMore": false
+      },
+      "fileStorage.getDownloadUrl": {
+        "downloadUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "expiresAt": "2099-01-01T00:00:00Z"
+      },
+      "sandboxes.get": { "name": "news-roundup-polsia", "source": "agent", "status": "running", "tier": "s", "url": null, "workspaceRoot": "/workspace", "expiresAt": null, "createdAt": "2026-07-22T00:00:00Z", "updatedAt": "2026-07-22T00:00:00Z" },
+      "sandbox.uploadFile": null,
+      "sandbox.deployPreview": { "url": "https://news-roundup-polsia.preview.example", "status": "deployed", "logs": "" }
+    }
+  }
+}

--- a/examples/news-roundup/AGENTS.md
+++ b/examples/news-roundup/AGENTS.md
@@ -1,0 +1,50 @@
+# Working in this agent project
+
+This project defines exactly one Sapiom agent in `index.ts`, authored against `@sapiom/agent`. Inside a step's `run`, Sapiom capabilities are on `ctx.sapiom` (e.g. `ctx.sapiom.repositories.list()`, `repo.pushFromSandbox(...)`).
+
+The full authoring guide is the `sapiom-agent-authoring` skill — it auto-loads in Claude Code via the Sapiom plugin (the scaffolder also drops it into new projects). Read it for the step model, directives, failure patterns, pause/resume, and stub rules.
+
+## Authoring
+
+- An orchestration is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — this project ships a near-complete local suite. Reach for it then; you don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so a workflow runs end-to-end with zero setup. Returns a per-step trace.
+- **deploy** — ship it.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+## Stubs (overrides)
+
+`run_local` works with **no stubs** — capabilities return sensible defaults. Add an override only when a step's logic branches on a specific result (e.g. "if `repositories.list()` already contains my repo, skip create"). Put overrides in `.sapiom-dev/stubs.json` (committed and human-reviewable); `run_local` reads it automatically. Shape:
+
+```jsonc
+{ "version": 1, "steps": { "<stepName>": { "<capability.path>": <response> } } }
+```
+
+- Capability paths are namespace methods (`repositories.list`, `repositories.create`, `models.coding.run`) or handle methods, which use the **singular** handle type (`repository.pushFromSandbox`, `sandbox.exec`) — not the plural namespace.
+- `<response>` is returned **verbatim** — it is the value that call would return, so match its real shape. `repositories.list` takes the array `list()` returns: `[{ "slug": "...", "cloneUrl": "..." }]` (each element a repository — *not* `[[ … ]]`). `repositories.create`/`get`/`attach` take a single `{ "slug", "cloneUrl" }`.
+- `run_local` reports **`unusedStubs`** (a key that matched no call — usually a typo or the plural/singular mistake) and **`stubWarnings`** (a key matched but the value was the wrong shape). A green run with either non-empty means a stub silently didn't take effect — check them.
+
+## Dispatched runs: pause & resume
+
+A long-running capability (today the coding agent) is launched fire-and-forget and the workflow suspends until it finishes:
+
+```ts
+const run = await ctx.sapiom.models.coding.launch({ task, gitRepository: repo }); // returns a handle, not a result
+return pauseUntilSignal(run, { resumeStep: "finalize" });                         // suspend on the run's result signal
+```
+
+- **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
+- That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
+- **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` *in the launching step* — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Don't rely on a value being recomputed identically across a pause/resume — capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared`.

--- a/examples/news-roundup/README.md
+++ b/examples/news-roundup/README.md
@@ -1,0 +1,95 @@
+# news-roundup
+
+A Sapiom agent, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent), that builds a small news-roundup website for a company. Given a company name, it searches the web for recent news, asks a model to pick the 3–5 most relevant articles and write a plain-language summary and an illustration prompt for each, generates one image per article, and publishes a dated roundup page to a per-company site. Each run adds a new dated page to that company's site without touching prior runs.
+
+## Steps
+
+`search` → `select` → `illustrate` → `publish` (defined in `index.ts`, backed by `lib/`):
+
+1. **search** — `ctx.sapiom.search.webSearch` for `"<companyName>" company news from the last 7 days`. If nothing comes back, the agent terminates gracefully (see "No news" below) instead of failing.
+2. **select** — `ctx.sapiom.models.run` picks 3–5 articles from the search results and returns, per article, a title/url/summary/imagePrompt.
+3. **illustrate** — `ctx.sapiom.contentGeneration.images.create` generates one image per selected article; each image is uploaded public to Sapiom file storage. A failed generation degrades that article to a text-only card (two attempts, then move on) rather than failing the run.
+4. **publish** — renders the dated HTML page, uploads it to file storage, then rebuilds the company's sandbox site entirely from what's in storage (see "Storage" and "Serving" below) and returns the live URLs.
+
+## Entry input
+
+```json
+{ "companyName": "Polsia" }
+```
+
+`companyName` is the only input; it's slugified (e.g. `Polsia` → `polsia`) to key storage paths and the sandbox name.
+
+## Output
+
+On success (`publish` terminates with):
+
+```json
+{
+  "status": "published",
+  "siteUrl": "https://news-roundup-polsia-<id>.sandbox.sapiom.ai",
+  "pageUrl": "https://news-roundup-polsia-<id>.sandbox.sapiom.ai/pages/2026-07-22.html",
+  "articles": [
+    { "title": "...", "sourceUrl": "...", "summary": "...", "imageUrl": "https://.../images/2026-07-22-1.png" }
+  ]
+}
+```
+
+`imageUrl` is `null` for an article whose illustration generation failed — the site still renders it as a text-only card.
+
+### No news
+
+If `search` finds zero results for the company, the agent terminates early with:
+
+```json
+{ "status": "no-news", "companyName": "Polsia" }
+```
+
+No page is published and the sandbox is left untouched for that run.
+
+## Storage layout
+
+Everything durable lives in Sapiom file storage under a per-company prefix, uploaded with `visibility: "public"`:
+
+```
+news-roundup/<companySlug>/
+  pages/<runDate>.html        # one dated roundup page per run
+  images/<runDate>-<n>.png    # one image per illustrated article that run
+```
+
+This is the source of truth. The sandbox (below) is a disposable, rebuildable view over it — losing the sandbox loses nothing; the next run (or a manual `deployPreview`) reconstructs the whole site from these files.
+
+## Sandbox naming & serving
+
+- Sandbox name: `news-roundup-<companySlug>` (find-or-create — reused across runs for the same company).
+- `ttl: "24h"`, `tier: "xs"`.
+- **Stateless**: on every `publish`, the agent lists all files under the company's storage prefix, mirrors them into the sandbox as `site/pages/...` and `site/images/...`, writes a generated `site/index.html` (links to every dated page) and `site/server.mjs` (a tiny static file server), then calls `deployPreview({ start: "node site/server.mjs", port: 3000 })`.
+- Because the TTL is 24h, the sandbox — and its preview URL — disappear roughly a day after the last run and get recreated (with a **new** preview URL) on the next run. Don't hardcode or bookmark a `siteUrl`/`pageUrl` long-term; re-run or check the latest execution's output for the current one.
+
+## Testing locally (free — no real capability calls)
+
+```sh
+npm run typecheck && npm test
+```
+
+Then validate the step graph and bundle offline:
+
+- MCP `sapiom_dev_agents_check` — bundles `index.ts`, derives the manifest, checks the step graph. Offline, instant.
+
+To exercise the real step code end-to-end against stubs:
+
+1. Start the local upload sink (services the presigned-PUT calls `uploadPublicFile` makes): `node test/upload-sink.mjs`
+2. In another terminal, MCP `sapiom_dev_agents_run_local` with input `{"companyName": "Polsia"}`. It reads the committed `.sapiom-dev/stubs.json` (stubbed search results, model selection output, image generation, and file-storage/sandbox responses for a `polsia` run) and runs every step's real code against those stubs — zero spend, no live Sapiom calls.
+
+## Running for real
+
+MCP `sapiom_dev_agents_run` with input `{ "companyName": "Polsia" }` runs the deployed agent (slug `news-roundup`) live: real web search, real model call, real image generation, and a real sandbox rebuild/deploy. Inspect the execution's output for the current `siteUrl`/`pageUrl`.
+
+## Schedule
+
+A weekly cron schedule is active for this agent: **every Monday at 08:00 UTC**, input `{ "companyName": "Polsia" }` (schedule id `78`, `definition` slug `news-roundup`). Inspect or manage it with `sapiom_dev_agents_schedule_inspect` / `sapiom_dev_agents_schedule_cancel`.
+
+## Authoring
+
+The orchestration is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`. No credentials to wire — a per-execution tenant credential is injected when the orchestration runs.
+
+See `AGENTS.md` for the full authoring loop (`check` → `run_local` → `deploy`).

--- a/examples/news-roundup/index.ts
+++ b/examples/news-roundup/index.ts
@@ -1,0 +1,207 @@
+import {
+  defineAgent,
+  defineStep,
+  fail,
+  goto,
+  retry,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import { z } from "zod/v4";
+import {
+  buildIndexPage,
+  buildRoundupPage,
+  imageStorageName,
+  pageStorageName,
+  roundupDatesFromFileNames,
+  SERVER_JS,
+} from "./lib/html.js";
+import { buildSelectionPrompt, parseSelection } from "./lib/select.js";
+import { downloadFileBytes, listFilesByPrefix, uploadPublicFile } from "./lib/storage.js";
+import type {
+  IllustratedArticle,
+  RawArticle,
+  RoundupShared,
+  SelectedArticle,
+} from "./lib/types.js";
+import { slugify, todayIso } from "./lib/util.js";
+
+const entryInput = z.object({ companyName: z.string().min(1) });
+const SITE_PORT = 3000;
+
+const search = defineStep({
+  name: "search",
+  next: ["select"],
+  terminal: true,
+  canFail: true,
+  inputSchema: entryInput,
+  async run(input: { companyName: string }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = input.companyName.trim();
+    const companySlug = slugify(companyName);
+    ctx.shared.set("companyName", companyName);
+    ctx.shared.set("companySlug", companySlug);
+    ctx.shared.set("runDate", todayIso());
+    ctx.shared.set("storagePrefix", `news-roundup/${companySlug}/`);
+    try {
+      const res = await ctx.sapiom.search.webSearch({
+        query: `"${companyName}" company news from the last 7 days`,
+        intent: "links",
+      });
+      const articles: RawArticle[] = res.results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.snippet,
+      }));
+      if (articles.length === 0) {
+        ctx.logger.info("no news found", { companyName });
+        return terminate({ status: "no-news", companyName });
+      }
+      ctx.logger.info("search done", { count: articles.length });
+      return goto("select", { articles });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`search failed: ${String(err)}`);
+    }
+  },
+});
+
+const select = defineStep({
+  name: "select",
+  next: ["illustrate"],
+  canFail: true,
+  async run(input: { articles: RawArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = ctx.shared.get("companyName") ?? "";
+    const runDate = ctx.shared.get("runDate") ?? "";
+    try {
+      const res = await ctx.sapiom.models.run({
+        prompt: buildSelectionPrompt(companyName, runDate, input.articles),
+        maxTokens: 2000,
+      });
+      if (res.status !== "completed" || !res.output) {
+        throw new Error(res.error?.message ?? `model run ended as ${res.status}`);
+      }
+      const selected = parseSelection(res.output);
+      ctx.logger.info("selection done", { count: selected.length });
+      return goto("illustrate", { selected });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`select failed: ${String(err)}`);
+    }
+  },
+});
+
+const illustrate = defineStep({
+  name: "illustrate",
+  next: ["publish"],
+  canFail: true,
+  async run(input: { selected: SelectedArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const prefix = ctx.shared.get("storagePrefix") ?? "news-roundup/company/";
+    const runDate = ctx.shared.get("runDate") ?? todayIso();
+    try {
+      const articles: IllustratedArticle[] = [];
+      for (const [i, art] of input.selected.entries()) {
+        let imageFileName: string | null = null;
+        // Per-article: one inline retry (two attempts), then degrade to a text-only card.
+        for (let attempt = 0; attempt < 2 && imageFileName === null; attempt++) {
+          try {
+            const gen = await ctx.sapiom.contentGeneration.images.create({ prompt: art.imagePrompt });
+            const url = gen.images?.[0]?.url;
+            if (!url) throw new Error("no image in generation result");
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`image fetch failed: ${res.status}`);
+            const bytes = new Uint8Array(await res.arrayBuffer());
+            const fileName = imageStorageName(prefix, runDate, i + 1);
+            await uploadPublicFile(ctx.sapiom, { fileName, contentType: "image/png", bytes });
+            imageFileName = fileName;
+          } catch (err) {
+            ctx.logger.warn("image failed", { article: art.title, attempt, err: String(err) });
+          }
+        }
+        articles.push({ title: art.title, sourceUrl: art.url, summary: art.summary, imageFileName });
+      }
+      ctx.logger.info("illustrations done", {
+        withImage: articles.filter((a) => a.imageFileName !== null).length,
+        total: articles.length,
+      });
+      return goto("publish", { articles });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 1000 });
+      return fail(`illustrate failed: ${String(err)}`);
+    }
+  },
+});
+
+const publish = defineStep({
+  name: "publish",
+  next: [],
+  terminal: true,
+  canFail: true,
+  async run(input: { articles: IllustratedArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = ctx.shared.get("companyName") ?? "";
+    const companySlug = ctx.shared.get("companySlug") ?? "company";
+    const runDate = ctx.shared.get("runDate") ?? todayIso();
+    const prefix = ctx.shared.get("storagePrefix") ?? `news-roundup/${companySlug}/`;
+    try {
+      // 1. Durable copy of the dated page.
+      const pageHtml = buildRoundupPage({ companyName, runDate, articles: input.articles });
+      await uploadPublicFile(ctx.sapiom, {
+        fileName: pageStorageName(prefix, runDate),
+        contentType: "text/html",
+        bytes: new TextEncoder().encode(pageHtml),
+      });
+      // 2. Full inventory — the sandbox is rebuilt from storage every run.
+      const stored = await listFilesByPrefix(ctx.sapiom, prefix);
+      // 3. Find-or-create the site sandbox.
+      const sandboxName = `news-roundup-${companySlug}`;
+      let sandbox;
+      try {
+        const info = await ctx.sapiom.sandboxes.get(sandboxName);
+        ctx.logger.info("sandbox found", { name: sandboxName, status: info.status });
+        if (info.status !== "running") throw new Error(`sandbox status ${info.status}`);
+        sandbox = ctx.sapiom.sandboxes.attach(sandboxName);
+      } catch (err) {
+        // Expired/missing sandbox is the normal weekly path; the reason distinguishes
+        // not-found from auth/network failures in the execution logs.
+        ctx.logger.warn("creating sandbox", { name: sandboxName, reason: String(err) });
+        sandbox = await ctx.sapiom.sandboxes.create({ name: sandboxName, ttl: "24h", tier: "xs", port: SITE_PORT });
+      }
+      // 4. Mirror storage into site/ (pages/... and images/...).
+      for (const f of stored) {
+        const rel = f.fileName.slice(prefix.length);
+        const bytes = await downloadFileBytes(ctx.sapiom, f.fileId);
+        await sandbox.uploadFile(`site/${rel}`, bytes);
+      }
+      // 5. Index + server, then (re)start.
+      const dates = roundupDatesFromFileNames(stored.map((f) => f.fileName), prefix);
+      await sandbox.uploadFile("site/index.html", buildIndexPage(companyName, dates));
+      await sandbox.uploadFile("site/server.mjs", SERVER_JS);
+      const deploy = await sandbox.deployPreview({ start: "node site/server.mjs", port: SITE_PORT });
+      if (!deploy.url || deploy.status !== "deployed") {
+        throw new Error(`deployPreview ${deploy.status}: ${deploy.logs.slice(-500)}`);
+      }
+      const siteUrl = deploy.url.replace(/\/+$/, "");
+      const imagesPrefix = `${prefix}images/`;
+      ctx.logger.info("published", { siteUrl, files: stored.length });
+      return terminate({
+        status: "published",
+        siteUrl,
+        pageUrl: `${siteUrl}/pages/${runDate}.html`,
+        articles: input.articles.map((a) => ({
+          title: a.title,
+          sourceUrl: a.sourceUrl,
+          summary: a.summary,
+          imageUrl: a.imageFileName ? `${siteUrl}/images/${a.imageFileName.slice(imagesPrefix.length)}` : null,
+        })),
+      });
+    } catch (err) {
+      if (ctx.attempts + 1 < 3) return retry({ delayMs: 2000 });
+      return fail(`publish failed: ${String(err)}`);
+    }
+  },
+});
+
+export const agent = defineAgent<{ companyName: string }, RoundupShared>({
+  name: "news-roundup",
+  entry: "search",
+  steps: { search, select, illustrate, publish },
+});

--- a/examples/news-roundup/lib/html.test.ts
+++ b/examples/news-roundup/lib/html.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIndexPage,
+  buildRoundupPage,
+  imageStorageName,
+  pageStorageName,
+  roundupDatesFromFileNames,
+} from "./html.js";
+
+const PREFIX = "news-roundup/polsia/";
+
+describe("storage names", () => {
+  it("builds page and image names", () => {
+    expect(pageStorageName(PREFIX, "2026-07-22")).toBe("news-roundup/polsia/pages/2026-07-22.html");
+    expect(imageStorageName(PREFIX, "2026-07-22", 1)).toBe("news-roundup/polsia/images/2026-07-22-1.png");
+  });
+});
+
+describe("buildRoundupPage", () => {
+  const page = buildRoundupPage({
+    companyName: "Polsia",
+    runDate: "2026-07-22",
+    articles: [
+      { title: "Big <news>", sourceUrl: "https://a.example/1", summary: "Short & sweet.", imageFileName: `${PREFIX}images/2026-07-22-1.png` },
+      { title: "No image story", sourceUrl: "https://a.example/2", summary: "Text only.", imageFileName: null },
+    ],
+  });
+  it("references images relative to /pages/", () => {
+    expect(page).toContain('src="../images/2026-07-22-1.png"');
+  });
+  it("escapes HTML in article fields", () => {
+    expect(page).toContain("Big &lt;news&gt;");
+    expect(page).toContain("Short &amp; sweet.");
+    expect(page).not.toContain("Big <news>");
+  });
+  it("renders a text-only card when imageFileName is null", () => {
+    expect(page).toContain("No image story");
+    const imgCount = (page.match(/<img /g) ?? []).length;
+    expect(imgCount).toBe(1);
+  });
+  it("links each source", () => {
+    expect(page).toContain('href="https://a.example/1"');
+  });
+  it("does not link non-http(s) source URLs", () => {
+    const p = buildRoundupPage({
+      companyName: "Polsia",
+      runDate: "2026-07-22",
+      articles: [
+        { title: "Evil", sourceUrl: "javascript:alert(1)", summary: "x", imageFileName: null },
+      ],
+    });
+    expect(p).not.toContain("javascript:");
+    expect(p).toContain("Evil");
+  });
+});
+
+describe("roundupDatesFromFileNames", () => {
+  it("extracts unique page dates sorted descending, ignoring other files", () => {
+    const dates = roundupDatesFromFileNames(
+      [
+        `${PREFIX}pages/2026-07-15.html`,
+        `${PREFIX}pages/2026-07-22.html`,
+        `${PREFIX}pages/2026-07-22.html`,
+        `${PREFIX}images/2026-07-22-1.png`,
+        "other/pages/2026-01-01.html",
+      ],
+      PREFIX,
+    );
+    expect(dates).toEqual(["2026-07-22", "2026-07-15"]);
+  });
+});
+
+describe("buildIndexPage", () => {
+  it("links every date page", () => {
+    const html = buildIndexPage("Polsia", ["2026-07-22", "2026-07-15"]);
+    expect(html).toContain('href="pages/2026-07-22.html"');
+    expect(html).toContain('href="pages/2026-07-15.html"');
+    expect(html).toContain("Polsia");
+  });
+});

--- a/examples/news-roundup/lib/html.ts
+++ b/examples/news-roundup/lib/html.ts
@@ -1,0 +1,119 @@
+import type { IllustratedArticle } from "./types.js";
+
+export function pageStorageName(prefix: string, runDate: string): string {
+  return `${prefix}pages/${runDate}.html`;
+}
+
+export function imageStorageName(prefix: string, runDate: string, n: number): string {
+  return `${prefix}images/${runDate}-${n}.png`;
+}
+
+function esc(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const STYLE = `<style>
+  body { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f7; color: #1c1c1e; }
+  main { max-width: 720px; margin: 0 auto; padding: 2rem 1rem; }
+  h1 { font-size: 1.6rem; }
+  .card { background: #fff; border-radius: 12px; padding: 1.25rem; margin: 1rem 0; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+  .card img { max-width: 100%; border-radius: 8px; }
+  .card h2 { font-size: 1.15rem; margin: .75rem 0 .5rem; }
+  .card p { line-height: 1.5; margin: 0 0 .5rem; }
+  a { color: #0a5dc2; }
+  ul.dates { list-style: none; padding: 0; } ul.dates li { margin: .5rem 0; }
+</style>`;
+
+export function buildRoundupPage(opts: {
+  companyName: string;
+  runDate: string;
+  articles: IllustratedArticle[];
+}): string {
+  const cards = opts.articles
+    .map((a) => {
+      const base = a.imageFileName ? a.imageFileName.split("/").pop() : null;
+      const img = base ? `<img src="../images/${esc(base)}" alt="${esc(a.title)}">` : "";
+      const safeHref = /^https?:\/\//i.test(a.sourceUrl) ? a.sourceUrl : null;
+      return `<article class="card">
+${img}
+<h2>${esc(a.title)}</h2>
+<p>${esc(a.summary)}</p>
+${safeHref ? `<p><a href="${esc(safeHref)}">Read the full article</a></p>` : ""}
+</article>`;
+    })
+    .join("\n");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(opts.companyName)} news roundup — ${opts.runDate}</title>${STYLE}</head>
+<body><main>
+<p><a href="../index.html">← All roundups</a></p>
+<h1>${esc(opts.companyName)} news roundup — ${opts.runDate}</h1>
+${cards}
+</main></body></html>`;
+}
+
+export function roundupDatesFromFileNames(fileNames: string[], prefix: string): string[] {
+  const pagePrefix = `${prefix}pages/`;
+  const dates = new Set<string>();
+  for (const name of fileNames) {
+    if (name.startsWith(pagePrefix) && name.endsWith(".html")) {
+      dates.add(name.slice(pagePrefix.length, -".html".length));
+    }
+  }
+  return [...dates].sort().reverse();
+}
+
+export function buildIndexPage(companyName: string, dates: string[]): string {
+  const items = dates
+    .map((d) => `<li class="card"><a href="pages/${esc(d)}.html">Roundup of ${esc(d)}</a></li>`)
+    .join("\n");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(companyName)} news roundups</title>${STYLE}</head>
+<body><main>
+<h1>${esc(companyName)} news roundups</h1>
+<ul class="dates">
+${items}
+</ul>
+</main></body></html>`;
+}
+
+/** Dependency-free static server, written into the sandbox as site/server.js. */
+export const SERVER_JS = `import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const port = Number(process.env.PORT ?? 3000);
+const types = {
+  ".html": "text/html; charset=utf-8",
+  ".png": "image/png",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+};
+
+createServer(async (req, res) => {
+  try {
+    const urlPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+    let rel = normalize(urlPath).replace(/^[/\\\\]+/, "");
+    if (rel === "" || rel === ".") rel = "index.html";
+    const file = resolve(join(root, rel));
+    if (file !== root && !file.startsWith(root + "/")) {
+      res.writeHead(403, { "content-type": "text/plain" });
+      res.end("forbidden");
+      return;
+    }
+    const body = await readFile(file);
+    res.writeHead(200, { "content-type": types[extname(file)] ?? "application/octet-stream" });
+    res.end(body);
+  } catch {
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  }
+}).listen(port, () => console.log("serving on " + port));
+`;

--- a/examples/news-roundup/lib/select.test.ts
+++ b/examples/news-roundup/lib/select.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildSelectionPrompt, parseSelection } from "./select.js";
+
+const articles = [
+  { title: "Polsia raises funds", url: "https://a.example/1", snippet: "Polsia announced..." },
+  { title: "Unrelated Polsia GmbH", url: "https://b.example/2", snippet: "A German bakery..." },
+];
+
+describe("buildSelectionPrompt", () => {
+  it("mentions company, date, and every article", () => {
+    const p = buildSelectionPrompt("Polsia", "2026-07-22", articles);
+    expect(p).toContain("Polsia");
+    expect(p).toContain("2026-07-22");
+    expect(p).toContain("https://a.example/1");
+    expect(p).toContain("https://b.example/2");
+    expect(p).toContain("imagePrompt");
+  });
+});
+
+describe("parseSelection", () => {
+  const good = JSON.stringify([
+    { title: "T", url: "https://a.example/1", summary: "S.", imagePrompt: "P" },
+  ]);
+  it("parses a bare JSON array", () => {
+    expect(parseSelection(good)).toHaveLength(1);
+  });
+  it("parses an array wrapped in prose/code fences", () => {
+    expect(parseSelection("Here you go:\n```json\n" + good + "\n```")).toHaveLength(1);
+  });
+  it("rejects output without a JSON array", () => {
+    expect(() => parseSelection("no json here")).toThrow();
+  });
+  it("rejects items missing required keys", () => {
+    expect(() => parseSelection('[{"title":"T"}]')).toThrow();
+  });
+  it("rejects more than 5 items", () => {
+    const six = JSON.stringify(Array.from({ length: 6 }, () => JSON.parse(good)[0]));
+    expect(() => parseSelection(six)).toThrow();
+  });
+});

--- a/examples/news-roundup/lib/select.ts
+++ b/examples/news-roundup/lib/select.ts
@@ -1,0 +1,45 @@
+import { z } from "zod/v4";
+import type { RawArticle, SelectedArticle } from "./types.js";
+
+const selectionSchema = z
+  .array(
+    z.object({
+      title: z.string().min(1),
+      url: z.string().min(1),
+      summary: z.string().min(1),
+      imagePrompt: z.string().min(1),
+    }),
+  )
+  .min(1)
+  .max(5);
+
+export function buildSelectionPrompt(
+  companyName: string,
+  runDate: string,
+  articles: RawArticle[],
+): string {
+  const list = articles
+    .map((a, i) => `${i + 1}. ${a.title}\n   URL: ${a.url}\n   Excerpt: ${a.snippet}`)
+    .join("\n");
+  return `Today is ${runDate}. Below are web search results for news about the company "${companyName}".
+
+Select the 3 to 5 results that are genuinely recent news (roughly the last 7 days) about this specific company. Drop results about unrelated companies or people with similar names, duplicates, and pages that are not news articles. If fewer than 3 qualify, select only those that do (minimum 1).
+
+For each selected article provide:
+- "title": the article title
+- "url": the article URL, copied exactly as given
+- "summary": 2-3 plain-language sentences a non-expert understands (no jargon)
+- "imagePrompt": one sentence describing a simple, friendly illustration of the story (no text or logos in the image)
+
+Respond with ONLY a JSON array of objects with keys "title", "url", "summary", "imagePrompt".
+
+Search results:
+${list}`;
+}
+
+export function parseSelection(output: string): SelectedArticle[] {
+  const start = output.indexOf("[");
+  const end = output.lastIndexOf("]");
+  if (start === -1 || end <= start) throw new Error("no JSON array found in model output");
+  return selectionSchema.parse(JSON.parse(output.slice(start, end + 1)));
+}

--- a/examples/news-roundup/lib/server.test.ts
+++ b/examples/news-roundup/lib/server.test.ts
@@ -1,0 +1,50 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SERVER_JS } from "./html.js";
+
+const PORT = 4712;
+let child: ChildProcess;
+
+beforeAll(async () => {
+  const dir = await mkdtemp(join(tmpdir(), "roundup-server-"));
+  await writeFile(join(dir, "server.js"), SERVER_JS);
+  await writeFile(join(dir, "index.html"), "<h1>idx</h1>");
+  child = spawn(process.execPath, [join(dir, "server.js")], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: "ignore",
+  });
+  // wait for the server to accept connections
+  for (let i = 0; i < 50; i++) {
+    try {
+      await fetch(`http://127.0.0.1:${PORT}/`);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error("server never came up");
+}, 15000);
+
+afterAll(() => {
+  child?.kill();
+});
+
+describe("SERVER_JS", () => {
+  it("serves index.html at / with html content type", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("idx");
+  });
+  it("404s missing files", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/nope.html`);
+    expect(res.status).toBe(404);
+  });
+  it("refuses path traversal", async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/%2e%2e/%2e%2e/etc/passwd`);
+    expect([403, 404]).toContain(res.status);
+  });
+});

--- a/examples/news-roundup/lib/storage.test.ts
+++ b/examples/news-roundup/lib/storage.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Sapiom } from "@sapiom/tools";
+import { downloadFileBytes, listFilesByPrefix, uploadPublicFile } from "./storage.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function fakeSapiom(fileStorage: Record<string, unknown>): Sapiom {
+  return { fileStorage } as unknown as Sapiom;
+}
+
+describe("uploadPublicFile", () => {
+  it("initiates a public upload and PUTs the bytes", async () => {
+    const upload = vi.fn().mockResolvedValue({
+      fileId: "f1",
+      uploadUrl: "https://signed.example/put",
+      expiresAt: "2099-01-01T00:00:00Z",
+      requiredHeaders: { "content-type": "text/html" },
+    });
+    const put = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", put);
+    const id = await uploadPublicFile(fakeSapiom({ upload }), {
+      fileName: "news-roundup/polsia/pages/2026-07-22.html",
+      contentType: "text/html",
+      bytes: new TextEncoder().encode("<p>hi</p>"),
+    });
+    expect(id).toBe("f1");
+    expect(upload).toHaveBeenCalledWith({
+      contentType: "text/html",
+      fileName: "news-roundup/polsia/pages/2026-07-22.html",
+      visibility: "public",
+      fileSize: 9,
+    });
+    expect(put).toHaveBeenCalledWith("https://signed.example/put", expect.objectContaining({ method: "PUT" }));
+  });
+  it("throws when the PUT fails", async () => {
+    const upload = vi.fn().mockResolvedValue({
+      fileId: "f1", uploadUrl: "https://signed.example/put", expiresAt: "x", requiredHeaders: {},
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(
+      uploadPublicFile(fakeSapiom({ upload }), { fileName: "a", contentType: "t", bytes: new Uint8Array(1) }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("listFilesByPrefix", () => {
+  const file = (fileId: string, fileName: string, createdAt: string, status = "uploaded") => ({
+    fileId, fileName, createdAt, status, contentType: "x", visibility: "public", fileSize: "1", downloadRequestCount: 0,
+  });
+  it("paginates, filters by prefix, drops deleted, dedupes keeping newest", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: [
+          file("a", "news-roundup/polsia/pages/2026-07-22.html", "2026-07-22T01:00:00Z"),
+          file("b", "other/x.html", "2026-07-22T01:00:00Z"),
+        ],
+        limit: 100, offset: 0, hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        files: [
+          file("c", "news-roundup/polsia/pages/2026-07-22.html", "2026-07-22T02:00:00Z"),
+          file("d", "news-roundup/polsia/images/2026-07-22-1.png", "2026-07-22T01:00:00Z"),
+          file("e", "news-roundup/polsia/pages/old.html", "2026-01-01T00:00:00Z", "deleted"),
+        ],
+        limit: 100, offset: 100, hasMore: false,
+      });
+    const out = await listFilesByPrefix(fakeSapiom({ list }), "news-roundup/polsia/");
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(out).toEqual(
+      expect.arrayContaining([
+        { fileId: "c", fileName: "news-roundup/polsia/pages/2026-07-22.html" },
+        { fileId: "d", fileName: "news-roundup/polsia/images/2026-07-22-1.png" },
+      ]),
+    );
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("downloadFileBytes", () => {
+  it("resolves a fresh URL and GETs the bytes", async () => {
+    const getDownloadUrl = vi.fn().mockResolvedValue({ downloadUrl: "https://signed.example/get", expiresAt: "x" });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    }));
+    const bytes = await downloadFileBytes(fakeSapiom({ getDownloadUrl }), "f1");
+    expect([...bytes]).toEqual([1, 2, 3]);
+  });
+});

--- a/examples/news-roundup/lib/storage.ts
+++ b/examples/news-roundup/lib/storage.ts
@@ -1,0 +1,51 @@
+import type { Sapiom } from "@sapiom/tools";
+
+/** Upload bytes to Sapiom file storage with public visibility; returns the fileId. */
+export async function uploadPublicFile(
+  sapiom: Sapiom,
+  opts: { fileName: string; contentType: string; bytes: Uint8Array },
+): Promise<string> {
+  const res = await sapiom.fileStorage.upload({
+    contentType: opts.contentType,
+    fileName: opts.fileName,
+    visibility: "public",
+    fileSize: opts.bytes.byteLength,
+  });
+  const put = await fetch(res.uploadUrl, {
+    method: "PUT",
+    headers: res.requiredHeaders,
+    body: opts.bytes as unknown as BodyInit,
+  });
+  if (!put.ok) throw new Error(`upload PUT for ${opts.fileName} failed: ${put.status}`);
+  return res.fileId;
+}
+
+/** All non-deleted files whose fileName starts with prefix, newest per fileName. */
+export async function listFilesByPrefix(
+  sapiom: Sapiom,
+  prefix: string,
+): Promise<Array<{ fileId: string; fileName: string }>> {
+  const newest = new Map<string, { fileId: string; fileName: string; createdAt: string }>();
+  let offset = 0;
+  for (;;) {
+    const page = await sapiom.fileStorage.list({ limit: 100, offset });
+    for (const f of page.files) {
+      if (!f.fileName?.startsWith(prefix) || f.status === "deleted") continue;
+      const prev = newest.get(f.fileName);
+      if (!prev || f.createdAt > prev.createdAt) {
+        newest.set(f.fileName, { fileId: f.fileId, fileName: f.fileName, createdAt: f.createdAt });
+      }
+    }
+    if (!page.hasMore || page.files.length === 0) break;
+    offset += page.limit;
+  }
+  return [...newest.values()].map(({ fileId, fileName }) => ({ fileId, fileName }));
+}
+
+/** Download a stored file's bytes via a fresh presigned URL. */
+export async function downloadFileBytes(sapiom: Sapiom, fileId: string): Promise<Uint8Array> {
+  const { downloadUrl } = await sapiom.fileStorage.getDownloadUrl(fileId);
+  const res = await fetch(downloadUrl);
+  if (!res.ok) throw new Error(`download GET for ${fileId} failed: ${res.status}`);
+  return new Uint8Array(await res.arrayBuffer());
+}

--- a/examples/news-roundup/lib/types.ts
+++ b/examples/news-roundup/lib/types.ts
@@ -1,0 +1,27 @@
+export interface RawArticle {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export interface SelectedArticle {
+  title: string;
+  url: string;
+  summary: string;
+  imagePrompt: string;
+}
+
+export interface IllustratedArticle {
+  title: string;
+  sourceUrl: string;
+  summary: string;
+  /** File-storage fileName of the article image, or null when generation failed. */
+  imageFileName: string | null;
+}
+
+export interface RoundupShared extends Record<string, unknown> {
+  companyName: string;
+  companySlug: string;
+  runDate: string;
+  storagePrefix: string;
+}

--- a/examples/news-roundup/lib/util.test.ts
+++ b/examples/news-roundup/lib/util.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { slugify, todayIso } from "./util.js";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugify("Polsia")).toBe("polsia");
+    expect(slugify("Acme Corp, Inc.")).toBe("acme-corp-inc");
+  });
+  it("strips accents and trims hyphens", () => {
+    expect(slugify("Café Été!")).toBe("cafe-ete");
+  });
+  it("caps length at 40 and never returns empty", () => {
+    expect(slugify("x".repeat(80)).length).toBe(40);
+    expect(slugify("!!!")).toBe("company");
+  });
+});
+
+describe("todayIso", () => {
+  it("returns YYYY-MM-DD", () => {
+    expect(todayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/examples/news-roundup/lib/util.ts
+++ b/examples/news-roundup/lib/util.ts
@@ -1,0 +1,16 @@
+/** Lowercase-ascii-hyphen slug, ≤40 chars so "news-roundup-<slug>" fits sandbox name limits. */
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/, "");
+  return slug || "company";
+}
+
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/examples/news-roundup/package-lock.json
+++ b/examples/news-roundup/package-lock.json
@@ -1,0 +1,1394 @@
+{
+  "name": "news-roundup",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "news-roundup",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sapiom/agent": "0.6.5",
+        "@sapiom/tools": "0.20.1",
+        "zod": "4.1.12"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.2",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sapiom/agent": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@sapiom/agent/-/agent-0.6.5.tgz",
+      "integrity": "sha512-SmEXNtp0ZI6zA3jtUueVx0EBfjnstz9Qh2EPawBqbBRHr7eEvvmVxWzKEKt6njZ2oGg69A0JMOy27qjQHpCJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/tools": "^0.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.0.0"
+      }
+    },
+    "node_modules/@sapiom/analytics-core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/analytics-core/-/analytics-core-0.2.1.tgz",
+      "integrity": "sha512-IZaSdegheySbLxSwmrvcKFKpog3+Ef8IP/hkd7Qjp7uxgo7pfwkmjy9nFH9lXDH4ALeW5+Fhs717+RKwkW1EJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sapiom/tools": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@sapiom/tools/-/tools-0.20.1.tgz",
+      "integrity": "sha512-Pv2Uy0PdS9bkvEWxitNoGrUXCMlmI7QLUkBlLAxgL89/dXgWfSiD50DP/KUfIlbyFbW+5fWZR7syhpFj1YkpDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sapiom/analytics-core": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/news-roundup/package.json
+++ b/examples/news-roundup/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "news-roundup",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\"",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@sapiom/agent": "0.6.5",
+    "@sapiom/tools": "0.20.1",
+    "zod": "4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/examples/news-roundup/template.json
+++ b/examples/news-roundup/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a company name. It searches the web for that company's news from the last week, asks an LLM to pick the three-to-five most relevant articles, and writes a plain-language summary and an illustration prompt for each. It generates one image per article, then publishes a dated roundup page to a small website for that company.\n\nEverything durable lives in file storage under a per-company prefix — one HTML page and its images per run. The website itself is disposable: every run rebuilds it from scratch out of storage, so losing it costs nothing, and each run just adds a new dated page without touching the earlier ones. The site is served from a sandbox that expires after a day and is recreated — with a new URL — on the next run.\n\nIf an image fails to generate, that article still shows up as a text-only card instead of failing the run. If the search turns up nothing for the company, it stops early and tells you rather than publishing an empty page.\n\nYou pay for the web search, the model that picks and summarizes the articles, and the images it generates — plus the short-lived sandbox that serves the site. A run that finds no news costs only the search.",
+  "useCases": [
+    "Keep a shareable news page for a company you track — a competitor, a partner, or a portfolio company — refreshed on a schedule.",
+    "Turn a week of scattered press coverage into one dated, illustrated summary you can send someone.",
+    "Run it for several companies so each gets its own standing news site, built and rebuilt automatically."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `companyName` — that's the only input. Each run adds a new dated page to that company's site and returns the live URL. The site is served from a sandbox with a 24-hour TTL, so its URL changes once the sandbox expires and is recreated on the next run — read the latest run's output for the current link instead of bookmarking one. To keep a company's page fresh, put it on a schedule (the shipped example runs weekly).\n\nPrefer to work from the code? Run it locally with `run_local` and `{ \"companyName\": \"Polsia\" }` to trace search → select → illustrate → publish for free against the committed stubs — nothing generated or deployed. (For a local run that exercises the real uploads, start the bundled upload sink first; see the README.) Or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A published roundup",
+      "input": {
+        "companyName": "Polsia"
+      },
+      "output": {
+        "status": "published",
+        "siteUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai",
+        "pageUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai/pages/2026-07-22.html",
+        "articles": [
+          {
+            "title": "Polsia raises Series B to expand its logistics network",
+            "sourceUrl": "https://example.com/polsia-series-b",
+            "summary": "Polsia closed a Series B this week and says the funding will go toward opening two regional warehouses and doubling its delivery fleet.",
+            "imageUrl": "https://news-roundup-polsia-a1b2c3.sandbox.sapiom.ai/images/2026-07-22-1.png"
+          },
+          {
+            "title": "Polsia partners with a regional grocer on same-day delivery",
+            "sourceUrl": "https://example.com/polsia-grocery-pilot",
+            "summary": "A pilot with a regional grocery chain brings Polsia's same-day delivery to three new cities, its first move into groceries.",
+            "imageUrl": null
+          }
+        ]
+      }
+    },
+    {
+      "title": "No recent news found",
+      "input": {
+        "companyName": "Polsia"
+      },
+      "output": {
+        "status": "no-news",
+        "companyName": "Polsia"
+      }
+    }
+  ]
+}

--- a/examples/news-roundup/test/upload-sink.mjs
+++ b/examples/news-roundup/test/upload-sink.mjs
@@ -1,0 +1,11 @@
+// Local sink for presigned-PUT calls during sapiom_dev_agents_run_local.
+// Accepts any method/path with 200 so uploadPublicFile's fetch succeeds.
+import { createServer } from "node:http";
+const port = Number(process.env.PORT ?? 4599);
+createServer((req, res) => {
+  req.resume();
+  req.on("end", () => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{}");
+  });
+}).listen(port, () => console.log(`upload sink on ${port}`));

--- a/examples/news-roundup/tsconfig.json
+++ b/examples/news-roundup/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/newsletter-autopilot/.gitignore
+++ b/examples/newsletter-autopilot/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json*

--- a/examples/newsletter-autopilot/AGENTS.md
+++ b/examples/newsletter-autopilot/AGENTS.md
@@ -1,0 +1,55 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Newsletter
+Autopilot** — authored against `@sapiom/agent`. It has five steps: `search`
+(calls `web.search`) → `scrape` (calls `web.scrape`) → `write` (calls
+`models.run`, the live LLM) → `header` (calls `contentGeneration.images`) →
+`deliver` (emails the issue to a list). Inside a step's `run`, Sapiom
+capabilities are pre-auth'd on `ctx.sapiom` (e.g. `ctx.sapiom.search.webSearch(...)`,
+`ctx.sapiom.models.run(...)`, `ctx.sapiom.contentGeneration.images.create(...)`,
+`ctx.sapiom.email.messages.send(...)`).
+
+It is the published-newsletter evolution of `scheduled-research-brief`. That
+template curates a private one-recipient brief with no image; this one has the
+LLM write a full issue (subject + body + image prompt), generates a header
+image, and emails it to a whole subscriber list on a cadence.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **Keep the edges slim.** The scraped article bodies are the only large data here; they stay bounded (truncated, capped count) and die at the `write` boundary — they never enter `ctx.shared`. Large shared state stalls transitions on the cloud engine (the `backlog-nudge` boundary lesson).
+- **Gate real side effects behind `dryRun`.** `deliver` sends email only on a live run with `dryRun` off and subscribers resolved; otherwise it returns the finished issue as a preview. Keep new external side effects behind the same guard.
+- **Keep best-effort steps best-effort.** `header` never throws — a missing image is a warning, not a failed run. This is also what lets `run_local` (which stubs image generation) trace the full graph.
+- **Read secrets/config at runtime, never persist them.** The subscriber list falls back to the vault (`ctx.sapiom.vault.get("newsletter-autopilot", "SUBSCRIBERS")`) inside `deliver`, not carried through `ctx.shared`.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd run tests in any project — reach for the local suite. You don't need to run it after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so `web.search` / `web.scrape` / `models.run` / `images.create` return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `deliver` skips the (stubbed) send and returns the preview. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed search + scrape + LLM write + header image, and deliver the issue. Attach the `schedule` as a cron trigger to run it weekly.
+
+> Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Delivery channel: email vs. memory
+
+This template delivers by **email** (`ctx.sapiom.email`) to a list. To fan the issue into Sapiom **memory** instead — a searchable long-term archive of past issues — swap the per-subscriber send in `deliver` for an append, e.g.:
+
+```ts
+await ctx.sapiom.memory.append({
+  content: body,
+  scope: "newsletter-autopilot",
+  metadata: { niche, subject, sources },
+});
+```
+
+Keep the same `dryRun` guard around it. Memory needs no recipients, so you can drop the vault lookup. Recall past issues later with `ctx.sapiom.memory.recall({ query, scope })`.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/newsletter-autopilot/README.md
+++ b/examples/newsletter-autopilot/README.md
@@ -1,0 +1,69 @@
+# Newsletter Autopilot
+
+Research a niche, write the issue, illustrate it, and email it to your
+subscribers — on a weekly cadence. The published-newsletter sibling of
+[`scheduled-research-brief`](../scheduled-research-brief).
+
+## What it does
+
+```
+search  ──▶  scrape  ──▶  write  ──▶  header  ──▶  deliver  (terminal)
+(web.search)  (web.scrape)  (models.run)  (images)   (email)
+```
+
+1. **search** — takes a `niche`, calls `ctx.sapiom.search.webSearch` for
+   candidate results.
+2. **scrape** — reads the top candidates for full article text
+   (`ctx.sapiom.search.scrape`), degrading per-item on failure. Bodies are
+   truncated and stay bounded — they never enter shared state.
+3. **write** — hands the ranked, scraped sources to an LLM
+   (`ctx.sapiom.models.run` — the live x402-served model) to curate and write
+   this week's issue: a subject, a markdown body, and a header-image prompt.
+4. **header** — generates a header image for the issue
+   (`ctx.sapiom.contentGeneration.images.create`). Best-effort: if nothing comes
+   back, the issue still goes out without it.
+5. **deliver** — emails each subscriber their own copy. A `dryRun` guard writes
+   and renders the full issue but skips the real send; the subscriber list is
+   read from the Sapiom vault at runtime, never persisted.
+
+Input: `{ "niche": "indie game development", "newsletterName": "Pixel Weekly", "schedule": "0 8 * * 1", "subscribers": ["you@example.com"] }`.
+
+- `niche` and `newsletterName` set what it writes about and the masthead.
+- `schedule` is the cron cadence — it defaults to Mondays at 08:00.
+- `subscribers` is the recipient list; omit it to use the vault-configured list.
+- `dryRun: true` returns the finished issue as a preview without emailing anyone.
+
+### `scheduled-research-brief` vs. this
+
+Fork [`scheduled-research-brief`](../scheduled-research-brief) for a **private,
+one-recipient brief** — search → scrape → curate → email, no image. Fork **this**
+when the deliverable is a **published-feeling newsletter**: an LLM writes the
+issue with a subject and a header image, and it goes out to a whole list.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed; pass `dryRun: true` to skip delivery, free) → `sapiom_dev_agents_link`
+   → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real, billed
+   search + scrape + LLM write + header image, and a delivered issue).
+
+4. To run it weekly, attach the `schedule` as a cron trigger on the deployed
+   agent.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/newsletter-autopilot/index.ts
+++ b/examples/newsletter-autopilot/index.ts
@@ -1,0 +1,498 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Newsletter Autopilot — a standing, self-writing newsletter.
+ *
+ * On each tick (built to run weekly) it searches a `niche`, scrapes the top
+ * results for full text, asks an LLM (`ctx.sapiom.models.run` — the live
+ * x402-served model, NOT a hardcoded formatter) to curate and WRITE the issue,
+ * generates a header image for it, and emails the finished issue to a subscriber
+ * list.
+ *
+ * Composition, in one legible graph:
+ *   search    →   scrape    →   write      →   header               →   deliver
+ *  (web.search)  (web.scrape)  (models.run)  (contentGeneration.images)  (email)
+ *
+ * vs. `scheduled-research-brief`: fork THAT for a private, one-recipient brief
+ * (search → scrape → curate → email). Fork THIS when the deliverable is a
+ * published-feeling newsletter — an LLM writes the issue with a subject line and
+ * an image prompt, a header image is generated, and it goes out to a whole list.
+ *
+ * Side-effect discipline (copied from `scheduled-research-brief`):
+ *   - `dryRun` gates the real send: it still searches, writes, and generates the
+ *     header image, then returns the finished issue as a preview WITHOUT emailing
+ *     anyone. `run_local` uses this to trace the whole graph offline (capabilities
+ *     stubbed) for free before a billed, delivering deploy + run.
+ *   - The subscriber list falls back to the Sapiom vault at runtime and is never
+ *     baked into the code — the same seam you'd read any delivery config from.
+ *   - The header image is best-effort: if generation returns nothing (e.g. a
+ *     stubbed `run_local`), the issue still goes out without it rather than
+ *     aborting the run.
+ *   - Each edge carries a slim payload; the large scraped bodies stay bounded and
+ *     die at the `write` boundary — they never enter `ctx.shared` (big shared
+ *     state stalls transitions, per the `backlog-nudge` boundary lesson).
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Default cadence when the caller doesn't pass one: 08:00 every Monday. */
+const DEFAULT_SCHEDULE = "0 8 * * 1";
+/** Default masthead when the caller doesn't name the newsletter. */
+const DEFAULT_NEWSLETTER_NAME = "Weekly Autopilot";
+/** How many search hits to consider as scrape candidates. */
+const MAX_CANDIDATES = 6;
+/** How many candidates to actually scrape (keeps latency + cost bounded). */
+const MAX_SCRAPES = 4;
+/** Truncate each scraped body — the ONLY large data on the search→write path. */
+const MAX_BODY_CHARS = 1200;
+/** Cap the fan-out of per-subscriber sends (keeps a run's cost bounded). */
+const MAX_RECIPIENTS = 50;
+/** Vault ref holding delivery config (a default SUBSCRIBERS list). Read at runtime. */
+const DELIVERY_VAULT_REF = "newsletter-autopilot";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "newsletter";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** The niche / topic to research and write about on each tick. */
+  niche: string;
+  /** Masthead shown in the subject and header (defaults to a generic name). */
+  newsletterName?: string;
+  /** Cron cadence this newsletter is meant to run on (default weekly Monday 08:00). */
+  schedule?: string;
+  /** Subscriber emails; falls back to the vault-configured list when omitted. */
+  subscribers?: string[];
+  /** Write + render the issue but skip the real send. `run_local` passes this. */
+  dryRun?: boolean;
+}
+
+/** Slim search hit carried across the search → scrape boundary. */
+interface Candidate {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/** A candidate plus its (bounded) scraped body — the scrape → write payload. */
+interface ScrapedSource extends Candidate {
+  /** Extracted article text (markdown, truncated); absent when scraping failed. */
+  content?: string;
+}
+
+/** The slim source reference that crosses write → deliver and lands in output. */
+interface Source {
+  title: string;
+  url: string;
+}
+
+/** The LLM's written issue: a subject, a markdown body, and a header image prompt. */
+interface Issue {
+  subject: string;
+  body: string;
+  imagePrompt: string;
+}
+
+interface Shared extends Record<string, unknown> {
+  niche: string;
+  newsletterName: string;
+  schedule: string;
+  subscribers: string[];
+  dryRun: boolean;
+  subject: string;
+  body: string;
+  imagePrompt: string;
+  headerImageUrl: string | null;
+  headerImageFileId: string | null;
+  sources: Source[];
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/**
+ * Resolve the subscriber list from the vault at runtime. The stored value is a
+ * comma- or newline-separated list of emails. A missing ref/key is an expected
+ * outcome (`vault.get` returns null), not an error — the caller then falls back
+ * to a dry-run preview. Never persisted in execution state.
+ */
+async function subscribersFromVault(ctx: Ctx): Promise<string[]> {
+  try {
+    const raw = await ctx.sapiom.vault.get(DELIVERY_VAULT_REF, "SUBSCRIBERS");
+    return parseRecipients(raw);
+  } catch (err) {
+    ctx.logger.warn("vault: no subscriber list configured", {
+      err: String(err),
+    });
+    return [];
+  }
+}
+
+/** Split a raw address list (commas or newlines) into de-duped, trimmed emails. */
+function parseRecipients(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  for (const part of raw.split(/[,\n]/)) {
+    const email = part.trim();
+    if (email && email.includes("@")) seen.add(email);
+  }
+  return [...seen];
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "Newsletter Autopilot",
+  });
+  return inbox.inboxId;
+}
+
+/**
+ * Parse the LLM's minified-JSON issue defensively. A model may wrap the JSON in
+ * prose or fences, so we slice to the outermost object before parsing and fall
+ * back to a plain issue built from the sources when anything is off — the
+ * newsletter still goes out rather than failing on a malformed reply. Mirrors
+ * `scene-to-video`'s `parsePlan`.
+ */
+function parseIssue(
+  output: string | null,
+  niche: string,
+  newsletterName: string,
+  sources: Source[],
+): Issue {
+  const fallbackSubject = `${newsletterName}: ${niche || "this week"}`;
+  const fallbackBody =
+    `# ${fallbackSubject}\n\n` +
+    (sources.length > 0
+      ? `This week in ${niche}:\n\n` +
+        sources.map((s) => `- [${s.title}](${s.url})`).join("\n")
+      : `_No sources were found for this topic this week._`);
+  const fallback: Issue = {
+    subject: fallbackSubject,
+    body: fallbackBody,
+    imagePrompt:
+      `Editorial header illustration for a newsletter about ${niche || newsletterName}. ` +
+      `Clean, modern, magazine cover style. No text.`,
+  };
+  if (!output) return fallback;
+  try {
+    const json = output.slice(output.indexOf("{"), output.lastIndexOf("}") + 1);
+    const raw = JSON.parse(json) as Partial<Issue>;
+    return {
+      subject:
+        typeof raw.subject === "string" && raw.subject.trim()
+          ? raw.subject.trim()
+          : fallback.subject,
+      body:
+        typeof raw.body === "string" && raw.body.trim()
+          ? raw.body
+          : fallback.body,
+      imagePrompt:
+        typeof raw.imagePrompt === "string" && raw.imagePrompt.trim()
+          ? raw.imagePrompt
+          : fallback.imagePrompt,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/** Escape the small set of characters that would break out of HTML text. */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render the issue as a minimal HTML email: the header image (when present) on
+ * top, then the markdown body as pre-wrapped text. Kept deliberately small — a
+ * real newsletter would use a templating layer, but this shows the shape.
+ */
+function renderHtml(issue: Issue, headerImageUrl: string | null): string {
+  const header = headerImageUrl
+    ? `<img src="${escapeHtml(headerImageUrl)}" alt="${escapeHtml(issue.subject)}" style="max-width:100%;border-radius:8px;" />`
+    : "";
+  return (
+    `<div style="font-family:system-ui,sans-serif;max-width:640px;margin:0 auto;">` +
+    header +
+    `<div style="white-space:pre-wrap;line-height:1.5;">${escapeHtml(issue.body)}</div>` +
+    `</div>`
+  );
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const search = defineStep({
+  name: "search",
+  next: ["scrape"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const niche = input.niche?.trim() ?? "";
+    ctx.shared.set("niche", niche);
+    ctx.shared.set(
+      "newsletterName",
+      input.newsletterName?.trim() || DEFAULT_NEWSLETTER_NAME,
+    );
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set(
+      "subscribers",
+      Array.isArray(input.subscribers)
+        ? parseRecipients(input.subscribers.join(","))
+        : [],
+    );
+    ctx.shared.set("dryRun", input.dryRun === true);
+
+    if (!niche) {
+      // Nothing to research — hand an empty candidate list forward so the graph
+      // still traces end to end.
+      return goto("scrape", { candidates: [] as Candidate[] });
+    }
+
+    ctx.logger.info("searching the web", { niche });
+    const hits = await ctx.sapiom.search.webSearch({
+      query: niche,
+      intent: "links",
+    });
+    const candidates: Candidate[] = hits.results
+      .slice(0, MAX_CANDIDATES)
+      .map((r) => ({ title: r.title, url: r.url, snippet: r.snippet }));
+    ctx.logger.info("search returned candidates", { count: candidates.length });
+    return goto("scrape", { candidates });
+  },
+});
+
+const scrape = defineStep({
+  name: "scrape",
+  next: ["write"],
+  async run(input: { candidates: Candidate[] }, ctx: Ctx) {
+    const candidates = input.candidates ?? [];
+    const sources: ScrapedSource[] = [];
+    let scraped = 0;
+    for (const c of candidates) {
+      // Beyond the scrape budget we still forward the candidate — the snippet
+      // alone is useful writing context.
+      if (scraped >= MAX_SCRAPES) {
+        sources.push(c);
+        continue;
+      }
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: c.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        scraped += 1;
+        sources.push({
+          title: page.metadata?.title || c.title,
+          url: c.url,
+          snippet: c.snippet,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Scrapes fail routinely (paywalls, timeouts); degrade per-item, never
+        // throw — an issue written from the survivors beats an aborted run.
+        ctx.logger.warn("scrape failed; keeping snippet only", {
+          url: c.url,
+          err: String(err),
+        });
+        sources.push(c);
+      }
+    }
+    ctx.logger.info("scraped candidates", { scraped, total: sources.length });
+    return goto("write", { sources });
+  },
+});
+
+const write = defineStep({
+  name: "write",
+  next: ["header"],
+  async run(input: { sources: ScrapedSource[] }, ctx: Ctx) {
+    const niche = ctx.shared.get("niche") || "your niche";
+    const newsletterName =
+      ctx.shared.get("newsletterName") || DEFAULT_NEWSLETTER_NAME;
+    const sources = input.sources ?? [];
+    // Slim references only — the scraped bodies stop here and never reach shared
+    // state or the deliver boundary.
+    const slimSources: Source[] = sources.map((s) => ({
+      title: s.title,
+      url: s.url,
+    }));
+
+    let issue: Issue;
+    if (sources.length === 0) {
+      issue = parseIssue(null, niche, newsletterName, slimSources);
+    } else {
+      const research = sources
+        .map(
+          (s, i) =>
+            `[${i + 1}] ${s.title} (${s.url})\n${(s.content || s.snippet).slice(0, MAX_BODY_CHARS)}`,
+        )
+        .join("\n\n");
+      // The live, x402-served model curates AND writes the issue — ranking the
+      // sources, dropping the weak ones, and producing a subject, a markdown
+      // body, and a header-image prompt in one structured reply.
+      const res = await ctx.sapiom.models.run({
+        system:
+          `You are the editor of a newsletter called "${newsletterName}". Given a ` +
+          "NICHE and a set of web SOURCES (each: [n] title, url, extracted text), " +
+          "curate the strongest items, drop thin or duplicate ones, and write this " +
+          "week's issue. The body is markdown: an engaging '# ' subject headline, a " +
+          "2-3 sentence intro, then 3-5 short sections that each summarize a story " +
+          "and link it as a [n] reference, then a '## Sources' list mapping each [n] " +
+          "to its title and url. Also write a vivid header-image prompt (no text in " +
+          "the image). Reply with ONLY minified JSON: " +
+          '{"subject":string,"body":string,"imagePrompt":string}.',
+        prompt: `NICHE: ${niche}\n\nSOURCES:\n${research}`,
+        maxTokens: 1200,
+      });
+      issue = parseIssue(res.output, niche, newsletterName, slimSources);
+    }
+
+    ctx.shared.set("subject", issue.subject);
+    ctx.shared.set("body", issue.body);
+    ctx.shared.set("imagePrompt", issue.imagePrompt);
+    ctx.shared.set("sources", slimSources);
+    ctx.logger.info("wrote issue", {
+      subject: issue.subject,
+      chars: issue.body.length,
+      sources: slimSources.length,
+    });
+    return goto("header", { imagePrompt: issue.imagePrompt });
+  },
+});
+
+const header = defineStep({
+  name: "header",
+  next: ["deliver"],
+  async run(input: { imagePrompt: string }, ctx: Ctx) {
+    const imagePrompt =
+      input.imagePrompt || ctx.shared.get("imagePrompt") || "";
+    let headerImageUrl: string | null = null;
+    let headerImageFileId: string | null = null;
+
+    // Best-effort: a header image is a nice-to-have, not a gate. If generation
+    // returns nothing (e.g. a stubbed `run_local`) or errors, the issue still
+    // goes out without it.
+    try {
+      const result = await ctx.sapiom.contentGeneration.images.create({
+        prompt: imagePrompt,
+        numImages: 1,
+        storage: { visibility: "public" },
+      });
+      const img = result.images?.[0];
+      if (img) {
+        headerImageUrl = img.downloadUrl ?? img.url;
+        headerImageFileId = img.fileId ?? null;
+      } else {
+        ctx.logger.warn("header image returned no output; sending without it");
+      }
+    } catch (err) {
+      ctx.logger.warn("header image generation failed; sending without it", {
+        err: String(err),
+      });
+    }
+
+    ctx.shared.set("headerImageUrl", headerImageUrl);
+    ctx.shared.set("headerImageFileId", headerImageFileId);
+    ctx.logger.info("header ready", { hasImage: Boolean(headerImageUrl) });
+    return goto("deliver", {});
+  },
+});
+
+const deliver = defineStep({
+  name: "deliver",
+  next: [],
+  terminal: true,
+  async run(_input: unknown, ctx: Ctx) {
+    const niche = ctx.shared.get("niche") || "your niche";
+    const schedule = ctx.shared.get("schedule") || DEFAULT_SCHEDULE;
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const subject = ctx.shared.get("subject") || `Newsletter: ${niche}`;
+    const body = ctx.shared.get("body") || "";
+    const sources = ctx.shared.get("sources") ?? [];
+    const headerImageUrl = ctx.shared.get("headerImageUrl") ?? null;
+    const issue: Issue = {
+      subject,
+      body,
+      imagePrompt: ctx.shared.get("imagePrompt") || "",
+    };
+    const html = renderHtml(issue, headerImageUrl);
+
+    // Explicit input list wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state), capped to bound the fan-out.
+    const configured = ctx.shared.get("subscribers") ?? [];
+    const subscribers = (
+      configured.length > 0 ? configured : await subscribersFromVault(ctx)
+    ).slice(0, MAX_RECIPIENTS);
+
+    // The safe path: a dry run — or a live run with no subscribers configured yet —
+    // returns the finished issue without sending anything.
+    if (dryRun || subscribers.length === 0) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        subscribers: subscribers.length,
+      });
+      return terminate({
+        niche,
+        schedule,
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-subscribers",
+        recipients: 0,
+        subject,
+        headerImageUrl,
+        body,
+        sources,
+      });
+    }
+
+    // Send each subscriber their own copy so the list is never exposed across
+    // recipients. Degrade per-item — one bad address shouldn't sink the issue.
+    const inboxId = await resolveSenderInbox(ctx);
+    const messageIds: string[] = [];
+    let failed = 0;
+    for (const to of subscribers) {
+      try {
+        const sent = await ctx.sapiom.email.messages.send(inboxId, {
+          to,
+          subject,
+          text: body,
+          html,
+        });
+        messageIds.push(sent.messageId);
+      } catch (err) {
+        failed += 1;
+        ctx.logger.warn("send failed for one subscriber", {
+          to,
+          err: String(err),
+        });
+      }
+    }
+    ctx.logger.info("issue delivered", {
+      recipients: messageIds.length,
+      failed,
+    });
+    return terminate({
+      niche,
+      schedule,
+      delivered: messageIds.length > 0,
+      dryRun: false,
+      recipients: messageIds.length,
+      failed,
+      subject,
+      headerImageUrl,
+      messageIds,
+      sources,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "newsletter-autopilot",
+  entry: "search",
+  steps: { search, scrape, write, header, deliver },
+});

--- a/examples/newsletter-autopilot/package.json
+++ b/examples/newsletter-autopilot/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-newsletter-autopilot",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a weekly cron, search + scrape a niche, curate and write a newsletter issue with an LLM (models.run), generate a header image, and email it to your subscriber list.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/newsletter-autopilot/template.json
+++ b/examples/newsletter-autopilot/template.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You give it a niche and a subscriber list. Every week it searches the web, reads the top results, and writes that week's issue — a subject line, a short intro, a few curated sections that link back to their sources, and a header image to go with it. Then it emails the issue to your list.\n\nThe graph is five steps: `search` (web.search) finds candidates, `scrape` reads them for full text, `write` (`models.run`, the live x402-served model) curates and writes the issue plus a header-image prompt, `header` (`contentGeneration.images`) generates the image, and `deliver` emails each subscriber their own copy. Scrapes fail routinely on paywalls and timeouts — when one does, it keeps the search snippet and writes from the survivors. The header image is best-effort: if it doesn't come back, the issue goes out without it. A `dryRun` flag writes and renders the full issue and returns it as a preview without emailing anyone, and the subscriber list is read from the Sapiom vault at runtime rather than stored in the run.\n\nIts simpler sibling is `scheduled-research-brief`: fork that for a private, one-recipient brief with no image. Fork this one when the deliverable is a published-feeling newsletter that goes out to a whole list on a cadence.\n\nYou pay for the web search, the scrapes, the model writing the issue, and the header image on each run — the emails are cheap, and a dry run still writes and illustrates the issue but sends nothing.",
+  "useCases": [
+    "Run a niche newsletter on autopilot — it researches, writes, and illustrates each issue so you only review and hit send.",
+    "Turn a topic you follow into a weekly email your subscribers get without you drafting anything by hand.",
+    "See how web search, scraping, LLM writing, image generation, and list email compose in one agent, with a safe dry-run preview."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `niche` (what to write about) and a `newsletterName`. Set who receives it with the `subscribers` input (a list of emails), or store a default list under the `newsletter-autopilot` vault ref (key `SUBSCRIBERS`, comma- or newline-separated) — it's read at runtime, never saved into the run. Pass `dryRun: true` to write and illustrate the issue and get it back without emailing anyone. To run it weekly, attach the `schedule` as a cron trigger on the deployed workflow (it defaults to Mondays at 08:00).\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole search → scrape → write → header → deliver flow for free (capabilities stubbed, delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A weekly issue on indie game development",
+      "input": {
+        "niche": "indie game development",
+        "newsletterName": "Pixel Weekly",
+        "schedule": "0 8 * * 1",
+        "dryRun": true
+      },
+      "output": {
+        "niche": "indie game development",
+        "schedule": "0 8 * * 1",
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "recipients": 0,
+        "subject": "Pixel Weekly: what shipped in indie games this week",
+        "headerImageUrl": "https://files.sapiom.ai/…/header.png",
+        "body": "# Pixel Weekly: what shipped in indie games this week\n\nA quieter week for launches, but two engine updates worth your time...\n\n## A solo dev's roguelike hits 1.0 [1]\n...\n\n## Sources\n1. [Roguelike 1.0 launch](https://example.com/launch)\n2. [Engine 5.4 release notes](https://example.com/engine)",
+        "sources": [
+          {
+            "title": "Roguelike 1.0 launch",
+            "url": "https://example.com/launch"
+          },
+          {
+            "title": "Engine 5.4 release notes",
+            "url": "https://example.com/engine"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/newsletter-autopilot/tsconfig.json
+++ b/examples/newsletter-autopilot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/nl-db-query-endpoint/.gitignore
+++ b/examples/nl-db-query-endpoint/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/nl-db-query-endpoint/AGENTS.md
+++ b/examples/nl-db-query-endpoint/AGENTS.md
@@ -1,0 +1,49 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Natural-Language DB
+Query Endpoint**, authored against `@sapiom/agent`. It provisions a live HTTP
+endpoint: `validate` → `resolve` (`database.get`) → `plan` (`models.run`) → `guard`
+(read-only check) → `deploy` (`vault.get` + `sandboxes.deployPreview`) → terminal
+`deployed` / `deploy_failed` / `rejected`. Inside a step's `run`, Sapiom
+capabilities are pre-auth'd on `ctx.sapiom`.
+
+The deployed endpoint's code is `SERVER_SOURCE` — a self-contained ESM server that
+re-runs translate → guard → execute per request. It reads all config from env
+(injected at `deploy` time), so it has no build-time interpolation.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- The guardrail lives in two places on purpose: `guardReadOnly` in `index.ts` (the `guard` step's preview) and an identical copy embedded in `SERVER_SOURCE` (the per-request check). Keep them in sync if you change one.
+- The real safety boundary is `BEGIN TRANSACTION READ ONLY` in the server — the keyword checks are belt-and-suspenders in front of it. Don't weaken the transaction.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it after
+every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**. The `models.run` stub returns a non-SQL placeholder, so on defaults `guard` routes to `rejected` (a legible demo of the guardrail refusing junk). To trace the deploy branch, pass `{ "dryRun": true }` *and* a stub override so `plan` returns real SQL:
+
+  ```json
+  { "version": 1, "steps": { "plan": { "models.run": { "output": "SELECT count(*) FROM users" } } } }
+  ```
+
+  Under `dryRun`, `deploy` assembles the env (keys only, never values) and reports the generated server without calling `deployPreview`.
+- **deploy**, then **run** — ship it, then a real run stands up the endpoint at a stable URL. Hit it with `POST /query { "question": "…" }`.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities), not the other way around — never weaken or drop real
+> logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev tools
+(`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). Capture non-deterministic values (timestamps, ids) once and pass them
+forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.

--- a/examples/nl-db-query-endpoint/README.md
+++ b/examples/nl-db-query-endpoint/README.md
@@ -1,0 +1,95 @@
+# Natural-Language DB Query Endpoint
+
+Deploy a live HTTP endpoint that turns a plain-English question into a **read-only**
+SQL query and returns the answer. One run stands up the endpoint; the endpoint
+answers questions.
+
+## What it does
+
+```
+validate ─▶ resolve ─▶ plan ─▶ guard ─┬─▶ deploy ─┬─▶ deployed      (terminal)
+           (database   (models  (read- │           └─▶ deploy_failed (terminal)
+            .get)       .run)   only    └─▶ rejected                 (terminal)
+                                check)
+```
+
+1. **validate** — checks the input (a `dbHandle` or `connectionString`) and resolves
+   config (sample question, port, row cap, model). No target → `rejected`.
+2. **resolve** — reads the target Postgres connection string from a Sapiom-managed
+   database handle (`database.get`) to inject into the endpoint.
+3. **plan** — previews the pipeline: translates the sample question into SQL with an
+   LLM (`models.run`), system-prompted to emit a single read-only `SELECT`.
+4. **guard** — applies the read-only guardrail to that sample SQL. Anything that
+   isn't a single read-only statement → `rejected`, so the endpoint is only
+   deployed once the safe path is proven.
+5. **deploy** — writes a small server into a sandbox and exposes it at a stable URL
+   (`sandboxes.deployPreview`). `DATABASE_URL` and the server's own
+   `SAPIOM_API_KEY` (read from the vault at deploy time, `vault.get`) are injected
+   as env — never baked into source.
+6. **deployed** / **deploy_failed** / **rejected** — terminal; report the endpoint
+   URL, surface the deploy logs, or explain the rejection.
+
+## The endpoint
+
+The deployed server exposes:
+
+- `POST /query` with `{ "question": "…" }` → `{ question, sql, columns, rows, rowCount, truncated }`
+- `GET /health` → `{ "ok": true }`
+
+Per request it introspects the schema (cached), asks the LLM for a read-only
+`SELECT`, re-checks it with the same guardrail, then runs it inside
+`BEGIN TRANSACTION READ ONLY` with a statement timeout and a `LIMIT` cap.
+
+## The read-only guardrail
+
+Defense-in-depth, so a write can't slip through even if one layer is wrong:
+
+1. The LLM is **told** to emit a single `SELECT`.
+2. The SQL is **checked** — single statement, starts with `SELECT`/`WITH`, no
+   `INSERT`/`UPDATE`/`DELETE`/DDL keywords.
+3. The endpoint **executes** it in a `READ ONLY` transaction, which Postgres
+   enforces at the engine level, with a statement timeout and a row cap.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; the steps inherit that
+   authority to read the DB handle / vault and deploy the sandbox.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local`
+   (pass a stub override returning a real SELECT plus `{ "dryRun": true }` to trace
+   the deploy branch offline, free) → `sapiom_dev_agents_link` →
+   `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run` (a real deploy that stands
+   up the endpoint).
+
+Example `run_local` input:
+
+```json
+{
+  "dbHandle": "analytics",
+  "sampleQuestion": "How many rows are in each table?",
+  "vaultRef": "nl-db-query-endpoint",
+  "vaultKey": "sapiom_api_key",
+  "dryRun": true
+}
+```
+
+with the stub override so `plan` returns real SQL and `guard` passes:
+
+```json
+{ "version": 1, "steps": { "plan": { "models.run": { "output": "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC" } } } }
+```
+
+## Files
+
+- `index.ts` — the agent + the embedded endpoint server (`SERVER_SOURCE`). Edit this.
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -1,0 +1,582 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Natural-Language DB Query Endpoint — deploy a live HTTP endpoint that turns a
+ * plain-English question into a read-only SQL query and returns the answer.
+ *
+ * One run stands up the endpoint; the endpoint answers questions.
+ *
+ *   validate ─▶ resolve ─▶ plan ─▶ guard ─┬─▶ deploy ─┬─▶ deployed      (terminal)
+ *              (database   (models  (read-  │          └─▶ deploy_failed (terminal)
+ *               .get)       .run)   only    └─▶ rejected                (terminal)
+ *                                   check)
+ *
+ *   1. validate — check the input (a database handle or connection string) and
+ *      resolve config (sample question, port, row cap, model).
+ *   2. resolve  — read the target Postgres connection string from a Sapiom-managed
+ *      database handle (`database.get`) so it can be injected into the endpoint.
+ *   3. plan     — preview the pipeline: translate the sample question into SQL with
+ *      an LLM (`models.run`), system-prompted to emit a single read-only SELECT.
+ *   4. guard    — apply the read-only guardrail to that sample SQL. Anything that
+ *      isn't a single read-only statement routes to `rejected` — the endpoint is
+ *      only deployed once the safe path is proven.
+ *   5. deploy   — write a small server (which re-runs translate → guard → execute
+ *      per request) into a sandbox and expose it at a stable URL
+ *      (`sandboxes.deployPreview`). DATABASE_URL and the server's own
+ *      SAPIOM_API_KEY (read from the vault at deploy time, `vault.get`) are
+ *      injected as env — never baked into source.
+ *   6. deployed / deploy_failed / rejected — terminal.
+ *
+ * The read-only guardrail is defense-in-depth: the LLM is *told* to emit a SELECT,
+ * the SQL is *checked* (single statement, starts with SELECT/WITH, no DDL/DML
+ * keywords), and the endpoint *executes* it inside `BEGIN TRANSACTION READ ONLY`
+ * with a statement timeout and a row cap — the last of which Postgres enforces at
+ * the engine level, so a write can't slip through even if the first two are wrong.
+ *
+ * `run_local` stubs `models.run`, so on defaults the `plan` output is a non-SQL
+ * placeholder and `guard` routes to `rejected` — a legible demo of the guardrail
+ * refusing junk. Pass a stub override that returns a real SELECT (see AGENTS.md)
+ * and add `{ "dryRun": true }` to trace the deploy branch offline for free.
+ */
+
+// ────────────────────────────────────────────────────────────────── config ──
+
+interface EntryInput {
+  /** Sapiom-managed Postgres handle; its connection string is injected as DATABASE_URL. */
+  dbHandle?: string;
+  /** Explicit Postgres connection string (overrides `dbHandle`). */
+  connectionString?: string;
+  /** Sandbox name to host the endpoint (default `nl-db-query-endpoint`). */
+  sandboxName?: string;
+  /** A question used to preview the translate → guard path before deploying. */
+  sampleQuestion?: string;
+  /** LLM model / routing alias override for the translation. */
+  model?: string;
+  /** Max rows the endpoint returns per query (default 100). */
+  maxRows?: number;
+  /** Port the endpoint listens on (default 3000). */
+  port?: number;
+  /** Vault ref holding the server's SAPIOM_API_KEY (best practice). */
+  vaultRef?: string;
+  /** Vault key name for the server's API key (default `sapiom_api_key`). */
+  vaultKey?: string;
+  /** Dev-only fallback: inject the server's SAPIOM_API_KEY directly. Prefer the vault. */
+  sapiomApiKey?: string;
+  /**
+   * Assemble everything but skip the real `deployPreview` — so `run_local` traces
+   * the full graph offline, with no sandbox and no real deploy.
+   */
+  dryRun?: boolean;
+}
+
+interface Config {
+  dbHandle: string;
+  connectionString: string;
+  sandboxName: string;
+  sampleQuestion: string;
+  model: string;
+  maxRows: number;
+  port: number;
+  vaultRef: string;
+  vaultKey: string;
+  sapiomApiKey: string;
+  dryRun: boolean;
+}
+
+interface Shared extends Record<string, unknown> {
+  config: Config;
+  connectionString: string;
+  sampleSql: string;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+const DEFAULT_SANDBOX = "nl-db-query-endpoint";
+const DEFAULT_QUESTION = "How many rows are in each table?";
+const DEFAULT_MAX_ROWS = 100;
+const DEFAULT_PORT = 3000;
+const DEFAULT_VAULT_KEY = "sapiom_api_key";
+
+function resolveConfig(input: EntryInput | undefined): Config {
+  return {
+    dbHandle: input?.dbHandle?.trim() ?? "",
+    connectionString: input?.connectionString?.trim() ?? "",
+    sandboxName: input?.sandboxName?.trim() || DEFAULT_SANDBOX,
+    sampleQuestion: input?.sampleQuestion?.trim() || DEFAULT_QUESTION,
+    model: input?.model?.trim() ?? "",
+    maxRows: input?.maxRows ?? DEFAULT_MAX_ROWS,
+    port: input?.port ?? DEFAULT_PORT,
+    vaultRef: input?.vaultRef?.trim() ?? "",
+    vaultKey: input?.vaultKey?.trim() || DEFAULT_VAULT_KEY,
+    sapiomApiKey: input?.sapiomApiKey ?? "",
+    dryRun: input?.dryRun === true,
+  };
+}
+
+// ─────────────────────────────────────────────── the read-only guardrail ──
+// Mirrors the guard embedded in the deployed server (see SERVER_SOURCE). Both
+// are belt-and-suspenders in front of the real boundary — the endpoint runs
+// every query inside `BEGIN TRANSACTION READ ONLY`, which Postgres enforces.
+
+const WRITE_KEYWORDS =
+  /\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|do|copy|vacuum|analyze|reindex|refresh|lock|comment|attach|detach|set|reset|begin|commit|rollback|savepoint|prepare|execute|listen|notify|discard|cluster|reassign|security|import)\b/i;
+
+/** Strip markdown fences and trailing semicolons from an LLM SQL reply. */
+function cleanSql(raw: string): string {
+  let sql = (raw ?? "").trim();
+  // Remove a ```sql ... ``` (or bare ```) fence if the model wrapped its reply.
+  const fence = sql.match(/^```(?:sql)?\s*([\s\S]*?)\s*```$/i);
+  if (fence) sql = fence[1].trim();
+  // Drop a single trailing semicolon (a lone statement terminator is fine).
+  return sql.replace(/;\s*$/, "").trim();
+}
+
+interface GuardResult {
+  ok: boolean;
+  sql: string;
+  reason?: string;
+}
+
+/** True only for a single read-only SELECT/WITH statement. */
+function guardReadOnly(raw: string): GuardResult {
+  const sql = cleanSql(raw);
+  if (!sql) return { ok: false, sql, reason: "empty query" };
+  // No stacked statements — a stray `;` splitting into two is rejected outright.
+  if (sql.split(";").filter((s) => s.trim().length > 0).length > 1) {
+    return { ok: false, sql, reason: "multiple statements are not allowed" };
+  }
+  const first = sql
+    .replace(/^\(+/, "")
+    .trimStart()
+    .split(/\s+/)[0]
+    ?.toLowerCase();
+  if (first !== "select" && first !== "with") {
+    return { ok: false, sql, reason: "only SELECT / WITH queries are allowed" };
+  }
+  const write = sql.match(WRITE_KEYWORDS);
+  if (write) {
+    return {
+      ok: false,
+      sql,
+      reason: `disallowed keyword: ${write[0].toUpperCase()}`,
+    };
+  }
+  return { ok: true, sql };
+}
+
+// ─────────────────────────────────────────────────────── the endpoint app ──
+// Uploaded verbatim to the sandbox. Reads all config from env (injected at
+// deploy time). On POST /query it introspects the schema (cached), asks the LLM
+// for a read-only SELECT, re-checks it with the same guardrail, then runs it in a
+// READ ONLY transaction with a statement timeout and a row cap. No backticks / no
+// ${} here so it embeds cleanly as a template-literal string above.
+
+const SERVER_SOURCE = `import http from "node:http";
+import { createClient } from "@sapiom/tools";
+import pg from "pg";
+
+const PORT = Number(process.env.PORT || 3000);
+const MODEL = process.env.SAPIOM_MODEL || "";
+const MAX_ROWS = Number(process.env.MAX_ROWS || 100);
+const STATEMENT_TIMEOUT_MS = Number(process.env.STATEMENT_TIMEOUT_MS || 10000);
+
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 4 });
+
+const WRITE_KEYWORDS =
+  /\\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|do|copy|vacuum|analyze|reindex|refresh|lock|comment|attach|detach|set|reset|begin|commit|rollback|savepoint|prepare|execute|listen|notify|discard|cluster|reassign|security|import)\\b/i;
+
+function cleanSql(raw) {
+  let sql = (raw || "").trim();
+  const fence = sql.match(/^\`\`\`(?:sql)?\\s*([\\s\\S]*?)\\s*\`\`\`$/i);
+  if (fence) sql = fence[1].trim();
+  return sql.replace(/;\\s*$/, "").trim();
+}
+
+function guardReadOnly(raw) {
+  const sql = cleanSql(raw);
+  if (!sql) return { ok: false, sql, reason: "empty query" };
+  if (sql.split(";").filter((s) => s.trim().length > 0).length > 1)
+    return { ok: false, sql, reason: "multiple statements are not allowed" };
+  const first = sql.replace(/^\\(+/, "").trimStart().split(/\\s+/)[0];
+  const kw = (first || "").toLowerCase();
+  if (kw !== "select" && kw !== "with")
+    return { ok: false, sql, reason: "only SELECT / WITH queries are allowed" };
+  const write = sql.match(WRITE_KEYWORDS);
+  if (write)
+    return { ok: false, sql, reason: "disallowed keyword: " + write[0].toUpperCase() };
+  return { ok: true, sql };
+}
+
+function ensureLimit(sql, max) {
+  return /\\blimit\\b/i.test(sql) ? sql : sql + " LIMIT " + max;
+}
+
+let schemaCache = null;
+async function describeSchema() {
+  if (schemaCache) return schemaCache;
+  const { rows } = await pool.query(
+    "SELECT table_name, column_name, data_type FROM information_schema.columns " +
+      "WHERE table_schema NOT IN ('pg_catalog','information_schema') " +
+      "ORDER BY table_name, ordinal_position",
+  );
+  const byTable = new Map();
+  for (const r of rows) {
+    if (!byTable.has(r.table_name)) byTable.set(r.table_name, []);
+    byTable.get(r.table_name).push(r.column_name + " " + r.data_type);
+  }
+  const lines = [];
+  for (const [t, cols] of byTable) lines.push(t + "(" + cols.join(", ") + ")");
+  schemaCache = lines.join("\\n") || "(no user tables)";
+  return schemaCache;
+}
+
+const SYSTEM = [
+  "You translate a natural-language question into ONE read-only SQL query for PostgreSQL.",
+  "Rules:",
+  "- Output ONLY the SQL. No prose, no markdown fences, no trailing semicolon.",
+  "- It MUST be a single SELECT (a leading WITH/CTE is fine). Never write or modify data.",
+  "- Use only the tables and columns in the provided schema.",
+].join("\\n");
+
+async function answer(question) {
+  const schema = await describeSchema();
+  const res = await sapiom.models.run({
+    system: SYSTEM,
+    prompt: "Schema:\\n" + schema + "\\n\\nQuestion: " + question,
+    model: MODEL || undefined,
+    maxTokens: 500,
+  });
+  const guard = guardReadOnly(res.output || "");
+  if (!guard.ok) {
+    const err = new Error(guard.reason);
+    err.statusCode = 400;
+    err.sql = guard.sql;
+    throw err;
+  }
+  const sql = ensureLimit(guard.sql, MAX_ROWS);
+  const client = await pool.connect();
+  try {
+    await client.query("SET statement_timeout = " + STATEMENT_TIMEOUT_MS);
+    await client.query("BEGIN TRANSACTION READ ONLY");
+    const result = await client.query(sql);
+    await client.query("ROLLBACK");
+    return {
+      question,
+      sql,
+      columns: result.fields.map((f) => f.name),
+      rows: result.rows,
+      rowCount: result.rowCount,
+      truncated: result.rowCount >= MAX_ROWS,
+    };
+  } finally {
+    client.release();
+  }
+}
+
+function send(res, code, body) {
+  const json = JSON.stringify(body);
+  res.writeHead(code, { "content-type": "application/json" });
+  res.end(json);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") return send(res, 200, { ok: true });
+  if (req.method !== "POST" || (req.url || "").split("?")[0] !== "/query")
+    return send(res, 404, { error: "POST /query { question } or GET /health" });
+  let raw = "";
+  req.on("data", (c) => {
+    raw += c;
+  });
+  req.on("end", async () => {
+    try {
+      const question = (JSON.parse(raw || "{}").question || "").trim();
+      if (!question) return send(res, 400, { error: "missing 'question'" });
+      send(res, 200, await answer(question));
+    } catch (err) {
+      send(res, err && err.statusCode ? err.statusCode : 500, {
+        error: String(err && err.message ? err.message : err),
+        sql: err && err.sql ? err.sql : undefined,
+      });
+    }
+  });
+});
+
+server.listen(PORT, () => console.log("nl-db-query-endpoint listening on " + PORT));
+`;
+
+const SERVER_PACKAGE_JSON = JSON.stringify(
+  {
+    name: "nl-db-query-endpoint-server",
+    private: true,
+    type: "module",
+    dependencies: { "@sapiom/tools": "^0.20.0", pg: "^8.11.0" },
+  },
+  null,
+  2,
+);
+
+// ──────────────────────────────────────────────────────────────── steps ──
+
+/** Validate the input and resolve config. Missing DB target → rejected. */
+const validate = defineStep({
+  name: "validate",
+  next: ["resolve", "rejected"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const config = resolveConfig(input);
+    ctx.shared.set("config", config);
+    if (!config.dbHandle && !config.connectionString) {
+      return goto("rejected", {
+        reason:
+          "provide a `dbHandle` or a `connectionString` for the target database",
+      });
+    }
+    ctx.logger.info("input validated", {
+      sandbox: config.sandboxName,
+      hasHandle: Boolean(config.dbHandle),
+      dryRun: config.dryRun,
+    });
+    return goto("resolve", {});
+  },
+});
+
+/** Read the Postgres connection string to inject into the endpoint. */
+const resolve = defineStep({
+  name: "resolve",
+  next: ["plan"],
+  async run(_input: unknown, ctx: Ctx) {
+    const config = ctx.shared.get("config")!;
+    let connectionString = config.connectionString;
+    if (!connectionString && config.dbHandle) {
+      const db = await ctx.sapiom.database.get(config.dbHandle);
+      connectionString = db.connection?.connectionString ?? "";
+    }
+    if (!connectionString && config.dryRun) {
+      // No live handle needed to trace the graph offline.
+      connectionString = "postgres://user:pass@localhost:5432/db";
+    }
+    ctx.shared.set("connectionString", connectionString);
+    ctx.logger.info("resolved connection string", {
+      resolved: Boolean(connectionString),
+    });
+    return goto("plan", {});
+  },
+});
+
+/** Preview the translate step: sample question → SQL via the LLM. */
+const plan = defineStep({
+  name: "plan",
+  next: ["guard"],
+  async run(_input: unknown, ctx: Ctx) {
+    const config = ctx.shared.get("config")!;
+    const system = [
+      "You translate a natural-language question into ONE read-only SQL query for PostgreSQL.",
+      "Output ONLY the SQL: no prose, no markdown fences, no trailing semicolon.",
+      "It MUST be a single SELECT (a leading WITH/CTE is fine). Never write or modify data.",
+    ].join("\n");
+    const res = await ctx.sapiom.models.run({
+      system,
+      prompt: `Question: ${config.sampleQuestion}`,
+      model: config.model || undefined,
+      maxTokens: 500,
+    });
+    ctx.logger.info("sample translated", { question: config.sampleQuestion });
+    return goto("guard", { sql: res.output ?? "" });
+  },
+});
+
+/** Apply the read-only guardrail to the sample SQL. Unsafe → rejected. */
+const guard = defineStep({
+  name: "guard",
+  next: ["deploy", "rejected"],
+  async run(input: { sql: string }, ctx: Ctx) {
+    const result = guardReadOnly(input?.sql ?? "");
+    if (!result.ok) {
+      ctx.logger.warn("guardrail rejected sample sql", {
+        reason: result.reason,
+      });
+      return goto("rejected", { reason: result.reason, sql: result.sql });
+    }
+    ctx.shared.set("sampleSql", result.sql);
+    ctx.logger.info("sample sql passed guardrail", { sql: result.sql });
+    return goto("deploy", {});
+  },
+});
+
+/** Write the endpoint server into a sandbox and expose it at a stable URL. */
+const deploy = defineStep({
+  name: "deploy",
+  next: ["deployed", "deploy_failed"],
+  async run(_input: unknown, ctx: Ctx) {
+    const config = ctx.shared.get("config")!;
+    const connectionString = ctx.shared.get("connectionString") ?? "";
+    const sampleSql = ctx.shared.get("sampleSql") ?? "";
+
+    // The server's own API key (used to call models.run per request): read from
+    // the vault at deploy time, or fall back to the dev-only input.
+    let apiKey = config.sapiomApiKey;
+    if (!apiKey && config.vaultRef) {
+      try {
+        apiKey =
+          (await ctx.sapiom.vault.get(config.vaultRef, config.vaultKey)) ?? "";
+      } catch (err) {
+        ctx.logger.warn("vault read failed", {
+          ref: config.vaultRef,
+          key: config.vaultKey,
+          err: String(err),
+        });
+      }
+    }
+
+    const env: Record<string, string> = {
+      PORT: String(config.port),
+      DATABASE_URL: connectionString,
+      SAPIOM_MODEL: config.model,
+      MAX_ROWS: String(config.maxRows),
+    };
+    if (apiKey) env.SAPIOM_API_KEY = apiKey;
+
+    const queryEndpoint = (url: string) => `${url.replace(/\/$/, "")}/query`;
+    const healthEndpoint = (url: string) => `${url.replace(/\/$/, "")}/health`;
+
+    // Dry run: report the assembled env keys (names only, never values) and the
+    // generated server, then stop before any real actuation.
+    if (config.dryRun) {
+      ctx.logger.info("dry run — skipping deployPreview", {
+        sandbox: config.sandboxName,
+        envKeys: Object.keys(env),
+        hasApiKey: Boolean(apiKey),
+      });
+      return goto("deployed", {
+        dryRun: true,
+        url: null,
+        queryEndpoint: null,
+        healthEndpoint: null,
+        sampleQuestion: config.sampleQuestion,
+        sampleSql,
+        envKeys: Object.keys(env),
+        serverBytes: SERVER_SOURCE.length,
+      });
+    }
+
+    try {
+      const box = await ctx.sapiom.sandboxes.create({
+        name: config.sandboxName,
+        port: config.port,
+      });
+      await box.writeFile("server.js", SERVER_SOURCE);
+      await box.writeFile("package.json", SERVER_PACKAGE_JSON);
+      const res = await box.deployPreview({
+        source: { kind: "fs" },
+        build: "npm install",
+        start: "node server.js",
+        port: config.port,
+        env,
+      });
+      ctx.logger.info("deployPreview result", {
+        sandbox: config.sandboxName,
+        status: res.status,
+        url: res.url,
+      });
+      if (res.status === "failed" || !res.url) {
+        return goto("deploy_failed", { status: res.status, logs: res.logs });
+      }
+      return goto("deployed", {
+        dryRun: false,
+        url: res.url,
+        queryEndpoint: queryEndpoint(res.url),
+        healthEndpoint: healthEndpoint(res.url),
+        sampleQuestion: config.sampleQuestion,
+        sampleSql,
+        envKeys: Object.keys(env),
+        serverBytes: SERVER_SOURCE.length,
+      });
+    } catch (err) {
+      ctx.logger.error("deploy threw", {
+        sandbox: config.sandboxName,
+        err: String(err),
+      });
+      return goto("deploy_failed", { status: "error", logs: String(err) });
+    }
+  },
+});
+
+/** The endpoint is live (or, under dryRun, assembled). Terminal. */
+const deployed = defineStep({
+  name: "deployed",
+  next: [],
+  terminal: true,
+  async run(input: {
+    dryRun: boolean;
+    url: string | null;
+    queryEndpoint: string | null;
+    healthEndpoint: string | null;
+    sampleQuestion: string;
+    sampleSql: string;
+    envKeys: string[];
+    serverBytes: number;
+  }) {
+    return terminate({
+      deployed: !input?.dryRun,
+      dryRun: input?.dryRun ?? false,
+      url: input?.url ?? null,
+      queryEndpoint: input?.queryEndpoint ?? null,
+      healthEndpoint: input?.healthEndpoint ?? null,
+      sampleQuestion: input?.sampleQuestion ?? null,
+      sampleSql: input?.sampleSql ?? null,
+      envKeys: input?.envKeys ?? null,
+      serverBytes: input?.serverBytes ?? null,
+    });
+  },
+});
+
+/** The deploy failed — surface the deployPreview logs. Terminal. */
+const deploy_failed = defineStep({
+  name: "deploy_failed",
+  next: [],
+  terminal: true,
+  async run(input: { status: string; logs: string | null }) {
+    return terminate({
+      deployed: false,
+      failed: true,
+      status: input?.status ?? null,
+      logs: input?.logs ?? null,
+    });
+  },
+});
+
+/** Input or the sample SQL failed the guardrail — nothing was deployed. Terminal. */
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason: string; sql?: string }) {
+    return terminate({
+      deployed: false,
+      rejected: true,
+      reason: input?.reason ?? "rejected",
+      sql: input?.sql ?? null,
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "nl-db-query-endpoint",
+  entry: "validate",
+  steps: {
+    validate,
+    resolve,
+    plan,
+    guard,
+    deploy,
+    deployed,
+    deploy_failed,
+    rejected,
+  },
+});

--- a/examples/nl-db-query-endpoint/package.json
+++ b/examples/nl-db-query-endpoint/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-nl-db-query-endpoint",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: deploy a live endpoint that turns a plain-English question into a read-only SQL query and returns the answer — LLM translation, a read-only guardrail, and a sandbox-hosted endpoint.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/nl-db-query-endpoint/template.json
+++ b/examples/nl-db-query-endpoint/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "Deploy a live endpoint that answers questions about your database in plain English. One run stands up the endpoint; then anyone can `POST /query` a question and get the data back — no SQL required.\n\nEach request introspects your schema, asks an LLM (`models.run`) for a single `SELECT`, and returns the rows. The read-only guardrail is the point: the model is told to write only a `SELECT`, the query is checked (single statement, starts with `SELECT`/`WITH`, no write or DDL keywords), and it runs inside a `READ ONLY` transaction that Postgres enforces at the engine level — with a statement timeout and a row cap. A write can't slip through even if the model misbehaves.\n\nThe workflow itself is the deployer: it reads the connection string from a Sapiom database handle (`database.get`), previews the translation on a sample question so a bad path fails before anything ships, then writes a small server into a sandbox and exposes it at a stable URL (`sandboxes.deployPreview`). The server's own API key is read from the vault at deploy time (`vault.get`), never baked into source.\n\nYou pay for the deploy (one sandbox) plus the model reasoning on each question the endpoint answers — the endpoint sitting idle is free.",
+  "useCases": [
+    "Give your ops or analyst team a question box over a read-only database, without building a UI.",
+    "Stand up a self-serve metrics endpoint another service can POST questions to.",
+    "Let non-technical teammates ask 'how many…' and 'which…' questions without waiting on SQL."
+  ],
+  "notes": "**Use this template.** Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page to stand up the endpoint. Your $5 signup credit covers first runs.\n\nYou need a target database: pass a Sapiom Postgres handle as `dbHandle` (or a full `connectionString`). The deployed server calls the LLM per request, so it needs its own key — store one in the vault and pass `vaultRef` (and `vaultKey`, default `sapiom_api_key`); a dev-only `sapiomApiKey` input is also accepted but the vault is the right way. Once deployed, `POST /query { \"question\": \"…\" }` to the returned URL.\n\n**Advanced (prefer to work from the code?):** Run it locally with `run_local` to trace the whole flow for free. The `models.run` stub returns non-SQL, so on defaults `guard` routes to `rejected` — a legible demo of the guardrail. To trace the deploy branch, pass `{ \"dryRun\": true }` and a stub override returning a real SELECT (see `AGENTS.md`). Then edit and deploy with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "Deploy the endpoint (real run)",
+      "input": {
+        "dbHandle": "analytics",
+        "sampleQuestion": "How many rows are in each table?",
+        "vaultRef": "nl-db-query-endpoint",
+        "vaultKey": "sapiom_api_key",
+        "port": 3000,
+        "maxRows": 100
+      },
+      "output": {
+        "deployed": true,
+        "dryRun": false,
+        "url": "https://your-preview-hash.preview.bl.run",
+        "queryEndpoint": "https://your-preview-hash.preview.bl.run/query",
+        "healthEndpoint": "https://your-preview-hash.preview.bl.run/health",
+        "sampleQuestion": "How many rows are in each table?",
+        "sampleSql": "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC",
+        "envKeys": ["PORT", "DATABASE_URL", "SAPIOM_MODEL", "MAX_ROWS", "SAPIOM_API_KEY"],
+        "serverBytes": 3400
+      }
+    },
+    {
+      "title": "The guardrail rejects a write",
+      "input": {
+        "dbHandle": "analytics",
+        "sampleQuestion": "delete every user"
+      },
+      "output": {
+        "deployed": false,
+        "rejected": true,
+        "reason": "only SELECT / WITH queries are allowed",
+        "sql": "DELETE FROM users"
+      }
+    }
+  ]
+}

--- a/examples/nl-db-query-endpoint/tsconfig.json
+++ b/examples/nl-db-query-endpoint/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -698,6 +698,453 @@
           "terminal": true
         }
       ]
+    },
+    {
+      "id": "news-roundup",
+      "name": "Company News Roundup",
+      "description": "Search the web for a company's recent news, then publish a dated, illustrated roundup page to a small website for that company.",
+      "tags": ["news", "summarize", "images", "publish"],
+      "sourcePath": "examples/news-roundup",
+      "capabilities": [
+        "web.search",
+        "models.run",
+        "contentGeneration.images",
+        "fileStorage.upload",
+        "sandboxes.create",
+        "sandboxes.deployPreview"
+      ],
+      "whatItDoes": "For keeping a shareable news page for a company you care about, refreshed whenever you run it. You give it a company name and it searches the web (web.search) for that company's news from the last week. An LLM (models.run) picks the three-to-five most relevant articles and writes a plain-language summary and an image prompt for each, and it generates one illustration per article (contentGeneration.images). It saves the page and images to file storage, then rebuilds the company's website from storage in a sandbox and deploys it (sandboxes.deployPreview), handing back the live URL. Each run adds a new dated page without touching the earlier ones. If an image fails it becomes a text-only card, and if there's no news the run stops early instead of publishing an empty page.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Search the web for the company's news from the last week. If nothing comes back, stop early and report no news instead of publishing.",
+          "capability": "web.search",
+          "next": ["select"]
+        },
+        {
+          "name": "select",
+          "description": "Ask an LLM to pick the three-to-five most relevant articles and write a plain-language summary and an image prompt for each.",
+          "capability": "models.run",
+          "next": ["illustrate"]
+        },
+        {
+          "name": "illustrate",
+          "description": "Generate one image per selected article and save each to storage; an article whose image fails degrades to a text-only card.",
+          "capability": "contentGeneration.images",
+          "next": ["publish"]
+        },
+        {
+          "name": "publish",
+          "description": "Save the dated page, rebuild the company's site from storage in a sandbox, and deploy it — returning the live site and page URLs.",
+          "capability": "sandboxes.deployPreview",
+          "next": [],
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "dependency-upgrade",
+      "name": "Dependency Upgrade",
+      "description": "On a schedule, a coding agent bumps a repo's dependencies in a sandbox, runs the tests, and pushes only when the build is green.",
+      "tags": ["dependencies", "coding-agent", "scheduled", "ci"],
+      "sourcePath": "examples/dependency-upgrade",
+      "capabilities": [
+        "models.coding",
+        "sandboxes.exec",
+        "models.run",
+        "fileStorage.upload",
+        "repositories.pushFromSandbox"
+      ],
+      "whatItDoes": "For keeping a project's dependencies current without a human driving each bump. On each scheduled run a coding agent (`models.coding`) clones your repo into a sandbox and upgrades its dependencies, and because that run is long the workflow pauses at $0 until it finishes. It then re-attaches the same sandbox and runs your real test suite there (`sandboxes.exec`) — a red build is dropped, never pushed. A green build gets a model risk rating of the changed dependencies (`models.run`); anything above your risk bar is held for a person instead of pushed. When it does push, it commits the bumped branch straight from the sandbox. Every run — pushed, held, or dropped — archives a triage report to file storage (`fileStorage.upload`) so you can see what changed and why it did or didn't ship.",
+      "steps": [
+        {
+          "name": "plan",
+          "description": "Resolves the repo and the install and test commands and checks the input; with no repo it stops right away.",
+          "next": ["bump", "rejected"]
+        },
+        {
+          "name": "bump",
+          "description": "Launches a coding agent to bump the repo's dependencies in a sandbox, then pauses until the run finishes.",
+          "capability": "models.coding",
+          "next": ["verify"]
+        },
+        {
+          "name": "verify",
+          "description": "Re-attaches that sandbox and runs the install and test suite there; a failed run or a red build is rejected.",
+          "capability": "sandboxes.exec",
+          "next": ["assess", "rejected"]
+        },
+        {
+          "name": "assess",
+          "description": "Asks a model to rate the upgrade's risk from the dependency diff, holding anything above your bar.",
+          "capability": "models.run",
+          "next": ["publish", "held"]
+        },
+        {
+          "name": "publish",
+          "description": "Pushes the bumped branch from the sandbox and archives the triage report.",
+          "capability": "repositories.pushFromSandbox",
+          "terminal": true
+        },
+        {
+          "name": "held",
+          "description": "The build was green but the risk was too high, so it archives the report and waits for a human.",
+          "capability": "fileStorage.upload",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "The coding run failed or the tests were red, so it archives the report and pushes nothing.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "meeting-notes-crm",
+      "name": "Meeting Notes to CRM Updater",
+      "description": "Take a meeting transcript, pull out the contact, the CRM fields to update, and the action items, write them to a database, and email a summary.",
+      "tags": ["crm", "sales", "transcript", "pause-resume"],
+      "sourcePath": "examples/meeting-notes-crm",
+      "capabilities": ["models.run", "database.get", "database.create", "email.send"],
+      "whatItDoes": "For turning what was said on a call into an updated CRM record without hand-copying anything. It takes the transcript either way: a run hands it one directly, or you set `webhook: true` and it pauses at $0 until your note-taker pushes one as the `transcript.ready` signal. An LLM (`models.run`) reads the transcript and returns structured data — the contact the call was with, the fields to change (deal stage, next step), and the action items with owners and due dates. It writes them to a small Postgres store it owns, updating the contact's row without wiping fields the call didn't mention and recording each action item under a stable id so a re-run logs it once. Then it emails a recap that splits action items into new versus already tracked. A dryRun computes the recap and returns it without touching the database or sending mail.",
+      "steps": [
+        {
+          "name": "intake",
+          "description": "Takes the transcript — passed in directly, or, with webhook set, pauses at $0 until a note-taker pushes one via the transcript.ready signal.",
+          "next": ["extract"]
+        },
+        {
+          "name": "extract",
+          "description": "Hands the transcript to an LLM to pull the contact, the CRM fields to update, and the action items as structured JSON.",
+          "capability": "models.run",
+          "next": ["upsert"]
+        },
+        {
+          "name": "upsert",
+          "description": "Writes to a Postgres CRM store: updates the contact's row without wiping unmentioned fields, and records each action item under a stable id. Skipped on a dry run.",
+          "capability": "database.get",
+          "next": ["summary"]
+        },
+        {
+          "name": "summary",
+          "description": "Writes a markdown recap — fields updated, action items new vs. already tracked — and emails it. A dry run, or a run with no recipient, returns it without sending.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "approval-chain",
+      "name": "Multi-Party Approval Chain (Saga)",
+      "description": "A durable sequential sign-off chain — pause-per-gate approvals with reminders, timeout escalation, and compensation on rejection.",
+      "tags": ["approval", "saga", "pause-resume", "durable"],
+      "sourcePath": "examples/approval-chain",
+      "capabilities": ["email.send", "database.create"],
+      "whatItDoes": "Routes a subject — a contract, a budget, a policy change — through an ordered chain of approvers (e.g. legal → finance → the CEO) who must each sign off IN ORDER. Every gate is a durable pauseUntilSignal: the run emails the current approver and suspends at $0 until they fire approval.decision, then advances to the next gate. A reject walks a saga compensation — notifying everyone who already approved that the chain was cancelled — so a half-signed contract is never left behind. Between gates, a resume with no decision (the pause timeoutMs, an auto-resume, or an explicit remind) is a reminder tick that re-notifies and re-pauses, up to maxReminders, after which a silent gate escalates to a human channel. The canonical chain state lives in ctx.shared and survives every pause; when a ledgerHandle is set, each transition is also appended to a durable Postgres table (the database capability) as a best-effort, queryable audit trail. pauseUntilSignal is a runtime primitive, not a metered capability — the billed calls are the notifications and the ledger database.",
+      "steps": [
+        {
+          "name": "start",
+          "description": "Resolve the subject, the ordered approvers, and the escalation / ledger / reminder settings; initialise the chain state. An empty chain escalates.",
+          "capability": "database.create",
+          "next": ["present", "escalate"]
+        },
+        {
+          "name": "present",
+          "description": "Record the gate as pending and email the current approver, then pause until the approval signal (resumes at 'decide').",
+          "capability": "email.send",
+          "next": ["decide"]
+        },
+        {
+          "name": "decide",
+          "description": "Resume target — its input is the approval payload; approve advances to the next gate or finalises, reject compensates, timeout/no-response escalates, and any other resume is a reminder tick.",
+          "next": ["present", "remind", "finalize", "compensate", "escalate"]
+        },
+        {
+          "name": "remind",
+          "description": "Email a reminder to the current approver, then pause again on the same gate (resumes at 'decide').",
+          "capability": "email.send",
+          "next": ["decide"]
+        },
+        {
+          "name": "finalize",
+          "description": "The single irreversible action — reached only after every party approved; a dryRun guard makes it a no-op offline.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "compensate",
+          "description": "Saga rollback: someone rejected — notify everyone who already approved that the chain was cancelled.",
+          "capability": "email.send",
+          "terminal": true
+        },
+        {
+          "name": "escalate",
+          "description": "Terminal branch: a gate went silent or timed out — escalate to a human channel.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "scheduled-db-insight-report",
+      "name": "Scheduled DB Snapshot to Insight Report",
+      "description": "On a schedule, query a database, write the narrative and render charts, then email the insight report.",
+      "tags": ["scheduled", "database", "analytics", "report"],
+      "sourcePath": "examples/scheduled-db-insight-report",
+      "capabilities": [
+        "database.get",
+        "database.create",
+        "models.run",
+        "sandboxes.create",
+        "fileStorage.upload",
+        "fileStorage.getDownloadUrl",
+        "email.send",
+        "vault.get"
+      ],
+      "whatItDoes": "The standing \"metrics email\" you'd otherwise assemble by hand. On each tick it runs a set of read-only SQL queries and turns every result into a metric — a labeled series or a single number. A model (`models.run`) reads those numbers and writes a short report: a summary, a few insights that cite the figures, and a line on what to watch. Then it spins up a sandbox, renders the series into an SVG bar chart with a tiny dependency-free script, and hosts that chart in file storage so the report can link to it. Finally it emails the whole thing. With no config it introspects the database's own catalog — rows per table, size — so it reports on any database immediately; pass your own `queries` to report on real data. A `dryRun` reports on sample metrics and skips the send.",
+      "steps": [
+        {
+          "name": "snapshot",
+          "description": "Runs the read-only queries against the database and normalizes each result into a metric — a labeled series or a scalar KPI.",
+          "capability": "database.get",
+          "next": ["narrate"]
+        },
+        {
+          "name": "narrate",
+          "description": "Hands the metrics to a model to write a short markdown report — a summary, insights that cite the numbers, and what to watch.",
+          "capability": "models.run",
+          "next": ["chart"]
+        },
+        {
+          "name": "chart",
+          "description": "Renders the series into an SVG bar chart inside a sandbox, hosts it in file storage, and takes a shareable link.",
+          "capability": "sandboxes.create",
+          "next": ["deliver"]
+        },
+        {
+          "name": "deliver",
+          "description": "Emails the report — narrative, chart link, and a metrics table. A dry run or a missing recipient returns it as a preview instead.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "newsletter-autopilot",
+      "name": "Newsletter Autopilot",
+      "description": "On a weekly schedule, it researches a niche, writes and illustrates the issue, and emails it to your subscriber list.",
+      "tags": ["newsletter", "scheduled", "llm", "email"],
+      "sourcePath": "examples/newsletter-autopilot",
+      "capabilities": ["web.search", "models.run", "contentGeneration.images"],
+      "whatItDoes": "For running a niche newsletter without drafting each issue by hand. It searches the web for your niche, then reads the top results for their full text. It hands those sources to an LLM (models.run) to curate the strongest items and write the issue — a subject line, an intro, a few sections that cite their sources, and a header-image prompt. It generates that header image, then emails each subscriber their own copy. Give it a cron schedule and it publishes on its own, defaulting to Mondays at 08:00. A dryRun flag writes and illustrates the full issue and returns it without emailing anyone, so you can review before it goes out.",
+      "steps": [
+        {
+          "name": "search",
+          "description": "Search the web for the niche and collect candidate sources.",
+          "capability": "web.search",
+          "next": ["scrape"]
+        },
+        {
+          "name": "scrape",
+          "description": "Read the top candidates for their full article text, keeping just the snippet when a page won't load.",
+          "capability": "web.search",
+          "next": ["write"]
+        },
+        {
+          "name": "write",
+          "description": "Hand the sources to an LLM to curate them and write this week's issue: a subject, a body that cites each source, and a header-image prompt.",
+          "capability": "models.run",
+          "next": ["header"]
+        },
+        {
+          "name": "header",
+          "description": "Generate a header image for the issue; if none comes back, the issue still goes out without it.",
+          "capability": "contentGeneration.images",
+          "next": ["deliver"]
+        },
+        {
+          "name": "deliver",
+          "description": "Email each subscriber their own copy; a dry run, or a run with no subscribers set, returns the issue without sending.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "durable-backfill",
+      "name": "Durable Backfill / Long-Job Runner",
+      "description": "Process a huge dataset in resumable chunks, checkpointing progress so the job survives restarts and picks up where it left off.",
+      "tags": ["durable", "backfill", "batch", "cron"],
+      "sourcePath": "examples/durable-backfill",
+      "capabilities": [
+        "database.get",
+        "sandboxes.create",
+        "sandboxes.exec",
+        "fileStorage.upload",
+        "fileStorage.getDownloadUrl",
+        "fileStorage.list",
+        "fileStorage.delete"
+      ],
+      "whatItDoes": "For long jobs that are too big for one pass — a backfill, a migration, a reprocess. It walks the dataset one chunk at a time. Each chunk's work runs in a sandbox that gets the dataset's connection string and the chunk's range, and after every chunk it writes a checkpoint to file storage and pauses until a heartbeat wakes it for the next one — so nothing runs and nothing is billed while it waits. Progress survives restarts: start a fresh run with the same job id and it reads the checkpoint and resumes mid-dataset. Leave the database handle unset (or pass dryRun) and it counts each chunk in-process, so you can trace the whole loop for free.",
+      "steps": [
+        {
+          "name": "plan",
+          "description": "Works out the job — dataset size, chunk size, and a stable job id — then resumes from a saved checkpoint if one exists for that id.",
+          "next": ["process"]
+        },
+        {
+          "name": "process",
+          "description": "Processes the current chunk in a sandbox, saves a result file and rewrites the checkpoint, then pauses for the next heartbeat — or finishes once the last chunk is done.",
+          "capability": "sandboxes.exec",
+          "next": ["finalize"]
+        },
+        {
+          "name": "finalize",
+          "description": "Writes a manifest of the run and returns a summary.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "nl-db-query-endpoint",
+      "name": "Natural-Language DB Query Endpoint",
+      "description": "Deploy a live endpoint that turns a plain-English question into a read-only SQL query and returns the answer.",
+      "tags": ["database", "sql", "endpoint", "llm"],
+      "sourcePath": "examples/nl-db-query-endpoint",
+      "capabilities": ["database.get", "models.run", "sandboxes.deployPreview", "vault.get"],
+      "whatItDoes": "For giving your team a question box over a read-only database. One run stands up a live endpoint; then anyone can POST a plain-English question to it. It reads the connection string from a Sapiom database handle, previews the translation on a sample question so a bad path fails before anything ships, then writes a small server into a sandbox and exposes it at a stable URL. Each request asks an LLM for a single SELECT, checks it, and runs it inside a READ ONLY transaction Postgres enforces — with a statement timeout and a row cap, so a write can't slip through. The server's own key is read from the vault at deploy time, never baked into source.",
+      "steps": [
+        {
+          "name": "validate",
+          "description": "Checks the input (a database handle or connection string) and resolves config.",
+          "next": ["resolve", "rejected"]
+        },
+        {
+          "name": "resolve",
+          "description": "Reads the target Postgres connection string from a Sapiom database handle to inject into the endpoint.",
+          "capability": "database.get",
+          "next": ["plan"]
+        },
+        {
+          "name": "plan",
+          "description": "Previews the pipeline: translates the sample question into SQL with an LLM.",
+          "capability": "models.run",
+          "next": ["guard"]
+        },
+        {
+          "name": "guard",
+          "description": "Applies the read-only guardrail to the sample SQL; anything that isn't a single read-only statement is rejected.",
+          "next": ["deploy", "rejected"]
+        },
+        {
+          "name": "deploy",
+          "description": "Writes the endpoint server into a sandbox and exposes it at a stable URL, injecting DATABASE_URL and a vault-read API key.",
+          "capability": "sandboxes.deployPreview",
+          "next": ["deployed", "deploy_failed"]
+        },
+        {
+          "name": "deployed",
+          "description": "The endpoint is live — returns its URL and the previewed sample query.",
+          "terminal": true
+        },
+        {
+          "name": "deploy_failed",
+          "description": "The deploy failed — surfaces the deployPreview logs.",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "Input or the sample SQL failed the guardrail; nothing was deployed.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "scheduled-compliance-audit",
+      "name": "Scheduled Compliance Audit + Attestation",
+      "description": "On a schedule, it audits your resources against a policy, waits for a person to sign off, then archives the signed attestation.",
+      "tags": ["compliance", "scheduled", "human-in-the-loop", "attestation"],
+      "sourcePath": "examples/scheduled-compliance-audit",
+      "capabilities": [
+        "web.scrape",
+        "models.run",
+        "fileStorage.upload",
+        "fileStorage.getDownloadUrl"
+      ],
+      "whatItDoes": "For a recurring policy audit you need a signed record of. On each tick it reads the current state of the resources you point it at — a config page, a status endpoint, a policy doc — and hands that state and your policy to an LLM (models.run) that returns an overall verdict plus one check per requirement, with evidence and a fix for each failure. Then it pauses and waits for a person to sign off, costing nothing while idle. Only an explicit approval archives the signed attestation to durable file storage (fileStorage) and hands back a download link — because an attestation records that a human reviewed and approved, it is never filed automatically. Decline and the findings come back, but nothing is archived. A dryRun flag returns the whole attestation as a preview without archiving.",
+      "steps": [
+        {
+          "name": "collect",
+          "description": "Read the current state of each resource with a scrape, keeping the error as missing evidence when a page won't load.",
+          "capability": "web.scrape",
+          "next": ["audit"]
+        },
+        {
+          "name": "audit",
+          "description": "Hand the collected state and your policy to an LLM to produce a verdict and one evidence-cited check per requirement.",
+          "capability": "models.run",
+          "next": ["review"]
+        },
+        {
+          "name": "review",
+          "description": "Pause and wait for a human sign-off signal, costing nothing while idle (resumes at 'onSignoff').",
+          "next": ["onSignoff"]
+        },
+        {
+          "name": "onSignoff",
+          "description": "Read the sign-off reply: an explicit approve archives the attestation, anything else backs out with nothing filed.",
+          "next": ["archive", "rejected"]
+        },
+        {
+          "name": "archive",
+          "description": "Write the signed attestation to durable file storage and return its file id and download link; a dry run skips the upload.",
+          "capability": "fileStorage.upload",
+          "terminal": true
+        },
+        {
+          "name": "rejected",
+          "description": "Sign-off was declined — return the audit findings, having archived nothing.",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "error-triage-digest",
+      "name": "Error / Log Triage Digest",
+      "description": "Ingest errors by webhook or a scheduled pull, cluster and summarize them with an LLM, dedupe against a database, and email a daily digest.",
+      "tags": ["errors", "triage", "digest", "dedupe", "scheduled"],
+      "sourcePath": "examples/error-triage-digest",
+      "capabilities": [
+        "models.run",
+        "database.get",
+        "database.create",
+        "email.send"
+      ],
+      "whatItDoes": "For turning a noisy error stream into one digest that tells you what's actually new. It takes a batch of errors two ways from the same entry: a cron-triggered run pulls one in (or is handed one), or with `webhook: true` it pauses at $0 until your pipeline pushes one as the `errors.pushed` signal. An LLM (`models.run`) clusters the raw entries into a handful of issues, each with a stable fingerprint that strips out volatile ids and line numbers. It looks each fingerprint up in a Postgres store it owns (`database`): unseen ones are new, the rest are recurring with their running totals updated — so the daily digest surfaces new problems instead of re-alerting on known ones. Then it emails a markdown digest, new issues first. A dryRun computes the digest without touching the database or sending mail.",
+      "steps": [
+        {
+          "name": "collect",
+          "description": "Gather the error batch — take it directly, GET it from a pull URL, or pause at $0 until a webhook pushes one via the errors.pushed signal.",
+          "next": ["triage"]
+        },
+        {
+          "name": "triage",
+          "description": "Hand the raw errors to an LLM to cluster them into distinct issues, each with a stable fingerprint, a severity, and an occurrence count.",
+          "capability": "models.run",
+          "next": ["dedupe"]
+        },
+        {
+          "name": "dedupe",
+          "description": "Look each fingerprint up in a Postgres store: never-seen ones are new, the rest are recurring, and their running totals are updated. Skipped on a dry run.",
+          "capability": "database.get",
+          "next": ["digest"]
+        },
+        {
+          "name": "digest",
+          "description": "Write a markdown digest — new issues first, recurring below — and email it. A dry run, or a run with no recipient, returns it without sending.",
+          "capability": "email.send",
+          "terminal": true
+        }
+      ]
     }
   ]
 }

--- a/examples/scheduled-compliance-audit/.gitignore
+++ b/examples/scheduled-compliance-audit/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/scheduled-compliance-audit/AGENTS.md
+++ b/examples/scheduled-compliance-audit/AGENTS.md
@@ -1,0 +1,83 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Scheduled
+Compliance Audit + Attestation** — authored against `@sapiom/agent`. It has six
+steps: `collect` (calls `web.scrape`) → `audit` (calls `models.run`, the live
+LLM) → `review` (pauses on the `attestation.signoff` signal) → `onSignoff`
+(reads the decision) → `archive` (calls `fileStorage.upload`) or `rejected`.
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (e.g.
+`ctx.sapiom.search.scrape(...)`, `ctx.sapiom.models.run(...)`,
+`ctx.sapiom.fileStorage.upload(...)`).
+
+It composes the scheduled-collect-and-curate shape of `scheduled-research-brief`
+with the pause-for-a-human gate of `human-in-the-loop`. The gate here protects
+the **attestation archive**: nothing is filed until a person explicitly signs off.
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is
+  defined by `@sapiom/tools` — read the types / use autocomplete rather than
+  guessing. A wrong capability or method name fails typecheck.
+- **The durable pause is a primitive, not a capability.** `review` declares a
+  static `pause: { signal, resumeStep }` edge AND returns
+  `pauseUntilSignal({ signal, resumeStep, correlationId: ctx.executionId })`. The
+  resume target (`onSignoff`) receives the signal payload as its `run` input.
+- **Gate real side effects behind `dryRun`.** `archive` uploads the attestation
+  only on a live run with `dryRun` off; otherwise it returns the computed
+  attestation as a preview. The upload's presigned PUT is a raw `fetch` (not a
+  stubbed capability), so it MUST stay behind this guard or it would hit the
+  network during `run_local`.
+- **Safe by default on resume.** Only an explicit `approve` archives; a resume
+  with no decision (what `run_local` sends) takes the `rejected` branch. This is
+  deliberate — an attestation asserts a human reviewed and signed off, so it is
+  never filed without one.
+- **Keep the edges slim.** The scraped bodies are the only large data; they stay
+  bounded (truncated, capped count) and die at the `audit` boundary — they never
+  enter `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*`
+  capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full
+  local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so
+  `web.scrape` / `models.run` / `fileStorage.upload` return built-in defaults and
+  the agent runs end-to-end offline for free. The pause is auto-resumed with no
+  decision, so the offline trace lands on `rejected`; pass `dryRun: true` so
+  `archive` would skip the (stubbed) upload if you drive the approve path with a
+  real signal. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed collect + policy
+  check that pauses for sign-off. Fire the `attestation.signoff` signal to resume
+  (see `README.md`). Attach the `schedule` as a cron trigger to run it on a cadence.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities), not the other way around — never weaken or drop real
+> logic to shape a local run.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Collection channel: scrape vs. sandbox
+
+This template collects state over the network with `web.scrape` — the simplest
+way to read a config page, a status endpoint, or a published policy doc. To audit
+state that only exists inside a running environment — files on disk, a service's
+live config, a command's output — swap the scrape in `collect` for a sandbox
+attach + exec, e.g. `ctx.sapiom.sandboxes.attach(id)` then run a read-only command
+and capture stdout as the collected evidence. Keep the same per-item
+degrade-on-failure loop and the `MAX_BODY_CHARS` bound so a body never lands in
+shared state.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). The audit timestamp is captured once in `collect` and carried forward via
+`ctx.shared` rather than recomputed downstream — do the same for any id or clock
+value a later step depends on.

--- a/examples/scheduled-compliance-audit/README.md
+++ b/examples/scheduled-compliance-audit/README.md
@@ -1,0 +1,105 @@
+# Scheduled Compliance Audit + Attestation
+
+On a cron cadence, collect the current state of your resources, check it against
+your policy with an LLM, **pause for a human sign-off**, and — only once a person
+approves — archive the signed attestation as a durable file.
+
+Nothing is filed until a human signs off: an attestation is a record that a
+person reviewed and approved, so it is never archived automatically.
+
+## What it does
+
+```
+collect ──▶ audit ─(pause: attestation.signoff, $0 while idle)─▶ onSignoff
+(web.scrape)  (models.run)                                          │
+                                             reject ◀────────────────┼─▶ approve
+                                               │                      ▼
+                                           rejected (terminal)   archive (fileStorage, terminal)
+```
+
+1. **collect** — reads each resource's current state with
+   `ctx.sapiom.search.scrape` (a config page, a status endpoint, a policy doc),
+   degrading per-item on failure. Bodies are truncated and stay bounded — they
+   never enter shared state.
+2. **audit** — hands the collected state and your `policy` to an LLM
+   (`ctx.sapiom.models.run` — the live x402-served model) to produce a structured
+   report: an overall verdict plus one check per requirement, each with evidence
+   and a remediation for failures.
+3. **review** — `pauseUntilSignal({ signal: "attestation.signoff", resumeStep: "onSignoff" })`.
+   The run suspends here at $0 until a person signs off.
+4. **onSignoff** (resume target) — its **input is the sign-off payload**. Only an
+   explicit `{ "decision": "approve" }` proceeds to `archive`; anything else takes
+   the safe `rejected` branch, and nothing is archived.
+5. **archive** — writes the signed attestation to `ctx.sapiom.fileStorage` and
+   returns its `fileId` and a download URL. A `dryRun` guard computes the
+   attestation and returns it as a preview without uploading anything.
+
+Input:
+
+```json
+{
+  "resources": [
+    { "id": "api-config", "url": "https://example.com/security.txt", "label": "API security policy" },
+    { "id": "status", "url": "https://example.com/status", "label": "Service status" }
+  ],
+  "policy": "All services must publish a security contact and enforce TLS. Status page must show 99.9% uptime.",
+  "schedule": "0 6 * * 1",
+  "framework": "SOC 2 CC6",
+  "signOffBy": "compliance@example.com"
+}
+```
+
+- `resources` and `policy` are the two knobs — what to audit, and the rules to
+  audit it against.
+- `schedule` is the cron cadence; `framework` and `signOffBy` are recorded in the
+  attestation.
+- `dryRun: true` returns the attestation as a preview without archiving anything.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities
+   stubbed, the pause auto-resumed, free — pass `dryRun: true` so `archive` skips
+   the upload) → `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` →
+   `sapiom_dev_agents_run` (a real, billed collect + policy check that pauses for
+   sign-off).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the
+   deployed agent.
+
+## Resuming a paused run in dev
+
+A real `run` pauses at `review`. Instead of a real approver, fire the sign-off
+signal yourself via the MCP `workflow_signal` / `signal_workflow` tool. The
+`correlationId` is the paused run's `executionId`, and the `payload` becomes
+`onSignoff`'s input.
+
+**Approve** (resumes `onSignoff` → `archive`):
+
+```json
+{
+  "signal": "attestation.signoff",
+  "correlationId": "<executionId of the paused run>",
+  "payload": { "decision": "approve", "signer": "compliance@example.com" }
+}
+```
+
+Send `{ "decision": "reject" }` instead to see the safe `rejected` path, where
+the audit findings come back but nothing is archived.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/scheduled-compliance-audit/index.ts
+++ b/examples/scheduled-compliance-audit/index.ts
@@ -1,0 +1,566 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  pauseUntilSignal,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Scheduled Compliance Audit + Attestation — the recurring "prove we're still
+ * compliant" pattern.
+ *
+ * On each tick it collects the current state of the resources you point it at
+ * (config pages, status endpoints, policy docs — read with `web.scrape`), asks
+ * an LLM (`ctx.sapiom.models.run` — the live x402 path) to check that state
+ * against your `policy` and produce a structured finding, then **pauses for a
+ * human sign-off**. Only after a person explicitly approves does it archive the
+ * signed attestation as a durable file (`fileStorage.upload`) — because an
+ * attestation is a record that a human reviewed and signed off, auto-archiving
+ * one without a real sign-off would be a lie.
+ *
+ *   collect (web.scrape) → audit (models.run) ─(pause: attestation.signoff, $0)─▶ onSignoff
+ *                                                                                    │
+ *                                              reject ◀───────────────────────────────┼─▶ approve
+ *                                                │                                     ▼
+ *                                            rejected (terminal)                  archive (fileStorage, terminal)
+ *
+ * The durable pause (`pauseUntilSignal`) suspends the run at $0 until a person
+ * fires the sign-off signal — it is a runtime primitive, not a metered
+ * capability. The billed calls are the scrapes (`web.scrape`), the model
+ * reasoning (`ctx.sapiom.models.run` — `ctx.sapiom.llm` does NOT exist), and the
+ * attestation upload (`fileStorage.upload`).
+ *
+ * Side-effect discipline (copied from `scheduled-research-brief` /
+ * `human-in-the-loop`):
+ *   - `dryRun` gates the one irreversible action: `archive` computes the
+ *     attestation and returns it as a preview WITHOUT uploading anything. The
+ *     upload's presigned PUT is a raw `fetch` (not a stubbed capability), so it
+ *     must stay behind this guard or it would hit the network offline.
+ *   - A resume with no explicit `approve` takes the SAFE branch (`rejected`,
+ *     nothing archived). `run_local` auto-resumes the pause, so the offline trace
+ *     lands on `rejected` by default; fire a real `attestation.signoff` signal
+ *     with `{ "decision": "approve" }` to drive the archive path (see README).
+ *   - The scraped bodies are the only large data; they stay bounded (truncated,
+ *     capped count) and die at the `audit` boundary — they never enter
+ *     `ctx.shared` (large shared state stalls transitions on the cloud engine).
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Default cadence when the caller doesn't pass one: 06:00 every Monday. */
+const DEFAULT_SCHEDULE = "0 6 * * 1";
+/** Cap on how many resources we scrape per run (keeps latency + cost bounded). */
+const MAX_RESOURCES = 8;
+/** Truncate each scraped body — the ONLY large data on the collect→audit path. */
+const MAX_BODY_CHARS = 2000;
+/** The signal a human fires to approve or reject the attestation. */
+const SIGNOFF_SIGNAL = "attestation.signoff";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** A resource whose current state should be audited against the policy. */
+interface ResourceRef {
+  /** Stable id echoed into findings so a check maps back to its resource. */
+  id: string;
+  /** Where to read the resource's current config/state from. */
+  url: string;
+  /** Human-readable label shown in the attestation. Falls back to `id`. */
+  label?: string;
+}
+
+interface EntryInput {
+  /** The resources/config to collect and audit on each tick. */
+  resources: ResourceRef[];
+  /** The policy the collected state is checked against (free text or rules). */
+  policy: string;
+  /** Cron cadence this audit is meant to run on (e.g. "0 6 * * 1"). */
+  schedule?: string;
+  /** Compliance framework label for the attestation title (e.g. "SOC 2 CC6"). */
+  framework?: string;
+  /** Who is expected to sign off; recorded in the attestation. Informational. */
+  signOffBy?: string;
+  /** Compute + pause but never perform the real archive upload. `run_local` sets this. */
+  dryRun?: boolean;
+}
+
+/** A resource plus its (bounded) collected content — the collect→audit payload. */
+interface CollectedResource extends ResourceRef {
+  /** Extracted current state (markdown, truncated); absent when collection failed. */
+  content?: string;
+  /** Why collection failed, when it did — surfaced to the audit as missing evidence. */
+  error?: string;
+}
+
+/** One requirement check the model produced against the policy. */
+interface CheckFinding {
+  /** Resource id this check concerns, or a policy-level id. */
+  id: string;
+  /** The requirement being checked, in plain words. */
+  requirement: string;
+  /** Verdict for this requirement. */
+  status: "pass" | "fail" | "unknown";
+  /** What in the collected state supports the verdict. */
+  evidence: string;
+  /** Suggested fix when the verdict is `fail`. */
+  remediation?: string;
+}
+
+/** Overall verdict of the audit. */
+type AuditStatus = "compliant" | "non_compliant" | "needs_review";
+
+/** The structured audit report, computed by `audit` and stored in shared. */
+interface ComplianceReport {
+  status: AuditStatus;
+  summary: string;
+  checks: CheckFinding[];
+}
+
+/** The payload a human delivers on the `attestation.signoff` signal. */
+interface SignoffDecision {
+  /** `approve` archives the attestation; anything else takes the safe reject branch. */
+  decision?: "approve" | "reject";
+  /** Who signed off; recorded in the archived attestation. */
+  signer?: string;
+  /** Optional free-text rationale carried through to the outcome. */
+  notes?: string;
+}
+
+interface Shared extends Record<string, unknown> {
+  policy: string;
+  schedule: string;
+  framework: string;
+  signOffBy: string | null;
+  dryRun: boolean;
+  collectedAt: string;
+  report: ComplianceReport;
+  /** Slim resource references for the attestation; scraped bodies do NOT live here. */
+  resources: Array<{ id: string; label: string; url: string; error?: string }>;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function must<T>(value: T | undefined, name: string): T {
+  if (value === undefined) throw new Error(`missing shared state: ${name}`);
+  return value;
+}
+
+/** Status glyph for the attestation checklist. */
+function glyph(status: CheckFinding["status"]): string {
+  return status === "pass" ? "✓" : status === "fail" ? "✗" : "?";
+}
+
+// ─────────────────────────────────────────────────────── model reasoning ──
+/**
+ * Ask the model to check the collected state against the policy and return a
+ * structured report. Parsed defensively — a malformed reply degrades to a
+ * `needs_review` verdict rather than throwing, so the sign-off gate still runs.
+ */
+async function runPolicyCheck(
+  ctx: Ctx,
+  policy: string,
+  collected: CollectedResource[],
+): Promise<ComplianceReport> {
+  if (collected.length === 0) {
+    return {
+      status: "needs_review",
+      summary: "No resources were collected, so nothing could be audited.",
+      checks: [],
+    };
+  }
+  const evidence = collected
+    .map((r, i) => {
+      const head = `[${i + 1}] ${r.label ?? r.id} (${r.url})`;
+      if (r.error) return `${head}\n(collection failed: ${r.error})`;
+      return `${head}\n${(r.content ?? "").slice(0, MAX_BODY_CHARS)}`;
+    })
+    .join("\n\n");
+  const system =
+    "You are a compliance auditor. Given a POLICY and the current STATE of a set " +
+    "of resources (each: [n] label, url, then its collected text or a collection " +
+    "error), check the state against the policy. Produce one check per distinct " +
+    "requirement, cite the evidence you relied on, and suggest a remediation for " +
+    "each failure. A requirement you cannot evaluate from the evidence is " +
+    '"unknown", not "pass". Set the overall status to "compliant" only if every ' +
+    'check passes, "non_compliant" if any check fails, else "needs_review". ' +
+    "Reply with ONLY minified JSON: " +
+    '{"status":"compliant|non_compliant|needs_review","summary":string,' +
+    '"checks":[{"id":string,"requirement":string,"status":"pass|fail|unknown",' +
+    '"evidence":string,"remediation":string}]}.';
+  const res = await ctx.sapiom.models.run({
+    system,
+    prompt: `POLICY:\n${policy}\n\nSTATE:\n${evidence}`,
+    maxTokens: 900,
+  });
+  return coerceReport(res.output);
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const collect = defineStep({
+  name: "collect",
+  next: ["audit"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const policy = input.policy?.trim() ?? "";
+    ctx.shared.set("policy", policy);
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set("framework", input.framework?.trim() || "General policy");
+    ctx.shared.set("signOffBy", input.signOffBy?.trim() || null);
+    ctx.shared.set("dryRun", input.dryRun === true);
+    // Capture the audit timestamp once; steps re-run only on retry, so pin it
+    // here and carry it forward rather than recomputing downstream.
+    ctx.shared.set("collectedAt", new Date().toISOString());
+
+    const resources = (input.resources ?? []).slice(0, MAX_RESOURCES);
+    const collected: CollectedResource[] = [];
+    for (const r of resources) {
+      const base: ResourceRef = { id: r.id, url: r.url };
+      if (r.label !== undefined) base.label = r.label;
+      try {
+        const page = await ctx.sapiom.search.scrape({
+          url: r.url,
+          formats: ["markdown"],
+          onlyMainContent: true,
+        });
+        collected.push({
+          ...base,
+          label: r.label || page.metadata?.title || r.id,
+          content: (page.markdown ?? "").slice(0, MAX_BODY_CHARS),
+        });
+      } catch (err) {
+        // Collection fails routinely (auth walls, timeouts, dead endpoints).
+        // Degrade per-item and forward the error as missing evidence — the audit
+        // then marks that requirement "unknown" rather than the run aborting.
+        ctx.logger.warn("collection failed; forwarding as missing evidence", {
+          url: r.url,
+          err: String(err),
+        });
+        collected.push({ ...base, error: String(err) });
+      }
+    }
+
+    // Slim references for the attestation — the scraped bodies stop here.
+    ctx.shared.set(
+      "resources",
+      collected.map((r) => ({
+        id: r.id,
+        label: r.label ?? r.id,
+        url: r.url,
+        ...(r.error !== undefined && { error: r.error }),
+      })),
+    );
+    ctx.logger.info("collected resources", {
+      total: collected.length,
+      failed: collected.filter((r) => r.error).length,
+    });
+    return goto("audit", { collected });
+  },
+});
+
+const audit = defineStep({
+  name: "audit",
+  next: ["review"],
+  async run(input: { collected: CollectedResource[] }, ctx: Ctx) {
+    const policy = must(ctx.shared.get("policy"), "policy");
+    const report = await runPolicyCheck(ctx, policy, input.collected ?? []);
+    ctx.shared.set("report", report);
+    ctx.logger.info("policy check complete", {
+      status: report.status,
+      checks: report.checks.length,
+      failing: report.checks.filter((c) => c.status === "fail").length,
+    });
+    return goto("review", {});
+  },
+});
+
+const review = defineStep({
+  name: "review",
+  next: [],
+  // Static graph edge: on the sign-off signal, resume at `onSignoff`. Must match
+  // the `pauseUntilSignal` directive below.
+  pause: { signal: SIGNOFF_SIGNAL, resumeStep: "onSignoff" },
+  async run(_input: unknown, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    const framework = ctx.shared.get("framework") ?? "General policy";
+    const signOffBy = ctx.shared.get("signOffBy") ?? null;
+
+    // No notification capability here (by design — this template's surface is
+    // cron + scrape + LLM + pause + file storage). The pending attestation is in
+    // the run's output/logs; the reviewer reads it there and fires the signal.
+    ctx.logger.info("attestation ready for sign-off; pausing", {
+      framework,
+      status: report.status,
+      signOffBy,
+      checks: report.checks.length,
+    });
+
+    // Suspend at $0 until a human fires the sign-off signal for this run.
+    return pauseUntilSignal({
+      signal: SIGNOFF_SIGNAL,
+      resumeStep: "onSignoff",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const onSignoff = defineStep({
+  name: "onSignoff",
+  next: ["archive", "rejected"],
+  // `payload` IS the sign-off signal body.
+  async run(payload: SignoffDecision, ctx: Ctx) {
+    // Safe default: only an explicit `approve` archives — the whole point of the
+    // gate is that no attestation is filed without a deliberate human sign-off.
+    const approved = payload?.decision === "approve";
+    ctx.logger.info("sign-off decision", {
+      decision: payload?.decision ?? "(none)",
+      approved,
+      signer: payload?.signer ?? null,
+    });
+    if (!approved) {
+      return goto("rejected", {
+        reason: payload?.notes ?? "not-approved",
+      });
+    }
+    return goto("archive", {
+      signer: payload?.signer ?? null,
+      notes: payload?.notes ?? null,
+    });
+  },
+});
+
+const archive = defineStep({
+  name: "archive",
+  next: [],
+  terminal: true,
+  async run(input: { signer: string | null; notes: string | null }, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    const framework = ctx.shared.get("framework") ?? "General policy";
+    const schedule = ctx.shared.get("schedule") ?? DEFAULT_SCHEDULE;
+    const collectedAt = ctx.shared.get("collectedAt") ?? "";
+    const resources = ctx.shared.get("resources") ?? [];
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+    const signer = input?.signer ?? ctx.shared.get("signOffBy") ?? null;
+    const signedAt = new Date().toISOString();
+
+    const attestation = buildAttestation({
+      framework,
+      schedule,
+      collectedAt,
+      signedAt,
+      signer,
+      notes: input?.notes ?? null,
+      report,
+      resources,
+    });
+    const fileName = `attestation-${collectedAt.slice(0, 10) || "latest"}.md`;
+
+    if (dryRun) {
+      // Offline / preview: the single irreversible action (the upload PUT, a raw
+      // fetch that is NOT a stubbed capability) is skipped. Everything up to here
+      // — collect, audit, the sign-off gate — already ran for real.
+      ctx.logger.info("dry run: skipping the attestation upload", {
+        status: report.status,
+        fileName,
+      });
+      return terminate({
+        archived: false,
+        dryRun: true,
+        status: report.status,
+        framework,
+        signer,
+        signedAt,
+        fileName,
+        attestation,
+        fileId: null,
+        downloadUrl: null,
+      });
+    }
+
+    // ── The single billed/irreversible action ──────────────────────────────
+    // Reached ONLY after a human approved. Persist the signed attestation as a
+    // durable, private file and hand back a download URL for the archive.
+    const bytes = new TextEncoder().encode(attestation);
+    const { fileId, uploadUrl, requiredHeaders } =
+      await ctx.sapiom.fileStorage.upload({
+        contentType: "text/markdown",
+        fileName,
+        fileSize: bytes.byteLength,
+        visibility: "private",
+      });
+    // You own the bytes transfer: PUT them to the presigned URL yourself.
+    const put = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: requiredHeaders,
+      body: bytes,
+    });
+    if (!put.ok) {
+      const detail = await put.text().catch(() => put.statusText);
+      throw new Error(`attestation upload failed: ${put.status} ${detail}`);
+    }
+    const { downloadUrl } = await ctx.sapiom.fileStorage.getDownloadUrl(fileId);
+
+    ctx.logger.info("attestation archived", {
+      fileId,
+      status: report.status,
+      signer,
+    });
+    return terminate({
+      archived: true,
+      dryRun: false,
+      status: report.status,
+      framework,
+      signer,
+      signedAt,
+      fileName,
+      fileId,
+      downloadUrl,
+    });
+  },
+});
+
+const rejected = defineStep({
+  name: "rejected",
+  next: [],
+  terminal: true,
+  async run(input: { reason?: string }, ctx: Ctx) {
+    const report = must(ctx.shared.get("report"), "report");
+    // Nothing was archived — the sign-off was declined (or absent). The audit
+    // findings are still returned so a reviewer can act on them.
+    ctx.logger.info("sign-off declined — nothing archived", {
+      status: report.status,
+      reason: input?.reason ?? "not-approved",
+    });
+    return terminate({
+      archived: false,
+      outcome: "rejected",
+      status: report.status,
+      reason: input?.reason ?? "not-approved",
+      summary: report.summary,
+      checks: report.checks,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────── attestation body ──
+function buildAttestation(a: {
+  framework: string;
+  schedule: string;
+  collectedAt: string;
+  signedAt: string;
+  signer: string | null;
+  notes: string | null;
+  report: ComplianceReport;
+  resources: Array<{ id: string; label: string; url: string; error?: string }>;
+}): string {
+  const checks =
+    a.report.checks.length > 0
+      ? a.report.checks
+          .map((c) => {
+            const remediation =
+              c.status === "fail" && c.remediation
+                ? `\n  - Remediation: ${c.remediation}`
+                : "";
+            return `- [${glyph(c.status)}] ${c.requirement} — ${c.status}: ${c.evidence}${remediation}`;
+          })
+          .join("\n")
+      : "_No checks were produced._";
+  const sources =
+    a.resources.length > 0
+      ? a.resources
+          .map(
+            (r) =>
+              `- ${r.label} (${r.url})${r.error ? ` — collection failed: ${r.error}` : ""}`,
+          )
+          .join("\n")
+      : "_No resources were collected._";
+  return [
+    `# Compliance Attestation — ${a.framework}`,
+    "",
+    `- **Overall status:** ${a.report.status}`,
+    `- **Audited at:** ${a.collectedAt || "(unknown)"}`,
+    `- **Cadence:** ${a.schedule}`,
+    `- **Resources audited:** ${a.resources.length}`,
+    "",
+    "## Summary",
+    a.report.summary || "_No summary._",
+    "",
+    "## Checks",
+    checks,
+    "",
+    "## Sign-off",
+    `- **Decision:** approved`,
+    `- **Signed by:** ${a.signer ?? "(unspecified)"}`,
+    `- **Signed at:** ${a.signedAt}`,
+    ...(a.notes ? [`- **Notes:** ${a.notes}`] : []),
+    "",
+    "## Sources",
+    sources,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────── output parsing ──
+/** Coerce the audit-step model output into a `ComplianceReport`, with fallbacks. */
+function coerceReport(output: string | null): ComplianceReport {
+  const fallback: ComplianceReport = {
+    status: "needs_review",
+    summary: "The auditor returned no usable report; a human should review.",
+    checks: [],
+  };
+  const obj = extractJson(output);
+  if (!obj) return fallback;
+
+  const status = coerceStatus(obj.status);
+  const summary =
+    typeof obj.summary === "string" && obj.summary.trim()
+      ? obj.summary.trim()
+      : fallback.summary;
+  const checks = Array.isArray(obj.checks)
+    ? obj.checks.map(coerceCheck).filter((c): c is CheckFinding => c !== null)
+    : [];
+  return { status, summary, checks };
+}
+
+function coerceStatus(value: unknown): AuditStatus {
+  return value === "compliant" || value === "non_compliant"
+    ? value
+    : "needs_review";
+}
+
+function coerceCheck(entry: unknown): CheckFinding | null {
+  if (!entry || typeof entry !== "object") return null;
+  const e = entry as Record<string, unknown>;
+  const requirement =
+    typeof e.requirement === "string" ? e.requirement.trim() : "";
+  if (!requirement) return null;
+  const status: CheckFinding["status"] =
+    e.status === "pass" || e.status === "fail" ? e.status : "unknown";
+  const check: CheckFinding = {
+    id: typeof e.id === "string" ? e.id : requirement.slice(0, 40),
+    requirement,
+    status,
+    evidence:
+      typeof e.evidence === "string" ? e.evidence : "(no evidence cited)",
+  };
+  if (status === "fail" && typeof e.remediation === "string" && e.remediation) {
+    check.remediation = e.remediation;
+  }
+  return check;
+}
+
+/** Best-effort extraction of a single JSON object from model output. */
+function extractJson(output: string | null): Record<string, unknown> | null {
+  if (!output) return null;
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < 0 || end < start) return null;
+  try {
+    return JSON.parse(output.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "scheduled-compliance-audit",
+  entry: "collect",
+  steps: { collect, audit, review, onSignoff, archive, rejected },
+});

--- a/examples/scheduled-compliance-audit/package.json
+++ b/examples/scheduled-compliance-audit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-scheduled-compliance-audit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a cron cadence, collect resource/config state (web.scrape), run an LLM policy check (models.run), pause for human sign-off, then archive the signed attestation (fileStorage).",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.0",
+    "@sapiom/tools": "^0.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/scheduled-compliance-audit/template.json
+++ b/examples/scheduled-compliance-audit/template.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "You point it at the resources that prove you're compliant — a config page, a status endpoint, a published policy doc — and give it the policy to hold them to. On each tick it reads the current state of each resource, hands that state and your policy to an LLM (`models.run`), and gets back a structured report: an overall verdict, plus one check per requirement with the evidence it relied on and a fix for anything that failed.\n\nThen it stops and waits for a person. The run pauses on a sign-off signal, costing nothing while idle, and only an explicit approval moves it forward. That gate is the point: an attestation is a record that a human reviewed and signed off, so it is never filed automatically. Approve, and it writes the signed attestation — verdict, checks, sources, signer, and timestamp — to durable file storage and hands back a download link. Decline, and the findings come back but nothing is archived.\n\nCollection fails routinely on auth walls and dead endpoints — when a resource won't load, the auditor sees it as missing evidence and marks that requirement unknown rather than the run aborting. A `dryRun` flag computes the whole attestation and returns it as a preview without archiving anything.\n\nYou pay for the scrapes, the model reasoning, and the one attestation upload on each run — the waiting is free, and a dry run costs only the collect and the check it still performs.",
+  "useCases": [
+    "Run a recurring policy audit — SOC 2, an internal security baseline, a data-retention rule — and keep a signed record each time.",
+    "Require a human sign-off before an attestation is filed, so no compliance record is ever created without a real review.",
+    "Archive every audit's signed attestation to durable storage, building an evidence trail you can hand an auditor later."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it `resources` (the config/status/policy URLs to audit) and a `policy` (the rules to hold them to). Set the `schedule` cron cadence, and optionally a `framework` label and `signOffBy` address, both recorded in the attestation. This template **pauses for a human sign-off**: a real run stops after the policy check and waits. Resume it by firing the `attestation.signoff` signal with `{ \"decision\": \"approve\" }` (today via the MCP `workflow_signal` tool / the API — there is no one-click sign-off button yet); the `correlationId` is the paused run's `executionId`. Only an explicit approval archives the attestation — anything else returns the findings without filing anything. Pass `dryRun: true` to compute the attestation and get it back without archiving.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole collect → audit → sign-off → archive flow for free (capabilities stubbed, the pause auto-resumed, the archive skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A weekly SOC 2 access-control audit (dry-run preview)",
+      "input": {
+        "resources": [
+          {
+            "id": "api-config",
+            "url": "https://example.com/.well-known/security.txt",
+            "label": "API security policy"
+          }
+        ],
+        "policy": "Every service must publish a security contact and enforce TLS 1.2+.",
+        "schedule": "0 6 * * 1",
+        "framework": "SOC 2 CC6",
+        "signOffBy": "compliance@example.com",
+        "dryRun": true
+      },
+      "output": {
+        "archived": false,
+        "dryRun": true,
+        "status": "needs_review",
+        "framework": "SOC 2 CC6",
+        "signer": "compliance@example.com",
+        "signedAt": "2026-01-05T06:00:12.000Z",
+        "fileName": "attestation-2026-01-05.md",
+        "attestation": "# Compliance Attestation — SOC 2 CC6\n\n- **Overall status:** needs_review\n- **Audited at:** 2026-01-05T06:00:00.000Z\n- **Cadence:** 0 6 * * 1\n- **Resources audited:** 1\n\n## Summary\nA security contact is published, but TLS version enforcement could not be confirmed from the collected state.\n\n## Checks\n- [✓] A security contact is published — pass: security.txt lists a Contact field.\n- [?] TLS 1.2+ is enforced — unknown: the collected page does not state the TLS policy.\n\n## Sign-off\n- **Decision:** approved\n- **Signed by:** compliance@example.com\n- **Signed at:** 2026-01-05T06:00:12.000Z\n\n## Sources\n- API security policy (https://example.com/.well-known/security.txt)",
+        "fileId": null,
+        "downloadUrl": null
+      }
+    }
+  ]
+}

--- a/examples/scheduled-compliance-audit/tsconfig.json
+++ b/examples/scheduled-compliance-audit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/scheduled-db-insight-report/.gitignore
+++ b/examples/scheduled-db-insight-report/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/examples/scheduled-db-insight-report/AGENTS.md
+++ b/examples/scheduled-db-insight-report/AGENTS.md
@@ -1,0 +1,45 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Scheduled DB
+Snapshot to Insight Report** — authored against `@sapiom/agent`. It has four steps:
+`snapshot` (queries a database) → `narrate` (calls `models.run`, the live LLM) →
+`chart` (renders an SVG in a sandbox and hosts it in file storage) → `deliver`
+(emails the report). Inside a step's `run`, Sapiom capabilities are pre-auth'd on
+`ctx.sapiom` (e.g. `ctx.sapiom.database.get(...)`, `ctx.sapiom.models.run(...)`,
+`ctx.sapiom.sandboxes.create(...)`, `ctx.sapiom.fileStorage.upload(...)`,
+`ctx.sapiom.email.messages.send(...)`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
+- **Keep the edges slim.** The rendered SVG is the only large data here; it is read, hosted, and dropped inside `chart` — only its URL crosses to `deliver`. It never enters `ctx.shared`. Large shared state stalls transitions on the cloud engine.
+- **Gate real side effects behind `dryRun`.** The real SQL query runs only on a live run; a dry run reports on `SAMPLE_METRICS` so the graph traces without a database. `deliver` sends email only on a live run with a recipient resolved; otherwise it returns the report as a preview. Keep new external side effects behind the same guard.
+- **Read secrets/config at runtime, never persist them.** The recipient and an optional external `DATABASE_URL` are read from the vault (`ctx.sapiom.vault.get("scheduled-db-insight-report", ...)`) at the point of use, not carried through `ctx.shared`.
+- **The chart renderer is self-contained on purpose.** `CHART_SCRIPT` is a dependency-free Node script written into the sandbox and run with `node` — no `npm install`, so it's fast and can't fail on a dependency. Swap it for a charting library (Chart.js, Vega, matplotlib) if you want richer output, and add the install to the sandbox command.
+
+## Validating
+
+When you've made a coherent change and want to validate it — the same point you'd
+run tests in any project — reach for the local suite. You don't need to run it
+after every small edit.
+
+- **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
+- **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
+- **run_local** — runs your **real** step code against **stub capabilities**, so the database, `models.run`, the sandbox, and file storage return built-in defaults and the agent runs end-to-end offline for free. Pass `dryRun: true` so `snapshot` uses sample metrics and `deliver` skips the (stubbed) send. Returns a per-step trace.
+- **deploy**, then **run** — ship it, then perform a real, billed snapshot + LLM narration + sandbox chart render, and deliver the report. Attach the `schedule` as a cron trigger to run it on a cadence.
+
+> Write each step the way it should run in production. `run_local` adapts to your
+> code (stub capabilities), not the other way around — never weaken or drop real
+> logic to shape a local run. The stubbed sandbox returns an empty file read, so
+> `chart` degrades to a chart-less report locally — that is expected, not a bug.
+
+Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev
+tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
+
+## Determinism
+
+A step body runs **once** on the happy path; it re-runs only on retry (after a
+throw). The snapshot timestamp is captured once server-side via Postgres `now()`
+and passed forward via `ctx.shared`, rather than recomputed per step. Capture other
+non-deterministic values (ids, timestamps) the same way.

--- a/examples/scheduled-db-insight-report/README.md
+++ b/examples/scheduled-db-insight-report/README.md
@@ -1,0 +1,67 @@
+# Scheduled DB Snapshot to Insight Report
+
+On a cron cadence, snapshot a database, write the narrative with an LLM, render
+the numbers into charts in a sandbox, and email the finished report.
+
+## What it does
+
+```
+snapshot  ──▶  narrate  ──▶  chart  ──▶  deliver  (terminal)
+(database)    (models.run)   (sandbox +   (email)
+                             fileStorage)
+```
+
+1. **snapshot** — runs a set of read-only SQL queries against a Postgres database
+   (`ctx.sapiom.database`) and normalizes each result into a metric: a labeled
+   series or a scalar KPI. The defaults introspect the database's own catalog
+   (rows per table, table count, size), so it works on any database with no setup.
+2. **narrate** — hands the metrics to an LLM (`ctx.sapiom.models.run` — the live
+   x402-served model) to write a short markdown report: a summary, bullet insights
+   that cite the numbers, and a line on what to watch.
+3. **chart** — spins up a sandbox (`ctx.sapiom.sandboxes`), renders the series into
+   an SVG bar chart with a tiny dependency-free script, uploads it to file storage
+   (`ctx.sapiom.fileStorage`), and takes a shareable download URL. The sandbox is
+   torn down when the step ends; the SVG never enters shared state.
+4. **deliver** — emails the report (narrative + chart link + a metrics table). A
+   `dryRun` guard reports on sample metrics and skips the real send; the recipient
+   is read from the Sapiom vault at runtime, never persisted.
+
+Input: `{ "schedule": "0 8 * * *", "deliverTo": "you@example.com" }`.
+
+- `queries` — an array of `{ name, sql }` to snapshot; each query returns `label`
+  and `value` columns. Omit it to introspect the database catalog.
+- `dbHandle` — the Sapiom Postgres to snapshot (get-or-created). To report on an
+  external database instead, store its connection string under the
+  `scheduled-db-insight-report` vault ref (key `DATABASE_URL`).
+- `deliverTo` sets the recipient; omit it to use the vault-configured default
+  (`RECIPIENT`).
+- `dryRun: true` reports on sample metrics and returns the report without emailing.
+
+## Run it with Claude + the Sapiom MCP
+
+1. Add the MCP:
+
+   ```bash
+   claude mcp add sapiom -- npx -y @sapiom/mcp
+   ```
+
+2. In your client, authenticate: run `sapiom_authenticate`, then confirm with
+   `sapiom_status`. Your agent becomes an API-key principal; each step inherits
+   that authority to call its metered capability.
+
+3. From this directory: `npm install`, then drive the lifecycle via the MCP —
+   `sapiom_dev_agents_check` → `sapiom_dev_agents_run_local` (capabilities stubbed;
+   pass `dryRun: true` to report on sample metrics and skip delivery, free) →
+   `sapiom_dev_agents_link` → `sapiom_dev_agents_deploy` → `sapiom_dev_agents_run`
+   (a real, billed snapshot + LLM narration + sandbox chart render, and a
+   delivered report).
+
+4. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed
+   agent.
+
+## Files
+
+- `index.ts` — the agent (edit this).
+- `package.json` / `tsconfig.json` — pinned SDK deps and typecheck config.
+
+Run `npm run typecheck` to confirm it compiles.

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -1,0 +1,575 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+import postgres from "postgres";
+
+/**
+ * Scheduled DB Snapshot to Insight Report — on a cron cadence, take a snapshot of
+ * a database, have an LLM write the narrative, render the numbers into charts in a
+ * sandbox, and email the finished report.
+ *
+ * In one legible graph:
+ *   snapshot (database) ──▶ narrate (models.run) ──▶ chart (sandbox + fileStorage) ──▶ deliver (email)
+ *
+ *   - **snapshot** runs a set of read-only SQL queries against a Postgres database
+ *     and normalizes each result into a metric — a labeled series (for a bar chart)
+ *     or a single scalar (a KPI). The default queries introspect the database's own
+ *     catalog (rows per table, table count, database size), so it produces a real
+ *     snapshot on any database with zero configuration; pass your own `queries` to
+ *     report on your actual data.
+ *   - **narrate** hands those metrics to an LLM (`ctx.sapiom.models.run` — the live
+ *     x402-served model, not a hardcoded formatter) to write a short markdown
+ *     insight report: an executive summary, a few bullet insights that cite the
+ *     numbers, and a line on what to watch.
+ *   - **chart** spins up a sandbox, writes a tiny dependency-free Node renderer plus
+ *     the metrics as JSON, runs it to produce an SVG bar chart, then uploads that
+ *     SVG to file storage and takes a shareable download URL. The sandbox is torn
+ *     down when the step ends. The rendered SVG is the only large payload here — it
+ *     dies at the chart boundary; only the URL crosses into the report.
+ *   - **deliver** assembles the report (narrative + chart link + a compact metrics
+ *     table) and emails it. A `dryRun` (or a run with no recipient) returns the
+ *     report as a preview without sending, so `run_local` traces the whole graph
+ *     for free (capabilities stubbed, the real DB query and the send skipped).
+ *
+ * Side-effect discipline (copied from `error-triage-digest` / `scheduled-research-brief`):
+ *   - The real SQL is gated behind `dryRun`: a dry run reports on sample metrics so
+ *     the graph traces offline without connecting to a database.
+ *   - The recipient — and an optional external database URL — are read from the
+ *     Sapiom vault at runtime and never persisted in execution state.
+ *   - Non-deterministic values (the snapshot timestamp) are captured once at the DB
+ *     boundary via Postgres `now()`, not recomputed per step.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Postgres handle the report reads from — created on first run, reused after. */
+const DEFAULT_DB_HANDLE = "scheduled-db-insight-report";
+/** Vault ref holding delivery + connection config. Read at runtime. */
+const VAULT_REF = "scheduled-db-insight-report";
+/** Username for the inbox we send from (created once, then reused). */
+const SENDER_USERNAME = "db-insight-report";
+/** Default cadence documented for the cron trigger: 08:00 every day. */
+const DEFAULT_SCHEDULE = "0 8 * * *";
+/** Cap the queries a single run will execute — bounds cost + latency. */
+const MAX_QUERIES = 12;
+/** Cap the rows charted per series — a bar chart past this is unreadable anyway. */
+const MAX_POINTS = 12;
+/** Per-query statement timeout so one slow query can't stall the run. */
+const STATEMENT_TIMEOUT_MS = 15_000;
+
+/**
+ * Default queries: catalog introspection that works on ANY Postgres database and
+ * needs no knowledge of the schema. Override with your own `queries` to report on
+ * real data. Each query returns `label` / `value` columns (a single `value` row is
+ * read as a scalar KPI).
+ */
+const DEFAULT_QUERIES: MetricQuery[] = [
+  {
+    name: "Rows per table (top 10)",
+    sql: `select relname as label, n_live_tup as value
+            from pg_stat_user_tables
+            order by n_live_tup desc
+            limit 10`,
+  },
+  {
+    name: "User tables",
+    sql: `select count(*)::int as value from pg_stat_user_tables`,
+  },
+  {
+    name: "Database size (MB)",
+    sql: `select round(pg_database_size(current_database()) / 1048576.0, 2) as value`,
+  },
+];
+
+/** Sample metrics used on a dry run so the graph traces without a real database. */
+const SAMPLE_METRICS: Metric[] = [
+  {
+    name: "Rows per table (top 10)",
+    kind: "series",
+    points: [
+      { label: "events", value: 81_300 },
+      { label: "users", value: 12_840 },
+      { label: "orders", value: 9_420 },
+      { label: "sessions", value: 6_110 },
+      { label: "invoices", value: 2_305 },
+    ],
+  },
+  { name: "User tables", kind: "scalar", value: 14 },
+  { name: "Database size (MB)", kind: "scalar", value: 48.2 },
+];
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+/** A named read-only query. `sql` should return `label` / `value` columns. */
+interface MetricQuery {
+  name: string;
+  sql: string;
+}
+
+interface EntryInput {
+  /** Queries to snapshot; defaults to catalog introspection when omitted. */
+  queries?: MetricQuery[];
+  /** Cron cadence this report is meant to run on (documentation only). */
+  schedule?: string;
+  /** Postgres handle to snapshot; defaults to the template handle. */
+  dbHandle?: string;
+  /** Recipient email; falls back to the vault-configured default when omitted. */
+  deliverTo?: string;
+  /** Report on sample metrics and skip the DB query and the real send. */
+  dryRun?: boolean;
+}
+
+/** A metric: either a labeled series (charted) or a single scalar (a KPI). */
+type Metric =
+  | {
+      name: string;
+      kind: "series";
+      points: Array<{ label: string; value: number }>;
+    }
+  | { name: string; kind: "scalar"; value: number };
+
+interface Shared extends Record<string, unknown> {
+  dbHandle: string;
+  schedule: string;
+  deliverTo: string | null;
+  dryRun: boolean;
+  generatedAt: string;
+  narrative: string;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+type Sql = ReturnType<typeof postgres>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+function truthy(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+/** Coerce a pg value to a finite number, defaulting to 0. */
+function num(v: unknown): number {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Bound + validate the caller's queries; fall back to the defaults. */
+function resolveQueries(raw: unknown): MetricQuery[] {
+  if (!Array.isArray(raw)) return DEFAULT_QUERIES;
+  const queries = raw
+    .filter((q): q is MetricQuery => Boolean(q) && typeof q === "object")
+    .map((q) => ({
+      name: String((q as MetricQuery).name ?? "").trim() || "Metric",
+      sql: String((q as MetricQuery).sql ?? "").trim(),
+    }))
+    .filter((q) => q.sql.length > 0)
+    .slice(0, MAX_QUERIES);
+  return queries.length > 0 ? queries : DEFAULT_QUERIES;
+}
+
+/**
+ * Normalize a query result into a metric. A single row with only a `value` column
+ * is a scalar KPI; anything else is a labeled series (first/`label` column as the
+ * label, `value`/second column as the number).
+ */
+function toMetric(name: string, rows: Record<string, unknown>[]): Metric {
+  if (rows.length === 0) return { name, kind: "series", points: [] };
+  const cols = Object.keys(rows[0]);
+  const labelCol = cols.find((c) => c.toLowerCase() === "label") ?? cols[0];
+  const valueCol =
+    cols.find((c) => c.toLowerCase() === "value") ??
+    cols.find((c) => c !== labelCol) ??
+    cols[0];
+
+  if (rows.length === 1 && (cols.length === 1 || labelCol === valueCol)) {
+    return { name, kind: "scalar", value: num(rows[0][valueCol]) };
+  }
+  const points = rows.slice(0, MAX_POINTS).map((row) => ({
+    label: String(row[labelCol] ?? ""),
+    value: num(row[valueCol]),
+  }));
+  return { name, kind: "series", points };
+}
+
+/**
+ * Resolve the connection string at runtime. An external `DATABASE_URL` in the
+ * vault wins (report on your own database, secret never persisted); otherwise a
+ * Sapiom-managed Postgres is looked up by handle, provisioned on first run.
+ */
+async function resolveConnectionString(
+  ctx: Ctx,
+  handle: string,
+): Promise<string | null> {
+  try {
+    const external = await ctx.sapiom.vault.get(VAULT_REF, "DATABASE_URL");
+    if (external) return external;
+  } catch (err) {
+    ctx.logger.warn("vault: no DATABASE_URL configured", { err: String(err) });
+  }
+  let db;
+  try {
+    db = await ctx.sapiom.database.get(handle);
+  } catch {
+    db = await ctx.sapiom.database.create({
+      handle,
+      duration: "7d",
+      name: "DB Insight Report",
+      description: "Database the scheduled insight report snapshots",
+    });
+  }
+  return db.connection?.connectionString ?? null;
+}
+
+/**
+ * Resolve the recipient from the vault at runtime. A missing ref/key is an
+ * expected outcome (returns null), not an error — the caller then falls back to a
+ * preview. Never persisted in execution state.
+ */
+async function recipientFromVault(ctx: Ctx): Promise<string | null> {
+  try {
+    return await ctx.sapiom.vault.get(VAULT_REF, "RECIPIENT");
+  } catch (err) {
+    ctx.logger.warn("vault: no recipient configured", { err: String(err) });
+    return null;
+  }
+}
+
+/** Reuse an existing inbox to send from, else provision one. */
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  const inbox = await ctx.sapiom.email.inboxes.create({
+    username: SENDER_USERNAME,
+    displayName: "DB Insight Report",
+  });
+  return inbox.inboxId;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const snapshot = defineStep({
+  name: "snapshot",
+  next: ["narrate"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const dryRun = truthy(input.dryRun);
+    const handle = input.dbHandle?.trim() || DEFAULT_DB_HANDLE;
+    ctx.shared.set("dbHandle", handle);
+    ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
+    ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
+    ctx.shared.set("dryRun", dryRun);
+
+    // Dry run (and run_local's stubbed DB): report on sample metrics so the graph
+    // traces end to end without connecting to a real database.
+    if (dryRun) {
+      ctx.shared.set("generatedAt", "2099-01-01T00:00:00.000Z");
+      ctx.logger.info("dry run — using sample metrics");
+      return goto("narrate", { metrics: SAMPLE_METRICS });
+    }
+
+    const queries = resolveQueries(input.queries);
+    const conn = await resolveConnectionString(ctx, handle);
+    if (!conn) {
+      ctx.logger.warn("no database connection; snapshotting nothing", {
+        handle,
+      });
+      ctx.shared.set("generatedAt", "");
+      return goto("narrate", { metrics: [] as Metric[] });
+    }
+
+    const sql = postgres(conn, {
+      ssl: "require",
+      max: 1,
+      idle_timeout: 5,
+      connect_timeout: 10,
+      // Bound every query on this connection so one slow statement can't stall
+      // the run.
+      connection: { statement_timeout: STATEMENT_TIMEOUT_MS },
+    });
+    const metrics: Metric[] = [];
+    try {
+      // Capture the snapshot time server-side so it stays deterministic on retry.
+      const nowRow = await sql<{ now: unknown }[]>`select now() as now`;
+      ctx.shared.set(
+        "generatedAt",
+        nowRow[0]?.now instanceof Date
+          ? (nowRow[0].now as Date).toISOString()
+          : String(nowRow[0]?.now ?? ""),
+      );
+
+      for (const q of queries) {
+        try {
+          const rows = await sql.unsafe(q.sql);
+          metrics.push(
+            toMetric(q.name, rows as unknown as Record<string, unknown>[]),
+          );
+        } catch (err) {
+          // A failing query (bad SQL, missing table) degrades per-item — the
+          // report still goes out with the metrics that succeeded.
+          ctx.logger.warn("query failed; skipping", {
+            name: q.name,
+            err: String(err),
+          });
+        }
+      }
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+
+    ctx.logger.info("snapshot complete", { metrics: metrics.length });
+    return goto("narrate", { metrics });
+  },
+});
+
+const narrate = defineStep({
+  name: "narrate",
+  next: ["chart"],
+  async run(input: { metrics: Metric[] }, ctx: Ctx) {
+    const metrics = Array.isArray(input?.metrics) ? input.metrics : [];
+
+    let narrative: string;
+    if (metrics.length === 0) {
+      narrative =
+        "# Database insight report\n\n_No metrics were collected for this snapshot._";
+    } else {
+      const rendered = metrics
+        .map((m) =>
+          m.kind === "scalar"
+            ? `${m.name}: ${m.value}`
+            : `${m.name}:\n${m.points
+                .map((p) => `  - ${p.label}: ${p.value}`)
+                .join("\n")}`,
+        )
+        .join("\n");
+      // The live, x402-served model writes the narrative from the numbers.
+      const res = await ctx.sapiom.models.run({
+        system:
+          "You are a data analyst writing a short insight report from a database " +
+          "snapshot. Given a set of METRICS (named series of label/value pairs, and " +
+          "scalar KPIs), write markdown with: a 2-3 sentence executive summary, then " +
+          "3-5 bullet insights that each cite the actual numbers, then a one-line " +
+          "'What to watch'. Be concrete and quantitative. Do not invent metrics that " +
+          "aren't given. Output ONLY the markdown report — no preamble, no code fences.",
+        prompt: `METRICS:\n${rendered}`,
+        maxTokens: 700,
+      });
+      narrative =
+        (res.output ?? "").trim() ||
+        "# Database insight report\n\n_The model returned no content._";
+    }
+
+    ctx.logger.info("narrated report", { chars: narrative.length });
+    // Metrics continue to `chart`; the narrative rides in shared for `deliver`.
+    ctx.shared.set("narrative", narrative);
+    return goto("chart", { metrics });
+  },
+});
+
+/**
+ * A tiny, dependency-free SVG bar-chart renderer, run inside the sandbox. Reads a
+ * `{ charts: [{ title, points: [{ label, value }] }] }` JSON file and writes a
+ * single SVG stacking one bar chart per series. Kept self-contained on purpose —
+ * no npm install, so the render is fast and can't fail on a dependency.
+ */
+const CHART_SCRIPT = `import { readFileSync, writeFileSync } from "node:fs";
+const [, , dataPath, outPath] = process.argv;
+const { charts } = JSON.parse(readFileSync(dataPath, "utf8"));
+const W = 760, pad = 32, barH = 22, gap = 10, titleH = 34, labelW = 190;
+const esc = (s) =>
+  String(s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const blocks = [];
+let y = 0;
+for (const chart of charts) {
+  const pts = (chart.points || []).slice(0, 12);
+  const max = Math.max(1, ...pts.map((p) => Number(p.value) || 0));
+  const rows = pts
+    .map((p, i) => {
+      const bw = Math.round(((Number(p.value) || 0) / max) * (W - pad * 2 - labelW - 60));
+      const by = titleH + i * (barH + gap);
+      return (
+        \`<text x="0" y="\${by + 15}" font-size="12" fill="#334155">\${esc(p.label).slice(0, 26)}</text>\` +
+        \`<rect x="\${labelW}" y="\${by}" width="\${bw}" height="\${barH}" rx="3" fill="#4f46e5"/>\` +
+        \`<text x="\${labelW + bw + 8}" y="\${by + 15}" font-size="12" fill="#334155">\${esc(p.value)}</text>\`
+      );
+    })
+    .join("");
+  const h = titleH + pts.length * (barH + gap) + gap;
+  blocks.push(
+    \`<g transform="translate(\${pad},\${y + pad})"><text x="0" y="18" font-size="16" font-weight="600" fill="#0f172a">\${esc(chart.title)}</text>\${rows}</g>\`,
+  );
+  y += h + pad;
+}
+const height = Math.max(y + pad, 80);
+const svg =
+  \`<svg xmlns="http://www.w3.org/2000/svg" width="\${W}" height="\${height}" viewBox="0 0 \${W} \${height}" font-family="system-ui,-apple-system,sans-serif">\` +
+  \`<rect width="100%" height="100%" fill="#ffffff"/>\${blocks.join("")}</svg>\`;
+writeFileSync(outPath, svg);
+process.stdout.write(String(svg.length));
+`;
+
+const chart = defineStep({
+  name: "chart",
+  next: ["deliver"],
+  async run(input: { metrics: Metric[] }, ctx: Ctx) {
+    const metrics = Array.isArray(input?.metrics) ? input.metrics : [];
+    const charts = metrics
+      .filter(
+        (m): m is Extract<Metric, { kind: "series" }> =>
+          m.kind === "series" && m.points.length > 0,
+      )
+      .map((m) => ({ title: m.name, points: m.points }));
+
+    // Nothing chartable — hand the report on without a chart.
+    if (charts.length === 0) {
+      ctx.logger.info("no series metrics; skipping chart render");
+      return goto("deliver", { chartUrl: null, metrics });
+    }
+
+    const sandboxName = `db-insight-${ctx.executionId}`;
+    let chartUrl: string | null = null;
+    let box: Awaited<ReturnType<typeof ctx.sapiom.sandboxes.create>> | null =
+      null;
+    try {
+      box = await ctx.sapiom.sandboxes.create({
+        name: sandboxName,
+        ttl: "15m",
+      });
+      await box.writeFile("render.mjs", CHART_SCRIPT);
+      await box.writeFile("data.json", JSON.stringify({ charts }));
+
+      const res = await box.exec("node render.mjs data.json chart.svg");
+      if (res.exitCode !== 0) {
+        throw new Error(`renderer exited ${res.exitCode}: ${res.stderr}`);
+      }
+
+      const svg = await box.readFile("chart.svg");
+      // An empty read is the stubbed (`run_local`) path — no bytes to host.
+      if (svg.trim().length > 0) {
+        const bytes = new TextEncoder().encode(svg);
+        const up = await ctx.sapiom.fileStorage.upload({
+          contentType: "image/svg+xml",
+          fileName: `${sandboxName}.svg`,
+          fileSize: bytes.byteLength,
+          visibility: "public",
+        });
+        await fetch(up.uploadUrl, {
+          method: "PUT",
+          headers: up.requiredHeaders,
+          body: bytes,
+        });
+        const dl = await ctx.sapiom.fileStorage.getDownloadUrl(up.fileId);
+        chartUrl = dl.downloadUrl;
+        ctx.logger.info("chart rendered + hosted", {
+          fileId: up.fileId,
+          bytes: bytes.byteLength,
+        });
+      }
+    } catch (err) {
+      // A render/upload failure degrades to a chart-less report rather than
+      // aborting the run — the narrative and metrics table still go out.
+      ctx.logger.warn("chart render failed; continuing without a chart", {
+        err: String(err),
+      });
+    } finally {
+      if (box) await box.destroy().catch(() => {});
+    }
+
+    return goto("deliver", { chartUrl, metrics });
+  },
+});
+
+const deliver = defineStep({
+  name: "deliver",
+  next: [],
+  terminal: true,
+  async run(input: { chartUrl: string | null; metrics: Metric[] }, ctx: Ctx) {
+    const metrics = Array.isArray(input?.metrics) ? input.metrics : [];
+    const chartUrl = input?.chartUrl ?? null;
+    const narrative = ctx.shared.get("narrative") || "";
+    const generatedAt = ctx.shared.get("generatedAt") || "";
+    const schedule = ctx.shared.get("schedule") || DEFAULT_SCHEDULE;
+    const dryRun = ctx.shared.get("dryRun") ?? true;
+
+    const report = renderReport(narrative, metrics, chartUrl, generatedAt);
+    const subject = "Database insight report";
+
+    // Explicit input wins; otherwise resolve the default from the vault at
+    // runtime (never carried through state).
+    const deliverTo =
+      ctx.shared.get("deliverTo") || (await recipientFromVault(ctx));
+
+    // Safe path: a dry run, or a live run with no recipient, returns the report
+    // without sending anything.
+    if (dryRun || !deliverTo) {
+      ctx.logger.info("skipping delivery", {
+        dryRun,
+        hasRecipient: Boolean(deliverTo),
+      });
+      return terminate({
+        delivered: false,
+        dryRun,
+        reason: dryRun ? "dry-run" : "no-recipient",
+        to: deliverTo ?? null,
+        subject,
+        schedule,
+        generatedAt,
+        chartUrl,
+        metricCount: metrics.length,
+        report,
+      });
+    }
+
+    const inboxId = await resolveSenderInbox(ctx);
+    const sent = await ctx.sapiom.email.messages.send(inboxId, {
+      to: deliverTo,
+      subject,
+      text: report,
+    });
+    ctx.logger.info("report delivered", {
+      to: deliverTo,
+      messageId: sent.messageId,
+    });
+    return terminate({
+      delivered: true,
+      dryRun: false,
+      to: deliverTo,
+      subject,
+      schedule,
+      generatedAt,
+      chartUrl,
+      metricCount: metrics.length,
+      messageId: sent.messageId,
+    });
+  },
+});
+
+// ─────────────────────────────────────────────────────────────── render ──
+/** Assemble the emailed report: narrative, chart link, and a metrics appendix. */
+function renderReport(
+  narrative: string,
+  metrics: Metric[],
+  chartUrl: string | null,
+  generatedAt: string,
+): string {
+  const parts = [narrative.trim()];
+  if (generatedAt) parts.push(`\n_Snapshot taken ${generatedAt}._`);
+  if (chartUrl) parts.push(`\n## Chart\n\n[View chart](${chartUrl})`);
+
+  if (metrics.length > 0) {
+    const lines = ["\n## Metrics"];
+    for (const m of metrics) {
+      if (m.kind === "scalar") {
+        lines.push(`- **${m.name}:** ${m.value}`);
+      } else if (m.points.length > 0) {
+        lines.push(`- **${m.name}:**`);
+        for (const p of m.points) lines.push(`  - ${p.label}: ${p.value}`);
+      }
+    }
+    parts.push(lines.join("\n"));
+  }
+  return parts.join("\n");
+}
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "scheduled-db-insight-report",
+  entry: "snapshot",
+  steps: { snapshot, narrate, chart, deliver },
+});

--- a/examples/scheduled-db-insight-report/package.json
+++ b/examples/scheduled-db-insight-report/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sapiom/example-scheduled-db-insight-report",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: on a cron cadence, snapshot a database, write the narrative with an LLM (models.run), render charts in a sandbox, host them in file storage, and email the insight report.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.6.5",
+    "@sapiom/tools": "^0.20.0",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/scheduled-db-insight-report/template.json
+++ b/examples/scheduled-db-insight-report/template.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "longDescription": "On a schedule, this queries a database, turns the numbers into a written report and a chart, and emails it — the standing \"metrics email\" you'd otherwise assemble by hand.\n\nThe graph is four steps: `snapshot` (database) runs a set of read-only SQL queries and turns each result into a metric — a labeled series or a single number. `narrate` (`models.run`, the live x402-served model) reads those numbers and writes a short markdown report: a summary, a few insights that cite the figures, and a line on what to watch. `chart` spins up a sandbox, renders the series into an SVG bar chart with a tiny dependency-free script, and hosts it in file storage so the report can link to it. `deliver` emails the whole thing.\n\nOut of the box it introspects the database's own catalog — rows per table, table count, database size — so it produces a real report on any database with no setup. Point it at your own data by passing `queries` (each returns `label` and `value` columns), and set an external database with a `DATABASE_URL` in the vault, read at runtime and never stored in the run. A `dryRun` reports on sample metrics and skips the send, so you can trace the whole flow for free.\n\nYou pay for the database snapshot, the model that writes the narrative, and the sandbox that renders the chart, on each run — the email is cheap, and a dry run reports on sample data without touching a database.",
+  "useCases": [
+    "Wake up to a metrics email — a written summary plus a chart — pulled straight from your production database.",
+    "Turn a recurring \"how are the numbers looking?\" query into a scheduled report you never assemble by hand.",
+    "See how a database snapshot, LLM narration, sandbox chart rendering, and email delivery compose in one agent, with a safe dry-run path."
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nWith no config it reports on the database's own catalog (rows per table, size), so you get a real report immediately. To report on your own data, pass `queries` — an array of `{ name, sql }` where each query returns `label` and `value` columns (a single `value` row is read as a KPI). To point at an external database, store its connection string under the `scheduled-db-insight-report` vault ref (key `DATABASE_URL`); it's read at runtime, never saved into the run. Set who gets the email with `deliverTo`, or store a default under the same vault ref (key `RECIPIENT`). Pass `dryRun: true` to report on sample metrics and get the report back without sending. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed workflow.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole snapshot → narrate → chart → deliver flow for free (capabilities stubbed, the DB query and delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "examples": [
+    {
+      "title": "A daily catalog snapshot, previewed",
+      "input": {
+        "schedule": "0 8 * * *",
+        "dryRun": true
+      },
+      "output": {
+        "delivered": false,
+        "dryRun": true,
+        "reason": "dry-run",
+        "to": null,
+        "subject": "Database insight report",
+        "schedule": "0 8 * * *",
+        "generatedAt": "2099-01-01T00:00:00.000Z",
+        "chartUrl": null,
+        "metricCount": 3,
+        "report": "# Database insight report\n\nThe database holds roughly 112k rows across 14 user tables and occupies 48.2 MB. Activity is concentrated in `events`, which alone accounts for the large majority of stored rows.\n\n- `events` is by far the largest table at 81,300 rows [1]\n- `users` (12,840) and `orders` (9,420) are the next largest [1]\n- Total footprint is a modest 48.2 MB across 14 tables\n\n**What to watch:** growth in `events` relative to the rest.\n\n## Metrics\n- **Rows per table (top 10):**\n  - events: 81300\n  - users: 12840\n  - orders: 9420\n  - sessions: 6110\n  - invoices: 2305\n- **User tables:** 14\n- **Database size (MB):** 48.2"
+      }
+    },
+    {
+      "title": "A weekly report on your own data",
+      "input": {
+        "schedule": "0 9 * * 1",
+        "queries": [
+          {
+            "name": "Signups per day (last 7d)",
+            "sql": "select to_char(created_at::date, 'Dy') as label, count(*) as value from users where created_at > now() - interval '7 days' group by 1 order by min(created_at)"
+          },
+          {
+            "name": "Active subscriptions",
+            "sql": "select count(*) as value from subscriptions where status = 'active'"
+          }
+        ],
+        "deliverTo": "founders@example.com"
+      }
+    }
+  ]
+}

--- a/examples/scheduled-db-insight-report/tsconfig.json
+++ b/examples/scheduled-db-insight-report/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
Combines ten approved/ready example-template PRs into a single PR so they can land with **one review and one merge** instead of ten sequential `examples/registry.json` conflicts. Each template adds exactly one `examples/<slug>/` directory plus one `templates[]` entry in the registry — no other files are touched.

## Templates added (10)
| Template id | Directory | Supersedes | Ticket |
|---|---|---|---|
| `news-roundup` | `examples/news-roundup` | #402 | — |
| `dependency-upgrade` | `examples/dependency-upgrade` | #379 | SAP-1872 |
| `meeting-notes-crm` | `examples/meeting-notes-crm` | #378 | SAP-1859 |
| `approval-chain` | `examples/approval-chain` | #377 | SAP-1882 |
| `scheduled-db-insight-report` | `examples/scheduled-db-insight-report` | #376 | SAP-1877 |
| `newsletter-autopilot` | `examples/newsletter-autopilot` | #375 | SAP-1854 |
| `durable-backfill` | `examples/durable-backfill` | #374 | SAP-1886 |
| `nl-db-query-endpoint` | `examples/nl-db-query-endpoint` | #373 | SAP-1881 |
| `scheduled-compliance-audit` | `examples/scheduled-compliance-audit` | #372 | SAP-1878 |
| `error-triage-digest` | `examples/error-triage-digest` | #370 | SAP-1883 |

Each directory is copied verbatim from its source PR head; the registry entries are the source PRs' entries appended to main's current `templates[]` (a pure addition, no reformatting of existing content).

## Note on CI
`playwright-mock` is currently **red on `main` itself** (pre-existing `canvas-inspector.spec.ts` regression from the Harness Studio release #404) — unrelated to these template-only changes. The template-relevant checks (`test 20.x/22.x`, `Analyze`, `CodeQL`) are what matter here.

## Related
Supersedes: #402, #379, #378, #377, #376, #375, #374, #373, #372, #370

## Checklist
- [x] Each template adds one dir + one registry entry, nothing else
- [x] `registry.json` validates as JSON; all `sourcePath`s resolve
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)