### PR TITLE
feat(harness): portable continue — rehydrated context instead of vendor resume (SAP-2059)

### DIFF
--- a/.changeset/harness-portable-continue.md
+++ b/.changeset/harness-portable-continue.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/harness": patch
+---
+
+Portable continue: a session the agent can no longer reattach to is now continuable, by seeding a fresh session with our own reconstruction of it (SAP-2059).
+
+H1 stopped offering Resume on rows that would fail; that left them with nowhere to go — a disabled button and "start a new session instead", even when our event log held the whole conversation. Resume-as-reattach can only ever work for the vendor that wrote the transcript, on the machine that wrote it. This adds the other half: `POST /api/sessions` takes `rehydrateFrom`, and the new session launches with a bounded markdown briefing about the old one.
+
+- New `src/core/resume-brief.ts`: `buildResumeBrief(record, opts)` renders a `SessionRecord` as ~6k tokens of markdown — what the session was (title, cwd, branch, bound workflow + `definitionId`), the rolling summary when present, the last N turns with tool calls collapsed to name + target, and files written / commands run derived from `tool.call` inputs. Over budget it drops turns oldest-first, then the (hard-capped) digests, and clamps the summary only as a last resort.
+- It leads with an honesty header and spells out each of the record's `limitations` in prose. A brief that reads like restored memory is worse than no brief: the agent would assert file contents and command results it never saw.
+- Delivery is per-adapter, declared not inferred (`HarnessAdapter.systemPromptDelivery`). Both shipped adapters use `launch-flag` — the brief is appended to the generated system-prompt file, which claude-code reads via `--append-system-prompt` and codex inlines as `developer_instructions`, so one code path serves both with no adapter change. A harness with no prompt flag declares `post-ready-injection` and gets the brief through the ordinary input path once the session reports `ready`, never into a TUI sitting on a trust prompt.
+- New `src/core/rolling-summary.ts`: opt-in via `HarnessSettings.rollingSummary` (off by default; toggle in Settings). Every 10 completed turns and once at session end, a bounded headless run (`launchTask`, cheap model, `--max-turns 1`) folds the record into `<generated>/<sessionId>/summary.md`. Fully detached from the ingest path — a turn is never slower or riskier for it. Codex has no `launchTask`, so its briefs degrade to last-N-turns, as does everyone's with the setting off.
+- `HarnessSession.rehydratedFrom` records what actually happened, not what was asked for: a `rehydrateFrom` id our log holds nothing for still creates the session, with the field null and the UI saying the continue carried no context.
+- UI: `resumeFromHistory` branches on the server-verified `resumeMode` instead of guessing, and the dead-session pane offers "Continue here" (with what will and won't carry over) wherever it has a record to seed from, instead of a disabled Resume.

--- a/packages/harness/src/cli/settings.test.ts
+++ b/packages/harness/src/cli/settings.test.ts
@@ -33,14 +33,14 @@ describe("settings persistence", () => {
   });
 
   it("loadSettings returns defaults when nothing is persisted", async () => {
-    expect(await loadSettings()).toEqual({ telemetryOptIn: false, recentDirs: [] });
+    expect(await loadSettings()).toEqual({ telemetryOptIn: false, recentDirs: [], rollingSummary: false });
   });
 
   it("round-trips saved settings", async () => {
     const a = await makeRealDir("a");
     await saveSettings({ telemetryOptIn: true, recentDirs: [a] });
     expect(await hasStoredSettings()).toBe(true);
-    expect(await loadSettings()).toEqual({ telemetryOptIn: true, recentDirs: [a] });
+    expect(await loadSettings()).toEqual({ telemetryOptIn: true, recentDirs: [a], rollingSummary: false });
   });
 
   describe("recordRecentDir", () => {
@@ -155,7 +155,7 @@ describe("settings persistence", () => {
       await saveSettings({ telemetryOptIn: true, recentDirs: [a] }, customPath);
 
       expect(await hasStoredSettings(customPath)).toBe(true);
-      expect(await loadSettings(customPath)).toEqual({ telemetryOptIn: true, recentDirs: [a] });
+      expect(await loadSettings(customPath)).toEqual({ telemetryOptIn: true, recentDirs: [a], rollingSummary: false });
       // The (mocked-home) default location was never touched.
       expect(await hasStoredSettings()).toBe(false);
     });

--- a/packages/harness/src/cli/settings.ts
+++ b/packages/harness/src/cli/settings.ts
@@ -6,6 +6,10 @@ import { expandHome } from "./paths.js";
 const DEFAULT_SETTINGS: HarnessSettings = {
   telemetryOptIn: false,
   recentDirs: [],
+  // Opt-in: the rolling summary spends tokens on a background LLM call the
+  // user never asked for. Off, portable continue still works — its brief just
+  // degrades to the last N turns. See core/rolling-summary.ts.
+  rollingSummary: false,
 };
 
 const MAX_RECENT_DIRS = 8;

--- a/packages/harness/src/core/adapters/claude-code.ts
+++ b/packages/harness/src/core/adapters/claude-code.ts
@@ -303,6 +303,10 @@ function buildConfigArgs(opts: LaunchOpts): string[] {
 export class ClaudeCodeAdapter implements HarnessAdapter {
   readonly id = "claude-code" as const;
   readonly eventSource = "hooks" as const;
+  /** `--append-system-prompt` carries `systemPromptFile`'s contents on every
+   *  launch/resume path below, so a rehydration brief composed into that file
+   *  needs no separate delivery. */
+  readonly systemPromptDelivery = "launch-flag" as const;
   private readonly binary: string;
   private readonly homeDir: string;
   private readonly fullScanMaxBytes: number;

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -208,6 +208,11 @@ async function collectRolloutFiles(dir: string, depth = 0): Promise<string[]> {
 export class CodexAdapter implements HarnessAdapter {
   readonly id = "codex" as const;
   readonly eventSource = "transcript-tail" as const;
+  /** `buildConfigArgs` inlines `systemPromptFile`'s contents as
+   *  `developer_instructions`, on both launch and resume — same delivery as
+   *  claude-code's flag, so a rehydration brief rides the generated file here
+   *  too and neither adapter needs a rehydration-specific code path. */
+  readonly systemPromptDelivery = "launch-flag" as const;
   private readonly binary: string;
   private readonly homeDir: string;
 

--- a/packages/harness/src/core/inject/system-prompt.ts
+++ b/packages/harness/src/core/inject/system-prompt.ts
@@ -17,6 +17,14 @@ export interface GenerateSystemPromptFileOptions {
   generatedRoot?: string;
   /** Defaults to the harness's default profile (DEFAULT_SYSTEM_PROMPT). */
   prompt?: string;
+  /**
+   * Extra text appended after the prompt, separated by a blank line — today
+   * the portable-continue brief (core/rehydration.ts). Kept distinct from
+   * `prompt` so a caller that only wants to *add* context doesn't have to
+   * re-import and re-compose the default profile (and can't accidentally
+   * replace it). Empty/whitespace appendices are ignored.
+   */
+  appendix?: string;
 }
 
 /** Writes `<generated>/<harnessSessionId>/system-prompt.txt`. Returns its
@@ -29,7 +37,9 @@ export async function generateSystemPromptFile(
   const dir = path.join(root, harnessSessionId);
   await fs.mkdir(dir, { recursive: true });
 
+  const base = options.prompt ?? DEFAULT_SYSTEM_PROMPT;
+  const appendix = options.appendix?.trim();
   const filePath = path.join(dir, "system-prompt.txt");
-  await fs.writeFile(filePath, options.prompt ?? DEFAULT_SYSTEM_PROMPT, "utf8");
+  await fs.writeFile(filePath, appendix ? `${base}\n\n${appendix}\n` : base, "utf8");
   return filePath;
 }

--- a/packages/harness/src/core/rehydration.test.ts
+++ b/packages/harness/src/core/rehydration.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildRehydrationBrief, systemPromptDeliveryFor } from "./rehydration.js";
+import { ClaudeCodeAdapter } from "./adapters/claude-code.js";
+import { CodexAdapter } from "./adapters/codex.js";
+import type { HarnessAdapter, SessionRecord } from "../shared/types.js";
+
+function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    harnessSessionId: "harness-1",
+    mergedSessionIds: ["harness-1"],
+    agentSessionId: "agent-1",
+    harness: "claude-code",
+    cwd: "/Users/dev/project",
+    startedAt: "2026-07-27T10:00:00.000Z",
+    endedAt: "2026-07-27T11:00:00.000Z",
+    turns: [
+      {
+        index: 1,
+        prompt: "wire the retry backoff",
+        promptAt: "2026-07-27T10:00:00.000Z",
+        toolCalls: [],
+        assistantText: "wired it",
+        model: null,
+        usage: null,
+        completedAt: "2026-07-27T10:01:00.000Z",
+        incomplete: false,
+      },
+    ],
+    turnCount: 1,
+    eventCount: 2,
+    reconstructed: true,
+    limitations: [],
+    ...overrides,
+  };
+}
+
+describe("systemPromptDeliveryFor", () => {
+  it("reports launch-flag for both shipped adapters", () => {
+    // Both put the generated prompt file in front of the agent themselves
+    // (claude's --append-system-prompt, codex's developer_instructions), which
+    // is what makes portable continue one code path for the two of them.
+    expect(systemPromptDeliveryFor(new ClaudeCodeAdapter())).toBe("launch-flag");
+    expect(systemPromptDeliveryFor(new CodexAdapter())).toBe("launch-flag");
+  });
+
+  it("falls back to post-ready injection for an adapter that declares nothing", () => {
+    // Failing toward "delivered noisily" rather than "silently dropped": an
+    // adapter that never wired systemPromptFile would otherwise have its brief
+    // written to a file nothing ever reads.
+    const undeclared = { id: "codex", eventSource: "hooks" } as unknown as HarnessAdapter;
+    expect(systemPromptDeliveryFor(undeclared)).toBe("post-ready-injection");
+    expect(systemPromptDeliveryFor(undefined)).toBe("post-ready-injection");
+  });
+});
+
+describe("buildRehydrationBrief", () => {
+  it("renders a labelled brief for a recorded session", async () => {
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => record(),
+      readSummary: async () => null,
+    });
+    expect(brief).toContain("reconstruction, not restored context");
+    expect(brief).toContain("wire the retry backoff");
+  });
+
+  it("is null when our event log holds nothing for the id", async () => {
+    // The honest answer — it lets the caller say "this continue carried no
+    // context" instead of dressing a blank session up as a continuation.
+    const brief = await buildRehydrationBrief("never-recorded", {
+      readRecord: async () => null,
+      readSummary: async () => "should never be read",
+    });
+    expect(brief).toBeNull();
+  });
+
+  it("never throws when the record reader fails", async () => {
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => Promise.reject(new Error("store on fire")),
+      readSummary: async () => null,
+    });
+    expect(brief).toBeNull();
+  });
+
+  it("takes the newest summary when a conversation spans several harness sessions", async () => {
+    // A resumed conversation folds several harness sessions into one record,
+    // each with its own summary.md. The last one saw the most.
+    const readSummary = vi.fn(async (id: string) =>
+      id === "harness-2" ? "the later, fuller summary" : "the first segment's summary",
+    );
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => record({ mergedSessionIds: ["harness-1", "harness-2"] }),
+      readSummary,
+    });
+    expect(brief).toContain("the later, fuller summary");
+    expect(brief).not.toContain("the first segment's summary");
+    expect(readSummary).toHaveBeenCalledWith("harness-2");
+  });
+
+  it("falls back to an earlier segment's summary when the newest has none", async () => {
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => record({ mergedSessionIds: ["harness-1", "harness-2"] }),
+      readSummary: async (id) => (id === "harness-1" ? "the only summary there is" : null),
+    });
+    expect(brief).toContain("the only summary there is");
+  });
+
+  it("degrades to the turns alone when a summary read fails", async () => {
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => record(),
+      readSummary: async () => Promise.reject(new Error("unreadable")),
+    });
+    expect(brief).toContain("wire the retry backoff");
+    expect(brief).not.toContain("Rolling summary");
+  });
+
+  it("folds in caller-resolved context the record cannot know", async () => {
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => record(),
+      readSummary: async () => null,
+      resolveContext: async () => ({
+        title: "Retry backoff",
+        gitBranch: "feat/SAP-2059",
+        workflow: { name: "order-triage", path: "/Users/dev/project/order-triage", definitionId: 188 },
+      }),
+    });
+    expect(brief).toContain("Retry backoff");
+    expect(brief).toContain("feat/SAP-2059");
+    expect(brief).toContain("definition 188");
+  });
+
+  it("honours the caller's token ceiling", async () => {
+    const chatty = record({
+      turns: Array.from({ length: 30 }, (_, i) => ({
+        index: i + 1,
+        prompt: `prompt ${i + 1} ${"p".repeat(500)}`,
+        promptAt: "2026-07-27T10:00:00.000Z",
+        toolCalls: [],
+        assistantText: "ok",
+        model: null,
+        usage: null,
+        completedAt: "2026-07-27T10:01:00.000Z",
+        incomplete: false,
+      })),
+    });
+    const brief = await buildRehydrationBrief("harness-1", {
+      readRecord: async () => chatty,
+      readSummary: async () => null,
+      maxTokens: 1_000,
+    });
+    expect(brief!.length).toBeLessThanOrEqual(1_000 * 4);
+  });
+});

--- a/packages/harness/src/core/rehydration.ts
+++ b/packages/harness/src/core/rehydration.ts
@@ -1,0 +1,107 @@
+/**
+ * Portable continue, wiring layer: turns a `rehydrateFrom` id into brief text,
+ * and decides which of the two delivery channels carries it.
+ *
+ * The brief itself is pure (core/resume-brief.ts); this is the part that has to
+ * touch the record reader, the summary cache, and the session registry. Kept
+ * out of server/index.ts so the resolution order — and the honest "there was
+ * nothing recorded for that id" answer — is testable without standing up a
+ * server.
+ *
+ * THE TWO CHANNELS, and why there are two:
+ *
+ * - `launch-flag` — the brief is composed into the generated system-prompt
+ *   file, which claude-code reads via `--append-system-prompt` and codex via
+ *   `developer_instructions` (see core/adapters/codex.ts's header for why it
+ *   uses that rather than `model_instructions_file`). Both shipped harnesses
+ *   use this: no adapter change, no injected keystrokes, and the brief is in
+ *   place before the agent's first token.
+ * - `post-ready-injection` — the universal fallback for a harness with no
+ *   prompt flag at all: wait for the session to report `ready`, then send the
+ *   brief through the ordinary input path. It is gated on readiness because
+ *   writing into a TUI that is sitting on a "trust this directory?" prompt
+ *   feeds the brief to the prompt instead of the agent.
+ *
+ * No adapter shipped today needs the second channel — which is exactly why it
+ * is declared per-adapter rather than inferred: a future adapter that cannot
+ * take a prompt flag says so in one line and the context still gets across,
+ * instead of being silently dropped.
+ */
+
+import type {
+  HarnessAdapter,
+  SessionRecord,
+  SystemPromptDelivery,
+} from "../shared/types.js";
+import { buildResumeBrief, type ResumeBriefWorkflow } from "./resume-brief.js";
+
+/**
+ * How a harness receives a rehydration brief. Absent on the adapter means the
+ * fallback, not the flag: an adapter that never wired `systemPromptFile` and
+ * never declared anything would otherwise have its brief written to a file
+ * nothing reads. Failing toward "delivered noisily" beats failing toward
+ * "silently dropped" for a feature whose entire purpose is that the context
+ * arrives.
+ */
+export function systemPromptDeliveryFor(adapter: HarnessAdapter | undefined): SystemPromptDelivery {
+  return adapter?.systemPromptDelivery ?? "post-ready-injection";
+}
+
+/** Context only the caller can resolve — the record carries no title, no git
+ *  branch, and no workflow binding (those live in the session registry and the
+ *  workflow registry respectively). */
+export interface RehydrationContext {
+  title?: string | null;
+  gitBranch?: string | null;
+  workflow?: ResumeBriefWorkflow | null;
+}
+
+export interface RehydrationDeps {
+  /** `SessionRecordReader.read` — resolves a harnessSessionId or an agent
+   *  session id to the folded record. */
+  readRecord: (id: string) => Promise<SessionRecord | null>;
+  /** The cached rolling summary for one harness session, or null. */
+  readSummary: (harnessSessionId: string) => Promise<string | null>;
+  /** Registry-only context for the record. Optional; the brief renders
+   *  without it, just less specifically. May be async — the git branch, for
+   *  one, is only knowable from an adapter history scan. */
+  resolveContext?: (
+    record: SessionRecord,
+  ) => RehydrationContext | undefined | Promise<RehydrationContext | undefined>;
+  /** Token ceiling override, forwarded to `buildResumeBrief`. */
+  maxTokens?: number;
+}
+
+/**
+ * The brief for `rehydrateFrom`, or null when our event log holds nothing for
+ * it — the honest answer, and the one that lets a caller say "this continue
+ * carried no context" rather than opening a fresh session dressed up as a
+ * continuation.
+ *
+ * Never throws: a rehydration that can't be assembled must degrade to a plain
+ * new session, never fail the session-create it is decorating.
+ */
+export async function buildRehydrationBrief(
+  rehydrateFrom: string,
+  deps: RehydrationDeps,
+): Promise<string | null> {
+  const record = await deps.readRecord(rehydrateFrom).catch(() => null);
+  if (!record) return null;
+
+  // A conversation can span several harness sessions (a resume, or an adopt),
+  // each with its own summary file. Newest-last is the fold that saw the most,
+  // so walk backwards and take the first one that exists rather than merging
+  // several partial accounts of the same work.
+  let summary: string | null = null;
+  for (const harnessSessionId of [...record.mergedSessionIds].reverse()) {
+    summary = await deps.readSummary(harnessSessionId).catch(() => null);
+    if (summary) break;
+  }
+
+  const context = (await deps.resolveContext?.(record)) ?? {};
+  return buildResumeBrief(record, {
+    ...context,
+    summary,
+    ...(deps.maxTokens !== undefined ? { maxTokens: deps.maxTokens } : {}),
+  });
+}

--- a/packages/harness/src/core/resume-brief.test.ts
+++ b/packages/harness/src/core/resume-brief.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHARS_PER_TOKEN,
+  buildResumeBrief,
+  deriveDigests,
+  describeToolTarget,
+  estimateBriefTokens,
+} from "./resume-brief.js";
+import type {
+  SessionRecord,
+  SessionRecordToolCall,
+  SessionRecordTurn,
+} from "../shared/types.js";
+
+function toolCall(
+  name: string,
+  input: unknown,
+  overrides: Partial<SessionRecordToolCall> = {},
+): SessionRecordToolCall {
+  return {
+    name,
+    input: typeof input === "string" ? input : JSON.stringify(input),
+    responseSummary: null,
+    responseTruncated: false,
+    at: "2026-07-27T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function turn(index: number, overrides: Partial<SessionRecordTurn> = {}): SessionRecordTurn {
+  return {
+    index,
+    prompt: `prompt number ${index}`,
+    promptAt: `2026-07-27T10:${String(index).padStart(2, "0")}:00.000Z`,
+    toolCalls: [],
+    assistantText: `reply number ${index}`,
+    model: "claude-opus-5",
+    usage: null,
+    completedAt: `2026-07-27T10:${String(index).padStart(2, "0")}:30.000Z`,
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+/** The body of one `## `-headed section, so an assertion about (say) the files
+ *  digest isn't accidentally satisfied by the turn list further down. */
+function section(brief: string, heading: string): string {
+  const start = brief.indexOf(heading);
+  expect(start, `brief has no ${heading} section`).toBeGreaterThanOrEqual(0);
+  const next = brief.indexOf("\n## ", start + heading.length);
+  return next === -1 ? brief.slice(start) : brief.slice(start, next);
+}
+
+function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const turns = overrides.turns ?? [turn(1)];
+  return {
+    harnessSessionId: "harness-1",
+    mergedSessionIds: ["harness-1"],
+    agentSessionId: "agent-1",
+    harness: "claude-code",
+    cwd: "/Users/dev/project",
+    startedAt: "2026-07-27T10:00:00.000Z",
+    endedAt: "2026-07-27T11:00:00.000Z",
+    turnCount: turns.filter((t) => t.prompt !== null).length,
+    eventCount: turns.length * 2,
+    reconstructed: true,
+    limitations: [],
+    ...overrides,
+    turns,
+  };
+}
+
+describe("buildResumeBrief", () => {
+  describe("honesty", () => {
+    it("always leads with the reconstruction disclaimer, whatever else is dropped", () => {
+      // Even at a budget far below the preamble floor, the label survives:
+      // an unlabelled reconstruction is the failure this feature exists to
+      // prevent, so it is not a thing the budget is allowed to squeeze.
+      for (const maxTokens of [6_000, 400, 10, 0]) {
+        const brief = buildResumeBrief(record(), { maxTokens });
+        expect(brief).toContain("reconstruction, not restored context");
+        expect(brief).toContain("You are a **fresh session**");
+        expect(brief).toContain("check the current state of the");
+      }
+    });
+
+    it("spells out each machine-readable limitation in prose", () => {
+      const brief = buildResumeBrief(
+        record({ limitations: ["truncated-tool-output", "missing-assistant-text"] }),
+      );
+      expect(brief).toContain("Known gaps in this reconstruction");
+      expect(brief).toContain("Tool output was size-capped");
+      expect(brief).toContain("no assistant text at all");
+      // Not asserted for a gap the record didn't report.
+      expect(brief).not.toContain("ended mid-turn");
+    });
+
+    it("says a prompt was not recorded rather than inventing one", () => {
+      const brief = buildResumeBrief(
+        record({ turns: [turn(1, { prompt: null, promptAt: null })] }),
+      );
+      expect(brief).toContain("**Prompt:** _not recorded");
+      expect(brief).not.toContain("prompt number 1");
+    });
+
+    it("marks a trailing turn that never completed", () => {
+      const brief = buildResumeBrief(
+        record({ turns: [turn(1, { incomplete: true, completedAt: null, assistantText: null })] }),
+      );
+      expect(brief).toContain("never completed");
+    });
+  });
+
+  describe("what the session was", () => {
+    it("carries title, cwd, branch, harness and the bound workflow with its definitionId", () => {
+      const brief = buildResumeBrief(record(), {
+        title: "Fix the retry backoff",
+        gitBranch: "feat/SAP-2059",
+        workflow: { name: "order-triage", path: "/Users/dev/project/order-triage", definitionId: 188 },
+      });
+      expect(brief).toContain("Fix the retry backoff");
+      expect(brief).toContain("/Users/dev/project");
+      expect(brief).toContain("feat/SAP-2059");
+      expect(brief).toContain("claude-code");
+      expect(brief).toContain("order-triage");
+      expect(brief).toContain("definition 188");
+    });
+
+    it("says a workflow is not linked rather than printing a null definition", () => {
+      const brief = buildResumeBrief(record(), {
+        workflow: { name: "draft", path: "/Users/dev/project/draft", definitionId: null },
+      });
+      expect(brief).toContain("not yet linked to a deployed definition");
+      expect(brief).not.toContain("definition null");
+    });
+  });
+
+  describe("rolling summary", () => {
+    it("includes it when present", () => {
+      const brief = buildResumeBrief(record(), { summary: "Rewrote the backoff to be jittered." });
+      expect(brief).toContain("Rolling summary of the prior session");
+      expect(brief).toContain("Rewrote the backoff to be jittered.");
+    });
+
+    it("degrades to the turns alone when no summary was ever produced", () => {
+      // The default case — the setting is opt-in — so the brief must be
+      // useful without one and must not imply a summary exists.
+      const brief = buildResumeBrief(record({ turns: [turn(1), turn(2)] }));
+      expect(brief).not.toContain("Rolling summary");
+      expect(brief).toContain("prompt number 2");
+    });
+  });
+
+  describe("derived digests", () => {
+    it("lists files written (not merely read), newest first, with edit counts", () => {
+      const brief = buildResumeBrief(
+        record({
+          turns: [
+            turn(1, {
+              toolCalls: [
+                toolCall("Read", { file_path: "/Users/dev/project/src/read-only.ts" }),
+                toolCall("Edit", { file_path: "/Users/dev/project/src/a.ts" }),
+                toolCall("Edit", { file_path: "/Users/dev/project/src/a.ts" }),
+                toolCall("Write", { file_path: "/Users/dev/project/src/b.ts" }),
+              ],
+            }),
+          ],
+        }),
+      );
+      const files = section(brief, "## Files the prior session wrote to");
+      expect(files).toContain("`src/b.ts`");
+      expect(files).toContain("`src/a.ts` (2 edits)");
+      // A file the session only read is not a file it wrote — it still shows
+      // in the turn's tool list, which is why this is scoped to the section.
+      expect(files).not.toContain("read-only.ts");
+      expect(brief).toContain("`Read` src/read-only.ts");
+      // Newest first.
+      expect(files.indexOf("src/b.ts")).toBeLessThan(files.indexOf("src/a.ts"));
+    });
+
+    it("lists distinct shell commands and dedupes repeats", () => {
+      const brief = buildResumeBrief(
+        record({
+          turns: [
+            turn(1, {
+              toolCalls: [
+                toolCall("Bash", { command: "pnpm build" }),
+                toolCall("Bash", { command: "pnpm build" }),
+                toolCall("Bash", { command: "pnpm lint" }),
+              ],
+            }),
+          ],
+        }),
+      );
+      const commands = section(brief, "## Shell commands it ran");
+      expect(commands.match(/pnpm build/g)).toHaveLength(1);
+      expect(commands).toContain("pnpm lint");
+    });
+
+    it("reads codex's argv-array shell input as one command line", () => {
+      const digests = deriveDigests(
+        record({
+          turns: [turn(1, { toolCalls: [toolCall("shell", { command: ["bash", "-lc", "pnpm test"] })] })],
+        }),
+      );
+      expect(digests.commands).toEqual(["bash -lc pnpm test"]);
+    });
+
+    it("omits both sections entirely when the session wrote nothing and ran nothing", () => {
+      const brief = buildResumeBrief(record());
+      expect(brief).not.toContain("## Files the prior session wrote to");
+      expect(brief).not.toContain("## Shell commands it ran");
+    });
+  });
+
+  describe("tool targets", () => {
+    it("names the file for a file tool and the command for a shell tool", () => {
+      expect(
+        describeToolTarget(toolCall("Edit", { file_path: "/Users/dev/project/src/a.ts" }), "/Users/dev/project"),
+      ).toBe("src/a.ts");
+      expect(describeToolTarget(toolCall("Bash", { command: "pnpm build" }), "/Users/dev/project")).toBe(
+        "pnpm build",
+      );
+    });
+
+    it("keeps a path outside the cwd absolute rather than emitting ../.. noise", () => {
+      expect(describeToolTarget(toolCall("Edit", { file_path: "/etc/hosts" }), "/Users/dev/project")).toBe(
+        "/etc/hosts",
+      );
+    });
+
+    it("falls back to a flattened slice of input the collector truncated mid-JSON", () => {
+      // A real shape: normalizer.truncateForPayload cuts a big tool_input, so
+      // JSON.parse fails. The target must still say something rather than
+      // rendering a bare tool name.
+      const target = describeToolTarget(
+        toolCall("Edit", '{"file_path":"/Users/dev/project/src/a.ts","old_st…[truncated 900 chars]'),
+        "/Users/dev/project",
+      );
+      expect(target).toContain("file_path");
+    });
+
+    it("returns null for a tool call with no recorded input at all", () => {
+      expect(describeToolTarget(toolCall("Bash", null as unknown as string, { input: null }), null)).toBeNull();
+    });
+  });
+
+  describe("token budget", () => {
+    const chatty = record({
+      turns: Array.from({ length: 40 }, (_, i) =>
+        turn(i + 1, {
+          prompt: `prompt ${i + 1} ${"p".repeat(400)}`,
+          assistantText: `reply ${i + 1} ${"r".repeat(400)}`,
+          toolCalls: [toolCall("Edit", { file_path: `/Users/dev/project/src/file-${i}.ts` })],
+        }),
+      ),
+    });
+
+    it("stays within the budget", () => {
+      for (const maxTokens of [6_000, 2_000, 800]) {
+        const brief = buildResumeBrief(chatty, { maxTokens, maxTurns: 40 });
+        expect(estimateBriefTokens(brief)).toBeLessThanOrEqual(maxTokens);
+        expect(brief.length).toBeLessThanOrEqual(maxTokens * CHARS_PER_TOKEN);
+      }
+    });
+
+    it("truncates oldest-first, keeping the newest turns", () => {
+      const brief = buildResumeBrief(chatty, { maxTokens: 1_500, maxTurns: 40 });
+      expect(brief).toContain("prompt 40 ");
+      expect(brief).not.toContain("prompt 1 ");
+      expect(brief).not.toContain("prompt 20 ");
+    });
+
+    it("keeps the summary while dropping turns to fit", () => {
+      const summary = "The session was migrating the retry path to jittered backoff.";
+      const brief = buildResumeBrief(chatty, { maxTokens: 900, maxTurns: 40, summary });
+      expect(brief).toContain(summary);
+      expect(estimateBriefTokens(brief)).toBeLessThanOrEqual(900);
+    });
+
+    it("says how many turns it omitted instead of silently shortening", () => {
+      const brief = buildResumeBrief(chatty, { maxTokens: 1_500, maxTurns: 40 });
+      expect(brief).toMatch(/The earliest \d+ of 40 recorded turns are omitted here/);
+    });
+
+    it("keeps the capped digests while turns are still being dropped", () => {
+      // The digests cost a few hundred tokens for a WHOLE session, where one
+      // verbose turn costs about as much — so trading the whole-session view
+      // away to keep one more ancient turn is the wrong way round.
+      const squeezed = buildResumeBrief(chatty, { maxTokens: 2_000, maxTurns: 40 });
+      expect(squeezed).toMatch(/The earliest \d+ of 40 recorded turns are omitted/);
+      expect(squeezed).toContain("## Files the prior session wrote to");
+    });
+
+    it("clamps an oversized summary only as a last resort, and marks the cut", () => {
+      // A summary that busts the whole budget on its own is outside its
+      // ≤500-word contract; the budget is still hard, so it gets clamped
+      // rather than allowed through.
+      const brief = buildResumeBrief(record({ turns: [] }), {
+        maxTokens: 600,
+        summary: "s".repeat(50_000),
+      });
+      expect(brief.length).toBeLessThanOrEqual(600 * CHARS_PER_TOKEN);
+      expect(brief).toContain("…[truncated]");
+    });
+
+    it("drops the digests only once no turn is left to give, and says so", () => {
+      const brief = buildResumeBrief(chatty, { maxTokens: 400, maxTurns: 40 });
+      expect(brief).toContain("_No turns fit the context budget._");
+      expect(brief).not.toContain("## Files the prior session wrote to");
+      expect(brief).toContain("Also omitted to fit the context budget: files written");
+      // Still labelled, and still under budget.
+      expect(brief).toContain("reconstruction, not restored context");
+      expect(brief.length).toBeLessThanOrEqual(400 * CHARS_PER_TOKEN);
+    });
+  });
+
+  it("renders nothing turn-shaped for a record with no turns", () => {
+    const brief = buildResumeBrief(record({ turns: [], turnCount: 0 }));
+    expect(brief).not.toContain("## Recent turns");
+    expect(brief).toContain("**Recorded turns:** 0");
+  });
+});

--- a/packages/harness/src/core/resume-brief.ts
+++ b/packages/harness/src/core/resume-brief.ts
@@ -1,0 +1,468 @@
+/**
+ * The "portable continue" brief: a bounded markdown reconstruction of a prior
+ * session, rendered from the SessionRecord our own events already produce (see
+ * core/session-record.ts).
+ *
+ * Why this exists rather than a vendor resume: `claude --resume` / `codex
+ * resume` only work when that agent, on this machine, still holds that
+ * conversation. H1 (SAP-2057) made us stop pretending otherwise; this is the
+ * other half — for every row where the agent does NOT hold it, start a fresh
+ * session seeded with what we recorded. Because the input is our normalized
+ * record and the output is plain text, the same code path serves claude-code
+ * (`--append-system-prompt`) and codex (`developer_instructions`), and would
+ * serve a harness with no prompt flag at all via post-ready injection.
+ *
+ * HONESTY IS THE PRODUCT HERE. A brief that reads like restored memory is
+ * worse than no brief: the agent will assert a file's contents or a command's
+ * outcome it never saw. So the header says outright that this is a
+ * reconstruction, `record.limitations` are spelled out, and every omission
+ * (dropped turns, clamped text, capped file lists) is stated in the text
+ * rather than silently applied.
+ *
+ * BUDGET. The brief is capped at `maxTokens` (default
+ * {@link RESUME_BRIEF_DEFAULT_MAX_TOKENS}), estimated at
+ * {@link CHARS_PER_TOKEN} characters per token — deliberately a crude
+ * estimator, since the consumer is a system prompt with room to spare, not a
+ * hard API limit, and a tokenizer dependency here would have to be right for
+ * two different vendors' tokenizers anyway. What gets squeezed, in order:
+ *
+ *   1. turns, oldest-first — the newest are the ones that explain what is in
+ *      flight right now, and an old turn is the most verbose thing here per
+ *      unit of usefulness;
+ *   2. the derived digests (files written, commands run). They go AFTER turns,
+ *      not before, because they are hard-capped ({@link MAX_FILES} /
+ *      {@link MAX_COMMANDS}) at a few hundred tokens for a whole session,
+ *      where each turn costs a comparable amount on its own — trading a
+ *      whole-session view for one more ancient turn is a bad deal. They can
+ *      also be recovered by looking at the repository, so this only bites
+ *      once every turn is already gone;
+ *   3. only then the rolling summary, tail-clamped. It is squeezed last
+ *      because it is the one section that is a lossy fold of turns already
+ *      dropped in step 1: cutting it loses history nothing else carries.
+ *
+ * The honesty header and the identity block are never dropped — a brief
+ * without them is a lie, not a shorter brief — so they act as a floor of
+ * roughly {@link RESUME_BRIEF_MIN_TOKENS} tokens that a smaller `maxTokens`
+ * cannot squeeze below.
+ */
+
+import * as path from "node:path";
+
+import type {
+  SessionRecord,
+  SessionRecordLimitation,
+  SessionRecordToolCall,
+  SessionRecordTurn,
+} from "../shared/types.js";
+
+/** Default token ceiling for a brief — see the module header on the estimate. */
+export const RESUME_BRIEF_DEFAULT_MAX_TOKENS = 6_000;
+/** Turns considered before budgeting; the budget may keep fewer, never more. */
+export const RESUME_BRIEF_DEFAULT_MAX_TURNS = 12;
+/**
+ * Characters per token. Roughly right for English prose and code across both
+ * vendors' tokenizers, and biased the safe way: real text averages slightly
+ * more than 4 chars/token, so this over-counts and lands under the ceiling.
+ */
+export const CHARS_PER_TOKEN = 4;
+/**
+ * Floor the budget can never squeeze below — the honesty header plus the
+ * identity block. Approximate (it moves with the header's wording); it exists
+ * so callers can reason about "what does maxTokens: 200 even mean" rather than
+ * as an assertion about exact size.
+ */
+export const RESUME_BRIEF_MIN_TOKENS = 400;
+
+/** Per-turn clamps, so one pathological prompt can't consume the whole budget. */
+const MAX_PROMPT_CHARS = 1_200;
+const MAX_ASSISTANT_CHARS = 1_200;
+/** How much of a tool call's target (path or command) to show. */
+const MAX_TOOL_TARGET_CHARS = 80;
+/** Tool calls listed per turn before the rest are counted rather than named. */
+const MAX_TOOLS_PER_TURN = 12;
+/** Entries in the derived digests. */
+const MAX_FILES = 30;
+const MAX_COMMANDS = 10;
+const MAX_COMMAND_CHARS = 120;
+
+/** The marker `truncateForPayload` (core/collector/normalizer.ts) leaves. */
+const CLAMP_MARKER = "…[truncated]";
+
+/** The workflow the prior session was bound to, resolved by the caller against
+ *  the live workflow registry (the record itself has no binding). */
+export interface ResumeBriefWorkflow {
+  name: string;
+  path: string;
+  definitionId: number | null;
+}
+
+export interface BuildResumeBriefOptions {
+  /** Display title of the prior session, when a history row knew one. */
+  title?: string | null;
+  /** Git branch the prior session was last on, when a history row knew one. */
+  gitBranch?: string | null;
+  /** The prior session's bound workflow. */
+  workflow?: ResumeBriefWorkflow | null;
+  /**
+   * The rolling summary (`<generated>/<sessionId>/summary.md`) when one was
+   * ever produced. Absent, the brief degrades to the last N turns — which is
+   * the normal case, since the summary is opt-in (see core/rolling-summary.ts).
+   */
+  summary?: string | null;
+  /** Token ceiling. Default {@link RESUME_BRIEF_DEFAULT_MAX_TOKENS}. */
+  maxTokens?: number;
+  /** Newest turns considered. Default {@link RESUME_BRIEF_DEFAULT_MAX_TURNS}. */
+  maxTurns?: number;
+}
+
+/** The crude char-count estimate the budget is enforced against. */
+export function estimateBriefTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/** Clamp `text` to `maxChars`, marking the cut so nothing reads as complete
+ *  when it isn't. */
+function clamp(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars).trimEnd()}${CLAMP_MARKER}`;
+}
+
+/**
+ * The tool's target as a human would name it: the file it edited, the command
+ * it ran, or — failing both — a clamped slice of the raw input.
+ *
+ * `toolInput` is a string on the wire for both harnesses: claude-code's
+ * normalizer stores `JSON.stringify(tool_input)` and codex's tailer stores the
+ * function call's raw `arguments`, so a JSON parse covers both and a plain
+ * string (an untruncated free-text argument) falls through to the raw slice.
+ * Never throws on malformed input — a brief must render from whatever was
+ * recorded, including a payload the collector truncated mid-JSON.
+ */
+export function describeToolTarget(call: SessionRecordToolCall, cwd: string | null): string | null {
+  const parsed = parseToolInput(call.input);
+  if (parsed) {
+    const filePath = firstString(parsed, ["file_path", "filePath", "notebook_path", "path"]);
+    if (filePath) return clamp(displayPath(filePath, cwd), MAX_TOOL_TARGET_CHARS);
+    const command = readCommand(parsed);
+    if (command) return clamp(command, MAX_TOOL_TARGET_CHARS);
+  }
+  if (!call.input) return null;
+  // No structure to read — show a slice of what was recorded rather than
+  // nothing, on one line so a turn's tool list stays scannable.
+  return clamp(call.input.replace(/\s+/g, " "), MAX_TOOL_TARGET_CHARS);
+}
+
+function parseToolInput(input: string | null): Record<string, unknown> | null {
+  if (!input) return null;
+  try {
+    const parsed: unknown = JSON.parse(input);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function firstString(source: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+/** claude-code's Bash carries `command` as a string; codex's shell tool carries
+ *  it as an argv array (`["bash", "-lc", "…"]`). Both read as one line here. */
+function readCommand(source: Record<string, unknown>): string | null {
+  const command = source.command;
+  if (typeof command === "string" && command.length > 0) return command.replace(/\s+/g, " ").trim();
+  if (Array.isArray(command)) {
+    const joined = command.filter((part): part is string => typeof part === "string").join(" ").trim();
+    return joined.length > 0 ? joined.replace(/\s+/g, " ") : null;
+  }
+  return null;
+}
+
+/** Paths under the session's cwd read far better relative; anything else (or a
+ *  record with no recorded cwd) stays absolute so it's never ambiguous. */
+function displayPath(filePath: string, cwd: string | null): string {
+  if (!cwd || !path.isAbsolute(filePath)) return filePath;
+  const relative = path.relative(cwd, filePath);
+  return relative && !relative.startsWith("..") ? relative : filePath;
+}
+
+/** Tools whose input names a file the session wrote to. Read-only tools are
+ *  deliberately excluded: "files touched" that includes everything the agent
+ *  merely looked at stops being a signal. */
+const WRITE_TOOL_NAMES = new Set([
+  "write",
+  "edit",
+  "multiedit",
+  "notebookedit",
+  "update",
+  "apply_patch",
+  "str_replace_editor",
+]);
+
+const SHELL_TOOL_NAMES = new Set(["bash", "shell", "run_terminal_cmd", "local_shell"]);
+
+interface DerivedDigests {
+  /** Files written, most-recently-touched first, with their touch counts. */
+  files: Array<{ display: string; count: number }>;
+  /** Total distinct files, which may exceed `files.length` after the cap. */
+  totalFiles: number;
+  /** Distinct shell commands, most recent first. */
+  commands: string[];
+  totalCommands: number;
+}
+
+/**
+ * Files touched and commands run, derived from `tool.call` inputs. Exported
+ * for tests and because the same derivation is worth reusing anywhere that
+ * needs "what did this session actually do to the tree".
+ */
+export function deriveDigests(record: SessionRecord): DerivedDigests {
+  const fileCounts = new Map<string, number>();
+  const commands: string[] = [];
+  const seenCommands = new Set<string>();
+
+  for (const turn of record.turns) {
+    for (const call of turn.toolCalls) {
+      const name = (call.name ?? "").toLowerCase();
+      const parsed = parseToolInput(call.input);
+      if (WRITE_TOOL_NAMES.has(name)) {
+        const filePath = parsed
+          ? firstString(parsed, ["file_path", "filePath", "notebook_path", "path"])
+          : null;
+        if (filePath) {
+          const display = displayPath(filePath, record.cwd);
+          fileCounts.set(display, (fileCounts.get(display) ?? 0) + 1);
+        }
+      } else if (SHELL_TOOL_NAMES.has(name)) {
+        const command = parsed ? readCommand(parsed) : null;
+        if (command && !seenCommands.has(command)) {
+          seenCommands.add(command);
+          commands.push(clamp(command, MAX_COMMAND_CHARS));
+        }
+      }
+    }
+  }
+
+  // Insertion order is chronological; both digests read newest-first, which is
+  // what a reader scanning for "where did this leave off" wants.
+  const files = [...fileCounts.entries()].reverse().map(([display, count]) => ({ display, count }));
+  return {
+    files: files.slice(0, MAX_FILES),
+    totalFiles: files.length,
+    commands: commands.reverse().slice(0, MAX_COMMANDS),
+    totalCommands: commands.length,
+  };
+}
+
+/** Plain-language wording for each machine-readable gap on the record.
+ *  Addressed to the agent reading the brief, so it says what to do about the
+ *  gap rather than merely naming it — the web view (web/src/lib/
+ *  session-record-view.ts) words the same codes for a human reader. */
+const LIMITATION_PROSE: Record<SessionRecordLimitation, string> = {
+  "truncated-tool-output":
+    "Tool output was size-capped when recorded. Any command result quoted below may be cut off — re-run it rather than trusting the excerpt.",
+  "assistant-narration-gap":
+    "Only the final assistant message of each turn was recorded. Whatever was said between tool calls — including reasoning for a change — is missing.",
+  "missing-assistant-text":
+    "At least one turn has no assistant text at all (Codex records none). Those turns show prompts and tool calls only.",
+  "incomplete-final-turn":
+    "The last turn never completed — the session ended mid-turn, so its work may be half-applied.",
+};
+
+function renderTurn(turn: SessionRecordTurn, cwd: string | null): string {
+  const lines: string[] = [];
+  const when = turn.promptAt ?? turn.completedAt;
+  lines.push(`### Turn ${turn.index}${when ? ` · ${when}` : ""}${turn.incomplete ? " · never completed" : ""}`);
+
+  if (turn.prompt !== null) {
+    lines.push("", "**Prompt:**", "", blockquote(clamp(turn.prompt, MAX_PROMPT_CHARS)));
+  } else {
+    lines.push("", "**Prompt:** _not recorded — our recording started mid-turn, or the agent started this turn itself._");
+  }
+
+  if (turn.toolCalls.length > 0) {
+    const shown = turn.toolCalls.slice(0, MAX_TOOLS_PER_TURN).map((call) => {
+      const target = describeToolTarget(call, cwd);
+      return `\`${call.name ?? "unknown tool"}\`${target ? ` ${target}` : ""}`;
+    });
+    const overflow = turn.toolCalls.length - shown.length;
+    lines.push("", `**Tools:** ${shown.join(" · ")}${overflow > 0 ? ` · …and ${overflow} more` : ""}`);
+  }
+
+  if (turn.assistantText !== null) {
+    lines.push("", "**Reply:**", "", blockquote(clamp(turn.assistantText, MAX_ASSISTANT_CHARS)));
+  } else if (!turn.incomplete) {
+    lines.push("", "**Reply:** _not recorded._");
+  }
+
+  return lines.join("\n");
+}
+
+function blockquote(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+/**
+ * The fixed preamble. Never dropped by the budget: an unlabelled
+ * reconstruction is the failure mode this whole feature exists to avoid.
+ */
+const HONESTY_HEADER = `# Continuing a prior session — reconstruction, not restored context
+
+You are a **fresh session**. The agent that ran the session described below is
+gone and none of its context is loaded. What follows was assembled by the
+Sapiom Harness from its own recorded events — it is a briefing about that
+session, not a replay of it, and it is partial by construction.
+
+Treat every claim here as something a colleague told you, not as something you
+remember. Before you rely on any of it — what a file contains, what a command
+returned, whether a task was finished — check the current state of the
+repository yourself. If the brief and the working tree disagree, the working
+tree is right.`;
+
+/**
+ * Render a bounded brief for `record`. Pure and synchronous; the caller
+ * supplies the rolling summary and any registry-only context (title, branch,
+ * bound workflow) it can resolve.
+ */
+export function buildResumeBrief(
+  record: SessionRecord,
+  options: BuildResumeBriefOptions = {},
+): string {
+  const maxTokens = options.maxTokens ?? RESUME_BRIEF_DEFAULT_MAX_TOKENS;
+  const maxTurns = options.maxTurns ?? RESUME_BRIEF_DEFAULT_MAX_TURNS;
+  const budgetChars = Math.max(0, maxTokens) * CHARS_PER_TOKEN;
+
+  const identity = renderIdentity(record, options);
+  // The floor: these two are unconditional, so everything else is budgeted
+  // against whatever remains after them.
+  const fixed = `${HONESTY_HEADER}\n\n${identity}`;
+
+  const digests = deriveDigests(record);
+  const renderedTurns = (maxTurns > 0 ? record.turns.slice(-maxTurns) : []).map((turn) =>
+    renderTurn(turn, record.cwd),
+  );
+
+  // Mutable knobs, squeezed in the order the module header documents: the
+  // derived digests first (recoverable from the tree), then turns oldest-first,
+  // then — only if the summary alone still overflows — the summary itself.
+  let summaryText = options.summary?.trim() ?? "";
+  let keepFiles = true;
+  let keepCommands = true;
+  let keptTurns = renderedTurns.length;
+
+  const assemble = (): string => {
+    const parts = [fixed];
+    const summarySection = renderSummary(summaryText);
+    if (summarySection) parts.push(summarySection);
+    const dropped: string[] = [];
+    const filesSection = keepFiles ? renderFiles(digests) : null;
+    if (filesSection) parts.push(filesSection);
+    else if (!keepFiles && digests.files.length > 0) dropped.push("files written");
+    const commandsSection = keepCommands ? renderCommands(digests) : null;
+    if (commandsSection) parts.push(commandsSection);
+    else if (!keepCommands && digests.commands.length > 0) dropped.push("commands run");
+
+    if (record.turns.length > 0) {
+      const heading = ["## Recent turns"];
+      const omitted = record.turns.length - keptTurns;
+      if (omitted > 0) {
+        heading.push(
+          "",
+          `_The earliest ${omitted} of ${record.turns.length} recorded turns are omitted here to fit the context budget._`,
+        );
+      }
+      if (keptTurns === 0) heading.push("", "_No turns fit the context budget._");
+      parts.push(heading.join("\n"));
+      parts.push(...renderedTurns.slice(renderedTurns.length - keptTurns));
+    }
+    if (dropped.length > 0) {
+      parts.push(`_Also omitted to fit the context budget: ${dropped.join(", ")}._`);
+    }
+    return parts.join("\n\n").trimEnd() + "\n";
+  };
+
+  const over = (): boolean => assemble().length > budgetChars;
+
+  // 1. Turns, oldest-first.
+  while (keptTurns > 0 && over()) keptTurns -= 1;
+  // 2. Derived digests, once no turn is left to give. Commands go first — the
+  //    shorter list, and the one most cheaply reconstructed from the repo.
+  if (over()) keepCommands = false;
+  if (over()) keepFiles = false;
+  // 3. Last resort. Only reachable when the fixed preamble plus the summary
+  //    alone overflow, which means either the summary was produced outside its
+  //    own ≤500-word contract or `maxTokens` is below the preamble floor. Each
+  //    pass strictly shortens `summaryText`, so this terminates.
+  while (summaryText.length > 0 && over()) {
+    const overflow = assemble().length - budgetChars;
+    summaryText = clamp(summaryText, Math.max(0, summaryText.length - overflow - CLAMP_MARKER.length));
+    if (summaryText === CLAMP_MARKER) summaryText = "";
+  }
+
+  return assemble();
+}
+
+function renderIdentity(record: SessionRecord, options: BuildResumeBriefOptions): string {
+  const lines = ["## What the prior session was", ""];
+  if (options.title) lines.push(`- **Title:** ${options.title}`);
+  lines.push(`- **Directory:** ${record.cwd ?? "not recorded"}`);
+  if (options.gitBranch) lines.push(`- **Git branch:** ${options.gitBranch}`);
+  lines.push(`- **Agent:** ${record.harness}`);
+  if (options.workflow) {
+    const { name, path: workflowPath, definitionId } = options.workflow;
+    lines.push(
+      `- **Bound workflow:** ${name} (\`${workflowPath}\`)${
+        definitionId !== null ? ` — definition ${definitionId}` : " — not yet linked to a deployed definition"
+      }`,
+    );
+  } else {
+    lines.push("- **Bound workflow:** none");
+  }
+  const span = [record.startedAt, record.endedAt].filter(Boolean).join(" → ");
+  if (span) lines.push(`- **Ran:** ${span}`);
+  lines.push(`- **Recorded turns:** ${record.turnCount}`);
+
+  if (record.limitations.length > 0) {
+    lines.push("", "**Known gaps in this reconstruction:**", "");
+    for (const limitation of record.limitations) lines.push(`- ${LIMITATION_PROSE[limitation]}`);
+  }
+  return lines.join("\n");
+}
+
+function renderSummary(summary: string | null | undefined): string | null {
+  const trimmed = summary?.trim();
+  if (!trimmed) return null;
+  return `## Rolling summary of the prior session\n\n${trimmed}`;
+}
+
+function renderFiles(digests: DerivedDigests): string | null {
+  if (digests.files.length === 0) return null;
+  const lines = ["## Files the prior session wrote to", "", "_Derived from recorded tool calls, newest first._", ""];
+  for (const file of digests.files) {
+    lines.push(`- \`${file.display}\`${file.count > 1 ? ` (${file.count} edits)` : ""}`);
+  }
+  if (digests.totalFiles > digests.files.length) {
+    lines.push(`- …and ${digests.totalFiles - digests.files.length} more`);
+  }
+  return lines.join("\n");
+}
+
+function renderCommands(digests: DerivedDigests): string | null {
+  if (digests.commands.length === 0) return null;
+  const lines = ["## Shell commands it ran", "", "_Distinct commands, newest first._", ""];
+  for (const command of digests.commands) lines.push(`- \`${command}\``);
+  if (digests.totalCommands > digests.commands.length) {
+    lines.push(`- …and ${digests.totalCommands - digests.commands.length} more`);
+  }
+  return lines.join("\n");
+}

--- a/packages/harness/src/core/rolling-summary.test.ts
+++ b/packages/harness/src/core/rolling-summary.test.ts
@@ -1,0 +1,316 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ROLLING_SUMMARY_MACRO_ID,
+  ROLLING_SUMMARY_MAX_TURNS,
+  ROLLING_SUMMARY_MODEL,
+  buildRollingSummaryPrompt,
+  clampToWords,
+  createRollingSummarizer,
+  readRollingSummary,
+  rollingSummaryPath,
+  type RollingSummarizerDeps,
+} from "./rolling-summary.js";
+import type { AnalyticsEvent, BackgroundTask, SessionRecord } from "../shared/types.js";
+
+const SESSION = "harness-1";
+
+function event(type: AnalyticsEvent["type"], harnessSessionId = SESSION): AnalyticsEvent {
+  return {
+    type,
+    ts: "2026-07-27T10:00:00.000Z",
+    seq: 1,
+    harnessSessionId,
+    harness: "claude-code",
+    agentSessionId: "agent-1",
+    machineId: "machine-1",
+    userId: null,
+    tenantId: null,
+    payload: {},
+  } as AnalyticsEvent;
+}
+
+function record(): SessionRecord {
+  return {
+    harnessSessionId: SESSION,
+    mergedSessionIds: [SESSION],
+    agentSessionId: "agent-1",
+    harness: "claude-code",
+    cwd: "/Users/dev/project",
+    startedAt: "2026-07-27T10:00:00.000Z",
+    endedAt: null,
+    turns: [
+      {
+        index: 1,
+        prompt: "make the backoff jittered",
+        promptAt: "2026-07-27T10:00:00.000Z",
+        toolCalls: [],
+        assistantText: "done",
+        model: "claude-opus-5",
+        usage: null,
+        completedAt: "2026-07-27T10:01:00.000Z",
+        incomplete: false,
+      },
+    ],
+    turnCount: 1,
+    eventCount: 2,
+    reconstructed: true,
+    limitations: [],
+  };
+}
+
+function task(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: "task-1",
+    macroId: ROLLING_SUMMARY_MACRO_ID,
+    label: "Session summary",
+    harnessSessionId: SESSION,
+    cwd: "/Users/dev/project",
+    workflowPath: null,
+    status: "completed",
+    startedAt: "2026-07-27T10:00:00.000Z",
+    endedAt: "2026-07-27T10:00:10.000Z",
+    exitCode: 0,
+    statusLines: [],
+    resultText: "The session made the retry backoff jittered.",
+    errorTail: null,
+    ...overrides,
+  };
+}
+
+describe("rolling summary", () => {
+  let generatedRoot: string;
+  let runs: Parameters<RollingSummarizerDeps["runTask"]>[0][];
+  let errors: unknown[];
+
+  beforeEach(async () => {
+    generatedRoot = await mkdtemp(join(tmpdir(), "harness-rolling-summary-"));
+    runs = [];
+    errors = [];
+  });
+
+  afterEach(async () => {
+    await rm(generatedRoot, { recursive: true, force: true });
+  });
+
+  function summarizer(overrides: Partial<RollingSummarizerDeps> = {}) {
+    return createRollingSummarizer({
+      generatedRoot,
+      enabled: async () => true,
+      readRecord: async () => record(),
+      getSession: () => ({ harness: "claude-code", cwd: "/Users/dev/project" }),
+      runTask: async (req) => {
+        runs.push(req);
+        return task({ id: `task-${runs.length}`, status: "running", resultText: null, endedAt: null });
+      },
+      turnInterval: 3,
+      onError: (err) => errors.push(err),
+      ...overrides,
+    });
+  }
+
+  describe("the opt-in gate", () => {
+    it("never runs a fold when the setting is off", async () => {
+      const rolling = summarizer({ enabled: async () => false });
+      for (let i = 0; i < 10; i += 1) rolling.noteEvent(event("turn.completed"));
+      rolling.noteEvent(event("session.end"));
+      await rolling.idle();
+      expect(runs).toEqual([]);
+      expect(await readRollingSummary(generatedRoot, SESSION)).toBeNull();
+    });
+
+    it("re-reads the gate per fold, so toggling it takes effect without a restart", async () => {
+      let on = false;
+      const rolling = summarizer({ enabled: async () => on });
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toHaveLength(0);
+
+      on = true;
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toHaveLength(1);
+    });
+  });
+
+  describe("when it folds", () => {
+    it("waits for the turn interval rather than folding every turn", async () => {
+      const rolling = summarizer();
+      rolling.noteEvent(event("turn.completed"));
+      rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toHaveLength(0);
+
+      rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toHaveLength(1);
+    });
+
+    it("folds again at session end when turns accumulated since the last one", async () => {
+      const rolling = summarizer();
+      for (let i = 0; i < 4; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toHaveLength(1);
+
+      // The 4th turn is unaccounted for — the summary a later rehydration
+      // reads must not be a whole interval stale.
+      rolling.noteEvent(event("session.end"));
+      await rolling.idle();
+      expect(runs).toHaveLength(2);
+    });
+
+    it("does not fold at session end when nothing happened since the last fold", async () => {
+      const rolling = summarizer();
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      rolling.noteEvent(event("session.end"));
+      await rolling.idle();
+      expect(runs).toHaveLength(1);
+    });
+
+    it("counts turns per session, so two live sessions don't fold each other early", async () => {
+      const rolling = summarizer();
+      rolling.noteEvent(event("turn.completed", "session-a"));
+      rolling.noteEvent(event("turn.completed", "session-b"));
+      rolling.noteEvent(event("turn.completed", "session-a"));
+      await rolling.idle();
+      expect(runs).toHaveLength(0);
+
+      rolling.noteEvent(event("turn.completed", "session-a"));
+      await rolling.idle();
+      expect(runs.map((run) => run.harnessSessionId)).toEqual(["session-a"]);
+    });
+
+    it("skips a session with nothing recorded", async () => {
+      const rolling = summarizer({ readRecord: async () => null });
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toEqual([]);
+    });
+
+    it("skips an id the registry no longer knows (a swept session, or a task's own id)", async () => {
+      const rolling = summarizer({ getSession: () => undefined });
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs).toEqual([]);
+    });
+  });
+
+  describe("the task it runs", () => {
+    it("is a bounded, cheap, one-shot run", async () => {
+      const rolling = summarizer();
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      expect(runs[0]).toMatchObject({
+        macroId: ROLLING_SUMMARY_MACRO_ID,
+        harness: "claude-code",
+        cwd: "/Users/dev/project",
+        model: ROLLING_SUMMARY_MODEL,
+        maxTurns: ROLLING_SUMMARY_MAX_TURNS,
+      });
+    });
+
+    it("never throws into the ingest path when the task can't be spawned", async () => {
+      // TaskManager throws TaskNotSupportedError for a harness with no
+      // launchTask (codex today). That must be a log line, not an exception
+      // travelling back up through a hook POST.
+      const rolling = summarizer({
+        runTask: async () => {
+          throw new Error("codex sessions don't support background tasks yet");
+        },
+      });
+      expect(() => {
+        for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      }).not.toThrow();
+      await rolling.idle();
+      expect(errors).toHaveLength(1);
+      expect(await readRollingSummary(generatedRoot, SESSION)).toBeNull();
+    });
+  });
+
+  describe("writing summary.md", () => {
+    it("writes the completed task's result text", async () => {
+      const rolling = summarizer();
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      rolling.noteTaskStatus(task({ id: "task-1" }));
+      await rolling.idle();
+      expect(await readRollingSummary(generatedRoot, SESSION)).toBe(
+        "The session made the retry backoff jittered.",
+      );
+    });
+
+    it("ignores a task it did not start", async () => {
+      const rolling = summarizer();
+      rolling.noteTaskStatus(task({ id: "some-other-task", macroId: "visualize" }));
+      await rolling.idle();
+      expect(await readRollingSummary(generatedRoot, SESSION)).toBeNull();
+    });
+
+    it("leaves the previous summary in place when a fold fails", async () => {
+      await mkdir(join(generatedRoot, SESSION), { recursive: true });
+      await writeFile(rollingSummaryPath(generatedRoot, SESSION), "the older, still-true summary\n");
+
+      const rolling = summarizer();
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      rolling.noteTaskStatus(task({ id: "task-1", status: "failed", resultText: null, errorTail: "boom" }));
+      await rolling.idle();
+
+      expect(await readRollingSummary(generatedRoot, SESSION)).toBe("the older, still-true summary");
+      expect(errors).toHaveLength(1);
+    });
+
+    it("clamps a runaway summary to the word cap and marks the cut", async () => {
+      const rolling = summarizer();
+      for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+      await rolling.idle();
+      rolling.noteTaskStatus(task({ id: "task-1", resultText: "word ".repeat(2_000) }));
+      await rolling.idle();
+      const written = await readRollingSummary(generatedRoot, SESSION);
+      expect(written).toContain("…[summary truncated]");
+      expect(written!.split(/\s+/).length).toBeLessThan(2_000);
+    });
+  });
+
+  describe("the fold prompt", () => {
+    it("carries the record and asks for a bounded, tool-free, honest summary", () => {
+      const prompt = buildRollingSummaryPrompt(record(), null);
+      expect(prompt).toContain("at most 500 words");
+      expect(prompt).toContain("Do not use any tools");
+      expect(prompt).toContain("Do not invent anything the material does not state");
+      expect(prompt).toContain("make the backoff jittered");
+    });
+
+    it("folds the previous summary back in, since the material is itself capped", () => {
+      const prompt = buildRollingSummaryPrompt(record(), "earlier: chose exponential backoff");
+      expect(prompt).toContain("earlier: chose exponential backoff");
+    });
+  });
+
+  it("clampToWords leaves a summary inside the cap untouched", () => {
+    expect(clampToWords("a short summary", 500)).toBe("a short summary");
+  });
+
+  it("readRollingSummary answers null for a missing or blank file", async () => {
+    expect(await readRollingSummary(generatedRoot, "never-existed")).toBeNull();
+    await mkdir(join(generatedRoot, "blank"), { recursive: true });
+    await writeFile(rollingSummaryPath(generatedRoot, "blank"), "   \n");
+    expect(await readRollingSummary(generatedRoot, "blank")).toBeNull();
+  });
+
+  it("never lets a fold reject unhandled", async () => {
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const rolling = summarizer({ readRecord: async () => Promise.reject(new Error("store on fire")) });
+    for (let i = 0; i < 3; i += 1) rolling.noteEvent(event("turn.completed"));
+    await rolling.idle();
+    await new Promise((resolve) => setImmediate(resolve));
+    process.off("unhandledRejection", unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/packages/harness/src/core/rolling-summary.ts
+++ b/packages/harness/src/core/rolling-summary.ts
@@ -1,0 +1,283 @@
+/**
+ * Rolling session summary — the thing that makes rehydration good rather than
+ * merely possible.
+ *
+ * A resume brief built from the last N turns alone tells a fresh session what
+ * just happened; it cannot tell it what the session was *for*. So, opt-in, we
+ * periodically fold the whole record down to a ≤500-word summary and cache it
+ * at `<generated>/<harnessSessionId>/summary.md`. The brief
+ * (core/resume-brief.ts) picks it up when it's there and degrades cleanly to
+ * last-N-turns when it isn't — which is the default, since this is
+ * setting-gated (`HarnessSettings.rollingSummary`).
+ *
+ * NEVER BLOCKS A TURN. Everything here is fire-and-forget off the ingest path:
+ * `noteEvent` returns synchronously, the fold runs as a headless one-shot
+ * `TaskManager` job (a separate process, a cheap model, `--max-turns 1` — the
+ * bounded shape `HarnessAdapter.launchTask` exists for), and every failure
+ * mode short-circuits to "no summary". A user's session must never be slower,
+ * or fail, because a summary didn't happen.
+ *
+ * The task does not write the file itself. It is asked for the summary text
+ * and nothing else; we write `summary.md` from its `resultText` when it
+ * completes. Two reasons: the target lives under `<generated>/`, outside the
+ * session's cwd — which codex's `workspace-write` sandbox forbids and
+ * claude-code's `acceptEdits` shouldn't be asked to reach — and a task that
+ * writes its own output can half-write it, where a task that returns text
+ * either produces a whole summary or none.
+ *
+ * WHERE IT DOESN'T WORK: `launchTask` is optional on the adapter contract and
+ * codex has no non-interactive mode wired for it, so a codex session simply
+ * never produces a summary and its briefs are last-N-turns. That is a real
+ * gap, stated rather than papered over; the brief is honest either way.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import type { AnalyticsEvent, BackgroundTask, HarnessKind, SessionRecord } from "../shared/types.js";
+import { buildResumeBrief } from "./resume-brief.js";
+
+/** Filename under `<generated>/<harnessSessionId>/`. */
+export const ROLLING_SUMMARY_FILE = "summary.md";
+/** Completed turns that must accumulate before a re-fold is worth its cost. */
+export const ROLLING_SUMMARY_TURN_INTERVAL = 10;
+/** The contract stated in the prompt, and the clamp applied to what comes back. */
+export const ROLLING_SUMMARY_MAX_WORDS = 500;
+/**
+ * Model alias for the fold. A summary of text we already hold is the cheapest
+ * possible LLM job — pinning a small model here keeps an opt-in background
+ * feature from quietly costing what the user's own session does.
+ */
+export const ROLLING_SUMMARY_MODEL = "haiku";
+/** Hard turn cap: one turn in, one summary out. */
+export const ROLLING_SUMMARY_MAX_TURNS = 1;
+/** Macro id the task is registered under — also TaskManager's dedupe key, so
+ *  a session can never have two folds in flight at once. */
+export const ROLLING_SUMMARY_MACRO_ID = "rolling-summary";
+/**
+ * Token budget for the material handed to the fold. Larger than a brief's
+ * (this is throwaway input to a cheap model, not a system prompt competing
+ * with the user's own context) but still bounded, so a marathon session can't
+ * turn one fold into a huge request.
+ */
+export const ROLLING_SUMMARY_INPUT_MAX_TOKENS = 20_000;
+
+/** Absolute path of a session's cached summary. */
+export function rollingSummaryPath(generatedRoot: string, harnessSessionId: string): string {
+  return path.join(generatedRoot, harnessSessionId, ROLLING_SUMMARY_FILE);
+}
+
+/**
+ * The cached summary for a session, or null when there is none — never throws.
+ * A brief that fails to find a summary is a brief without one, not an error.
+ */
+export async function readRollingSummary(
+  generatedRoot: string,
+  harnessSessionId: string,
+): Promise<string | null> {
+  try {
+    const text = await fs.readFile(rollingSummaryPath(generatedRoot, harnessSessionId), "utf8");
+    const trimmed = text.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Trim `text` to at most `maxWords` words, marking the cut. */
+export function clampToWords(text: string, maxWords: number = ROLLING_SUMMARY_MAX_WORDS): string {
+  const words = text.trim().split(/\s+/);
+  if (words.length <= maxWords) return text.trim();
+  return `${words.slice(0, maxWords).join(" ")} …[summary truncated]`;
+}
+
+/**
+ * The one-shot prompt handed to `launchTask`. The material is the record
+ * rendered by {@link buildResumeBrief} at a larger budget — deliberately the
+ * same renderer the brief uses, so the fold reads exactly the shape a future
+ * brief will present, and there is one place where "what a record looks like
+ * as text" is defined.
+ *
+ * `previous` is folded back in rather than discarded: the record itself is
+ * capped at the input budget, so on a long session the earliest turns are
+ * already gone from the material, and the last summary is the only surviving
+ * account of them.
+ */
+export function buildRollingSummaryPrompt(record: SessionRecord, previous: string | null): string {
+  const material = buildResumeBrief(record, {
+    summary: previous,
+    maxTokens: ROLLING_SUMMARY_INPUT_MAX_TOKENS,
+    maxTurns: Number.MAX_SAFE_INTEGER,
+  });
+  return [
+    `Summarize the coding session described below in at most ${ROLLING_SUMMARY_MAX_WORDS} words.`,
+    "",
+    "The summary is read by a FRESH agent session that has none of this context,",
+    "so write for someone picking the work up cold. Cover, in this order and only",
+    "where the material actually supports it:",
+    "",
+    "1. What the session was trying to accomplish.",
+    "2. What was decided, and why — decisions are the part a transcript replay",
+    "   cannot reconstruct.",
+    "3. What was actually changed (files, behaviour).",
+    "4. What is unfinished, blocked, or known-broken.",
+    "",
+    "Rules:",
+    "- Output ONLY the summary as markdown prose. No preamble, no sign-off, no",
+    "  code fences around the whole thing.",
+    "- Do not invent anything the material does not state. If something is",
+    "  unclear or was never recorded, say so or leave it out — a confident",
+    "  summary of a gap is the single worst outcome here.",
+    "- Do not use any tools. Everything you need is in this prompt.",
+    "",
+    "--- SESSION MATERIAL ---",
+    "",
+    material,
+  ].join("\n");
+}
+
+/** What the summarizer needs from the outside world. All injectable, so the
+ *  unit tests drive it without a filesystem or a spawned process. */
+export interface RollingSummarizerDeps {
+  /** Root the per-session generated dirs live under. */
+  generatedRoot: string;
+  /** The `HarnessSettings.rollingSummary` gate, re-read per fold so toggling
+   *  the setting takes effect without a restart. Never throws. */
+  enabled: () => Promise<boolean>;
+  /** Reads the reconstructed record for a session (SessionRecordReader.read). */
+  readRecord: (harnessSessionId: string) => Promise<SessionRecord | null>;
+  /** The live session, for the harness kind and cwd the task runs as. Returns
+   *  undefined once the session is gone from the registry. */
+  getSession: (harnessSessionId: string) => { harness: HarnessKind; cwd: string } | undefined;
+  /** TaskManager.run, narrowed to what this needs. */
+  runTask: (req: {
+    macroId: string;
+    label: string;
+    harnessSessionId: string;
+    harness: HarnessKind;
+    cwd: string;
+    prompt: string;
+    model: string;
+    maxTurns: number;
+  }) => Promise<BackgroundTask>;
+  /** Completed turns between folds. Default {@link ROLLING_SUMMARY_TURN_INTERVAL}. */
+  turnInterval?: number;
+  /** Diagnostics sink. Defaults to console.error — a fold failing is worth a
+   *  log line and nothing more. */
+  onError?: (err: unknown) => void;
+}
+
+export interface RollingSummarizer {
+  /**
+   * Feed one normalized analytics event. Synchronous and total: it counts
+   * `turn.completed`, triggers a fold on the interval and on `session.end`,
+   * and ignores everything else. Any work it starts is detached.
+   */
+  noteEvent(event: AnalyticsEvent): void;
+  /**
+   * Feed a task status change (TaskManager.onStatusChange). A completed fold
+   * task's `resultText` is what becomes `summary.md`.
+   */
+  noteTaskStatus(task: BackgroundTask): void;
+  /** Resolves when no fold this summarizer started is still in flight. For
+   *  tests and for shutdown; production callers never need to await it. */
+  idle(): Promise<void>;
+}
+
+export function createRollingSummarizer(deps: RollingSummarizerDeps): RollingSummarizer {
+  const turnInterval = deps.turnInterval ?? ROLLING_SUMMARY_TURN_INTERVAL;
+  const onError = deps.onError ?? ((err: unknown) => console.error("[harness] rolling summary failed:", err));
+
+  /** Completed turns seen for a session since its last fold was *started*. */
+  const turnsSinceFold = new Map<string, number>();
+  /** Fold task id → the session it summarizes, so a completion can be routed
+   *  back. Only ids this summarizer started are ever in here, which is what
+   *  keeps it from writing summary.md for some other background task. */
+  const foldTargets = new Map<string, string>();
+  /** In-flight promises, awaited by `idle()`. */
+  const pending = new Set<Promise<void>>();
+
+  const track = (work: Promise<void>): void => {
+    const tracked = work.catch(onError).finally(() => pending.delete(tracked));
+    pending.add(tracked);
+  };
+
+  async function fold(harnessSessionId: string): Promise<void> {
+    if (!(await deps.enabled())) return;
+    const session = deps.getSession(harnessSessionId);
+    // Gone from the registry (swept, or a task's own id leaking through the
+    // ingest path) — there is nothing to run the fold as.
+    if (!session) return;
+    const record = await deps.readRecord(harnessSessionId);
+    if (!record || record.turns.length === 0) return;
+
+    const previous = await readRollingSummary(deps.generatedRoot, harnessSessionId);
+    const task = await deps.runTask({
+      macroId: ROLLING_SUMMARY_MACRO_ID,
+      label: "Session summary",
+      harnessSessionId,
+      harness: session.harness,
+      cwd: session.cwd,
+      prompt: buildRollingSummaryPrompt(record, previous),
+      model: ROLLING_SUMMARY_MODEL,
+      maxTurns: ROLLING_SUMMARY_MAX_TURNS,
+    });
+    foldTargets.set(task.id, harnessSessionId);
+  }
+
+  async function writeSummary(harnessSessionId: string, text: string): Promise<void> {
+    const clamped = clampToWords(text.trim());
+    if (clamped.length === 0) return;
+    const filePath = rollingSummaryPath(deps.generatedRoot, harnessSessionId);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${clamped}\n`, "utf8");
+  }
+
+  return {
+    noteEvent(event: AnalyticsEvent): void {
+      const sessionId = event.harnessSessionId;
+      if (event.type === "turn.completed") {
+        const count = (turnsSinceFold.get(sessionId) ?? 0) + 1;
+        if (count < turnInterval) {
+          turnsSinceFold.set(sessionId, count);
+          return;
+        }
+        // Reset BEFORE the fold rather than after it completes: the counter
+        // paces how often folds are *started*, and resetting on completion
+        // would let a slow fold queue up a second one the moment it lands.
+        turnsSinceFold.set(sessionId, 0);
+        track(fold(sessionId));
+        return;
+      }
+      if (event.type === "session.end") {
+        // Always fold at session end when anything at all happened since the
+        // last one — this is the summary a future rehydration will actually
+        // read, so it must not be `turnInterval - 1` turns stale.
+        const pendingTurns = turnsSinceFold.get(sessionId) ?? 0;
+        turnsSinceFold.delete(sessionId);
+        if (pendingTurns > 0) track(fold(sessionId));
+      }
+    },
+
+    noteTaskStatus(task: BackgroundTask): void {
+      const harnessSessionId = foldTargets.get(task.id);
+      if (harnessSessionId === undefined) return;
+      if (task.status === "running") return;
+      foldTargets.delete(task.id);
+      if (task.status === "failed" || !task.resultText) {
+        // A failed fold leaves the previous summary in place — a stale summary
+        // is strictly better than none, and the brief labels its own age via
+        // the record's own timestamps either way.
+        if (task.status === "failed") onError(new Error(task.errorTail ?? "rolling summary task failed"));
+        return;
+      }
+      track(writeSummary(harnessSessionId, task.resultText));
+    },
+
+    async idle(): Promise<void> {
+      // Re-read the set each pass: writing a summary is itself tracked work
+      // started by an earlier tracked promise.
+      while (pending.size > 0) await Promise.all([...pending]);
+    },
+  };
+}

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -187,7 +187,7 @@ export type SessionActivityListener = (harnessSessionId: string) => void;
  */
 export type LaunchOptsBuilder = (
   harnessSessionId: string,
-  req: Pick<CreateSessionRequest, "cwd" | "harness" | "profile">,
+  req: Pick<CreateSessionRequest, "cwd" | "harness" | "profile" | "rehydrateFrom">,
 ) => Omit<LaunchOpts, "harnessSessionId" | "cwd"> | Promise<Omit<LaunchOpts, "harnessSessionId" | "cwd">>;
 
 const defaultBuildLaunchOpts: LaunchOptsBuilder = () => ({});
@@ -398,6 +398,11 @@ export class SessionManager {
       lastActiveAt: this.now(),
       exitCode: null,
       boundWorkflowPath: null,
+      // What the builder actually managed to assemble, not what the caller
+      // asked for: `req.rehydrateFrom` naming a session our event log holds
+      // nothing for yields no brief, and this stays null so nothing downstream
+      // presents an empty-handed fresh session as a continuation.
+      rehydratedFrom: opts.rehydratedFrom ?? null,
       ready: false,
     };
     this.sessions.set(id, session);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -24,6 +24,8 @@ import type {
   HarnessAdapter,
   HarnessKind,
   HarnessSession,
+  SessionRecord,
+  SystemPromptDelivery,
   WorkflowInfo,
 } from "../shared/types.js";
 import { JSON_BODY_LIMIT_BYTES } from "../shared/types.js";
@@ -46,6 +48,14 @@ import {
   createClaudeTranscriptEnricher,
   createSessionRecordReader,
 } from "../core/session-record.js";
+import {
+  buildRehydrationBrief,
+  systemPromptDeliveryFor,
+} from "../core/rehydration.js";
+import {
+  createRollingSummarizer,
+  readRollingSummary,
+} from "../core/rolling-summary.js";
 import { createHarnessEmitter } from "../core/collector/analytics-emitter.js";
 import { migrateHarnessIdentity } from "../core/collector/identity-migration.js";
 import { normalizeHookEvent } from "../core/collector/normalizer.js";
@@ -57,7 +67,7 @@ import {
   type CodexTailerHandle,
 } from "../core/collector/codex-tailer.js";
 import { getOrCreateMachineId } from "../cli/machine-id.js";
-import { pruneDeadRecentDirs } from "../cli/settings.js";
+import { loadSettings, pruneDeadRecentDirs } from "../cli/settings.js";
 import type { HarnessIdentity } from "../cli/auth.js";
 import { generateClaudeSettings } from "../core/inject/claude-settings.js";
 import { generateMcpConfig } from "../core/inject/mcp-config.js";
@@ -282,8 +292,38 @@ function readVersion(): string {
 function createDefaultBuildLaunchOpts(
   apiKey: string | null,
   generatedRoot?: string,
+  rehydration?: {
+    /** Brief text for a prior session id, or null when nothing was recorded. */
+    buildBrief: (rehydrateFrom: string) => Promise<string | null>;
+    /** Which channel this harness receives a brief on. */
+    deliveryFor: (harness: HarnessKind) => SystemPromptDelivery;
+  },
 ): LaunchOptsBuilder {
-  return async (harnessSessionId) => {
+  return async (harnessSessionId, req) => {
+    // Portable continue (SAP-2059). Resolved before the prompt file is
+    // written, because for a `launch-flag` harness the brief IS part of that
+    // file. Best-effort throughout: a brief that can't be assembled leaves
+    // `rehydratedFrom` unset and the session launches as an ordinary fresh
+    // one rather than failing — see CreateSessionRequest.rehydrateFrom.
+    //
+    // Only ever set on create(): resume() calls this builder with the persisted
+    // HarnessSession, which carries no `rehydrateFrom`, so a rehydrated session
+    // that is later resumed does not get the brief a second time (the agent's
+    // own conversation already holds it).
+    const rehydrateFrom = req.rehydrateFrom;
+    const brief =
+      rehydrateFrom && rehydration
+        ? await rehydration.buildBrief(rehydrateFrom).catch((err: unknown) => {
+            console.error("[harness] rehydration brief failed:", err);
+            return null;
+          })
+        : null;
+    // The other channel (post-ready injection, for a harness with no prompt
+    // flag) is driven from the session status handler in startServer — the
+    // brief must not go into a file that adapter never reads.
+    const viaSystemPrompt =
+      brief !== null && rehydration?.deliveryFor(req.harness) === "launch-flag";
+
     const [settings, mcpConfigFile, systemPromptFile, pluginDir] =
       await Promise.all([
         generateClaudeSettings({ harnessSessionId, generatedRoot }),
@@ -292,7 +332,10 @@ function createDefaultBuildLaunchOpts(
           apiKey,
           generatedRoot,
         }),
-        generateSystemPromptFile(harnessSessionId, { generatedRoot }),
+        generateSystemPromptFile(harnessSessionId, {
+          generatedRoot,
+          ...(viaSystemPrompt ? { appendix: brief } : {}),
+        }),
         generateSkillsPlugin(harnessSessionId, { generatedRoot }),
       ]);
     return {
@@ -300,6 +343,9 @@ function createDefaultBuildLaunchOpts(
       mcpConfigFile,
       systemPromptFile,
       ...(pluginDir ? { pluginDir } : {}),
+      // Set on BOTH channels: the post-ready path hasn't delivered yet, but a
+      // brief exists and will, and this is the flag that tells it to.
+      ...(brief !== null && rehydrateFrom ? { rehydratedFrom: rehydrateFrom } : {}),
     };
   };
 }
@@ -491,6 +537,22 @@ export const startServer = async (
     await writeHarnessContext(session, boundWorkflow, workflowsCache);
   };
 
+  // Declared before the launch-opts builder (rather than beside the ingest
+  // pipeline, where the rest of the event wiring lives) because portable
+  // continue resolves a rehydration brief from this reader at session-create
+  // time — see createDefaultBuildLaunchOpts below.
+  const eventStorePath = options.eventStorePath ?? statePaths.events;
+  const eventStore = createEventStore(eventStorePath);
+
+  // Past-session transcripts, rebuilt from our own events rather than from
+  // any vendor's history file — the same code path for claude-code and codex.
+  // The claude enricher is a pure bonus on top: when that transcript happens
+  // to still exist, the final turn gains its model/usage; when it doesn't, the
+  // record renders unchanged.
+  const sessionRecordReader = createSessionRecordReader(eventStore, {
+    enrichFinalTurn: createClaudeTranscriptEnricher(),
+  });
+
   // Exit-time deletion of generated/<id> (see the onStatusChange handler
   // below) can race a fast resume(): resume regenerates the dir via
   // buildLaunchOpts, and the rm scheduled at the previous exit could still
@@ -498,9 +560,67 @@ export const startServer = async (
   // before (re)generating its files.
   const generatedRoot = options.generatedRoot ?? statePaths.generated;
   const pendingGeneratedRemovals = new Map<string, Promise<void>>();
+
+  /**
+   * The git branch the PRIOR session was last on, from whichever adapter
+   * recorded it — our own events never carry one. One adapter history scan per
+   * rehydrate, which is a user-initiated "continue this session" click rather
+   * than a hot path (the reason `GET /sessions/history` avoids per-row probes
+   * doesn't apply to a single deliberate action). Null for a harness whose
+   * transcript doesn't record a branch, and never throws.
+   */
+  const priorGitBranch = async (record: SessionRecord): Promise<string | null> => {
+    if (!record.cwd || !record.agentSessionId) return null;
+    const adapter = adapters[record.harness];
+    if (!adapter) return null;
+    try {
+      const rows = await adapter.listPastSessions(record.cwd);
+      return rows.find((row) => row.agentSessionId === record.agentSessionId)?.gitBranch ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  /**
+   * Portable continue: the brief text for a `rehydrateFrom` id, or null when
+   * our event log holds nothing for it.
+   *
+   * Closes over `sessionManager` (declared just below, since it consumes the
+   * builder this feeds) for the prior session's title and workflow binding —
+   * safe because nothing can create a session before the manager that creates
+   * them exists.
+   */
+  const resolveRehydrationBrief = (rehydrateFrom: string): Promise<string | null> =>
+    buildRehydrationBrief(rehydrateFrom, {
+      readRecord: (id) => sessionRecordReader.read(id),
+      readSummary: (harnessSessionId) => readRollingSummary(generatedRoot, harnessSessionId),
+      resolveContext: async (record) => {
+        // The earliest merged session the registry still knows — the record's
+        // own primary id first, so a conversation that spans a resume reports
+        // where it began rather than whichever segment happens to be indexed.
+        const prior = record.mergedSessionIds
+          .map((id) => sessionManager.get(id))
+          .find((session) => session !== undefined);
+        const workflowPath = prior?.boundWorkflowPath ?? null;
+        const workflow = workflowPath
+          ? (workflowsCache.find((w) => w.path === workflowPath) ?? null)
+          : null;
+        return {
+          title: prior?.title ?? null,
+          gitBranch: await priorGitBranch(record),
+          workflow: workflow
+            ? { name: workflow.name, path: workflow.path, definitionId: workflow.definitionId }
+            : null,
+        };
+      },
+    });
+
   const innerBuildLaunchOpts =
     options.buildLaunchOpts ??
-    createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot);
+    createDefaultBuildLaunchOpts(identity?.apiKey ?? null, generatedRoot, {
+      buildBrief: resolveRehydrationBrief,
+      deliveryFor: (harness) => systemPromptDeliveryFor(adapters[harness]),
+    });
   const buildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId, req) => {
     await pendingGeneratedRemovals.get(harnessSessionId);
     return innerBuildLaunchOpts(harnessSessionId, req);
@@ -527,6 +647,38 @@ export const startServer = async (
   );
   sessionSweepTimer.unref?.();
 
+  // Portable continue, second channel: for a harness whose adapter never puts
+  // `systemPromptFile` in front of the agent, the brief is injected once the
+  // session reports `ready` — not merely "running", which for a TUI sitting on
+  // a "trust this directory?" prompt would feed the brief to the prompt. No
+  // adapter shipped today needs this (both declare `launch-flag`), so it is
+  // dormant rather than dead: a new harness with no prompt flag gets working
+  // rehydration from one line in its adapter.
+  const briefsDelivered = new Set<string>();
+  sessionManager.onStatusChange((session) => {
+    if (session.status === "exited") {
+      briefsDelivered.delete(session.id);
+      return;
+    }
+    const rehydratedFrom = session.rehydratedFrom;
+    if (!session.ready || !rehydratedFrom) return;
+    if (systemPromptDeliveryFor(adapters[session.harness]) !== "post-ready-injection") return;
+    if (briefsDelivered.has(session.id)) return;
+    // Claimed before the await so a burst of status frames can't double-inject.
+    briefsDelivered.add(session.id);
+    void (async () => {
+      const brief = await resolveRehydrationBrief(rehydratedFrom);
+      if (!brief) return;
+      // submit:true — the brief has to enter the conversation to be context at
+      // all; left unsubmitted it would just sit in the composer as a wall of
+      // text the user has to deal with before they can type.
+      await sessionManager.submitInput(session.id, brief, true);
+    })().catch((err: unknown) => {
+      briefsDelivered.delete(session.id);
+      console.error("[harness] post-ready rehydration injection failed:", err);
+    });
+  });
+
   // Background tasks (canvas enrichment today): headless one-shot agent
   // runs that never touch a user's interactive session. They
   // reuse the exact same per-id config generation as sessions — a task's
@@ -550,6 +702,25 @@ export const startServer = async (
   taskManager.onStatusChange((task) => {
     bus.publish({ type: "task.status", task });
   });
+
+  // Rolling summary (opt-in, `HarnessSettings.rollingSummary`): folds a live
+  // session's record into a ≤500-word summary.md that a later portable
+  // continue reads. Everything about it is detached from the session's own
+  // path — `noteEvent` is synchronous and the fold is a separate headless
+  // process — so a turn is never slower or riskier for it being on. A codex
+  // session produces none (no `launchTask`); its briefs degrade to
+  // last-N-turns, which is also the default for everyone with the setting off.
+  const rollingSummarizer = createRollingSummarizer({
+    generatedRoot,
+    enabled: async () => (await loadSettings(statePaths.settings)).rollingSummary === true,
+    readRecord: (harnessSessionId) => sessionRecordReader.read(harnessSessionId),
+    getSession: (harnessSessionId) => {
+      const session = sessionManager.get(harnessSessionId);
+      return session ? { harness: session.harness, cwd: session.cwd } : undefined;
+    },
+    runTask: (req) => taskManager.run(req),
+  });
+  taskManager.onStatusChange((task) => rollingSummarizer.noteTaskStatus(task));
 
   // One boot-time sweep for generated dirs the exit-time cleanup below never
   // reached (crashes, force-kills, accumulation from before retention
@@ -738,18 +909,6 @@ export const startServer = async (
       return [] as WorkflowInfo[];
     },
   );
-
-  const eventStorePath = options.eventStorePath ?? statePaths.events;
-  const eventStore = createEventStore(eventStorePath);
-
-  // Past-session transcripts, rebuilt from the events above rather than from
-  // any vendor's history file — the same code path for claude-code and codex.
-  // The claude enricher is a pure bonus on top: when that transcript happens
-  // to still exist, the final turn gains its model/usage; when it doesn't, the
-  // record renders unchanged.
-  const sessionRecordReader = createSessionRecordReader(eventStore, {
-    enrichFinalTurn: createClaudeTranscriptEnricher(),
-  });
 
   // Boot-time retention sweep: keeps events.ndjson within the 50 MB / 30-day
   // caps even on long-lived installs. Runs through the store's exclusive queue
@@ -1010,6 +1169,9 @@ export const startServer = async (
     batcher,
     enrichFromTranscript: enrichTurnCompleted,
     onNormalizedEvent: (event: AnalyticsEvent) => {
+      // Synchronous and total — it counts turns and detaches any fold it
+      // decides to start, so the ingest path never waits on a summary.
+      rollingSummarizer.noteEvent(event);
       if (event.type !== "tool.call") return;
       const { toolInput, toolResponseSummary } = event.payload as {
         toolInput?: unknown;

--- a/packages/harness/src/server/rehydrate-session.test.ts
+++ b/packages/harness/src/server/rehydrate-session.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Wiring-level proof of portable continue (SAP-2059): a `rehydrate` history
+ * row starts a FRESH session that knows what the previous one was doing,
+ * without any vendor transcript being involved.
+ *
+ * Deliberately end-to-end through the real server: the units are covered in
+ * core/resume-brief.test.ts and core/rehydration.test.ts, and what those
+ * cannot show is that the brief actually reaches the file the adapter reads.
+ * The assertions run against `<generated>/<id>/system-prompt.txt` — the exact
+ * bytes claude-code passes to `--append-system-prompt` and codex inlines as
+ * `developer_instructions` — which is why the same test body runs for both
+ * harnesses.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer, type HarnessServer } from "./index.js";
+import { DEFAULT_SYSTEM_PROMPT } from "../profiles/default.js";
+import { rollingSummaryPath } from "../core/rolling-summary.js";
+import type {
+  AnalyticsEvent,
+  AnalyticsEventType,
+  HarnessAdapter,
+  HarnessKind,
+  LaunchOpts,
+  SpawnSpec,
+} from "../shared/types.js";
+
+const PRIOR_SESSION = "prior-harness-session";
+const PRIOR_AGENT_SESSION = "prior-agent-session";
+
+/** An adapter shaped like the real one for `harness`, spawning bash so the pty
+ *  is real and killable. Declares `launch-flag` exactly as both shipped
+ *  adapters do, so the delivery channel under test is the production one. */
+function fakeAdapter(harness: HarnessKind): HarnessAdapter {
+  const spec = (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd });
+  return {
+    id: harness,
+    eventSource: harness === "codex" ? "transcript-tail" : "hooks",
+    systemPromptDelivery: "launch-flag",
+    doctor: async () => [],
+    launch: spec,
+    resume: (_agentSessionId, opts) => spec(opts),
+    listPastSessions: async () => [
+      {
+        agentSessionId: PRIOR_AGENT_SESSION,
+        harness,
+        cwd: "",
+        title: "Retry backoff",
+        lastActiveAt: "2026-07-27T11:00:00.000Z",
+        source: "transcript" as const,
+        gitBranch: "feat/SAP-2059",
+      },
+    ],
+    canResume: async () => false,
+  };
+}
+
+describe("portable continue — rehydrating a fresh session", () => {
+  let dir: string;
+  let generatedRoot: string;
+  let cwd: string;
+  let server: HarnessServer | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "harness-rehydrate-"));
+    generatedRoot = join(dir, "generated");
+    cwd = join(dir, "project");
+    await mkdir(cwd, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    await server?.sessionManager.flush();
+    server = undefined;
+    // Retried: a session's exit-time `removeGeneratedSessionDir` is
+    // fire-and-forget, so it can still be deleting inside `generated/` while
+    // this tears the whole scratch root down (ENOTEMPTY).
+    await rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  });
+
+  /** Seed events.ndjson with a prior session the harness recorded itself —
+   *  the whole point being that no vendor transcript exists for it. */
+  async function seedPriorSession(harness: HarnessKind): Promise<void> {
+    const base = {
+      seq: 1,
+      userId: null,
+      tenantId: null,
+      machineId: "machine-1",
+      harnessSessionId: PRIOR_SESSION,
+      agentSessionId: PRIOR_AGENT_SESSION,
+      harness,
+    };
+    const at = (minutes: number): string =>
+      `2026-07-27T10:${String(minutes).padStart(2, "0")}:00.000Z`;
+    const event = (
+      n: number,
+      type: AnalyticsEventType,
+      payload: Record<string, unknown>,
+    ): AnalyticsEvent => ({ ...base, eventId: `event-${n}`, seq: n, ts: at(n), type, payload });
+
+    const events: AnalyticsEvent[] = [
+      event(1, "session.start", { source: "startup", cwd }),
+      event(2, "prompt.submitted", { prompt: "make the retry backoff jittered" }),
+      event(3, "tool.call", {
+        toolName: "Edit",
+        toolInput: JSON.stringify({ file_path: join(cwd, "src/retry.ts") }),
+        toolResponseSummary: "ok",
+      }),
+      event(4, "tool.call", {
+        toolName: "Bash",
+        toolInput: JSON.stringify({ command: "pnpm build" }),
+        toolResponseSummary: "built",
+      }),
+      event(5, "turn.completed", { assistantText: "Jitter is in; the tests still need updating." }),
+      event(6, "session.end", { reason: "exit" }),
+    ];
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "events.ndjson"),
+      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
+      "utf8",
+    );
+  }
+
+  async function boot(harness: HarnessKind): Promise<HarnessServer> {
+    return startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      adapters: { [harness]: fakeAdapter(harness) },
+      stateRoot: dir,
+    });
+  }
+
+  async function systemPrompt(harnessSessionId: string): Promise<string> {
+    return readFile(join(generatedRoot, harnessSessionId, "system-prompt.txt"), "utf8");
+  }
+
+  // The acceptance criterion "same code path works for claude-code and codex"
+  // is the reason this is a table rather than one case: nothing in the body
+  // differs per harness, which is exactly the claim.
+  for (const harness of ["claude-code", "codex"] as const) {
+    describe(harness, () => {
+      it("seeds a fresh session with what the prior one was doing", async () => {
+        await seedPriorSession(harness);
+        server = await boot(harness);
+
+        const session = await server.sessionManager.create({
+          cwd,
+          harness,
+          rehydrateFrom: PRIOR_SESSION,
+        });
+        expect(session.rehydratedFrom).toBe(PRIOR_SESSION);
+        // A genuinely new session, not a reattach — nothing was resumed.
+        expect(session.id).not.toBe(PRIOR_SESSION);
+        expect(session.agentSessionId).toBeNull();
+
+        const prompt = await systemPrompt(session.id);
+        // The harness's own profile is still there — the brief is appended to
+        // it, never a replacement for it.
+        expect(prompt).toContain(DEFAULT_SYSTEM_PROMPT.slice(0, 60));
+        // …and it is labelled as a reconstruction before anything else.
+        expect(prompt).toContain("reconstruction, not restored context");
+        // What the session was doing.
+        expect(prompt).toContain("make the retry backoff jittered");
+        expect(prompt).toContain("Jitter is in; the tests still need updating.");
+        expect(prompt).toContain("src/retry.ts");
+        expect(prompt).toContain("pnpm build");
+        expect(prompt).toContain(cwd);
+        // Registry-only context the record itself cannot carry.
+        expect(prompt).toContain("feat/SAP-2059");
+      });
+
+      it("resolves the prior session by the agent's own id too", async () => {
+        // Transcript-only history rows carry no harnessSessionId at all, so
+        // the id the SPA posts is often the agent's.
+        await seedPriorSession(harness);
+        server = await boot(harness);
+        const session = await server.sessionManager.create({
+          cwd,
+          harness,
+          rehydrateFrom: PRIOR_AGENT_SESSION,
+        });
+        expect(session.rehydratedFrom).toBe(PRIOR_AGENT_SESSION);
+        expect(await systemPrompt(session.id)).toContain("make the retry backoff jittered");
+      });
+
+      it("includes the rolling summary when one was produced, and degrades without it", async () => {
+        await seedPriorSession(harness);
+        server = await boot(harness);
+
+        const withoutSummary = await server.sessionManager.create({
+          cwd,
+          harness,
+          rehydrateFrom: PRIOR_SESSION,
+        });
+        expect(await systemPrompt(withoutSummary.id)).not.toContain("Rolling summary");
+
+        await mkdir(join(generatedRoot, PRIOR_SESSION), { recursive: true });
+        await writeFile(
+          rollingSummaryPath(generatedRoot, PRIOR_SESSION),
+          "Migrating the retry path to jittered backoff; tests not yet updated.\n",
+        );
+        const withSummary = await server.sessionManager.create({
+          cwd,
+          harness,
+          rehydrateFrom: PRIOR_SESSION,
+        });
+        expect(await systemPrompt(withSummary.id)).toContain(
+          "Migrating the retry path to jittered backoff",
+        );
+      });
+
+      it("starts a plain session, honestly unmarked, when nothing was recorded for the id", async () => {
+        // A history row can exist with no events of ours behind it. Refusing
+        // would block the only thing still possible for that row; pretending
+        // would be the dishonesty this epic exists to remove.
+        server = await boot(harness);
+        const session = await server.sessionManager.create({
+          cwd,
+          harness,
+          rehydrateFrom: "never-recorded-anything",
+        });
+        expect(session.status).toBe("running");
+        expect(session.rehydratedFrom).toBeNull();
+        const prompt = await systemPrompt(session.id);
+        expect(prompt).not.toContain("reconstruction, not restored context");
+        expect(prompt).toContain(DEFAULT_SYSTEM_PROMPT.slice(0, 60));
+      });
+
+      it("leaves an ordinary new session untouched", async () => {
+        await seedPriorSession(harness);
+        server = await boot(harness);
+        const session = await server.sessionManager.create({ cwd, harness });
+        expect(session.rehydratedFrom).toBeNull();
+        expect(await systemPrompt(session.id)).not.toContain("reconstruction, not restored context");
+      });
+    });
+  }
+
+  describe("the post-ready injection channel", () => {
+    /** No shipped adapter needs this — both declare `launch-flag` — so this
+     *  is the proof that a future harness with no prompt flag gets working
+     *  rehydration from one line in its adapter rather than silence. */
+    function promptFlaglessAdapter(): HarnessAdapter {
+      return { ...fakeAdapter("claude-code"), systemPromptDelivery: "post-ready-injection" };
+    }
+
+    async function bootFlagless(): Promise<HarnessServer> {
+      return startServer({
+        port: 0,
+        bootToken: "test-token",
+        telemetryOptIn: false,
+        autoCreateSession: false,
+        adapters: { "claude-code": promptFlaglessAdapter() },
+        stateRoot: dir,
+      });
+    }
+
+    it("keeps the brief out of the prompt file and injects it once the session is ready", async () => {
+      await seedPriorSession("claude-code");
+      server = await bootFlagless();
+      const submitInput = vi.spyOn(server.sessionManager, "submitInput");
+
+      const session = await server.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+        rehydrateFrom: PRIOR_SESSION,
+      });
+      // A brief exists and will be delivered, so the session says so — but not
+      // through a file this adapter never reads.
+      expect(session.rehydratedFrom).toBe(PRIOR_SESSION);
+      expect(await systemPrompt(session.id)).not.toContain("reconstruction, not restored context");
+      // Nothing injected yet: the pty is running but not `ready`, which is the
+      // state a TUI sitting on a trust prompt is in.
+      expect(submitInput).not.toHaveBeenCalled();
+
+      server.sessionManager.setReady(session.id);
+      await vi.waitFor(() => {
+        expect(submitInput).toHaveBeenCalledTimes(1);
+      });
+      const [injectedId, text, submit] = submitInput.mock.calls[0];
+      expect(injectedId).toBe(session.id);
+      expect(text).toContain("reconstruction, not restored context");
+      expect(text).toContain("make the retry backoff jittered");
+      expect(submit).toBe(true);
+    });
+
+    it("injects once, not once per status frame", async () => {
+      await seedPriorSession("claude-code");
+      server = await bootFlagless();
+      const submitInput = vi.spyOn(server.sessionManager, "submitInput");
+      const session = await server.sessionManager.create({
+        cwd,
+        harness: "claude-code",
+        rehydrateFrom: PRIOR_SESSION,
+      });
+
+      server.sessionManager.setReady(session.id);
+      await vi.waitFor(() => {
+        expect(submitInput).toHaveBeenCalledTimes(1);
+      });
+      // Any further status broadcast (a title change, a bind) must not re-send.
+      server.sessionManager.setTitle(session.id, "renamed");
+      server.sessionManager.setBoundWorkflowPath(session.id, null);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(submitInput).toHaveBeenCalledTimes(1);
+    });
+
+    it("injects nothing for a session that was never rehydrated", async () => {
+      server = await bootFlagless();
+      const submitInput = vi.spyOn(server.sessionManager, "submitInput");
+      const session = await server.sessionManager.create({ cwd, harness: "claude-code" });
+      server.sessionManager.setReady(session.id);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(submitInput).not.toHaveBeenCalled();
+    });
+  });
+
+  it("is reachable over POST /api/sessions", async () => {
+    await seedPriorSession("claude-code");
+    server = await boot("claude-code");
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-harness-token": "test-token" },
+      body: JSON.stringify({ cwd, harness: "claude-code", rehydrateFrom: PRIOR_SESSION }),
+    });
+    expect(response.status).toBe(201);
+    const session = (await response.json()) as { id: string; rehydratedFrom: string | null };
+    expect(session.rehydratedFrom).toBe(PRIOR_SESSION);
+    expect(await systemPrompt(session.id)).toContain("make the retry backoff jittered");
+  });
+
+  it("rejects an empty rehydrateFrom rather than silently ignoring it", async () => {
+    server = await boot("claude-code");
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-harness-token": "test-token" },
+      body: JSON.stringify({ cwd, harness: "claude-code", rehydrateFrom: "" }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -263,9 +263,13 @@ describe("createRestRouter", () => {
     it("returns defaults before anything is persisted", async () => {
       start();
       const res = await fetch(`${baseUrl}/settings`);
+      // Exact shape, deliberately: every default here is a contract with the
+      // SPA, and `rollingSummary` in particular must default OFF — it spends
+      // tokens on a background LLM call the user never asked for.
       expect(await res.json()).toEqual({
         telemetryOptIn: false,
         recentDirs: [],
+        rollingSummary: false,
       });
     });
 
@@ -279,13 +283,27 @@ describe("createRestRouter", () => {
       expect(await res.json()).toEqual({
         telemetryOptIn: true,
         recentDirs: [],
+        rollingSummary: false,
       });
 
       const reread = await fetch(`${baseUrl}/settings`);
       expect(await reread.json()).toEqual({
         telemetryOptIn: true,
         recentDirs: [],
+        rollingSummary: false,
       });
+    });
+
+    it("persists the rolling-summary opt-in", async () => {
+      start();
+      const res = await fetch(`${baseUrl}/settings`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ rollingSummary: true }),
+      });
+      expect(await res.json()).toMatchObject({ rollingSummary: true });
+      const reread = await fetch(`${baseUrl}/settings`);
+      expect(await reread.json()).toMatchObject({ rollingSummary: true });
     });
 
     it("calls onTelemetryOptInChange only when telemetryOptIn actually changes", async () => {

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -76,6 +76,7 @@ const createSessionSchema = z.object({
   cwd: z.string().min(1),
   harness: z.enum(SPAWNABLE_HARNESS_KINDS),
   profile: z.string().optional(),
+  rehydrateFrom: z.string().min(1).optional(),
 }) satisfies z.ZodType<CreateSessionRequest>;
 
 const injectInputSchema = z.object({
@@ -96,6 +97,7 @@ const settingsPatchSchema = z.object({
   telemetryOptIn: z.boolean().optional(),
   recentDirs: z.array(z.string()).optional(),
   projectRoot: z.string().optional(),
+  rollingSummary: z.boolean().optional(),
 }) satisfies z.ZodType<Partial<HarnessSettings>>;
 
 const UI_EVENT_NAMES: readonly UiEventName[] = [

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -161,6 +161,16 @@ export interface HarnessSession {
    *  HARNESS_CONTEXT_FILE in the session's cwd so the agent can read it. */
   boundWorkflowPath: string | null;
   /**
+   * The prior session this one was seeded from (portable continue — see
+   * core/rehydration.ts), when a brief was ACTUALLY produced and delivered.
+   * Null/absent otherwise, including when the client asked to rehydrate from
+   * an id our event log holds nothing for: this field is the record of what
+   * happened, not of what was requested, so the UI can never present an
+   * empty-handed fresh session as a continuation. Absent on sessions
+   * persisted by builds from before this existed.
+   */
+  rehydratedFrom?: string | null;
+  /**
    * `status === "running"` only means the pty is alive — the agent's TUI
    * can still be sitting on a blocking prompt (most commonly: "trust this
    * directory?") that isn't accepting real input yet. `ready` is the
@@ -288,7 +298,32 @@ export interface LaunchOpts {
   /** Only consulted by `launchTask` — hard cap on agent turns
    *  (`--max-turns`), so a bounded task can't run away. */
   maxTurns?: number;
+  /**
+   * Set by the launch-opts builder when this launch's context was seeded from
+   * a prior session's recorded events (portable continue — see
+   * core/rehydration.ts). Carries the id the brief was built from. Adapters
+   * ignore it entirely; `SessionManager.create()` copies it onto
+   * {@link HarnessSession.rehydratedFrom} so the UI can say whether the
+   * continue really carried context instead of implying it did.
+   */
+  rehydratedFrom?: string;
 }
+
+/**
+ * How a harness receives the rehydration brief for a continued session.
+ *
+ * - `launch-flag`: the adapter puts `LaunchOpts.systemPromptFile`'s contents in
+ *   front of the agent at spawn time (claude-code's `--append-system-prompt`,
+ *   codex's `developer_instructions`), so composing the brief into that file is
+ *   the whole delivery.
+ * - `post-ready-injection`: the harness has no such flag, so the brief is sent
+ *   through the ordinary input path once the session reports `ready` — gated on
+ *   readiness so it is never written into a TUI sitting on a trust prompt.
+ *
+ * See `systemPromptDeliveryFor` (core/rehydration.ts) for why the absent case
+ * resolves to the fallback rather than the flag.
+ */
+export type SystemPromptDelivery = "launch-flag" | "post-ready-injection";
 
 /**
  * One implementation per supported coding agent. Implementations must be
@@ -302,6 +337,14 @@ export interface HarnessAdapter {
   resume(agentSessionId: string, opts: LaunchOpts): SpawnSpec;
   /** How analytics events are sourced for this harness. */
   eventSource: "hooks" | "transcript-tail";
+  /**
+   * Whether `launch`/`resume` actually put `LaunchOpts.systemPromptFile` in
+   * front of the agent. Declared rather than inferred, because the alternative
+   * — assuming every adapter honours the field — silently drops a rehydration
+   * brief for one that doesn't. Omitted resolves to `post-ready-injection`
+   * (see `systemPromptDeliveryFor` in core/rehydration.ts).
+   */
+  systemPromptDelivery?: SystemPromptDelivery;
   /** Past sessions this agent recorded for a directory (agent-side history).
    *  Reports what it found; `resumeMode` is the server's call — see
    *  {@link PastSessionRecord}. */
@@ -841,6 +884,19 @@ export interface CreateSessionRequest {
   harness: HarnessKind;
   /** Profile id; omit for default. */
   profile?: string;
+  /**
+   * Portable continue: seed this fresh session with a reconstruction of a
+   * prior one instead of asking the vendor to reattach. Accepts either a
+   * `harnessSessionId` or the agent's own session id — whichever the history
+   * row carries — and is what a `resumeMode: "rehydrate"` row posts.
+   *
+   * Best-effort by contract: an id our event log holds nothing for still
+   * creates the session, with `HarnessSession.rehydratedFrom` left null so the
+   * caller can tell that no context came across. Refusing instead would block
+   * the only thing still possible for that row (a fresh session in the same
+   * directory) on a summary that was never going to exist.
+   */
+  rehydrateFrom?: string;
 }
 
 /**
@@ -1172,6 +1228,14 @@ export interface HarnessSettings {
    * rather than a door value that silently diverges from a settings value.
    */
   projectRoot?: string;
+  /**
+   * Opt-in: periodically fold a live session's record into a ≤500-word rolling
+   * summary (see core/rolling-summary.ts), which a later portable continue
+   * reads to explain what the session was *for* rather than only what it last
+   * did. Off by default because it spends tokens on a background LLM call the
+   * user never asked for. With it off, briefs degrade to last-N-turns.
+   */
+  rollingSummary?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/e2e/portable-continue.spec.ts
+++ b/packages/harness/web/e2e/portable-continue.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Portable continue (SAP-2059): a session the agent can no longer reattach to
+ * is still continuable, because the Studio seeds a FRESH session with its own
+ * reconstruction of the old one.
+ *
+ * What this tier proves that the unit and server tests can't:
+ *   - the `rehydrate` branch is wired to the button a user actually presses —
+ *     which is the dead-session pane's, since a registry row's history entry
+ *     dedupes into its session row (see WorkflowsRail's `pastSummaries`);
+ *   - pressing it creates a NEW session rather than attempting a resume that
+ *     is guaranteed to 409;
+ *   - the pane says which of the two it is about to do, before the click, and
+ *     the difference is driven by whether we recorded the session — not by
+ *     whether the agent did.
+ *
+ * Mock mode, against MOCK_SESSIONS / MOCK_HISTORY / MOCK_SESSION_RECORDS
+ * (../src/lib/mock-data.ts).
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+/** Exited, `rehydrate`, AND recorded — the case this feature exists for. */
+const REHYDRATABLE_ROW = "exited-session-sess-pricing";
+/** Exited, `rehydrate`, nothing recorded either side: SAP-2057's phantom. */
+const PHANTOM_ROW = "exited-session-sess-phantom";
+/** Exited but the agent still holds it — resume, not rehydrate. */
+const RESUMABLE_ROW = "exited-session-sess-leasing";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?seed=0");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+async function openPastRow(page: Page, testid: string): Promise<void> {
+  await page.getByTestId("history-trigger").click();
+  await expect(page.getByTestId("history-menu")).toBeVisible();
+  await page.getByTestId(testid).click();
+  await expect(page.getByTestId("dead-session-pane")).toBeVisible();
+}
+
+test("a recorded, un-resumable session offers Continue and says what carries over", async ({ page }) => {
+  await openPastRow(page, REHYDRATABLE_ROW);
+
+  // The conversation is here — read from OUR events, not the agent's store,
+  // which is the whole reason this session is continuable at all.
+  await expect(page.getByTestId("dead-session-record")).toBeVisible();
+  await expect(page.getByTestId("transcript-turn").first()).toContainText("Rework the pricing tiers");
+
+  await expect(page.getByTestId("dead-session-continue")).toBeVisible();
+  // The dead end this replaces: a disabled Resume and nowhere to go.
+  await expect(page.getByTestId("dead-session-resume")).toHaveCount(0);
+
+  const reason = page.getByTestId("dead-session-resume-reason");
+  await expect(reason).toContainText("no saved conversation for this session");
+  await expect(reason).toContainText("seeded with the reconstruction below");
+  // Honest about what the new agent is actually getting.
+  await expect(reason).toContainText("a briefing about this session, not its context");
+
+  await page.screenshot({ path: "web/e2e/screenshots/portable-continue-pane.png", fullPage: true });
+});
+
+test("continuing it opens a NEW session rather than resuming the old one", async ({ page }) => {
+  await openPastRow(page, REHYDRATABLE_ROW);
+  const tabs = page.getByTestId("session-tabs").locator(".session-tab");
+  const before = await tabs.count();
+
+  await page.getByTestId("dead-session-continue").click();
+
+  await expect(tabs).toHaveCount(before + 1);
+  // The old session is not what came back — it stays exited.
+  await expect(page.getByTestId("session-tab-sess-pricing")).toHaveCount(0);
+  // And no failure toast: this path never attempts the resume that would 409.
+  await expect(page.getByTestId("toast")).toHaveCount(0);
+});
+
+test("a session with nothing recorded keeps the honest dead end", async ({ page }) => {
+  await openPastRow(page, PHANTOM_ROW);
+
+  // Nothing to seed a continuation with, so there is no Continue to offer.
+  await expect(page.getByTestId("dead-session-continue")).toHaveCount(0);
+  await expect(page.getByTestId("dead-session-resume")).toBeDisabled();
+  await expect(page.getByTestId("dead-session-resume-reason")).toContainText(
+    "no recording of this one to carry over either",
+  );
+  // The metadata card alone — never an empty transcript that reads like an
+  // empty session.
+  await expect(page.getByTestId("dead-session-record")).toHaveCount(0);
+});
+
+test("a session the agent still holds is unchanged — it resumes, it does not rehydrate", async ({ page }) => {
+  await openPastRow(page, RESUMABLE_ROW);
+  await expect(page.getByTestId("dead-session-resume")).toBeEnabled();
+  await expect(page.getByTestId("dead-session-continue")).toHaveCount(0);
+  await expect(page.getByTestId("dead-session-resume-reason")).toHaveCount(0);
+});
+
+test("the rolling summary is off by default and reachable from settings", async ({ page }) => {
+  // Settings live behind the account menu — same path consent.spec.ts uses.
+  await page.getByTestId("brand-identity").click();
+  await expect(page.getByTestId("profile-menu")).toBeVisible();
+  await page.getByTestId("settings-trigger").click();
+  await expect(page.getByTestId("settings-popover")).toBeVisible();
+
+  const toggle = page.getByTestId("rolling-summary-toggle");
+  // Opt-in: it spends tokens on a background LLM call nobody asked for, and
+  // portable continue works without it.
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -655,6 +655,10 @@ export const App = (): JSX.Element => {
           onToggleTelemetry={async (next) => {
             await harness.updateSettings({ telemetryOptIn: next });
           }}
+          rollingSummary={harness.settings?.rollingSummary === true}
+          onToggleRollingSummary={async (next) => {
+            await harness.updateSettings({ rollingSummary: next });
+          }}
           onStartAuth={harness.startAuth}
           onDisconnect={harness.disconnect}
           settingsOpen={settingsOpen}
@@ -811,6 +815,13 @@ export const App = (): JSX.Element => {
                   resumeMode={deadResumeMode}
                   loadRecord={harness.sessionRecord}
                   onResume={() => void harness.resumeSession(activeSession.id)}
+                  onContinue={() =>
+                    void harness.rehydrateSession({
+                      cwd: activeSession.cwd,
+                      harness: activeSession.harness,
+                      from: activeSession.id,
+                    })
+                  }
                   onClose={() => void harness.closeSession(activeSession.id)}
                 />
               ) : showAgentEmpty && focusedWorkflow ? (

--- a/packages/harness/web/src/components/DeadSessionPane.tsx
+++ b/packages/harness/web/src/components/DeadSessionPane.tsx
@@ -19,16 +19,25 @@ interface DeadSessionPaneProps {
   /** Fetches the reconstructed transcript; resolves null when nothing was recorded. */
   loadRecord: (id: string) => Promise<SessionRecord | null>;
   onResume: () => void;
+  /**
+   * Portable continue: start a FRESH session here, seeded with the
+   * reconstruction below. Offered only when the agent can't hand this
+   * conversation back but we recorded it ourselves — the case that used to be
+   * a dead end with a disabled button and "start a new session instead".
+   */
+  onContinue: () => void;
   onClose: () => void;
 }
 
-/** Why a session can't be handed back, in the user's terms. Two distinct
- *  causes — never started vs. started but left no transcript — and conflating
- *  them is what made the old single message misleading for most rows. */
+/** Why the agent can't hand this session back, in the user's terms. Two
+ *  distinct causes — never started vs. started but left no transcript — and
+ *  conflating them is what made the old single message misleading for most
+ *  rows. Says nothing about what to do instead: that depends on whether we
+ *  recorded the session, which is a separate question (see `canContinue`). */
 function resumeBlockedReason(session: HarnessSession): string {
   return session.agentSessionId == null
-    ? "This session can't be resumed. It exited before establishing a session id."
-    : `${HARNESS_LABELS[session.harness]} has no saved conversation for this session, so there's nothing to hand back. That happens when a session ends before its first prompt — the agent never writes a transcript for those. Start a new session in this directory instead.`;
+    ? "This session can't be resumed: it exited before establishing a session id."
+    : `${HARNESS_LABELS[session.harness]} has no saved conversation for this session, so there's nothing to hand back. That happens when a session ends before its first prompt — the agent never writes a transcript for those.`;
 }
 
 /**
@@ -63,6 +72,7 @@ export function DeadSessionPane({
   resumeMode,
   loadRecord,
   onResume,
+  onContinue,
   onClose,
 }: DeadSessionPaneProps): JSX.Element {
   const canResume = session.agentSessionId != null && resumeMode !== "rehydrate";
@@ -71,6 +81,11 @@ export function DeadSessionPane({
   // "empty" collapses the section entirely rather than showing an empty box:
   // the metadata card alone is the honest pane for a session we never recorded.
   const showRecord = record.status !== "empty";
+  // The two questions are independent (see the header): the agent may be
+  // unable to hand this conversation back while OUR recording of it is right
+  // there. When both are true, the way forward is portable continue rather
+  // than the dead end this pane used to be.
+  const canContinue = !canResume && record.status === "ready";
 
   return (
     <div className="dead-session-pane" data-testid="dead-session-pane" data-has-record={showRecord}>
@@ -106,22 +121,31 @@ export function DeadSessionPane({
           </div>
         </dl>
         <div className="dead-session-actions">
-          <button
-            className="btn-primary"
-            data-testid="dead-session-resume"
-            onClick={onResume}
-            disabled={!canResume}
-            title={canResume ? undefined : resumeBlockedReason(session)}
-          >
-            Resume
-          </button>
+          {canContinue ? (
+            <button className="btn-primary" data-testid="dead-session-continue" onClick={onContinue}>
+              Continue here
+            </button>
+          ) : (
+            <button
+              className="btn-primary"
+              data-testid="dead-session-resume"
+              onClick={onResume}
+              disabled={!canResume}
+              title={canResume ? undefined : resumeBlockedReason(session)}
+            >
+              Resume
+            </button>
+          )}
           <button className="btn-ghost" data-testid="dead-session-close" onClick={onClose}>
             Close
           </button>
         </div>
         {!canResume && (
           <div className="dead-session-resume-reason" data-testid="dead-session-resume-reason">
-            {resumeBlockedReason(session)}
+            {resumeBlockedReason(session)}{" "}
+            {canContinue
+              ? "Continuing opens a fresh session in this directory, seeded with the reconstruction below — a briefing about this session, not its context. The new agent will need to check the repository before relying on any of it."
+              : "Start a new session in this directory instead; there is no recording of this one to carry over either."}
           </div>
         )}
       </div>
@@ -177,6 +201,11 @@ export function PastSessionPane({
   // server resolves either (see core/session-record.ts's resolveSessionIds).
   const recordId = summary.harnessSessionId ?? summary.agentSessionId;
   const record = useSessionRecord(recordId, loadRecord);
+  // What the button will ACTUALLY do for a non-resumable row now that portable
+  // continue exists: with a record, the fresh session is seeded with the
+  // reconstruction shown below; without one, it really is just a new session
+  // in this directory. The two must not read the same.
+  const canRehydrate = !resumable && record.status === "ready";
 
   return (
     <div className="past-session-pane" data-testid="past-session-pane">
@@ -189,7 +218,7 @@ export function PastSessionPane({
         </div>
         <div className="dead-session-actions">
           <button className="btn-primary" data-testid="past-session-start" onClick={onStart}>
-            {resumable ? "Resume" : "New session here"}
+            {resumable ? "Resume" : canRehydrate ? "Continue here" : "New session here"}
           </button>
           <button className="btn-ghost" data-testid="past-session-close" onClick={onClose}>
             Close
@@ -201,7 +230,10 @@ export function PastSessionPane({
         <div className="dead-session-resume-reason" data-testid="past-session-reason">
           {HARNESS_LABELS[summary.harness]} has no saved conversation for this session, so it can't
           be reattached — sessions that end before their first prompt are never written to the
-          agent's history. Starting opens a fresh session in the same directory.
+          agent's history.{" "}
+          {canRehydrate
+            ? "Continuing opens a fresh session here, seeded with the reconstruction below. The new agent gets a briefing about this session, not its context — it will need to check the repository before relying on any of it."
+            : "Starting opens a fresh session in the same directory, with no context from this one."}
         </div>
       )}
 

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -22,6 +22,9 @@ interface SettingsPopoverProps {
   /** Which env var forced telemetry off, when consentSource is "env-forced-off". */
   consentEnvReason?: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  /** `HarnessSettings.rollingSummary` — see the toggle's own note below. */
+  rollingSummary: boolean;
+  onToggleRollingSummary: (next: boolean) => Promise<void>;
   /** Kick off the browser OAuth flow — see HarnessApi.startAuth(). */
   onStartAuth: () => Promise<AuthStartResponse>;
   /** Sign out and clear credentials — see HarnessApi.disconnect(). */
@@ -35,6 +38,8 @@ export function SettingsPopover({
   consentSource,
   consentEnvReason,
   onToggleTelemetry,
+  rollingSummary,
+  onToggleRollingSummary,
   onStartAuth,
   onDisconnect,
 }: SettingsPopoverProps): JSX.Element {
@@ -51,6 +56,15 @@ export function SettingsPopover({
     try {
       await onToggleTelemetry(next);
       track("consent.changed", { optIn: next });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggleRollingSummary = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      await onToggleRollingSummary(!rollingSummary);
     } finally {
       setBusy(false);
     }
@@ -169,6 +183,29 @@ export function SettingsPopover({
       <p className="settings-note">
         Prompts, tool calls, and session lifecycle events are always written locally to{" "}
         <code>{HARNESS_PATHS.events}</code>. With your consent, they&rsquo;re also sent to Sapiom.
+      </p>
+
+      <label className="settings-toggle-row">
+        <span>Summarize sessions in the background</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={rollingSummary}
+          data-testid="rolling-summary-toggle"
+          className={"toggle-switch" + (rollingSummary ? " is-on" : "")}
+          disabled={busy}
+          onClick={() => void handleToggleRollingSummary()}
+        >
+          <span className="toggle-knob" />
+        </button>
+      </label>
+
+      <p className="settings-note">
+        Off by default, because it uses tokens you didn&rsquo;t ask to use: every 10 turns, and
+        once at the end, a cheap one-shot agent run folds the session into a short summary.
+        Continuing a session the agent can no longer reattach to then explains what the work was{" "}
+        <em>for</em>, not just what it last did. With this off, continuing still works — it
+        carries the last few turns instead.
       </p>
     </>
   );

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -81,11 +81,13 @@ interface WorkflowsRailProps {
   /** Push a message onto the app's toast rail (copy confirmations etc.). */
   onToast: (message: string) => void;
   telemetryOptIn: boolean;
+  rollingSummary: boolean;
   consentSource?: AppState["consentSource"];
   consentEnvReason?: string | null;
   authenticated: boolean;
   organizationName: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  onToggleRollingSummary: (next: boolean) => Promise<void>;
   /** Kick off the browser OAuth flow for the in-app Connect button. */
   onStartAuth: () => Promise<AuthStartResponse>;
   /** Sign out and clear credentials. */
@@ -319,11 +321,13 @@ export function WorkflowsRail({
   onOpenInEditor,
   onToast,
   telemetryOptIn,
+  rollingSummary,
   consentSource,
   consentEnvReason,
   authenticated,
   organizationName,
   onToggleTelemetry,
+  onToggleRollingSummary,
   onStartAuth,
   onDisconnect,
   settingsOpen,
@@ -639,9 +643,11 @@ export function WorkflowsRail({
           authenticated={authenticated}
           organizationName={organizationName}
           telemetryOptIn={telemetryOptIn}
+          rollingSummary={rollingSummary}
           consentSource={consentSource}
           consentEnvReason={consentEnvReason}
           onToggleTelemetry={onToggleTelemetry}
+          onToggleRollingSummary={onToggleRollingSummary}
           onStartAuth={onStartAuth}
           onDisconnect={onDisconnect}
           settingsOpen={settingsOpen}
@@ -707,9 +713,11 @@ function ProfileRow({
   authenticated,
   organizationName,
   telemetryOptIn,
+  rollingSummary,
   consentSource,
   consentEnvReason,
   onToggleTelemetry,
+  onToggleRollingSummary,
   onStartAuth,
   onDisconnect,
   settingsOpen,
@@ -720,9 +728,11 @@ function ProfileRow({
   authenticated: boolean;
   organizationName: string | null;
   telemetryOptIn: boolean;
+  rollingSummary: boolean;
   consentSource?: AppState["consentSource"];
   consentEnvReason?: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  onToggleRollingSummary: (next: boolean) => Promise<void>;
   onStartAuth: () => Promise<AuthStartResponse>;
   onDisconnect: () => Promise<void>;
   settingsOpen: boolean;
@@ -808,9 +818,11 @@ function ProfileRow({
           authenticated={authenticated}
           organizationName={organizationName}
           telemetryOptIn={telemetryOptIn}
+          rollingSummary={rollingSummary}
           consentSource={consentSource}
           consentEnvReason={consentEnvReason}
           onToggleTelemetry={onToggleTelemetry}
+          onToggleRollingSummary={onToggleRollingSummary}
           onStartAuth={onStartAuth}
           onDisconnect={onDisconnect}
         />

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -782,6 +782,11 @@ class MockApi implements HarnessApi {
       status: "starting",
       createdAt: new Date().toISOString(),
       lastActiveAt: new Date().toISOString(),
+      // Mirrors the real server: portable continue only claims to have carried
+      // context when a record for that id exists. The fixtures have records for
+      // MOCK_SESSION_RECORDS' keys and nothing else.
+      rehydratedFrom:
+        req.rehydrateFrom && MOCK_SESSION_RECORDS[req.rehydrateFrom] ? req.rehydrateFrom : null,
       ready: false,
     };
     this.sessions = [...this.sessions, session];

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -367,6 +367,23 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     ready: false,
   },
   {
+    // Exited, and the agent's transcript for it is gone — so its history row
+    // is `rehydrate` even though we recorded the whole conversation (see
+    // MOCK_SESSION_RECORDS["sess-pricing"]). Continuing it starts a fresh
+    // session seeded from that record rather than resuming anything.
+    id: "sess-pricing",
+    agentSessionId: "4d8c1e77-9a03-4b52-8e61-0c2d5f7a1b93",
+    boundWorkflowPath: null,
+    harness: "claude-code",
+    cwd: "/Users/demo/acme-app",
+    title: "Rework the pricing tiers",
+    status: "exited",
+    createdAt: daysAgo(3),
+    lastActiveAt: daysAgo(3),
+    exitCode: 0,
+    ready: false,
+  },
+  {
     id: "sess-leasing-2",
     agentSessionId: "1a2b3c4d-5e6f-4a71-8b2c-3d4e5f6a7b8c",
     // A SECOND live session bound to leasing, so the focused agent's main-panel
@@ -476,6 +493,23 @@ export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
       // turnCount comes from OUR event index and wins over messageCount when
       // both are present — the two disagreeing here is deliberate.
       turnCount: 3,
+    },
+    {
+      // The row portable continue exists for: the agent's transcript is gone
+      // (rotated, or the machine changed), so nothing can reattach — but WE
+      // recorded the conversation, so continuing it means a fresh session
+      // seeded from our own record. Contrast the phantom above, which is
+      // `rehydrate` with nothing recorded either side.
+      harnessSessionId: "sess-pricing",
+      agentSessionId: "4d8c1e77-9a03-4b52-8e61-0c2d5f7a1b93",
+      harness: "claude-code",
+      cwd: "/Users/demo/acme-app",
+      title: "Rework the pricing tiers",
+      lastActiveAt: daysAgo(3),
+      source: "registry",
+      resumeMode: "rehydrate",
+      gitBranch: "feat/pricing-tiers",
+      turnCount: 2,
     },
     {
       // A session the Studio never ran: the agent's own transcript knows it,
@@ -638,6 +672,62 @@ export const MOCK_SESSION_RECORDS: Record<string, SessionRecord> = {
       },
     ],
   },
+  // The rehydration fixture: a record whose agent no longer holds the
+  // conversation, so "Continue" seeds a fresh session from this instead of
+  // resuming. See its MOCK_HISTORY row.
+  "sess-pricing": {
+    harnessSessionId: "sess-pricing",
+    mergedSessionIds: ["sess-pricing"],
+    agentSessionId: "4d8c1e77-9a03-4b52-8e61-0c2d5f7a1b93",
+    harness: "claude-code",
+    cwd: "/Users/demo/acme-app",
+    startedAt: daysAgo(3),
+    endedAt: daysAgo(3),
+    turnCount: 2,
+    eventCount: 8,
+    reconstructed: true,
+    limitations: ["assistant-narration-gap"],
+    turns: [
+      {
+        index: 1,
+        prompt: "Rework the pricing tiers so the mid tier is usage-metered.",
+        promptAt: daysAgo(3),
+        toolCalls: [
+          {
+            name: "Edit",
+            input: '{"file_path":"/Users/demo/acme-app/src/pricing/tiers.ts"}',
+            responseSummary: "updated 1 hunk",
+            responseTruncated: false,
+            at: daysAgo(3),
+          },
+        ],
+        assistantText: "Mid tier is metered now; the annual discount still needs deciding.",
+        model: "claude-opus-4-6",
+        usage: { inputTokens: 8210, outputTokens: 280 },
+        completedAt: daysAgo(3),
+        incomplete: false,
+      },
+      {
+        index: 2,
+        prompt: "Leave the discount for now — add the migration.",
+        promptAt: daysAgo(3),
+        toolCalls: [
+          {
+            name: "Write",
+            input: '{"file_path":"/Users/demo/acme-app/migrations/0042-pricing.sql"}',
+            responseSummary: "wrote 34 lines",
+            responseTruncated: false,
+            at: daysAgo(3),
+          },
+        ],
+        assistantText: "Migration 0042 added. Not run anywhere yet.",
+        model: "claude-opus-4-6",
+        usage: { inputTokens: 8940, outputTokens: 160 },
+        completedAt: daysAgo(3),
+        incomplete: false,
+      },
+    ],
+  },
   "sess-rfq": {
     harnessSessionId: "sess-rfq",
     mergedSessionIds: ["sess-rfq"],
@@ -781,6 +871,9 @@ export const MOCK_HARNESSES: HarnessEntry[] = [
 export const MOCK_SETTINGS: HarnessSettings = {
   telemetryOptIn: false,
   recentDirs: ["/Users/demo/acme-app", "/Users/demo/rfq-workflows", "/Users/demo/onboarding-flow"],
+  // Matches the real default: opt-in, because it spends tokens on a background
+  // LLM call the user never asked for.
+  rollingSummary: false,
 };
 
 

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -5,6 +5,7 @@ import type {
   BusMessage,
   RunView,
   CreateSessionRequest,
+  HarnessKind,
   HarnessSession,
   HarnessSettings,
   RunMacroRequest,
@@ -101,6 +102,17 @@ export interface HarnessStateHook {
    *  recorded for it). Stable identity — safe as an effect dependency. */
   sessionRecord: (id: string) => Promise<SessionRecord | null>;
   resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
+  /**
+   * Portable continue: a fresh session in `cwd`, seeded with our own
+   * reconstruction of the session `from` identifies (either id form). For a
+   * conversation the agent no longer holds — the only thing still possible for
+   * it, and now a real continuation rather than a blank start.
+   */
+  rehydrateSession: (req: {
+    cwd: string;
+    harness: HarnessKind;
+    from: string;
+  }) => Promise<HarnessSession>;
   resumeFromHistory: (summary: SessionSummary) => Promise<HarnessSession>;
   /** Dismisses an exited session (DELETE): drops it from the list and, if it was active, falls back to another running session or clears the pane. */
   closeSession: (id: string) => Promise<void>;
@@ -733,15 +745,43 @@ export function useHarnessState(): HarnessStateHook {
   );
 
   /**
-   * Resumes a history entry, in the order that preserves the most context:
+   * Portable continue. A conversation the agent no longer holds can't be
+   * reattached by anyone, so this starts a fresh session and hands it our own
+   * reconstruction of the old one — the same path for every harness, including
+   * ones with no resume flag at all.
    *
-   *  1. A row the registry already tracks → resume that record.
-   *  2. A transcript-only row the agent still holds (`resumeMode:
-   *     "agent-resume"`, verified server-side) → adopt it into the registry
-   *     and resume for real. This is the case that used to silently start a
-   *     fresh session and throw the conversation away.
-   *  3. Anything else (`rehydrate`) → a fresh session in the same directory,
-   *     which is all that's possible until H3 lands portable continue.
+   * `rehydratedFrom` on the response is the server's account of what actually
+   * happened, not an echo of the request: when our event log held nothing for
+   * that id, it comes back null and this says so. Silence there would be the
+   * exact dishonesty this epic removes — a blank session presented as a
+   * continuation.
+   */
+  const rehydrateSession = useCallback(
+    async ({ cwd, harness, from }: { cwd: string; harness: HarnessKind; from: string }) => {
+      const session = await createSession({ cwd, harness, rehydrateFrom: from });
+      if (!session.rehydratedFrom) {
+        setToast("Nothing was recorded for that session, so this one starts fresh.");
+      }
+      return session;
+    },
+    [createSession],
+  );
+
+  /**
+   * Resumes a history entry by branching on the server-verified `resumeMode`
+   * — never on what we happen to hold. Before H1 this guessed (a row with an
+   * `agentSessionId` was treated as resumable), which made one in three rows a
+   * button guaranteed to fail; the mode is now resolved against the agent's
+   * own store by `GET /sessions/history`, and this just obeys it.
+   *
+   *  1. `agent-resume` + a registry record → resume that record; the agent
+   *     genuinely reattaches to the conversation.
+   *  2. `agent-resume`, transcript-only → adopt it into the registry first,
+   *     then resume for real.
+   *  3. `rehydrate` → the agent does NOT hold this conversation, so nothing
+   *     can reattach to it. Start a fresh session seeded with our own
+   *     reconstruction of it (`rehydrateFrom`), which is what makes continue
+   *     work for a harness with no resume flag at all.
    *
    * A failed adopt does NOT fall through to a fresh session: it surfaces the
    * server's reason as a toast, because quietly starting something different
@@ -752,36 +792,43 @@ export function useHarnessState(): HarnessStateHook {
       const harnessSessionId =
         summary.harnessSessionId ??
         state?.sessions.find((session) => session.agentSessionId === summary.agentSessionId)?.id;
-      if (harnessSessionId) return resumeSession(harnessSessionId);
-      if (summary.resumeMode === "agent-resume") {
-        try {
-          const adopted = await api.adoptSession({
-            agentSessionId: summary.agentSessionId,
-            harness: summary.harness,
-            cwd: summary.cwd,
-            title: summary.title,
-            lastActiveAt: summary.lastActiveAt,
-          });
-          // Upsert: the adopted record is new to the registry in the normal
-          // case, but the server resumes an existing one when the row was
-          // already tracked, and then this response is the fresher copy.
-          setState((prev) => {
-            if (!prev) return prev;
-            const sessions = prev.sessions.some((s) => s.id === adopted.id)
-              ? prev.sessions.map((s) => (s.id === adopted.id ? adopted : s))
-              : [...prev.sessions, adopted];
-            return { ...prev, sessions };
-          });
-          selectSession(adopted.id);
-          return adopted;
-        } catch (err) {
-          setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
-          throw err;
-        }
+      if (summary.resumeMode === "rehydrate") {
+        // Prefer our own id: it resolves the whole conversation (every harness
+        // session that shares this agent session), where the agent session id
+        // alone only finds it if our events recorded one.
+        return rehydrateSession({
+          cwd: summary.cwd,
+          harness: summary.harness,
+          from: harnessSessionId ?? summary.agentSessionId,
+        });
       }
-      return createSession({ cwd: summary.cwd, harness: summary.harness });
+      if (harnessSessionId) return resumeSession(harnessSessionId);
+      try {
+        const adopted = await api.adoptSession({
+          agentSessionId: summary.agentSessionId,
+          harness: summary.harness,
+          cwd: summary.cwd,
+          title: summary.title,
+          lastActiveAt: summary.lastActiveAt,
+        });
+        // Upsert: the adopted record is new to the registry in the normal
+        // case, but the server resumes an existing one when the row was
+        // already tracked, and then this response is the fresher copy.
+        setState((prev) => {
+          if (!prev) return prev;
+          const sessions = prev.sessions.some((s) => s.id === adopted.id)
+            ? prev.sessions.map((s) => (s.id === adopted.id ? adopted : s))
+            : [...prev.sessions, adopted];
+          return { ...prev, sessions };
+        });
+        selectSession(adopted.id);
+        return adopted;
+      } catch (err) {
+        setToast(err instanceof ApiError && err.reason ? err.reason : (err as Error).message);
+        throw err;
+      }
     },
-    [state, resumeSession, createSession, selectSession],
+    [state, resumeSession, rehydrateSession, selectSession],
   );
 
   const closeSession = useCallback(
@@ -975,6 +1022,7 @@ export function useHarnessState(): HarnessStateHook {
     getTemplate,
     sessionRecord,
     resumeSession,
+    rehydrateSession,
     resumeFromHistory,
     closeSession,
     connectWorkflow,


### PR DESCRIPTION
Closes [SAP-2059](https://linear.app/sapiom/issue/SAP-2059/h3-portable-continue-rehydrated-context-instead-of-vendor-resume) (Epic H, parent SAP-2056).

## Why

H1 stopped offering Resume on rows that were guaranteed to fail. That left them with nowhere to go — a disabled button and "start a new session in this directory instead" — **even when our own event log held the entire conversation**. Resume-as-reattach can only ever work for the vendor that wrote the transcript, on the machine that wrote it.

So: don't ask the vendor to reattach. Start a fresh session and hand it a reconstruction of the old one. Because the input is the `SessionRecord` H2 already folds from our normalized events, and the output is plain text, this works identically for claude-code and codex, would work for a harness with no resume flag at all, and is what the chatbot will use.

## What changed

**The brief** — `src/core/resume-brief.ts`, `buildResumeBrief(record, opts)`:

- What the session was: title, cwd, git branch, bound workflow + `definitionId`, span, turn count.
- The rolling summary when there is one.
- The last N turns verbatim — prompts and assistant text, tool calls collapsed to name + target.
- Files written and shell commands run, derived from `tool.call` inputs. Read-only tools are excluded: "files touched" that includes everything the agent merely looked at stops being a signal.
- Bounded at ~6k tokens (`chars/4`, deliberately crude — the consumer is a system prompt, not a hard API limit, and a tokenizer dep would have to be right for two vendors' tokenizers). Over budget it drops **turns oldest-first**, then the hard-capped digests, and clamps the summary only as a last resort. Every omission is stated in the text.

**Honesty is the product here.** A brief that reads like restored memory is worse than no brief: the agent will assert a file's contents or a command's outcome it never saw. So it opens with "reconstruction, not restored context", tells the reader the working tree outranks the brief, and renders each of the record's machine-readable `limitations` as prose aimed at the agent ("re-run it rather than trusting the excerpt") rather than at a human.

**Delivery — declared per-adapter, not inferred.** `HarnessAdapter.systemPromptDelivery`:

- `launch-flag` (both shipped adapters): the brief is appended to the generated system-prompt file, which claude-code reads via `--append-system-prompt` and codex inlines as `developer_instructions`. **No adapter change** — the integration test runs the same body for both harnesses and asserts against the bytes each one actually consumes.
- `post-ready-injection`: the universal fallback. Gated on `ready`, not `running` — writing into a TUI sitting on "trust this directory?" feeds the brief to the prompt.

Absent resolves to the *fallback*, not the flag: an adapter that never wired `systemPromptFile` and declared nothing would otherwise have its brief written to a file nothing reads. Failing toward "delivered noisily" beats failing toward "silently dropped" for a feature whose whole point is that the context arrives. No shipped adapter needs the second channel today, so it is dormant rather than dead — and tested, so a new harness gets working rehydration from one line.

**Rolling summary** — `src/core/rolling-summary.ts`, opt-in via `HarnessSettings.rollingSummary` (off by default, with a toggle in Settings). Every 10 completed turns and once at session end, a bounded headless run (`launchTask`, cheap model, `--max-turns 1`) folds the record into `<generated>/<sessionId>/summary.md`. It **never blocks a turn**: `noteEvent` is synchronous, the fold is a separate process, and every failure short-circuits to "no summary". The task returns text and *we* write the file — the target is outside the session's cwd (which codex's `workspace-write` forbids), and a task that writes its own output can half-write it. Codex has no `launchTask`, so its briefs degrade to last-N-turns; so does everyone's with the setting off.

**Truthful outcome** — `HarnessSession.rehydratedFrom` records what actually happened, not what was requested. A `rehydrateFrom` id our log holds nothing for still creates the session (refusing would block the only thing still possible for that row), with the field null, and the UI says so.

**UI** — `resumeFromHistory` branches on the server-verified `resumeMode` instead of guessing. The dead-session pane — which is where a `rehydrate` row actually lands, since a registry row's history entry dedupes into its session row — now offers **"Continue here"** wherever it has a record to seed from, with copy saying what will and won't carry over, instead of the disabled Resume it had.

## Two things worth a reviewer's attention

**The squeeze order puts turns ahead of the digests, which is the opposite of what I wrote first.** The digests are hard-capped (30 files / 10 commands ≈ a few hundred tokens for a whole session) where one verbose turn costs about as much — so dropping the whole-session view to keep one more ancient turn is a bad trade. They now go only once no turn is left. The first version dropped them at 6k tokens on a 40-turn record, which the test caught.

**Git branch costs one adapter history scan per rehydrate.** Our events never carry a branch; only the adapter's transcript does. `GET /sessions/history` avoids per-row probes because codex's walks the whole `~/.codex/sessions` tree — but that reasoning doesn't apply to a single deliberate "continue this session" click. It's `catch`-wrapped: a slow or failing scan degrades one bullet, never the continue.

## Verification

- `pnpm build`, `pnpm typecheck`, `pnpm lint` — green across the workspace (0 errors; the single harness lint warning is the pre-existing unused import at `rest.test.ts:7`).
- Harness unit suite: **1427 passing**, 96 files, plus the 4 perf tests. New coverage: the brief (honesty header survives any budget, limitation prose, budget ceiling at 6k/2k/800, oldest-first truncation, summary kept while turns drop, digests kept while turns drop, oversized-summary clamp, tool-target extraction including a payload the collector truncated mid-JSON and codex's argv-array shell input); the rolling summarizer (the gate, re-read per fold; the interval; the session-end fold; per-session counting; never throwing into the ingest path when `launchTask` is unsupported; writing/clamping `summary.md`; leaving the old summary in place on failure); rehydration resolution (null when nothing recorded, newest-segment summary, degrade on a failed summary read); and a wiring-level suite that boots a real server, seeds `events.ndjson`, and asserts the brief lands in the prompt file **for claude-code and codex from the same test body**, plus the post-ready channel (nothing until `ready`, injected once, not once per status frame).
- Playwright: **264 passing**, including 5 new specs for the Continue affordance, the honest dead end when nothing was recorded, and the rolling-summary toggle.

**Two flakes to know about, neither from this branch:**

1. The harness unit suite fails one fs-watch/timing test per full run and it's a *different* one each time (`workspace-rescan`, `canvas-watcher`, …); each passes in isolation. Same flake SAP-2058's PR documented — the last two full runs here were clean.
2. Playwright's `reuseExistingServer` + fixed port 5299 means a dev server from another worktree gets reused and produces ~36 unrelated failures. Run with `E2E_PORT=<free port>` when several checkouts are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZrcsK1SKm2zjseX9Wqnvj
