### PR TITLE
feat(harness): canvas board redesign + deterministic step/workflow metadata

### DIFF
--- a/.changeset/agent-step-description-capabilities.md
+++ b/.changeset/agent-step-description-capabilities.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent": minor
+---
+
+Add optional authoring fields to the workflow SDK, surfaced by the harness canvas:
+
+- `defineStep` gains `description` (a one-line summary of what the step does) and `capabilities` (the Sapiom capability ids the step declares it calls).
+- `defineAgent` gains `description` (a one-line summary of the whole workflow).
+
+All three are optional and flow through `buildManifest` into `AgentStepManifest` / `AgentManifest` as optional fields, so manifests emitted before this release keep validating unchanged. No runtime behavior change — the fields are read only by tooling (the canvas step inspector and workflow overview).

--- a/.changeset/canvas-descriptions-and-redesign.md
+++ b/.changeset/canvas-descriptions-and-redesign.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness": minor
+---
+
+Canvas board redesign + deterministic step/workflow metadata.
+
+- **Board redesign** matching the new design: in-drawer step navigation removed (the chart is beside it), chat split into a standalone toggleable panel independent of the info panel, the board subheader dropped with the deployed pill and expand relocated to the tab bar, and the manual "Render diagram" button replaced by auto-render on bind/session-start.
+- **Deterministic metadata:** the renderer surfaces per-step `description` / `inputSchema` / `capabilities` / `timeoutMs` and a workflow Overview payload, all read from the manifest (no LLM in the render path). When a step doesn't call a capability or declare a description, the field is simply absent — the shape summary still renders.
+- **Capability auto-detect** from `sapiom.*` call sites in the workflow source, attributed to the `defineStep` block the call sits in (calls in shared helpers are left unattributed rather than mis-billed to the nearest step).
+
+Reads the new optional `description` / `capabilities` fields from `@sapiom/agent`; workflows on an older SDK render with those fields blank.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -45,6 +45,9 @@ export interface AgentDefinition<
   TShared extends Record<string, unknown> = Record<string, unknown>,
 > {
   readonly name: string;
+  /** Human-authored workflow summary for the canvas Overview panel (Option A —
+   *  deterministic, no LLM). */
+  readonly description?: string;
   readonly entry: string;
   readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
   /**

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -35,6 +35,8 @@ export function buildManifest(
       timeoutMs: number | null;
       inputSchema: Record<string, unknown> | null;
       transitions: ManifestTransition[];
+      description: string | null;
+      capabilities: readonly string[];
     }
   > = {};
 
@@ -50,12 +52,15 @@ export function buildManifest(
       timeoutMs: step.timeoutMs ?? null,
       inputSchema,
       transitions: transitionsFor(step),
+      description: step.description ?? null,
+      capabilities: step.capabilities ?? [],
     };
   }
 
   return {
     protocol: MANIFEST_PROTOCOL,
     name: def.name,
+    description: def.description ?? null,
     entry: def.entry,
     sdkVersion: opts.sdkVersion,
     artifact: opts.artifact,

--- a/packages/agent/src/manifest.ts
+++ b/packages/agent/src/manifest.ts
@@ -47,6 +47,11 @@ export interface AgentStepManifest {
    * per-kind); the renderer draws one edge per entry. `reachable ⊆ declared`.
    */
   readonly transitions: readonly ManifestTransition[];
+  /** Human-authored step description (Option A). Optional for back-compat with
+   *  manifests emitted before this field existed. */
+  readonly description?: string | null;
+  /** Author-declared Sapiom capabilities this step calls. */
+  readonly capabilities?: readonly string[];
 }
 
 /**
@@ -59,6 +64,8 @@ export interface AgentManifest {
   readonly protocol: typeof MANIFEST_PROTOCOL;
   /** Agent name (matches AgentDefinition.name). */
   readonly name: string;
+  /** Human-authored workflow description (Option A); optional for back-compat. */
+  readonly description?: string | null;
   /** Entry step name (matches AgentDefinition.entry). */
   readonly entry: string;
   /** Version of @sapiom/workflow-sdk used to build the definition. */

--- a/packages/agent/src/step.ts
+++ b/packages/agent/src/step.ts
@@ -81,6 +81,12 @@ export interface StepDefinition<TShared extends Record<string, unknown> = Record
   readonly pause?: { readonly signal: string; readonly resumeStep: string };
   readonly inputSchema?: ZodType<unknown>;
   readonly timeoutMs?: number;
+  /** Human-authored one-liner for the canvas step inspector (Option A —
+   *  deterministic, no LLM; read by buildManifest exactly like inputSchema). */
+  readonly description?: string;
+  /** Sapiom capabilities this step declares it calls, shown in the inspector;
+   *  a run's actual call trace supersedes this when observed. */
+  readonly capabilities?: readonly string[];
   run(input: unknown, ctx: AgentExecutionContext<TShared>): Promise<NextStepDirective>;
 }
 
@@ -113,6 +119,8 @@ export function defineStep<
   pause?: PauseDecl;
   inputSchema?: ZodType<TIn>;
   timeoutMs?: number;
