### PR TITLE
fix(tools): support synchronous video responses

### DIFF
--- a/.changeset/calm-videos-return.md
+++ b/.changeset/calm-videos-return.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+Accept synchronous video responses and status-URL-only asynchronous handles from content-generation providers.

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -273,6 +273,57 @@ describe("createClient().contentGeneration.images.create", () => {
 // ---------------------------------------------------------------------------
 
 describe("contentGeneration.video.create()", () => {
+  it("returns a synchronous video result without trying to poll", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              video: {
+                url: "https://media/merged.mp4",
+                content_type: "video/mp4",
+              },
+            })
+          : null,
+    ]);
+
+    const out = await createVideo({ prompt: "merge" }, transport, BASE);
+
+    expect(out).toEqual({
+      video: {
+        url: "https://media/merged.mp4",
+        contentType: "video/mp4",
+      },
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("derives the result URL when Fal returns only status_url", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              request_id: "req-status-only",
+              status_url: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/merged.mp4" } })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "merge", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out.video?.url).toBe("https://media/merged.mp4");
+    expect(calls[1]!.url).toBe(
+      `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only`,
+    );
+  });
+
   it("submits the default video model, polls until ready, and maps the result to camelCase", async () => {
     let polls = 0;
     const { transport, calls } = makeTransport([
@@ -534,6 +585,23 @@ function makeLaunchTransport(
 }
 
 describe("contentGeneration.video.launch()", () => {
+  it("accepts a status_url-only submit handle", async () => {
+    const { transport } = makeLaunchTransport(
+      {
+        request_id: "req-status-only",
+        status_url: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
+      },
+      { video: { url: "https://media/merged.mp4" } },
+    );
+
+    const handle = await launchVideo({ prompt: "merge" }, transport, BASE);
+
+    expect(handle.requestId).toBe("req-status-only");
+    await expect(handle.wait({ pollMs: 1 })).resolves.toMatchObject({
+      video: { url: "https://media/merged.mp4" },
+    });
+  });
+
   it("submits to the right URL and method, returns a handle with requestId and dispatch", async () => {
     const { transport, calls } = makeLaunchTransport(
       {

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -334,6 +334,21 @@ interface QueueHandle {
   status_url?: string;
 }
 
+/**
+ * Fal occasionally omits `response_url` while still returning the canonical
+ * `.../requests/:id/status` URL. The result endpoint is the same URL without
+ * the final `/status` segment, so keep async video launches usable in that
+ * valid response shape.
+ */
+function queueResultUrl(handle: QueueHandle): string | undefined {
+  if (handle.response_url) return handle.response_url;
+  if (!handle.status_url) return undefined;
+  const url = new URL(handle.status_url);
+  if (!url.pathname.endsWith("/status")) return undefined;
+  url.pathname = url.pathname.slice(0, -"/status".length);
+  return url.toString();
+}
+
 function mapVideo(raw: RawMedia): GeneratedVideo {
   return {
     url: raw.url,
@@ -387,8 +402,13 @@ export async function createVideo(
     }),
     "Failed to submit video generation",
   );
-  const handle = (await submitRes.json()) as QueueHandle;
-  if (!handle.response_url) {
+  const submitted = (await submitRes.json()) as QueueHandle & RawVideoResult;
+  // Some Fal video operations (notably ffmpeg merge) complete synchronously and
+  // return the final `video` object instead of a queue handle.
+  if (submitted.video?.url) return mapVideoResult(submitted);
+  const handle = submitted;
+  const responseUrl = queueResultUrl(handle);
+  if (!responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");
   }
 
@@ -398,7 +418,7 @@ export async function createVideo(
   const timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const res = await transport.fetch(handle.response_url, { method: "GET" });
+    const res = await transport.fetch(responseUrl, { method: "GET" });
     if (res.ok) {
       const raw = (await res.json()) as RawVideoResult;
       if (raw.video?.url) return mapVideoResult(raw);
@@ -527,12 +547,12 @@ export async function launchVideo(
     "Failed to submit video generation",
   );
   const handle = (await submitRes.json()) as QueueHandle;
-  if (!handle.response_url) {
+  const responseUrl = queueResultUrl(handle);
+  if (!responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");
   }
 
   const requestId = handle.request_id ?? "unknown";
-  const responseUrl = handle.response_url;
 
   const wait = async ({
     timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

Make `@sapiom/tools` content-generation video calls handle both synchronous provider results and valid asynchronous handles that expose only a status URL.

## Changes

- Return synchronous `{ video }` results without entering the polling loop.
- Derive the canonical result endpoint from a `status_url` when `response_url` is absent.
- Preserve existing queued-video launch, wait, and resume behavior.
- Add regression coverage and a patch changeset for `@sapiom/tools`.

## Root cause

The SDK assumed every video operation returned an async queue handle with `response_url`. FAL ffmpeg merge may return the completed video synchronously, and some queue handles expose only `status_url`.

## Testing

- [x] Content-generation SDK suite: 55/55 tests
- [x] `@sapiom/tools` typecheck
- [x] `@sapiom/tools` lint
- [x] Changeset validation
- [x] `git diff --check`

## Related

- Refs: SAP-2143

## Checklist

- [x] Patch release metadata included
- [x] No unrelated template or deployment changes
- [x] Self-reviewed