### PR TITLE
ci(harness-desktop): ship macOS .dmg only, skip artifact recompression

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -53,7 +53,7 @@ jobs:
             artifact_path: |
               packages/harness-desktop/release/*.AppImage
               packages/harness-desktop/release/*.deb
-          - os: macos-14 # Apple Silicon; builds an arm64 .app (+ .dmg/.zip)
+          - os: macos-14 # Apple Silicon; builds an arm64 .app → .dmg
             packflag: "--mac"
             # The .dmg is what a tester should get: signed + notarized, it opens
             # with no Gatekeeper prompt, and it's a single file rather than a
@@ -61,9 +61,14 @@ jobs:
             # previously uploaded the raw .app to dodge the zip-of-installers
             # unwrapping, at the cost of needing `chmod -R +x` + `xattr -dr
             # com.apple.quarantine` by hand — which signing exists to remove.)
+            #
+            # .dmg ONLY — no .zip. electron-builder's macOS `zip` target is the
+            # auto-update artifact (Squirrel.Mac), a second full copy of the same
+            # .app; with no updater wired up yet it just doubled the download.
+            # It's no longer built (electron-builder.yml mac.target); re-add it
+            # here and there when auto-update ships in Phase 5+.
             artifact_path: |
               packages/harness-desktop/release/*.dmg
-              packages/harness-desktop/release/*.zip
           # Pinned to windows-2022 (VS 2022 / v17). windows-latest rolled to an
           # image with Visual Studio 18, whose version node-gyp's VS detection
           # doesn't recognize ("unknown version undefined") → the node-pty
@@ -225,6 +230,10 @@ jobs:
           path: ${{ matrix.artifact_path }}
           if-no-files-found: warn
           retention-days: 14
+          # Every uploaded file (.dmg/.AppImage/.deb/.exe) is already a
+          # compressed container, so the default level-6 zip wrapper burns
+          # runner CPU on the upload for ≈0 size gain. Store, don't recompress.
+          compression-level: 0
 
   # Collect every OS's artifacts and attach them to the GitHub Release — only
   # on a real tag push (workflow_dispatch has no tag, so it stops at Artifacts).
@@ -246,9 +255,9 @@ jobs:
           # Pre-release while Windows is unsigned (and currently non-launching).
           prerelease: true
           fail_on_unmatched_files: false
-          # Every OS now uploads installer FILES only (macOS: .dmg/.zip, not the
-          # raw .app bundle), so this glob attaches a handful of assets rather
-          # than the hundreds of inner files an .app directory would produce.
+          # Every OS now uploads installer FILES only (macOS: .dmg, not the raw
+          # .app bundle), so this glob attaches a handful of assets rather than
+          # the hundreds of inner files an .app directory would produce.
           files: dist-artifacts/**/*
           body: |
             Desktop installers built by CI. Each one was **launched by CI before

--- a/packages/harness-desktop/electron-builder.yml
+++ b/packages/harness-desktop/electron-builder.yml
@@ -49,9 +49,14 @@ linux:
   synopsis: One-click Sapiom harness — run your coding agent on Sapiom.
 
 mac:
+  # dmg only. electron-builder also emits a `zip` for macOS auto-update
+  # (Squirrel.Mac consumes zips, not dmgs), but no updater is wired up yet
+  # (Phase 4: unsigned, no publish provider), so the zip was a second full copy
+  # of the same .app — doubling the artifact a tester downloads for nothing.
+  # Re-add `zip` here (and to the upload glob in desktop-release.yml) when macOS
+  # auto-update ships in Phase 5+.
   target:
     - dmg
-    - zip
   category: public.app-category.developer-tools
   icon: assets/icon.png
   hardenedRuntime: true


### PR DESCRIPTION
electron-builder's macOS `zip` target is the Squirrel.Mac auto-update artifact — a second full copy of the same .app. With no updater wired up yet (Phase 4), it just doubled the artifact a tester downloads. Drop it from mac.target and the upload glob; re-add both when auto-update ships.

Also set compression-level: 0 on upload-artifact: every uploaded file (.dmg/.AppImage/.deb/.exe) is already a compressed container, so the default level-6 zip wrapper burns runner CPU for ~0 size gain.