### PR TITLE
feat(tools): repoint video verbs to /v1 content.generation.video (SAP-1927)

### DIFF
--- a/packages/tools/src/_client/capability-call.ts
+++ b/packages/tools/src/_client/capability-call.ts
@@ -54,6 +54,14 @@ export interface CapabilityCallOptions {
   makeError: (message: string, status: number, body: unknown) => Error;
   /** Human-readable prefix for the thrown error's message. */
   errorPrefix: string;
+  /**
+   * Extra request headers merged into the routed call (over `content-type`, under
+   * the credential/attribution the Transport injects). An async-dispatch launch
+   * uses this to carry `x-sapiom-workflow-token` so the router forwards the resume
+   * token to the gateway and a paused workflow step still resumes (SAP-1927).
+   * Omit for the common case.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -75,7 +83,7 @@ export async function capabilityCall<Res>(
     `${baseUrl}/v1/capabilities/${id}`,
     {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...opts.headers },
       body: JSON.stringify(req),
     },
     { authHeader: "x-api-key" },

--- a/packages/tools/src/content-generation/errors.ts
+++ b/packages/tools/src/content-generation/errors.ts
@@ -14,26 +14,3 @@ export class ContentGenerationHttpError extends Error {
     this.body = body;
   }
 }
-
-/**
- * Return the response when 2xx, otherwise throw a {@link ContentGenerationHttpError}.
- * Parses the error body as JSON when possible; falls back to raw text.
- */
-export async function ensureOk(
-  response: Response,
-  errorPrefix: string,
-): Promise<Response> {
-  if (response.ok) return response;
-  let body: unknown;
-  const text = await response.text().catch(() => "");
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = text;
-  }
-  throw new ContentGenerationHttpError(
-    `${errorPrefix}: ${response.status} ${text}`,
-    response.status,
-    body,
-  );
-}

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -273,15 +273,15 @@ describe("createClient().contentGeneration.images.create", () => {
 // ---------------------------------------------------------------------------
 
 describe("contentGeneration.video.create()", () => {
-  it("submits the default video model, polls until ready, and maps the result to camelCase", async () => {
+  it("routes the submit to /v1, polls the returned handle until ready, and maps the result to camelCase", async () => {
     let polls = 0;
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-1",
-              response_url: `${BASE}/queue/fal-ai/veo3/requests/req-1`,
-              status_url: `${BASE}/queue/fal-ai/veo3/requests/req-1/status`,
+              requestId: "req-1",
+              responseUrl: `${BASE}/queue/fal-ai/veo3/requests/req-1`,
+              statusUrl: `${BASE}/queue/fal-ai/veo3/requests/req-1/status`,
             })
           : null,
       (c) => {
@@ -308,13 +308,17 @@ describe("contentGeneration.video.create()", () => {
       video: { url: "https://media/v.mp4", contentType: "video/mp4" },
       seed: 9,
     });
-    // submit: default model, prompt only (no provider named, no storage).
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
+    // submit: routed POST, x-api-key (the /v1 guard header, NOT gateway-direct
+    // x-sapiom-api-key), prompt only — model omitted so the router's adapter
+    // defaults it; no SDK-side /run/<model> URL building.
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/content.generation.video`);
     expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       prompt: "a wave",
     });
-    // polled the rewritten result URL until it carried output.
+    // polled the routed result URL the handle returned until it carried output.
     expect(
       calls.filter(
         (c) =>
@@ -324,13 +328,41 @@ describe("contentGeneration.video.create()", () => {
     ).toHaveLength(2);
   });
 
+  it("forwards an explicit model in the body and `params` as a nested field (adapter forwards it verbatim)", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ requestId: "req-mp", responseUrl: `${BASE}/queue/req-mp` })
+          : jsonResponse({ video: { url: "u" } }),
+    ]);
+
+    await createVideo(
+      {
+        prompt: "x",
+        model: "kling-standard",
+        params: { duration: 5, aspect_ratio: "16:9" },
+        pollIntervalMs: 1,
+      },
+      transport,
+      BASE,
+    );
+
+    // model rides in the body (the router adapter turns it into the provider path),
+    // and params is nested — NOT spread — so the adapter forwards it verbatim.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      model: "kling-standard",
+      params: { duration: 5, aspect_ratio: "16:9" },
+    });
+  });
+
   it("sends storage on submit and surfaces fileId + downloadUrl on the polled result", async () => {
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-2",
-              response_url: `${BASE}/queue/req-2`,
+              requestId: "req-2",
+              responseUrl: `${BASE}/queue/req-2`,
             })
           : null,
       (c) =>
@@ -371,8 +403,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-4",
-              response_url: `${BASE}/queue/req-4`,
+              requestId: "req-4",
+              responseUrl: `${BASE}/queue/req-4`,
             })
           : null,
       (c) =>
@@ -411,8 +443,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-3",
-              response_url: `${BASE}/queue/req-3`,
+              requestId: "req-3",
+              responseUrl: `${BASE}/queue/req-3`,
             })
           : null,
       (c) =>
@@ -436,8 +468,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-5",
-              response_url: `${BASE}/queue/req-5`,
+              requestId: "req-5",
+              responseUrl: `${BASE}/queue/req-5`,
             })
           : null,
       (c) => {
@@ -474,8 +506,8 @@ describe("createClient().contentGeneration.video.create", () => {
       calls.push({ url: String(input), init });
       if (init.method === "POST") {
         return jsonResponse({
-          request_id: "r",
-          response_url: "https://fal.services.sapiom.ai/queue/r",
+          requestId: "r",
+          responseUrl: "https://fal.services.sapiom.ai/queue/r",
         });
       }
       polls += 1;
@@ -492,10 +524,14 @@ describe("createClient().contentGeneration.video.create", () => {
     });
 
     expect(out.video?.fileId).toBe("f");
+    // Routed submit lands on the single Core base URL with x-api-key…
     expect(calls[0]!.url).toBe(
-      "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+      "https://api.sapiom.ai/v1/capabilities/content.generation.video",
     );
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    // …while the poll rides the returned handle URL with the gateway header.
+    expect(headerOf(calls[1]!, "x-sapiom-api-key")).toBe("client-key");
   });
 });
 
@@ -537,24 +573,25 @@ describe("contentGeneration.video.launch()", () => {
   it("submits to the right URL and method, returns a handle with requestId and dispatch", async () => {
     const { transport, calls } = makeLaunchTransport(
       {
-        request_id: "req-launch-1",
-        response_url: `${BASE}/queue/req-launch-1`,
+        requestId: "req-launch-1",
+        responseUrl: `${BASE}/queue/req-launch-1`,
       },
       { video: { url: "https://media/v.mp4" } },
     );
 
     const handle = await launchVideo({ prompt: "a wave" }, transport, BASE);
 
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/capabilities/content.generation.video`);
     expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
     expect(handle.requestId).toBe("req-launch-1");
   });
 
   it("dispatch.correlationId equals requestId and dispatch.resultSignal equals VIDEO_RESULT_SIGNAL", async () => {
     const { transport } = makeLaunchTransport(
       {
-        request_id: "req-dispatch",
-        response_url: `${BASE}/queue/req-dispatch`,
+        requestId: "req-dispatch",
+        responseUrl: `${BASE}/queue/req-dispatch`,
       },
       { video: { url: "https://media/v.mp4" } },
     );
@@ -571,7 +608,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("includes x-sapiom-workflow-token when transport.resumeToken is set", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-tok", response_url: `${BASE}/queue/req-tok` },
+      { requestId: "req-tok", responseUrl: `${BASE}/queue/req-tok` },
       { video: { url: "u" } },
       "tok-workflow-abc",
     );
@@ -585,7 +622,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("omits x-sapiom-workflow-token when resumeToken is not set", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-notok", response_url: `${BASE}/queue/req-notok` },
+      { requestId: "req-notok", responseUrl: `${BASE}/queue/req-notok` },
       { video: { url: "u" } },
     );
 
@@ -605,8 +642,8 @@ describe("contentGeneration.video.launch()", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "req-env",
-          response_url: `${BASE}/queue/req-env`,
+          requestId: "req-env",
+          responseUrl: `${BASE}/queue/req-env`,
         });
       }) as typeof globalThis.fetch;
       // Transport reads env var when resumeToken is not explicitly set
@@ -620,7 +657,7 @@ describe("contentGeneration.video.launch()", () => {
     }
   });
 
-  it("wait() polls the response_url and returns the mapped result", async () => {
+  it("wait() polls the returned handle URL and returns the mapped result", async () => {
     let polls = 0;
     const calls: FetchCall[] = [];
     const fetchMock = (async (
@@ -631,8 +668,8 @@ describe("contentGeneration.video.launch()", () => {
       calls.push({ url, init });
       if (init.method === "POST") {
         return jsonResponse({
-          request_id: "req-wait",
-          response_url: `${BASE}/queue/req-wait`,
+          requestId: "req-wait",
+          responseUrl: `${BASE}/queue/req-wait`,
         });
       }
       polls += 1;
@@ -660,7 +697,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("wait() maps fileId and passes storage on submit", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-store", response_url: `${BASE}/queue/req-store` },
+      { requestId: "req-store", responseUrl: `${BASE}/queue/req-store` },
       { video: { url: "https://media/v.mp4", file_id: "f-store" } },
     );
 
@@ -691,7 +728,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("wait() throws if the result isn't ready before the timeout", async () => {
     const { transport } = makeLaunchTransport(
-      { request_id: "req-timeout", response_url: `${BASE}/queue/req-timeout` },
+      { requestId: "req-timeout", responseUrl: `${BASE}/queue/req-timeout` },
       { status: "IN_PROGRESS" },
     );
 
@@ -712,8 +749,8 @@ describe("contentGeneration.video.launch()", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "req-explicit",
-          response_url: `${BASE}/queue/req-explicit`,
+          requestId: "req-explicit",
+          responseUrl: `${BASE}/queue/req-explicit`,
         });
       }) as typeof globalThis.fetch;
       const transport = new Transport({
@@ -747,8 +784,8 @@ describe("createClient().contentGeneration.video.launch", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "r-client",
-          response_url: "https://fal.services.sapiom.ai/queue/r-client",
+          requestId: "r-client",
+          responseUrl: "https://fal.services.sapiom.ai/queue/r-client",
         });
       }) as typeof globalThis.fetch;
 
@@ -760,9 +797,9 @@ describe("createClient().contentGeneration.video.launch", () => {
       expect(handle.requestId).toBe("r-client");
       expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
       expect(calls[0]!.url).toBe(
-        "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+        "https://api.sapiom.ai/v1/capabilities/content.generation.video",
       );
-      expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+      expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
       expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
         "tok-client-bind",
       );

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -25,21 +25,10 @@ import {
   defaultTransport,
   resolveCoreBaseUrl,
 } from "../_client/index.js";
-import { resolveServiceUrl } from "../_client/service-url.js";
-import { ensureOk, ContentGenerationHttpError } from "./errors.js";
+import { ContentGenerationHttpError } from "./errors.js";
 import type { DispatchHandle } from "../dispatch.js";
 
 export { ContentGenerationHttpError };
-
-/**
- * Base URL for the still-provider-direct video ops (deferred — async/poll, SAP-1117).
- * The routed `images.create` verb does NOT use this; it resolves the single Core
- * base URL at call time via {@link resolveCoreBaseUrl} (SAP-1116).
- */
-const DEFAULT_BASE_URL = resolveServiceUrl(
-  "fal",
-  process.env.SAPIOM_CONTENT_GENERATION_URL,
-);
 
 /**
  * Capability-stable signal a video launch fires when the video reaches a terminal
@@ -167,11 +156,6 @@ function mapResult(raw: RawImageResult): ImageGenerationResult {
 
 // ----- Capability operations -----
 
-/** Encode a model id into a URL path, preserving its `/` separators. */
-function modelToPath(model: string): string {
-  return model.split("/").filter(Boolean).map(encodeURIComponent).join("/");
-}
-
 /**
  * Guard a prompt value: throw a clear error before a paid job is submitted when
  * the prompt is absent, empty, or not a string. A JS caller passing `null`,
@@ -250,9 +234,15 @@ export async function createImage(
 export const images = { create: createImage };
 
 // ----- Video (async) -----
+//
+// Routed (SAP-1927): the submit goes through the shared {@link capabilityCall}
+// seam to `POST /v1/capabilities/content.generation.video` on the single Core base
+// URL — no direct fal host, no SDK-side `fal-ai/*` default (the router's adapter
+// owns model defaulting/aliasing). Video is async, so the router returns a
+// {@link VideoDispatchHandle}, not the result; completion is out-of-band — poll the
+// handle's `responseUrl` (the Sapiom-hosted queue URL the router hands back) until
+// the asset is ready.
 
-/** Default video model when the caller doesn't pick one. */
-const DEFAULT_VIDEO_MODEL = "fal-ai/veo3/fast";
 /** How often to poll for the async result, and when to give up. Caller-overridable. */
 const DEFAULT_VIDEO_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_VIDEO_TIMEOUT_MS = 5 * 60_000;
@@ -327,11 +317,15 @@ interface RawVideoResult {
   [key: string]: unknown;
 }
 
-/** The async submit handle: a queue id + the Sapiom URL to poll for the result. */
-interface QueueHandle {
-  request_id?: string;
-  response_url?: string;
-  status_url?: string;
+/**
+ * The router's normalized async-dispatch handle (camelCase — the fal adapter maps
+ * fal's snake_case queue fields away, `servedBy` stripped at the public boundary):
+ * a queue id plus the Sapiom-hosted URLs to poll for the result / status.
+ */
+interface VideoDispatchHandle {
+  requestId?: string;
+  responseUrl?: string;
+  statusUrl?: string;
 }
 
 function mapVideo(raw: RawMedia): GeneratedVideo {
@@ -356,49 +350,38 @@ const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Generate a video from a prompt. Video generation is asynchronous: this submits the
- * job, then polls the result through Sapiom until it's ready and returns it — so you
- * `await` it just like {@link createImage}, it just takes longer. Pass `storage` to
- * persist the output (the returned `video` then carries `fileId`). Throws
- * {@link ContentGenerationHttpError} on a failed submit, or an `Error` if the result
- * isn't ready within `timeoutMs`.
+ * Map a {@link VideoCreateInput} to the router's `VideoCreateRequest` DTO. Mirrors
+ * {@link createImage}: `model` is a body field the router's adapter turns into the
+ * provider path (and defaults when omitted), and `params` rides as a NESTED field
+ * (not spread) so the adapter forwards it verbatim. `!= null` keeps a JS caller's
+ * explicit null off the wire; `storage` uses a truthy check so `storage: null` is
+ * "no storage" rather than a null field. The poll-timing options
+ * (`pollIntervalMs`/`timeoutMs`) are SDK-local and never sent.
  */
-export async function createVideo(
-  input: VideoCreateInput,
-  transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
-): Promise<VideoGenerationResult> {
-  assertPrompt(input.prompt);
-  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
-
-  const body: Record<string, unknown> = {
-    prompt: input.prompt,
-    ...input.params,
-  };
-  // Truthy check (not `!== undefined`) so `storage: null` is treated as "no storage".
+function buildVideoRequest(input: VideoCreateInput): Record<string, unknown> {
+  const body: Record<string, unknown> = { prompt: input.prompt };
+  if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  if (input.params != null) body.params = input.params;
+  return body;
+}
 
-  // Submit — for an async model Sapiom returns a queue handle, not the result.
-  const submitRes = await ensureOk(
-    await transport.fetch(`${baseUrl}/run/${path}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
-    "Failed to submit video generation",
-  );
-  const handle = (await submitRes.json()) as QueueHandle;
-  if (!handle.response_url) {
-    throw new Error("Video submit did not return a result URL to poll");
-  }
-
-  // Poll the result THROUGH Sapiom until it's ready. The poll is what persists the
-  // output when `storage` was requested, so `fileId` is filled in by the time it returns.
-  const intervalMs = input.pollIntervalMs ?? DEFAULT_VIDEO_POLL_INTERVAL_MS;
-  const timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS;
+/**
+ * Poll a routed video handle's `responseUrl` (the Sapiom-hosted queue URL) until the
+ * asset is ready, then return the mapped result. The poll is what persists the output
+ * when `storage` was requested, so `fileId` is filled in by the time it returns.
+ * Throws once `timeoutMs` elapses with no result.
+ */
+async function pollVideoResult(
+  transport: Transport,
+  responseUrl: string,
+  requestId: string,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<VideoGenerationResult> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const res = await transport.fetch(handle.response_url, { method: "GET" });
+    const res = await transport.fetch(responseUrl, { method: "GET" });
     if (res.ok) {
       const raw = (await res.json()) as RawVideoResult;
       if (raw.video?.url) return mapVideoResult(raw);
@@ -412,10 +395,55 @@ export async function createVideo(
         // best-effort drain
       }
     }
-    await sleep(intervalMs);
+    await sleep(pollMs);
   }
   throw new Error(
-    `Video generation did not complete within ${timeoutMs}ms (request id: ${handle.request_id ?? "unknown"})`,
+    `Video generation did not complete within ${timeoutMs}ms (request id: ${requestId})`,
+  );
+}
+
+/**
+ * Generate a video from a prompt. Video generation is asynchronous: this submits the
+ * job, then polls the result through Sapiom until it's ready and returns it — so you
+ * `await` it just like {@link createImage}, it just takes longer. Pass `storage` to
+ * persist the output (the returned `video` then carries `fileId`). Throws
+ * {@link ContentGenerationHttpError} on a failed submit, or an `Error` if the result
+ * isn't ready within `timeoutMs`.
+ *
+ * Routed (SAP-1927): the submit goes through the shared {@link capabilityCall} seam
+ * to `POST /v1/capabilities/content.generation.video` on the single Core base URL,
+ * which returns a {@link VideoDispatchHandle}; the SDK then polls the handle's routed
+ * `responseUrl`. No direct fal host, no SDK-side `fal-ai/*` default.
+ */
+export async function createVideo(
+  input: VideoCreateInput,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = resolveCoreBaseUrl(),
+): Promise<VideoGenerationResult> {
+  assertPrompt(input.prompt);
+
+  // Submit — for an async capability the router returns a dispatch handle, not the result.
+  const handle = await capabilityCall<VideoDispatchHandle>(
+    "content.generation.video",
+    buildVideoRequest(input),
+    {
+      transport,
+      baseUrl,
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to submit video generation",
+    },
+  );
+  if (!handle.responseUrl) {
+    throw new Error("Video submit did not return a result URL to poll");
+  }
+
+  return pollVideoResult(
+    transport,
+    handle.responseUrl,
+    handle.requestId ?? "unknown",
+    input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS,
+    input.pollIntervalMs ?? DEFAULT_VIDEO_POLL_INTERVAL_MS,
   );
 }
 
@@ -502,64 +530,41 @@ export function toVideoResumePayload(
 export async function launchVideo(
   input: VideoCreateInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<VideoLaunchHandle> {
   assertPrompt(input.prompt);
-  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
 
-  const body: Record<string, unknown> = {
-    prompt: input.prompt,
-    ...input.params,
-  };
-  if (input.storage) body.storage = input.storage;
-
-  // Submit — includes the workflow resume token header so the service can resume
-  // the paused step when the job completes (no-op outside a workflow context).
-  const submitRes = await ensureOk(
-    await transport.fetch(`${baseUrl}/run/${path}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        ...workflowResumeHeaders(transport.resumeToken),
-      },
-      body: JSON.stringify(body),
-    }),
-    "Failed to submit video generation",
+  // Submit through the router, carrying the workflow resume token header so the
+  // gateway can resume the paused step when the job completes (no-op outside a
+  // workflow context — no token, no header). The `/v1` router forwards the header
+  // downstream so `pauseUntilSignal` still resumes through the routed path (SAP-1927).
+  const handle = await capabilityCall<VideoDispatchHandle>(
+    "content.generation.video",
+    buildVideoRequest(input),
+    {
+      transport,
+      baseUrl,
+      headers: workflowResumeHeaders(transport.resumeToken),
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to submit video generation",
+    },
   );
-  const handle = (await submitRes.json()) as QueueHandle;
-  if (!handle.response_url) {
+  if (!handle.responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");
   }
 
-  const requestId = handle.request_id ?? "unknown";
-  const responseUrl = handle.response_url;
+  const requestId = handle.requestId ?? "unknown";
+  const responseUrl = handle.responseUrl;
 
-  const wait = async ({
+  const wait = ({
     timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS,
     pollMs = input.pollIntervalMs ?? DEFAULT_VIDEO_POLL_INTERVAL_MS,
   }: {
     timeoutMs?: number;
     pollMs?: number;
-  } = {}): Promise<VideoGenerationResult> => {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      const res = await transport.fetch(responseUrl, { method: "GET" });
-      if (res.ok) {
-        const raw = (await res.json()) as RawVideoResult;
-        if (raw.video?.url) return mapVideoResult(raw);
-      } else {
-        try {
-          await res.body?.cancel();
-        } catch {
-          // best-effort drain
-        }
-      }
-      await sleep(pollMs);
-    }
-    throw new Error(
-      `Video generation did not complete within ${timeoutMs}ms (request id: ${requestId})`,
-    );
-  };
+  } = {}): Promise<VideoGenerationResult> =>
+    pollVideoResult(transport, responseUrl, requestId, timeoutMs, pollMs);
 
   return {
     requestId,


### PR DESCRIPTION
## What

Route `contentGeneration.video.create` / `.launch` (`createVideo` / `launchVideo`) through the Capability Router instead of the direct fal gateway host:

```
createVideo / launchVideo  →  POST /v1/capabilities/content.generation.video
```

This is deliverable #3 of SAP-1666 — the backend endpoint shipped in `sapiom/Sapiom` #3313; this lands the SDK repoint it was waiting on. Mirrors the image repoint ([SAP-1116](https://linear.app/sapiom/issue/SAP-1116)).

## Why

`createVideo`/`launchVideo` still POSTed to `resolveServiceUrl("fal")` → `fal.services.sapiom.ai/run/<model>` with a SDK-side `DEFAULT_VIDEO_MODEL = "fal-ai/veo3/fast"` — the fal host, fal path, and a `fal-ai/*` model id all on the wire, in violation of the relaunch "everything routes through /v1" bar. Only `createImage` had been repointed.

## Change

- **Submit routes through `capabilityCall`** on `resolveCoreBaseUrl()`, authenticating via `x-api-key` (the `/v1` guard header). `model` is now a request-body field the router's adapter turns into the provider path (and defaults when omitted) — the SDK-side `fal-ai/veo3/fast` default and the `resolveServiceUrl("fal")` host are **removed**. `params` rides as a nested field (mirrors images), so nothing `fal-ai/*` reaches the wire.
- **Async handle, not a base-URL swap.** Video is async: the router returns `{ requestId, responseUrl, statusUrl }` (camelCase — normalized, `servedBy` stripped). The SDK polls the returned **routed** `responseUrl` to completion (store-on-poll persists `fileId`).
- **Workflow resume preserved.** `launchVideo` carries `x-sapiom-workflow-token` on the routed submit via a new optional `headers` on the `capabilityCall` seam, so `pauseUntilSignal` still resumes through the routed handle.
- Extracts shared `buildVideoRequest` / `pollVideoResult` helpers; drops the now-dead `modelToPath` and `ensureOk` (the routed path owns its error mapping).

Public verb names, signatures, and result shapes are **unchanged** (non-breaking).

## Depends on

**`sapiom/Sapiom` #3612** — forwards `x-sapiom-workflow-token` through the `/v1` router to the gateway. Required for `launchVideo` + `pauseUntilSignal` to resume end-to-end (the router previously dropped the token). The base-URL/submit repoint works independently; only the resume path depends on it.

## Tests

`content-generation/index.spec.ts` rewritten for the routed path: submit URL/method/`x-api-key`, `model` defaulted server-side, `params` nested, camelCase handle, poll on the returned `responseUrl`, and the workflow-token header on the routed submit. 53 content-generation + 55 client-seam tests pass; typecheck + lint clean.

## Out of scope

The "routed `/v1` poll URL" item from SAP-1666 — the handle's `responseUrl` still points at the Sapiom-hosted `fal.services.sapiom.ai/queue/...` gateway URL, matching the shipped image-async precedent. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)