### PR TITLE
feat(examples): let templates declare their own complexity band (SAP-2086)

### DIFF
--- a/examples/AUTHORING.md
+++ b/examples/AUTHORING.md
@@ -9,7 +9,7 @@ The path is five steps:
 
 1. **[Develop](#1-develop)** — write the agent and its manifest in a new directory.
 2. **[Build & test](#2-build--test)** — compile it, trace a run for free, and validate the files.
-3. **[Categorize](#3-categorize)** — set its category, cadence, and step kinds.
+3. **[Categorize](#3-categorize)** — set its category, cadence, complexity, and step kinds.
 4. **[Write the copy](#4-write-the-copy)** — the words a user reads. This is most of the work.
 5. **[Submit](#5-submit)** — open a PR; once merged, Sapiom picks it up automatically.
 
@@ -56,9 +56,10 @@ authors don't need this — the published `@sapiom/*` versions are enough.
    template's `README.md` shows it.
 3. **Validate the registry and your manifest.** Run `pnpm examples:check` from the repo root.
    It checks that `registry.json` matches the schema (including a valid `category`, `cadence`,
-   and step `kind`), is sorted by `id`, that every `sourcePath` points at a real directory with
-   a `template.json`, that any `checkpoint` is a single genuine human gate, and that **each
-   `template.json` matches `template.schema.json`**. The manifest schema is
+   `complexity`, and step `kind`), is sorted by `id`, that every `sourcePath` points at a real
+   directory with a `template.json`, that any `checkpoint` is a single genuine human gate, that
+   your `complexity` doesn't sit 2+ bands from the one derived from your declared shape, and
+   that **each `template.json` matches `template.schema.json`**. The manifest schema is
    `additionalProperties: false`, so a mistyped field name fails here rather than being
    silently dropped by the backend parser. Run `pnpm examples:sort` first to put your entry in
    order.
@@ -71,8 +72,9 @@ authors don't need this — the published `@sapiom/*` versions are enough.
 
 ## 3. Categorize
 
-Set three things in your `registry.json` entry: one `category`, one `cadence`, and a `kind` on
-every step. They drive how the gallery groups, filters, and describes your template.
+Set four things in your `registry.json` entry: one `category`, one `cadence`, one `complexity`,
+and a `kind` on every step. They drive how the gallery groups, filters, and describes your
+template.
 
 ### `category` — the outcome, not the mechanism
 
@@ -110,6 +112,47 @@ chosen by the app; you only set the id.)
 This describes the **entry only**, not what happens mid-run. `wait-for-webhook` is `on-demand`:
 you start it, and it pauses for a callback partway through. `pr-review-bot` is `on-webhook`:
 the PR event itself is what starts it.
+
+### `complexity` — how much judgment is in the output
+
+**The axis is variance and judgment, not graph size.** A deterministic saga with a wide
+fan-out is `simple` — `approval-chain` declares seven steps, two durable pauses, a reminder
+loop and a compensation branch, but every branch is a state check and the answer is always
+approve or reject. Two chained model steps are not simple, however short the graph: each one's
+output is the next one's input, so drift compounds and there is no single place to inspect the
+result. Steps, capabilities and fan-out are a **tiebreak**, never the reason for a band.
+
+To pick a band, count the template's **judgment points** — the places where something
+non-deterministic is produced:
+
+- a step with `kind: "llm"` (a model call — `models.run`, `models.coding`),
+- a generated image or video (`content.generation.*`),
+- a capability that synthesizes prose for you, e.g. `web.search`'s `answer` field. It counts
+  even with no `llm` step in the graph, because the user still reads model-written output.
+
+| `complexity` | Use when |
+|---|---|
+| `minimal` | **No judgment points.** Re-run it with the same input and you get the same output. A greeting, a Slack post, a health check. |
+| `simple` | **One judgment point**, and you can read the output and tell at a glance whether it's right. Also: any fully deterministic template whose scaffolding is substantial — durable checkpoints, a compensation branch, several capabilities. |
+| `moderate` | **Two judgment points**, or one whose output then drives structured work — a branch, a database write, a rendered artifact — so a bad generation has a consequence past the text itself. |
+| `involved` | **Three judgment points**, or one to two whose output drives something **irreversible or outward-facing**: mail to a real prospect, SQL against your database, a deployed endpoint, a filed attestation. Checking it means checking each stage. |
+| `advanced` | **Chained judgment** — a model consuming another model's output, or a coding agent whose artifact is then built and deployed. Error compounds across stages. Three or more chained generative stages land here regardless of graph size. |
+
+Then apply the nudge, **at most one band, and only upward**: raise it if the deterministic
+scaffolding around those judgment points is heavy (many distinct capabilities, a resumable
+loop, a saga rollback), or if a judgment point's output drives something you can't take back.
+Don't nudge for step count alone. If two bands still feel equally right, pick the lower one —
+the gallery over-promising difficulty costs a user a template they could have used.
+
+`pnpm examples:check` validates the enum, and warns when your band sits **2+ bands** from the
+score derived from `steps[].kind` and `capabilities`. That gap means one of two things, and
+both want a human: your label is wrong, or your **declared shape** is wrong — a step that
+calls a model but says `kind: "compute"` also draws the wrong glyph in the gallery graph. Fix
+whichever is actually untrue; don't inflate the label to silence the warning.
+
+One band apart is expected and prints as a `note:`, not a warning. That is where the rubric
+and the scorer legitimately disagree — the scorer can't see a synthesizing capability, so
+`web-research-digest` derives `minimal` while its authored band is `simple`. Leave those alone.
 
 ### `kind` and `checkpoint` — what each step is
 
@@ -174,6 +217,7 @@ offending word.
 | `tags` | Chips under the title | 3–4 lowercase, kebab or single words. Concrete, searchable ("approval", "hitl", "fallback"). This is where mechanism words go. |
 | `category` | Which gallery group it files under | One id from the enum. The **outcome**, not the mechanism — see [Categorize](#3-categorize). |
 | `cadence` | The "Trigger" fact | One id from the enum. What **starts** a run, not what it does mid-run — see [Categorize](#3-categorize). |
+| `complexity` | The "Complexity" band | One id from the enum. Variance and judgment in the output, **not** graph size — see [Categorize](#3-categorize). |
 | `capabilities` | Capability chips + est. cost | The exact `ctx.sapiom.*` capability ids the source calls. Must match the code (see "Capability ids"). |
 | `steps[].description` | Node labels in the Definition graph | One plain sentence per step: what THIS step does. Preserve `name`/`next`/`terminal`/`capability` exactly. |
 | `steps[].kind` | The step's glyph in the graph | `capability` / `llm` / `compute` / `pause`, one per step — see [Categorize](#3-categorize). |
@@ -340,6 +384,7 @@ Never present the MCP path as the only way to build and run — the webapp does 
 - [ ] `npm run typecheck` passes in the template directory.
 - [ ] Traced a `run_local` end to end (free) before deploying.
 - [ ] One `category` (the outcome, not the mechanism) and one `cadence`; `tags` kept freeform.
+- [ ] One `complexity`, picked by counting judgment points — not by counting steps.
 - [ ] A `kind` on every step, and `checkpoint: true` only on a real human approval gate.
 - [ ] `pnpm examples:sort` then `pnpm examples:check` both clean.
 

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -9,6 +9,7 @@
       "tags": ["approval", "saga", "pause-resume", "durable"],
       "category": "reliability-governance",
       "cadence": "on-demand",
+      "complexity": "simple",
       "sourcePath": "examples/approval-chain",
       "capabilities": ["email.send", "database.create"],
       "steps": [
@@ -70,6 +71,7 @@
       "tags": ["outreach", "sales", "drip", "personalization"],
       "category": "revenue-marketing",
       "cadence": "on-demand",
+      "complexity": "involved",
       "sourcePath": "examples/cold-outreach-engine",
       "capabilities": [
         "email.domain.search",
@@ -145,6 +147,7 @@
       "tags": ["content", "marketing", "media", "scheduled", "pipeline"],
       "category": "revenue-marketing",
       "cadence": "scheduled",
+      "complexity": "advanced",
       "sourcePath": "examples/content-repurposing-pipeline",
       "capabilities": [
         "models.run",
@@ -204,6 +207,7 @@
       "tags": ["dependencies", "coding-agent", "scheduled", "ci"],
       "category": "product-engineering",
       "cadence": "scheduled",
+      "complexity": "advanced",
       "sourcePath": "examples/dependency-upgrade",
       "capabilities": [
         "models.coding",
@@ -270,6 +274,7 @@
       "tags": ["durable", "backfill", "batch", "cron"],
       "category": "data-knowledge",
       "cadence": "scheduled",
+      "complexity": "simple",
       "sourcePath": "examples/durable-backfill",
       "capabilities": [
         "database.get",
@@ -309,6 +314,7 @@
       "tags": ["errors", "triage", "digest", "dedupe", "scheduled", "logs"],
       "category": "reliability-governance",
       "cadence": "scheduled",
+      "complexity": "moderate",
       "sourcePath": "examples/error-triage-digest",
       "capabilities": [
         "models.run",
@@ -353,6 +359,7 @@
       "tags": ["evals", "quality-gate", "llm-judge", "composition"],
       "category": "product-engineering",
       "cadence": "on-demand",
+      "complexity": "moderate",
       "sourcePath": "examples/eval-gate",
       "capabilities": ["models.run"],
       "steps": [
@@ -390,6 +397,7 @@
       "tags": ["starter", "minimal"],
       "category": "starter",
       "cadence": "on-demand",
+      "complexity": "minimal",
       "sourcePath": "examples/hello-agent",
       "capabilities": [],
       "steps": [
@@ -408,6 +416,7 @@
       "tags": ["approval", "human-in-the-loop", "hitl", "fallback"],
       "category": "reliability-governance",
       "cadence": "on-demand",
+      "complexity": "advanced",
       "sourcePath": "examples/human-in-the-loop",
       "capabilities": ["models.run", "email.send"],
       "steps": [
@@ -481,6 +490,7 @@
       "tags": ["crm", "sales", "transcript", "pause-resume"],
       "category": "revenue-marketing",
       "cadence": "on-demand",
+      "complexity": "moderate",
       "sourcePath": "examples/meeting-notes-crm",
       "capabilities": [
         "models.run",
@@ -525,6 +535,7 @@
       "tags": ["news", "summarize", "images", "publish"],
       "category": "revenue-marketing",
       "cadence": "on-demand",
+      "complexity": "involved",
       "sourcePath": "examples/news-roundup",
       "capabilities": [
         "web.search",
@@ -573,6 +584,7 @@
       "tags": ["newsletter", "scheduled", "llm", "email"],
       "category": "revenue-marketing",
       "cadence": "scheduled",
+      "complexity": "involved",
       "sourcePath": "examples/newsletter-autopilot",
       "capabilities": ["web.search", "models.run", "contentGeneration.images"],
       "steps": [
@@ -619,6 +631,7 @@
       "tags": ["database", "sql", "endpoint", "llm", "natural-language"],
       "category": "data-knowledge",
       "cadence": "on-event",
+      "complexity": "involved",
       "sourcePath": "examples/nl-db-query-endpoint",
       "capabilities": [
         "database.get",
@@ -687,6 +700,7 @@
       "tags": ["marketing", "generative", "media", "scheduled"],
       "category": "revenue-marketing",
       "cadence": "scheduled",
+      "complexity": "involved",
       "sourcePath": "examples/personalized-media-at-scale",
       "capabilities": [
         "database.get",
@@ -739,6 +753,7 @@
       "tags": ["coding-agent", "review", "pause-resume", "webhook"],
       "category": "product-engineering",
       "cadence": "on-webhook",
+      "complexity": "advanced",
       "sourcePath": "examples/pr-review-bot",
       "capabilities": [
         "models.coding",
@@ -802,6 +817,7 @@
       "tags": ["sandbox", "self-healing", "cron", "keep-alive"],
       "category": "reliability-governance",
       "cadence": "scheduled",
+      "complexity": "simple",
       "sourcePath": "examples/preview-keep-alive",
       "capabilities": [
         "sandboxes.deployPreview",
@@ -850,6 +866,7 @@
       "tags": ["sales", "pdf", "approval", "human-in-the-loop", "quote"],
       "category": "revenue-marketing",
       "cadence": "on-demand",
+      "complexity": "involved",
       "sourcePath": "examples/proposal-generator",
       "capabilities": [
         "models.run",
@@ -908,6 +925,7 @@
       "tags": ["research", "coding-agent", "sandbox", "publish"],
       "category": "data-knowledge",
       "cadence": "on-demand",
+      "complexity": "advanced",
       "sourcePath": "examples/research-to-microsite",
       "capabilities": [
         "web.search",
@@ -987,6 +1005,7 @@
       "tags": ["generative", "video", "pipeline", "media"],
       "category": "revenue-marketing",
       "cadence": "on-demand",
+      "complexity": "advanced",
       "sourcePath": "examples/scene-to-video",
       "capabilities": [
         "models.run",
@@ -1043,6 +1062,7 @@
       "tags": ["compliance", "scheduled", "human-in-the-loop", "attestation"],
       "category": "finance-legal-people",
       "cadence": "scheduled",
+      "complexity": "involved",
       "sourcePath": "examples/scheduled-compliance-audit",
       "capabilities": [
         "web.scrape",
@@ -1100,6 +1120,7 @@
       "tags": ["scheduled", "database", "analytics", "report"],
       "category": "data-knowledge",
       "cadence": "scheduled",
+      "complexity": "involved",
       "sourcePath": "examples/scheduled-db-insight-report",
       "capabilities": [
         "database.get",
@@ -1149,6 +1170,7 @@
       "tags": ["research", "search", "scheduled", "llm"],
       "category": "data-knowledge",
       "cadence": "scheduled",
+      "complexity": "moderate",
       "sourcePath": "examples/scheduled-research-brief",
       "capabilities": ["web.search", "models.run"],
       "steps": [
@@ -1188,6 +1210,7 @@
       "tags": ["integration", "starter", "slack"],
       "category": "starter",
       "cadence": "on-demand",
+      "complexity": "minimal",
       "sourcePath": "examples/slack-notifier",
       "capabilities": ["vault"],
       "steps": [
@@ -1231,6 +1254,7 @@
       "tags": ["orchestration", "agents-managing-agents", "meta-workflow"],
       "category": "reliability-governance",
       "cadence": "scheduled",
+      "complexity": "involved",
       "sourcePath": "examples/the-brain",
       "capabilities": [
         "models.run",
@@ -1274,6 +1298,7 @@
       "tags": ["durable", "pause-resume", "webhook", "async"],
       "category": "product-engineering",
       "cadence": "on-demand",
+      "complexity": "simple",
       "sourcePath": "examples/wait-for-webhook",
       "capabilities": ["models.run"],
       "steps": [
@@ -1311,6 +1336,7 @@
       "tags": ["research", "search"],
       "category": "data-knowledge",
       "cadence": "on-demand",
+      "complexity": "simple",
       "sourcePath": "examples/web-research-digest",
       "capabilities": ["web.search"],
       "steps": [

--- a/examples/registry.schema.json
+++ b/examples/registry.schema.json
@@ -28,6 +28,11 @@
           "enum": ["starter", "product-engineering", "reliability-governance", "revenue-marketing", "customer-experience", "data-knowledge", "finance-legal-people"],
           "description": "Primary gallery category (the source-of-truth taxonomy). Exactly one per template; the frontend owns the display label, icon, and section order keyed off this id. The axis is OUTCOME — \"what am I trying to produce?\" — not mechanism: `starter` aside, a template belongs to the business job it does, never to the primitive it demonstrates. Mechanism words (durable, pause-resume, hitl, evals, media, orchestration) stay in freeform `tags`, which drive secondary browse/search. Optional for now — every template should carry one, and the examples CI check flags any invalid value."
         },
+        "complexity": {
+          "type": "string",
+          "enum": ["minimal", "simple", "moderate", "involved", "advanced"],
+          "description": "How much VARIATION AND JUDGMENT is in this template's output — authored, not derived from the graph. The axis is not graph size: a deterministic saga with a wide fan-out is `simple` (its answer is always approve/reject), while two chained model steps are not (each one's output is the next one's input, so drift compounds). Count the points where something non-deterministic is produced — a model call, a generated image or video, a capability that synthesizes prose for you — then nudge up one band, never more, when the scaffolding around them is heavy or their output drives something irreversible. See AUTHORING.md §3 for the rubric. Optional for now — every template should carry one, and the examples CI check nudges any that don't. The check also validates the enum and warns when the authored band sits 2+ bands from the score derived from `steps[].kind` / `capabilities`, which means either the label or the declared shape is wrong."
+        },
         "cadence": {
           "type": "string",
           "enum": ["on-demand", "scheduled", "on-event", "on-webhook"],

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -8,7 +8,7 @@
 //
 // Checks:
 //   1. registry.json validates against examples/registry.schema.json
-//      (draft-07, includes the `category` enum).
+//      (draft-07, includes the `category` and `complexity` enums).
 //   2. `templates` is sorted by `id` ascending  (run `pnpm examples:sort` to fix).
 //   3. every `sourcePath` dir exists and contains a `template.json`.
 //   4. checkpoint discipline (human gates only, at most one per template).
@@ -18,6 +18,8 @@
 //   6. house-style copy rules the schemas cannot express — see
 //      scripts/examples-copy-check.mjs. (The length caps ARE in the schemas,
 //      as `maxLength`, so they surface through checks 1 and 5.)
+//   7. the authored `complexity` band against the one DERIVED from the declared
+//      shape; a 2+ band gap warns (see the divergence section for why).
 //
 // Exits non-zero with a readable report on the first category of failure it
 // finds, so a bad registry fails CI before it reaches the backend.
@@ -31,6 +33,10 @@ import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import { createManifestChecker } from "./examples-manifest-check.mjs";
 import { checkCopy } from "./examples-copy-check.mjs";
+import {
+  complexityBandScore,
+  scoreTemplateComplexity,
+} from "./lib/template-complexity.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const EXAMPLES_DIR = path.join(ROOT, "examples");
@@ -140,11 +146,65 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
+// 7. Complexity divergence. The `complexity` enum itself is hard-validated by
+// the schema (check 1); this compares the AUTHORED band against the one derived
+// from `steps[].kind` / `capabilities` and warns at a 2+ band gap.
+//
+// The derived score is the guardrail here, not the answer. It is a proxy for
+// what the band communicates — how much variation and judgment is in the
+// output — and it reads only what the author declared, so a wide gap means one
+// of two things, both worth a human look: the label is wrong, or the declared
+// shape is wrong. The second case is the valuable one: a step that calls a model
+// but says `kind: "compute"` also draws the wrong glyph in the gallery graph, so
+// catching it pays for itself beyond this field.
+//
+// A warning and not an error on purpose. An author who has read the rubric and
+// still disagrees with the scorer should be able to land that; a hard gate would
+// make the proxy authoritative again, which is exactly what authoring this field
+// was meant to stop.
+const divergences = [];
+for (const t of templates) {
+  const authored = complexityBandScore(t.complexity);
+  // Unset or unknown: the schema owns invalid values, the nudge below owns absent ones.
+  if (authored === null) continue;
+  const derived = scoreTemplateComplexity(t);
+  const gap = Math.abs(authored - derived.score);
+  if (gap > 0)
+    divergences.push({ id: t.id, authored: t.complexity, derived, gap });
+}
+
+for (const d of divergences.filter((x) => x.gap >= 2)) {
+  const { basis, raw, label } = d.derived;
+  console.warn(
+    `warning: complexity: "${d.id}" declares "${d.authored}" but its declared shape derives ` +
+      `"${label}" (raw ${raw}: llm=${basis.llmSteps} chained=${basis.chainedLlmSteps} ` +
+      `media=${basis.mediaCapabilities} caps=${basis.capabilityCount} steps=${basis.stepCount} ` +
+      `fanOut=${basis.maxFanOut}) — a ${d.gap}-band gap. Either the band is wrong, or a ` +
+      `\`steps[].kind\` is (a model step declared "compute" also draws the wrong glyph). ` +
+      `See AUTHORING.md §3.`,
+  );
+}
+
+// One band apart is expected and fine — the rubric's nudge is a whole band wide.
+// Reported as a single line so a day-one divergence stays visible without
+// becoming noise that trains authors to ignore the warnings above.
+const nearMisses = divergences.filter((x) => x.gap === 1);
+if (nearMisses.length > 0) {
+  console.log(
+    `note: ${nearMisses.length} template(s) one band from the derived score (authored → derived): ` +
+      nearMisses
+        .map((d) => `${d.id} ${d.authored}→${d.derived.label}`)
+        .join(", "),
+  );
+}
+
 const uncategorized = templates.filter((t) => !t.category).map((t) => t.id);
 const noCadence = templates.filter((t) => !t.cadence).map((t) => t.id);
+const noComplexity = templates.filter((t) => !t.complexity).map((t) => t.id);
 for (const [label, ids] of [
   ["category", uncategorized],
   ["cadence", noCadence],
+  ["complexity", noComplexity],
 ]) {
   // Both are optional in the schema, so this is a nudge, not a gate — flip to
   // `errors.push` once every template carries them and the field goes required.

--- a/scripts/examples-complexity.test.mjs
+++ b/scripts/examples-complexity.test.mjs
@@ -1,0 +1,159 @@
+// =============================================================================
+// scripts/examples-complexity.test.mjs
+//
+// Fixture tests for the authored `complexity` band (SAP-2086) — the enum in
+// registry.schema.json, and the DERIVED scorer that guards it.
+//
+// Two things are worth pinning here. The enum, because a band that doesn't
+// validate is a band the gallery can't render. And the scorer's ORDERING,
+// because the whole point of the field is that complexity means variance and
+// judgment rather than graph size — an accidental reweighting that made a
+// deterministic saga outrank a two-model pipeline would flip the axis with no
+// other test noticing.
+//
+// Run:  pnpm examples:check:test   (node --test)
+// =============================================================================
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import Ajv from "ajv";
+import {
+  COMPLEXITY_BANDS,
+  complexityBandScore,
+  scoreTemplateComplexity,
+} from "./lib/template-complexity.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schema = JSON.parse(
+  readFileSync(path.join(ROOT, "examples", "registry.schema.json"), "utf8"),
+);
+const registry = JSON.parse(
+  readFileSync(path.join(ROOT, "examples", "registry.json"), "utf8"),
+);
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+/** Validate a registry containing one template with the given complexity. */
+const check = (complexity) =>
+  validate({
+    version: 1,
+    templates: [
+      {
+        id: "fixture",
+        name: "Fixture",
+        description: "One line.",
+        sourcePath: "examples/fixture",
+        ...(complexity === undefined ? {} : { complexity }),
+      },
+    ],
+  });
+
+test("every band in the enum validates", () => {
+  for (const band of COMPLEXITY_BANDS) {
+    assert.equal(check(band), true, `${band} should be a valid complexity`);
+  }
+});
+
+test("a band outside the enum fails rather than reaching the gallery", () => {
+  assert.equal(check("trivial"), false);
+  assert.equal(check("Simple"), false, "the enum is lowercase");
+  assert.equal(check(3), false, "a numeric score is not the authored shape");
+});
+
+test("complexity stays optional — absent is valid, the check nudges instead", () => {
+  assert.equal(check(undefined), true);
+});
+
+test("band scores are 1-5 ascending, and unknown labels score null", () => {
+  assert.deepEqual(
+    COMPLEXITY_BANDS.map(complexityBandScore),
+    [1, 2, 3, 4, 5],
+    "the divergence gap is arithmetic on these, so the order is load-bearing",
+  );
+  assert.equal(complexityBandScore("trivial"), null);
+  assert.equal(complexityBandScore(undefined), null);
+});
+
+test("all 26 templates declare a band the enum accepts", () => {
+  const undeclared = registry.templates.filter((t) => !t.complexity);
+  assert.deepEqual(undeclared, [], "every template should carry a complexity");
+  for (const t of registry.templates) {
+    assert.ok(
+      COMPLEXITY_BANDS.includes(t.complexity),
+      `${t.id} declares "${t.complexity}", which is not a band`,
+    );
+  }
+});
+
+test("no template diverges 2+ bands from its derived score", () => {
+  // The same threshold examples-check.mjs warns on. Asserted here so a future
+  // registry edit that breaks the authored/declared agreement fails a test
+  // rather than only printing a warning nobody reads in CI output.
+  const wide = registry.templates
+    .map((t) => ({
+      id: t.id,
+      authored: t.complexity,
+      derived: scoreTemplateComplexity(t),
+    }))
+    .filter(
+      (r) => Math.abs(complexityBandScore(r.authored) - r.derived.score) >= 2,
+    )
+    .map((r) => `${r.id}: authored ${r.authored}, derived ${r.derived.label}`);
+  assert.deepEqual(wide, []);
+});
+
+test("judgment outranks graph size — the axis the rubric leads with", () => {
+  // approval-chain's real shape: seven steps, a fan-out of five, two pauses, a
+  // compensation branch — and every branch a state check.
+  const saga = scoreTemplateComplexity({
+    capabilities: ["email.send", "database.create"],
+    steps: [
+      { name: "start", kind: "capability", next: ["present", "escalate"] },
+      { name: "present", kind: "pause", next: ["decide"] },
+      {
+        name: "decide",
+        kind: "compute",
+        next: ["present", "remind", "finalize", "compensate", "escalate"],
+      },
+      { name: "remind", kind: "pause", next: ["decide"] },
+      { name: "finalize", kind: "capability" },
+      { name: "compensate", kind: "capability" },
+      { name: "escalate", kind: "capability" },
+    ],
+  });
+  // Two chained model steps in a graph less than half the size.
+  const chained = scoreTemplateComplexity({
+    capabilities: ["models.run"],
+    steps: [
+      { name: "parse", kind: "llm", next: ["rank"] },
+      { name: "rank", kind: "llm", next: [] },
+    ],
+  });
+
+  assert.ok(
+    chained.score > saga.score,
+    `a two-model chain (${chained.label}, raw ${chained.raw}) must outrank a ` +
+      `seven-step deterministic saga (${saga.label}, raw ${saga.raw})`,
+  );
+  assert.equal(saga.label, "simple");
+});
+
+test("the scorer is total — an empty template scores minimal, not a throw", () => {
+  assert.equal(scoreTemplateComplexity({ capabilities: [] }).label, "minimal");
+  assert.equal(scoreTemplateComplexity({}).label, "minimal");
+});
+
+test("both media capability spellings count, so the pending id fix can't silently drop a band", () => {
+  const dotted = scoreTemplateComplexity({
+    capabilities: ["content.generation.images"],
+  });
+  const camel = scoreTemplateComplexity({
+    capabilities: ["contentGeneration.images"],
+  });
+  assert.equal(dotted.raw, camel.raw);
+  assert.ok(dotted.basis.mediaCapabilities === 1);
+});

--- a/scripts/lib/template-complexity.mjs
+++ b/scripts/lib/template-complexity.mjs
@@ -1,0 +1,148 @@
+// =============================================================================
+// scripts/lib/template-complexity.mjs
+//
+// The DERIVED complexity scorer, as a guardrail for the AUTHORED `complexity`
+// band in `examples/registry.json`.
+//
+// This is a port of the Sapiom backend's `template-complexity.ts` (SAP-2085).
+// It reads nothing but a registry entry — no network, no filesystem — so the
+// port is a pure-function copy rather than a shared dependency; the two repos
+// have no build relationship to hang a package off. The weights and band edges
+// below are the one source of truth on THIS side of that line: keep them in
+// sync with the backend module when either changes, and the divergence check in
+// `examples-check.mjs` will tell you loudly if a template's shape and its label
+// have drifted apart.
+//
+// WHY it is a guardrail and not the answer: derivation is a proxy for what the
+// band actually communicates — how much variation and judgment is in a
+// template's output. The proxy reads only `kind` and `capabilities`, so it is
+// blind to judgment that arrives any other way. `web-research-digest` is the
+// standing example: it derives `minimal` (no `llm` step — its `summarize` step
+// really is a pure formatter) while the whole product a user reads is the
+// model-written `answer` that `web.search` returned, so its authored band is
+// `simple`. A 2+ band gap therefore means one of two things, both worth a human
+// look: the label is wrong, or the DECLARED SHAPE is wrong (a mis-declared
+// `kind` also corrupts the gallery's step glyphs, so catching it pays for
+// itself).
+// =============================================================================
+
+/**
+ * Media generation, which produces a high-variance artifact.
+ *
+ * Both spellings are intentional: the catalog ids are dotted
+ * (`content.generation.images`) but the registry currently declares the
+ * camelCase near-miss `contentGeneration.images`. Matching one spelling only
+ * would make the scorer quietly wrong on whichever side of that fix it is not.
+ *
+ * `models.run` / `models.coding` are deliberately absent — a step calling
+ * either is already declared `kind: "llm"` and counted as a judgment point, so
+ * counting both would double-weight the same signal.
+ */
+const MEDIA_CAPABILITIES = new Set([
+  "content.generation.images",
+  "content.generation.video",
+  "contentGeneration.images",
+  "contentGeneration.video",
+]);
+
+/**
+ * Weights. Judgment dominates; size is a nudge; topology is deliberately the
+ * lightest term — a wide fan-out of deterministic branches is not what makes a
+ * workflow hard to reason about. This ordering is the axis the AUTHORING rubric
+ * asks authors to apply by hand.
+ */
+const WEIGHT = {
+  llmStep: 4,
+  chainedLlmStep: 3,
+  mediaCapability: 3,
+  capability: 0.4,
+  step: 0.2,
+  /** Applied to `maxFanOut - 1`, so a linear workflow contributes nothing. */
+  fanOut: 0.2,
+};
+
+/** Upper bound (exclusive) of each band, ascending. Same edges as the backend. */
+const BANDS = [
+  { max: 1.5, score: 1, label: "minimal" },
+  { max: 4, score: 2, label: "simple" },
+  { max: 7, score: 3, label: "moderate" },
+  { max: 11, score: 4, label: "involved" },
+  { max: Number.POSITIVE_INFINITY, score: 5, label: "advanced" },
+];
+
+/** The authored enum, ascending — index + 1 is the band's numeric score. */
+export const COMPLEXITY_BANDS = [
+  "minimal",
+  "simple",
+  "moderate",
+  "involved",
+  "advanced",
+];
+
+/** Numeric score (1–5) of an authored band, or `null` if it isn't a known band. */
+export function complexityBandScore(label) {
+  const index = COMPLEXITY_BANDS.indexOf(label);
+  return index === -1 ? null : index + 1;
+}
+
+function basisOf(template) {
+  const steps = Array.isArray(template.steps) ? template.steps : [];
+  const capabilities = Array.isArray(template.capabilities)
+    ? template.capabilities
+    : [];
+
+  // A chained pair is an `llm` step continuing into another `llm` step. Counted
+  // per edge, not per step, so a model step fanning out to two more counts
+  // twice — two independent compounding paths. An unresolvable `next` target
+  // simply matches nothing (this must not throw on a malformed registry, which
+  // the other checks in examples-check.mjs report on their own terms).
+  const kindByName = new Map(steps.map((step) => [step.name, step.kind]));
+  let chainedLlmSteps = 0;
+  for (const step of steps) {
+    if (step.kind !== "llm") continue;
+    for (const target of step.next ?? []) {
+      if (kindByName.get(target) === "llm") chainedLlmSteps += 1;
+    }
+  }
+
+  return {
+    llmSteps: steps.filter((step) => step.kind === "llm").length,
+    chainedLlmSteps,
+    mediaCapabilities: capabilities.filter((id) => MEDIA_CAPABILITIES.has(id))
+      .length,
+    capabilityCount: capabilities.length,
+    stepCount: steps.length,
+    maxFanOut: steps.reduce(
+      (max, step) => Math.max(max, (step.next ?? []).length),
+      0,
+    ),
+  };
+}
+
+/** The raw weighted sum. Exposed so a divergence report can show its work. */
+export function templateComplexityRawScore(basis) {
+  const raw =
+    WEIGHT.llmStep * basis.llmSteps +
+    WEIGHT.chainedLlmStep * basis.chainedLlmSteps +
+    WEIGHT.mediaCapability * basis.mediaCapabilities +
+    WEIGHT.capability * basis.capabilityCount +
+    WEIGHT.step * basis.stepCount +
+    WEIGHT.fanOut * Math.max(0, basis.maxFanOut - 1);
+  // One decimal: the inputs are small integers, so this only trims float noise.
+  return Math.round(raw * 10) / 10;
+}
+
+/**
+ * Score a registry entry's complexity from its declared shape.
+ *
+ * Total-function by contract: an entry with no steps and no capabilities scores
+ * `minimal` rather than throwing.
+ */
+export function scoreTemplateComplexity(template) {
+  const basis = basisOf(template);
+  const raw = templateComplexityRawScore(basis);
+  // BANDS is ascending and ends at +Infinity, so this always matches.
+  const band =
+    BANDS.find((candidate) => raw < candidate.max) ?? BANDS[BANDS.length - 1];
+  return { score: band.score, label: band.label, raw, basis };
+}


### PR DESCRIPTION
Closes SAP-2086 — https://linear.app/sapiom/issue/SAP-2086

## Why

[SAP-2085](https://linear.app/sapiom/issue/SAP-2085) shipped a complexity band **derived** in the Sapiom backend from `steps[].kind` / `capabilities` / `next`. That was the right interim — it needed no sapiom-js change and no authoring — but derivation is a *proxy* for what the band actually communicates: **how much variation and judgment is in a template's output.**

The proxy is blind to judgment that arrives any other way. `web-research-digest` is the standing case: no `llm` step in its graph, so it derives `minimal`, while the whole product a user reads is the model-written `answer` that `web.search` returned. An author would say "simple" and be right.

Every other piece of template metadata — `category`, `cadence`, `kind`, `checkpoint` — is authored in `registry.json`, guided by `AUTHORING.md` §3, and enforced by `pnpm examples:check`. Complexity now rides that same pattern.

## What changed

| | |
|---|---|
| `examples/registry.schema.json` | Optional `complexity` enum (`minimal` \| `simple` \| `moderate` \| `involved` \| `advanced`) on `definitions/template`. Required first — the definition is `additionalProperties: false`, so no template could declare the field without it. |
| `examples/AUTHORING.md` | New `### complexity` rubric in §3, same table-of-values + "Use when" shape as the `kind` / `checkpoint` sections. Plus the field table row, the §2 validation step, and the checklist. |
| `examples/registry.json` | `complexity` on all **26** templates. |
| `scripts/lib/template-complexity.mjs` | The derived weights + band edges, ported from the backend's `template-complexity.ts`. |
| `scripts/examples-check.mjs` | Divergence check: warn at a 2+ band gap between authored and derived; a compact `note:` line for 1-band gaps. |

### The rubric

It leads with the axis — **variance and judgment, not graph size** — and is deliberately mechanical so two authors land in the same band:

1. Count **judgment points**: an `llm` step, a generated image/video, or a capability that synthesizes prose for you (`web.search`'s `answer`, which the derived scorer cannot see).
2. Nudge **at most one band, only upward**, for heavy deterministic scaffolding or an output that drives something irreversible.
3. Break remaining ties **downward** — over-promising difficulty costs a user a template they could have used.

`approval-chain` is the headline example: seven steps, two durable pauses, a reminder loop, a saga compensation branch — and `simple`, because every branch is a state check and the answer is always approve or reject.

### Why the divergence check matters

It turns the derived scorer from *the answer* into *the guardrail*, which is what makes an authored label trustworthy. A wide gap means the label is wrong **or the declared shape is wrong** — and a step that calls a model but says `kind: "compute"` also draws the wrong glyph in the gallery graph, so catching it pays for itself beyond this field.

It's a warning and not a hard gate on purpose: failing the build would make the proxy authoritative again, which is exactly what authoring this field was meant to stop.

### Authored distribution

| band | n | templates |
|---|---|---|
| `minimal` | 2 | hello-agent, slack-notifier |
| `simple` | 5 | approval-chain, durable-backfill, preview-keep-alive, wait-for-webhook, web-research-digest |
| `moderate` | 4 | error-triage-digest, eval-gate, meeting-notes-crm, scheduled-research-brief |
| `involved` | 9 | cold-outreach-engine, news-roundup, newsletter-autopilot, nl-db-query-endpoint, personalized-media-at-scale, proposal-generator, scheduled-compliance-audit, scheduled-db-insight-report, the-brain |
| `advanced` | 6 | content-repurposing-pipeline, dependency-upgrade, human-in-the-loop, pr-review-bot, research-to-microsite, scene-to-video |

22 of 26 land exactly on the derived band; 4 sit one band away. **Nothing trips the 2+ warning today.**

## One correction to the ticket's premise

The ticket expected `web-research-digest` to trip the 2+ warning because its `summarize` step is "declared `kind: "compute"` despite plainly calling a model."

Verified against `examples/web-research-digest/index.ts` — `summarize` really is a pure formatter (it string-builds a markdown digest from `response.answer` and `response.results`) and makes **no** model call. So the `kind` is correct and there is nothing to fix. The judgment lives one level down, in what `web.search` returned. Its authored `simple` vs derived `minimal` is a 1-band gap, reported as a `note:` line rather than a warning — which is the honest read, and the rubric documents that exact case as legitimate disagreement.

The ticket's acceptance allowed for this ("...*or* that template's `kind` is fixed and it no longer diverges"). I did not inflate its band to make the warning fire.

## Verification

```
$ pnpm examples:check
note: 4 template(s) one band from the derived score (authored → derived): slack-notifier
  minimal→simple, the-brain involved→moderate, wait-for-webhook simple→moderate,
  web-research-digest simple→minimal
examples/registry.json OK — 26 templates, sorted, schema-valid, all sourcePaths present.
```

All three new code paths were exercised by temporarily mutating the registry, then reverting:

- **bad enum value** → hard fail, exit 1: `schema: /templates/7/complexity must be equal to one of the allowed values`
- **inflated band** (`web-research-digest` → `involved`) → `warning: complexity: "web-research-digest" declares "involved" but its declared shape derives "minimal" (raw 0.8: llm=0 chained=0 media=0 caps=1 steps=2 fanOut=1) — a 3-band gap. …` exit 0
- **missing field** → `warning: 1 template(s) missing 'complexity': eval-gate`, exit 0

Also confirmed: `pnpm examples:sort` is idempotent with the new field (pure reorder, no formatting churn), and `pnpm build && pnpm typecheck && pnpm lint` are clean — the one harness lint warning is pre-existing on `main`.

### Tests

Rebasing onto `feat/SAP-2076` brought a `scripts/` test harness (`node --test` via `pnpm examples:check:test`) that doesn't exist on `main`, so `scripts/examples-complexity.test.mjs` pins the enum, the 1–5 band ordering the divergence gap does arithmetic on, the 2+ threshold as an assertion over the live registry, the total-function contract, the both-spellings media set — and the **axis**: a two-model chain must outrank a seven-step deterministic saga. That last one is the whole point of the field; a reweighting that inverted it would pass every other test.

49 tests pass (40 pre-existing + 9 new). Verified the divergence assertion bites: flipping `hello-agent` to `involved` fails that test alone.

## Stacking

Based on **`feat/SAP-2076`**, not `main`, at Dave's request so it can merge without a separate approval. Rebased twice — SAP-2076 gained a commit mid-review that moved `whatItDoes` out of `registry.json` and reworked `AUTHORING.md` + `examples-check.mjs`. All conflicts were additive (two sections landing in the same place); resolution kept both sides and renumbered my check to 7. `registry.json` and `registry.schema.json` auto-merged, and the derived scores are unaffected by the `whatItDoes` move since the scorer reads only `steps` and `capabilities`.

## Follow-ups (separate tickets, not this PR)

- [SAP-2087](https://linear.app/sapiom/issue/SAP-2087) — backend: prefer the authored band, fall back to derived.
- [SAP-2088](https://linear.app/sapiom/issue/SAP-2088) — Studio: swap the cost estimate for the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tC8hKHqNtuCRmHtjbcL8z