+  description?: string;
+  capabilities?: readonly string[];
   // Arrow-property (not method) type so `def.run` can be read as a value below
   // without tripping @typescript-eslint/unbound-method.
   run: (
@@ -128,6 +136,8 @@ export function defineStep<
     ...(def.pause ? { pause: def.pause } : {}),
     ...(def.inputSchema ? { inputSchema: def.inputSchema as ZodType<unknown> } : {}),
     ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+    ...(def.description !== undefined ? { description: def.description } : {}),
+    ...(def.capabilities !== undefined ? { capabilities: def.capabilities } : {}),
     run: def.run as unknown as (input: unknown, ctx: AgentExecutionContext<TShared>) => Promise<NextStepDirective>,
   };
 }

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -91,7 +91,12 @@ function buildGraphPayload(graph: CanvasGraph, enrichment?: CanvasEnrichment | n
         kind: n.kind,
         label: n.label,
         role: details?.sublabel ?? n.sublabel ?? "",
-        description: details?.description ?? "",
+        // Manifest-authored description (Option A) wins; enrichment is the
+        // legacy fallback (currently always undefined).
+        description: details?.description ?? n.description ?? "",
+        inputSchema: n.inputSchema ?? null,
+        capabilities: n.capabilities ?? [],
+        timeoutMs: n.timeoutMs ?? null,
       };
     }),
     edges: graph.edges.map((e) => ({
@@ -103,6 +108,31 @@ function buildGraphPayload(graph: CanvasGraph, enrichment?: CanvasEnrichment | n
     warnings: graph.warnings,
   };
   return JSON.stringify(payload).replace(/</g, "\\u003c");
+}
+
+/** The workflow-level overview the Canvas tab's bottom panel shows: a
+ *  deterministic stats line ("N steps · M exits · <entry> entry"), the shape
+ *  summary as the description, and the graph's validation notes. Embedded as a
+ *  JSON data block (read by bootCanvasOverview), the same pattern as the step
+ *  graph — everything here is derived from the graph, no LLM. */
+function buildOverviewPayload(graph: CanvasGraph, enrichment?: CanvasEnrichment | null): string {
+  const exits = graph.nodes.filter(
+    (n) => n.kind === "terminal-success" || n.kind === "terminal-warn",
+  ).length;
+  const steps = graph.nodes.length - exits;
+  const entryLabel = graph.nodes.find((n) => n.id === graph.entry)?.label ?? graph.entry;
+  const parts = [`${steps} ${steps === 1 ? "step" : "steps"}`];
+  if (exits > 0) parts.push(`${exits} ${exits === 1 ? "exit" : "exits"}`);
+  if (entryLabel) parts.push(`${entryLabel} entry`);
+  const overview = {
+    // Human-authored workflow description from the manifest (Option A); "" when
+    // the workflow declares none (the shape summary still renders on the board).
+    description: graph.description ?? "",
+    stats: parts.join(" · "),
+    notes: enrichment?.notes ?? [],
+  };
+  // JSON in a <script> block: neutralize any "</script>"/"<" in derived text.
+  return JSON.stringify(overview).replace(/</g, "\\u003c");
 }
 
 /** One workflow's full panel: title/badges + summary header and the SVG
@@ -126,6 +156,7 @@ export function buildWorkflowPanelHtml(
   const legend = buildLegendHtml(used.nodeKinds, used.edgeKinds);
   const legendHtml = legend ? `\n  ${legend}` : "";
   const graphData = buildGraphPayload(graph, enrichment);
+  const overviewData = buildOverviewPayload(graph, enrichment);
   return `<section class="canvas-panel">
   <header class="canvas-header">
     <div class="canvas-title-row">
@@ -137,6 +168,7 @@ export function buildWorkflowPanelHtml(
 ${renderGraphSvg(graph, enrichment)}
   </div>${legendHtml}
   <script type="application/json" id="sapiom-graph">${graphData}</script>
+  <script type="application/json" id="sapiom-overview">${overviewData}</script>
 </section>`;
 }
 

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -11,7 +11,12 @@
  */
 import type { AgentManifest, AgentStepManifest } from "@sapiom/agent";
 import { runManifestCheck } from "./canvas-manifest-check.js";
-import { detectWorkflowLaunches, type DetectedLaunch } from "./canvas-interconnections.js";
+import {
+  detectWorkflowLaunches,
+  detectStepCapabilities,
+  type DetectedLaunch,
+  type DetectedCapability,
+} from "./canvas-interconnections.js";
 
 export type CanvasNodeKind = "entry" | "step" | "pause" | "terminal-success" | "terminal-warn" | "launched-workflow";
 export type CanvasEdgeKind = "sequential" | "branching" | "cross" | "launch";
@@ -21,6 +26,14 @@ export interface CanvasNode {
   kind: CanvasNodeKind;
   label: string;
   sublabel?: string;
+  /** Human-authored step description from the manifest (Option A); "" when none. */
+  description?: string;
+  /** The step's declared input contract (JSON Schema) from the manifest. */
+  inputSchema?: Record<string, unknown> | null;
+  /** Author-declared Sapiom capabilities the step calls. */
+  capabilities?: readonly string[];
+  /** The step's declared dispatch timeout (ms); null when unset. */
+  timeoutMs?: number | null;
 }
 
 export interface CanvasEdge {
@@ -35,6 +48,8 @@ export interface CanvasGraph {
   /** The manifest's own name — used both as a display title fallback and as
    *  the match key for cross-workflow interconnection detection. */
   manifestName: string;
+  /** Human-authored workflow description from the manifest (Option A); "" when none. */
+  description?: string;
   entry: string;
   nodes: CanvasNode[];
   edges: CanvasEdge[];
@@ -116,12 +131,28 @@ function edgesForStep(name: string, step: AgentStepManifest): CanvasEdge[] {
 export function graphFromManifest(manifest: AgentManifest, warnings: string[]): CanvasGraph {
   const nodes: CanvasNode[] = Object.entries(manifest.steps).map(([name, step]) => {
     const { kind, sublabel } = classifyNode(name, manifest.entry, step);
-    return { id: name, kind, label: name, sublabel };
+    return {
+      id: name,
+      kind,
+      label: name,
+      sublabel,
+      description: step.description ?? "",
+      inputSchema: step.inputSchema ?? null,
+      capabilities: step.capabilities ?? [],
+      timeoutMs: step.timeoutMs ?? null,
+    };
   });
   const edges: CanvasEdge[] = Object.entries(manifest.steps).flatMap(([name, step]) =>
     edgesForStep(name, step),
   );
-  return { manifestName: manifest.name, entry: manifest.entry, nodes, edges, warnings };
+  return {
+    manifestName: manifest.name,
+    description: manifest.description ?? "",
+    entry: manifest.entry,
+    nodes,
+    edges,
+    warnings,
+  };
 }
 
 /**
@@ -155,6 +186,31 @@ export function mergeLaunchesIntoGraph(graph: CanvasGraph, launches: readonly De
   return { ...graph, nodes, edges };
 }
 
+/** Fills each step node's `capabilities` from statically-detected
+ *  `ctx.sapiom.*` calls, unless the manifest already declared them (authored
+ *  capabilities win). Pure — returns a new graph. */
+export function mergeCapabilitiesIntoGraph(
+  graph: CanvasGraph,
+  detected: readonly DetectedCapability[],
+): CanvasGraph {
+  if (detected.length === 0) return graph;
+  const byStep = new Map<string, Set<string>>();
+  for (const d of detected) {
+    if (!d.fromStepId) continue;
+    const set = byStep.get(d.fromStepId) ?? new Set<string>();
+    set.add(d.capability);
+    byStep.set(d.fromStepId, set);
+  }
+  return {
+    ...graph,
+    nodes: graph.nodes.map((n) => {
+      if ((n.capabilities?.length ?? 0) > 0) return n; // authored capabilities win
+      const caps = byStep.get(n.id);
+      return caps ? { ...n, capabilities: [...caps].sort() } : n;
+    }),
+  };
+}
+
 /**
  * Extracts a workflow's step graph from its project directory, with detected
  * cross-workflow launches merged in as dashed nodes. Never throws: any
@@ -168,6 +224,9 @@ export async function extractWorkflowGraph(sourceDir: string): Promise<Extractio
   const result = await runManifestCheck(sourceDir);
   if (!result.ok) return { ok: false, reason: result.reason };
   const graph = graphFromManifest(result.manifest as AgentManifest, result.warnings);
-  const launches = await detectWorkflowLaunches(sourceDir, new Set(graph.nodes.map((n) => n.id)));
-  return { ok: true, graph: mergeLaunchesIntoGraph(graph, launches) };
+  const stepIds = new Set(graph.nodes.map((n) => n.id));
+  const launches = await detectWorkflowLaunches(sourceDir, stepIds);
+  const capabilities = await detectStepCapabilities(sourceDir, stepIds);
+  const withLaunches = mergeLaunchesIntoGraph(graph, launches);
+  return { ok: true, graph: mergeCapabilitiesIntoGraph(withLaunches, capabilities) };
 }

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -12,8 +12,7 @@
 import type { AgentManifest, AgentStepManifest } from "@sapiom/agent";
 import { runManifestCheck } from "./canvas-manifest-check.js";
 import {
-  detectWorkflowLaunches,
-  detectStepCapabilities,
+  scanWorkflowSources,
   type DetectedLaunch,
   type DetectedCapability,
 } from "./canvas-interconnections.js";
@@ -225,8 +224,9 @@ export async function extractWorkflowGraph(sourceDir: string): Promise<Extractio
   if (!result.ok) return { ok: false, reason: result.reason };
   const graph = graphFromManifest(result.manifest as AgentManifest, result.warnings);
   const stepIds = new Set(graph.nodes.map((n) => n.id));
-  const launches = await detectWorkflowLaunches(sourceDir, stepIds);
-  const capabilities = await detectStepCapabilities(sourceDir, stepIds);
+  // One walk over the sources yields both — halves the I/O on the auto-render
+  // hot path (this runs on every workflow-source save).
+  const { launches, capabilities } = await scanWorkflowSources(sourceDir, stepIds);
   const withLaunches = mergeLaunchesIntoGraph(graph, launches);
   return { ok: true, graph: mergeCapabilitiesIntoGraph(withLaunches, capabilities) };
 }

--- a/packages/harness/src/core/canvas-interconnections.test.ts
+++ b/packages/harness/src/core/canvas-interconnections.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { detectWorkflowLaunches } from "./canvas-interconnections.js";
+import { detectStepCapabilities, detectWorkflowLaunches } from "./canvas-interconnections.js";
 
 const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__");
 
@@ -95,5 +95,73 @@ export async function kickOff(agents: { launch: (spec: { definition: string }) =
 
   it("never throws for a directory that doesn't exist", async () => {
     await expect(detectWorkflowLaunches(path.join(FIXTURES_DIR, "does-not-exist"), new Set())).resolves.toEqual([]);
+  });
+});
+
+describe("detectStepCapabilities", () => {
+  it("attributes each ctx.sapiom.*() call to the step whose defineStep block it sits in", async () => {
+    const dir = await tmpProject({
+      "index.ts": `
+const draft = defineStep({
+  name: "draft",
+  async run(input, ctx) {
+    const reply = await ctx.sapiom.models.run({ prompt: "hi" });
+    return goto("notify", { reply });
+  },
+});
+const notify = defineStep({
+  name: "notify",
+  terminal: true,
+  async run(input, ctx) {
+    await ctx.sapiom.email.messages.send({ to: "x@y.z" });
+    return terminate({});
+  },
+});
+`,
+    });
+    const caps = await detectStepCapabilities(dir, new Set(["draft", "notify"]));
+    expect(caps).toEqual([
+      { capability: "models.run", fromStepId: "draft" },
+      { capability: "email.messages.send", fromStepId: "notify" },
+    ]);
+  });
+
+  it("does NOT attribute a call in a trailing helper to the last step — a wrong chip is a false billing claim", async () => {
+    const dir = await tmpProject({
+      "index.ts": `
+const classify = defineStep({
+  name: "classify",
+  terminal: true,
+  async run(input, ctx) {
+    return terminate({ label: categorize(input) });
+  },
+});
+
+// A helper BELOW the last step — its sapiom call must stay UNattributed
+// (fromStepId null), not get billed to "classify".
+function categorize(input) {
+  return sapiom.rules.classify({ input });
+}
+`,
+    });
+    const caps = await detectStepCapabilities(dir, new Set(["classify"]));
+    expect(caps).toEqual([{ capability: "rules.classify", fromStepId: null }]);
+  });
+
+  it("excludes launch calls — they render as launched-workflow nodes, not capability chips", async () => {
+    const dir = await tmpProject({
+      "index.ts": `
+const kickoff = defineStep({
+  name: "kickoff",
+  async run(input, ctx) {
+    await ctx.sapiom.agents.launch({ definition: "child-flow" });
+    await ctx.sapiom.web.search({ q: "x" });
+    return terminate({});
+  },
+});
+`,
+    });
+    const caps = await detectStepCapabilities(dir, new Set(["kickoff"]));
+    expect(caps).toEqual([{ capability: "web.search", fromStepId: "kickoff" }]);
   });
 });

--- a/packages/harness/src/core/canvas-interconnections.ts
+++ b/packages/harness/src/core/canvas-interconnections.ts
@@ -1,16 +1,23 @@
 /**
- * Heuristic cross-workflow launch detection: greps a workflow project's
- * TypeScript sources for `orchestrations.launch({ definition: "<slug>" })`
- * (the pre-rename SDK's capability) and `agents.launch({ definition: ... })`
- * (the current SDK, e.g. `ctx.sapiom.agents.launch`) calls, and best-effort
- * attributes each call to the step whose `defineStep({ name: ... })` block it
- * sits in. The result is merged into the workflow's own rendered graph as
- * dashed "launched workflow" nodes (see core/canvas-graph.ts).
+ * Heuristic scan of a workflow project's TypeScript sources for two things the
+ * canvas surfaces, in a single pass:
+ *
+ *  - cross-workflow launches — `orchestrations.launch({ definition: "<slug>" })`
+ *    (old SDK) and `agents.launch({ definition: ... })` (current SDK), rendered
+ *    as dashed "launched workflow" nodes; and
+ *  - Sapiom capabilities — `ctx.sapiom.<ns>.<method>(...)` call sites, rendered
+ *    as capability chips on the step (the thing Sapiom bills for).
+ *
+ * Each call is attributed to the step whose `defineStep({ ... })` block it
+ * literally sits inside — a brace-balanced extent, not merely the nearest
+ * preceding `name:`. A call in a shared helper (or anywhere outside a step
+ * block) is left unattributed (`fromStepId: null`) rather than mis-billed to
+ * the last step in the file — for a capability chip that would read as a false
+ * claim about what a step calls.
  *
  * This is deliberately a grep, not a type-aware analysis — a step can compute
- * its `definition` dynamically, in which case it's simply not detected; false
- * negatives are fine here, the launch nodes are a bonus, not a source of
- * truth.
+ * its `definition`/call dynamically, in which case it's simply not detected;
+ * false negatives are fine here.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -27,10 +34,25 @@ const MAX_FILE_BYTES = 512 * 1024;
 const LAUNCH_CALL_PATTERN =
   /(?:orchestrations|agents)\s*\.\s*launch\s*\(\s*\{[\s\S]{0,400}?definition\s*:\s*(['"`])([^'"`]+)\1/g;
 
+// Matches `sapiom.<ns>.<method>(` chains — e.g. `ctx.sapiom.web.search(`,
+// `sapiom.email.messages.send(`. Captures the dotted chain AFTER `sapiom.`
+// (the capability id: "web.search", "email.messages.send"), tolerating
+// whitespace around the dots. The negative lookbehind avoids matching an
+// identifier that merely ends in "sapiom".
+const CAPABILITY_CALL_PATTERN =
+  /(?<![\w$])sapiom\s*\.\s*([a-z][\w$]*(?:\s*\.\s*[a-z][\w$]*)+)\s*\(/gi;
+
+// Launch calls are surfaced as dashed launched-workflow nodes, not capabilities.
+const NON_CAPABILITY_CALLS = new Set(["agents.launch", "orchestrations.launch"]);
+
 // A `name: "..."` property declaration — the step-name key `defineStep`
 // blocks always open with. The lookbehind rejects longer identifiers ending
 // in "name" (fromName, vendorName) without consuming the preceding char.
 const STEP_NAME_PATTERN = /(?<![\w$.])name\s*:\s*(['"`])([^'"`]+)\1/g;
+
+// A `defineStep(` call opener (not `myDefineStep(`). Its brace-balanced extent
+// is what bounds a step's attribution below.
+const DEFINE_STEP_PATTERN = /(?<![\w$.])defineStep\s*\(/g;
 
 /**
  * Lists the workflow's own `.ts`/`.tsx` sources (skipping node_modules and
@@ -62,60 +84,98 @@ export async function listSourceFiles(root: string): Promise<string[]> {
   return files;
 }
 
+// --- attribution: which step's defineStep(...) block a call sits in ---------
+
+/** From the opening quote at `open`, the index of the matching close quote (or
+ *  the last index). Escapes are honored; a template literal is treated as one
+ *  opaque span (its balanced `${…}` parens never leak into the paren count). */
+function skipString(content: string, open: number): number {
+  const quote = content[open];
+  for (let i = open + 1; i < content.length; i++) {
+    if (content[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (content[i] === quote) return i;
+  }
+  return content.length - 1;
+}
+
+/** From the `(` at `open`, the index of its matching `)` (or end of file),
+ *  skipping string and comment content so parens inside them can't miscount. */
+function matchingParen(content: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < content.length; i++) {
+    const c = content[i];
+    if (c === "'" || c === '"' || c === "`") {
+      i = skipString(content, i);
+      continue;
+    }
+    if (c === "/" && content[i + 1] === "/") {
+      const nl = content.indexOf("\n", i);
+      if (nl === -1) return content.length;
+      i = nl;
+      continue;
+    }
+    if (c === "/" && content[i + 1] === "*") {
+      const close = content.indexOf("*/", i + 2);
+      i = close === -1 ? content.length : close + 1;
+      continue;
+    }
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return content.length;
+}
+
+interface StepBlock {
+  /** Index of the `(` opening the `defineStep(` call. */
+  start: number;
+  /** Index of the matching `)`. */
+  end: number;
+  /** The known step this block declares (its first known `name:`). */
+  stepId: string;
+}
+
+/** The brace-balanced extent of each `defineStep(...)` call whose declared
+ *  `name` is a known step — so a call can be attributed to the step it sits in,
+ *  not the nearest preceding `name:` (which mis-binds trailing helpers). */
+function stepBlockRanges(content: string, knownStepIds: ReadonlySet<string>): StepBlock[] {
+  const blocks: StepBlock[] = [];
+  for (const match of content.matchAll(DEFINE_STEP_PATTERN)) {
+    const open = match.index + match[0].length - 1; // the `(` of defineStep(
+    const end = matchingParen(content, open);
+    let stepId: string | null = null;
+    for (const nameMatch of content.slice(open, end).matchAll(STEP_NAME_PATTERN)) {
+      if (knownStepIds.has(nameMatch[2]!)) {
+        stepId = nameMatch[2]!;
+        break;
+      }
+    }
+    if (stepId) blocks.push({ start: open, end, stepId });
+  }
+  return blocks;
+}
+
+/** The step whose block contains `index`, or null (top-level / shared helper). */
+function attributeTo(blocks: readonly StepBlock[], index: number): string | null {
+  for (const block of blocks) {
+    if (index > block.start && index < block.end) return block.stepId;
+  }
+  return null;
+}
+
 export interface DetectedLaunch {
   /** The `definition` slug the launch call referenced. */
   slug: string;
-  /** The step (by declared name) the call was attributed to — the nearest
-   *  preceding `name: "<known step>"` declaration in the same file — or null
-   *  when no known step precedes it (e.g. a launch in a shared helper). */
+  /** The step (by declared name) the call was attributed to — the step whose
+   *  `defineStep` block it sits in — or null when it sits outside any step
+   *  (e.g. a launch in a shared helper). */
   fromStepId: string | null;
 }
-
-/**
- * Every `*.launch({ definition: "..." })` call in `root`'s sources, each
- * best-effort attributed to the step whose `defineStep` block it sits in
- * (`knownStepIds` = the workflow's real step names, so an unrelated `name:`
- * property can never be mistaken for a step). Never throws: unreadable
- * files/directories simply contribute no launches.
- */
-export async function detectWorkflowLaunches(
-  root: string,
-  knownStepIds: ReadonlySet<string>,
-): Promise<DetectedLaunch[]> {
-  const launches: DetectedLaunch[] = [];
-  for (const file of await listSourceFiles(root)) {
-    let content: string;
-    try {
-      const stat = await fs.stat(file);
-      if (stat.size > MAX_FILE_BYTES) continue;
-      content = await fs.readFile(file, "utf8");
-    } catch {
-      continue;
-    }
-
-    const stepDeclarations: Array<{ index: number; stepId: string }> = [];
-    for (const match of content.matchAll(STEP_NAME_PATTERN)) {
-      if (knownStepIds.has(match[2]!)) stepDeclarations.push({ index: match.index, stepId: match[2]! });
-    }
-
-    for (const match of content.matchAll(LAUNCH_CALL_PATTERN)) {
-      const preceding = stepDeclarations.filter((d) => d.index < match.index).at(-1);
-      launches.push({ slug: match[2]!, fromStepId: preceding?.stepId ?? null });
-    }
-  }
-  return launches;
-}
-
-// Matches `sapiom.<ns>.<method>(` chains — e.g. `ctx.sapiom.web.search(`,
-// `sapiom.email.messages.send(`. Captures the dotted chain AFTER `sapiom.`
-// (the capability id: "web.search", "email.messages.send"), tolerating
-// whitespace around the dots. The negative lookbehind avoids matching an
-// identifier that merely ends in "sapiom".
-const CAPABILITY_CALL_PATTERN =
-  /(?<![\w$])sapiom\s*\.\s*([a-z][\w$]*(?:\s*\.\s*[a-z][\w$]*)+)\s*\(/gi;
-
-// Launch calls are surfaced as dashed launched-workflow nodes, not capabilities.
-const NON_CAPABILITY_CALLS = new Set(["agents.launch", "orchestrations.launch"]);
 
 export interface DetectedCapability {
   /** The dotted capability id (e.g. "web.search", "email.messages.send"). */
@@ -124,19 +184,28 @@ export interface DetectedCapability {
   fromStepId: string | null;
 }
 
+export interface WorkflowSourceScan {
+  launches: DetectedLaunch[];
+  capabilities: DetectedCapability[];
+}
+
 /**
- * Every `ctx.sapiom.<ns>.<method>(...)` call in `root`'s sources — the Sapiom
- * capabilities each step calls — best-effort attributed to the step whose
- * `defineStep` block it sits in (same attribution as detectWorkflowLaunches).
- * A deterministic grep (no LLM): a step computing its call dynamically simply
- * isn't detected; false negatives are fine. Launch calls are excluded (they
- * render as launched-workflow nodes instead).
+ * One pass over `root`'s sources returning both the cross-workflow launches and
+ * the Sapiom capability calls, each attributed to the `defineStep` block it
+ * sits in (`knownStepIds` = the workflow's real step names, so an unrelated
+ * `name:` property can never be mistaken for a step). Never throws: unreadable
+ * files/directories simply contribute nothing.
+ *
+ * A single walk + read + block computation per file: the callers used to scan
+ * the tree twice (once per detector), and auto-render now fires on every save,
+ * so the shared pass halves the I/O on the hot path.
  */
-export async function detectStepCapabilities(
+export async function scanWorkflowSources(
   root: string,
   knownStepIds: ReadonlySet<string>,
-): Promise<DetectedCapability[]> {
-  const found: DetectedCapability[] = [];
+): Promise<WorkflowSourceScan> {
+  const launches: DetectedLaunch[] = [];
+  const capabilities: DetectedCapability[] = [];
   for (const file of await listSourceFiles(root)) {
     let content: string;
     try {
@@ -147,17 +216,32 @@ export async function detectStepCapabilities(
       continue;
     }
 
-    const stepDeclarations: Array<{ index: number; stepId: string }> = [];
-    for (const match of content.matchAll(STEP_NAME_PATTERN)) {
-      if (knownStepIds.has(match[2]!)) stepDeclarations.push({ index: match.index, stepId: match[2]! });
-    }
+    const blocks = stepBlockRanges(content, knownStepIds);
 
+    for (const match of content.matchAll(LAUNCH_CALL_PATTERN)) {
+      launches.push({ slug: match[2]!, fromStepId: attributeTo(blocks, match.index) });
+    }
     for (const match of content.matchAll(CAPABILITY_CALL_PATTERN)) {
       const capability = match[1]!.replace(/\s+/g, "");
       if (NON_CAPABILITY_CALLS.has(capability)) continue;
-      const preceding = stepDeclarations.filter((d) => d.index < match.index).at(-1);
-      found.push({ capability, fromStepId: preceding?.stepId ?? null });
+      capabilities.push({ capability, fromStepId: attributeTo(blocks, match.index) });
     }
   }
-  return found;
+  return { launches, capabilities };
+}
+
+/** Just the launches from {@link scanWorkflowSources}. */
+export async function detectWorkflowLaunches(
+  root: string,
+  knownStepIds: ReadonlySet<string>,
+): Promise<DetectedLaunch[]> {
+  return (await scanWorkflowSources(root, knownStepIds)).launches;
+}
+
+/** Just the capabilities from {@link scanWorkflowSources}. */
+export async function detectStepCapabilities(
+  root: string,
+  knownStepIds: ReadonlySet<string>,
+): Promise<DetectedCapability[]> {
+  return (await scanWorkflowSources(root, knownStepIds)).capabilities;
 }

--- a/packages/harness/src/core/canvas-interconnections.ts
+++ b/packages/harness/src/core/canvas-interconnections.ts
@@ -105,3 +105,59 @@ export async function detectWorkflowLaunches(
   }
   return launches;
 }
+
+// Matches `sapiom.<ns>.<method>(` chains — e.g. `ctx.sapiom.web.search(`,
+// `sapiom.email.messages.send(`. Captures the dotted chain AFTER `sapiom.`
+// (the capability id: "web.search", "email.messages.send"), tolerating
+// whitespace around the dots. The negative lookbehind avoids matching an
+// identifier that merely ends in "sapiom".
+const CAPABILITY_CALL_PATTERN =
+  /(?<![\w$])sapiom\s*\.\s*([a-z][\w$]*(?:\s*\.\s*[a-z][\w$]*)+)\s*\(/gi;
+
+// Launch calls are surfaced as dashed launched-workflow nodes, not capabilities.
+const NON_CAPABILITY_CALLS = new Set(["agents.launch", "orchestrations.launch"]);
+
+export interface DetectedCapability {
+  /** The dotted capability id (e.g. "web.search", "email.messages.send"). */
+  capability: string;
+  /** The step the call was attributed to, or null (a shared helper). */
+  fromStepId: string | null;
+}
+
+/**
+ * Every `ctx.sapiom.<ns>.<method>(...)` call in `root`'s sources — the Sapiom
+ * capabilities each step calls — best-effort attributed to the step whose
+ * `defineStep` block it sits in (same attribution as detectWorkflowLaunches).
+ * A deterministic grep (no LLM): a step computing its call dynamically simply
+ * isn't detected; false negatives are fine. Launch calls are excluded (they
+ * render as launched-workflow nodes instead).
+ */
+export async function detectStepCapabilities(
+  root: string,
+  knownStepIds: ReadonlySet<string>,
+): Promise<DetectedCapability[]> {
+  const found: DetectedCapability[] = [];
+  for (const file of await listSourceFiles(root)) {
+    let content: string;
+    try {
+      const stat = await fs.stat(file);
+      if (stat.size > MAX_FILE_BYTES) continue;
+      content = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    const stepDeclarations: Array<{ index: number; stepId: string }> = [];
+    for (const match of content.matchAll(STEP_NAME_PATTERN)) {
+      if (knownStepIds.has(match[2]!)) stepDeclarations.push({ index: match.index, stepId: match[2]! });
+    }
+
+    for (const match of content.matchAll(CAPABILITY_CALL_PATTERN)) {
+      const capability = match[1]!.replace(/\s+/g, "");
+      if (NON_CAPABILITY_CALLS.has(capability)) continue;
+      const preceding = stepDeclarations.filter((d) => d.index < match.index).at(-1);
+      found.push({ capability, fromStepId: preceding?.stepId ?? null });
+    }
+  }
+  return found;
+}

--- a/packages/harness/src/core/canvas-run-state.ts
+++ b/packages/harness/src/core/canvas-run-state.ts
@@ -301,3 +301,38 @@ export function bootCanvasGraph(): void {
     post();
   }
 }
+
+/**
+ * Posts the workflow-level overview (`{ description, stats, notes }`) so the
+ * Canvas tab's bottom panel can show it — the deterministic equivalent of the
+ * demo doc's overview. Embedded by `canvas-body.ts` as a `<script
+ * type="application/json" id="sapiom-overview">` data block (read as text, same
+ * pattern as the graph). A missing block posts nothing and the parent keeps its
+ * empty state; a malformed one is swallowed rather than thrown. Stringified into
+ * the template by `canvas-template.ts`.
+ */
+export function bootCanvasOverview(): void {
+  function post(): void {
+    const el = document.getElementById("sapiom-overview");
+    if (!el) return;
+    try {
+      const data = JSON.parse(el.textContent || "{}");
+      window.parent.postMessage(
+        {
+          type: "sapiom-canvas:overview",
+          description: typeof data.description === "string" ? data.description : "",
+          stats: typeof data.stats === "string" ? data.stats : "",
+          notes: Array.isArray(data.notes) ? data.notes : [],
+        },
+        "*",
+      );
+    } catch {
+      /* malformed payload — leave the overview empty rather than throw */
+    }
+  }
+  if (document.readyState === "loading") {
+    window.addEventListener("DOMContentLoaded", post);
+  } else {
+    post();
+  }
+}

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -21,6 +21,7 @@ import { isLegacyDeterministicCanvas } from "./canvas-index-classify.js";
 import {
   applyRunStateToCanvas,
   bootCanvasGraph,
+  bootCanvasOverview,
   bootCanvasNodeClicks,
   bootCanvasRunState,
   bootCanvasView,
@@ -94,11 +95,16 @@ html, body {
    pane centers within the VISIBLE area — with min-height the body would grow and
    push the card off-screen — and overflow is clipped (pan/zoom navigates instead
    of scrollbars). */
-body { display: flex; align-items: center; justify-content: center; height: 100vh; overflow: hidden; }
+body {
+  display: flex; align-items: center; justify-content: center; height: 100vh; overflow: hidden;
+  /* Dotted grid behind the board — matches the studio's demo canvas. */
+  background-image: radial-gradient(var(--canvas-border-strong) 1px, transparent 1px);
+  background-size: 16px 16px;
+}
 #canvas-root { max-width: 1100px; padding: 24px 20px; display: flex; flex-direction: column; gap: 18px; }
 
 /* --- structural classes: keep these, and their names, untouched --- */
-.canvas-panel { background: var(--canvas-panel); border: 1px solid var(--canvas-border); border-radius: 16px; padding: 20px; }
+.canvas-panel { background: transparent; border: 0; padding: 20px; }
 .canvas-header { display: flex; flex-direction: column; gap: 10px; margin-bottom: 14px; }
 .canvas-title-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .canvas-title { margin: 0; font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
@@ -355,7 +361,7 @@ const NAME_SHIM = "function __name(fn){return fn;}";
  *  embedded step graph so the Steps tab can project it — all via the same
  *  stringify pattern. `NAME_SHIM` MUST come first (see its doc — without it,
  *  esbuild/tsx output throws in the iframe). */
-const RUN_STATE_SCRIPT = `${NAME_SHIM}\n${runStateNodeClass.toString()}\n${applyRunStateToCanvas.toString()}\n${bootCanvasRunState.toString()}\nbootCanvasRunState();\n${bootCanvasNodeClicks.toString()}\nbootCanvasNodeClicks();\n${bootCanvasView.toString()}\nbootCanvasView();\n${bootCanvasGraph.toString()}\nbootCanvasGraph();`;
+const RUN_STATE_SCRIPT = `${NAME_SHIM}\n${runStateNodeClass.toString()}\n${applyRunStateToCanvas.toString()}\n${bootCanvasRunState.toString()}\nbootCanvasRunState();\n${bootCanvasNodeClicks.toString()}\nbootCanvasNodeClicks();\n${bootCanvasView.toString()}\nbootCanvasView();\n${bootCanvasGraph.toString()}\nbootCanvasGraph();\n${bootCanvasOverview.toString()}\nbootCanvasOverview();`;
 
 /**
  * Wraps `bodyHtml` in the shared canvas document shell: doctype, the theme

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -118,6 +118,7 @@ const RouteInput = z.object({ order: OrderSchema, receivedAt: z.string(), catego
 const intake = defineStep({
   name: 'intake',
   next: ['classify'],
+  description: 'Logs the incoming order and stamps the time it arrived.',
   async run(input, ctx) {
     ctx.logger.info('order received', { input });
     return goto('classify', { order: input, receivedAt: new Date().toISOString() });
@@ -128,6 +129,8 @@ const classify = defineStep({
   name: 'classify',
   next: ['route'],
   inputSchema: ClassifyInput,
+  description: 'Tags the order with a category for routing.',
+  capabilities: ['rules.classify'],
   async run(input, ctx) {
     const category = input.order.category ?? 'general';
     ctx.logger.info('classified order', { category });
@@ -139,6 +142,8 @@ const route = defineStep({
   name: 'route',
   next: ['auto_resolve', 'escalate'],
   inputSchema: RouteInput,
+  description: 'Branches on the category: billing disputes escalate to a human; everything else auto-resolves.',
+  capabilities: ['rules.evaluate'],
   async run(input) {
     const needsHuman = input.category === 'billing_dispute';
     return goto(needsHuman ? 'escalate' : 'auto_resolve', input);
@@ -150,6 +155,7 @@ const auto_resolve = defineStep({
   next: [],
   terminal: true,
   inputSchema: RouteInput,
+  description: 'Auto-resolves the order and completes.',
   async run(input) {
     return terminate({ resolved: true, category: input.category });
   },
@@ -160,6 +166,7 @@ const escalate = defineStep({
   next: [],
   terminal: true,
   inputSchema: RouteInput,
+  description: 'Escalates the order to a human for manual handling.',
   async run(input, ctx) {
     ctx.logger.info('escalating to human', { category: input.category });
     return terminate({ resolved: false, escalated: true });
@@ -168,6 +175,7 @@ const escalate = defineStep({
 
 export const agent = defineAgent({
   name: 'order-triage',
+  description: 'Triages incoming support orders end to end: classify, route, then auto-resolve or escalate to a human.',
   entry: 'intake',
   steps: { intake, classify, route, auto_resolve, escalate },
 });

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -118,7 +118,6 @@ const RouteInput = z.object({ order: OrderSchema, receivedAt: z.string(), catego
 const intake = defineStep({
   name: 'intake',
   next: ['classify'],
-  description: 'Logs the incoming order and stamps the time it arrived.',
   async run(input, ctx) {
     ctx.logger.info('order received', { input });
     return goto('classify', { order: input, receivedAt: new Date().toISOString() });
@@ -129,8 +128,6 @@ const classify = defineStep({
   name: 'classify',
   next: ['route'],
   inputSchema: ClassifyInput,
-  description: 'Tags the order with a category for routing.',
-  capabilities: ['rules.classify'],
   async run(input, ctx) {
     const category = input.order.category ?? 'general';
     ctx.logger.info('classified order', { category });
@@ -142,8 +139,6 @@ const route = defineStep({
   name: 'route',
   next: ['auto_resolve', 'escalate'],
   inputSchema: RouteInput,
-  description: 'Branches on the category: billing disputes escalate to a human; everything else auto-resolves.',
-  capabilities: ['rules.evaluate'],
   async run(input) {
     const needsHuman = input.category === 'billing_dispute';
     return goto(needsHuman ? 'escalate' : 'auto_resolve', input);
@@ -155,7 +150,6 @@ const auto_resolve = defineStep({
   next: [],
   terminal: true,
   inputSchema: RouteInput,
-  description: 'Auto-resolves the order and completes.',
   async run(input) {
     return terminate({ resolved: true, category: input.category });
   },
@@ -166,7 +160,6 @@ const escalate = defineStep({
   next: [],
   terminal: true,
   inputSchema: RouteInput,
-  description: 'Escalates the order to a human for manual handling.',
   async run(input, ctx) {
     ctx.logger.info('escalating to human', { category: input.category });
     return terminate({ resolved: false, escalated: true });
@@ -175,7 +168,6 @@ const escalate = defineStep({
 
 export const agent = defineAgent({
   name: 'order-triage',
-  description: 'Triages incoming support orders end to end: classify, route, then auto-resolve or escalate to a human.',
   entry: 'intake',
   steps: { intake, classify, route, auto_resolve, escalate },
 });

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -641,6 +641,15 @@ export const startServer = async (
         void rescanWorkspaceForSession(session.id).catch((err: unknown) => {
           console.error("[harness] initial workspace rescan failed:", err);
         });
+        // A resumed/already-bound session skips the rescan's auto-bind render
+        // (guarded by !boundWorkflowPath), so render it here — a reopened
+        // workflow shows its diagram on start without any manual trigger, now
+        // that the empty-state render button is gone.
+        if (session.boundWorkflowPath) {
+          void autoRenderCanvas(session).catch((err: unknown) => {
+            console.error("[harness] on-start canvas render failed:", err);
+          });
+        }
       }
     } else if (session.status === "exited") {
       canvasWatcher.stop(session.id);

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -5,7 +5,7 @@
  * - A board node pick (the document's {type:"sapiom-canvas:node"} answer)
  *   populates the bottom panel with that step's detail IN PLACE — the right
  *   pane stays on the Canvas tab; the Steps tab is only the inspector's
- *   explicit "Open in Steps" drill.
+ *   explicit "Open step" drill.
  * - Deselect (Esc / empty board space / the panel's close) restores the
  *   general workflow overview unchanged.
  * - Height hugs the content up to half the canvas pane; taller content
@@ -59,20 +59,16 @@ test("a board pick populates the inspector in place, with no tab switch", async 
   await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "board");
   const inspector = page.getByTestId("canvas-step-inspector");
   await expect(inspector).toContainText("Logs the incoming order");
-  // Contract chips and transitions render from the posted graph.
+  // Contract chips render from the posted graph.
   await expect(inspector).toContainText("records.read");
-  await expect(inspector).toContainText("screen");
 
-  // A transition row retargets the selection without leaving the board.
-  await inspector.locator(".canvas-step-transition.is-link").filter({ hasText: "screen" }).click();
-  await expect(page.getByTestId("canvas-inspector-title")).toHaveText("screen");
-  await expect(page.getByTestId("right-tab-canvas")).toHaveClass(/is-active/);
-
-  // "Open in Steps" is the explicit full-pane drill.
+  // The drawer no longer carries step-navigation links — the chart is right
+  // there for that. "Open step" is the explicit full-pane drill, and it opens
+  // the picked step (still intake, since nothing retargeted the selection).
   await page.getByTestId("canvas-inspector-open-steps").click();
   await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
   await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "detail");
-  await expect(page.getByTestId("canvas-detail-title")).toHaveText("screen");
+  await expect(page.getByTestId("canvas-detail-title")).toHaveText("intake");
 });
 
 test("deselect restores the overview: Esc, the panel's close, and empty board space", async ({ page }) => {
@@ -109,9 +105,11 @@ test("deselect restores the overview: Esc, the panel's close, and empty board sp
 
 test("the panel hugs its content up to half the pane; taller content scrolls inside", async ({ page }) => {
   // A short pane makes the 50% cap bite: the inspector's content for a
-  // contract-heavy step is taller than half the pane at this height.
+  // contract-heavy step is taller than half the pane at this height. (The chat
+  // moved to its own toggled panel, so the inspector itself is shorter now —
+  // hence the shorter viewport to keep the cap biting.)
   // Collapse the overview first so the whole cascade stays clickable.
-  await page.setViewportSize({ width: 1280, height: 560 });
+  await page.setViewportSize({ width: 1280, height: 400 });
   await loadBoard(page);
   await page.getByTestId("canvas-overview-toggle").click();
   await pickNode(page, "credit-check");

--- a/packages/harness/web/e2e/direct-actions.spec.ts
+++ b/packages/harness/web/e2e/direct-actions.spec.ts
@@ -323,65 +323,8 @@ test.describe("Run-local button — offline stub run, per-step inspector render,
 // 4. Contrast — macros (Visualize) STILL go through runMacro (NOT direct route)
 // ---------------------------------------------------------------------------
 
-test.describe("Contrast: macros use runMacro (NOT the direct route)", () => {
-  test("Visualize CTA fires runMacro, sets lastMacroRun, never sets lastDirectAction", async ({ page }) => {
-    // Switch to a session with no bundled canvas doc so the empty-state CTA
-    // is available (the boot session opens on its board, which hides it).
-    await page.getByTestId("workspace-focus-scratch").click();
-    await expect(page.locator(".canvas-empty")).toBeVisible();
-
-    const ctaBefore = await readTestHook(page);
-    // No prior direct action from this fresh page load.
-    expect(ctaBefore?.lastDirectAction).toBeUndefined();
-
-    // Click the one-click Visualize CTA (render-canvas macro path — NOT inject).
-    const cta = page.getByTestId("canvas-visualize-cta");
-    await expect(cta).toBeEnabled();
-    await cta.click();
-
-    // runMacro records lastMacroRun — wait for it.
-    await page.waitForFunction(
-      () => (window as unknown as HarnessTestWindow).__HARNESS_TEST__?.lastMacroRun,
-    );
-    const hook = await readTestHook(page);
-    expect(hook?.lastMacroRun?.id).toBe("visualize");
-
-    // The direct-action hatch must NEVER be set — Visualize is a
-    // render-canvas macro, NOT a direct server action.
-    expect(hook?.lastDirectAction).toBeUndefined();
-  });
-
-  test("direct/inject split is exclusive: running Deploy then Visualize records both hooks in the right slots", async ({
-    page,
-  }) => {
-    // Step 1: fire the direct Deploy button.
-    const deployBtn = page.getByTestId("session-step-deploy");
-    await expect(deployBtn).toBeEnabled();
-    await deployBtn.click();
-
-    // Wait for the direct action to land.
-    const directAfterDeploy = await waitForDirectAction(page);
-    expect(directAfterDeploy.action).toBe("deploy");
-    // At this point, no macro run should have happened.
-    const hookAfterDeploy = await readTestHook(page);
-    expect(hookAfterDeploy?.lastMacroRun).toBeUndefined();
-
-    // Step 2: fire the Visualize CTA on the scratch session (render-canvas macro path).
-    await page.getByTestId("workspace-focus-scratch").click();
-    const cta = page.getByTestId("canvas-visualize-cta");
-    await expect(cta).toBeEnabled();
-    await cta.click();
-
-    await page.waitForFunction(
-      () => (window as unknown as HarnessTestWindow).__HARNESS_TEST__?.lastMacroRun,
-    );
-    const hookAfterVisualize = await readTestHook(page);
-
-    // The macro slot now has the visualize entry.
-    expect(hookAfterVisualize?.lastMacroRun?.id).toBe("visualize");
-
-    // The direct-action slot still carries the deploy (lastDirectAction is the
-    // LAST direct action; the visualize click must NOT overwrite it).
-    expect(hookAfterVisualize?.lastDirectAction?.action).toBe("deploy");
-  });
-});
+// NOTE: the "Contrast: macros use runMacro" describe lived here. It exercised
+// the canvas Visualize CTA (empty-state render button), which has been removed
+// — the diagram now renders automatically on bind/start and on code changes,
+// so there is no manual render macro surface left to contrast against the
+// direct-action route.

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -213,7 +213,7 @@ test("workflows rail lists the fixtures and the FOCUSED one drives macro gating"
   await expect(prodRun).toBeEnabled();
 
   // The open_prod button has been removed from the action bar (SAP-1899);
-  // the "Go to dashboard" link now lives in the canvas header for deployed workflows.
+  // the deployed pill (→ dashboard) now lives in the canvas tab bar for deployed workflows.
   await expect(page.getByTestId("macro-open_prod")).toHaveCount(0);
 
   // Focusing "rfq" (no live session) does NOT rebind the boot session or start
@@ -378,7 +378,6 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     // the right pane renders leasing's board.
     await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
     await expect(page.getByTestId("session-workflow-chip")).toContainText("leasing");
-    await expect(page.getByTestId("workflow-actions-header")).toContainText("leasing");
     await expect(page.locator(".canvas-iframe")).toBeVisible();
 
     // Focus rfq and start its session: all four move together to rfq.
@@ -387,7 +386,6 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-focused/);
     await expect(page.getByTestId("workflow-leasing")).not.toHaveClass(/is-focused/);
     await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");
-    await expect(page.getByTestId("workflow-actions-header")).toContainText("rfq");
     // Still exactly one filled row.
     await expect(
       page.locator(".rail-list .workflow-item.is-focused, .rail-list .workspace-row.is-selected"),
@@ -781,34 +779,6 @@ test("settings popover: identity, telemetry toggle, and it persists across close
   await expect(page.getByTestId("telemetry-toggle")).toHaveAttribute("aria-checked", "true");
 });
 
-test("visualize macro is one click — no subject dialog", async ({ page }) => {
-  // Visualize lives on the canvas (empty-state CTA + header re-visualize),
-  // not on the lifecycle wizard — it's a view action, not a funnel step. The
-  // scratch session has no bundled board, so its empty-state CTA is present.
-  await page.getByTestId("workspace-focus-scratch").click();
-  await expect(page.getByTestId("canvas-visualize-cta")).toBeEnabled();
-
-  await page.getByTestId("canvas-visualize-cta").click();
-
-  // No modal, no free-text field — the click alone fires the macro.
-  await expect(page.locator(".modal-backdrop")).toHaveCount(0);
-  await expect(page.getByPlaceholder("What should the agent visualize?")).toHaveCount(0);
-
-  // MockApi.runMacro has no other observable effect (it's a no-op against real
-  // infra), so the test hook is what confirms the click actually fired — and
-  // fired with no subject, since that plumbing is gone.
-  await page.waitForFunction(
-    () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
-  );
-  const lastRun = await page.evaluate(
-    () =>
-      (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
-        .__HARNESS_TEST__.lastMacroRun,
-  );
-  expect(lastRun?.id).toBe("visualize");
-  expect(lastRun?.req.subject).toBeUndefined();
-});
-
 test.describe("workflow actions", () => {
   test("agent rows carry no macro strip and show their full untruncated name", async ({ page }) => {
     // The explorer row is [zap][name][cloud] only — no macro strip, no hover
@@ -840,15 +810,15 @@ test.describe("workflow actions", () => {
     // Rail workflow rows still carry no macro strips — the wizard owns them.
     await expect(page.getByTestId("workflow-macros")).toHaveCount(0);
 
-    // The "Go to dashboard" link appears in the canvas header for deployed workflows.
-    // leasing is deployed (definitionId set) on load.
+    // The deployed pill doubles as the dashboard link and sits in the canvas
+    // tab bar for deployed workflows. leasing is deployed (definitionId set) on load.
     const dashLink = page.getByTestId("workflow-dashboard-link");
     await expect(dashLink).toBeVisible();
     await expect(dashLink).toHaveAttribute("href", /app\.sapiom\.ai\/workflows\//);
     await expect(dashLink).toHaveAttribute("target", "_blank");
   });
 
-  test("the canvas header stays fully on-screen even when the app is narrower than the default pane widths", async ({
+  test("the canvas tab bar stays fully on-screen even when the app is narrower than the default pane widths", async ({
     page,
   }) => {
     // Rail (320 default, shrinkable to 180) + terminal/canvas floors (20rem
@@ -858,60 +828,47 @@ test.describe("workflow actions", () => {
     await page.setViewportSize({ width: 900, height: 640 });
     await page.waitForTimeout(50);
 
-    const header = page.getByTestId("workflow-actions-header");
-    await expect(header).toBeVisible();
+    // The canvas pane's top chrome is the tab bar now (Canvas/Steps/Code + the
+    // deployed pill + expand/collapse) — the board dropped its subheader. The
+    // bar spans the pane, so its right edge is the sentinel for h-overflow.
+    const tabBar = page.locator(".right-pane-tabs");
+    await expect(tabBar).toBeVisible();
 
-    const headerBox = await header.boundingBox();
-    expect(headerBox).not.toBeNull();
-    expect((headerBox?.x ?? 0) + (headerBox?.width ?? 0)).toBeLessThanOrEqual(900);
+    const tabBarBox = await tabBar.boundingBox();
+    expect(tabBarBox).not.toBeNull();
+    expect((tabBarBox?.x ?? 0) + (tabBarBox?.width ?? 0)).toBeLessThanOrEqual(900);
 
     await page.screenshot({ path: "web/e2e/screenshots/narrow-viewport-header.png", fullPage: true });
   });
 
 });
 
-test("canvas empty state explains itself and offers a one-click render CTA", async ({ page }) => {
+test("canvas empty state explains itself — no manual render action", async ({ page }) => {
   // The scratch session has no bundled doc, so its Canvas is the empty state
   // (the boot session opens on its board).
   await page.getByTestId("workspace-focus-scratch").click();
   await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
-  // Short supporting line, no file-editing instructions (there is no editor
-  // in this harness), CTA after.
+  // Short supporting line, no file-editing instructions (there is no editor in
+  // this harness). The diagram generates automatically from the bound workflow
+  // — there is no manual render button anymore.
   await expect(page.locator(".canvas-empty")).toContainText("Generated automatically from the bound workflow");
   await expect(page.locator(".canvas-empty")).not.toContainText(".sapiom/canvas/index.html");
+  await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
 
   await page.screenshot({ path: "web/e2e/screenshots/canvas-empty-state.png" });
-
-  const cta = page.getByTestId("canvas-visualize-cta");
-  await expect(cta).toBeVisible();
-  await cta.click();
-
-  // One click and done — no dialog, no free-text field.
-  await expect(page.locator(".modal-backdrop")).toHaveCount(0);
-  await page.waitForFunction(
-    () => (window as unknown as { __HARNESS_TEST__?: { lastMacroRun?: unknown } }).__HARNESS_TEST__?.lastMacroRun,
-  );
-  const lastRun = await page.evaluate(
-    () =>
-      (window as unknown as { __HARNESS_TEST__: { lastMacroRun?: { id: string; req: { subject?: string } } } })
-        .__HARNESS_TEST__.lastMacroRun,
-  );
-  expect(lastRun?.id).toBe("visualize");
-  expect(lastRun?.req.subject).toBeUndefined();
 });
 
 test("steps tab shows its own empty state (not canvas copy) before anything is rendered", async ({ page }) => {
   // The scratch session has no generated canvas content, so the Steps tab hits
-  // the same early-return state as the board — but must talk about steps, with
-  // the SAME one-click render CTA (it works from here). (The boot session
-  // opens on its board, which does post a step graph.)
+  // the same early-return state as the board — but must talk about steps. (The
+  // boot session opens on its board, which does post a step graph.)
   await page.getByTestId("workspace-focus-scratch").click();
   await page.getByTestId("right-tab-steps").click();
   const empty = page.locator(".canvas-empty");
   await expect(empty).toContainText("No steps yet");
   await expect(empty).toContainText("Steps are read from the bound workflow");
   await expect(empty).not.toContainText("Nothing generated yet");
-  await expect(page.getByTestId("canvas-visualize-cta")).toBeVisible();
+  await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
 
   // The board keeps its own copy on the Canvas tab.
   await page.getByTestId("right-tab-canvas").click();
@@ -1613,10 +1570,10 @@ test("canvas controls: the board widget zooms; the subheader's expand lifts the 
   // The gesture surface for drag-pan/wheel-zoom covers the board.
   await expect(page.getByTestId("canvas-pan-layer")).toBeVisible();
 
-  // The board widget carries zoom only — panel-level expand lives on the
-  // subheader row, right-anchored next to refresh.
+  // The board widget carries zoom only — the panel-level expand lives in the
+  // right-pane tab bar, right beside the collapse-panel toggle.
   await expect(controls.getByTestId("canvas-expand")).toHaveCount(0);
-  const expand = page.getByTestId("workflow-actions-header").getByTestId("canvas-expand");
+  const expand = page.getByTestId("canvas-expand");
 
   // Expand: same node, fixed overlay — the iframe is not remounted. The
   // overlay covers the subheader, so it carries its own exit control.
@@ -1705,10 +1662,6 @@ test("steps tab drills into a step's real transitions and slides back", async ({
   await expect(contract).toContainText("score");
   await expect(contract).toContainText("number");
   await expect(detail.getByTestId("canvas-detail-capabilities")).toContainText("rules.evaluate");
-
-  // An edge row links deeper: jump to the terminal it points at.
-  await detail.getByText("draft-lease").click();
-  await expect(header.getByTestId("canvas-detail-title")).toHaveText("draft-lease");
 
   await page.screenshot({ path: "web/e2e/screenshots/canvas-step-detail.png" });
 
@@ -1872,7 +1825,7 @@ test("board nodes get hover and selected states through the message contract", a
   await expect(page.getByTestId("canvas-pan-layer")).toHaveAttribute("data-over-node", "true");
 
   // A non-drag click on a node is a PICK: the bottom inspector populates in
-  // place (no tab switch — the Steps tab is its explicit "Open in Steps"
+  // place (no tab switch — the Steps tab is its explicit "Open step"
   // drill), and the board rings the selected node. Collapse the overview
   // sheet first so it can't overlay the lower nodes — the taller board
   // refits (larger zoom), so wait for that view to settle too.

--- a/packages/harness/web/e2e/step-macros.spec.ts
+++ b/packages/harness/web/e2e/step-macros.spec.ts
@@ -55,6 +55,13 @@ const pickNode = async (page: Page, nodeId: string): Promise<void> => {
   await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 };
 
+/** Open the standalone chat panel (macros + ask) via the 💬 toggle — closed by
+ *  default now, independent of the step inspector. */
+const openChat = async (page: Page): Promise<void> => {
+  await page.getByTestId("canvas-chat-toggle").click();
+  await expect(page.getByTestId("canvas-chat-panel")).toBeVisible();
+};
+
 /** Poll for the last inject recorded by MockApi.injectInput (mock delay is ~180ms). */
 const lastInject = async (page: Page): Promise<{ id: string; req: { text: string; submit: boolean } }> => {
   let result: { id: string; req: { text: string; submit: boolean } } | null = null;
@@ -97,41 +104,46 @@ const seedRunState = (page: Page, executionId: string, view: RunView): Promise<v
 // Macro bar visibility
 // ---------------------------------------------------------------------------
 
-test.describe("macro bar visibility", () => {
+test.describe("chat panel visibility", () => {
   test.beforeEach(async ({ page }) => {
     await loadBoard(page);
   });
 
-  test("picking a board node shows the macro bar in the inspector", async ({ page }) => {
-    // No inspector yet — macro bar absent.
+  test("the chat is closed by default and opens via the 💬 toggle", async ({ page }) => {
+    // Closed by default — no chat/macros on load.
+    await expect(page.getByTestId("canvas-chat-panel")).toHaveCount(0);
     await expect(page.getByTestId("canvas-inspector-macros")).toHaveCount(0);
 
+    await openChat(page);
+    // With no step selected the chat is a general ask — freeform only, no
+    // step-specific macros.
+    await expect(page.getByTestId("canvas-freeform-input")).toBeVisible();
+    await expect(page.getByTestId("canvas-macro-debug")).toHaveCount(0);
+  });
+
+  test("picking a step surfaces the step macros in the chat", async ({ page }) => {
+    await openChat(page);
     await pickNode(page, "intake");
     await expect(page.getByTestId("canvas-inspector-title")).toHaveText("intake");
 
-    // The macro bar should be visible inside the inspector.
     const macros = page.getByTestId("canvas-inspector-macros");
-    await expect(macros).toBeVisible();
     await expect(macros.getByTestId("canvas-macro-debug")).toBeVisible();
     await expect(macros.getByTestId("canvas-macro-slow")).toBeVisible();
     await expect(macros.getByTestId("canvas-macro-explain")).toBeVisible();
     await expect(macros.getByTestId("canvas-freeform-input")).toBeVisible();
   });
 
-  test("closing the inspector hides the macro bar", async ({ page }) => {
+  test("the chat closes on its own X — independent of the step inspector", async ({ page }) => {
     await pickNode(page, "intake");
-    await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
+    await openChat(page);
+    // Both open at once: the step inspector (info) AND the chat.
+    await expect(page.getByTestId("canvas-step-inspector")).toBeVisible();
+    await expect(page.getByTestId("canvas-chat-panel")).toBeVisible();
 
-    await page.getByTestId("canvas-inspector-close").click();
-    await expect(page.getByTestId("canvas-inspector-macros")).toHaveCount(0);
-  });
-
-  test("Esc also dismisses the inspector and the macro bar", async ({ page }) => {
-    await pickNode(page, "intake");
-    await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
-
-    await page.keyboard.press("Escape");
-    await expect(page.getByTestId("canvas-inspector-macros")).toHaveCount(0);
+    // Closing the chat leaves the inspector untouched.
+    await page.getByTestId("canvas-chat-close").click();
+    await expect(page.getByTestId("canvas-chat-panel")).toHaveCount(0);
+    await expect(page.getByTestId("canvas-step-inspector")).toBeVisible();
   });
 });
 
@@ -143,6 +155,7 @@ test.describe("debug macros — pre-run (no run data)", () => {
   test.beforeEach(async ({ page }) => {
     await loadBoard(page);
     await pickNode(page, "intake");
+    await openChat(page);
     await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
     await clearLastInject(page);
   });
@@ -246,6 +259,7 @@ test.describe("debug macros — prod run data enriches the context", () => {
     // races with the node pick and clears the run from the inspector.
     await page.getByTestId("right-tab-canvas").click();
     await pickNode(page, "intake");
+    await openChat(page);
     await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
     // Run data is in state (chip confirmed above); inspector must show it.
     await expect(page.getByTestId("canvas-inspector-run")).toBeVisible({ timeout: 5000 });
@@ -288,6 +302,7 @@ test.describe("debug macros — prod run data enriches the context", () => {
     // races with the node pick and clears the run from the inspector.
     await page.getByTestId("right-tab-canvas").click();
     await pickNode(page, "intake");
+    await openChat(page);
     await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
     // Run data is in state (chip confirmed above); inspector must show it.
     await expect(page.getByTestId("canvas-inspector-run")).toBeVisible({ timeout: 5000 });
@@ -325,6 +340,7 @@ test.describe("debug macros — offline stub run", () => {
     // race with the node pick and clear the run from the inspector.
     await page.getByTestId("right-tab-canvas").click();
     await pickNode(page, "intake");
+    await openChat(page);
     await expect(page.getByTestId("canvas-inspector-macros")).toBeVisible();
     // Run data is in state (chip confirmed above); inspector must show it.
     await expect(page.getByTestId("canvas-inspector-run")).toBeVisible({ timeout: 5000 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -126,6 +126,10 @@ export const App = (): JSX.Element => {
   const [rightCollapsed, setRightCollapsed] = useState(
     () => isMobileShell() || (loadUiPrefs().rightCollapsed ?? false),
   );
+  // Canvas full-screen expand — lifted here so its control sits next to the
+  // collapse-panel toggle in the right-pane tab bar (the frame itself lives in
+  // CanvasPane, which reads these props).
+  const [canvasExpanded, setCanvasExpanded] = useState(false);
   const isMobile = useMobileShell();
 
   const { widths, startRailDrag, startCanvasDrag, resetRail, resetCanvas } = usePaneWidths();
@@ -833,15 +837,46 @@ export const App = (): JSX.Element => {
               >
                 Code
               </button>
-              <button
-                className="theme-toggle right-pane-collapse"
-                data-testid="right-collapse"
-                aria-label="Collapse canvas panel"
-                title="Collapse canvas panel"
-                onClick={() => setRightCollapsed(true)}
-              >
-                <Icon name="PanelRightClose" size={15} />
-              </button>
+              <div className="right-pane-corner">
+                {/* Deployed pill → dashboard. The board has no subheader now, so
+                    its deploy status lives here in the tab bar (Tidjane's design:
+                    nothing sits between the tabs and the canvas). */}
+                {rightTab === "canvas" && rightPaneWorkflow?.definitionId != null && (
+                  <a
+                    className="status-tag status-tag-action workflow-deployed-tag right-pane-deployed"
+                    data-testid="workflow-dashboard-link"
+                    href={`https://app.sapiom.ai/workflows/${rightPaneWorkflow.definitionId}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="Deployed — open in the Sapiom dashboard"
+                    data-tooltip="Open this workflow in the Sapiom dashboard"
+                  >
+                    <Icon name="Cloud" size={12} />
+                    deployed
+                  </a>
+                )}
+                {/* Canvas expand sits right beside the collapse-panel toggle. */}
+                {rightTab === "canvas" && (
+                  <button
+                    className="theme-toggle"
+                    data-testid="canvas-expand"
+                    aria-label={canvasExpanded ? "Exit expanded canvas" : "Expand canvas"}
+                    title={canvasExpanded ? "Exit expanded canvas" : "Expand canvas"}
+                    onClick={() => setCanvasExpanded((v) => !v)}
+                  >
+                    <Icon name={canvasExpanded ? "Minimize2" : "Maximize2"} size={15} />
+                  </button>
+                )}
+                <button
+                  className="theme-toggle right-pane-collapse"
+                  data-testid="right-collapse"
+                  aria-label="Collapse canvas panel"
+                  title="Collapse canvas panel"
+                  onClick={() => setRightCollapsed(true)}
+                >
+                  <Icon name="PanelRightClose" size={15} />
+                </button>
+              </div>
             </div>
 
             <div
@@ -853,9 +888,10 @@ export const App = (): JSX.Element => {
                 lastMessage={harness.lastMessage}
                 boundWorkflow={rightPaneWorkflow}
                 noSessionAgent={noSessionAgentName}
-                activeSessionId={harness.activeSessionId}
                 overviewActive={showWelcome}
                 sessionExited={showDead}
+                expanded={canvasExpanded}
+                onToggleExpanded={() => setCanvasExpanded((v) => !v)}
                 macros={state.macros}
                 tasks={harness.tasks}
                 surface={rightTab === "steps" ? "steps" : "board"}

--- a/packages/harness/web/src/components/CanvasOverviewPanel.tsx
+++ b/packages/harness/web/src/components/CanvasOverviewPanel.tsx
@@ -29,17 +29,12 @@ interface CanvasOverviewPanelProps {
   run: RunView | null;
   workflows: WorkflowInfo[];
   onOpenWorkflow: (path: string) => void;
-  /** Retargets the selection (a transition row picks a neighbor step). */
-  onSelectStep: (id: string) => void;
   /** The full-pane drill: opens the selected step in the Steps tab. */
   onOpenSteps: () => void;
   /** Clears the selection — back to the overview. */
   onDeselect: () => void;
   /** Collapses the overview to its ⓘ reopen affordance (overview mode only). */
   onCollapse: () => void;
-  /** Inject a prompt into the active terminal session (forwarded to the step
-   *  inspector's debug macros). Absent when no session is live. */
-  onInjectPrompt?: (text: string) => void;
 }
 
 /**
@@ -60,11 +55,9 @@ export function CanvasOverviewPanel({
   run,
   workflows,
   onOpenWorkflow,
-  onSelectStep,
   onOpenSteps,
   onDeselect,
   onCollapse,
-  onInjectPrompt,
 }: CanvasOverviewPanelProps): JSX.Element {
   const panelRef = useRef<HTMLDivElement>(null);
   const headRef = useRef<HTMLDivElement>(null);
@@ -215,7 +208,7 @@ export function CanvasOverviewPanel({
               data-tooltip="Full details in the Steps tab"
               onClick={onOpenSteps}
             >
-              Open in Steps <Icon name="ArrowRight" size={12} />
+              Open step <Icon name="ArrowRight" size={12} />
             </button>
             <button
               className="theme-toggle canvas-overview-close"
@@ -264,15 +257,15 @@ export function CanvasOverviewPanel({
               graph={graph}
               node={selectedNode}
               run={run}
-              onSelectStep={onSelectStep}
               workflows={workflows}
               onOpenWorkflow={onOpenWorkflow}
-              onInjectPrompt={onInjectPrompt}
             />
           ) : (
             overview && (
               <>
-                <p className="canvas-overview-desc">{overview.description}</p>
+                {overview.description && (
+                  <p className="canvas-overview-desc">{overview.description}</p>
+                )}
                 {overview.notes.length > 0 && (
                   <ul className="canvas-overview-notes">
                     {overview.notes.map((note) => (

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -4,13 +4,11 @@ import type { BackgroundTask, BusMessage, MacroDef, RunView, WorkflowInfo } from
 
 import { isMockMode } from "../lib/api";
 import { MOCK_CANVAS_OVERVIEWS, hasMockCanvasDoc } from "../lib/mock-data";
-import { findVisualizeMacro, macroDisabledReason } from "../lib/macro-gating";
 import { getTheme, subscribeTheme } from "../lib/theme";
-import { track } from "../lib/track";
 import { type CanvasGraph, formatGraphCounts, parseCanvasGraph } from "../lib/canvas-graph";
 import type { ObservedRun, RunTarget } from "../lib/use-harness-state";
 import { CanvasOverviewPanel } from "./CanvasOverviewPanel";
-import { CanvasStepDetail, CanvasStepsList, RunStepsList } from "./CanvasStepDetail";
+import { CanvasChatPanel, CanvasStepDetail, CanvasStepsList, RunStepsList } from "./CanvasStepDetail";
 import { EmptyState } from "./EmptyState";
 import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
@@ -27,7 +25,6 @@ interface CanvasPaneProps {
    *  agent's board (the canvas is served per session, so an
    *  unsessioned agent has no board to render). */
   noSessionAgent?: string | null;
-  activeSessionId: string | null;
   /** the overview/welcome panel owns the center pane — no session is
    *  displayed, so the canvas shows the fresh-install "start a session"
    *  state instead of the previous session's empty state and CTA. */
@@ -35,6 +32,10 @@ interface CanvasPaneProps {
   /** the displayed session has exited — Visualize can't do anything,
    *  so the empty state swaps to a resume invitation. */
   sessionExited: boolean;
+  /** Canvas full-screen state + toggle — owned by App so the control sits in
+   *  the right-pane tab bar; CanvasPane renders the frame + exit affordance. */
+  expanded: boolean;
+  onToggleExpanded: () => void;
   macros: MacroDef[];
   /** All background tasks (any session) — filtered to `sessionId` here. */
   tasks: BackgroundTask[];
@@ -69,9 +70,10 @@ export function CanvasPane({
   lastMessage,
   boundWorkflow,
   noSessionAgent = null,
-  activeSessionId,
   overviewActive,
   sessionExited,
+  expanded,
+  onToggleExpanded,
   macros,
   tasks,
   onRunMacro,
@@ -355,7 +357,6 @@ export function CanvasPane({
     layer.addEventListener("pointercancel", onUp);
   };
 
-  const [expanded, setExpanded] = useState(false);
   // The board-picked step whose detail the bottom inspector shows. Separate
   // from detailStepId (the Steps tab's full-pane drill): a pick stays on the
   // Canvas tab now, populating the panel below the board in real time.
@@ -368,12 +369,16 @@ export function CanvasPane({
     const onKey = (e: KeyboardEvent): void => {
       if (e.key !== "Escape") return;
       if (selectedNodeId != null) setSelectedNodeId(null);
-      else setExpanded(false);
+      else onToggleExpanded();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [expanded, selectedNodeId]);
+  }, [expanded, selectedNodeId, onToggleExpanded]);
   const [overviewOpen, setOverviewOpen] = useState(true);
+  // The chat (macros + ask) is a standalone panel, CLOSED by default and
+  // toggled by the 💬 control — independent of the info panel (both can be
+  // open at once; the chat also opens with no step selected, as a general ask).
+  const [chatOpen, setChatOpen] = useState(false);
   // Overview contract: a rendered document may post its chrome content
   // ({type:"sapiom-canvas:overview", description, stats, notes[]}) so the APP
   // renders the overview panel and the document stays a pure board. Live
@@ -609,11 +614,6 @@ export function CanvasPane({
     userAdjustedRef.current = false;
   }, [boundWorkflowPath]);
 
-  const visualizeMacro = findVisualizeMacro(macros);
-  const visualizeDisabledReason = visualizeMacro
-    ? macroDisabledReason(visualizeMacro, boundWorkflow, activeSessionId)
-    : null;
-
   // Background-task state for THIS session's pane, scoped to the CURRENT
   // binding: a task that carries a workflowPath only surfaces while the pane
   // is showing that workflow — switching the binding mid-run must not bleed
@@ -645,16 +645,12 @@ export function CanvasPane({
   // GitHub's 404 page rendered inside the pane.
   const sessionHasServableDoc = sessionId != null && (!isMockMode() || hasMockCanvasDoc(sessionId));
   const showsContent = hasGeneratedContent && sessionHasServableDoc;
-  const showingFrame = Boolean(sessionId) && !failedTask && showsContent && !probing;
 
   return (
     <aside className="canvas-pane">
       {boundWorkflow && !overviewActive && (
         <WorkflowActionsHeader
           workflow={boundWorkflow}
-          expanded={expanded}
-          onToggleExpanded={() => setExpanded((v) => !v)}
-          canExpand={showingFrame}
           detailStep={detailNode}
           onBack={() => setDetailStepId(null)}
           onAskAgent={onInjectPrompt}
@@ -777,10 +773,11 @@ export function CanvasPane({
           body={`Resume the session to see its ${surface === "steps" ? "workflow steps" : "workflow diagram"} here.`}
         />
       ) : !showsContent ? (
-        /* Header claim, one supporting line, then the action — top to bottom.
-           The diagram is generated deterministically from the bound workflow
-           (no AI); the render CTA works from either tab — it (re)renders the
-           board AND posts the step graph the Steps tab projects. */
+        /* Header claim + one supporting line — no action. The diagram is
+           generated deterministically from the bound workflow (no AI),
+           automatically on bind/start and on every code change, so there's
+           nothing to trigger by hand; an unbound session simply has nothing
+           to show yet. */
         <EmptyState
           className="canvas-empty"
           icon="Workflow"
@@ -789,22 +786,6 @@ export function CanvasPane({
             surface === "steps"
               ? "Steps are read from the bound workflow's diagram — generated automatically from its code."
               : "Generated automatically from the bound workflow; it refreshes when the code changes."
-          }
-          cta={
-            visualizeMacro && (
-              <button
-                className="btn-primary canvas-visualize-cta"
-                data-testid="canvas-visualize-cta"
-                data-tooltip={visualizeDisabledReason ?? visualizeMacro.label}
-                disabled={Boolean(visualizeDisabledReason)}
-                onClick={() => {
-                  onRunMacro(visualizeMacro);
-                  track("visualize.triggered");
-                }}
-              >
-                <Icon name="Workflow" size={14} /> Render diagram
-              </button>
-            )
           }
         />
       ) : (
@@ -877,7 +858,7 @@ export function CanvasPane({
               data-testid="canvas-expand-exit"
               aria-label="Exit expanded canvas"
               title="Exit expanded canvas (Esc)"
-              onClick={() => setExpanded(false)}
+              onClick={onToggleExpanded}
             >
               <Icon name="Minimize2" size={14} />
             </button>
@@ -987,6 +968,19 @@ export function CanvasPane({
               i
             </button>
           )}
+          {/* Chat toggle — the ask/macros panel is standalone and closed by
+              default; independent of the info panel (both can be open). */}
+          {surface === "board" && (
+            <button
+              className={"theme-toggle canvas-chat-toggle" + (chatOpen ? " is-active" : "")}
+              data-testid="canvas-chat-toggle"
+              aria-label={chatOpen ? "Close chat" : "Open chat"}
+              data-tooltip="Chat — ask about this workflow or the selected step"
+              onClick={() => setChatOpen((c) => !c)}
+            >
+              <Icon name="MessageSquare" size={14} />
+            </button>
+          )}
           <iframe
             ref={frameRef}
             key={`${sessionId}:${reloadKey}`}
@@ -1068,14 +1062,23 @@ export function CanvasPane({
               run={run}
               workflows={workflows}
               onOpenWorkflow={onOpenWorkflow}
-              onSelectStep={setSelectedNodeId}
               onOpenSteps={() => {
                 if (selectedNodeId) setDetailStepId(selectedNodeId);
                 onOpenSteps();
               }}
               onDeselect={() => setSelectedNodeId(null)}
               onCollapse={() => setOverviewOpen(false)}
+            />
+          )}
+          {/* Standalone chat panel — independent of the info panel above; shows
+              whenever the 💬 toggle is on and a session can receive the inject.
+              Targets the selected step, or a general ask when none is selected. */}
+          {surface === "board" && chatOpen && (
+            <CanvasChatPanel
+              node={selectedNode}
+              run={run}
               onInjectPrompt={onInjectPrompt}
+              onClose={() => setChatOpen(false)}
             />
           )}
           </div>
@@ -1085,7 +1088,6 @@ export function CanvasPane({
                 graph={graph}
                 node={renderedDetail}
                 run={run}
-                onSelectStep={setDetailStepId}
                 workflows={workflows}
                 onOpenWorkflow={onOpenWorkflow}
               />

--- a/packages/harness/web/src/components/CanvasStepDetail.tsx
+++ b/packages/harness/web/src/components/CanvasStepDetail.tsx
@@ -263,44 +263,27 @@ function StepCapabilities({ node }: { node: CanvasGraphNode }): JSX.Element | nu
 /**
  * A step's real transitions as compact elbow rows — what it leads to
  * (CornerDownRight, with branch condition / pause signal) and what reaches
- * it (CornerLeftUp). Shared by the steps accordion and the board's bottom
- * inspector; with `onSelectStep` the rows become links that retarget the
- * selection, without it they stay plain information.
+ * it (CornerLeftUp). Read-only information for the steps accordion; the
+ * board's bottom inspector relies on the chart itself for navigation.
  */
 export function StepTransitions({
   graph,
   node,
-  onSelectStep,
 }: {
   graph: CanvasGraph;
   node: CanvasGraphNode;
-  onSelectStep?: (id: string) => void;
 }): JSX.Element | null {
   const outgoing = graph.edges.filter((e) => e.from === node.id);
   const incoming = graph.edges.filter((e) => e.to === node.id);
   if (outgoing.length === 0 && incoming.length === 0) return null;
   const labelFor = (id: string): string => graph.nodes.find((n) => n.id === id)?.label ?? id;
   const row = (edge: CanvasGraphEdge, target: string, icon: "CornerDownRight" | "CornerLeftUp"): JSX.Element => {
-    const body = (
-      <>
+    const key = `${icon}${edge.from}->${edge.to}`;
+    return (
+      <div key={key} className="canvas-step-transition">
         <Icon name={icon} size={12} />
         <span className="canvas-step-transition-target">{labelFor(target)}</span>
         {edge.label && <span className="canvas-step-transition-cond">{edge.label}</span>}
-      </>
-    );
-    const key = `${icon}${edge.from}->${edge.to}`;
-    return onSelectStep ? (
-      <button
-        key={key}
-        className="canvas-step-transition is-link"
-        data-tooltip={`Inspect ${labelFor(target)}`}
-        onClick={() => onSelectStep(target)}
-      >
-        {body}
-      </button>
-    ) : (
-      <div key={key} className="canvas-step-transition">
-        {body}
       </div>
     );
   };
@@ -543,14 +526,9 @@ interface CanvasStepDetailProps {
   node: CanvasGraphNode;
   /** The session's shown run, if any (see CanvasStepsList). */
   run: RunView | null;
-  /** Jump to another step's detail (from a transition row). */
-  onSelectStep: (id: string) => void;
   /** Registry workflows — launched-workflow nodes link through to theirs. */
   workflows: WorkflowInfo[];
   onOpenWorkflow: (path: string) => void;
-  /** Inject a prompt into the active terminal session (used by the debug macros).
-   *  Absent when no session is live; the macro buttons are hidden in that case. */
-  onInjectPrompt?: (text: string) => void;
 }
 
 /**
@@ -558,13 +536,12 @@ interface CanvasStepDetailProps {
  * in the canvas subheader; see WorkflowActionsHeader). Driven entirely by
  * the posted graph: the step's role and description, then its real
  * transitions — what it leads to (with branch condition / pause signal) and
- * what reaches it. Each transition links deeper into the graph.
+ * what reaches it, shown as read-only lineage.
  */
 export function CanvasStepDetail({
   graph,
   node,
   run,
-  onSelectStep,
   workflows,
   onOpenWorkflow,
 }: CanvasStepDetailProps): JSX.Element {
@@ -702,16 +679,12 @@ export function CanvasStepDetail({
             <ul className="canvas-detail-edges">
               {outgoing.map((e) => (
                 <li key={`${e.from}->${e.to}`}>
-                  <button
-                    className="canvas-detail-edge"
-                    data-tooltip={`Open ${labelFor(e.to)}`}
-                    onClick={() => onSelectStep(e.to)}
-                  >
+                  <div className="canvas-detail-edge">
                     <Icon name="CornerDownRight" size={13} />
                     <span className="canvas-detail-edge-target">{labelFor(e.to)}</span>
                     {edgeKindLabel(e) && <span className="canvas-detail-edge-kind">{edgeKindLabel(e)}</span>}
                     {e.label && <span className="canvas-detail-edge-cond">{e.label}</span>}
-                  </button>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -730,16 +703,12 @@ export function CanvasStepDetail({
             <ul className="canvas-detail-edges">
               {incoming.map((e) => (
                 <li key={`${e.from}->${e.to}`}>
-                  <button
-                    className="canvas-detail-edge"
-                    data-tooltip={`Open ${labelFor(e.from)}`}
-                    onClick={() => onSelectStep(e.from)}
-                  >
+                  <div className="canvas-detail-edge">
                     <Icon name="CornerLeftUp" size={13} />
                     <span className="canvas-detail-edge-target">{labelFor(e.from)}</span>
                     {edgeKindLabel(e) && <span className="canvas-detail-edge-kind">{edgeKindLabel(e)}</span>}
                     {e.label && <span className="canvas-detail-edge-cond">{e.label}</span>}
-                  </button>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -780,45 +749,12 @@ export function CanvasStepDetail({
  * cost data is injected — `extractStepContext` is cost-free by contract.
  */
 export function CanvasStepInspector({
-  graph,
   node,
   run,
-  onSelectStep,
   workflows,
   onOpenWorkflow,
-  onInjectPrompt,
 }: CanvasStepDetailProps): JSX.Element {
   const runStep = runStepFor(run, node.id);
-  const [freeformText, setFreeformText] = useState("");
-
-  /** Build the step context + question and inject into the terminal. */
-  function injectMacro(question: string): void {
-    if (!onInjectPrompt) return;
-    // Compose the trace from what the StepView already carries: input, output,
-    // and calls (the per-step capability call trace — present for local runs).
-    // Also forward run-level stub bookkeeping when the run carries it.
-    const trace = runStep
-      ? {
-          input: runStep.input,
-          output: runStep.output,
-          calls: runStep.calls,
-          unusedStubs: run?.unusedStubs?.map((u) => u.key),
-          stubWarnings: run?.stubWarnings,
-        }
-      : undefined;
-    // Declared capabilities as graph-facts fallback (no call trace available).
-    const facts =
-      node.capabilities.length > 0 ? { capabilities: node.capabilities } : undefined;
-    const ctx = extractStepContext(runStep ?? { id: node.id, name: node.id, status: "pending" }, trace, facts);
-    onInjectPrompt(`${ctx}\n\n${question}`);
-  }
-
-  function handleFreeformAsk(): void {
-    const trimmed = freeformText.trim();
-    if (!trimmed) return;
-    injectMacro(trimmed);
-    setFreeformText("");
-  }
 
   return (
     <div className="canvas-inspector" data-testid="canvas-step-inspector">
@@ -832,7 +768,6 @@ export function CanvasStepInspector({
           <span className="canvas-detail-timeout">{formatTimeout(node.timeoutMs)}</span>
         </div>
       )}
-      <StepTransitions graph={graph} node={node} onSelectStep={onSelectStep} />
       <OpenLaunchedWorkflow node={node} workflows={workflows} onOpenWorkflow={onOpenWorkflow} />
       {runStep && (
         <div className="canvas-inspector-run" data-testid="canvas-inspector-run">
@@ -874,62 +809,125 @@ export function CanvasStepInspector({
       {/* Links: scan output, logs, and call results for URLs. */}
       {runStep && <StepLinksBlock step={runStep} />}
       <StubNoticeSection run={run} />
+    </div>
+  );
+}
 
-      {/* Debug macros — only when an active session can receive the inject.
-          Shown whenever onInjectPrompt is wired (a live session exists).
-          "Debug this step" is primary-styled on a failed step, ghost otherwise. */}
-      {onInjectPrompt && (
-        <div className="canvas-inspector-macros" data-testid="canvas-inspector-macros">
-          <button
-            className="canvas-inspector-macro-btn btn-ghost"
-            data-testid="canvas-macro-slow"
-            onClick={() => injectMacro("Why is this step slow / stuck?")}
-          >
-            Why is this step slow / stuck?
-          </button>
-          <button
-            className={
-              "canvas-inspector-macro-btn " +
-              (runStep?.status === "failed" ? "btn-primary" : "btn-ghost")
-            }
-            data-testid="canvas-macro-debug"
-            onClick={() => injectMacro("Debug this step")}
-          >
-            Debug this step
-          </button>
-          <button
-            className="canvas-inspector-macro-btn btn-ghost"
-            data-testid="canvas-macro-explain"
-            onClick={() => injectMacro("Explain this step")}
-          >
-            Explain this step
-          </button>
-          <div className="canvas-inspector-freeform">
-            <textarea
-              className="canvas-inspector-freeform-input"
-              data-testid="canvas-freeform-input"
-              placeholder="Ask about this step…"
-              rows={2}
-              value={freeformText}
-              onChange={(e) => setFreeformText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  handleFreeformAsk();
-                }
-              }}
-            />
+/**
+ * The step chat: debug macros + a free-form ask, injected into the active
+ * terminal session. A STANDALONE panel — toggled by the canvas 💬 button,
+ * closed by default, and independent of the step-detail info panel (both can be
+ * open at once). With a step selected it targets that step (context-aware
+ * macros); with none it is a general ask about the workflow.
+ */
+export function CanvasChatPanel({
+  node,
+  run,
+  onInjectPrompt,
+  onClose,
+}: {
+  node: CanvasGraphNode | null;
+  run: RunView | null;
+  onInjectPrompt: (text: string) => void;
+  onClose: () => void;
+}): JSX.Element {
+  const runStep = node ? runStepFor(run, node.id) : null;
+  const [freeformText, setFreeformText] = useState("");
+
+  /** Prepend the selected step's context (when there is one) and inject. */
+  function inject(question: string): void {
+    if (!node) {
+      onInjectPrompt(question);
+      return;
+    }
+    const trace = runStep
+      ? {
+          input: runStep.input,
+          output: runStep.output,
+          calls: runStep.calls,
+          unusedStubs: run?.unusedStubs?.map((u) => u.key),
+          stubWarnings: run?.stubWarnings,
+        }
+      : undefined;
+    const facts = node.capabilities.length > 0 ? { capabilities: node.capabilities } : undefined;
+    const ctx = extractStepContext(runStep ?? { id: node.id, name: node.id, status: "pending" }, trace, facts);
+    onInjectPrompt(`${ctx}\n\n${question}`);
+  }
+
+  function handleFreeformAsk(): void {
+    const trimmed = freeformText.trim();
+    if (!trimmed) return;
+    inject(trimmed);
+    setFreeformText("");
+  }
+
+  return (
+    <div className="canvas-chat-panel" data-testid="canvas-chat-panel">
+      <div className="canvas-chat-head">
+        <span className="canvas-chat-title" data-testid="canvas-chat-title">
+          {node ? `Chat · ${node.label}` : "Chat"}
+        </span>
+        <button
+          className="theme-toggle canvas-chat-close"
+          data-testid="canvas-chat-close"
+          aria-label="Close chat"
+          data-tooltip="Close chat"
+          onClick={onClose}
+        >
+          <Icon name="X" size={13} />
+        </button>
+      </div>
+      <div className="canvas-inspector-macros" data-testid="canvas-inspector-macros">
+        {node && (
+          <>
             <button
-              className="btn-primary canvas-inspector-freeform-ask"
-              data-testid="canvas-freeform-ask"
-              disabled={!freeformText.trim()}
-              onClick={handleFreeformAsk}
+              className="canvas-inspector-macro-btn btn-ghost"
+              data-testid="canvas-macro-slow"
+              onClick={() => inject("Why is this step slow / stuck?")}
             >
-              Ask
+              Why slow / stuck?
             </button>
-          </div>
+            <button
+              className={"canvas-inspector-macro-btn " + (runStep?.status === "failed" ? "btn-primary" : "btn-ghost")}
+              data-testid="canvas-macro-debug"
+              onClick={() => inject("Debug this step")}
+            >
+              Debug this step
+            </button>
+            <button
+              className="canvas-inspector-macro-btn btn-ghost"
+              data-testid="canvas-macro-explain"
+              onClick={() => inject("Explain this step")}
+            >
+              Explain this step
+            </button>
+          </>
+        )}
+        <div className="canvas-inspector-freeform">
+          <textarea
+            className="canvas-inspector-freeform-input"
+            data-testid="canvas-freeform-input"
+            placeholder={node ? "Ask about this step…" : "Ask about this workflow…"}
+            rows={2}
+            value={freeformText}
+            onChange={(e) => setFreeformText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                handleFreeformAsk();
+              }
+            }}
+          />
+          <button
+            className="btn-primary canvas-inspector-freeform-ask"
+            data-testid="canvas-freeform-ask"
+            disabled={!freeformText.trim()}
+            onClick={handleFreeformAsk}
+          >
+            Ask
+          </button>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -11,10 +11,6 @@ import { Icon } from "./Icon";
 
 interface WorkflowActionsHeaderProps {
   workflow: WorkflowInfo;
-  /** Panel-level expand lives here (subheader), not in the board's zoom widget. */
-  expanded: boolean;
-  onToggleExpanded: () => void;
-  canExpand: boolean;
   /** Drilled step, when the pane shows a step detail instead of the board. */
   detailStep: CanvasGraphNode | null;
   onBack: () => void;
@@ -42,9 +38,10 @@ function runChipLabel(run: RunView, target: RunTarget | null): string {
 }
 
 /**
- * The canvas pane's subheader. Three modes on one bar:
- * - Board: workflow name + deployed dot, expand (the canvas re-renders itself
- *   on any workflow-source edit, so there's no manual refresh action).
+ * The canvas pane's subheader. Renders only for the Steps list and a drilled
+ * step — the board shows no subheader at all (its deployed pill and
+ * expand/collapse live in the tab bar, its name in the rail), so this returns
+ * null in that case.
  * - Steps list: the workflow name and the real step count, info left, no
  *   competing actions (rows are the interface).
  * - Step detail: 1×1 back left-anchored, the step's name and kind, then the
@@ -53,9 +50,6 @@ function runChipLabel(run: RunView, target: RunTarget | null): string {
  */
 export function WorkflowActionsHeader({
   workflow,
-  expanded,
-  onToggleExpanded,
-  canExpand,
   detailStep,
   onBack,
   onAskAgent,
@@ -65,7 +59,7 @@ export function WorkflowActionsHeader({
   runTarget,
   runs,
   onSelectRun,
-}: WorkflowActionsHeaderProps): JSX.Element {
+}: WorkflowActionsHeaderProps): JSX.Element | null {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const closeMenu = useCallback(() => setMenuOpen(false), []);
@@ -235,46 +229,8 @@ export function WorkflowActionsHeader({
     );
   }
 
-  return (
-    <div className="workflow-actions-header" data-testid="workflow-actions-header">
-      <span className="workflow-actions-name">{workflow.name}</span>
-      {workflow.definitionId != null && (
-        /* Flat status tag: the dot carries the hue, the word carries the
-           meaning — never a bare colored mark alone. */
-        <span
-          className="status-tag workflow-deployed-tag"
-          data-testid="workflow-deployed-tag"
-          data-tooltip="Deployed to production"
-        >
-          <span className="workflow-dot workflow-dot-pinned" aria-hidden="true" />
-          Deployed
-        </span>
-      )}
-      {workflow.definitionId != null && (
-        <a
-          className="status-tag status-tag-action workflow-dashboard-link"
-          data-testid="workflow-dashboard-link"
-          href={`https://app.sapiom.ai/workflows/${workflow.definitionId}`}
-          target="_blank"
-          rel="noreferrer"
-          aria-label="Go to dashboard"
-          data-tooltip="Open this workflow in the Sapiom dashboard"
-        >
-          <Icon name="ExternalLink" size={12} />
-          <span className="workflow-dashboard-link-label">Go to dashboard</span>
-        </a>
-      )}
-      {canExpand && (
-        <button
-          className="macro-icon-btn"
-          data-testid="canvas-expand"
-          aria-label={expanded ? "Exit expanded canvas" : "Expand canvas"}
-          data-tooltip={expanded ? "Exit expanded canvas" : "Expand canvas"}
-          onClick={onToggleExpanded}
-        >
-          <Icon name={expanded ? "Minimize2" : "Maximize2"} size={14} />
-        </button>
-      )}
-    </div>
-  );
+  // The board renders no subheader at all: its deployed pill (→ dashboard) and
+  // expand/collapse live in the tab bar, its name in the rail. Tidjane's board
+  // design has nothing between the tabs and the canvas, so return null here.
+  return null;
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -3275,8 +3275,7 @@ input {
 }
 
 .canvas-step-row:focus-visible,
-.canvas-step-open:focus-visible,
-.canvas-detail-edge:focus-visible {
+.canvas-step-open:focus-visible {
   outline: 1.5px solid var(--brand);
   outline-offset: 1px;
 }
@@ -3789,6 +3788,9 @@ input {
   border-top: 1px solid var(--ui-line);
 }
 
+/* Read-only lineage rows: "Leads to" / "Reached from" show a step's real
+   edges and branch conditions as reference. Navigation is the chart's job, so
+   no hover/press/link affordances here. */
 .canvas-detail-edge {
   display: flex;
   align-items: center;
@@ -3796,24 +3798,8 @@ input {
   width: 100%;
   min-height: 40px;
   padding: var(--sp1) var(--sp3);
-  border: 0;
-  background: transparent;
   color: var(--text-dim);
   text-align: left;
-  transition: background-color var(--transition-fast);
-}
-
-.canvas-detail-edge:hover {
-  background: var(--surface-hover);
-  color: var(--text);
-}
-
-.canvas-detail-edge:active {
-  background: var(--surface-selected);
-}
-
-.canvas-detail-edge:focus-visible {
-  outline-offset: -2px;
 }
 
 .canvas-detail-edge > svg {
@@ -3834,10 +3820,6 @@ input {
   background: var(--surface-inset);
   font-size: var(--type-micro);
   color: var(--text-faint);
-}
-
-.canvas-detail-edge:hover .canvas-detail-edge-target {
-  text-decoration: underline;
 }
 
 .canvas-detail-edge-cond {
@@ -3954,38 +3936,6 @@ input {
   margin: 0;
 }
 
-/* Transition rows double as links in the inspector: same elbow anatomy,
-   plus real interaction states on the target's name. */
-.canvas-step-transition.is-link {
-  border: 0;
-  background: none;
-  /* A little inset padding gives the soft-shade hover something to fill. */
-  padding: 2px var(--sp1);
-  text-align: left;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: background-color var(--transition-fast);
-}
-
-/* Selectable inspector rows get the same soft-shade language as the board's
-   selected node when they are the interaction target. */
-.canvas-step-transition.is-link:hover,
-.canvas-step-transition.is-link:active {
-  background: var(--active-shade);
-}
-
-.canvas-step-transition.is-link:hover .canvas-step-transition-target,
-.canvas-step-transition.is-link:active .canvas-step-transition-target {
-  color: var(--text);
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.canvas-step-transition.is-link:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 1px;
-}
-
 /* The selected step's observed run facts: one meta-size row — status ink
    from the shared run-text scale, then duration. */
 .canvas-inspector-run {
@@ -4007,19 +3957,25 @@ input {
    reads as native to the panel above it. */
 .canvas-inspector-macros {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--sp1);
   margin-top: var(--sp1);
   padding-top: var(--sp2);
   border-top: 1px solid var(--ui-line);
 }
 
+/* The three macros ride as a single wrapping row of pills (they inherit
+   .btn-ghost / .btn-primary); each grows to share the row, wrapping when the
+   drawer is too narrow. */
 .canvas-inspector-macro-btn {
-  width: 100%;
-  text-align: left;
+  flex: 1 1 auto;
+  text-align: center;
 }
 
+/* The free-form ask always drops to its own full-width row below the pills. */
 .canvas-inspector-freeform {
+  flex: 1 0 100%;
   display: flex;
   flex-direction: column;
   gap: var(--sp1);
@@ -4086,13 +4042,59 @@ input {
 
 .canvas-overview-open {
   position: absolute;
-  right: var(--sp3);
+  /* Left of the chat toggle so both corner controls sit side by side. */
+  right: calc(var(--sp3) + 40px);
   bottom: var(--sp3);
   z-index: 3;
   background: var(--surface-raised);
   border: 1px solid var(--ui-line);
   box-shadow: var(--shadow-soft);
   font-weight: 590;
+}
+
+/* Chat toggle — the corner control that opens/closes the standalone chat
+   panel (closed by default), beside the info (ⓘ) reopen affordance. */
+.canvas-chat-toggle {
+  position: absolute;
+  right: var(--sp3);
+  bottom: var(--sp3);
+  z-index: 3;
+  background: var(--surface-raised);
+  border: 1px solid var(--ui-line);
+  box-shadow: var(--shadow-soft);
+}
+.canvas-chat-toggle.is-active {
+  background: var(--active-shade);
+  border-color: var(--ui-line-strong);
+  color: var(--text);
+}
+
+/* Standalone chat panel — its own bottom-drawer section, below the info panel;
+   both can be open at once. Content (macros + ask) is short, so it hugs, capped
+   so it never eats the whole pane. */
+.canvas-chat-panel {
+  flex: 0 0 auto;
+  max-height: 45%;
+  overflow-y: auto;
+  border-top: 1px solid var(--ui-line);
+  background: var(--surface-raised);
+  padding: var(--sp3);
+}
+.canvas-chat-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  margin-bottom: var(--sp2);
+}
+.canvas-chat-title {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--type-label);
+  font-weight: 590;
+  color: var(--text);
+}
+.canvas-chat-close {
+  flex: 0 0 auto;
 }
 
 /* Expanded: the same node lifts to a fixed overlay (never remounted, so the
@@ -4634,14 +4636,6 @@ input {
   max-width: 320px;
   color: var(--text-faint);
   font-size: var(--type-meta);
-}
-
-.canvas-visualize-cta {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin: 4px 0;
 }
 
 /* Background-task states (see CanvasPane) ------------------------------- */
@@ -5522,8 +5516,20 @@ input {
   display: none;
 }
 
-.right-pane-collapse {
+/* The canvas expand + collapse-panel toggles sit together, right-anchored at
+   the end of the tab bar. */
+.right-pane-corner {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp1);
+}
+
+/* Deploy pill in the canvas tab bar — the board dropped its subheader, so the
+   deploy status + dashboard link sit up here beside expand/collapse. */
+.right-pane-deployed {
+  flex: 0 0 auto;
+  gap: 4px;
 }
 
 /* The canvas-pane child panel must fill the slot fully. */


### PR DESCRIPTION
## What & why

A fidelity pass on the canvas pane (Canvas / Steps / Code) against the new design, **plus** the step/workflow metadata it surfaces — descriptions, inputs, capabilities, overview — is now produced **deterministically** (no LLM, no user token).

## Board & drawer redesign

- **Step navigation removed from the drawer.** The workflow chart sits right beside it, so the in-drawer transition links were redundant. The Steps-tab lineage ("Leads to" / "Reached from") is kept but made **read-only** — there's no chart there to click into.
- **Macros** are a horizontal pill row now; the first label is shortened to **"Why slow / stuck?"**; the drill action reads **"Open step"**.
- **Chat is a standalone, toggleable panel** (`CanvasChatPanel`) — closed by default, opens **independently** of the ⓘ info panel, and both can be open at once.
- **Header matches the design:**
  - workflow **name dropped** (it already lives in the rail),
  - **expand** moved into the tab bar, next to collapse-panel,
  - the board **subheader bar is gone entirely** (deployed *and* non-deployed),
  - the **deployed pill** now lives in the tab bar (right of the tabs) and **doubles as the dashboard link**.
- **"Render diagram" button removed** — the canvas auto-generates from the bound workflow, including **on session start** for an already-bound / resumed session (`server/index.ts`).

## Deterministic step & workflow metadata (Option A — no LLM)

- **Agent SDK**: `defineStep` gains optional `description` + `capabilities`; `defineAgent` gains `description`. They flow through `buildManifest` into `AgentStepManifest` / `AgentManifest` (both optional → back-compat with older manifests).
- **Canvas renderer** posts per-node `description` / `inputSchema` / `capabilities` / `timeoutMs`, plus a new **Overview** payload (`bootCanvasOverview` / `buildOverviewPayload`) with step / exit / entry stats.
- **Capabilities auto-detect** from the workflow source when not authored (`detectStepCapabilities` over `sapiom.*` call patterns), so real `sapiom.models.run`, `email.messages.send`, etc. render as chips with zero authoring.
- **Canvas template** gets the design's dotted-grid background + transparent panel.

## Verification

| Check | Result |
| --- | --- |
| Web e2e (Playwright) | **242 pass** |
| Harness unit | **1220 pass** |
| Agent SDK unit | **77 pass** |
| Web typecheck (`tsc`) | clean |
| Full build (agent + server + web) | clean |

e2e updated for the removed drawer nav, relocated deployed pill, read-only Steps lineage, and removed render CTA.

## Notes

- The authored `description` / `capabilities` on the on-disk sample are **inert** until the sample adopts the new `@sapiom/agent` (it currently pins published `0.6.7`); capabilities and inputs already render deterministically today.
- Local test workspaces (`packages/harness/hello-agent`, `web-research-digest`) are nested git repos and are intentionally **not** part of this PR.

## Follow-up (not in this PR)

- **Branch-condition tags** ("why this branch was taken") — pending a decision between an authored SDK field (e.g. `next: [{ target, when }]`) and AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
