### PR TITLE
chore(examples): warn on template copy the gallery card can't render

### DIFF
--- a/examples/AUTHORING.md
+++ b/examples/AUTHORING.md
@@ -145,6 +145,25 @@ choosing whether to use your template.
 Two files per template feed the UI. Keep them consistent — the same template, described
 the same way, at two levels of depth.
 
+### House-style limits (`pnpm examples:check` warns)
+
+The gallery card has finite room, and the rules below are sized from it — a name that wraps the
+title or a use case that can't sit on a chip is a layout bug, not a matter of taste.
+
+| Field | Limit |
+|---|---|
+| `name` | ≤ 32 chars. No `→`, no `/`, no parentheticals, no mechanism word (`saga`, `engine`, `pipeline`, `runner`, `endpoint`, `gate`, `durable`, `keep-alive`, …). |
+| `description` | ≤ 160 chars — one plain sentence. |
+| `whatItDoes` | ≤ 320 chars, and **lead with the verb**. "Create a cited account brief…", not "For turning a…". |
+| `useCases[]` | ≤ 40 chars each — a short noun phrase ("Relationship graph"), not a sentence. |
+
+**Name the outcome, not the machinery.** This is the same rule `category` already follows: the axis
+is *"what am I trying to produce?"* Mechanism words belong in `tags`, which is what drives search —
+putting one in the name doesn't make it more findable, it just spends the title on it.
+
+These are warnings today, not errors, because the existing 26 templates predate them. Don't add to
+the pile; the count is a burn-down.
+
 ### `examples/registry.json` — the gallery index (one entry per template)
 
 | Field | Shows up as | Write it as |

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -27,6 +27,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import { createManifestChecker } from "./examples-manifest-check.mjs";
+import { checkCopy } from "./examples-copy-check.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const EXAMPLES_DIR = path.join(ROOT, "examples");
@@ -70,6 +71,7 @@ for (let i = 0; i < ids.length; i++) {
 // manifest check needs the same resolved path — and because a manifest that only
 // had to *exist* is how `repoSlug: "my-app"` shipped.
 const checkManifest = createManifestChecker(ajv, manifestSchema);
+const manifests = new Map(); // id -> parsed manifest, reused by the copy check
 let manifestsChecked = 0;
 for (const t of templates) {
   if (!t.sourcePath) continue; // required-ness is a schema concern (check 1).
@@ -96,6 +98,7 @@ for (const t of templates) {
     continue;
   }
   errors.push(...checkManifest(t.id, manifest));
+  manifests.set(t.id, manifest);
   manifestsChecked++;
 }
 
@@ -139,6 +142,24 @@ for (const [label, ids] of [
       `warning: ${ids.length} template(s) missing \`${label}\`: ${ids.join(", ")}`,
     );
   }
+}
+
+// 6. House-style copy rules. Warnings on purpose — every limit fails every
+// template today, so a gate would block every PR. The count below is the
+// burn-down; when it hits zero, move the caps into the schemas as `maxLength`
+// and flip these to `errors.push`. See scripts/examples-copy-check.mjs.
+const copyWarnings = templates.flatMap((t) =>
+  checkCopy(t, manifests.get(t.id) ?? null),
+);
+if (copyWarnings.length > 0) {
+  const affected = new Set(
+    copyWarnings.map((w) => w.slice(w.indexOf('"') + 1, w.indexOf('" '))),
+  );
+  console.warn(
+    `\ncopy style: ${copyWarnings.length} warning(s) across ${affected.size} of ${templates.length} template(s) — not a gate yet:\n`,
+  );
+  for (const w of copyWarnings) console.warn(`  - ${w}`);
+  console.warn("");
 }
 
 console.log(

--- a/scripts/examples-copy-check.mjs
+++ b/scripts/examples-copy-check.mjs
@@ -1,0 +1,144 @@
+// =============================================================================
+// scripts/examples-copy-check.mjs
+//
+// House-style rules for the copy a buyer actually reads: `name`, `description`,
+// `whatItDoes` (registry) and `useCases` (manifest).
+//
+// Why these are rules and not just guidance in AUTHORING.md: every prose field
+// in both schemas is `{ "type": "string" }` with no constraint of any kind, so
+// the house style has only ever lived in prose no tool reads. 26 templates
+// drifted 26 directions — 11 names carry a mechanism word, 5 contain an arrow
+// or a slash doing a description's job, 19 of 26 `whatItDoes` open with "For",
+// and the SHORTEST of 79 use cases is 62 characters where the card has room for
+// ~27. That is the same failure as `requiredSecrets`: a rule that existed and
+// nothing checked.
+//
+// The mechanism-word rule is not new policy. `registry.schema.json`'s `category`
+// description already states it — "The axis is OUTCOME ... Mechanism words
+// (durable, pause-resume, hitl, evals, media, orchestration) stay in freeform
+// `tags`" — and we enforced it only on `category`, where an enum made it free.
+// This applies the same rule to the field a user reads and searches.
+//
+// EVERYTHING HERE IS A WARNING, not an error, and deliberately so: all four
+// limits fail all 26 templates today, so a gate would block every PR. This is
+// the same play `examples-check.mjs` already runs for `category`/`cadence`
+// ("a nudge, not a gate — flip to errors.push once every template carries
+// them"). The warning count is the burn-down. When it reaches zero, move the
+// length caps into the schemas as `maxLength` and flip the style rules to
+// errors; until then a schema `maxLength` would be a hard failure on day one.
+// =============================================================================
+
+/**
+ * Length caps, in characters. Sized from the rendered card, not from taste:
+ * a name that wraps the card title, a description that wraps the subtitle to
+ * three lines, or a use case that can't sit on one chip is a layout bug the
+ * schema is letting through.
+ */
+export const COPY_LIMITS = {
+  name: 32,
+  description: 160,
+  whatItDoes: 320,
+  useCase: 40,
+};
+
+/**
+ * Words that name the machinery rather than the job. Deliberately narrow: it
+ * flags implementation vocabulary a buyer would never search for, and leaves
+ * plain-English product words (Bot, Autopilot, Digest, Roundup) alone. Each one
+ * belongs in `tags`, which already drives search — the name is not where a
+ * mechanism becomes findable.
+ */
+export const MECHANISM_WORDS = [
+  "saga",
+  "engine",
+  "pipeline",
+  "runner",
+  "endpoint",
+  "gate",
+  "durable",
+  "keep-alive",
+  "multi-party",
+  "human-in-the-loop",
+  "orchestrator",
+  "daemon",
+  "worker",
+  "handler",
+];
+
+const MECHANISM_RE = new RegExp(`(?<![a-z])(${MECHANISM_WORDS.join("|")})(?![a-z])`, "i");
+
+/**
+ * Copy rules for one template.
+ *
+ * @param template  the registry entry (name, description, whatItDoes, tags)
+ * @param manifest  the co-located template.json, or null when unreadable
+ * @returns string[] of warnings, each naming the template, the field, and the fix
+ */
+export function checkCopy(template, manifest) {
+  const warnings = [];
+  const id = template?.id ?? "(unknown)";
+  const warn = (rule, message) => warnings.push(`${rule}: "${id}" ${message}`);
+
+  const name = typeof template?.name === "string" ? template.name : "";
+  if (name.length > COPY_LIMITS.name) {
+    warn(
+      "copy-name",
+      `name is ${name.length} chars (max ${COPY_LIMITS.name}) — "${name}" will wrap the card title.`,
+    );
+  }
+  if (/[→/]/.test(name)) {
+    warn(
+      "copy-name",
+      `name "${name}" contains an arrow or a slash — that is a description's job. Pick the one thing it produces.`,
+    );
+  }
+  if (/\(.*\)/.test(name)) {
+    warn(
+      "copy-name",
+      `name "${name}" carries a parenthetical — nobody searches for the part in brackets. Move it to \`tags\`.`,
+    );
+  }
+  const mechanism = MECHANISM_RE.exec(name);
+  if (mechanism) {
+    warn(
+      "copy-name",
+      `name "${name}" is built on the mechanism word "${mechanism[1]}" — the axis is the OUTCOME, not the machinery. Move "${mechanism[1].toLowerCase()}" to \`tags\`, which is what drives search.`,
+    );
+  }
+
+  const description =
+    typeof template?.description === "string" ? template.description : "";
+  if (description.length > COPY_LIMITS.description) {
+    warn(
+      "copy-description",
+      `description is ${description.length} chars (max ${COPY_LIMITS.description}) — one plain sentence, not two.`,
+    );
+  }
+
+  const whatItDoes =
+    typeof template?.whatItDoes === "string" ? template.whatItDoes : "";
+  if (whatItDoes.length > COPY_LIMITS.whatItDoes) {
+    warn(
+      "copy-what-it-does",
+      `whatItDoes is ${whatItDoes.length} chars (max ${COPY_LIMITS.whatItDoes}) — the card shows about three sentences.`,
+    );
+  }
+  if (/^For\b/.test(whatItDoes)) {
+    warn(
+      "copy-what-it-does",
+      `whatItDoes opens with "For" — lead with the verb ("Create a cited account brief…"), not with who it is for.`,
+    );
+  }
+
+  const useCases = Array.isArray(manifest?.useCases) ? manifest.useCases : [];
+  useCases.forEach((useCase, i) => {
+    if (typeof useCase === "string" && useCase.length > COPY_LIMITS.useCase) {
+      warn(
+        "copy-use-case",
+        `useCases[${i}] is ${useCase.length} chars (max ${COPY_LIMITS.useCase}) — a short noun phrase ("Relationship graph"), not a sentence.`,
+      );
+    }
+  });
+
+  return warnings;
+}

--- a/scripts/examples-copy-check.test.mjs
+++ b/scripts/examples-copy-check.test.mjs
@@ -1,0 +1,149 @@
+// =============================================================================
+// scripts/examples-copy-check.test.mjs
+//
+// Fixture tests for the house-style copy rules. Every rule here fires on real
+// templates today — these pin the rule so the burn-down can't silently reverse.
+//
+// Run:  pnpm examples:check:test   (node --test)
+// =============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { COPY_LIMITS, MECHANISM_WORDS, checkCopy } from "./examples-copy-check.mjs";
+
+/** A template whose copy is clean, plus whatever the case under test overrides. */
+const clean = {
+  id: "fixture",
+  name: "Account Research Brief",
+  description: "Create a cited account brief and review-ready next actions.",
+  whatItDoes:
+    "Create a cited account brief, relationship graph, and review-ready next actions from live and internal sources.",
+};
+const cleanManifest = {
+  useCases: ["Exact source links", "Relationship graph", "Approval before CRM write"],
+};
+
+const check = (template = {}, manifest = {}) =>
+  checkCopy({ ...clean, ...template }, { ...cleanManifest, ...manifest });
+
+test("copy taken straight from the card passes every rule", () => {
+  assert.deepEqual(check(), []);
+});
+
+test("the card's own use cases fit the cap", () => {
+  for (const useCase of cleanManifest.useCases) {
+    assert.ok(
+      useCase.length <= COPY_LIMITS.useCase,
+      `"${useCase}" is ${useCase.length}, cap is ${COPY_LIMITS.useCase}`,
+    );
+  }
+});
+
+test("an over-long name is flagged with its actual length", () => {
+  const warnings = check({ name: "Scheduled Compliance Audit + Attestation" });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^copy-name: "fixture" name is 40 chars \(max 32\)/);
+});
+
+test("an arrow or a slash in a name is flagged", () => {
+  for (const name of ["Scene → Images → Video", "Proposal / Quote Generator"]) {
+    const warnings = check({ name });
+    assert.equal(warnings.length, 1, `${name} → ${warnings.join("; ")}`);
+    assert.match(warnings[0], /contains an arrow or a slash/);
+  }
+});
+
+test("a parenthetical in a name is flagged and pointed at tags", () => {
+  const warnings = check({ name: "Approval Chain (Saga)" });
+  // Both the parenthetical rule and the mechanism rule fire — "Saga" is
+  // exactly the case that motivated each of them.
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0], /carries a parenthetical/);
+  assert.match(warnings[1], /mechanism word "Saga"/);
+  for (const w of warnings) assert.match(w, /`tags`/);
+});
+
+test("every mechanism word is caught, case-insensitively", () => {
+  for (const word of MECHANISM_WORDS) {
+    const warnings = check({ name: `Thing ${word}` });
+    assert.equal(warnings.length, 1, `${word} → ${warnings.join("; ")}`);
+    assert.match(warnings[0], /is built on the mechanism word/);
+  }
+});
+
+test("plain-English product words are left alone", () => {
+  // The denylist is narrow on purpose: a buyer reads these as English, not as
+  // machinery, and over-flagging would make the burn-down noise.
+  for (const name of ["PR Review Bot", "Newsletter Autopilot", "Company News Roundup"]) {
+    assert.deepEqual(check({ name }), [], name);
+  }
+});
+
+test("a mechanism word inside a longer word is not a match", () => {
+  // "Engine" must not fire on "Engineering", nor "gate" on "Aggregate".
+  for (const name of ["Engineering Digest", "Aggregate Report"]) {
+    assert.deepEqual(check({ name }), [], name);
+  }
+});
+
+test("a two-sentence description is flagged", () => {
+  const warnings = check({
+    name: "Scene to Video",
+    description:
+      "Turn one scene description into a short stitched video: an LLM plans the shots, each shot gets a keyframe image, each keyframe is animated into a clip, and the clips are joined into one video.",
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^copy-description: "fixture" description is 192 chars \(max 160\)/);
+});
+
+test("whatItDoes opening with \"For\" is flagged", () => {
+  const warnings = check({
+    whatItDoes: "For turning a noisy error stream into one digest.",
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /opens with "For" — lead with the verb/);
+});
+
+test("\"Format\" is not \"For\" — the rule is word-boundary aware", () => {
+  assert.deepEqual(check({ whatItDoes: "Format the digest and email it." }), []);
+});
+
+test("an over-long whatItDoes is flagged", () => {
+  const warnings = check({ whatItDoes: "Create ".repeat(60) });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /whatItDoes is 420 chars \(max 320\)/);
+});
+
+test("each over-long use case is flagged by index", () => {
+  const warnings = check(
+    {},
+    {
+      useCases: [
+        "Relationship graph",
+        "Wake up to a sourced brief on a topic you track — a competitor, a research area, a market.",
+      ],
+    },
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^copy-use-case: "fixture" useCases\[1\] is 90 chars \(max 40\)/);
+});
+
+test("a missing manifest is tolerated, not a crash", () => {
+  assert.deepEqual(checkCopy(clean, null), []);
+});
+
+test("missing copy fields are tolerated — the schema owns required-ness", () => {
+  assert.deepEqual(checkCopy({ id: "bare" }, {}), []);
+});
+
+test("the rules are warnings only — checkCopy never throws or exits", () => {
+  // Guard against someone promoting these to errors before the burn-down is
+  // done: the contract is "returns strings", nothing more.
+  const warnings = checkCopy(
+    { id: "worst", name: "Durable Backfill / Long-Job Runner (Saga)", whatItDoes: "For x." },
+    { useCases: ["x".repeat(100)] },
+  );
+  assert.ok(Array.isArray(warnings));
+  assert.ok(warnings.length >= 4);
+  for (const w of warnings) assert.equal(typeof w, "string");
+});


### PR DESCRIPTION
**Stacked on #424** — base is `feat/SAP-2076`, so this diff shows only the copy work. GitHub retargets to `main` when #424 merges.

No Linear ticket yet — this came out of a design review of the template overview card. Happy to file one and retro-link.

## The problem, measured

| | Today (26 templates) | The card |
|---|---|---|
| Names with a mechanism word | **11 / 26** | — |
| Names containing `→` or `/` | **5 / 26** | — |
| `whatItDoes` starting with the word *"For"* | **19 / 26** | starts with a verb |
| `whatItDoes` length | median **651**, max 1071 | ~200 |
| `useCases` item length | median 96, **min 62** | **14–27** |

The shortest of our 79 use cases is 62 characters — more than double the longest one the card has room for. Not one of them fits.

Root cause: **every prose field in both schemas is `{"type": "string"}` with no constraint of any kind.** The house style has only ever lived in `AUTHORING.md` prose and in `description` text no tool reads. That is the same failure as `requiredSecrets` in #424 — a rule that existed, nothing checked, 26 templates drifting 26 directions.

## The naming rule is not new policy

`registry.schema.json`'s own `category` description already states it:

> The axis is OUTCOME — "what am I trying to produce?" — not mechanism… Mechanism words (durable, pause-resume, hitl, evals, media, orchestration) stay in freeform `tags`.

We enforced that on `category`, where an enum made it free, and never on the field a user reads and searches. And **five of the eleven offending names repeat a word the same template already carries as a tag**:

| Name | Word | Tags today |
|---|---|---|
| Multi-Party Approval Chain **(Saga)** | `saga` | `approval`, **`saga`**, `pause-resume`, `durable` |
| **Durable** Backfill / Long-Job Runner | `durable` | **`durable`**, `backfill`, `batch`, `cron` |
| Eval **Gate** | `gate` | `evals`, **`quality-gate`**, `llm-judge`, `composition` |
| **Human-in-the-Loop** Approval | `human-in-the-loop` | `approval`, **`human-in-the-loop`**, **`hitl`**, `fallback` |
| Natural-Language DB Query **Endpoint** | `endpoint` | `database`, `sql`, **`endpoint`**, `llm` |

Cutting the word from the name loses nothing in search and buys the title back for the job.

## What this adds

`scripts/examples-copy-check.mjs` — four rules, all **warnings**:

- `copy-name` — ≤32 chars; no `→` `/` `( )`; no mechanism word (narrow denylist: `saga`, `engine`, `pipeline`, `runner`, `endpoint`, `gate`, `durable`, `keep-alive`, `multi-party`, `human-in-the-loop`, `orchestrator`, `daemon`, `worker`, `handler`)
- `copy-description` — ≤160
- `copy-what-it-does` — ≤320, and reject a leading `"For "`
- `copy-use-case` — ≤40 per item

## Why warnings, and why not `maxLength` in the schema

All four limits fail all 26 templates today, so a schema `maxLength` would be a hard CI failure on day one and a gate would block every PR. This follows the play already in `examples-check.mjs:135` for `category`/`cadence` — *"a nudge, not a gate — flip to `errors.push` once every template carries them."*

```
copy style: 145 warning(s) across 26 of 26 template(s) — not a gate yet:
```

145 is the starting burn-down: 79 `copy-use-case`, 45 `copy-what-it-does`, 20 `copy-name`, 1 `copy-description`. When it reaches zero, the caps move into the schemas as `maxLength` and the style rules flip to errors.

## The copy itself

A redline for all 26 — proposed names, verb-first `whatItDoes`, and three short use cases each — is drafted in the Sapiom repo at `plans/onboarding-templates/copy-clarity-redline.md`. I ran the proposals through this checker: **145 → 0**. It is a redline, not a decision; names especially are a judgment call.

## Verification

- `pnpm build && pnpm typecheck && pnpm lint` — exit 0. (Per a new project rule, this branch does **not** run the jest suite; CI owns it.)
- `pnpm examples:check:test` — 44 tests pass (16 new), including: every denylisted word is caught case-insensitively, `Engine` does not fire on "Engineering", `gate` does not fire on "Aggregate", `"Format"` is not `"For"`, plain-English product words (PR Review Bot, Newsletter Autopilot) are left alone, and `checkCopy` never throws so nobody can promote these to errors by accident.
- `pnpm examples:check` — still exits 0; warnings do not gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCBPYYakJZZaPysmTECLix