### PR TITLE
fix(harness): remove redundant deploy/prod-run/run-local PTY macros (SAP-1985)

### DIFF
--- a/.changeset/remove-pty-inject-macros.md
+++ b/.changeset/remove-pty-inject-macros.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Removed the legacy deploy / prod-run / run-local terminal macros. The Studio performs these actions through its direct API routes now, so the old macros were an unused duplicate path that would have started the coding agent (and its cost) unnecessarily.

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -2,25 +2,15 @@ import { describe, it, expect } from "vitest";
 import { DEFAULT_MACROS } from "./macros.js";
 
 describe("DEFAULT_MACROS", () => {
-  it("defines the 5 registered macros (open_prod is served by the API but is no longer an action-rail button)", () => {
-    expect(DEFAULT_MACROS.map((m) => m.id)).toEqual([
-      "run_local",
-      "deploy",
-      "prod_run",
-      "open_prod",
-      "visualize",
-    ]);
+  it("defines exactly the 2 registered macros — open_prod and visualize", () => {
+    expect(DEFAULT_MACROS.map((m) => m.id)).toEqual(["open_prod", "visualize"]);
   });
 
-  it("run_local, deploy, and prod_run require a selected workflow and template {{workflow.path}}", () => {
-    for (const id of ["run_local", "deploy", "prod_run"]) {
-      const macro = DEFAULT_MACROS.find((m) => m.id === id)!;
-      expect(macro.requiresWorkflow).toBe(true);
-      expect(macro.action.kind).toBe("inject");
-      if (macro.action.kind === "inject") {
-        expect(macro.action.text).toContain("{{workflow.path}}");
-      }
-    }
+  it("no longer contains the deprecated pty-inject macros (run_local, deploy, prod_run)", () => {
+    const ids = DEFAULT_MACROS.map((m) => m.id);
+    expect(ids).not.toContain("run_local");
+    expect(ids).not.toContain("deploy");
+    expect(ids).not.toContain("prod_run");
   });
 
   it("open_prod deep-links to the workflow and requires one to be selected", () => {

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -9,42 +9,6 @@ import type { MacroDef } from "../shared/types.js";
 
 export const DEFAULT_MACROS: MacroDef[] = [
   {
-    id: "run_local",
-    label: "Run local",
-    icon: "Play",
-    requiresWorkflow: true,
-    action: {
-      kind: "inject",
-      submit: true,
-      // {{workflow.path}} is POSIX single-quoted at resolution time (macro-runner.ts
-      // shellQuote), which stops spaces, dollar signs, backticks, and embedded
-      // double-quotes from being interpreted by the shell.
-      text: "cd {{workflow.path}} && sapiom agents run --target local",
-    },
-  },
-  {
-    id: "deploy",
-    label: "Deploy",
-    icon: "Cloud",
-    requiresWorkflow: true,
-    action: {
-      kind: "inject",
-      submit: true,
-      text: "cd {{workflow.path}} && sapiom agents deploy",
-    },
-  },
-  {
-    id: "prod_run",
-    label: "Prod run",
-    icon: "Zap",
-    requiresWorkflow: true,
-    action: {
-      kind: "inject",
-      submit: true,
-      text: "cd {{workflow.path}} && sapiom agents run --target prod",
-    },
-  },
-  {
     id: "open_prod",
     label: "Open prod",
     icon: "ExternalLink",

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -6,7 +6,7 @@ import { DEFAULT_MACROS } from "../core/macros.js";
 import { ExternalHarnessError } from "../core/errors.js";
 import { SessionNotReadyError } from "../core/session-manager.js";
 import { TaskAlreadyRunningError, TaskNotSupportedError } from "../core/task-manager.js";
-import type { WorkflowInfo } from "../shared/types.js";
+import type { MacroDef, WorkflowInfo } from "../shared/types.js";
 
 let server: Server;
 let baseUrl: string;
@@ -17,6 +17,20 @@ const workflow: WorkflowInfo = {
   definitionId: 4821,
   definitionSlug: "leasing",
   source: "scan",
+};
+
+/** A custom inject macro used in tests that need an inject-kind macro to exercise the
+ *  PTY path — since deploy/prod_run/run_local are no longer in DEFAULT_MACROS. */
+const CUSTOM_INJECT_MACRO: MacroDef = {
+  id: "test-inject",
+  label: "Test inject",
+  icon: "Play",
+  requiresWorkflow: true,
+  action: {
+    kind: "inject",
+    submit: true,
+    text: "cd {{workflow.path}} && sapiom agents deploy",
+  },
 };
 
 function makeDeps(overrides: Partial<MacrosRouterDeps> = {}): MacrosRouterDeps {
@@ -61,11 +75,108 @@ describe("macros router", () => {
     expect(await res.json()).toEqual(DEFAULT_MACROS);
   });
 
-  it("POST /api/macros/:id/run injects the resolved text for an inject macro", async () => {
+  // ---------------------------------------------------------------------------
+  // Removed PTY-inject macros — must all return 404, never inject
+  // ---------------------------------------------------------------------------
+
+  it("404s POST /api/macros/deploy/run — deploy is no longer in DEFAULT_MACROS", async () => {
+    const deps = makeDeps();
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("deploy");
+    // Critically: no PTY injection occurred.
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("404s POST /api/macros/prod_run/run — prod_run is no longer in DEFAULT_MACROS", async () => {
+    const deps = makeDeps();
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/prod_run/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("prod_run");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("404s POST /api/macros/run_local/run — run_local is no longer in DEFAULT_MACROS", async () => {
+    const deps = makeDeps();
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/run_local/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("run_local");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Kept macros — open_prod and visualize still work
+  // ---------------------------------------------------------------------------
+
+  it("opens the resolved URL for open_prod (open-url macro)", async () => {
     const deps = makeDeps();
     await start(deps);
 
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/open_prod/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deps.openUrl).toHaveBeenCalledWith("https://app.sapiom.ai/workflows/4821");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("runs visualize with no workflow bound at all — refreshes server-side, never touches the pty", async () => {
+    const deps = makeDeps(); // getBoundWorkflowPath defaults to () => null
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }), // no subject, no workflowPath, no binding
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  it("also runs visualize when a workflow IS bound — same server-side refresh either way", async () => {
+    const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
+    await start(deps);
+    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ harnessSessionId: "sess-1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
+    expect(deps.injectInput).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // General router contract
+  // ---------------------------------------------------------------------------
+
+  it("POST /api/macros/:id/run injects the resolved text for a registered inject macro", async () => {
+    const deps = makeDeps({ listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO] });
+    await start(deps);
+
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
@@ -81,24 +192,9 @@ describe("macros router", () => {
     expect(deps.openUrl).not.toHaveBeenCalled();
   });
 
-  it("opens the resolved URL for an open-url macro", async () => {
-    const deps = makeDeps();
-    await start(deps);
-
-    const res = await fetch(`${baseUrl}/api/macros/open_prod/run`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
-    });
-
-    expect(res.status).toBe(200);
-    expect(deps.openUrl).toHaveBeenCalledWith("https://app.sapiom.ai/workflows/4821");
-    expect(deps.injectInput).not.toHaveBeenCalled();
-  });
-
   it("400s a workflow-required macro run without a workflowPath", async () => {
-    await start(makeDeps());
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    await start(makeDeps({ listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO] }));
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
@@ -139,10 +235,13 @@ describe("macros router", () => {
   });
 
   it("falls back to the session's bound workflow when the request omits workflowPath", async () => {
-    const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
+    const deps = makeDeps({
+      listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
+      getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null),
+    });
     await start(deps);
 
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }), // no workflowPath
@@ -159,12 +258,13 @@ describe("macros router", () => {
   it("prefers an explicit workflowPath on the request over the session's bound workflow", async () => {
     const otherWorkflow: WorkflowInfo = { name: "rfq", path: "/Users/demo/acme-app/rfq", definitionId: 7, definitionSlug: "rfq", source: "scan" };
     const deps = makeDeps({
+      listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
       findWorkflow: (p) => (p === workflow.path ? workflow : p === otherWorkflow.path ? otherWorkflow : null),
       getBoundWorkflowPath: (id) => (id === "sess-1" ? otherWorkflow.path : null),
     });
     await start(deps);
 
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
@@ -188,6 +288,7 @@ describe("macros router", () => {
     function makeWithPath(p: string) {
       const evil: WorkflowInfo = { name: "evil", path: p, definitionId: null, definitionSlug: null, source: "scan" };
       return makeDeps({
+        listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
         findWorkflow: (wp) => (wp === p ? evil : null),
         getBoundWorkflowPath: () => p,
       });
@@ -196,7 +297,7 @@ describe("macros router", () => {
     it("wraps a path containing spaces in single quotes (not word-split)", async () => {
       const deps = makeWithPath("/Users/demo/my workflow");
       await start(deps);
-      const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: "/Users/demo/my workflow" }),
@@ -213,7 +314,7 @@ describe("macros router", () => {
       const p = "/Users/demo/$(evil)";
       const deps = makeWithPath(p);
       await start(deps);
-      const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: p }),
@@ -230,7 +331,7 @@ describe("macros router", () => {
       const p = "/Users/demo/`evil`";
       const deps = makeWithPath(p);
       await start(deps);
-      const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: p }),
@@ -247,7 +348,7 @@ describe("macros router", () => {
       const p = '/Users/demo/path"with"quotes';
       const deps = makeWithPath(p);
       await start(deps);
-      const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: p }),
@@ -266,7 +367,7 @@ describe("macros router", () => {
       const p = "/Users/demo/it's here";
       const deps = makeWithPath(p);
       await start(deps);
-      const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+      const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: p }),
@@ -281,41 +382,17 @@ describe("macros router", () => {
   });
 
   it("400s a workflow-required macro when both the request and the session binding lack a workflow", async () => {
-    const deps = makeDeps({ getBoundWorkflowPath: () => null });
+    const deps = makeDeps({
+      listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
+      getBoundWorkflowPath: () => null,
+    });
     await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1" }),
     });
     expect(res.status).toBe(400);
-  });
-
-  it("runs visualize with no workflow bound at all — refreshes server-side, never touches the pty", async () => {
-    const deps = makeDeps(); // getBoundWorkflowPath defaults to () => null
-    await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ harnessSessionId: "sess-1" }), // no subject, no workflowPath, no binding
-    });
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
-    expect(deps.injectInput).not.toHaveBeenCalled();
-  });
-
-  it("also runs visualize when a workflow IS bound — same server-side refresh either way", async () => {
-    const deps = makeDeps({ getBoundWorkflowPath: (id) => (id === "sess-1" ? workflow.path : null) });
-    await start(deps);
-    const res = await fetch(`${baseUrl}/api/macros/visualize/run`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ harnessSessionId: "sess-1" }),
-    });
-    expect(res.status).toBe(200);
-    expect(deps.renderCanvas).toHaveBeenCalledWith("sess-1");
-    expect(deps.injectInput).not.toHaveBeenCalled();
   });
 
   it("routes an inject macro marked execution: 'background' to runBackgroundTask, never the pty", async () => {
@@ -406,11 +483,12 @@ describe("macros router", () => {
 
   it("409s with a UI-visible reason when the session isn't ready yet (SessionNotReadyError) — never silently swallows the macro", async () => {
     const deps = makeDeps({
+      listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
       injectInput: vi.fn().mockRejectedValue(new SessionNotReadyError("sess-1")),
     });
     await start(deps);
 
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),
@@ -424,11 +502,12 @@ describe("macros router", () => {
 
   it("409s when injectInput throws ExternalHarnessError (conductor session — inject not supported)", async () => {
     const deps = makeDeps({
+      listMacros: () => [...DEFAULT_MACROS, CUSTOM_INJECT_MACRO],
       injectInput: vi.fn().mockRejectedValue(new ExternalHarnessError("conductor", "Conductor")),
     });
     await start(deps);
 
-    const res = await fetch(`${baseUrl}/api/macros/deploy/run`, {
+    const res = await fetch(`${baseUrl}/api/macros/test-inject/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ harnessSessionId: "sess-1", workflowPath: workflow.path }),


### PR DESCRIPTION
Removes the redundant `deploy` / `prod_run` / `run_local` **PTY-inject** macros. The Studio performs these actions through its **direct API** now (`harness.deploy` / `harness.runLocal`), so the old `inject` macros were an unused, duplicate path: hitting `POST /api/macros/<id>/run` would type `sapiom agents …` into the terminal — spinning up the coding agent and burning LLM credits.

After this change `DEFAULT_MACROS` contains only `open_prod` (open-url) and `visualize` (render-canvas); the macros router already returns **404** for the removed ids, so the bypass is fully closed.

Fixes SAP-1985.

> ⚠️ **Targets the _next_ release (0.1.8).** Merge **after** 0.1.7 (#405) is published — changesets batch whatever is pending on `main`, so merging this before 0.1.7 releases would pull it into 0.1.7. Kept as a **draft** for that reason.

**Verification:** 33 macros tests + 8 macro-runner tests pass; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
