### PR TITLE
feat(harness): read the template gallery live; Overview for returning users

### DIFF
--- a/.changeset/studio-workspaces-live-templates.md
+++ b/.changeset/studio-workspaces-live-templates.md
@@ -1,5 +1,5 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 ---
 
 Studio: read the template gallery live, and stop pitching the product at returning users.
@@ -8,10 +8,12 @@ Studio: read the template gallery live, and stop pitching the product at returni
 
 `estCostPerRunUsd` is null for most templates (21 of 26 today); that renders as an em dash, never `$0.00`, which would assert a genuinely free run.
 
-The detail pane now projects the graph core actually serves — the engine's `DefinitionStepDto`/`DefinitionTransitionDto` shapes, where a step carries `stepName` and a singular `capabilityId`, edges reference steps by namespaced `id`, and terminality is a `terminate`/`fail` transition rather than a flag on the step. So a branch and a pause signal render for the first time, instead of edges inferred from array order.
+The detail pane now projects the graph core actually serves — the engine's `DefinitionStepDto`/`DefinitionTransitionDto` shapes, where a step carries `stepName` and a singular `capabilityId`, edges reference steps by namespaced `id`, and a step's role is decided by its transition kinds rather than array order. Node kinds come from `classifyStepKind`, extracted from `canvas-graph.ts`'s `classifyNode` and now shared: the preview claims parity with the canvas, so it must not own a second copy of that precedence. All four kinds (`continue`/`pause`/`terminate`/`fail`) survive the projection — a fail-only sink renders amber "needs attention" rather than a green success exit, a `continue`-plus-`terminate` gate stays a mid-flow step, and a pause step shows its signal.
 
 **Overview is a working surface, not a pitch.** `showWelcome` was `overviewSelected || (firstRun && !hasLiveSession)`, so the first-run hero rendered whenever the Overview tab was selected — including for someone with a rail full of workspaces. The hero is now genuine-first-run only; returning users get their recent workspaces, with the Docs / Templates / New workspace action band shared by both states.
 
 **Workspace terminology.** A workspace is a folder, matching the rail and the editor convention users arrive with: the rail header reads "Workspaces", and "New project" / "Add project" / "Project directory" become their workspace equivalents. "Agent project" is left alone deliberately — that is the SDK's own term for a `sapiom.json` directory, and `sapiom agents init` and `AGENTS.md` both use it.
 
 **The Sample project action is gone**, along with `POST /api/sample-project` and the exported `SampleProjectSeedResponse` type (nothing else in the repo referenced either). `core/example-seed.ts` remains — `scripts/seed-example.mjs` still uses it for demo prep.
+
+**Breaking for embedders** (hence `minor`, not `patch`): `src/index.ts` re-exports `./shared/types.js`, so `SampleProjectSeedResponse` was part of the published surface, and `HarnessServerOptions` loses its `sampleProjectRoot` field. Code typed against either stops compiling. `TemplateStepView` also carries `kind`/`sublabel` rather than a `terminal` boolean — see above for why that collapse was wrong. No in-repo consumer is affected.

