### PR TITLE
fix(harness): stabilize canvas-inspector resize e2e on CI viewport

### DIFF
--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -141,6 +141,12 @@ test("the panel hugs its content up to half the pane; taller content scrolls ins
 test("dragging the top edge resizes the panel and persists; double-click resets to auto", async ({
   page,
 }) => {
+  // This panel is capped at half the canvas pane. CI's default (short)
+  // viewport can leave the panel's natural height within a few px of that
+  // cap, so an 80px drag can't grow it past the +40 threshold below. Give
+  // this test a tall viewport so the resize has real headroom.
+  await page.setViewportSize({ width: 1280, height: 1024 });
+
   const panel = page.getByTestId("canvas-overview");
   const handle = page.getByTestId("canvas-overview-resize");
   await expect(handle).toHaveAttribute("role", "separator");


### PR DESCRIPTION
## Summary
`main` has been red on `playwright-mock` since the Harness Studio release (#404): the test `web/e2e/canvas-inspector.spec.ts` → "dragging the top edge resizes the panel" fails in CI (`304` vs expected `>321`).

## Root cause
The overview panel is hard-capped at **half the canvas pane** (`CanvasOverviewPanel.capHeight`). The test drags the top edge up 80px and asserts the panel grew by `>40px`. On CI's default short "Desktop Chrome" viewport (720px tall), the pane is small enough that the cap sits only ~20px above the panel's natural height — so the drag physically cannot grow it 40px, and the assertion fails. The resize itself works; the test just has no room at that viewport.

## Fix
Pin a tall viewport (`1280×1024`) for this one test so an 80px drag has real headroom, **preserving** the `+40` assertion rather than weakening it. Test-only change — no product code touched.

This PR's own `playwright-mock` run going green is the proof of the fix. Once merged, `main` (and the batched-templates PR #408) return to green on this check.

## Testing
- [x] Test-only change; `playwright-mock` on this PR exercises the fix directly

## Checklist
- [x] No product behavior changed
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)