--- a/.changeset/studio-workspaces-live-templates.md
+++ b/.changeset/studio-workspaces-live-templates.md
@@ -1,0 +1,17 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio: read the template gallery live, and stop pitching the product at returning users.
+
+**Templates come from the real catalog.** `web/src/lib/templates.ts` shipped a hardcoded copy of two registry entries (pinned at harness 0.1.4 / `f0e3406`) because, as its header said, no listing API exposed the gallery to any client. One exists now, so the Studio showed 2 templates while the dashboard's Template library showed 26. New `GET /api/templates` and `GET /api/templates/:id` relay core's `GET /v1/workflows/templates{,/:id}` — the same endpoint the dashboard renders, so the two surfaces can no longer drift. The dialog gains category grouping, search, and the per-run cost estimate. Two contract details, both verified against a running backend: the core surface authenticates with `Authorization: Bearer` (the `x-sapiom-api-key` header the *agents* surface takes returns 401 here), and the path carries the `/v1` prefix. The API key stays server-side, as with the runs router; a 401/403 triggers one credential refresh and retry. Signed out or with core unreachable, the dialog falls back to the bundled offline starters **and says which** — silence is what let a two-entry list read as the whole gallery.
+
+`estCostPerRunUsd` is null for most templates (21 of 26 today); that renders as an em dash, never `$0.00`, which would assert a genuinely free run.
+
+The detail pane now projects the graph core actually serves — the engine's `DefinitionStepDto`/`DefinitionTransitionDto` shapes, where a step carries `stepName` and a singular `capabilityId`, edges reference steps by namespaced `id`, and terminality is a `terminate`/`fail` transition rather than a flag on the step. So a branch and a pause signal render for the first time, instead of edges inferred from array order.
+
+**Overview is a working surface, not a pitch.** `showWelcome` was `overviewSelected || (firstRun && !hasLiveSession)`, so the first-run hero rendered whenever the Overview tab was selected — including for someone with a rail full of workspaces. The hero is now genuine-first-run only; returning users get their recent workspaces, with the Docs / Templates / New workspace action band shared by both states.
+
+**Workspace terminology.** A workspace is a folder, matching the rail and the editor convention users arrive with: the rail header reads "Workspaces", and "New project" / "Add project" / "Project directory" become their workspace equivalents. "Agent project" is left alone deliberately — that is the SDK's own term for a `sapiom.json` directory, and `sapiom agents init` and `AGENTS.md` both use it.
+
+**The Sample project action is gone**, along with `POST /api/sample-project` and the exported `SampleProjectSeedResponse` type (nothing else in the repo referenced either). `core/example-seed.ts` remains — `scripts/seed-example.mjs` still uses it for demo prep.

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -78,10 +78,33 @@ function classifyNode(
   entry: string,
   step: AgentStepManifest,
 ): { kind: CanvasNodeKind; sublabel: string } {
-  const continueTargets = step.transitions.filter((t) => t.kind === "continue");
-  const pause = step.transitions.find((t) => t.kind === "pause");
-  const hasTerminate = step.transitions.some((t) => t.kind === "terminate");
-  const hasFail = step.transitions.some((t) => t.kind === "fail");
+  return classifyStepKind({ name, entry, transitions: step.transitions });
+}
+
+/**
+ * The precedence table above, over nothing but a step's declared transition
+ * kinds — so a caller that has transitions from somewhere OTHER than a local
+ * `AgentManifest` classifies identically.
+ *
+ * Exported because the Studio's template preview projects the SAME graph from
+ * core's relayed `DefinitionTransitionDto[]` (see `core/template-catalog.ts`).
+ * That preview claims parity with the canvas, so it must not re-derive this:
+ * a second copy of the rule is a second answer to "what kind of node is this",
+ * and the two surfaces disagreeing is the exact class of bug the template work
+ * set out to remove. Collapsing the four kinds into a single `terminal` boolean
+ * (as the first cut of that preview did) renders a fail-only sink as a green
+ * success exit and a `continue`-plus-`terminate` gate as a terminal.
+ */
+export function classifyStepKind(input: {
+  name: string;
+  entry: string;
+  transitions: ReadonlyArray<{ kind: string; signal?: string | null }>;
+}): { kind: CanvasNodeKind; sublabel: string } {
+  const { name, entry, transitions } = input;
+  const continueTargets = transitions.filter((t) => t.kind === "continue");
+  const pause = transitions.find((t) => t.kind === "pause");
+  const hasTerminate = transitions.some((t) => t.kind === "terminate");
+  const hasFail = transitions.some((t) => t.kind === "fail");
 
   if (name === entry) return { kind: "entry", sublabel: "entry" };
   if (pause) return { kind: "pause", sublabel: `pause · ${pause.signal}` };

--- a/packages/harness/src/core/template-catalog.test.ts
+++ b/packages/harness/src/core/template-catalog.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTemplateCatalog } from "./template-catalog.js";
+import type { ApiKeyProvider } from "./api-key-provider.js";
+
+const BASE = "http://localhost:3000";
+
+/** A summary as core's `GET /v1/workflows/templates` serves it. */
+function upstreamSummary(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "web-research-digest",
+    name: "Web Research Digest",
+    description: "Search the web and return a sourced digest.",
+    tags: ["research"],
+    category: "data-knowledge",
+    cadence: "on-demand",
+    stepCount: 2,
+    capabilities: ["web.search"],
+    estCostPerRunUsd: 0.006,
+    ...over,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A provider whose key can change, so refresh-on-401 is observable. */
+function provider(keys: Array<string | null>): ApiKeyProvider & { refreshCalls: number } {
+  let index = 0;
+  const state = {
+    refreshCalls: 0,
+    getKey: () => keys[Math.min(index, keys.length - 1)],
+    refresh: async () => {
+      state.refreshCalls += 1;
+      index += 1;
+      return keys[Math.min(index, keys.length - 1)];
+    },
+    setKey: () => {},
+  };
+  return state as unknown as ApiKeyProvider & { refreshCalls: number };
+}
+
+describe("createTemplateCatalog", () => {
+  it("calls the CORE surface at the /v1 prefix with a Bearer token", async () => {
+    // Both halves are contracts verified against a real backend: the core
+    // surface rejects the `x-sapiom-api-key` header the AGENTS surface takes,
+    // and a bare `/workflows/templates` (no /v1) 404s.
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([upstreamSummary()]));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    await catalog.list();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE}/v1/workflows/templates`);
+    expect(init.headers).toEqual({ Authorization: "Bearer sk_test" });
+  });
+
+  it("returns the live catalog, preserving every template", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse([upstreamSummary(), upstreamSummary({ id: "hello-agent", name: "Hello Agent" })]),
+      );
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.source).toBe("live");
+    expect(result.templates.map((t) => t.id)).toEqual(["web-research-digest", "hello-agent"]);
+  });
+
+  it("reports signed-out without calling upstream (an expected state, not a fault)", async () => {
+    const fetchImpl = vi.fn();
+    const catalog = createTemplateCatalog({ apiKey: null, baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result).toEqual({ templates: [], source: "fallback", reason: "signed-out" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("degrades to fallback (never throws) when core is unreachable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    await expect(catalog.list()).resolves.toEqual({
+      templates: [],
+      source: "fallback",
+      reason: "unreachable",
+    });
+  });
+
+  it("refreshes the key once and retries on a 401", async () => {
+    const keys = provider(["sk_stale", "sk_fresh"]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse([upstreamSummary()]));
+    const catalog = createTemplateCatalog({ apiKey: keys, baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.source).toBe("live");
+    expect(keys.refreshCalls).toBe(1);
+    const [, secondInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
+    expect(secondInit.headers).toEqual({ Authorization: "Bearer sk_fresh" });
+  });
+
+  it("does not retry when refresh yields the same key (no infinite recovery loop)", async () => {
+    const keys = provider(["sk_same", "sk_same"]);
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ message: "Unauthorized" }, 401));
+    const catalog = createTemplateCatalog({ apiKey: keys, baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.source).toBe("fallback");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a successful list so reopening the dialog costs no round-trip", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([upstreamSummary()]));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    await catalog.list();
+    await catalog.list();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a template whose category is unknown or absent (the taxonomy is upstream)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse([upstreamSummary({ category: "brand-new-axis" }), upstreamSummary({ id: "b", category: null })]),
+      );
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.templates.map((t) => t.category)).toEqual(["brand-new-axis", null]);
+  });
+
+  it("normalizes a missing cost estimate to null, never 0", async () => {
+    // The majority case upstream. A 0 here would render as "$0" — a claim that
+    // the run is free, which is different from "we have no estimate".
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse([upstreamSummary({ estCostPerRunUsd: undefined })]));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.templates[0].estCostPerRunUsd).toBeNull();
+  });
+
+  it("drops an entry with no id rather than rendering a card that cannot be cloned", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([upstreamSummary(), { name: "Nameless" }]));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    const result = await catalog.list();
+
+    expect(result.templates.map((t) => t.id)).toEqual(["web-research-digest"]);
+  });
+
+  it("survives a non-array body (a proxy's HTML error page, say)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ message: "nope" }));
+    const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+    await expect(catalog.list()).resolves.toMatchObject({ source: "fallback" });
+  });
+
+  describe("detail", () => {
+    it("merges the manifest's rich fields with the top-level graph", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          ...upstreamSummary(),
+          whatItDoes: "Searches, then summarizes.",
+          sourcePath: "examples/web-research-digest",
+          // The ENGINE's projection, verbatim from a real backend: stepName (not
+          // name), a singular capabilityId, namespaced ids, and terminality
+          // carried by a `terminate` edge rather than a flag on the step.
+          steps: [
+            { id: "wrd::search", stepName: "search", ordinal: 0, kind: "capability", capabilityId: "web.search" },
+            { id: "wrd::summarize", stepName: "summarize", ordinal: 1, kind: "compute", capabilityId: null },
+          ],
+          transitions: [
+            {
+              id: "wrd::search->wrd::summarize",
+              fromStepDefinitionId: "wrd::search",
+              toStepDefinitionId: "wrd::summarize",
+              kind: "continue",
+              signal: null,
+              ordinal: 0,
+            },
+            {
+              id: "wrd::summarize::terminate",
+              fromStepDefinitionId: "wrd::summarize",
+              toStepDefinitionId: null,
+              kind: "terminate",
+              signal: null,
+              ordinal: 0,
+            },
+          ],
+          manifest: {
+            author: { name: "Sapiom", url: "https://sapiom.ai/" },
+            useCases: ["Brief yourself before a meeting."],
+            notes: "Some **markdown**.",
+            examples: [{ title: "Basic", input: { topic: "x" }, output: { digest: "y" } }],
+            requiredSecrets: [{ key: "API_TOKEN", label: "API token", description: null }],
+          },
+        }),
+      );
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("web-research-digest");
+
+      expect(fetchImpl.mock.calls[0][0]).toBe(`${BASE}/v1/workflows/templates/web-research-digest`);
+      expect(detail?.whatItDoes).toBe("Searches, then summarizes.");
+      expect(detail?.steps.map((s) => s.name)).toEqual(["search", "summarize"]);
+      // capabilityId → the view's list; terminate edge → the step's flag.
+      expect(detail?.steps[0].capabilities).toEqual(["web.search"]);
+      expect(detail?.steps.map((s) => s.terminal)).toEqual([false, true]);
+      // Ids resolve to names, and the terminate SINK is not a drawn edge.
+      expect(detail?.transitions).toEqual([{ from: "search", to: "summarize", label: null }]);
+      expect(detail?.author).toEqual({ name: "Sapiom", url: "https://sapiom.ai/" });
+      expect(detail?.useCases).toEqual(["Brief yourself before a meeting."]);
+      expect(detail?.requiredSecrets).toEqual([
+        { key: "API_TOKEN", label: "API token", description: null },
+      ]);
+    });
+
+    it("tolerates a template that ships no manifest at all", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ ...upstreamSummary(), steps: [], transitions: [] }));
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("web-research-digest");
+
+      expect(detail?.author).toBeNull();
+      expect(detail?.useCases).toEqual([]);
+      expect(detail?.examples).toEqual([]);
+      expect(detail?.notes).toBeNull();
+    });
+
+    it("labels a pause edge with the signal it waits for, and invents nothing else", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          ...upstreamSummary(),
+          steps: [
+            { id: "t::request", stepName: "request", ordinal: 0, kind: "compute", capabilityId: null },
+            { id: "t::approved", stepName: "approved", ordinal: 1, kind: "compute", capabilityId: null },
+          ],
+          transitions: [
+            {
+              id: "t::request->t::approved",
+              fromStepDefinitionId: "t::request",
+              toStepDefinitionId: "t::approved",
+              kind: "pause",
+              signal: "approval.granted",
+              ordinal: 0,
+            },
+          ],
+        }),
+      );
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("t");
+
+      expect(detail?.transitions).toEqual([
+        { from: "request", to: "approved", label: "approval.granted" },
+      ]);
+    });
+
+    it("a fail sink marks its step terminal without becoming a drawn edge", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          ...upstreamSummary(),
+          steps: [{ id: "t::check", stepName: "check", ordinal: 0, kind: "compute", capabilityId: null }],
+          transitions: [
+            {
+              id: "t::check::fail",
+              fromStepDefinitionId: "t::check",
+              toStepDefinitionId: null,
+              kind: "fail",
+              signal: null,
+              ordinal: 0,
+            },
+          ],
+        }),
+      );
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("t");
+
+      expect(detail?.steps[0].terminal).toBe(true);
+      expect(detail?.transitions).toEqual([]);
+    });
+
+    it("url-encodes the id", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ ...upstreamSummary(), id: "a/b" }));
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      await catalog.detail("a/b");
+
+      expect(fetchImpl.mock.calls[0][0]).toBe(`${BASE}/v1/workflows/templates/a%2Fb`);
+    });
+
+    it("returns null for an unknown id", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ message: "Not found" }, 404));
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      await expect(catalog.detail("nope")).resolves.toBeNull();
+    });
+  });
+});

--- a/packages/harness/src/core/template-catalog.test.ts
+++ b/packages/harness/src/core/template-catalog.test.ts
@@ -224,9 +224,14 @@ describe("createTemplateCatalog", () => {
       expect(detail?.steps.map((s) => s.name)).toEqual(["search", "summarize"]);
       // capabilityId → the view's list; terminate edge → the step's flag.
       expect(detail?.steps[0].capabilities).toEqual(["web.search"]);
-      expect(detail?.steps.map((s) => s.terminal)).toEqual([false, true]);
+      // Classified by the shared rule: lowest ordinal is the entry, the step
+      // whose only outgoing edge is `terminate` is a success exit.
+      expect(detail?.steps.map((s) => s.kind)).toEqual(["entry", "terminal-success"]);
+      expect(detail?.steps.map((s) => s.sublabel)).toEqual(["entry", "terminal · success"]);
       // Ids resolve to names, and the terminate SINK is not a drawn edge.
-      expect(detail?.transitions).toEqual([{ from: "search", to: "summarize", label: null }]);
+      expect(detail?.transitions).toEqual([
+        { from: "search", to: "summarize", label: null, kind: "continue" },
+      ]);
       expect(detail?.author).toEqual({ name: "Sapiom", url: "https://sapiom.ai/" });
       expect(detail?.useCases).toEqual(["Brief yourself before a meeting."]);
       expect(detail?.requiredSecrets).toEqual([
@@ -250,14 +255,26 @@ describe("createTemplateCatalog", () => {
       const fetchImpl = vi.fn().mockResolvedValue(
         jsonResponse({
           ...upstreamSummary(),
+          // `gate` is deliberately NOT the entry: entry outranks pause in the
+          // precedence, so a pause on the ordinal-0 step would classify as
+          // `entry` and this assertion would prove nothing.
           steps: [
             { id: "t::request", stepName: "request", ordinal: 0, kind: "compute", capabilityId: null },
-            { id: "t::approved", stepName: "approved", ordinal: 1, kind: "compute", capabilityId: null },
+            { id: "t::gate", stepName: "gate", ordinal: 1, kind: "compute", capabilityId: null },
+            { id: "t::approved", stepName: "approved", ordinal: 2, kind: "compute", capabilityId: null },
           ],
           transitions: [
             {
-              id: "t::request->t::approved",
+              id: "t::request->t::gate",
               fromStepDefinitionId: "t::request",
+              toStepDefinitionId: "t::gate",
+              kind: "continue",
+              signal: null,
+              ordinal: 0,
+            },
+            {
+              id: "t::gate->t::approved",
+              fromStepDefinitionId: "t::gate",
               toStepDefinitionId: "t::approved",
               kind: "pause",
               signal: "approval.granted",
@@ -271,16 +288,32 @@ describe("createTemplateCatalog", () => {
       const detail = await catalog.detail("t");
 
       expect(detail?.transitions).toEqual([
-        { from: "request", to: "approved", label: "approval.granted" },
+        { from: "request", to: "gate", label: null, kind: "continue" },
+        { from: "gate", to: "approved", label: "approval.granted", kind: "pause" },
       ]);
+      // The step that HOLDS the pause is the pause node — the canvas draws it
+      // dashed and labels it with the signal.
+      expect(detail?.steps[1].kind).toBe("pause");
+      expect(detail?.steps[1].sublabel).toBe("pause · approval.granted");
     });
 
-    it("a fail sink marks its step terminal without becoming a drawn edge", async () => {
+    it("a fail-only sink is terminal-WARN, not a green success exit", async () => {
       const fetchImpl = vi.fn().mockResolvedValue(
         jsonResponse({
           ...upstreamSummary(),
-          steps: [{ id: "t::check", stepName: "check", ordinal: 0, kind: "compute", capabilityId: null }],
+          steps: [
+            { id: "t::run", stepName: "run", ordinal: 0, kind: "compute", capabilityId: null },
+            { id: "t::check", stepName: "check", ordinal: 1, kind: "compute", capabilityId: null },
+          ],
           transitions: [
+            {
+              id: "t::run->t::check",
+              fromStepDefinitionId: "t::run",
+              toStepDefinitionId: "t::check",
+              kind: "continue",
+              signal: null,
+              ordinal: 0,
+            },
             {
               id: "t::check::fail",
               fromStepDefinitionId: "t::check",
@@ -296,8 +329,81 @@ describe("createTemplateCatalog", () => {
 
       const detail = await catalog.detail("t");
 
-      expect(detail?.steps[0].terminal).toBe(true);
-      expect(detail?.transitions).toEqual([]);
+      // The collapse this replaced rendered `check` as terminal-success (green),
+      // asserting a clean finish for a step that only ever fails out.
+      expect(detail?.steps[1].kind).toBe("terminal-warn");
+      expect(detail?.steps[1].sublabel).toBe("terminal · needs attention");
+      // The sink itself has no target, so it is not a drawn edge.
+      expect(detail?.transitions.map((t) => t.to)).toEqual(["check"]);
+    });
+
+    it("a step that can continue AND terminate stays a mid-flow step, not an exit", async () => {
+      // The gate shape: continues on approval, terminates on rejection. Marking
+      // it terminal drew an exit chip on a node that still has successors.
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          ...upstreamSummary(),
+          steps: [
+            { id: "t::decide", stepName: "decide", ordinal: 0, kind: "compute", capabilityId: null },
+            { id: "t::proceed", stepName: "proceed", ordinal: 1, kind: "compute", capabilityId: null },
+          ],
+          transitions: [
+            {
+              id: "t::decide->t::proceed",
+              fromStepDefinitionId: "t::decide",
+              toStepDefinitionId: "t::proceed",
+              kind: "continue",
+              signal: null,
+              ordinal: 0,
+            },
+            {
+              id: "t::decide::terminate",
+              fromStepDefinitionId: "t::decide",
+              toStepDefinitionId: null,
+              kind: "terminate",
+              signal: null,
+              ordinal: 1,
+            },
+          ],
+        }),
+      );
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("t");
+
+      // `decide` is the entry here (lowest ordinal), which outranks everything.
+      expect(detail?.steps[0].kind).toBe("entry");
+      // `proceed` has no outgoing edges at all — a plain step, not an exit.
+      expect(detail?.steps[1].kind).toBe("step");
+    });
+
+    it("classifies a non-entry continue+terminate gate as a step", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(
+        jsonResponse({
+          ...upstreamSummary(),
+          steps: [
+            { id: "t::start", stepName: "start", ordinal: 0, kind: "compute", capabilityId: null },
+            { id: "t::gate", stepName: "gate", ordinal: 1, kind: "compute", capabilityId: null },
+            { id: "t::done", stepName: "done", ordinal: 2, kind: "compute", capabilityId: null },
+          ],
+          transitions: [
+            { id: "e1", fromStepDefinitionId: "t::start", toStepDefinitionId: "t::gate", kind: "continue", signal: null, ordinal: 0 },
+            { id: "e2", fromStepDefinitionId: "t::gate", toStepDefinitionId: "t::done", kind: "continue", signal: null, ordinal: 0 },
+            { id: "e3", fromStepDefinitionId: "t::gate", toStepDefinitionId: null, kind: "terminate", signal: null, ordinal: 1 },
+            { id: "e4", fromStepDefinitionId: "t::done", toStepDefinitionId: null, kind: "terminate", signal: null, ordinal: 0 },
+          ],
+        }),
+      );
+      const catalog = createTemplateCatalog({ apiKey: "sk_test", baseUrl: BASE, fetchImpl });
+
+      const detail = await catalog.detail("t");
+
+      expect(detail?.steps.map((s) => `${s.name}:${s.kind}`)).toEqual([
+        "start:entry",
+        "gate:step",
+        "done:terminal-success",
+      ]);
+      expect(detail?.steps[1].sublabel).toBe("step · can also terminate");
     });
 
     it("url-encodes the id", async () => {

--- a/packages/harness/src/core/template-catalog.ts
+++ b/packages/harness/src/core/template-catalog.ts
@@ -39,6 +39,7 @@ import {
   type ApiKeyProvider,
   staticApiKeyProvider,
 } from "./api-key-provider.js";
+import { classifyStepKind } from "./canvas-graph.js";
 import { resolveCoreBaseUrl } from "./definition-slug-resolver.js";
 
 /** Upstream statuses meaning "the key was rejected" — worth one refresh + retry
@@ -140,34 +141,58 @@ function toGraph(rawSteps: unknown, rawTransitions: unknown): {
     return nameOf.get(key) ?? key;
   };
 
-  // A step is terminal when it has an outgoing terminate/fail edge — those are
-  // sinks with a null target, so they never become drawn edges.
-  const SINK_KINDS = new Set(["terminate", "fail"]);
-  const terminalSteps = new Set(
-    edges.filter((edge) => SINK_KINDS.has(str(edge.kind))).map((edge) => resolve(edge.fromStepDefinitionId)),
-  );
+  // Group each step's outgoing transitions so the shared classifier sees exactly
+  // what it sees for a local manifest. All FOUR kinds matter — `terminate` and
+  // `fail` are sinks with a null target (never drawn edges, but they decide the
+  // node's kind), and a step that can `continue` AND terminate is a mid-flow
+  // step, not an exit.
+  const outgoing = new Map<string, Array<{ kind: string; signal: string | null }>>();
+  for (const edge of edges) {
+    const from = resolve(edge.fromStepDefinitionId ?? edge.from);
+    const list = outgoing.get(from) ?? [];
+    list.push({ kind: str(edge.kind), signal: nullableStr(edge.signal) });
+    outgoing.set(from, list);
+  }
+
+  // Entry is the lowest `ordinal` — core documents that on DefinitionStepDto.
+  const entry = steps
+    .map((step) => ({
+      name: str(step.stepName) || str(step.name),
+      ordinal: typeof step.ordinal === "number" ? step.ordinal : Number.MAX_SAFE_INTEGER,
+    }))
+    .sort((a, b) => a.ordinal - b.ordinal)[0]?.name ?? "";
+
+  const DRAWN_KINDS = new Set(["continue", "pause"]);
 
   return {
     steps: steps.map((step) => {
       const name = str(step.stepName) || str(step.name);
       const capability = nullableStr(step.capabilityId);
+      const { kind, sublabel } = classifyStepKind({
+        name,
+        entry,
+        transitions: outgoing.get(name) ?? [],
+      });
       return {
         name,
         description: nullableStr(step.description),
         // Singular `capabilityId` upstream; the view carries a list because a
         // future step could bind more than one, and the older registry shape did.
         capabilities: capability ? [capability] : strArray(step.capabilities),
-        terminal: terminalSteps.has(name),
+        kind,
+        sublabel,
       };
     }),
+    // Only `continue` and `pause` have a target, so only they become edges.
     transitions: edges
-      .filter((edge) => !SINK_KINDS.has(str(edge.kind)))
+      .filter((edge) => DRAWN_KINDS.has(str(edge.kind)))
       .map((edge) => ({
         from: resolve(edge.fromStepDefinitionId ?? edge.from),
         to: resolve(edge.toStepDefinitionId ?? edge.to),
-        // A pause edge names the signal it waits for; that IS its condition.
-        // Nothing else in the DTO is a label, so nothing else is invented.
+        // A pause edge names the signal it waits for; that IS its label. Nothing
+        // else in the DTO is a label, so nothing else is invented.
         label: nullableStr(edge.signal),
+        kind: str(edge.kind) === "pause" ? ("pause" as const) : ("continue" as const),
       }))
       .filter((edge) => edge.from !== "" && edge.to !== ""),
   };

--- a/packages/harness/src/core/template-catalog.ts
+++ b/packages/harness/src/core/template-catalog.ts
@@ -1,0 +1,329 @@
+/**
+ * template-catalog — the Studio's template gallery, read from the Sapiom CORE
+ * surface so it can never disagree with the dashboard's Template library.
+ *
+ * WHY this replaced a hardcoded list: the Studio used to ship a pinned copy of
+ * two registry entries (`web/src/lib/templates.ts`, pinned at harness 0.1.4 /
+ * f0e3406) because — as that module's header said — "no listing API, MCP tool,
+ * or CLI command exposes the gallery to any client today". That is no longer
+ * true: core serves `GET /v1/workflows/templates` (26 templates) and
+ * `GET /v1/workflows/templates/:id`, which is exactly what the dashboard's
+ * gallery renders. Reading the same endpoint is what keeps the two surfaces from
+ * drifting; re-deriving the list from `registry.json` would just recreate the
+ * drift with extra steps (core also merges each example's `template.json` and
+ * computes the per-run cost estimate from live gateway pricing).
+ *
+ * Two non-obvious contract details, both verified against a local backend:
+ *
+ *  - **The core surface authenticates with `Authorization: Bearer`, NOT the
+ *    `x-sapiom-api-key` header the AGENTS surface takes.** The same key sent as
+ *    `x-sapiom-api-key` to `/v1/workflows/templates` returns 401. Don't copy the
+ *    header from `run-state.ts` / `definition-slug-resolver.ts` — those talk to
+ *    `tools.*`, this talks to `api.*`.
+ *  - **The path is prefixed `/v1`** (the backend's `GLOBAL_API_PREFIX`); a bare
+ *    `/workflows/templates` 404s.
+ *
+ * The key stays server-side and is never forwarded to the browser (same rule as
+ * the runs router). A 401/403 triggers exactly one credential refresh + retry,
+ * mirroring `run-state.ts`, so a rotated key recovers in place.
+ */
+
+import type {
+  TemplateDetailView,
+  TemplateListResponse,
+  TemplateStepView,
+  TemplateSummary,
+  TemplateTransitionView,
+} from "../shared/types.js";
+import {
+  type ApiKeyProvider,
+  staticApiKeyProvider,
+} from "./api-key-provider.js";
+import { resolveCoreBaseUrl } from "./definition-slug-resolver.js";
+
+/** Upstream statuses meaning "the key was rejected" — worth one refresh + retry
+ *  before giving up. Mirrors run-state.ts's `isAuthRejection`. */
+function isAuthRejection(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+/** How long a successful list/detail response is reused. The registry is read by
+ *  core from a pinned ref and changes on the order of releases, so a short TTL
+ *  removes the per-open round-trip without pinning a stale gallery for a session
+ *  that stays open for hours. */
+const CACHE_TTL_MS = 5 * 60_000;
+
+export interface TemplateCatalog {
+  /** The gallery list. Never throws: falls back to `source: "fallback"` with an
+   *  empty list when signed out or core is unreachable, so the dialog can say
+   *  what happened instead of rendering silence. */
+  list(): Promise<TemplateListResponse>;
+  /** One template's detail, or null when the id is unknown / unreachable. */
+  detail(id: string): Promise<TemplateDetailView | null>;
+}
+
+/** Unknown-shaped JSON from upstream, narrowed field by field below. */
+type Json = Record<string, unknown>;
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function nullableStr(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+function strArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+/**
+ * Narrow one summary. Defensive rather than trusting: the taxonomy and manifest
+ * are owned upstream in a public repo, so a template with a field we don't know
+ * about must still render as a card instead of throwing the whole list away.
+ */
+function toSummary(raw: Json): TemplateSummary {
+  return {
+    id: str(raw.id),
+    name: str(raw.name) || str(raw.id),
+    description: str(raw.description),
+    tags: strArray(raw.tags),
+    category: nullableStr(raw.category),
+    cadence: nullableStr(raw.cadence),
+    stepCount: typeof raw.stepCount === "number" ? raw.stepCount : 0,
+    capabilities: strArray(raw.capabilities),
+    // Only a real number survives: null/undefined/NaN all mean "no estimate",
+    // which the UI must render as an em dash rather than $0.00.
+    estCostPerRunUsd:
+      typeof raw.estCostPerRunUsd === "number" && Number.isFinite(raw.estCostPerRunUsd)
+        ? raw.estCostPerRunUsd
+        : null,
+  };
+}
+
+/**
+ * Core relays the ENGINE's graph projection (`DefinitionStepDto` /
+ * `DefinitionTransitionDto`), whose shape is not the registry's:
+ *
+ *  - a step is `{ id, stepName, ordinal, kind, capabilityId }` — `stepName`, a
+ *    SINGULAR nullable `capabilityId`, and **no `terminal` flag**;
+ *  - an edge is `{ fromStepDefinitionId, toStepDefinitionId, kind, signal }`,
+ *    referencing steps by their namespaced `id` (`<templateId>::<stepName>`),
+ *    not by name, and `toStepDefinitionId` is **null** for a `terminate`/`fail`
+ *    sink.
+ *
+ * So terminality is an EDGE property here, and ids must be resolved to names
+ * before the view can use them. Getting this wrong renders a step list with no
+ * connectors and nothing marked as an exit.
+ */
+function toGraph(rawSteps: unknown, rawTransitions: unknown): {
+  steps: TemplateStepView[];
+  transitions: TemplateTransitionView[];
+} {
+  const steps = Array.isArray(rawSteps)
+    ? rawSteps.filter((s): s is Json => typeof s === "object" && s !== null)
+    : [];
+  const edges = Array.isArray(rawTransitions)
+    ? rawTransitions.filter((t): t is Json => typeof t === "object" && t !== null)
+    : [];
+
+  // `<templateId>::<stepName>` → `stepName`. Fall back to `name` so a future
+  // registry-shaped payload still resolves.
+  const nameOf = new Map<string, string>();
+  for (const step of steps) {
+    const name = str(step.stepName) || str(step.name);
+    if (step.id !== undefined) nameOf.set(str(step.id), name);
+    if (name) nameOf.set(name, name);
+  }
+  const resolve = (ref: unknown): string => {
+    const key = str(ref);
+    return nameOf.get(key) ?? key;
+  };
+
+  // A step is terminal when it has an outgoing terminate/fail edge — those are
+  // sinks with a null target, so they never become drawn edges.
+  const SINK_KINDS = new Set(["terminate", "fail"]);
+  const terminalSteps = new Set(
+    edges.filter((edge) => SINK_KINDS.has(str(edge.kind))).map((edge) => resolve(edge.fromStepDefinitionId)),
+  );
+
+  return {
+    steps: steps.map((step) => {
+      const name = str(step.stepName) || str(step.name);
+      const capability = nullableStr(step.capabilityId);
+      return {
+        name,
+        description: nullableStr(step.description),
+        // Singular `capabilityId` upstream; the view carries a list because a
+        // future step could bind more than one, and the older registry shape did.
+        capabilities: capability ? [capability] : strArray(step.capabilities),
+        terminal: terminalSteps.has(name),
+      };
+    }),
+    transitions: edges
+      .filter((edge) => !SINK_KINDS.has(str(edge.kind)))
+      .map((edge) => ({
+        from: resolve(edge.fromStepDefinitionId ?? edge.from),
+        to: resolve(edge.toStepDefinitionId ?? edge.to),
+        // A pause edge names the signal it waits for; that IS its condition.
+        // Nothing else in the DTO is a label, so nothing else is invented.
+        label: nullableStr(edge.signal),
+      }))
+      .filter((edge) => edge.from !== "" && edge.to !== ""),
+  };
+}
+
+/**
+ * The rich fields live under `manifest` in core's detail DTO (the co-located
+ * `template.json`), while the graph is expanded at the top level. Read both
+ * shapes so the detail pane works whether or not a template ships a manifest.
+ */
+function toDetail(raw: Json): TemplateDetailView {
+  const manifest: Json =
+    typeof raw.manifest === "object" && raw.manifest !== null ? (raw.manifest as Json) : {};
+  const author: Json | null =
+    typeof manifest.author === "object" && manifest.author !== null ? (manifest.author as Json) : null;
+  const graph = toGraph(raw.steps, raw.transitions);
+  return {
+    ...toSummary(raw),
+    whatItDoes: nullableStr(raw.whatItDoes ?? manifest.whatItDoes),
+    sourcePath: nullableStr(raw.sourcePath),
+    steps: graph.steps,
+    transitions: graph.transitions,
+    author: author ? { name: str(author.name), url: nullableStr(author.url) } : null,
+    useCases: strArray(manifest.useCases),
+    notes: nullableStr(manifest.notes),
+    examples: Array.isArray(manifest.examples)
+      ? manifest.examples
+          .filter((e): e is Json => typeof e === "object" && e !== null)
+          .map((example) => ({
+            title: nullableStr(example.title),
+            input: example.input ?? null,
+            output: example.output ?? null,
+          }))
+      : [],
+    requiredSecrets: Array.isArray(manifest.requiredSecrets)
+      ? manifest.requiredSecrets
+          .filter((s): s is Json => typeof s === "object" && s !== null)
+          .map((secret) => ({
+            key: str(secret.key),
+            label: str(secret.label) || str(secret.key),
+            description: nullableStr(secret.description),
+          }))
+      : [],
+  };
+}
+
+export function createTemplateCatalog(opts: {
+  /** Accepts a provider (preferred — enables refresh-on-401) or a bare key. */
+  apiKey: string | null | ApiKeyProvider;
+  /** Override the core base URL (resolved from env by default). Test seam. */
+  baseUrl?: string;
+  /** Injectable fetch. Test seam, mirroring the resolver suite. */
+  fetchImpl?: typeof fetch;
+}): TemplateCatalog {
+  const provider: ApiKeyProvider =
+    opts.apiKey !== null && typeof opts.apiKey === "object"
+      ? opts.apiKey
+      : staticApiKeyProvider(opts.apiKey);
+  const baseUrl = opts.baseUrl ?? resolveCoreBaseUrl();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  let listCache: { at: number; value: TemplateListResponse } | null = null;
+  const detailCache = new Map<string, { at: number; value: TemplateDetailView }>();
+  // One line per distinct failure reason, not per poll — the dialog may reopen
+  // repeatedly and a persistent misconfiguration shouldn't flood the log.
+  const logged = new Set<string>();
+  const warnOnce = (reason: string): void => {
+    if (logged.has(reason)) return;
+    logged.add(reason);
+    console.error(
+      `[harness] template gallery unavailable from ${baseUrl} (${reason}); ` +
+        "showing the bundled starters only — check the harness is signed in " +
+        "and SAPIOM_CORE_URL points at a reachable Sapiom API",
+    );
+  };
+
+  /**
+   * GET `path` from the core surface with the held key, refreshing + retrying
+   * once on an auth rejection. Returns the parsed body, or null on any failure.
+   */
+  const getJson = async (path: string): Promise<unknown | null> => {
+    let apiKey = provider.getKey();
+    if (!apiKey) return null;
+
+    const attempt = async (key: string): Promise<Response | null> => {
+      try {
+        return await fetchImpl(`${baseUrl}${path}`, {
+          // Core (`api.*`) takes a Bearer token; the agents surface (`tools.*`)
+          // takes `x-sapiom-api-key`. Sending the latter here 401s — verified.
+          headers: { Authorization: `Bearer ${key}` },
+        });
+      } catch (err) {
+        warnOnce(err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    };
+
+    let response = await attempt(apiKey);
+    if (!response) return null;
+
+    if (isAuthRejection(response.status)) {
+      const refreshed = await provider.refresh();
+      if (refreshed && refreshed !== apiKey) {
+        apiKey = refreshed;
+        response = await attempt(refreshed);
+        if (!response) return null;
+      }
+    }
+
+    if (!response.ok) {
+      warnOnce(`HTTP ${response.status}`);
+      return null;
+    }
+    try {
+      return await response.json();
+    } catch {
+      warnOnce("response body was not JSON");
+      return null;
+    }
+  };
+
+  return {
+    async list(): Promise<TemplateListResponse> {
+      const fresh = listCache && Date.now() - listCache.at < CACHE_TTL_MS;
+      if (fresh && listCache) return listCache.value;
+
+      // Signed out is an expected state (a harness launched without auth), not a
+      // fault — distinguish it so the dialog can offer sign-in rather than
+      // implying the gallery is broken.
+      if (!provider.getKey()) {
+        return { templates: [], source: "fallback", reason: "signed-out" };
+      }
+
+      const body = await getJson("/v1/workflows/templates");
+      if (!Array.isArray(body)) {
+        return { templates: [], source: "fallback", reason: "unreachable" };
+      }
+      const templates = body
+        .filter((t): t is Json => typeof t === "object" && t !== null)
+        .map(toSummary)
+        .filter((t) => t.id !== "");
+      const value: TemplateListResponse = { templates, source: "live" };
+      listCache = { at: Date.now(), value };
+      return value;
+    },
+
+    async detail(id: string): Promise<TemplateDetailView | null> {
+      const cached = detailCache.get(id);
+      if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.value;
+
+      const body = await getJson(`/v1/workflows/templates/${encodeURIComponent(id)}`);
+      if (typeof body !== "object" || body === null) return null;
+      const value = toDetail(body as Json);
+      if (value.id === "") return null;
+      detailCache.set(id, { at: Date.now(), value });
+      return value;
+    },
+  };
+}

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -28,7 +28,6 @@ import type {
 } from "../shared/types.js";
 import { JSON_BODY_LIMIT_BYTES } from "../shared/types.js";
 import { resolveStatePaths } from "../core/paths.js";
-import { seedExampleProject } from "../core/example-seed.js";
 import {
   SessionManager,
   type LaunchOptsBuilder,
@@ -100,6 +99,7 @@ import { createCanvasRenderRouter } from "./canvas-render.js";
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 import { createRunsRouter } from "./runs.js";
+import { createTemplatesRouter } from "./templates.js";
 import { createActionsRouter } from "./actions.js";
 import {
   createAuthRouter,
@@ -212,9 +212,6 @@ export interface HarnessServerOptions {
    * Passed through into AppState.consentEnvReason.
    */
   consentEnvReason?: string | null;
-  /** Where POST /api/sample-project seeds the bundled example. Defaults to
-   *  `<stateRoot>/sample-project`. */
-  sampleProjectRoot?: string;
 }
 
 export interface HarnessServer {
@@ -854,12 +851,6 @@ export const startServer = async (
         userId: identity?.userId ?? null,
         tenantId: identity?.tenantId ?? null,
       },
-      seedSampleProject: async () => {
-        const { root, projectDir, created } = await seedExampleProject({
-          targetRoot: options.sampleProjectRoot ?? statePaths.sampleProject,
-        });
-        return { root, projectDir, created };
-      },
       settingsPath: statePaths.settings,
     }),
   );
@@ -885,6 +876,14 @@ export const startServer = async (
       // the API key on a 401 and retry, recovering instead of locking.
       apiKey: apiKeyProvider,
       baseUrl: resolveAgentsBaseUrl(),
+    }),
+  );
+  // The template gallery, relayed from CORE (not the agents surface) so the
+  // Studio's picker and the dashboard's Template library read one catalog.
+  // baseUrl omitted: the router self-defaults via resolveCoreBaseUrl().
+  app.use(
+    createTemplatesRouter({
+      apiKey: apiKeyProvider,
     }),
   );
   // Direct action macros (Deploy / Prod-run) — server-side, key never reaches

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -274,46 +274,6 @@ describe("createRestRouter", () => {
     expect(await res.json()).toEqual([]);
   });
 
-  describe("POST /sample-project", () => {
-    it("501s when no seeder is wired up", async () => {
-      start();
-      const res = await fetch(`${baseUrl}/sample-project`, {
-        method: "POST",
-        headers: TOKEN_HEADER,
-      });
-      expect(res.status).toBe(501);
-    });
-
-    it("returns the seeder's result", async () => {
-      const seeded = {
-        root: "/tmp/sample",
-        projectDir: "/tmp/sample/order-triage",
-        created: true,
-      };
-      const seedSampleProject = vi.fn().mockResolvedValue(seeded);
-      start({ seedSampleProject });
-
-      const res = await fetch(`${baseUrl}/sample-project`, {
-        method: "POST",
-        headers: TOKEN_HEADER,
-      });
-      expect(res.status).toBe(200);
-      expect(await res.json()).toEqual(seeded);
-      expect(seedSampleProject).toHaveBeenCalledOnce();
-    });
-
-    it("propagates a seeding failure as a server error, not a hang", async () => {
-      start({
-        seedSampleProject: vi.fn().mockRejectedValue(new Error("disk full")),
-      });
-      const res = await fetch(`${baseUrl}/sample-project`, {
-        method: "POST",
-        headers: TOKEN_HEADER,
-      });
-      expect(res.status).toBe(500);
-    });
-  });
-
   describe("POST /sessions", () => {
     it("calls onSessionCreated with the new session's cwd and id", async () => {
       const onSessionCreated = vi.fn();

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -26,7 +26,6 @@ import type {
   ImageMediaType,
   InjectInputRequest,
   MacroDef,
-  SampleProjectSeedResponse,
   SessionSummary,
   UiEventName,
   UiTrackRequest,
@@ -191,11 +190,6 @@ export interface RestRouterOptions {
   /** Which env var forced telemetry off — surfaced in AppState for the
    * tracking indicator's "off (env)" label. Null/absent otherwise. */
   consentEnvReason?: string | null;
-  /** Seeds (or reuses) the bundled example project and returns where it
-   * landed — backs POST /api/sample-project (the welcome panel's "Run the
-   * sample project"). Optional so callers without the real seeder (tests)
-   * get a 501 from the route instead of having to stub one. */
-  seedSampleProject?: () => Promise<SampleProjectSeedResponse>;
   /** Where GET/PATCH /settings (and /state's settings read) persist to.
    * Omitted, the real `~/.sapiom/harness/settings.json` — the integrator
    * (server/index.ts) passes the path under its resolved state root so an
@@ -294,26 +288,6 @@ export function createRestRouter(options: RestRouterOptions): Router {
         options.onTelemetryOptInChange?.(parsed.data.telemetryOptIn);
       }
       res.json(updated);
-    } catch (err) {
-      next(err);
-    }
-  });
-
-  // Deliberately does NOT create a session itself — the SPA follows up with
-  // its normal POST /sessions against the returned root, so recent-dirs
-  // bookkeeping, workflow scanning, and tab state all flow through the one
-  // existing session-creation path.
-  router.post("/sample-project", async (_req, res, next) => {
-    if (!options.seedSampleProject) {
-      res
-        .status(501)
-        .json({
-          error: "sample project seeding is not available on this server",
-        });
-      return;
-    }
-    try {
-      res.json(await options.seedSampleProject());
     } catch (err) {
       next(err);
     }

--- a/packages/harness/src/server/templates.ts
+++ b/packages/harness/src/server/templates.ts
@@ -1,0 +1,70 @@
+/**
+ * Templates router — backs GET /api/templates and GET /api/templates/:id.
+ *
+ * Relays the Sapiom core gallery (the same catalog the dashboard's Template
+ * library renders) to the SPA. The API key is held server-side and never
+ * forwarded to the browser — the router fetches on the dialog's behalf via
+ * {@link createTemplateCatalog}, exactly as the runs router does for live run
+ * state. That is also why this can't be a direct browser fetch of core: the
+ * `sk_…` key would have to reach the page, and core sends no CORS headers for
+ * the harness's origin.
+ */
+
+import { Router } from "express";
+
+import { createTemplateCatalog } from "../core/template-catalog.js";
+import { type ApiKeyProvider } from "../core/api-key-provider.js";
+
+export interface TemplatesRouterOpts {
+  /** The Sapiom API key (`sk_…`), NOT the local boot token. Pass a provider so a
+   *  rejected key can refresh + retry instead of locking the gallery. */
+  apiKey: string | null | ApiKeyProvider;
+  /** Override the core base URL (resolved from env by default). Test seam. */
+  baseUrl?: string;
+  /** Injectable fetch. Test seam. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createTemplatesRouter(opts: TemplatesRouterOpts): Router {
+  const router = Router();
+  const catalog = createTemplateCatalog({
+    apiKey: opts.apiKey,
+    baseUrl: opts.baseUrl,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  /**
+   * GET /api/templates
+   *
+   * 200 always — a `TemplateListResponse`. Deliberately never an error status:
+   * an unreachable or signed-out catalog is a degraded gallery (the bundled
+   * starters still work offline), not a failed request, and core's own endpoint
+   * makes the same choice. `source`/`reason` carry the degradation so the dialog
+   * can explain itself.
+   */
+  router.get("/api/templates", async (_req, res) => {
+    res.json(await catalog.list());
+  });
+
+  /**
+   * GET /api/templates/:id
+   *
+   * 200  TemplateDetailView
+   * 404  unknown id, or the catalog could not be reached
+   */
+  router.get("/api/templates/:id", async (req, res) => {
+    const id = req.params.id;
+    if (!id || id.trim() === "") {
+      res.status(400).json({ error: "template id is required" });
+      return;
+    }
+    const detail = await catalog.detail(id);
+    if (!detail) {
+      res.status(404).json({ error: `Template not found: ${id}` });
+      return;
+    }
+    res.json(detail);
+  });
+
+  return router;
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -642,7 +642,8 @@ export interface CollectorBatch {
 // POST   /api/macros/:id/run            RunMacroRequest → { ok: true }
 // GET    /api/settings                  → HarnessSettings
 // PATCH  /api/settings                  Partial<HarnessSettings> → HarnessSettings
-// POST   /api/sample-project            → SampleProjectSeedResponse (seed/reuse the bundled example)
+// GET    /api/templates                 → TemplateListResponse (relays core's gallery)
+// GET    /api/templates/:id             → TemplateDetailView
 // GET    /api/fs/list?path=&hidden=     → FsListResponse (directory autocomplete)
 // POST   /api/track                     UiTrackRequest → { ok: true }  (UI-interaction analytics)
 // POST   /ingest                        (hook payloads; bearer = ingest token)
@@ -781,14 +782,89 @@ export interface AppState {
   agentsBaseUrl?: string;
 }
 
-/** `POST /api/sample-project` response — the seeded (or reused) example. */
-export interface SampleProjectSeedResponse {
-  /** Directory to open a session in — contains the project + its canvas. */
-  root: string;
-  /** Absolute path of the scaffolded example project inside `root`. */
-  projectDir: string;
-  /** False when an already-seeded copy was reused as-is. */
-  created: boolean;
+// ---------------------------------------------------------------------------
+// Template gallery (relayed from the Sapiom core surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * A gallery card, relayed verbatim from core's `GET /v1/workflows/templates`
+ * (`TemplateSummaryDto`). The Studio does NOT own this taxonomy — the registry
+ * in the public sapiom-js repo does, and the backend computes `estCostPerRunUsd`
+ * from the declared capabilities against live gateway pricing. Fields are
+ * carried through untouched so the Studio's list and the dashboard's Template
+ * library can never disagree.
+ */
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  /** Registry outcome-axis id (`starter`, `revenue-marketing`, …), or null for a
+   *  template predating the field. A loose string on purpose: the taxonomy is
+   *  owned upstream, so an unrecognised id buckets as uncategorised rather than
+   *  dropping the card. */
+  category: string | null;
+  /** What starts a run (`on-demand` | `scheduled` | `on-webhook` | `on-event`),
+   *  or null when undeclared. */
+  cadence: string | null;
+  stepCount: number;
+  /** Dotted catalog capability ids (e.g. `web.search`). */
+  capabilities: string[];
+  /** Null when the template declares no per-call-priced capability — render an
+   *  em dash, NEVER a fabricated `$0.00` (21 of 26 templates are null today). */
+  estCostPerRunUsd: number | null;
+}
+
+/** One step of a template's declared graph (core's `DefinitionStepDto` subset the
+ *  detail pane renders). */
+export interface TemplateStepView {
+  name: string;
+  description: string | null;
+  capabilities: string[];
+  terminal: boolean;
+}
+
+/** One edge of a template's declared graph (core's `DefinitionTransitionDto`). */
+export interface TemplateTransitionView {
+  from: string;
+  to: string;
+  /** Condition label, when the transition is guarded. */
+  label: string | null;
+}
+
+/**
+ * `GET /api/templates/:id` — the summary plus the rich manifest the detail pane
+ * renders. Core expands the registry's hand-authored step list into the same
+ * graph shapes a real definition uses, so the preview and the post-clone canvas
+ * are the same vocabulary.
+ */
+export interface TemplateDetailView extends TemplateSummary {
+  /** Prose from the co-located `template.json`; null when the manifest omits it. */
+  whatItDoes: string | null;
+  /** Path inside the sapiom-js repo the fork is seeded from. */
+  sourcePath: string | null;
+  steps: TemplateStepView[];
+  transitions: TemplateTransitionView[];
+  author: { name: string; url: string | null } | null;
+  useCases: string[];
+  /** Markdown. */
+  notes: string | null;
+  examples: Array<{ title: string | null; input: unknown; output: unknown }>;
+  /** Credentials the template needs supplied before a deployed run works. */
+  requiredSecrets: Array<{ key: string; label: string; description: string | null }>;
+}
+
+/**
+ * `GET /api/templates` response. `source` tells the SPA whether it is looking at
+ * the live catalog or the offline fallback, so the dialog can say so instead of
+ * silently presenting two entries as the whole gallery — the failure mode this
+ * endpoint exists to fix.
+ */
+export interface TemplateListResponse {
+  templates: TemplateSummary[];
+  source: "live" | "fallback";
+  /** Why the live fetch was not used, when `source` is `fallback`. */
+  reason?: "signed-out" | "unreachable";
 }
 
 export interface HarnessSettings {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -815,21 +815,34 @@ export interface TemplateSummary {
   estCostPerRunUsd: number | null;
 }
 
-/** One step of a template's declared graph (core's `DefinitionStepDto` subset the
- *  detail pane renders). */
+/**
+ * One step of a template's declared graph (core's `DefinitionStepDto` subset the
+ * detail pane renders).
+ *
+ * `kind`/`sublabel` come from `classifyStepKind` — the SAME precedence the canvas
+ * applies to a real definition — so the preview and the post-clone canvas agree.
+ * There is deliberately no `terminal` boolean: the four transition kinds
+ * (`continue`/`pause`/`terminate`/`fail`) do not collapse into one, and pretending
+ * they do renders a fail-only sink as a green success exit.
+ */
 export interface TemplateStepView {
   name: string;
   description: string | null;
   capabilities: string[];
-  terminal: boolean;
+  /** Canvas node kind: `entry` | `step` | `pause` | `terminal-success` | `terminal-warn`. */
+  kind: string;
+  /** One-line role, e.g. `entry`, `step · can also fail`, `terminal · success`. */
+  sublabel: string;
 }
 
 /** One edge of a template's declared graph (core's `DefinitionTransitionDto`). */
 export interface TemplateTransitionView {
   from: string;
   to: string;
-  /** Condition label, when the transition is guarded. */
+  /** The signal a `pause` edge waits for; null for a plain `continue`. */
   label: string | null;
+  /** `cross` for a pause edge (as the canvas draws it), else continue flow. */
+  kind: "continue" | "pause";
 }
 
 /**

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -182,10 +182,10 @@ test("creation IA: the rail + adds projects; the tab strip + adds a session to t
   await page.getByTestId("add-workspace").click();
   const modal = page.locator(".modal-add-workspace");
   await expect(modal).toBeVisible();
-  await expect(modal.locator(".modal-header")).toContainText("Add project");
+  await expect(modal.locator(".modal-header")).toContainText("Add workspace");
   await expect(modal.getByTestId("add-mode-session")).toHaveCount(0);
   await expect(modal.getByTestId("add-mode-project")).toHaveCount(0);
-  await expect(modal.getByRole("button", { name: "Add project" })).toBeVisible();
+  await expect(modal.getByRole("button", { name: "Add workspace" })).toBeVisible();
   await expect(modal.getByTestId("harness-select")).toHaveCount(0);
   await page.getByRole("button", { name: "Cancel" }).click();
   await expect(modal).toHaveCount(0);
@@ -439,12 +439,12 @@ test("add project: the rail's + opens the same directory-picker dialog and regis
   // workspace title and CTA.
   const modal = page.locator(".modal-add-workspace");
   await expect(modal).toBeVisible();
-  await expect(modal).toContainText("Add project");
+  await expect(modal).toContainText("Add workspace");
   await expect(modal.getByTestId("harness-select")).toHaveCount(0);
 
   const input = modal.getByTestId("dir-picker-input");
   await input.fill("/Users/demo/scratch");
-  await modal.getByRole("button", { name: "Add project" }).click();
+  await modal.getByRole("button", { name: "Add workspace" }).click();
 
   await expect(modal).toBeHidden();
   // The connected path joins the rail as a workspace-owned workflow row.

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -1,10 +1,10 @@
 /**
  * Templates journey v0 (browse → preview → use), all in mock mode.
  *
- * Ground truth this exercises: the curated index in lib/templates.ts is a
- * pin of the harness gallery registry (browse has no listing API yet), the
- * preview renders only real manifest fields, and "Use template" performs the
- * REAL handoff shape — a session at the destination folder plus the agent
+ * Ground truth this exercises: the gallery is FETCHED (GET /api/templates, which
+ * the server relays from core) rather than pinned in lib/templates.ts, only the
+ * bundled starters are local, the preview renders only real manifest fields, and
+ * "Use template" performs the REAL handoff shape — a session at the destination folder plus the agent
  * prompt naming sapiom_dev_agents_clone (gallery) or `sapiom agents init -t`
  * (bundled starter). MockApi records the injection on
  * window.__HARNESS_TEST__.lastInjectInput for the clone assertions.
@@ -31,10 +31,10 @@ test.describe("templates journey v0 (from the welcome panel)", () => {
     await expect(page.getByTestId("templates-dialog")).toBeVisible();
   });
 
-  test("browse: the two clonable gallery ids and the two bundled starters", async ({
+  test("browse: catalog templates plus the two bundled starters", async ({
     page,
   }) => {
-    // Exactly the real clonable slugs — nothing invented.
+    // Real clonable slugs from the catalog, not a hardcoded pair.
     await expect(page.getByTestId("template-row-web-research-digest")).toBeVisible();
     await expect(page.getByTestId("template-row-hello-agent")).toBeVisible();
     await expect(page.getByTestId("template-row-default")).toBeVisible();
@@ -50,20 +50,29 @@ test.describe("templates journey v0 (from the welcome panel)", () => {
     await expect(detail).toContainText("By");
     await expect(detail).toContainText("Sapiom");
 
-    // Steps render in registry order: array order is execution order, the
-    // first step is the entry, terminal steps carry the exit marker.
+    // Steps render in declared order, each labelled with the role the SHARED
+    // classifier assigned (classifyStepKind) rather than a terminal-or-not guess:
+    // the entry says "entry", a terminate-only sink says "terminal · success".
     const stepNames = detail.locator(".template-step-name");
     await expect(stepNames.nth(0)).toContainText("search");
+    await expect(stepNames.nth(0)).toContainText("entry");
     await expect(stepNames.nth(1)).toContainText("summarize");
-    await expect(stepNames.nth(1)).toContainText("exit");
+    await expect(stepNames.nth(1)).toContainText("terminal · success");
     await expect(detail.locator(".template-cap").first()).toContainText("web.search");
   });
 
-  test("preview: cost is honestly absent — a stated basis, never a fabricated figure", async ({ page }) => {
+  test("preview: cost is the estimate core computed, or an honest absence — never fabricated", async ({ page }) => {
+    // Core now serves estCostPerRunUsd, so a known estimate is SHOWN (it used to
+    // say "not surfaced here yet", which was true of the pinned index).
     await page.getByTestId("template-row-web-research-digest").click();
-    const note = page.getByTestId("template-cost-note");
-    await expect(note).toContainText("not surfaced here yet");
-    expect(await note.textContent()).not.toMatch(/\$\s*\d/);
+    await expect(page.getByTestId("template-cost-note")).toContainText("per run");
+    await expect(page.getByTestId("template-cost-note")).toContainText("$0.0060");
+
+    // Capabilities but NO estimate: say so, never print $0.00.
+    await page.getByTestId("template-row-approval-chain").click();
+    const absent = page.getByTestId("template-cost-note");
+    await expect(absent).toContainText("no per-call price");
+    expect(await absent.textContent()).not.toMatch(/\$\s*\d/);
 
     // Zero capabilities is its own honest state, not an empty slot.
     await page.getByTestId("template-row-hello-agent").click();
@@ -132,11 +141,28 @@ test.describe("templates journey v0 (from the welcome panel)", () => {
     await expect(summarize.locator(".canvas-step-dot.dot--terminal-success")).toBeVisible();
     await expect(summarize).toContainText("exit");
 
-    // A single-step template still previews honestly: one terminal node,
-    // no edges.
+    // A single-step template still previews honestly: one node, no edges. Its
+    // step is the ENTRY — entry outranks terminal in classifyStepKind, same as
+    // the canvas does for a one-step definition.
     await page.getByTestId("template-row-hello-agent").click();
-    await expect(page.getByTestId("template-graph-node-greet")).toBeVisible();
+    const greet = page.getByTestId("template-graph-node-greet");
+    await expect(greet).toBeVisible();
+    await expect(greet.locator(".canvas-step-dot.dot--entry")).toBeVisible();
     await expect(page.getByTestId("template-graph").locator(".canvas-step-transition")).toHaveCount(0);
+  });
+
+  test("preview: a fail-only exit is amber, and a pause step names its signal", async ({ page }) => {
+    // The vocabulary the previous projection collapsed: every exit was a green
+    // terminal-success and no step could be a pause.
+    await page.getByTestId("template-row-dependency-upgrade").click();
+    const giveUp = page.getByTestId("template-graph-node-give_up");
+    await expect(giveUp.locator(".canvas-step-dot.dot--terminal-warn")).toBeVisible();
+    await expect(giveUp).toContainText("fails out");
+
+    await page.getByTestId("template-row-approval-chain").click();
+    const decide = page.getByTestId("template-graph-node-decide");
+    await expect(decide.locator(".canvas-step-dot.dot--pause")).toBeVisible();
+    await expect(page.getByTestId("template-detail")).toContainText("pause · approval.decided");
   });
 
   test("a hand-edited destination survives switching templates", async ({ page }) => {

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -74,7 +74,7 @@ test.describe("add dialog (Project mode)", () => {
     await modal.getByTestId("dir-picker-input").fill("/Users/demo/brand-new-agent");
     const cta = modal.getByTestId("modal-scaffold-cta");
     await expect(cta).toBeVisible();
-    await expect(modal.getByRole("button", { name: "Add project" })).toBeDisabled();
+    await expect(modal.getByRole("button", { name: "Add workspace" })).toBeDisabled();
 
     await cta.click();
     await expect(modal).toBeHidden();

--- a/packages/harness/web/e2e/welcome.spec.ts
+++ b/packages/harness/web/e2e/welcome.spec.ts
@@ -98,6 +98,40 @@ test.describe("returning user", () => {
     await expect(page.getByTestId("welcome-start-project")).toBeVisible();
     await expect(page.getByTestId("welcome-browse-templates")).toBeVisible();
   });
+
+  test("clicking a recent workspace opens a session in it", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await openOverview(page);
+
+    // Exercises the preferred-harness resolution chain too — it runs before the
+    // session is created, so a throw there would surface as welcome-error.
+    await page.getByTestId("welcome-recent-acme-app").click();
+
+    await expect(page.getByTestId("welcome-panel")).toHaveCount(0);
+    await expect(page.getByTestId("session-context-title")).toContainText("acme-app");
+  });
+
+  test("rows disable while one is opening, so a second click cannot double-fire", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await openOverview(page);
+
+    const row = page.getByTestId("welcome-recent-acme-app");
+    const sibling = page.getByTestId("welcome-recent-rfq-workflows");
+    // Don't wait for the navigation the click triggers — the guard's whole point
+    // is what the DOM looks like DURING the two awaits (harness registry, then
+    // session create), before the panel unmounts.
+    await row.click({ noWaitAfter: true });
+
+    // Both the clicked row and its siblings go disabled; a second click is then
+    // impossible rather than merely ignored. Without the guard these stay
+    // enabled and two clicks spawn two agent PTYs in the same folder.
+    await expect(row).toBeDisabled();
+    await expect(sibling).toBeDisabled();
+
+    await expect(page.getByTestId("session-context-title")).toContainText("acme-app");
+  });
 });
 
 test.describe("templates dialog", () => {

--- a/packages/harness/web/e2e/welcome.spec.ts
+++ b/packages/harness/web/e2e/welcome.spec.ts
@@ -1,27 +1,49 @@
 /**
- * First-run welcome panel — mock-mode UI smoke (see smoke.spec.ts for the
+ * The Overview / first-run panel — mock-mode UI smoke (see smoke.spec.ts for the
  * setup). `/?mockState=fresh` renders MockApi as a brand-new install: no
- * sessions, no recent dirs, no workflows, AppState.firstRun set — the state
- * the real CLI produces on a machine that's never run the harness (it also
- * skips the auto boot session then). The default fixtures (a lived-in
- * install) double as the returning-user case.
+ * sessions, no recent dirs, no workflows, AppState.firstRun set — the state the
+ * real CLI produces on a machine that's never run the harness (it also skips the
+ * auto boot session then). The default fixtures (a lived-in install) double as
+ * the returning-user case.
+ *
+ * The panel has two states and they are NOT interchangeable: the hero pitch is
+ * first-run only, and a returning user gets their recent workspaces instead. The
+ * bug this guards is the hero rendering for someone who already has workspaces.
  */
 import { expect, test } from "@playwright/test";
 
-test.describe("first-run welcome panel", () => {
+/** Open the Overview surface — it lives in the account menu, not a tab strip. */
+async function openOverview(page: import("@playwright/test").Page): Promise<void> {
+  await page.getByTestId("brand-identity").click();
+  await expect(page.getByTestId("profile-menu")).toBeVisible();
+  await page.getByTestId("rail-overview").click();
+  await expect(page.getByTestId("welcome-panel")).toBeVisible();
+}
+
+/** Open Overview, then the templates dialog from its action band. */
+async function openTemplates(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await openOverview(page);
+  await page.getByTestId("welcome-browse-templates").click();
+  await expect(page.getByTestId("templates-dialog")).toBeVisible();
+}
+
+test.describe("first run", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?mockState=fresh");
     await expect(page.locator(".rail-workflows")).toBeVisible();
   });
 
-  test("renders on fresh state instead of the bare terminal empty state", async ({ page }) => {
+  test("renders the hero pitch instead of the bare terminal empty state", async ({ page }) => {
     const panel = page.getByTestId("welcome-panel");
     await expect(panel).toBeVisible();
     await expect(page.locator(".terminal-empty")).toHaveCount(0);
 
+    await expect(panel).toContainText("Sapiom Studio for full-stack agentic products.");
     // The two primary actions plus the compact macros/⌘K hint.
     await expect(page.getByTestId("welcome-start-project")).toBeVisible();
-    await expect(page.getByTestId("welcome-run-sample")).toBeVisible();
+    await expect(page.getByTestId("welcome-browse-templates")).toBeVisible();
     const hints = page.getByTestId("welcome-hints");
     await expect(hints).toContainText("Visualize");
     await expect(hints).toContainText("Run local");
@@ -31,7 +53,7 @@ test.describe("first-run welcome panel", () => {
     await page.screenshot({ path: "web/e2e/screenshots/welcome-panel.png", fullPage: true });
   });
 
-  test("'Start a new project' opens the existing new-session flow and creating a session dismisses the panel", async ({
+  test("'New workspace' opens the existing new-session flow and creating a session dismisses the panel", async ({
     page,
   }) => {
     await page.getByTestId("welcome-start-project").click();
@@ -45,22 +67,6 @@ test.describe("first-run welcome panel", () => {
     await expect(page.getByTestId("session-context-title")).toContainText("acme-app");
   });
 
-  test("'Run the sample project' seeds the example and opens a session in it", async ({ page }) => {
-    await page.getByTestId("welcome-run-sample").click();
-
-    await expect(page.getByTestId("welcome-panel")).toHaveCount(0);
-    await expect(page.getByTestId("session-context-title")).toContainText("sample-project");
-
-    // MockApi.seedSampleProject has no other observable effect — the test
-    // hook confirms the click actually seeded before creating the session.
-    const lastSeed = await page.evaluate(
-      () =>
-        (window as unknown as { __HARNESS_TEST__?: { lastSampleSeed?: { root: string; created: boolean } } })
-          .__HARNESS_TEST__?.lastSampleSeed,
-    );
-    expect(lastSeed?.root).toBe("/Users/demo/.sapiom/harness/sample-project");
-  });
-
   test("the footer links out to the documentation instead of a dismiss", async ({ page }) => {
     const docs = page.getByTestId("welcome-docs");
     await expect(docs).toBeVisible();
@@ -69,11 +75,75 @@ test.describe("first-run welcome panel", () => {
   });
 });
 
-test("returning users never see the welcome panel — the default (lived-in) fixtures render straight into the boot session", async ({
-  page,
-}) => {
-  await page.goto("/");
-  await expect(page.locator(".rail-workflows")).toBeVisible();
-  await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
-  await expect(page.getByTestId("welcome-panel")).toHaveCount(0);
+test.describe("returning user", () => {
+  test("the lived-in fixtures render straight into the boot session, no panel", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
+    await expect(page.getByTestId("welcome-panel")).toHaveCount(0);
+  });
+
+  test("Overview shows recent workspaces, NOT the first-run pitch", async ({ page }) => {
+    // The regression: `showWelcome` used to be `overviewSelected || firstRun`,
+    // so opening Overview with 10 workspaces pitched the product at you.
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await openOverview(page);
+
+    const panel = page.getByTestId("welcome-panel");
+    await expect(panel).not.toContainText("Sapiom Studio for full-stack agentic products.");
+    await expect(page.getByTestId("welcome-recents")).toBeVisible();
+    // The action band is shared by both states.
+    await expect(page.getByTestId("welcome-start-project")).toBeVisible();
+    await expect(page.getByTestId("welcome-browse-templates")).toBeVisible();
+  });
+});
+
+test.describe("templates dialog", () => {
+  test("lists the live catalog grouped by category, with a per-run cost or an em dash", async ({ page }) => {
+    await openTemplates(page);
+    const dialog = page.getByTestId("templates-dialog");
+
+    // More than the two entries the old hardcoded pin carried, and grouped by
+    // the registry's outcome axes rather than one flat "Gallery" heading.
+    await expect(page.getByTestId("template-row-web-research-digest")).toBeVisible();
+    await expect(page.getByTestId("template-row-cold-outreach-engine")).toBeVisible();
+    await expect(dialog).toContainText("Revenue and marketing");
+    await expect(dialog).toContainText("Data and knowledge");
+    // Bundled starters remain, as their own offline group.
+    await expect(dialog).toContainText("Bundled starters");
+    await expect(page.getByTestId("template-row-coding-pause")).toBeVisible();
+
+    // approval-chain declares capabilities but has no price → em dash, not $0.00.
+    const noEstimate = page.getByTestId("template-row-approval-chain");
+    await expect(noEstimate).toContainText("—");
+    await expect(noEstimate).not.toContainText("$0.00");
+
+    await expect(page.getByTestId("template-row-dependency-upgrade")).toContainText("$0.42");
+  });
+
+  test("search filters across name, tag, and capability", async ({ page }) => {
+    await openTemplates(page);
+
+    await page.getByTestId("template-search").fill("outreach");
+
+    await expect(page.getByTestId("template-row-cold-outreach-engine")).toBeVisible();
+    await expect(page.getByTestId("template-row-web-research-digest")).toHaveCount(0);
+
+    await page.getByTestId("template-search").fill("zzz-no-such-template");
+    await expect(page.getByTestId("templates-no-results")).toBeVisible();
+  });
+
+  test("selecting a template loads its manifest into the detail pane", async ({ page }) => {
+    await openTemplates(page);
+
+    await page.getByTestId("template-row-dependency-upgrade").click();
+
+    const detail = page.getByTestId("template-detail");
+    await expect(detail).toContainText("Dependency Upgrade");
+    await expect(page.getByTestId("template-graph")).toBeVisible();
+    // The destination follows the selection while it's untouched.
+    await expect(page.getByTestId("template-dest-input")).toHaveValue(/dependency-upgrade$/);
+  });
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -583,6 +583,8 @@ export const App = (): JSX.Element => {
           onScaffoldSession={handleScaffoldSession}
           onScaffoldInSession={handleScaffoldInSession}
           onUseTemplate={handleUseTemplate}
+          listTemplates={harness.listTemplates}
+          getTemplate={harness.getTemplate}
           onScanWorkflows={handleScanWorkflows}
           onOpenInEditor={openInEditor}
           onToast={harness.showToast}
@@ -703,12 +705,9 @@ export const App = (): JSX.Element => {
                   onCreateSession={handleCreateSession}
                   listHarnesses={harness.listHarnesses}
                   onUseTemplate={handleUseTemplate}
-                  onRunSample={async () => {
-                    const session = await harness.createSampleSession();
-                    setOverviewSelected(false);
-                    setReviewSummary(null);
-                    setFocusedAgentPath(session.cwd);
-                  }}
+                  listTemplates={harness.listTemplates}
+                  getTemplate={harness.getTemplate}
+                  firstRun={state.firstRun === true}
                 />
               ) : showReview && reviewSummary ? (
                 <PastSessionPane
@@ -912,6 +911,8 @@ export const App = (): JSX.Element => {
           launchDir={activeSession?.cwd ?? state.launchDir ?? null}
           onClose={() => setTemplatesOpen(false)}
           onUse={handleUseTemplate}
+          listTemplates={harness.listTemplates}
+          getTemplate={harness.getTemplate}
         />
       )}
 

--- a/packages/harness/web/src/components/DirectoryPicker.tsx
+++ b/packages/harness/web/src/components/DirectoryPicker.tsx
@@ -174,11 +174,11 @@ export function DirectoryPicker({
         <input
           id="new-session-cwd"
           autoFocus
-          aria-label="Project directory"
+          aria-label="Workspace folder"
           className="modal-input dir-picker-input"
           data-testid="dir-picker-input"
           value={value}
-          placeholder="/path/to/project"
+          placeholder="/path/to/workspace"
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
         />

--- a/packages/harness/web/src/components/NewSessionModal.tsx
+++ b/packages/harness/web/src/components/NewSessionModal.tsx
@@ -223,14 +223,14 @@ export function NewSessionModal({
       <div
         className={"modal " + (isWorkspace ? "modal-add-workspace" : "modal-new-session")}
         role="dialog"
-        aria-label={isWorkspace ? "Add project" : "New session"}
+        aria-label={isWorkspace ? "Add workspace" : "New session"}
         ref={panelRef}
       >
         {/* Full-bleed dialog anatomy: hairline-separated header / body /
             footer blocks, no floating inner boxes — mirrors the design
             system's DialogSurface (.sapiom-dialog). */}
         <div className="modal-header">
-          {isWorkspace ? "Add project" : "New session"}
+          {isWorkspace ? "Add workspace" : "New session"}
           <button
             className="theme-toggle modal-close"
             aria-label="Close"
@@ -258,9 +258,9 @@ export function NewSessionModal({
           <p className="modal-field-hint">
             {isWorkspace
               ? newDirTyped
-                ? "This folder doesn't exist yet. Add an existing agent project instead, or scaffold a new one here:"
+                ? "This folder doesn't exist yet. Add a folder that already holds an agent project, or scaffold a new one here:"
                 : "Pick a folder that already contains an agent project (sapiom.json); its workflow joins the rail."
-              : "Pick the project directory the agent runs in; the session is named after the folder."}
+              : "Pick the workspace folder the agent runs in; the session is named after the folder."}
           </p>
           {/* The hint's "ask the agent to scaffold one" is an ACTION —
               one click starts the session and hands the agent the scaffold
@@ -366,7 +366,7 @@ export function NewSessionModal({
             onClick={() => void submit()}
             disabled={busy || !cwd.trim() || (isWorkspace && newDirTyped)}
           >
-            {isWorkspace ? (busy ? "Adding…" : "Add project") : busy ? "Starting…" : "Start session"}
+            {isWorkspace ? (busy ? "Adding…" : "Add workspace") : busy ? "Starting…" : "Start session"}
           </button>
         </div>
       </div>

--- a/packages/harness/web/src/components/TemplateDetail.tsx
+++ b/packages/harness/web/src/components/TemplateDetail.tsx
@@ -25,6 +25,10 @@ function TemplateGraphPreview({ detail }: { detail: TemplateDetailView }): JSX.E
               <span className={"canvas-step-dot dot--" + node.kind} aria-hidden="true" />
               <span className="template-graph-name">{node.label}</span>
               {node.kind === "terminal-success" && <span className="template-step-exit">exit</span>}
+              {node.kind === "terminal-warn" && (
+                <span className="template-step-exit template-step-exit--warn">fails out</span>
+              )}
+              {node.kind === "pause" && <span className="template-step-pause">pause</span>}
               {node.capabilities.map((capability) => (
                 <code key={capability} className="template-cap">
                   {capability}
@@ -98,7 +102,10 @@ function GalleryDetail({ detail }: { detail: TemplateDetailView }): JSX.Element 
                 <span className="template-step-copy">
                   <span className="template-step-name">
                     {step.name}
-                    {step.terminal && <span className="template-step-exit">exit</span>}
+                    {/* The classifier's own one-line role — "step · can also fail"
+                        for a gate, "terminal · needs attention" for a fail sink.
+                        Anything narrower re-invents the precedence. */}
+                    <span className="template-step-role">{step.sublabel}</span>
                   </span>
                   {step.description && <span className="template-step-desc">{step.description}</span>}
                 </span>

--- a/packages/harness/web/src/components/TemplateDetail.tsx
+++ b/packages/harness/web/src/components/TemplateDetail.tsx
@@ -1,17 +1,20 @@
+import { useEffect, useState } from "react";
 import type { JSX } from "react";
 
-import { templateGraph, type GalleryTemplate, type StudioTemplate, type TemplateExample } from "../lib/templates";
+import type { TemplateDetailView } from "@shared/types";
+
+import { formatEstCost, templateGraph, type StudioTemplate } from "../lib/templates";
 import { Icon } from "./Icon";
 import { Markdown } from "./Markdown";
 
 /**
  * The template's step structure, previewed with the canvas projections'
- * vocabulary (templateGraph → kind dots, elbow transition rows) before
- * anything is cloned. Pure manifest truth: the same nodes and edges the
+ * vocabulary (templateGraph → kind dots, elbow transition rows) before anything
+ * is cloned. Pure projection of what core served: the same nodes and edges the
  * canvas renders (deterministically) once the clone lands.
  */
-function TemplateGraphPreview({ template }: { template: GalleryTemplate }): JSX.Element {
-  const graph = templateGraph(template);
+function TemplateGraphPreview({ detail }: { detail: TemplateDetailView }): JSX.Element {
+  const graph = templateGraph(detail);
   return (
     <div className="template-graph" data-testid="template-graph">
       {graph.nodes.map((node) => {
@@ -32,6 +35,7 @@ function TemplateGraphPreview({ template }: { template: GalleryTemplate }): JSX.
               <div key={`${edge.from}->${edge.to}`} className="canvas-step-transition template-graph-edge">
                 <Icon name="CornerDownRight" size={12} />
                 <span className="canvas-step-transition-target">{edge.to}</span>
+                {edge.label && <span className="canvas-step-transition-label">{edge.label}</span>}
               </div>
             ))}
           </div>
@@ -42,67 +46,96 @@ function TemplateGraphPreview({ template }: { template: GalleryTemplate }): JSX.
 }
 
 /** Pretty-printed example payload — the manifest's own JSON, verbatim. */
-function ExampleBlock({ example }: { example: TemplateExample }): JSX.Element {
+function ExampleBlock({
+  example,
+  index,
+}: {
+  example: TemplateDetailView["examples"][number];
+  index: number;
+}): JSX.Element {
   return (
     <details className="template-example">
-      <summary className="template-example-summary">{example.title}</summary>
+      <summary className="template-example-summary">{example.title ?? `Example ${index + 1}`}</summary>
       <div className="template-example-body">
         <span className="template-example-label">Input</span>
         <pre className="template-example-json">{JSON.stringify(example.input, null, 2)}</pre>
-        <span className="template-example-label">Output</span>
-        <pre className="template-example-json">{JSON.stringify(example.output, null, 2)}</pre>
+        {/* A manifest may declare an input without an output; don't render an
+            empty "Output" block claiming the run produces null. */}
+        {example.output !== null && (
+          <>
+            <span className="template-example-label">Output</span>
+            <pre className="template-example-json">{JSON.stringify(example.output, null, 2)}</pre>
+          </>
+        )}
       </div>
     </details>
   );
 }
 
-function GalleryDetail({ template }: { template: GalleryTemplate }): JSX.Element {
+/**
+ * A catalog template's detail, from `GET /api/templates/:id`. Every section is
+ * conditional on the manifest actually carrying that field: templates in the
+ * registry declare these optionally, so an absent `notes`/`useCases`/`examples`
+ * must render as nothing rather than an empty heading.
+ */
+function GalleryDetail({ detail }: { detail: TemplateDetailView }): JSX.Element {
   return (
     <>
-      <p className="template-lead">{template.whatItDoes}</p>
+      {detail.whatItDoes && <p className="template-lead">{detail.whatItDoes}</p>}
 
-      <section className="template-section">
-        <h4 className="template-section-title">Steps</h4>
-        {/* Structure first (the canvas vocabulary), then the ordered list
-            with each step's description. Same manifest, two readings. */}
-        <TemplateGraphPreview template={template} />
-        <ol className="template-steps">
-          {template.steps.map((step, index) => (
-            <li key={step.name} className="template-step">
-              <span className="template-step-index" aria-hidden="true">
-                {index + 1}
-              </span>
-              <span className="template-step-copy">
-                <span className="template-step-name">
-                  {step.name}
-                  {step.terminal && <span className="template-step-exit">exit</span>}
+      {detail.steps.length > 0 && (
+        <section className="template-section">
+          <h4 className="template-section-title">Steps</h4>
+          {/* Structure first (the canvas vocabulary), then the ordered list with
+              each step's description. Same manifest, two readings. */}
+          <TemplateGraphPreview detail={detail} />
+          <ol className="template-steps">
+            {detail.steps.map((step, index) => (
+              <li key={step.name} className="template-step">
+                <span className="template-step-index" aria-hidden="true">
+                  {index + 1}
                 </span>
-                <span className="template-step-desc">{step.description}</span>
-              </span>
-              {step.capability && <code className="template-cap">{step.capability}</code>}
-            </li>
-          ))}
-        </ol>
-        <p className="template-note">Steps run in listed order; the first is the entry.</p>
-      </section>
+                <span className="template-step-copy">
+                  <span className="template-step-name">
+                    {step.name}
+                    {step.terminal && <span className="template-step-exit">exit</span>}
+                  </span>
+                  {step.description && <span className="template-step-desc">{step.description}</span>}
+                </span>
+                {step.capabilities.map((capability) => (
+                  <code key={capability} className="template-cap">
+                    {capability}
+                  </code>
+                ))}
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
 
       <section className="template-section">
         <h4 className="template-section-title">Capabilities and cost</h4>
-        {template.capabilities.length > 0 ? (
+        {detail.capabilities.length > 0 ? (
           <>
             <div className="template-caps">
-              {template.capabilities.map((capability) => (
+              {detail.capabilities.map((capability) => (
                 <code key={capability} className="template-cap">
                   {capability}
                 </code>
               ))}
             </div>
-            {/* Honest absence: the backend computes the per-run estimate from
-                this list, and no client surface exposes it yet.
-                Never a fabricated figure. */}
             <p className="template-note" data-testid="template-cost-note">
-              Metered capabilities set the per-run price. Sapiom estimates it from this list; the
-              estimate is not surfaced here yet. Local test runs stub every capability and are free.
+              {detail.estCostPerRunUsd === null ? (
+                <>
+                  Metered capabilities set the per-run price. Sapiom has no per-call price for these,
+                  so no estimate is shown. Local test runs stub every capability and are free.
+                </>
+              ) : (
+                <>
+                  Estimated <strong>{formatEstCost(detail.estCostPerRunUsd)}</strong> per run, from these
+                  capabilities at current prices. Local test runs stub every capability and are free.
+                </>
+              )}
             </p>
           </>
         ) : (
@@ -112,39 +145,91 @@ function GalleryDetail({ template }: { template: GalleryTemplate }): JSX.Element
         )}
       </section>
 
-      <section className="template-section">
-        <h4 className="template-section-title">Use cases</h4>
-        <ul className="template-usecases">
-          {template.useCases.map((useCase) => (
-            <li key={useCase}>{useCase}</li>
+      {detail.requiredSecrets.length > 0 && (
+        <section className="template-section">
+          <h4 className="template-section-title">Credentials you supply</h4>
+          <ul className="template-usecases">
+            {detail.requiredSecrets.map((secret) => (
+              <li key={secret.key}>
+                <code className="template-cap">{secret.key}</code> {secret.label}
+                {secret.description && <> — {secret.description}</>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {detail.useCases.length > 0 && (
+        <section className="template-section">
+          <h4 className="template-section-title">Use cases</h4>
+          <ul className="template-usecases">
+            {detail.useCases.map((useCase) => (
+              <li key={useCase}>{useCase}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {detail.examples.length > 0 && (
+        <section className="template-section">
+          <h4 className="template-section-title">Examples</h4>
+          {detail.examples.map((example, index) => (
+            <ExampleBlock key={example.title ?? index} example={example} index={index} />
           ))}
-        </ul>
-      </section>
+        </section>
+      )}
 
-      <section className="template-section">
-        <h4 className="template-section-title">Examples</h4>
-        {template.examples.map((example) => (
-          <ExampleBlock key={example.title} example={example} />
-        ))}
-      </section>
-
-      <section className="template-section">
-        <h4 className="template-section-title">Notes</h4>
-        <div className="template-notes">
-          <Markdown text={template.notes} />
-        </div>
-      </section>
+      {detail.notes && (
+        <section className="template-section">
+          <h4 className="template-section-title">Notes</h4>
+          <div className="template-notes">
+            <Markdown text={detail.notes} />
+          </div>
+        </section>
+      )}
     </>
   );
 }
 
 /**
- * The preview pane of the templates dialog: real manifest fields only. A
- * gallery template renders its registry entry + template.json detail; a
+ * The preview pane of the templates dialog: real manifest fields only. A catalog
+ * template's detail is fetched on selection (`GET /api/templates/:id`); a bundled
  * starter renders the one honest sentence the scaffold tool ships about it —
- * bundled starters have no manifest, so nothing more is claimed.
+ * starters have no manifest, so nothing more is claimed.
  */
-export function TemplateDetail({ template }: { template: StudioTemplate }): JSX.Element {
+export function TemplateDetail({
+  template,
+  getTemplate,
+}: {
+  template: StudioTemplate;
+  getTemplate: (id: string) => Promise<TemplateDetailView>;
+}): JSX.Element {
+  const [detail, setDetail] = useState<TemplateDetailView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (template.kind !== "gallery") {
+      setDetail(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    // Clear first so switching templates never shows the previous one's manifest
+    // under the new one's name.
+    setDetail(null);
+    setError(null);
+    getTemplate(template.id)
+      .then((loaded) => {
+        if (!cancelled) setDetail(loaded);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [template.kind, template.id, getTemplate]);
+
   return (
     <div className="template-detail" data-testid="template-detail">
       <div className="template-detail-head">
@@ -159,13 +244,27 @@ export function TemplateDetail({ template }: { template: StudioTemplate }): JSX.
       </div>
       {template.kind === "gallery" ? (
         <>
-          <span className="template-byline">
-            By{" "}
-            <a href={template.author.url} target="_blank" rel="noopener noreferrer">
-              {template.author.name}
-            </a>
-          </span>
-          <GalleryDetail template={template} />
+          {detail?.author && (
+            <span className="template-byline">
+              By{" "}
+              {detail.author.url ? (
+                <a href={detail.author.url} target="_blank" rel="noopener noreferrer">
+                  {detail.author.name}
+                </a>
+              ) : (
+                detail.author.name
+              )}
+            </span>
+          )}
+          {/* The summary's description always renders, so the pane is never bare
+              while the manifest loads. */}
+          {!detail && !error && <p className="template-lead">{template.description}</p>}
+          {error && (
+            <p className="template-note" data-testid="template-detail-error">
+              Could not load this template’s details: {error}
+            </p>
+          )}
+          {detail && <GalleryDetail detail={detail} />}
         </>
       ) : (
         <>

--- a/packages/harness/web/src/components/TemplatesDialog.tsx
+++ b/packages/harness/web/src/components/TemplatesDialog.tsx
@@ -97,7 +97,10 @@ export function TemplatesDialog({
   const [dest, setDest] = useState(() => templateDirSuggestion(STARTER_TEMPLATES[0], launchDir));
   // A hand-edited destination survives template switches; an untouched one
   // follows the selection so the default always names the picked template.
-  const [destEdited, setDestEdited] = useState(false);
+  // A REF, not state: the catalog effect below runs once (`[]` deps), so a
+  // state closure would capture `false` permanently and overwrite a destination
+  // the user typed while the fetch was in flight.
+  const destEdited = useRef(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -116,7 +119,7 @@ export function TemplatesDialog({
         if (first && !selectionTouched.current) {
           const template: GalleryTemplate = { ...first, kind: "gallery" };
           setSelected(template);
-          if (!destEdited) setDest(templateDirSuggestion(template, launchDir));
+          if (!destEdited.current) setDest(templateDirSuggestion(template, launchDir));
         }
       })
       .catch((err: unknown) => {
@@ -134,7 +137,7 @@ export function TemplatesDialog({
     selectionTouched.current = true;
     setSelected(template);
     setError(null);
-    if (!destEdited) setDest(templateDirSuggestion(template, launchDir));
+    if (!destEdited.current) setDest(templateDirSuggestion(template, launchDir));
   };
 
   const gallery = useMemo<GalleryTemplate[]>(
@@ -274,7 +277,7 @@ export function TemplatesDialog({
               disabled={busy}
               onChange={(e) => {
                 setDest(e.target.value);
-                setDestEdited(true);
+                destEdited.current = true;
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") void submit();

--- a/packages/harness/web/src/components/TemplatesDialog.tsx
+++ b/packages/harness/web/src/components/TemplatesDialog.tsx
@@ -1,10 +1,15 @@
-import { useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { JSX, RefObject } from "react";
 
+import type { TemplateDetailView, TemplateListResponse } from "@shared/types";
+
 import {
-  GALLERY_TEMPLATES,
   STARTER_TEMPLATES,
+  formatEstCost,
+  groupByCategory,
+  matchesQuery,
   templateDirSuggestion,
+  type GalleryTemplate,
   type StudioTemplate,
 } from "../lib/templates";
 import { useDismissable } from "../lib/use-dismissable";
@@ -18,6 +23,9 @@ interface TemplatesDialogProps {
   /** The real handoff (App.handleUseTemplate): starts a session in the
    *  destination folder and hands the agent the clone or scaffold prompt. */
   onUse: (dir: string, template: StudioTemplate) => Promise<void>;
+  /** The live catalog fetchers (server relays core; the key stays server-side). */
+  listTemplates: () => Promise<TemplateListResponse>;
+  getTemplate: (id: string) => Promise<TemplateDetailView>;
   /** The button that opened the dialog — Escape returns focus to it. */
   triggerRef?: RefObject<HTMLElement | null>;
 }
@@ -42,22 +50,51 @@ function TemplateRow({
     >
       <span className="template-row-name">{template.name}</span>
       <span className="template-row-desc">{template.description}</span>
+      {/* Cost is the one number that changes the decision, so it rides on the
+          card. An em dash means "no per-call-priced capability declared" —
+          never rendered as $0.00 (see formatEstCost). */}
+      {template.kind === "gallery" && (
+        <span className="template-row-meta">
+          <span className="template-row-steps">
+            {template.stepCount} {template.stepCount === 1 ? "step" : "steps"}
+          </span>
+          <span className="template-row-cost" title="Estimated capability cost per run">
+            {formatEstCost(template.estCostPerRunUsd)}
+          </span>
+        </span>
+      )}
     </button>
   );
 }
 
 /**
- * Start from a template (templates journey v0): browse the curated index,
- * preview a template's real manifest, and use it — which starts a session in
- * a new destination folder and hands the agent the real operation (the
- * clone MCP tool for gallery templates, `sapiom agents init -t` for bundled
- * starters). The cloned folder then joins the rail as a workspace and
- * editing/running is the normal loop — no special path. See lib/templates.ts
- * for the provenance of every word in the index.
+ * Start from a template: browse the LIVE catalog (the same one the dashboard's
+ * Template library renders, relayed by the harness server from core so the API
+ * key never reaches the browser), preview a template's real manifest, and use it
+ * — which starts a session in a new destination folder and hands the agent the
+ * real operation (the clone MCP tool for catalog templates, `sapiom agents init
+ * -t` for bundled starters). The cloned folder then joins the rail as a
+ * workspace and editing/running is the normal loop — no special path.
+ *
+ * The catalog is fetched, not pinned: this dialog previously rendered a
+ * hardcoded two-entry copy while the dashboard showed 26. If the fetch degrades
+ * (signed out, core unreachable) the bundled starters still work offline and the
+ * dialog SAYS the gallery is unavailable rather than presenting a short list as
+ * if it were complete.
  */
-export function TemplatesDialog({ launchDir, onClose, onUse, triggerRef }: TemplatesDialogProps): JSX.Element {
-  const [selected, setSelected] = useState<StudioTemplate>(GALLERY_TEMPLATES[0]);
-  const [dest, setDest] = useState(() => templateDirSuggestion(GALLERY_TEMPLATES[0], launchDir));
+export function TemplatesDialog({
+  launchDir,
+  onClose,
+  onUse,
+  listTemplates,
+  getTemplate,
+  triggerRef,
+}: TemplatesDialogProps): JSX.Element {
+  const [catalog, setCatalog] = useState<TemplateListResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<StudioTemplate>(STARTER_TEMPLATES[0]);
+  const [dest, setDest] = useState(() => templateDirSuggestion(STARTER_TEMPLATES[0], launchDir));
   // A hand-edited destination survives template switches; an untouched one
   // follows the selection so the default always names the picked template.
   const [destEdited, setDestEdited] = useState(false);
@@ -66,11 +103,53 @@ export function TemplatesDialog({ launchDir, onClose, onUse, triggerRef }: Templ
   const panelRef = useRef<HTMLDivElement>(null);
   useDismissable(true, { onDismiss: onClose, containerRef: panelRef, triggerRef });
 
+  // Selection follows the loaded catalog: default to the first gallery template
+  // once it arrives, but never clobber a choice the user already made.
+  const selectionTouched = useRef(false);
+  useEffect(() => {
+    let cancelled = false;
+    listTemplates()
+      .then((response) => {
+        if (cancelled) return;
+        setCatalog(response);
+        const first = response.templates[0];
+        if (first && !selectionTouched.current) {
+          const template: GalleryTemplate = { ...first, kind: "gallery" };
+          setSelected(template);
+          if (!destEdited) setDest(templateDirSuggestion(template, launchDir));
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally once-per-open: the dialog is short-lived and the server
+    // caches the upstream call, so re-fetching on a keystroke would be waste.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const select = (template: StudioTemplate): void => {
+    selectionTouched.current = true;
     setSelected(template);
     setError(null);
     if (!destEdited) setDest(templateDirSuggestion(template, launchDir));
   };
+
+  const gallery = useMemo<GalleryTemplate[]>(
+    () => (catalog?.templates ?? []).map((template) => ({ ...template, kind: "gallery" as const })),
+    [catalog],
+  );
+  const groups = useMemo(
+    () => groupByCategory(gallery.filter((template) => matchesQuery(template, query))),
+    [gallery, query],
+  );
+  const starters = useMemo(
+    () => STARTER_TEMPLATES.filter((template) => matchesQuery(template, query)),
+    [query],
+  );
+  const resultCount = groups.reduce((sum, group) => sum + group.templates.length, 0) + starters.length;
 
   const submit = async (): Promise<void> => {
     const trimmed = dest.trim();
@@ -85,6 +164,18 @@ export function TemplatesDialog({ launchDir, onClose, onUse, triggerRef }: Templ
       setBusy(false);
     }
   };
+
+  /** Why the gallery is short, in the user's terms — silence here is what made
+   *  the pinned two-entry list look like the whole catalog. */
+  const degraded = (): string | null => {
+    if (loadError) return `Could not load the template gallery: ${loadError}`;
+    if (!catalog) return null;
+    if (catalog.source === "live") return null;
+    return catalog.reason === "signed-out"
+      ? "Sign in to Sapiom to browse the template gallery. The bundled starters below work offline."
+      : "The template gallery is unreachable right now. The bundled starters below work offline.";
+  };
+  const degradedNote = degraded();
 
   return (
     <div className="modal-backdrop">
@@ -109,28 +200,67 @@ export function TemplatesDialog({ launchDir, onClose, onUse, triggerRef }: Templ
         </div>
 
         <div className="templates-layout">
-          <div className="templates-list" role="listbox" aria-label="Templates">
-            <div className="templates-list-section">Gallery</div>
-            {GALLERY_TEMPLATES.map((template) => (
-              <TemplateRow
-                key={template.id}
-                template={template}
-                isSelected={template.id === selected.id}
-                onSelect={select}
-              />
-            ))}
-            <div className="templates-list-section">Starters</div>
-            {STARTER_TEMPLATES.map((template) => (
-              <TemplateRow
-                key={template.id}
-                template={template}
-                isSelected={template.id === selected.id}
-                onSelect={select}
-              />
-            ))}
+          <div className="templates-sidebar">
+            <input
+              className="modal-input templates-search"
+              value={query}
+              placeholder="Search templates…"
+              aria-label="Search templates"
+              data-testid="template-search"
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <div className="templates-list" role="listbox" aria-label="Templates">
+              {catalog === null && !loadError && (
+                <div className="templates-list-empty" data-testid="templates-loading">
+                  Loading templates…
+                </div>
+              )}
+              {degradedNote && (
+                <div className="templates-list-note" data-testid="templates-degraded">
+                  {degradedNote}
+                </div>
+              )}
+              {groups.map((group) => (
+                <div key={group.label}>
+                  <div className="templates-list-section">
+                    {group.label}
+                    <span className="templates-list-count">{group.templates.length}</span>
+                  </div>
+                  {group.templates.map((template) => (
+                    <TemplateRow
+                      key={template.id}
+                      template={template}
+                      isSelected={template.id === selected.id}
+                      onSelect={select}
+                    />
+                  ))}
+                </div>
+              ))}
+              {starters.length > 0 && (
+                <>
+                  <div className="templates-list-section">
+                    Bundled starters
+                    <span className="templates-list-count">{starters.length}</span>
+                  </div>
+                  {starters.map((template) => (
+                    <TemplateRow
+                      key={template.id}
+                      template={template}
+                      isSelected={template.id === selected.id}
+                      onSelect={select}
+                    />
+                  ))}
+                </>
+              )}
+              {catalog !== null && resultCount === 0 && (
+                <div className="templates-list-empty" data-testid="templates-no-results">
+                  No templates match “{query}”.
+                </div>
+              )}
+            </div>
           </div>
 
-          <TemplateDetail template={selected} />
+          <TemplateDetail template={selected} getTemplate={getTemplate} />
         </div>
 
         <div className="modal-actions templates-actions">

--- a/packages/harness/web/src/components/WelcomePanel.tsx
+++ b/packages/harness/web/src/components/WelcomePanel.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState } from "react";
 import type { JSX } from "react";
-import type { HarnessEntry, HarnessKind } from "@shared/types";
+import { SPAWNABLE_HARNESS_KINDS } from "@shared/types";
+import type { HarnessEntry, HarnessKind, TemplateDetailView, TemplateListResponse } from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
 import type { StudioTemplate } from "../lib/templates";
+import { loadUiPrefs } from "../lib/ui-prefs";
 import { Icon } from "./Icon";
 import { NewSessionModal } from "./NewSessionModal";
 import { TemplatesDialog } from "./TemplatesDialog";
@@ -18,24 +20,42 @@ interface WelcomePanelProps {
   recentDirs: string[];
   launchDir: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
-  /** The existing new-session flow — "Start a new project" opens the same
+  /** The existing new-session flow — "New workspace" opens the same
    *  NewSessionModal the tab strip's "+" does, with the same handler. */
   onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
   /** Adapter registry fetch — keeps this modal's picker registry-driven too. */
   listHarnesses: () => Promise<HarnessEntry[]>;
-  /** Seeds the bundled example project and opens a session in it. On success
-   *  the panel unmounts by itself (a live session now exists). */
-  onRunSample: () => Promise<void>;
-  /** Templates journey v0 (App.handleUseTemplate): starts a session in the
+  /** Templates journey (App.handleUseTemplate): starts a session in the
    *  destination folder and hands the agent the clone/scaffold prompt. */
   onUseTemplate: (dir: string, template: StudioTemplate) => Promise<void>;
+  /** Forwarded to TemplatesDialog — the live catalog fetchers. */
+  listTemplates: () => Promise<TemplateListResponse>;
+  getTemplate: (id: string) => Promise<TemplateDetailView>;
+  /**
+   * True only on a genuine first run of this install (AppState.firstRun) — the
+   * hero pitch is for someone who has never seen the product. A returning user
+   * gets the recent-workspaces view instead: the pitch is noise once you have
+   * workspaces, and this panel also backs the Overview tab, which returning
+   * users open deliberately.
+   */
+  firstRun: boolean;
+}
+
+/** Basename of a workspace path — the folder name is what the rail shows. */
+function folderName(dir: string): string {
+  const parts = dir.replace(/[\\/]+$/, "").split(/[\\/]/);
+  return parts[parts.length - 1] || dir;
 }
 
 /**
- * First-run welcome — rendered in the terminal slot instead of a bare
- * terminal when this install has never been used before (AppState.firstRun)
- * and no session is live yet. Returning users never see it; a first-run
- * user leaves it by taking either action, which creates a session.
+ * Overview / first-run panel — rendered in the terminal slot when no session is
+ * live, and whenever the Overview tab is selected.
+ *
+ * Two states, because the audiences are different. On a genuine first run the
+ * hero pitches the product. For a returning user (the Overview tab's usual
+ * visitor) the pitch is dead weight — they get their recent workspaces, which is
+ * the thing they actually came here to pick from. Both states share the action
+ * band, so Templates / New workspace are always one click away.
  */
 export function WelcomePanel({
   recentDirs,
@@ -43,109 +63,157 @@ export function WelcomePanel({
   listDir,
   onCreateSession,
   listHarnesses,
-  onRunSample,
   onUseTemplate,
+  listTemplates,
+  getTemplate,
+  firstRun,
 }: WelcomePanelProps): JSX.Element {
   const [modalOpen, setModalOpen] = useState(false);
   const [templatesOpen, setTemplatesOpen] = useState(false);
-  const [sampleBusy, setSampleBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const startProjectRef = useRef<HTMLButtonElement>(null);
   const templatesTriggerRef = useRef<HTMLButtonElement>(null);
 
-  const runSample = async (): Promise<void> => {
-    setSampleBusy(true);
+  const openWorkspace = async (dir: string): Promise<void> => {
     setError(null);
     try {
-      await onRunSample();
-      // Success unmounts the whole panel — no state left to reset.
+      // Opening a workspace you already used shouldn't re-ask which agent to
+      // run, so resolve a default: the user's persisted preference when it is
+      // actually installed, else the first installed spawnable adapter. Same
+      // registry-driven correction NewSessionModal applies to its default.
+      const entries = await listHarnesses();
+      const spawnable = entries.filter(
+        (entry) => entry.installed && (SPAWNABLE_HARNESS_KINDS as readonly string[]).includes(entry.id),
+      );
+      const preferred = loadUiPrefs().preferredHarness;
+      const chosen =
+        (preferred && spawnable.some((entry) => entry.id === preferred) ? preferred : undefined) ??
+        (spawnable[0]?.id as HarnessKind | undefined) ??
+        "claude-code";
+      await onCreateSession(dir, chosen);
+      // Success unmounts this panel (a live session now exists).
     } catch (err) {
       setError((err as Error).message);
-      setSampleBusy(false);
     }
   };
 
+  const actions = (
+    <div className="welcome-footer">
+      <a
+        className="welcome-docs"
+        data-testid="welcome-docs"
+        href="https://docs.sapiom.ai"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Docs <Icon name="ExternalLink" size={12} />
+      </a>
+      <button
+        ref={templatesTriggerRef}
+        className="btn-ghost welcome-action"
+        data-testid="welcome-browse-templates"
+        onClick={() => setTemplatesOpen(true)}
+        title="Start from a template: the Sapiom template gallery and bundled starters"
+      >
+        Templates
+      </button>
+      <button
+        ref={startProjectRef}
+        className="btn-primary welcome-action"
+        data-testid="welcome-start-project"
+        onClick={() => setModalOpen(true)}
+      >
+        New workspace
+      </button>
+    </div>
+  );
+
   return (
     <div className="welcome-panel" data-testid="welcome-panel">
-      <div className="welcome-card">
-        {/* Product-as-hero: the app itself, cropped to its top band with a
-            fade into the card — the pitch is the picture, not paragraphs.
-            Each theme ships its own capture: CSS shows the matching
-            one so the fade always lands on the card surface behind it,
-            never a dark shot dissolving into a white card. Both are real
-            screenshots; regenerate via e2e/capture-welcome-hero.mjs. */}
-        <div className="welcome-hero" aria-hidden="true">
-          <img className="welcome-hero-dark" src={welcomeHeroDark} alt="" />
-          <img className="welcome-hero-light" src={welcomeHeroLight} alt="" />
-        </div>
-
-        <div className="welcome-copy">
-          <h1 className="welcome-title">Sapiom Studio for full-stack agentic products.</h1>
-          <p className="welcome-intro">
-            Your coding agent in a Sapiom-configured workspace: build agent workflows, see them on the canvas, run and
-            deploy them in one click.
-          </p>
-          {error && <div className="welcome-error">{error}</div>}
-
-          <div className="welcome-hints" data-testid="welcome-hints">
-            <div className="welcome-hint-chips">
-              <span className="welcome-hint-chip">
-                <Icon name="Workflow" size={11} /> Visualize
-              </span>
-              <span className="welcome-hint-chip">
-                <Icon name="Play" size={11} /> Run local
-              </span>
-              <span className="welcome-hint-chip">
-                <Icon name="Cloud" size={11} /> Deploy
-              </span>
+      <div className={"welcome-card" + (firstRun ? "" : " welcome-card--returning")}>
+        {firstRun ? (
+          <>
+            {/* Product-as-hero: the app itself, cropped to its top band with a
+                fade into the card — the pitch is the picture, not paragraphs.
+                Each theme ships its own capture: CSS shows the matching one so
+                the fade always lands on the card surface behind it, never a dark
+                shot dissolving into a white card. Both are real screenshots;
+                regenerate via e2e/capture-welcome-hero.mjs. */}
+            <div className="welcome-hero" aria-hidden="true">
+              <img className="welcome-hero-dark" src={welcomeHeroDark} alt="" />
+              <img className="welcome-hero-light" src={welcomeHeroLight} alt="" />
             </div>
-            {/* Its own centered line under the pill row — trailing it inline
-                read as a fourth pill. */}
+
+            <div className="welcome-copy">
+              <h1 className="welcome-title">Sapiom Studio for full-stack agentic products.</h1>
+              <p className="welcome-intro">
+                Your coding agent in a Sapiom-configured workspace: build agent workflows, see them on the canvas, run
+                and deploy them in one click.
+              </p>
+              {error && <div className="welcome-error">{error}</div>}
+
+              <div className="welcome-hints" data-testid="welcome-hints">
+                <div className="welcome-hint-chips">
+                  <span className="welcome-hint-chip">
+                    <Icon name="Workflow" size={11} /> Visualize
+                  </span>
+                  <span className="welcome-hint-chip">
+                    <Icon name="Play" size={11} /> Run local
+                  </span>
+                  <span className="welcome-hint-chip">
+                    <Icon name="Cloud" size={11} /> Deploy
+                  </span>
+                </div>
+                {/* Its own centered line under the pill row — trailing it inline
+                    read as a fourth pill. */}
+                <span className="welcome-hints-kbd">
+                  or press <kbd>⌘K</kbd>
+                </span>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="welcome-copy welcome-copy--returning">
+            <h1 className="welcome-title welcome-title--returning">Overview</h1>
+            {error && <div className="welcome-error">{error}</div>}
+            {recentDirs.length > 0 ? (
+              <>
+                <h2 className="welcome-recents-title">Recent workspaces</h2>
+                <ul className="welcome-recents" data-testid="welcome-recents">
+                  {recentDirs.slice(0, 8).map((dir) => (
+                    <li key={dir}>
+                      <button
+                        type="button"
+                        className="welcome-recent"
+                        data-testid={`welcome-recent-${folderName(dir)}`}
+                        title={dir}
+                        onClick={() => void openWorkspace(dir)}
+                      >
+                        <Icon name="Folder" size={13} />
+                        <span className="welcome-recent-name">{folderName(dir)}</span>
+                        <span className="welcome-recent-path">{dir}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              // Reachable: a workspace can be in the rail without ever having
+              // hosted a session (a scanned folder), so recents can be empty
+              // for someone who is not a first-run user.
+              <p className="welcome-intro" data-testid="welcome-no-recents">
+                No recent workspaces yet. Open a folder or start from a template.
+              </p>
+            )}
             <span className="welcome-hints-kbd">
               or press <kbd>⌘K</kbd>
             </span>
           </div>
-        </div>
+        )}
 
-        {/* Bottom-anchored action band: docs link leftmost, then the two CTAs
-            build rightward, primary at the right edge. */}
-        <div className="welcome-footer">
-          <a
-            className="welcome-docs"
-            data-testid="welcome-docs"
-            href="https://docs.sapiom.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Docs <Icon name="ExternalLink" size={12} />
-          </a>
-          <button
-            ref={templatesTriggerRef}
-            className="btn-ghost welcome-action"
-            data-testid="welcome-browse-templates"
-            onClick={() => setTemplatesOpen(true)}
-            title="Start from a template: cloneable gallery templates and bundled starters"
-          >
-            Templates
-          </button>
-          <button
-            className="btn-ghost welcome-action"
-            data-testid="welcome-run-sample"
-            onClick={() => void runSample()}
-            disabled={sampleBusy}
-            title="Seeds order-triage, a small support-ticket triage agent, and opens a session in it"
-          >
-            {sampleBusy ? "Setting up…" : "Sample project"}
-          </button>
-          <button
-            ref={startProjectRef}
-            className="btn-primary welcome-action"
-            data-testid="welcome-start-project"
-            onClick={() => setModalOpen(true)}
-          >
-            New project
-          </button>
-        </div>
+        {/* Bottom-anchored action band: docs link leftmost, then the CTAs build
+            rightward, primary at the right edge. Shared by both states. */}
+        {actions}
       </div>
 
       {modalOpen && (
@@ -160,13 +228,15 @@ export function WelcomePanel({
         />
       )}
 
-      {/* Templates journey v0: using one creates a session, which unmounts
-          this whole panel — the session pane is the destination. */}
+      {/* Templates journey: using one creates a session, which unmounts this
+          whole panel — the session pane is the destination. */}
       {templatesOpen && (
         <TemplatesDialog
           launchDir={launchDir}
           onClose={() => setTemplatesOpen(false)}
           onUse={onUseTemplate}
+          listTemplates={listTemplates}
+          getTemplate={getTemplate}
           triggerRef={templatesTriggerRef}
         />
       )}

--- a/packages/harness/web/src/components/WelcomePanel.tsx
+++ b/packages/harness/web/src/components/WelcomePanel.tsx
@@ -71,10 +71,19 @@ export function WelcomePanel({
   const [modalOpen, setModalOpen] = useState(false);
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** The workspace currently being opened, so a second click is a no-op and the
+   *  row can show it is working. Null when idle. */
+  const [opening, setOpening] = useState<string | null>(null);
   const startProjectRef = useRef<HTMLButtonElement>(null);
   const templatesTriggerRef = useRef<HTMLButtonElement>(null);
 
   const openWorkspace = async (dir: string): Promise<void> => {
+    // Guarded because opening spans two awaits (registry, then session create)
+    // and `handleCreateSession` does not dedupe by cwd — an impatient second
+    // click would spawn a second agent PTY in the same folder. The Sample
+    // project button this replaces had the same guard.
+    if (opening) return;
+    setOpening(dir);
     setError(null);
     try {
       // Opening a workspace you already used shouldn't re-ask which agent to
@@ -91,9 +100,11 @@ export function WelcomePanel({
         (spawnable[0]?.id as HarnessKind | undefined) ??
         "claude-code";
       await onCreateSession(dir, chosen);
-      // Success unmounts this panel (a live session now exists).
+      // Success unmounts this panel (a live session now exists), so `opening`
+      // is only cleared on the failure path below.
     } catch (err) {
       setError((err as Error).message);
+      setOpening(null);
     }
   };
 
@@ -187,11 +198,14 @@ export function WelcomePanel({
                         className="welcome-recent"
                         data-testid={`welcome-recent-${folderName(dir)}`}
                         title={dir}
+                        disabled={opening !== null}
                         onClick={() => void openWorkspace(dir)}
                       >
                         <Icon name="Folder" size={13} />
                         <span className="welcome-recent-name">{folderName(dir)}</span>
-                        <span className="welcome-recent-path">{dir}</span>
+                        <span className="welcome-recent-path">
+                          {opening === dir ? "Opening…" : dir}
+                        </span>
                       </button>
                     </li>
                   ))}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -6,6 +6,8 @@ import type {
   HarnessKind,
   HarnessSession,
   SessionSummary,
+  TemplateDetailView,
+  TemplateListResponse,
   WorkflowInfo,
 } from "@shared/types";
 
@@ -67,6 +69,9 @@ interface WorkflowsRailProps {
    *  scaffold its first agent (sapiom.json) in place. */
   onScaffoldInSession: (sessionId: string) => void;
   onUseTemplate: (dir: string, template: StudioTemplate) => Promise<void>;
+  /** Forwarded to TemplatesDialog — the live catalog fetchers. */
+  listTemplates: () => Promise<TemplateListResponse>;
+  getTemplate: (id: string) => Promise<TemplateDetailView>;
   onScanWorkflows: (root: string) => Promise<number>;
   /** Opens a project in the user's editor — URL scheme, cwd-scoped. */
   onOpenInEditor: (path: string) => void;
@@ -290,6 +295,8 @@ export function WorkflowsRail({
   onScaffoldSession,
   onScaffoldInSession,
   onUseTemplate,
+  listTemplates,
+  getTemplate,
   onScanWorkflows,
   onOpenInEditor,
   onToast,
@@ -388,7 +395,7 @@ export function WorkflowsRail({
       </div>
 
       <div className="rail-header">
-        Workspace
+        Workspaces
         <div className="rail-header-actions">
           <button
             ref={historyTriggerRef}
@@ -410,8 +417,8 @@ export function WorkflowsRail({
             ref={connectTriggerRef}
             className="theme-toggle rail-header-btn"
             data-testid="add-workspace"
-            aria-label="Add project"
-            title="Register an existing agent project folder (sapiom.json). Its agent appears in the rail."
+            aria-label="Add workspace"
+            title="Add a workspace: a folder containing an agent project (sapiom.json). Its agent appears in the rail."
             onClick={() => {
               setHistoryOpen(false);
               setAddDialogMode("workspace");
@@ -505,7 +512,7 @@ export function WorkflowsRail({
               className="rail-empty"
               icon="Folder"
               title="No agents yet"
-              body="Start a session in a project directory, or add a workspace. Agents (sapiom.json) appear here automatically."
+              body="Open a workspace folder to start a session, or add one. Agents (sapiom.json) appear here automatically."
             />
           )}
 
@@ -622,6 +629,8 @@ export function WorkflowsRail({
           launchDir={launchDir}
           onClose={() => setTemplatesOpen(false)}
           onUse={onUseTemplate}
+          listTemplates={listTemplates}
+          getTemplate={getTemplate}
           triggerRef={connectTriggerRef}
         />
       )}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -28,7 +28,7 @@ import type {
 
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
-import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_TEMPLATES, MOCK_WORKFLOWS } from "./mock-data";
+import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_TEMPLATE_GRAPHS, MOCK_TEMPLATES, MOCK_WORKFLOWS } from "./mock-data";
 
 /**
  * Body for `POST /api/runs/local` — run the agent project at `sourceDir`
@@ -954,25 +954,28 @@ class MockApi implements HarnessApi {
     await delay(150);
     const summary = MOCK_TEMPLATES.find((template) => template.id === id);
     if (!summary) throw new ApiError(404, `mock: no template ${id}`, `Template not found: ${id}`);
-    // Synthesize a linear graph of `stepCount` steps: mock mode only needs the
-    // detail pane to have SOMETHING structurally valid to project, and the real
-    // per-template graphs live upstream in the registry, not here.
-    const steps = Array.from({ length: Math.max(summary.stepCount, 1) }, (_, index) => ({
-      name: index === 0 ? "start" : index === summary.stepCount - 1 ? "finish" : `step-${index + 1}`,
-      description: `Mock step ${index + 1} of ${summary.stepCount}.`,
-      capabilities: index === 0 ? summary.capabilities : [],
-      terminal: index === Math.max(summary.stepCount, 1) - 1,
-    }));
+    // Real per-template graphs (MOCK_TEMPLATE_GRAPHS) with the registry's actual
+    // step names, so mock mode previews what live mode previews. A template with
+    // no graph fixture falls back to a single entry node rather than inventing a
+    // shape we would then assert against.
+    const graph = MOCK_TEMPLATE_GRAPHS[summary.id] ?? {
+      steps: [
+        {
+          name: "start",
+          description: null,
+          capabilities: summary.capabilities,
+          kind: "entry",
+          sublabel: "entry",
+        },
+      ],
+      transitions: [],
+    };
     return {
       ...summary,
       whatItDoes: summary.description,
       sourcePath: `examples/${summary.id}`,
-      steps,
-      transitions: steps.slice(0, -1).map((step, index) => ({
-        from: step.name,
-        to: steps[index + 1].name,
-        label: null,
-      })),
+      steps: graph.steps,
+      transitions: graph.transitions,
       author: { name: "Sapiom", url: "https://sapiom.ai/" },
       useCases: [`Use ${summary.name} as a starting point.`],
       notes: "Mock notes — the real manifest ships with the template.",

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -19,15 +19,16 @@ import type {
   InjectInputRequest,
   MacroDef,
   RunMacroRequest,
-  SampleProjectSeedResponse,
   SessionSummary,
+  TemplateDetailView,
+  TemplateListResponse,
   RunView,
   WorkflowInfo,
 } from "@shared/types";
 
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
-import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SAMPLE_PROJECT_ROOT, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_WORKFLOWS } from "./mock-data";
+import { MOCK_FS_TREE, MOCK_HARNESSES, MOCK_HISTORY, MOCK_LAUNCH_DIR, MOCK_MACROS, MOCK_SESSIONS, MOCK_SETTINGS, MOCK_TEMPLATES, MOCK_WORKFLOWS } from "./mock-data";
 
 /**
  * Body for `POST /api/runs/local` — run the agent project at `sourceDir`
@@ -231,9 +232,11 @@ export interface HarnessApi {
   updateSettings(patch: Partial<HarnessSettings>): Promise<HarnessSettings>;
   listDir(path?: string): Promise<FsListResponse>;
   bindWorkflow(sessionId: string, workflowPath: string | null): Promise<HarnessSession>;
-  /** Seeds (or reuses) the bundled example project; the caller follows up
-   *  with a normal createSession against the returned root. */
-  seedSampleProject(): Promise<SampleProjectSeedResponse>;
+  /** The live template gallery, relayed by the server from core (key stays
+   *  server-side). Never rejects on a degraded catalog — inspect `source`. */
+  listTemplates(): Promise<TemplateListResponse>;
+  /** One template's manifest + declared graph. Rejects 404 on an unknown id. */
+  getTemplate(id: string): Promise<TemplateDetailView>;
   /** Live run render state (upstream feat/harness-runtime-analytics):
    *  GET /api/runs/:id/state = inspect -> decode -> renderRunState. Poll
    *  after an execution.started bus message until the run is terminal. */
@@ -394,8 +397,12 @@ class RealApi implements HarnessApi {
     });
   }
 
-  seedSampleProject(): Promise<SampleProjectSeedResponse> {
-    return this.request<SampleProjectSeedResponse>("/api/sample-project", { method: "POST" });
+  listTemplates(): Promise<TemplateListResponse> {
+    return this.request<TemplateListResponse>("/api/templates");
+  }
+
+  getTemplate(id: string): Promise<TemplateDetailView> {
+    return this.request<TemplateDetailView>(`/api/templates/${encodeURIComponent(id)}`);
   }
 
   getRunState(executionId: string): Promise<RunView> {
@@ -804,7 +811,7 @@ class MockApi implements HarnessApi {
         throw new ApiError(409, `POST /api/sessions/${id}/input → 409: Session is still initialising`, "Session is still initialising");
       }
       // Record the submission for Playwright to assert on — same pattern as
-      // runMacro's lastMacroRun and seedSampleProject's lastSampleSeed.
+      // runMacro's lastMacroRun.
       win.__HARNESS_TEST__ = {
         ...(win.__HARNESS_TEST__ ?? {}),
         lastInjectInput: { id, req },
@@ -938,21 +945,40 @@ class MockApi implements HarnessApi {
     return bound;
   }
 
-  async seedSampleProject(): Promise<SampleProjectSeedResponse> {
-    await delay(300);
-    const response: SampleProjectSeedResponse = {
-      root: MOCK_SAMPLE_PROJECT_ROOT,
-      projectDir: `${MOCK_SAMPLE_PROJECT_ROOT}/order-triage`,
-      created: true,
+  async listTemplates(): Promise<TemplateListResponse> {
+    await delay(200);
+    return { templates: MOCK_TEMPLATES, source: "live" };
+  }
+
+  async getTemplate(id: string): Promise<TemplateDetailView> {
+    await delay(150);
+    const summary = MOCK_TEMPLATES.find((template) => template.id === id);
+    if (!summary) throw new ApiError(404, `mock: no template ${id}`, `Template not found: ${id}`);
+    // Synthesize a linear graph of `stepCount` steps: mock mode only needs the
+    // detail pane to have SOMETHING structurally valid to project, and the real
+    // per-template graphs live upstream in the registry, not here.
+    const steps = Array.from({ length: Math.max(summary.stepCount, 1) }, (_, index) => ({
+      name: index === 0 ? "start" : index === summary.stepCount - 1 ? "finish" : `step-${index + 1}`,
+      description: `Mock step ${index + 1} of ${summary.stepCount}.`,
+      capabilities: index === 0 ? summary.capabilities : [],
+      terminal: index === Math.max(summary.stepCount, 1) - 1,
+    }));
+    return {
+      ...summary,
+      whatItDoes: summary.description,
+      sourcePath: `examples/${summary.id}`,
+      steps,
+      transitions: steps.slice(0, -1).map((step, index) => ({
+        from: step.name,
+        to: steps[index + 1].name,
+        label: null,
+      })),
+      author: { name: "Sapiom", url: "https://sapiom.ai/" },
+      useCases: [`Use ${summary.name} as a starting point.`],
+      notes: "Mock notes — the real manifest ships with the template.",
+      examples: [],
+      requiredSecrets: [],
     };
-    // Test-only escape hatch, mock mode only — same pattern as runMacro's
-    // lastMacroRun: seeding has no other observable effect in mock mode, so
-    // Playwright reads this back to assert the click actually seeded.
-    if (typeof window !== "undefined") {
-      const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
-      win.__HARNESS_TEST__ = { ...(win.__HARNESS_TEST__ ?? {}), lastSampleSeed: response };
-    }
-    return response;
   }
 
   // Scripted completed run for the demo leasing workflow. Per-step latency

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -2,7 +2,7 @@
  * Fixture data for `VITE_MOCK=1` — lets the SPA render fully without a
  * running harness server (see MockApi in ./api).
  */
-import type { HarnessEntry, HarnessSession, HarnessSettings, MacroDef, SessionSummary, WorkflowInfo } from "@shared/types";
+import type { HarnessEntry, HarnessSession, HarnessSettings, MacroDef, SessionSummary, TemplateSummary, WorkflowInfo } from "@shared/types";
 
 const now = Date.now();
 const minutesAgo = (n: number): string => new Date(now - n * 60_000).toISOString();
@@ -41,9 +41,72 @@ export function hasMockCanvasDoc(sessionId: string): boolean {
   return MOCK_CANVAS_SESSIONS.includes(sessionId);
 }
 
-/** Where MockApi.seedSampleProject pretends the example project landed —
- *  mirrors the real HARNESS_PATHS.sampleProject location. */
-export const MOCK_SAMPLE_PROJECT_ROOT = "/Users/demo/.sapiom/harness/sample-project";
+/**
+ * A slice of the real template catalog for mock mode. Spans several categories
+ * on purpose — the dialog groups by category and shows a per-run cost estimate,
+ * and both need a mixed list (including a null `estCostPerRunUsd`, the majority
+ * case upstream) to be exercised without a backend.
+ */
+export const MOCK_TEMPLATES: TemplateSummary[] = [
+  {
+    id: "hello-agent",
+    name: "Hello Agent",
+    description: "The minimal single-step agent: a smoke test for the build, deploy, run path.",
+    tags: ["starter", "minimal"],
+    category: "starter",
+    cadence: "on-demand",
+    stepCount: 1,
+    capabilities: [],
+    estCostPerRunUsd: null,
+  },
+  {
+    id: "web-research-digest",
+    name: "Web Research Digest",
+    description: "Search the web for a topic and return a concise, sourced digest.",
+    tags: ["research", "search"],
+    category: "data-knowledge",
+    cadence: "on-demand",
+    stepCount: 2,
+    capabilities: ["web.search"],
+    estCostPerRunUsd: 0.006,
+  },
+  {
+    id: "dependency-upgrade",
+    name: "Dependency Upgrade",
+    description:
+      "On a schedule, a coding agent bumps a repo's dependencies in a sandbox, runs the tests, and opens a PR.",
+    tags: ["coding-agent", "scheduled"],
+    category: "product-engineering",
+    cadence: "scheduled",
+    stepCount: 5,
+    capabilities: ["sandbox.run"],
+    estCostPerRunUsd: 0.42,
+  },
+  {
+    id: "approval-chain",
+    name: "Multi-Party Approval Chain (Saga)",
+    description:
+      "A durable sequential sign-off chain — pause-per-gate approvals with reminders, timeout escalation, and compensation on rejection.",
+    tags: ["approval", "saga", "pause-resume", "durable"],
+    category: "reliability-governance",
+    cadence: "on-demand",
+    stepCount: 7,
+    capabilities: ["email.send", "database.create"],
+    estCostPerRunUsd: null,
+  },
+  {
+    id: "cold-outreach-engine",
+    name: "Cold Outreach Personalization Engine",
+    description:
+      "Enrich a lead list, write a personalized first line for each prospect, verify deliverability, then drip the sends.",
+    tags: ["outreach", "email", "fan-out"],
+    category: "revenue-marketing",
+    cadence: "scheduled",
+    stepCount: 6,
+    capabilities: ["web.search", "email.send"],
+    estCostPerRunUsd: 0.13,
+  },
+];
 
 export const MOCK_SESSIONS: HarnessSession[] = [
   {

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -2,7 +2,7 @@
  * Fixture data for `VITE_MOCK=1` — lets the SPA render fully without a
  * running harness server (see MockApi in ./api).
  */
-import type { HarnessEntry, HarnessSession, HarnessSettings, MacroDef, SessionSummary, TemplateSummary, WorkflowInfo } from "@shared/types";
+import type { HarnessEntry, HarnessSession, HarnessSettings, MacroDef, SessionSummary, TemplateDetailView, TemplateSummary, WorkflowInfo } from "@shared/types";
 
 const now = Date.now();
 const minutesAgo = (n: number): string => new Date(now - n * 60_000).toISOString();
@@ -107,6 +107,85 @@ export const MOCK_TEMPLATES: TemplateSummary[] = [
     estCostPerRunUsd: 0.13,
   },
 ];
+
+/**
+ * Real per-template graphs for mock mode, keyed by template id. Step NAMES are
+ * the registry's actual ones (`search`/`summarize`, `greet`) because the e2e
+ * suite addresses nodes by name — and because a synthesized `step-2` teaches a
+ * reader nothing about what the preview looks like.
+ *
+ * `kind`/`sublabel` are what the server's `classifyStepKind` produces for each
+ * shape, so mock mode renders the same branches live mode does. Note a
+ * single-step template's one step is the ENTRY (entry outranks terminal in the
+ * precedence), which is why `greet` is not an exit node.
+ */
+export const MOCK_TEMPLATE_GRAPHS: Record<
+  string,
+  Pick<TemplateDetailView, "steps" | "transitions">
+> = {
+  "hello-agent": {
+    steps: [
+      { name: "greet", description: "Validate the input and return a greeting.", capabilities: [], kind: "entry", sublabel: "entry" },
+    ],
+    transitions: [],
+  },
+  "web-research-digest": {
+    steps: [
+      { name: "search", description: "Query the web for the topic.", capabilities: ["web.search"], kind: "entry", sublabel: "entry" },
+      {
+        name: "summarize",
+        description: "Condense the results into a sourced digest.",
+        capabilities: [],
+        kind: "terminal-success",
+        sublabel: "terminal · success",
+      },
+    ],
+    transitions: [{ from: "search", to: "summarize", label: null, kind: "continue" }],
+  },
+  "dependency-upgrade": {
+    steps: [
+      { name: "scan", description: "List outdated dependencies.", capabilities: ["sandbox.run"], kind: "entry", sublabel: "entry" },
+      { name: "bump", description: "Apply the upgrades in a sandbox.", capabilities: [], kind: "step", sublabel: "step" },
+      { name: "test", description: "Run the suite against the bumped tree.", capabilities: [], kind: "step", sublabel: "step · can also terminate" },
+      { name: "open_pr", description: "Open a PR with the passing upgrade.", capabilities: [], kind: "terminal-success", sublabel: "terminal · success" },
+      // A fail-only sink: amber "needs attention", NOT a green success exit.
+      { name: "give_up", description: "Tests still failing after retries.", capabilities: [], kind: "terminal-warn", sublabel: "terminal · needs attention" },
+    ],
+    transitions: [
+      { from: "scan", to: "bump", label: null, kind: "continue" },
+      { from: "bump", to: "test", label: null, kind: "continue" },
+      { from: "test", to: "open_pr", label: null, kind: "continue" },
+      { from: "test", to: "give_up", label: null, kind: "continue" },
+    ],
+  },
+  "approval-chain": {
+    steps: [
+      { name: "start", description: "Record the request.", capabilities: ["database.create"], kind: "entry", sublabel: "entry" },
+      { name: "present", description: "Email the current gate's approver.", capabilities: ["email.send"], kind: "step", sublabel: "step" },
+      // A pause step shows the signal it waits for.
+      { name: "decide", description: "Wait for the approver's answer.", capabilities: [], kind: "pause", sublabel: "pause · approval.decided" },
+      { name: "finalize", description: "All gates passed.", capabilities: ["email.send"], kind: "terminal-success", sublabel: "terminal · success" },
+      { name: "compensate", description: "Roll back on rejection.", capabilities: ["email.send"], kind: "terminal-warn", sublabel: "terminal · needs attention" },
+    ],
+    transitions: [
+      { from: "start", to: "present", label: null, kind: "continue" },
+      { from: "present", to: "decide", label: null, kind: "continue" },
+      { from: "decide", to: "finalize", label: "approval.decided", kind: "pause" },
+      { from: "decide", to: "compensate", label: null, kind: "continue" },
+    ],
+  },
+  "cold-outreach-engine": {
+    steps: [
+      { name: "enrich", description: "Enrich the lead list.", capabilities: ["web.search"], kind: "entry", sublabel: "entry" },
+      { name: "personalize", description: "Write a first line per prospect.", capabilities: [], kind: "step", sublabel: "step" },
+      { name: "send", description: "Drip the sends.", capabilities: ["email.send"], kind: "terminal-success", sublabel: "terminal · success" },
+    ],
+    transitions: [
+      { from: "enrich", to: "personalize", label: null, kind: "continue" },
+      { from: "personalize", to: "send", label: null, kind: "continue" },
+    ],
+  },
+};
 
 export const MOCK_SESSIONS: HarnessSession[] = [
   {

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -161,10 +161,16 @@ describe("templateGraph", () => {
       whatItDoes: "Searches and summarizes.",
       sourcePath: "examples/web-research-digest",
       steps: [
-        { name: "search", description: "Query the web.", capabilities: ["web.search"], terminal: false },
-        { name: "summarize", description: "Condense the results.", capabilities: [], terminal: true },
+        { name: "search", description: "Query the web.", capabilities: ["web.search"], kind: "entry", sublabel: "entry" },
+        {
+          name: "summarize",
+          description: "Condense the results.",
+          capabilities: [],
+          kind: "terminal-success",
+          sublabel: "terminal · success",
+        },
       ],
-      transitions: [{ from: "search", to: "summarize", label: null }],
+      transitions: [{ from: "search", to: "summarize", label: null, kind: "continue" as const }],
       author: { name: "Sapiom", url: "https://sapiom.ai/" },
       useCases: [],
       notes: null,
@@ -185,7 +191,15 @@ describe("templateGraph", () => {
   it("a single terminal step yields one node and no edges", () => {
     const graph = templateGraph(
       detail({
-        steps: [{ name: "greet", description: "Say hi.", capabilities: [], terminal: true }],
+        steps: [
+          {
+            name: "greet",
+            description: "Say hi.",
+            capabilities: [],
+            kind: "terminal-success",
+            sublabel: "terminal · success",
+          },
+        ],
         transitions: [],
       }),
     );
@@ -194,26 +208,29 @@ describe("templateGraph", () => {
     expect(graph.edges).toEqual([]);
   });
 
-  it("marks a fan-out as branching and carries a guarded transition's label", () => {
+  it("marks a fan-out as branching and preserves each exit's own kind", () => {
     // The pinned copy could not express this: it inferred edges from array
-    // order. Core serves real transitions, conditions included.
+    // order, and had one terminal kind for every exit.
     const graph = templateGraph(
       detail({
         steps: [
-          { name: "check", description: null, capabilities: [], terminal: false },
-          { name: "approve", description: null, capabilities: [], terminal: true },
-          { name: "reject", description: null, capabilities: [], terminal: true },
+          { name: "check", description: null, capabilities: [], kind: "entry", sublabel: "entry" },
+          { name: "approve", description: null, capabilities: [], kind: "terminal-success", sublabel: "terminal · success" },
+          { name: "reject", description: null, capabilities: [], kind: "terminal-warn", sublabel: "terminal · needs attention" },
         ],
         transitions: [
-          { from: "check", to: "approve", label: "score > 0.8" },
-          { from: "check", to: "reject", label: null },
+          { from: "check", to: "approve", label: null, kind: "continue" as const },
+          { from: "check", to: "reject", label: null, kind: "continue" as const },
         ],
       }),
     );
     expect(graph.edges).toEqual([
-      { from: "check", to: "approve", kind: "branching", label: "score > 0.8" },
+      { from: "check", to: "approve", kind: "branching", label: "" },
       { from: "check", to: "reject", kind: "branching", label: "" },
     ]);
+    // Kinds come straight from the server-side classifier — a fail-only exit
+    // stays amber rather than being flattened into the success dot.
+    expect(graph.nodes.map((n) => n.kind)).toEqual(["entry", "terminal-success", "terminal-warn"]);
   });
 });
 

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -1,52 +1,141 @@
 import { describe, expect, it } from "vitest";
 
+import type { TemplateDetailView, TemplateSummary } from "@shared/types";
+
 import {
-  GALLERY_TEMPLATES,
   STARTER_TEMPLATES,
-  STUDIO_TEMPLATES,
+  categoryLabel,
+  formatEstCost,
+  groupByCategory,
+  matchesQuery,
   templateDirSuggestion,
   templateGraph,
   useTemplatePrompt,
+  type GalleryTemplate,
 } from "./templates";
 
-describe("curated template index", () => {
-  it("carries exactly the clonable gallery ids and bundled starter names", () => {
-    // These ids are contracts, not fixtures: templateId must match the
-    // registry (registry.json), starter ids must match the bundled template
-    // directory names `sapiom agents init -t` resolves.
-    expect(GALLERY_TEMPLATES.map((t) => t.id)).toEqual(["web-research-digest", "hello-agent"]);
+/** A catalog summary as core would serve it. */
+function summary(over: Partial<TemplateSummary> = {}): GalleryTemplate {
+  return {
+    kind: "gallery",
+    id: "web-research-digest",
+    name: "Web Research Digest",
+    description: "Search the web for a topic and return a concise, sourced digest.",
+    tags: ["research", "search"],
+    category: "data-knowledge",
+    cadence: "on-demand",
+    stepCount: 2,
+    capabilities: ["web.search"],
+    estCostPerRunUsd: 0.006,
+    ...over,
+  };
+}
+
+describe("bundled starters", () => {
+  it("carries exactly the bundled template directory names `init -t` resolves", () => {
+    // These ids are a contract with @sapiom/agent-core's templates/ dir, not
+    // fixtures — unlike the gallery, they are NOT fetched.
     expect(STARTER_TEMPLATES.map((t) => t.id)).toEqual(["default", "coding-pause"]);
   });
 
-  it("has unique ids across the whole index", () => {
-    const ids = STUDIO_TEMPLATES.map((t) => t.id);
-    expect(new Set(ids).size).toBe(ids.length);
+  it("never carries an em dash into starter copy (house style)", () => {
+    // Only the local copy can be held to this; catalog descriptions come from
+    // the upstream registry verbatim.
+    expect(JSON.stringify(STARTER_TEMPLATES)).not.toContain("—");
+  });
+});
+
+describe("formatEstCost", () => {
+  it("renders an em dash when core reports no estimate — never $0.00", () => {
+    // The majority case upstream (21 of 26 templates). Rendering $0.00 would
+    // assert a genuinely free run, which is a different and false claim.
+    expect(formatEstCost(null)).toBe("—");
   });
 
-  it("keeps registry invariants: ordered steps, entry first, terminal exits marked", () => {
-    for (const template of GALLERY_TEMPLATES) {
-      expect(template.steps.length).toBeGreaterThan(0);
-      // Every capability a step names must appear in the template's own list.
-      for (const step of template.steps) {
-        if (step.capability) expect(template.capabilities).toContain(step.capability);
-      }
-      // At least one exit — the schema requires a terminal step.
-      expect(template.steps.some((step) => step.terminal === true)).toBe(true);
-    }
+  it("keeps sub-cent estimates legible instead of rounding them to zero", () => {
+    expect(formatEstCost(0.006)).toBe("$0.0060");
   });
 
-  it("never carries an em-dash into product copy", () => {
-    expect(JSON.stringify(STUDIO_TEMPLATES)).not.toContain("—");
+  it("renders ordinary amounts to cents, and a true zero as $0", () => {
+    expect(formatEstCost(0.42)).toBe("$0.42");
+    expect(formatEstCost(0)).toBe("$0");
+  });
+});
+
+describe("categoryLabel", () => {
+  it("maps known registry ids to the dashboard's labels", () => {
+    expect(categoryLabel("revenue-marketing")).toBe("Revenue and marketing");
+    expect(categoryLabel("finance-legal-people")).toBe("Finance, legal and people");
+  });
+
+  it("humanizes an unknown id rather than dropping it (the taxonomy is upstream)", () => {
+    expect(categoryLabel("brand-new-axis")).toBe("Brand new axis");
+  });
+
+  it("names the absent category", () => {
+    expect(categoryLabel(null)).toBe("Uncategorised");
+  });
+});
+
+describe("groupByCategory", () => {
+  it("orders known categories as the dashboard sidebar does, starters first", () => {
+    const groups = groupByCategory([
+      summary({ id: "a", category: "revenue-marketing" }),
+      summary({ id: "b", category: "starter" }),
+      summary({ id: "c", category: "product-engineering" }),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["starter", "product-engineering", "revenue-marketing"]);
+  });
+
+  it("sorts an unknown category after the known ones and uncategorised last", () => {
+    const groups = groupByCategory([
+      summary({ id: "a", category: null }),
+      summary({ id: "b", category: "zzz-unknown" }),
+      summary({ id: "c", category: "starter" }),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["starter", "zzz-unknown", null]);
+  });
+
+  it("keeps every template — grouping never drops a card", () => {
+    const templates = [
+      summary({ id: "a", category: "starter" }),
+      summary({ id: "b", category: "starter" }),
+      summary({ id: "c", category: null }),
+    ];
+    const total = groupByCategory(templates).reduce((sum, g) => sum + g.templates.length, 0);
+    expect(total).toBe(3);
+  });
+});
+
+describe("matchesQuery", () => {
+  it("matches on name, tag, and capability, case-insensitively", () => {
+    const template = summary();
+    expect(matchesQuery(template, "RESEARCH")).toBe(true); // tag
+    expect(matchesQuery(template, "web.search")).toBe(true); // capability
+    expect(matchesQuery(template, "digest")).toBe(true); // name
+    expect(matchesQuery(template, "kubernetes")).toBe(false);
+  });
+
+  it("an empty query matches everything", () => {
+    expect(matchesQuery(summary(), "   ")).toBe(true);
+    expect(matchesQuery(STARTER_TEMPLATES[0], "")).toBe(true);
   });
 });
 
 describe("useTemplatePrompt", () => {
   it("gallery: names the real clone tool with dir and templateId, plus the auth fallback", () => {
-    const prompt = useTemplatePrompt(GALLERY_TEMPLATES[0], "/tmp/web-research-digest");
+    const prompt = useTemplatePrompt(summary(), "/tmp/web-research-digest");
     expect(prompt).toContain("sapiom_dev_agents_clone");
     expect(prompt).toContain('dir "/tmp/web-research-digest"');
     expect(prompt).toContain('templateId "web-research-digest"');
     expect(prompt).toContain("sapiom_authenticate");
+  });
+
+  it("works for any catalog id, not just the two once pinned in this module", () => {
+    // clone's templateId is relayed to core's fork endpoint with no allowlist,
+    // which is why fetching the full catalog needed no other change.
+    const prompt = useTemplatePrompt(summary({ id: "cold-outreach-engine" }), "/tmp/x");
+    expect(prompt).toContain('templateId "cold-outreach-engine"');
   });
 
   it("starter: names the real init command with the bundled template flag", () => {
@@ -55,7 +144,7 @@ describe("useTemplatePrompt", () => {
   });
 
   it("both paths end with the free local test continuation (use to run is one path)", () => {
-    for (const template of [GALLERY_TEMPLATES[0], STARTER_TEMPLATES[1]]) {
+    for (const template of [summary(), STARTER_TEMPLATES[1]]) {
       expect(useTemplatePrompt(template, "/tmp/x")).toContain(
         "free local test run (sapiom_dev_agents_run_local)",
       );
@@ -64,28 +153,73 @@ describe("useTemplatePrompt", () => {
 });
 
 describe("templateGraph", () => {
-  it("projects the manifest faithfully: entry first, next pointers as edges, terminals marked", () => {
-    const graph = templateGraph(GALLERY_TEMPLATES[0]); // web-research-digest
+  /** A detail payload as core serves it: steps plus explicit transitions. */
+  function detail(over: Partial<TemplateDetailView> = {}): TemplateDetailView {
+    const { kind: _kind, ...base } = summary();
+    return {
+      ...base,
+      whatItDoes: "Searches and summarizes.",
+      sourcePath: "examples/web-research-digest",
+      steps: [
+        { name: "search", description: "Query the web.", capabilities: ["web.search"], terminal: false },
+        { name: "summarize", description: "Condense the results.", capabilities: [], terminal: true },
+      ],
+      transitions: [{ from: "search", to: "summarize", label: null }],
+      author: { name: "Sapiom", url: "https://sapiom.ai/" },
+      useCases: [],
+      notes: null,
+      examples: [],
+      requiredSecrets: [],
+      ...over,
+    };
+  }
+
+  it("projects core's graph faithfully: entry first, transitions as edges, terminals marked", () => {
+    const graph = templateGraph(detail());
     expect(graph.entry).toBe("search");
-    expect(graph.nodes.map((n) => `${n.id}:${n.kind}`)).toEqual([
-      "search:entry",
-      "summarize:terminal-success",
-    ]);
+    expect(graph.nodes.map((n) => `${n.id}:${n.kind}`)).toEqual(["search:entry", "summarize:terminal-success"]);
     expect(graph.nodes[0].capabilities).toEqual(["web.search"]);
     expect(graph.edges).toEqual([{ from: "search", to: "summarize", kind: "sequential", label: "" }]);
   });
 
   it("a single terminal step yields one node and no edges", () => {
-    const graph = templateGraph(GALLERY_TEMPLATES[1]); // hello-agent
+    const graph = templateGraph(
+      detail({
+        steps: [{ name: "greet", description: "Say hi.", capabilities: [], terminal: true }],
+        transitions: [],
+      }),
+    );
     expect(graph.nodes).toHaveLength(1);
     expect(graph.nodes[0].kind).toBe("terminal-success");
     expect(graph.edges).toEqual([]);
+  });
+
+  it("marks a fan-out as branching and carries a guarded transition's label", () => {
+    // The pinned copy could not express this: it inferred edges from array
+    // order. Core serves real transitions, conditions included.
+    const graph = templateGraph(
+      detail({
+        steps: [
+          { name: "check", description: null, capabilities: [], terminal: false },
+          { name: "approve", description: null, capabilities: [], terminal: true },
+          { name: "reject", description: null, capabilities: [], terminal: true },
+        ],
+        transitions: [
+          { from: "check", to: "approve", label: "score > 0.8" },
+          { from: "check", to: "reject", label: null },
+        ],
+      }),
+    );
+    expect(graph.edges).toEqual([
+      { from: "check", to: "approve", kind: "branching", label: "score > 0.8" },
+      { from: "check", to: "reject", kind: "branching", label: "" },
+    ]);
   });
 });
 
 describe("templateDirSuggestion", () => {
   it("joins the launch dir with the template id", () => {
-    expect(templateDirSuggestion(GALLERY_TEMPLATES[1], "/Users/demo/acme-app")).toBe(
+    expect(templateDirSuggestion(summary({ id: "hello-agent" }), "/Users/demo/acme-app")).toBe(
       "/Users/demo/acme-app/hello-agent",
     );
   });
@@ -97,6 +231,6 @@ describe("templateDirSuggestion", () => {
   });
 
   it("is empty without a launch dir (the field asks instead of guessing)", () => {
-    expect(templateDirSuggestion(GALLERY_TEMPLATES[0], null)).toBe("");
+    expect(templateDirSuggestion(summary(), null)).toBe("");
   });
 });

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -194,33 +194,41 @@ export function useTemplatePrompt(template: StudioTemplate, dir: string): string
  * carries its condition label.
  */
 export function templateGraph(detail: TemplateDetailView): CanvasGraph {
-  const terminalOf = (name: string): boolean =>
-    detail.steps.find((s) => s.name === name)?.terminal === true;
-  const nodes: CanvasGraph["nodes"] = detail.steps.map((step, index) => ({
+  const nodes: CanvasGraph["nodes"] = detail.steps.map((step) => ({
     id: step.name,
-    kind: step.terminal ? "terminal-success" : index === 0 ? "entry" : "step",
+    // The kind is CLASSIFIED SERVER-SIDE by the same `classifyStepKind` the
+    // canvas uses (see core/template-catalog.ts). Re-deriving it here — or
+    // reducing it to terminal-vs-not — is what made a fail-only sink render as
+    // a green success exit.
+    kind: step.kind as CanvasGraph["nodes"][number]["kind"],
     label: step.name,
-    role: step.terminal ? "terminal" : index === 0 ? "entry" : "step",
+    role: step.kind.startsWith("terminal") ? "terminal" : step.kind === "entry" ? "entry" : "step",
     description: step.description ?? "",
     timeoutMs: null,
     inputSchema: null,
     capabilities: step.capabilities,
   }));
-  // A step with more than one outgoing edge is a branch — mark every edge out of
-  // it so the preview reads the same as the canvas does for a real definition.
-  const outDegree = new Map<string, number>();
+  // Branch styling counts only CONTINUE fan-out, matching the canvas: a pause
+  // edge is a `cross`, and it never turns its siblings into a branch.
+  const continueOutDegree = new Map<string, number>();
   for (const edge of detail.transitions) {
-    outDegree.set(edge.from, (outDegree.get(edge.from) ?? 0) + 1);
+    if (edge.kind !== "continue") continue;
+    continueOutDegree.set(edge.from, (continueOutDegree.get(edge.from) ?? 0) + 1);
   }
   const edges: CanvasGraph["edges"] = detail.transitions.map((edge) => ({
     from: edge.from,
     to: edge.to,
-    kind: (outDegree.get(edge.from) ?? 0) > 1 ? "branching" : "sequential",
+    kind:
+      edge.kind === "pause"
+        ? "cross"
+        : (continueOutDegree.get(edge.from) ?? 0) > 1
+          ? "branching"
+          : "sequential",
     label: edge.label ?? "",
   }));
   return {
     name: detail.name,
-    entry: detail.steps.find((s) => !terminalOf(s.name))?.name ?? detail.steps[0]?.name ?? "",
+    entry: detail.steps.find((s) => s.kind === "entry")?.name ?? detail.steps[0]?.name ?? "",
     nodes,
     edges,
     groups: [],

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -1,67 +1,32 @@
 /**
- * The Studio's curated template index (templates journey v0).
+ * The Studio's template index — two sources, deliberately different in kind.
  *
- * Provenance: the gallery entries are pinned copies of the harness source's
- * in-repo registry at origin/main f0e3406 (harness 0.1.4) — every field below
- * comes verbatim from `examples/registry.json` plus each example's
- * `template.json` detail manifest, with punctuation normalized to house style
- * (em-dashes become colons or commas; one upstream typo fixed). The starters
- * are the two templates bundled with `@sapiom/agent-core` (`templates/
- * {default,coding-pause}`), described with the wording the scaffold MCP tool
- * itself ships.
+ * **Gallery** templates come from the LIVE catalog: `GET /api/templates`, which
+ * the harness server relays from core's `GET /v1/workflows/templates` (the same
+ * endpoint the dashboard's Template library renders). This module used to ship a
+ * hardcoded pin of two entries because no listing API existed; it does now, and
+ * the pin was the reason the Studio showed 2 templates while the app showed 26.
+ * There is no local copy of the gallery any more — a stale copy IS the bug.
  *
- * WHY a pin and not a fetch: no listing API, MCP tool, or CLI command exposes
- * the gallery to any client today — the registry is read server-side by the
- * Sapiom backend for the dashboard only. This
- * module is the swap point: when a listing endpoint ships, a fetch of the
- * same shape replaces these constants without touching the dialog.
+ * **Starters** stay local, and should: they are the templates bundled with
+ * `@sapiom/agent-core` (`templates/{default,coding-pause}`), scaffolded by
+ * `sapiom agents init -t <name>` with no account and no network. They are the
+ * offline floor — what the dialog can still offer when the catalog is
+ * unreachable — so describing them from the package is correct, not a shortcut.
  *
- * Both "use" paths are real operations, driven through the session's agent:
- * - Gallery: the `sapiom_dev_agents_clone` MCP tool (`{dir, templateId}`)
- *   forks the template into a repo the user owns, clones it, and writes
- *   `sapiom.json` provenance. Needs a signed-in Sapiom account.
- * - Starters: `sapiom agents init <dir> -t <name>` scaffolds offline from
- *   the bundled template. No account, no network.
+ * Both "use" paths are real operations driven through the session's agent:
+ * - Gallery: `sapiom_dev_agents_clone` (`{dir, templateId}`) forks the template
+ *   into a repo the user owns, clones it, and writes `sapiom.json` provenance.
+ *   Its `templateId` is a free-form string relayed to core's fork endpoint — no
+ *   allowlist — so every catalog id works, not just the two once pinned here.
+ * - Starters: `sapiom agents init <dir> -t <name>`, offline.
  */
+import type { TemplateDetailView, TemplateSummary } from "@shared/types";
+
 import type { CanvasGraph } from "./canvas-graph";
 
-export interface TemplateStep {
-  name: string;
-  description: string;
-  /** Dotted capability catalog id (e.g. "web.search"); absent = unmetered. */
-  capability?: string;
-  /** Successor step names; array order in `steps` is execution order. */
-  next?: string[];
-  terminal?: boolean;
-}
-
-export interface TemplateExample {
-  title: string;
-  input: unknown;
-  output: unknown;
-}
-
-/** A registry entry + its template.json detail, pinned (see module header). */
-export interface GalleryTemplate {
-  kind: "gallery";
-  /** Stable gallery id — the `templateId` the clone tool takes. */
-  id: string;
-  name: string;
-  description: string;
-  tags: string[];
-  /** Path inside the harness repo; consumed by the fork handoff server-side. */
-  sourcePath: string;
-  /** Dotted capability ids. Drives the backend's per-run cost estimate,
-   *  which no client surface exposes yet. */
-  capabilities: string[];
-  whatItDoes: string;
-  steps: TemplateStep[];
-  author: { name: string; url: string };
-  useCases: string[];
-  /** Markdown. */
-  notes: string;
-  examples: TemplateExample[];
-}
+/** A live catalog entry. `kind` discriminates it from a bundled starter. */
+export type GalleryTemplate = TemplateSummary & { kind: "gallery" };
 
 /** A template bundled with @sapiom/agent-core — scaffolds offline. */
 export interface StarterTemplate {
@@ -74,88 +39,10 @@ export interface StarterTemplate {
 
 export type StudioTemplate = GalleryTemplate | StarterTemplate;
 
-/** What the curated gallery is pinned to — named in the dialog's note. */
-export const TEMPLATES_PIN = { harnessVersion: "0.1.4", ref: "f0e3406" };
-
-export const GALLERY_TEMPLATES: GalleryTemplate[] = [
-  {
-    kind: "gallery",
-    id: "web-research-digest",
-    name: "Web Research Digest",
-    description: "Search the web for a topic and return a concise, sourced digest.",
-    tags: ["research", "search"],
-    sourcePath: "examples/web-research-digest",
-    capabilities: ["web.search"],
-    whatItDoes:
-      "Takes a topic, runs a web search through the Sapiom search capability, then condenses the top results into a short digest with source links. A legible \"it did a thing\" flagship: one metered capability, an obvious output.",
-    steps: [
-      {
-        name: "search",
-        description: "Query the web for the topic.",
-        capability: "web.search",
-        next: ["summarize"],
-      },
-      {
-        name: "summarize",
-        description: "Condense the results into a sourced digest.",
-        terminal: true,
-      },
-    ],
-    author: { name: "Sapiom", url: "https://sapiom.ai/" },
-    useCases: [
-      "Get a quick, sourced briefing on an unfamiliar topic before a meeting.",
-      "Turn a research question into a shareable markdown digest with citations.",
-      "Learn how to wire a single capability into an agent you can extend.",
-    ],
-    notes:
-      "`run_local` stubs the `web.search` capability, so you can trace the full graph offline before deploying. A real `deploy` + `run` performs a live web search.\n\nTo extend it, add a step after `summarize`, e.g. store the digest with `ctx.sapiom.memory.*`, or fan out one search per subtopic. `AGENTS.md` in this directory has the authoring loop.",
-    examples: [
-      {
-        title: "Research an unfamiliar term",
-        input: { topic: "what is an LLM agent?" },
-        output: {
-          topic: "what is an LLM agent?",
-          digest:
-            "# Research digest: what is an LLM agent?\n\nAn LLM agent is a system that uses a large language model to decide and take actions...\n\n## Sources\n1. [What are LLM agents?](https://example.com/llm-agents)\n2. [Agents overview](https://example.com/agents-overview)",
-          sources: [
-            { title: "What are LLM agents?", url: "https://example.com/llm-agents" },
-            { title: "Agents overview", url: "https://example.com/agents-overview" },
-          ],
-        },
-      },
-    ],
-  },
-  {
-    kind: "gallery",
-    id: "hello-agent",
-    name: "Hello Agent",
-    description: "The minimal single-step agent: a smoke test for the build, deploy, run path.",
-    tags: ["starter", "minimal"],
-    sourcePath: "examples/hello-agent",
-    capabilities: [],
-    whatItDoes:
-      "Validates an input name and returns a greeting. The smallest valid definition: use it to confirm your MCP install and deploy path work end to end before reaching for a capability.",
-    steps: [
-      {
-        name: "greet",
-        description: "Validate the input and return a greeting.",
-        terminal: true,
-      },
-    ],
-    author: { name: "Sapiom", url: "https://sapiom.ai/" },
-    useCases: [
-      "Confirm your MCP install and deploy path work before building something real.",
-      "Start from the smallest valid definition and grow it one step at a time.",
-    ],
-    notes:
-      "No capabilities, so `run_local` and a real `run` behave identically and cost nothing. Once this deploys and runs cleanly, fork a capability-backed template (e.g. Web Research Digest) for the real thing. See `AGENTS.md` for the authoring loop.",
-    examples: [
-      { title: "Greet a name", input: { name: "Ada" }, output: { greeting: "Hello, Ada!" } },
-      { title: "Default greeting", input: {}, output: { greeting: "Hello, world!" } },
-    ],
-  },
-];
-
+/**
+ * The bundled starters. Wording is the scaffold tool's own, so the dialog never
+ * claims more about them than the CLI does.
+ */
 export const STARTER_TEMPLATES: StarterTemplate[] = [
   {
     kind: "starter",
@@ -171,16 +58,111 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
   },
 ];
 
-export const STUDIO_TEMPLATES: StudioTemplate[] = [...GALLERY_TEMPLATES, ...STARTER_TEMPLATES];
+/**
+ * Display labels for the registry's outcome-axis category ids. The taxonomy is
+ * owned by the sapiom-js registry, so an id we don't recognise falls back to a
+ * humanized form of the id itself rather than being dropped — same contract the
+ * dashboard follows. Labels match the dashboard's Template library sidebar.
+ */
+const CATEGORY_LABELS: Record<string, string> = {
+  starter: "Starter",
+  "product-engineering": "Product and engineering",
+  "reliability-governance": "Reliability and governance",
+  "revenue-marketing": "Revenue and marketing",
+  "customer-experience": "Customer experience",
+  "data-knowledge": "Data and knowledge",
+  "finance-legal-people": "Finance, legal and people",
+};
+
+export function categoryLabel(category: string | null): string {
+  if (!category) return "Uncategorised";
+  return (
+    CATEGORY_LABELS[category] ??
+    category.replace(/-/g, " ").replace(/^./, (c) => c.toUpperCase())
+  );
+}
 
 /**
- * The prompt handed to the session's agent after "Use template" starts a
- * session in the destination folder. Both branches name the REAL operation:
- * the clone MCP tool for gallery templates (with its auth failure path), the
- * bundled-template init command for starters — mirroring the scaffold prompt
- * App.tsx already ships for the blank-project path. Both end with the same
- * single next move (a free local test run), so use → edit → run is one
- * continuous path instead of a journey that stops at the clone.
+ * Group the catalog by category for the dialog's list, ordered to match the
+ * dashboard's sidebar (`starter` first — it is the on-ramp), with unknown
+ * categories after the known ones and `Uncategorised` last.
+ */
+const CATEGORY_ORDER = [
+  "starter",
+  "product-engineering",
+  "reliability-governance",
+  "revenue-marketing",
+  "customer-experience",
+  "data-knowledge",
+  "finance-legal-people",
+];
+
+export function groupByCategory(
+  templates: GalleryTemplate[],
+): Array<{ category: string | null; label: string; templates: GalleryTemplate[] }> {
+  const buckets = new Map<string, GalleryTemplate[]>();
+  for (const template of templates) {
+    const key = template.category ?? "";
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(template);
+    else buckets.set(key, [template]);
+  }
+  return [...buckets.entries()]
+    .sort(([a], [b]) => {
+      // "" (uncategorised) sorts last; known ids keep the dashboard's order;
+      // unknown-but-present ids sort alphabetically between the two.
+      if (a === "") return 1;
+      if (b === "") return -1;
+      const ia = CATEGORY_ORDER.indexOf(a);
+      const ib = CATEGORY_ORDER.indexOf(b);
+      if (ia !== -1 && ib !== -1) return ia - ib;
+      if (ia !== -1) return -1;
+      if (ib !== -1) return 1;
+      return a.localeCompare(b);
+    })
+    .map(([key, group]) => ({
+      category: key === "" ? null : key,
+      label: categoryLabel(key === "" ? null : key),
+      templates: group,
+    }));
+}
+
+/**
+ * Format a per-run cost estimate. Core returns null for any template that
+ * declares no per-call-priced capability (21 of 26 today) — that MUST render as
+ * an em dash, never `$0.00`, which would assert a real free run. Sub-cent
+ * estimates keep enough precision to not read as zero.
+ */
+export function formatEstCost(usd: number | null): string {
+  if (usd === null) return "—";
+  if (usd === 0) return "$0";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+/** Case-insensitive match over the fields a user would search by. */
+export function matchesQuery(template: StudioTemplate, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const haystack = [
+    template.name,
+    template.description,
+    template.id,
+    ...(template.kind === "gallery" ? template.tags : []),
+    ...(template.kind === "gallery" ? template.capabilities : []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
+/**
+ * The prompt handed to the session's agent after "Use template" starts a session
+ * in the destination folder. Both branches name the REAL operation: the clone
+ * MCP tool for gallery templates (with its auth failure path), the bundled
+ * template init command for starters. Both end with the same next move (a free
+ * local test run), so use → edit → run is one continuous path rather than a
+ * journey that stops at the clone.
  */
 export function useTemplatePrompt(template: StudioTemplate, dir: string): string {
   const runContinuation =
@@ -203,35 +185,42 @@ export function useTemplatePrompt(template: StudioTemplate, dir: string): string
 }
 
 /**
- * A gallery template's steps as a CanvasGraph, so the dialog can preview the
- * step structure with the same vocabulary the canvas projections use (kind
- * dots, elbow transitions). Pure projection of the pinned manifest: array
- * order is execution order, the first step is the entry, `next` names the
- * successors (falling back to the next listed step), `terminal` marks exits.
- * Nothing is invented — steps without a capability stay unmetered, and
- * conditions do not exist in the manifest so no edge carries a label.
+ * A template's declared graph as a CanvasGraph, so the dialog previews step
+ * structure in the same vocabulary the canvas projections use (kind dots, elbow
+ * transitions). Pure projection of what core served — core expands the registry's
+ * step list into definition graph shapes server-side, so `transitions` are
+ * authoritative here rather than inferred from array order as the old pinned
+ * copy had to do. Steps with no capability stay unmetered; a guarded transition
+ * carries its condition label.
  */
-export function templateGraph(template: GalleryTemplate): CanvasGraph {
-  const nodes: CanvasGraph["nodes"] = template.steps.map((step, index) => ({
+export function templateGraph(detail: TemplateDetailView): CanvasGraph {
+  const terminalOf = (name: string): boolean =>
+    detail.steps.find((s) => s.name === name)?.terminal === true;
+  const nodes: CanvasGraph["nodes"] = detail.steps.map((step, index) => ({
     id: step.name,
     kind: step.terminal ? "terminal-success" : index === 0 ? "entry" : "step",
     label: step.name,
     role: step.terminal ? "terminal" : index === 0 ? "entry" : "step",
-    description: step.description,
+    description: step.description ?? "",
     timeoutMs: null,
     inputSchema: null,
-    capabilities: step.capability ? [step.capability] : [],
+    capabilities: step.capabilities,
   }));
-  const edges: CanvasGraph["edges"] = [];
-  template.steps.forEach((step, index) => {
-    const successors = step.next ?? (template.steps[index + 1] && !step.terminal ? [template.steps[index + 1].name] : []);
-    for (const next of successors) {
-      edges.push({ from: step.name, to: next, kind: successors.length > 1 ? "branching" : "sequential", label: "" });
-    }
-  });
+  // A step with more than one outgoing edge is a branch — mark every edge out of
+  // it so the preview reads the same as the canvas does for a real definition.
+  const outDegree = new Map<string, number>();
+  for (const edge of detail.transitions) {
+    outDegree.set(edge.from, (outDegree.get(edge.from) ?? 0) + 1);
+  }
+  const edges: CanvasGraph["edges"] = detail.transitions.map((edge) => ({
+    from: edge.from,
+    to: edge.to,
+    kind: (outDegree.get(edge.from) ?? 0) > 1 ? "branching" : "sequential",
+    label: edge.label ?? "",
+  }));
   return {
-    name: template.name,
-    entry: template.steps[0]?.name ?? "",
+    name: detail.name,
+    entry: detail.steps.find((s) => !terminalOf(s.name))?.name ?? detail.steps[0]?.name ?? "",
     nodes,
     edges,
     groups: [],
@@ -239,8 +228,8 @@ export function templateGraph(template: GalleryTemplate): CanvasGraph {
   };
 }
 
-/** Default destination: a new folder named after the template, under the
- *  launch dir. "default" would make a meaningless folder name, so it gets a
+/** Default destination: a new folder named after the template, under the launch
+ *  dir. "default" would make a meaningless folder name, so it gets a
  *  descriptive one instead. */
 export function templateDirSuggestion(template: StudioTemplate, launchDir: string | null): string {
   const folder = template.kind === "starter" && template.id === "default" ? "sapiom-agent" : template.id;

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -12,7 +12,7 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 
-import type { HarnessEntry } from "@shared/types";
+import type { HarnessEntry, TemplateDetailView, TemplateListResponse } from "@shared/types";
 
 import {
   ApiError,
@@ -85,9 +85,11 @@ export interface HarnessStateHook {
    *  resume view, not one directory at a time). */
   loadHistory: (cwds: string[]) => Promise<void>;
   createSession: (req: CreateSessionRequest) => Promise<HarnessSession>;
-  /** Welcome panel's "Run the sample project": seeds (or reuses) the bundled
-   *  example, then opens a normal session in it with the default harness. */
-  createSampleSession: () => Promise<HarnessSession>;
+  /** The live template gallery + one template's detail (server relays core;
+   *  the API key never reaches the browser). Surfaced here so components stay
+   *  prop-driven rather than reaching for a module-level api singleton. */
+  listTemplates: () => Promise<TemplateListResponse>;
+  getTemplate: (id: string) => Promise<TemplateDetailView>;
   resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
   resumeFromHistory: (summary: SessionSummary) => Promise<HarnessSession>;
   /** Dismisses an exited session (DELETE): drops it from the list and, if it was active, falls back to another running session or clears the pane. */
@@ -664,14 +666,8 @@ export function useHarnessState(): HarnessStateHook {
     return session;
   }, [selectSession]);
 
-  const createSampleSession = useCallback(async (): Promise<HarnessSession> => {
-    const seeded = await api.seedSampleProject();
-    // Same default-harness choice the auto-created boot session uses:
-    // doctor()'s preference order, falling back to claude-code when the
-    // server didn't report availability (see AppState.availableHarnesses).
-    const harness = state?.availableHarnesses?.[0] ?? "claude-code";
-    return createSession({ cwd: seeded.root, harness });
-  }, [state?.availableHarnesses, createSession]);
+  const listTemplates = useCallback((): Promise<TemplateListResponse> => api.listTemplates(), []);
+  const getTemplate = useCallback((id: string): Promise<TemplateDetailView> => api.getTemplate(id), []);
 
   const resumeSession = useCallback(
     async (harnessSessionId: string): Promise<HarnessSession> => {
@@ -900,7 +896,8 @@ export function useHarnessState(): HarnessStateHook {
     historyLoading,
     loadHistory,
     createSession,
-    createSampleSession,
+    listTemplates,
+    getTemplate,
     resumeSession,
     resumeFromHistory,
     closeSession,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -6202,6 +6202,29 @@ input {
   color: var(--text-faint);
 }
 
+/* A fail-only sink is NOT a success exit — it carries the canvas's amber, the
+   same signal `dot--terminal-warn` gives the node. */
+.template-step-exit--warn {
+  border-color: var(--amber);
+  color: var(--amber);
+}
+
+/* A step that waits for a signal, matching the canvas's dashed pause border. */
+.template-step-pause {
+  padding: 0 var(--sp1);
+  border: 1px dashed var(--text-faint);
+  border-radius: var(--radius-sm);
+  font-family: var(--font);
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+}
+
+/* The classifier's one-line role, beside the step name in the ordered list. */
+.template-step-role {
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+}
+
 .template-step-desc {
   font-size: var(--type-meta);
   color: var(--text-faint);

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2696,6 +2696,85 @@ input {
   color: var(--text-dim);
 }
 
+/* ── Returning user: Overview, not a pitch ──
+   The first-run card is a centered hero. This one is a working surface — a list
+   you scan and click — so it left-aligns and grows with the recents rather than
+   holding hero proportions with no hero in it. */
+.welcome-card--returning {
+  width: 560px;
+}
+
+.welcome-copy--returning {
+  align-items: stretch;
+  text-align: left;
+  gap: var(--sp2);
+}
+
+.welcome-title--returning {
+  font-size: var(--type-title);
+}
+
+.welcome-recents-title {
+  margin: var(--sp2) 0 0;
+  font-size: var(--type-micro);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--text-faint);
+}
+
+.welcome-recents {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.welcome-recent {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp2);
+  width: 100%;
+  padding: var(--sp2);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  text-align: left;
+  color: var(--text);
+  transition: background-color var(--transition-fast);
+}
+
+.welcome-recent:hover {
+  background: var(--surface-hover);
+}
+
+.welcome-recent:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.welcome-recent-name {
+  font-size: var(--type-ui);
+  font-weight: 550;
+  flex: 0 0 auto;
+}
+
+/* The full path is the disambiguator when two workspaces share a folder name,
+   so it stays visible — truncated from the LEFT, since the tail is what
+   identifies it. */
+.welcome-recent-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+  direction: rtl;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Bottom-anchored action BAND: full-bleed against the card's own edges
    (negative inline/bottom margins swallow the card padding), hairline on
    top — the same dialog-footer anatomy as .modal-actions. Docs link far
@@ -5867,21 +5946,61 @@ input {
   min-height: 0;
 }
 
+/* The sidebar owns the grid column now that a search field sits above the
+   scrolling list — the list alone can't both scroll and pin the input. */
+.templates-sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--ui-line);
+}
+
+.templates-search {
+  margin: var(--sp2) var(--sp2) 0;
+  flex: 0 0 auto;
+}
+
 .templates-list {
   display: flex;
   flex-direction: column;
   gap: var(--sp1);
   padding: var(--sp2);
-  border-right: 1px solid var(--ui-line);
   overflow-y: auto;
 }
 
 .templates-list-section {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp1);
   padding: var(--sp2) var(--sp2) 0;
   font-size: var(--type-micro);
   font-weight: 700;
   letter-spacing: 0.01em;
   color: var(--text-faint);
+}
+
+/* Per-category count, mirroring the dashboard's Template library sidebar. */
+.templates-list-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-faint);
+}
+
+/* Loading / no-results / degraded-catalog copy. The degraded note is deliberately
+   not styled as an error: a signed-out gallery is a state, not a fault. */
+.templates-list-empty,
+.templates-list-note {
+  padding: var(--sp2);
+  font-size: var(--type-micro);
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.templates-list-note {
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-hover);
 }
 
 .template-row {
@@ -5931,9 +6050,35 @@ input {
   overflow: hidden;
 }
 
+/* Step count + per-run cost estimate on the card: the two facts that change
+   which template you pick. Cost may be an em dash (no estimate) — see
+   formatEstCost; it must never read as $0.00. */
+.template-row-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp1);
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+}
+
+.template-row-cost {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
 .template-row.is-selected .template-row-name,
-.template-row.is-selected .template-row-desc {
+.template-row.is-selected .template-row-desc,
+.template-row.is-selected .template-row-meta {
   color: var(--accent-foreground);
+}
+
+/* A guarded transition's condition, shown beside the elbow target so a branch
+   reads the same here as it does on the canvas. */
+.canvas-step-transition-label {
+  font-family: var(--font-mono);
+  font-size: var(--type-micro);
+  color: var(--text-faint);
 }
 
 /* ── Preview pane: real manifest fields only ── */


### PR DESCRIPTION
## Summary

The Studio's template picker was a hardcoded copy of two registry entries, so it showed **2 templates while the dashboard's Template library showed 26**. It now relays core's real catalog, so the two surfaces cannot drift. Also fixes the first-run hero rendering for users who already have workspaces, adopts workspace-as-folder terminology, and removes the broken Sample project action.

## Changes

### Templates read the live catalog (the main fix)
- New `src/core/template-catalog.ts` + `src/server/templates.ts` → `GET /api/templates` and `GET /api/templates/:id`, relaying core's `GET /v1/workflows/templates{,/:id}` — the same endpoint the dashboard renders.
- `web/src/lib/templates.ts` no longer carries a gallery copy. It keeps the two **bundled starters** (`@sapiom/agent-core` templates — offline, no account), which are the fallback floor, plus the category/cost/search helpers.
- Dialog gains category grouping (matching the dashboard's sidebar), search across name/tag/capability, and the per-run cost estimate.
- API key stays server-side (same rule as the runs router); a 401/403 refreshes the credential once and retries.

Two contract details, **verified against a running backend rather than assumed**:
- The core surface authenticates with `Authorization: Bearer`. The `x-sapiom-api-key` header the *agents* surface takes returns **401** here — don't copy it from `run-state.ts` / `definition-slug-resolver.ts`.
- The path carries core's `/v1` prefix (`GLOBAL_API_PREFIX`); a bare `/workflows/templates` **404s**.

### Detail pane: the graph shape was wrong
Core relays the **engine's** projection, not the registry's: a step carries `stepName` and a singular `capabilityId`, edges reference steps by namespaced `id` (`<templateId>::<stepName>`), and terminality is a `terminate`/`fail` **transition**, not a flag on the step. My first pass assumed registry shapes and rendered every template with **zero connectors and no exits** — typecheck and unit tests were both green, because the mocks matched the wrong assumption. A live probe caught it. Narrowing to the real shape is what makes a branch and a pause signal render at all.

### Overview stops pitching at returning users
`App.tsx:235` was `overviewSelected || (firstRun && !hasLiveSession)` — the first clause short-circuited the gate, so the hero rendered whenever Overview was selected. The hero is now genuine-first-run only; returning users get their recent workspaces (click to open a session with their preferred agent). The Docs / Templates / New workspace band is shared by both states.

### Workspace terminology
Rail header → "Workspaces"; "New project" → "New workspace"; "Add project" → "Add workspace"; "Project directory" → "Workspace folder". **"Agent project" is left alone deliberately** — that's the SDK's own term for a `sapiom.json` directory (`sapiom agents init` scaffolds one, `AGENTS.md` uses it), so renaming it would fight the CLI and MCP vocabulary.

### Sample project removed
Button, `onRunSample`, `createSampleSession`, `POST /api/sample-project`, and the exported `SampleProjectSeedResponse` type. Nothing else in the repo referenced any of it (`harness-desktop` included — checked). `core/example-seed.ts` **stays**: `scripts/seed-example.mjs` still uses it for demo prep, and its tests still pass.

## Motivation

The pin was correct when written — its own header explains that no listing API, MCP tool, or CLI command exposed the gallery to a client, and names itself the swap point for when one shipped. One shipped. Leaving the copy in place meant the Studio and the dashboard disagreed about what Sapiom offers, and 24 templates were unreachable from the Studio despite `sapiom_dev_agents_clone` already accepting any catalog id (its `templateId` relays to core's fork endpoint with no allowlist — which is why nothing else needed changing for the other 24 to work).

## Testing

- [x] Unit tests added — `src/core/template-catalog.test.ts` (auth header, `/v1` path, refresh-on-401 incl. the no-retry-on-same-key case, caching, the engine graph shape, pause-signal and fail-sink edges, degraded paths)
- [x] Unit tests updated — `web/src/lib/templates.test.ts` rewritten for the fetched model; pins the null-cost → em-dash rule
- [x] e2e updated — `web/e2e/welcome.spec.ts` now asserts first-run vs returning-user states separately, plus catalog grouping, search, and that a no-estimate template shows `—` and not `$0.00`
- [x] **1245 unit tests pass**; typecheck and build clean
- [x] Manual: probed the live local stack — 26 templates, categories `{reliability-governance:5, revenue-marketing:8, product-engineering:4, data-knowledge:6, starter:2, finance-legal-people:1}` matching the dashboard exactly; `approval-chain` → 7 steps / 9 edges with the branch out of `decide` and 3 exits; unreachable core → `{source:"fallback", reason:"unreachable"}`

~~**Not verified:** `@sapiom/harness-desktop` doesn't typecheck in my tree.~~ **CI's `desktop-smoke` job passed**, confirming the desktop host is unaffected by the removed `sampleProjectRoot` / `SampleProjectSeedResponse` surface.

## Screenshots/Demos

Not attached — both states are reachable via `pnpm --filter @sapiom/harness dev` in mock mode: `/?mockState=fresh` for the first-run hero, `/` + account menu → Overview for the recent-workspaces view. `web/e2e/screenshots/welcome-panel.png` regenerates on an e2e run.

## Notes for the reviewer

- The catalog reflects **published `main`**, not a local checkout: `TemplateRegistryService` fetches `registry.json` from `raw.githubusercontent.com` at ref `main`, so a locally-added template won't appear until pushed. Configurable via `SAPIOM_JS_TEMPLATES_REGISTRY_PATH` if we want local reads.
- Changeset is now `minor` (was `patch`), per review — it removes a published type.
- One pre-existing lint warning in `src/server/rest.test.ts` (unused `createBootTokenMiddleware` import) is untouched — confirmed pre-existing by stashing.


## Review round 1 (commit `55015a1`)

**The graph projection collapsed core's node vocabulary — fixed, and this was the real one.** The preview reduced all four transition kinds (`continue`/`pause`/`terminate`/`fail`) to a single `terminal` boolean, so a fail-only sink rendered as a green success exit, a `continue`-plus-`terminate` gate rendered as an exit while still drawing its successors, and a pause step never got the pause kind. The repo already owned the answer — `canvas-graph.ts`'s `classifyNode` — so its precedence is now extracted as **`classifyStepKind` and shared by both callers**. A preview claiming parity with the canvas must not keep its own lossier copy. `TemplateStepView` carries `kind`/`sublabel` instead of a boolean; transitions carry their kind so a pause edge draws as a `cross` and does not turn siblings into a branch.

One correction to the review's evidence: it cited `approval-chain` as rendering a green exit with outgoing connectors. That does not reproduce. I audited all 26 templates against the live backend — the catalog currently emits **only `continue` and `terminate`**, with **0** steps having both, **0** fail-only sinks, and **0** pause edges. The bug was latent, reachable the moment any template declares a `fail` or `pause` edge. The verdict "fix before merge" still stands: it diverged from the canonical rule, and **one of my own tests asserted the wrong behaviour**, which the fix removes.

**Changeset `patch` → `minor`.** Correct call — `src/index.ts` re-exports `./shared/types.js`, so removing `SampleProjectSeedResponse` and `HarnessServerOptions.sampleProjectRoot` breaks any consumer typed against either.

**Stale `destEdited` closure — fixed.** The mount-once catalog effect captured `destEdited === false` permanently, so a destination typed while the catalog loaded was silently overwritten. It is a ref now, matching `selectionTouched`.

**Recent-workspace double-fire — fixed.** No busy guard (the Sample project button it replaces had one), so two clicks spawned two agent PTYs in the same folder. Rows now disable while one is opening, and there is e2e coverage for both the happy path and the guard.

### I had not run the e2e suite. Running it found six more failures.

My earlier grep for affected specs searched `e2e/` — these live in **`web/e2e/`** — so I missed an entire `templates.spec.ts` plus copy assertions in `smoke.spec.ts` and `wave5.spec.ts`. All six encoded the old contract and are updated:

- `templates.spec.ts` × 3 — the exit marker moved from the step name to the classifier's sublabel; the cost note now shows core's estimate (it used to say "not surfaced here yet", true only of the pinned index); the graph test addresses nodes by real step name.
- `smoke.spec.ts` × 2, `wave5.spec.ts` × 1 — "Add project" → "Add workspace".

Mock template graphs now carry the registry's **real step names** and the kinds the server's classifier produces, so mock mode exercises the same rendering branches as live mode — including a fail-only sink and a pause step, which no template does upstream yet.

**Now: 1247 unit tests + 251 Playwright tests pass, typecheck and build clean.** One `step-macros.spec.ts` canvas-zoom assertion flaked once under full-suite parallel load; it passes in isolation and on a clean re-run, and is unrelated to this diff.

Re-verified against the live backend after the fix:
```
web-research-digest: search[entry] summarize[terminal-success]
approval-chain:      start[entry] present[step] decide[step] remind[step]
                     finalize[terminal-success] compensate[terminal-success] escalate[terminal-success]
hello-agent:         greet[entry]          (entry outranks terminal, as on the canvas)
```

## Checklist
- [x] Code follows project guidelines
- [x] All tests passing
- [x] Documentation updated (changeset)
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZNHzppJVJiDRgaupQjxeh
