### PR TITLE
fix(examples): repair workflow template reliability

### DIFF
--- a/examples/approval-chain/AGENTS.md
+++ b/examples/approval-chain/AGENTS.md
@@ -37,8 +37,9 @@ went silent). Inside a step's `run`, Sapiom capabilities are pre-auth'd on
 The canonical state is `ctx.shared`. The `database` capability is an **optional,
 best-effort** durable copy: `recordTransition` appends every transition to
 `ctx.shared.trail` and, when a `ledgerHandle` is configured and it's not a
-`dryRun`, also to a Postgres `approval_chain_ledger` table (via a `pg` client on
-the provisioned connection string). A missing handle, a `dryRun`, or any DB error
+`dryRun`, also to a Postgres `approval_chain_ledger` table (via the ESM-safe
+`postgres` client on the provisioned connection string). TLS behavior follows
+the connection string's `sslmode`; a missing handle, a `dryRun`, or any DB error
 degrades to shared + logs and never fails the chain. Rows are keyed on
 `(execution_id, seq)` with `ON CONFLICT DO NOTHING`, so a step retry is idempotent.
 

--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -290,10 +290,12 @@ async function persistTransition(
     });
     return;
   }
-  // `postgres` is ESM-friendly and is included in the self-contained workflow
-  // artifact. A hidden runtime import of `pg` built successfully but left the
-  // driver out of the deployed bundle, so live ledger writes always failed.
-  const sql = postgres(connectionString, { ssl: "require", max: 1 });
+  // Both drivers are externalized into the deploy manifest. `postgres` works
+  // here because its ESM default export is stable; `pg` builds `module.exports`
+  // dynamically, so the previous named ESM import failed at runtime.
+  // Leave TLS policy to LEDGER_DATABASE_URL (`sslmode=...`) so local and
+  // in-network non-TLS databases keep working.
+  const sql = postgres(connectionString, { max: 1 });
   try {
     await sql.unsafe(
       `CREATE TABLE IF NOT EXISTS ${LEDGER_TABLE} (

--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -6,7 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
-import { Client } from "pg";
+import postgres from "postgres";
 
 /**
  * Multi-Party Approval Chain (Saga) — a durable, sequential sign-off flow.
@@ -290,10 +290,12 @@ async function persistTransition(
     });
     return;
   }
-  const client = new Client({ connectionString });
-  await client.connect();
+  // `postgres` is ESM-friendly and is included in the self-contained workflow
+  // artifact. A hidden runtime import of `pg` built successfully but left the
+  // driver out of the deployed bundle, so live ledger writes always failed.
+  const sql = postgres(connectionString, { ssl: "require", max: 1 });
   try {
-    await client.query(
+    await sql.unsafe(
       `CREATE TABLE IF NOT EXISTS ${LEDGER_TABLE} (
          execution_id text NOT NULL,
          seq          integer NOT NULL,
@@ -306,7 +308,7 @@ async function persistTransition(
          PRIMARY KEY (execution_id, seq)
        )`,
     );
-    await client.query(
+    await sql.unsafe(
       `INSERT INTO ${LEDGER_TABLE}
          (execution_id, seq, subject, gate_index, approver_id, phase, note)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -322,7 +324,7 @@ async function persistTransition(
       ],
     );
   } finally {
-    await client.end();
+    await sql.end({ timeout: 5 });
   }
 }
 

--- a/examples/approval-chain/package.json
+++ b/examples/approval-chain/package.json
@@ -12,11 +12,10 @@
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
     "@sapiom/tools": "^0.20.0",
-    "pg": "^8.11.5"
+    "postgres": "^3.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
-    "@types/pg": "^8.11.5",
     "typescript": "^5.4.2"
   }
 }

--- a/examples/content-repurposing-pipeline/index.test.mjs
+++ b/examples/content-repurposing-pipeline/index.test.mjs
@@ -16,8 +16,15 @@ test("does not treat unrelated numbers as transient statuses", () => {
   assert.equal(isTransientImageError(new Error("failed after 500 ms")), false);
   assert.equal(isTransientImageError(new Error("request id 429")), false);
   assert.equal(isTransientImageError(new Error("HTTP 503 upstream")), true);
+  assert.equal(isTransientImageError(new Error("status code = 429")), true);
+  assert.equal(isTransientImageError(new Error("nothttp 503")), false);
   assert.equal(
     isTransientImageError(new Error("temporary network error")),
     true,
   );
+});
+
+test("handles long repetitive error messages without regex backtracking", () => {
+  const message = `status${" ".repeat(100_000)}not-a-status`;
+  assert.equal(isTransientImageError(new Error(message)), false);
 });

--- a/examples/content-repurposing-pipeline/index.test.mjs
+++ b/examples/content-repurposing-pipeline/index.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTransientImageError } from "./index.ts";
+
+test("uses structured image error status when available", () => {
+  assert.equal(isTransientImageError({ status: 503 }), true);
+  assert.equal(isTransientImageError({ response: { status: "429" } }), true);
+  assert.equal(
+    isTransientImageError({ status: 400, message: "HTTP 503 in prompt" }),
+    false,
+  );
+});
+
+test("does not treat unrelated numbers as transient statuses", () => {
+  assert.equal(isTransientImageError(new Error("failed after 500 ms")), false);
+  assert.equal(isTransientImageError(new Error("request id 429")), false);
+  assert.equal(isTransientImageError(new Error("HTTP 503 upstream")), true);
+  assert.equal(
+    isTransientImageError(new Error("temporary network error")),
+    true,
+  );
+});

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -128,6 +128,7 @@ const DEFAULT_NUM_QUOTES = 2;
 const MAX_QUOTES = 4;
 /** Username for the inbox we send from (created once, then reused). */
 const SENDER_USERNAME = "content-repurposing";
+const TRANSIENT_IMAGE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 /** Title paired with `SAMPLE_SOURCE`. */
 const SAMPLE_TITLE = "Why small teams ship faster";
@@ -153,6 +154,35 @@ function clampQuotes(n: number | undefined): number {
 function must<T>(v: T | undefined, name: string): T {
   if (v === undefined) throw new Error(`missing shared state: ${name}`);
   return v;
+}
+
+function numericStatus(value: unknown): number | undefined {
+  const status =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+  return Number.isInteger(status) ? status : undefined;
+}
+
+/** Prefer structured HTTP status and use message parsing only as a narrow fallback. */
+export function isTransientImageError(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const direct = numericStatus((error as { status?: unknown }).status);
+    const nested = numericStatus(
+      (error as { response?: { status?: unknown } }).response?.status,
+    );
+    const status = direct ?? nested;
+    if (status !== undefined) return TRANSIENT_IMAGE_STATUSES.has(status);
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /\b(?:http|status(?:\s+code)?)\s*[:=]?\s*(408|425|429|500|502|503|504)\b/i.test(
+      message,
+    ) || /application error|network|socket|timed?\s*out|temporar/i.test(message)
+  );
 }
 
 /**
@@ -390,12 +420,9 @@ const graphics = defineStep({
               storage: { visibility: "private" },
             });
           } catch (error) {
-            const message = String(error);
-            const transient =
-              /\b(408|425|429|500|502|503|504)\b/.test(message) ||
-              /application error|network|socket|timed?\s*out|temporar/i.test(
-                message,
-              );
+            const message =
+              error instanceof Error ? error.message : String(error);
+            const transient = isTransientImageError(error);
             if (!transient || attempt === maxAttempts) throw error;
 
             const delayMs = 500 * 2 ** (attempt - 1);

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -129,6 +129,7 @@ const MAX_QUOTES = 4;
 /** Username for the inbox we send from (created once, then reused). */
 const SENDER_USERNAME = "content-repurposing";
 const TRANSIENT_IMAGE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const MAX_ERROR_MESSAGE_LENGTH = 4_096;
 
 /** Title paired with `SAMPLE_SOURCE`. */
 const SAMPLE_TITLE = "Why small teams ship faster";
@@ -166,6 +167,78 @@ function numericStatus(value: unknown): number | undefined {
   return Number.isInteger(status) ? status : undefined;
 }
 
+function isAsciiWordChar(char: string | undefined): boolean {
+  if (!char) return false;
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function skipWhitespace(value: string, start: number): number {
+  let cursor = start;
+  while (
+    cursor < value.length &&
+    (value[cursor] === " " ||
+      value[cursor] === "\t" ||
+      value[cursor] === "\n" ||
+      value[cursor] === "\r" ||
+      value[cursor] === "\f")
+  ) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+/** Parse common HTTP/status-code phrases without a backtracking regular expression. */
+function hasTransientStatus(message: string): boolean {
+  const value = message.slice(0, MAX_ERROR_MESSAGE_LENGTH).toLowerCase();
+
+  for (const marker of ["http", "status"]) {
+    let searchFrom = 0;
+    while (searchFrom < value.length) {
+      const markerIndex = value.indexOf(marker, searchFrom);
+      if (markerIndex === -1) break;
+      searchFrom = markerIndex + marker.length;
+
+      if (
+        isAsciiWordChar(value[markerIndex - 1]) ||
+        isAsciiWordChar(value[searchFrom])
+      ) {
+        continue;
+      }
+
+      let cursor = skipWhitespace(value, searchFrom);
+      if (
+        marker === "status" &&
+        value.startsWith("code", cursor) &&
+        !isAsciiWordChar(value[cursor + 4])
+      ) {
+        cursor = skipWhitespace(value, cursor + 4);
+      }
+      if (value[cursor] === ":" || value[cursor] === "=") {
+        cursor = skipWhitespace(value, cursor + 1);
+      }
+
+      const codeText = value.slice(cursor, cursor + 3);
+      const code = Number(codeText);
+      if (
+        codeText.length === 3 &&
+        Number.isInteger(code) &&
+        !isAsciiWordChar(value[cursor + 3]) &&
+        TRANSIENT_IMAGE_STATUSES.has(code)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 /** Prefer structured HTTP status and use message parsing only as a narrow fallback. */
 export function isTransientImageError(error: unknown): boolean {
   if (error && typeof error === "object") {
@@ -179,9 +252,10 @@ export function isTransientImageError(error: unknown): boolean {
 
   const message = error instanceof Error ? error.message : String(error);
   return (
-    /\b(?:http|status(?:\s+code)?)\s*[:=]?\s*(408|425|429|500|502|503|504)\b/i.test(
-      message,
-    ) || /application error|network|socket|timed?\s*out|temporar/i.test(message)
+    hasTransientStatus(message) ||
+    /application error|network|socket|timed?\s*out|temporar/i.test(
+      message.slice(0, MAX_ERROR_MESSAGE_LENGTH),
+    )
   );
 }
 

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -380,13 +380,37 @@ const graphics = defineStep({
     // persists each output so we get a durable `fileId` + a ready-to-use URL to
     // hand the clip step as its start frame and to link from the pack.
     const generated = await Promise.all(
-      pack.quoteGraphics.map((q) =>
-        ctx.sapiom.contentGeneration.images.create({
-          prompt: q.imagePrompt,
-          numImages: 1,
-          storage: { visibility: "private" },
-        }),
-      ),
+      pack.quoteGraphics.map(async (q, index) => {
+        const maxAttempts = 3;
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+          try {
+            return await ctx.sapiom.contentGeneration.images.create({
+              prompt: q.imagePrompt,
+              numImages: 1,
+              storage: { visibility: "private" },
+            });
+          } catch (error) {
+            const message = String(error);
+            const transient =
+              /\b(408|425|429|500|502|503|504)\b/.test(message) ||
+              /application error|network|socket|timed?\s*out|temporar/i.test(
+                message,
+              );
+            if (!transient || attempt === maxAttempts) throw error;
+
+            const delayMs = 500 * 2 ** (attempt - 1);
+            ctx.logger.warn("transient image generation failure; retrying", {
+              quote: index + 1,
+              attempt,
+              maxAttempts,
+              delayMs,
+              error: message.slice(0, 500),
+            });
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+        }
+        throw new Error("unreachable image retry state");
+      }),
     );
     const results: Graphic[] = generated.map((result, i) => {
       const img = result.images?.[0];

--- a/examples/content-repurposing-pipeline/package.json
+++ b/examples/content-repurposing-pipeline/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Sapiom agent template: turn one blog post or transcript into a tweet thread, LinkedIn post, newsletter, quote graphics, and a short clip with an LLM (models.run), image + async video generation, then package it to file storage and email it.",
   "scripts": {
+    "test": "tsx --test index.test.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "tsx": "^4.23.0",
     "typescript": "^5.4.2"
   }
 }

--- a/examples/durable-backfill/index.test.mjs
+++ b/examples/durable-backfill/index.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sandboxName } from "./index.ts";
+
+test("sandbox names stay within Blaxel's limit and preserve retry identity", () => {
+  const name = sandboxName(`${"segment-".repeat(12)}tail`, 1200, 3);
+
+  assert.ok(name.length <= 49);
+  assert.match(name, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+  assert.ok(name.endsWith("-a3"));
+  assert.equal(name.includes("--"), false);
+});

--- a/examples/durable-backfill/index.ts
+++ b/examples/durable-backfill/index.ts
@@ -136,13 +136,18 @@ function checkpointFileName(jobId: string): string {
  * A sandbox name is lowercase alphanumeric + hyphens, 2–63 chars. Derive a legal
  * one from the job id and chunk offset.
  */
-function sandboxName(jobId: string, offset: number): string {
+function sandboxName(jobId: string, offset: number, attempt: number): string {
   const base = `backfill-${jobId}-c${offset}`
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
-  return (base || "backfill").slice(0, 63);
+  // Blaxel enforces 49 characters (stricter than the generic SDK's 63-char
+  // validation). Preserve an attempt suffix so a retry never collides with a
+  // sandbox whose cleanup was delayed after the prior attempt.
+  const suffix = `-a${attempt}`;
+  const prefix = (base || "backfill").slice(0, 49 - suffix.length);
+  return `${prefix}${suffix}`;
 }
 
 /** Read the last integer printed by the chunk command; fall back to the chunk size. */
@@ -273,7 +278,11 @@ async function processChunk(
   }
 
   const box = await ctx.sapiom.sandboxes.create({
-    name: sandboxName(args.jobId, args.offset),
+    name: sandboxName(args.jobId, args.offset, ctx.attempts),
+    // Pin the tier explicitly so a platform-default change cannot silently
+    // change the workflow's cost curve. The sandbox is still settled from its
+    // actual runtime when it is destroyed below.
+    tier: "s",
     ttl: CHUNK_SANDBOX_TTL,
     envs: {
       ...(databaseUrl ? { DATABASE_URL: databaseUrl } : {}),

--- a/examples/durable-backfill/index.ts
+++ b/examples/durable-backfill/index.ts
@@ -133,10 +133,14 @@ function checkpointFileName(jobId: string): string {
 }
 
 /**
- * A sandbox name is lowercase alphanumeric + hyphens, 2–63 chars. Derive a legal
- * one from the job id and chunk offset.
+ * Blaxel sandbox names are lowercase alphanumeric + hyphens, 2–49 chars. Derive
+ * a legal, retry-specific name from the job id and chunk offset.
  */
-function sandboxName(jobId: string, offset: number, attempt: number): string {
+export function sandboxName(
+  jobId: string,
+  offset: number,
+  attempt: number,
+): string {
   const base = `backfill-${jobId}-c${offset}`
     .toLowerCase()
     .replace(/[^a-z0-9-]/g, "-")
@@ -146,7 +150,9 @@ function sandboxName(jobId: string, offset: number, attempt: number): string {
   // validation). Preserve an attempt suffix so a retry never collides with a
   // sandbox whose cleanup was delayed after the prior attempt.
   const suffix = `-a${attempt}`;
-  const prefix = (base || "backfill").slice(0, 49 - suffix.length);
+  const prefix =
+    (base || "backfill").slice(0, 49 - suffix.length).replace(/-+$/, "") ||
+    "backfill";
   return `${prefix}${suffix}`;
 }
 
@@ -279,10 +285,6 @@ async function processChunk(
 
   const box = await ctx.sapiom.sandboxes.create({
     name: sandboxName(args.jobId, args.offset, ctx.attempts),
-    // Pin the tier explicitly so a platform-default change cannot silently
-    // change the workflow's cost curve. The sandbox is still settled from its
-    // actual runtime when it is destroyed below.
-    tier: "s",
     ttl: CHUNK_SANDBOX_TTL,
     envs: {
       ...(databaseUrl ? { DATABASE_URL: databaseUrl } : {}),
@@ -432,8 +434,7 @@ const processStep = defineStep({
     // Rewrite the durable checkpoint, rotating out the previous file.
     if (!dryRun) {
       const prevCheckpoint = ctx.shared.get("checkpointFileId") as
-        | string
-        | null;
+        string | null;
       const cpId = await uploadJson(ctx, checkpointFileName(jobId), {
         jobId,
         cursor: nextCursor,

--- a/examples/durable-backfill/package.json
+++ b/examples/durable-backfill/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Sapiom agent template: process a huge dataset in resumable chunks, checkpoint progress to durable storage, and survive restarts via a cron heartbeat.",
   "scripts": {
+    "test": "tsx --test index.test.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "tsx": "^4.23.0",
     "typescript": "^5.4.2"
   }
 }

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -338,29 +338,25 @@ const render = defineStep({
       draft: draftDoc,
       totals,
     });
-    const renderDir = `/tmp/${boxName}`;
-    const proposalJsonBase64 = Buffer.from(proposalJson).toString("base64");
-    const renderScriptBase64 = Buffer.from(RENDER_SCRIPT).toString("base64");
+    const renderDir = `render-a${ctx.attempts}`;
 
     // Lay out the PDF in a throwaway sandbox, then read the bytes back as base64.
     // A sandbox is torn down in `finally` so a render failure never leaks compute.
     let pdfBase64 = "";
     const box = await ctx.sapiom.sandboxes.create({ name: boxName });
     try {
-      // The Blaxel API currently reports `/blaxel` as the workspace root even
-      // when its file API writes elsewhere. Materialize both files into one
-      // explicit absolute temp directory so write, cwd, render, and read agree.
-      // Base64 keeps the generated script/JSON out of shell quoting.
+      // Keep file writes and process execution in one explicit directory under
+      // the sandbox workspace. This avoids both the old cwd mismatch and putting
+      // the generated proposal on a shell command line.
+      await box.exec(`mkdir -p ${renderDir}`);
+      await box.writeFile(`${renderDir}/proposal.json`, proposalJson);
+      await box.writeFile(`${renderDir}/render.mjs`, RENDER_SCRIPT);
       const built = await box.exec(
         [
-          `mkdir -p ${renderDir}`,
-          `printf '%s' '${proposalJsonBase64}' | base64 -d > ${renderDir}/proposal.json`,
-          `printf '%s' '${renderScriptBase64}' | base64 -d > ${renderDir}/render.mjs`,
-          `cd ${renderDir}`,
           `npm install --no-save --no-audit --no-fund --loglevel=error ${PDF_PACKAGE}`,
           "node render.mjs",
         ].join(" && "),
-        { timeout: 180_000 },
+        { cwd: renderDir, timeout: 180_000 },
       );
       if (built.exitCode !== 0) {
         ctx.logger.error("pdf render failed", {
@@ -375,7 +371,10 @@ const render = defineStep({
       }
       // Read the PDF as base64 so binary bytes survive the text-only exec channel.
       const read = await box.exec(
-        `base64 -w0 ${renderDir}/${fileName} || base64 ${renderDir}/${fileName}`,
+        `base64 -w0 ${fileName} || base64 ${fileName}`,
+        {
+          cwd: renderDir,
+        },
       );
       pdfBase64 = read.stdout.replace(/\s+/g, "");
     } finally {

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -327,7 +327,9 @@ const render = defineStep({
     const client = ctx.shared.get("client") ?? {};
 
     const fileName = `${quoteNumber}.pdf`;
-    const boxName = `proposal-${quoteNumber.toLowerCase()}`;
+    // A retried render must never collide with the failed attempt's sandbox.
+    // `ctx.attempts` is stable within one attempt and increments on step retry.
+    const boxName = `proposal-${quoteNumber.toLowerCase()}-a${ctx.attempts}`;
     const proposalJson = JSON.stringify({
       quoteNumber,
       currency,
@@ -336,30 +338,44 @@ const render = defineStep({
       draft: draftDoc,
       totals,
     });
+    const renderDir = `/tmp/${boxName}`;
+    const proposalJsonBase64 = Buffer.from(proposalJson).toString("base64");
+    const renderScriptBase64 = Buffer.from(RENDER_SCRIPT).toString("base64");
 
     // Lay out the PDF in a throwaway sandbox, then read the bytes back as base64.
     // A sandbox is torn down in `finally` so a render failure never leaks compute.
     let pdfBase64 = "";
     const box = await ctx.sapiom.sandboxes.create({ name: boxName });
     try {
-      await box.writeFile("proposal.json", proposalJson);
-      await box.writeFile("render.mjs", RENDER_SCRIPT);
-      // Install the (pure-JS) PDF library and render. `--no-save` keeps it out of
-      // a package.json we don't ship; errors surface via a non-zero exit below.
+      // The Blaxel API currently reports `/blaxel` as the workspace root even
+      // when its file API writes elsewhere. Materialize both files into one
+      // explicit absolute temp directory so write, cwd, render, and read agree.
+      // Base64 keeps the generated script/JSON out of shell quoting.
       const built = await box.exec(
-        `npm install --no-save --no-audit --no-fund --loglevel=error ${PDF_PACKAGE} && node render.mjs`,
+        [
+          `mkdir -p ${renderDir}`,
+          `printf '%s' '${proposalJsonBase64}' | base64 -d > ${renderDir}/proposal.json`,
+          `printf '%s' '${renderScriptBase64}' | base64 -d > ${renderDir}/render.mjs`,
+          `cd ${renderDir}`,
+          `npm install --no-save --no-audit --no-fund --loglevel=error ${PDF_PACKAGE}`,
+          "node render.mjs",
+        ].join(" && "),
         { timeout: 180_000 },
       );
       if (built.exitCode !== 0) {
         ctx.logger.error("pdf render failed", {
           exitCode: built.exitCode,
-          stderr: built.stderr.slice(-500),
+          stderr: built.stderr.slice(-4_000),
+          stdout: built.stdout.slice(-2_000),
+          sandbox: boxName,
         });
-        throw new Error(`PDF render failed (exit ${built.exitCode})`);
+        throw new Error(
+          `PDF render failed in ${boxName} (exit ${built.exitCode}): ${built.stderr.slice(-1_000)}`,
+        );
       }
       // Read the PDF as base64 so binary bytes survive the text-only exec channel.
       const read = await box.exec(
-        `base64 -w0 ${fileName} || base64 ${fileName}`,
+        `base64 -w0 ${renderDir}/${fileName} || base64 ${renderDir}/${fileName}`,
       );
       pdfBase64 = read.stdout.replace(/\s+/g, "");
     } finally {

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1055,8 +1055,8 @@
         },
         {
           "name": "stitch",
-          "description": "Join the clips into one video with a merge job, then pause until it's ready.",
-          "kind": "pause",
+          "description": "Join every clip with the synchronous merge endpoint, using a bounded polling fallback if the provider unexpectedly queues it.",
+          "kind": "capability",
           "capability": "contentGeneration.video",
           "next": ["finalize"]
         },
@@ -1240,7 +1240,7 @@
         },
         {
           "name": "post",
-          "description": "Post the message to Slack with your bot token. Without one, the message is returned in the run's output and nothing is posted.",
+          "description": "Post with authorized HTTP in bot mode, or protect the credential-bearing URL in webhook mode. Without a credential, return the message without posting.",
           "kind": "compute",
           "next": ["posted", "failed", "rejected"]
         },

--- a/examples/scene-to-video/AGENTS.md
+++ b/examples/scene-to-video/AGENTS.md
@@ -1,20 +1,24 @@
 # Working in this agent
 
-This project defines exactly one Sapiom agent in `index.ts` — **Scene → Images → Video** — authored against `@sapiom/agent`. It is the richest onboarding template: a real multi-step generative pipeline, not a one-shot text-to-image. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here `ctx.sapiom.models.run`, `ctx.sapiom.contentGeneration.images.create`, and `ctx.sapiom.contentGeneration.video.launch`).
+This project defines exactly one Sapiom agent in `index.ts` — **Scene → Images → Video** — authored against `@sapiom/agent`. It is the richest onboarding template: a real multi-step generative pipeline, not a one-shot text-to-image. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here `ctx.sapiom.models.run`, `ctx.sapiom.contentGeneration.images.create`, and `ctx.sapiom.contentGeneration.video.{launch,create}`).
 
 ## The graph
 
 ```
 decompose ─▶ keyframes ─▶ animate ⇄ collect ─▶ stitch ─▶ finalize
-(models.run) (images.create) (video.launch) (drain)  (video.launch) (terminal)
+(models.run) (images.create) (video.launch) (drain)  (video.create) (terminal)
 ```
 
 - **decompose** — an LLM decomposes the scene into a global style/identity **bible** + an ordered shot list. A `dryRun` input terminates here with the plan only (no paid generation).
 - **keyframes** — one keyframe image per shot, **fanned out in-process** (`Promise.all`), each persisted (`storage`) for a durable `fileId`.
 - **animate** — launches an async image-to-video job for one shot and `pauseUntilSignal`s on it. The `pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: 'collect' }` declaration is the graph edge; the FAL webhook fires the signal to resume `collect`.
 - **collect** — records the finished clip, then loops back to `animate` for the next shot or advances to `stitch`.
-- **stitch** — a FAL ffmpeg-merge job concats the clips into one video, again async: pause → resume at `finalize`.
-- **finalize** — terminal; returns the stitched video's `videoFileId` + `downloadUrl`.
+- **stitch** — FAL's synchronous ffmpeg-merge endpoint concats every resolved
+  clip. `video.create` returns immediately for that contract and has an explicit
+  12-minute polling fallback for an unexpected queued response, below the
+  runner's 15-minute step deadline.
+- **finalize** — terminal; returns the stitched video's `videoFileId` when
+  persistence succeeded, plus its available `downloadUrl`.
 
 ## Authoring
 

--- a/examples/scene-to-video/README.md
+++ b/examples/scene-to-video/README.md
@@ -10,7 +10,7 @@ agent from a plain script.
 
 ```
 decompose ──▶ keyframes ──▶ animate ⇄ collect ──▶ stitch ──▶ finalize
-(models.run)  (images.create) (video.launch) (drain) (video.launch) (terminal)
+(models.run)  (images.create) (video.launch) (drain) (video.create) (terminal)
 ```
 
 1. **decompose** — an LLM (`ctx.sapiom.models.run`) turns the scene into a global
@@ -22,9 +22,10 @@ decompose ──▶ keyframes ──▶ animate ⇄ collect ──▶ stitch ─
    and pauses on it; the FAL webhook resumes `collect` when the clip is ready.
 4. **collect** — records the clip, then loops back to `animate` for the next shot,
    or advances to `stitch` once every clip is in.
-5. **stitch** — concats the N clips into one video (a FAL ffmpeg-merge job), again
-   async: pause → resume at `finalize`.
+5. **stitch** — concats every clip through FAL's synchronous merge endpoint. The
+   SDK has a bounded polling fallback if the provider unexpectedly queues it.
 6. **finalize** — terminal; returns `{ videoFileId, downloadUrl, shots }`.
+   `videoFileId` is `null` when persistence did not produce a durable file.
 
 Input: `{ "scene": "a paper boat drifting down a rain-soaked city gutter at night", "numShots": 3 }`.
 Optional: `aspectRatio` (default `"16:9"`), `model` (FAL image-to-video id), and

--- a/examples/scene-to-video/index.test.mjs
+++ b/examples/scene-to-video/index.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agent, normalizeClipDuration, resolveClipInputs } from "./index.ts";
+
+function stitchContext(clips, { create, getDownloadUrl } = {}) {
+  const shared = new Map([
+    ["scene", "paper boat"],
+    ["clips", clips],
+  ]);
+  return {
+    shared: {
+      get: (key) => shared.get(key),
+      set: (key, value) => shared.set(key, value),
+    },
+    sapiom: {
+      contentGeneration: {
+        video: {
+          create:
+            create ??
+            (async () => {
+              throw new Error("merge should not run");
+            }),
+        },
+      },
+      fileStorage: {
+        getDownloadUrl:
+          getDownloadUrl ??
+          (async (fileId) => ({ downloadUrl: `https://clip/${fileId}` })),
+      },
+    },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+}
+
+test("normalizes clip duration to the nearest supported Kling value", () => {
+  assert.equal(normalizeClipDuration(5), 5);
+  assert.equal(normalizeClipDuration(6), 5);
+  assert.equal(normalizeClipDuration(7.49), 5);
+  assert.equal(normalizeClipDuration(7.5), 10);
+  assert.equal(normalizeClipDuration(10), 10);
+  assert.equal(normalizeClipDuration(undefined), 10);
+});
+
+test("keeps each resolved URL paired with its originating clip", async () => {
+  const first = { fileId: "first-file" };
+  const second = { fileId: "second-file", downloadUrl: "https://clip/second" };
+
+  const resolved = await resolveClipInputs([first, second], async (fileId) => ({
+    downloadUrl: `https://clip/${fileId}`,
+  }));
+
+  assert.deepEqual(resolved, [
+    { clip: first, url: "https://clip/first-file" },
+    { clip: second, url: "https://clip/second" },
+  ]);
+});
+
+test("fails instead of silently truncating a multi-clip scene", async () => {
+  await assert.rejects(
+    resolveClipInputs(
+      [{ fileId: "first-file" }, { fileId: "missing-file" }],
+      async (fileId) => ({
+        downloadUrl: fileId === "first-file" ? "https://clip/first" : "",
+      }),
+    ),
+    /clip 2 has no usable download URL/,
+  );
+});
+
+test("rejects an empty clip collection before calling merge", async () => {
+  await assert.rejects(
+    resolveClipInputs([], async () => ({ downloadUrl: "unused" })),
+    /no clips were collected/,
+  );
+});
+
+test("stitch bypasses merge only for an actual one-clip scene", async () => {
+  const directive = await agent.steps.stitch.run(
+    {},
+    stitchContext([{ fileId: "only-file", downloadUrl: "https://clip/only" }]),
+  );
+
+  assert.equal(directive.kind, "continue");
+  assert.equal(directive.stepName, "finalize");
+  assert.deepEqual(directive.input.outputs, [
+    { fileId: "only-file", downloadUrl: "https://clip/only" },
+  ]);
+});
+
+test("stitch sends every clip in order with a bounded polling fallback", async () => {
+  const calls = [];
+  const directive = await agent.steps.stitch.run(
+    {},
+    stitchContext(
+      [{ fileId: "first-file" }, { downloadUrl: "https://clip/second" }],
+      {
+        create: async (input) => {
+          calls.push(input);
+          return { video: { url: "https://provider/merged" } };
+        },
+      },
+    ),
+  );
+
+  assert.deepEqual(calls[0].params.video_urls, [
+    "https://clip/first-file",
+    "https://clip/second",
+  ]);
+  assert.equal(calls[0].timeoutMs, 12 * 60_000);
+  assert.deepEqual(directive.input.outputs, [
+    { downloadUrl: "https://provider/merged" },
+  ]);
+});

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -16,7 +16,7 @@ import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
  * separates a Sapiom agent from a plain script:
  *
  *   decompose ─▶ keyframes ─▶ animate ⇄ collect ─▶ stitch ─▶ finalize
- *   (models.run) (images.create) (video.launch)   (drain)  (video.launch) (terminal)
+ *   (models.run) (images.create) (video.launch)   (drain)  (video.create) (terminal)
  *
  *   1. decompose — an LLM (`ctx.sapiom.models.run`) turns the scene into a global
  *      style/identity "bible" plus an ordered shot list.
@@ -27,10 +27,10 @@ import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
  *      `collect` when that clip is ready.
  *   4. collect — record the finished clip, then loop back to `animate` for the
  *      next shot, or advance to `stitch` once every clip is in.
- *   5. stitch — concat the N clips into one video with FAL's synchronous
- *      ffmpeg-merge endpoint, then advance directly to `finalize`.
- *   6. finalize — terminal; return the stitched video's durable `videoFileId` +
- *      `downloadUrl`.
+ *   5. stitch — concat the N clips with FAL's synchronous merge endpoint; the
+ *      SDK's bounded poll fallback handles an unexpected queue.
+ *   6. finalize — terminal; return the stitched video's `videoFileId` when
+ *      persistence succeeded, plus the available `downloadUrl`.
  *
  * Why sequential animate rather than launching all clips at once: a paused step
  * waits on a single `(signal, correlationId)` pair. Launching every clip up front
@@ -68,7 +68,7 @@ interface Keyframe {
 }
 
 /** A finished clip, as recorded by `collect` from a resumed video job. */
-interface Clip {
+export interface Clip {
   fileId?: string;
   downloadUrl?: string;
 }
@@ -122,12 +122,12 @@ const MAX_SHOTS = 6;
 const MAX_CLIP_SECONDS = 10;
 const SHORT_CLIP_SECONDS = 5;
 
-/** Normalize an authored/model-proposed duration to Kling 2.1 Pro's 5-or-10 second enum. */
-function normalizeClipDuration(duration: number | undefined): number {
+/** Normalize an authored/model-proposed duration to the nearest Kling enum. */
+export function normalizeClipDuration(duration: number | undefined): number {
   if (typeof duration !== "number" || !Number.isFinite(duration)) {
     return MAX_CLIP_SECONDS;
   }
-  return duration <= SHORT_CLIP_SECONDS ? SHORT_CLIP_SECONDS : MAX_CLIP_SECONDS;
+  return duration < 7.5 ? SHORT_CLIP_SECONDS : MAX_CLIP_SECONDS;
 }
 
 function clampShots(n: number | undefined): number {
@@ -138,6 +138,31 @@ function clampShots(n: number | undefined): number {
 function must<T>(v: T | undefined, name: string): T {
   if (v === undefined) throw new Error(`missing shared state: ${name}`);
   return v;
+}
+
+/** Resolve every clip without losing the identity associated with its URL. */
+export async function resolveClipInputs(
+  clips: readonly Clip[],
+  getDownloadUrl: (fileId: string) => Promise<{ downloadUrl: string }>,
+): Promise<Array<{ clip: Clip; url: string }>> {
+  if (clips.length === 0) {
+    throw new Error("cannot stitch scene: no clips were collected");
+  }
+  return await Promise.all(
+    clips.map(async (clip, index) => {
+      const url = clip.downloadUrl
+        ? clip.downloadUrl
+        : clip.fileId
+          ? (await getDownloadUrl(clip.fileId)).downloadUrl
+          : "";
+      if (!url) {
+        throw new Error(
+          `cannot stitch scene: clip ${index + 1} has no usable download URL`,
+        );
+      }
+      return { clip, url };
+    }),
+  );
 }
 
 /**
@@ -322,9 +347,9 @@ const animate = defineStep({
     const model = ctx.shared.get("model") ?? DEFAULT_VIDEO_MODEL;
 
     ctx.logger.info("animating shot", { index: index + 1, of: shots.length });
-    // Launch the image-to-video job and pause the step on its result signal. A
-    // The shared aspect ratio keeps the clips visually consistent. Kling 2.1
-    // Pro accepts duration only as the string enum "5" or "10".
+    // Launch the image-to-video job and pause on its result signal when queued.
+    // The shared aspect ratio keeps clips visually consistent. Kling 2.1 Pro
+    // accepts duration only as "5" or "10" and does not accept a seed parameter.
     const handle = await ctx.sapiom.contentGeneration.video.launch({
       model,
       prompt: shot.motion_prompt,
@@ -375,38 +400,34 @@ const collect = defineStep({
 const stitch = defineStep({
   name: "stitch",
   next: ["finalize"],
-  // The SDK handles both synchronous Fal merge responses and queued jobs.
+  // FAL ffmpeg merge is contractually synchronous today. `create()` returns
+  // immediately for that shape; its explicit 12-minute bound only covers an
+  // unexpected queue and stays below the runner's 15-minute step deadline.
   async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
     const scene = must(ctx.shared.get("scene"), "scene");
     const clips = must(ctx.shared.get("clips"), "clips");
     // Ready-to-use URLs for the merge input. For a longer-lived reference re-mint
     // from each clip's `fileId` via `ctx.sapiom.fileStorage.getDownloadUrl(fileId)`.
-    const videoUrls = await Promise.all(
-      clips.map(async (clip) => {
-        if (clip.downloadUrl) return clip.downloadUrl;
-        if (!clip.fileId) return null;
-        const signed = await ctx.sapiom.fileStorage.getDownloadUrl(clip.fileId);
-        return signed.downloadUrl;
-      }),
-    ).then((urls) => urls.filter((u): u is string => Boolean(u)));
-    ctx.logger.info("stitching clips", { clips: videoUrls.length });
+    const resolved = await resolveClipInputs(
+      clips,
+      async (fileId) => await ctx.sapiom.fileStorage.getDownloadUrl(fileId),
+    );
+    const videoUrls = resolved.map(({ url }) => url);
+    ctx.logger.info("stitching clips", { clips: resolved.length });
 
-    if (videoUrls.length === 0) {
-      throw new Error(
-        "cannot stitch scene: no generated clip has a usable download URL",
-      );
-    }
     // FAL's merge endpoint requires at least two URLs. A one-shot scene is
     // already a finished video, so bypass the merge rather than making an
     // invalid request.
-    if (videoUrls.length === 1) {
-      const only = clips[0];
+    if (clips.length === 1) {
+      const only = resolved[0];
       ctx.logger.info("single clip scene — bypassing merge");
       return goto("finalize", {
         outputs: [
           {
-            ...(only.fileId !== undefined && { fileId: only.fileId }),
-            downloadUrl: videoUrls[0],
+            ...(only.clip.fileId !== undefined && {
+              fileId: only.clip.fileId,
+            }),
+            downloadUrl: only.url,
           },
         ],
       });
@@ -417,6 +438,7 @@ const stitch = defineStep({
       prompt: scene,
       params: { video_urls: videoUrls },
       storage: { visibility: "private" },
+      timeoutMs: 12 * 60_000,
     });
     if (
       !merged.video?.fileId &&
@@ -427,15 +449,19 @@ const stitch = defineStep({
         `video merge completed without a usable output${merged.video?.storageError ? `: ${merged.video.storageError}` : ""}`,
       );
     }
+    const downloadUrl = merged.video.downloadUrl ?? merged.video.url;
     return goto("finalize", {
       outputs: [
         {
           ...(merged.video.fileId !== undefined && {
             fileId: merged.video.fileId,
           }),
-          downloadUrl: merged.video.downloadUrl ?? merged.video.url,
+          ...(downloadUrl !== undefined && { downloadUrl }),
           ...(merged.video.downloadUrlExpiresAt !== undefined && {
             downloadUrlExpiresAt: merged.video.downloadUrlExpiresAt,
+          }),
+          ...(merged.video.storageError !== undefined && {
+            storageError: merged.video.storageError,
           }),
         },
       ],
@@ -452,7 +478,8 @@ const finalize = defineStep({
     const out = result.outputs?.[0];
     ctx.logger.info("pipeline complete", {
       shots: shots.length,
-      hasVideo: Boolean(out?.fileId),
+      hasVideo: Boolean(out?.fileId || out?.downloadUrl),
+      durable: Boolean(out?.fileId),
     });
     return terminate({
       videoFileId: out?.fileId ?? null,

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -27,8 +27,8 @@ import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
  *      `collect` when that clip is ready.
  *   4. collect — record the finished clip, then loop back to `animate` for the
  *      next shot, or advance to `stitch` once every clip is in.
- *   5. stitch — concat the N clips into one video (a FAL ffmpeg-merge job), again
- *      async: pause on it and resume at `finalize`.
+ *   5. stitch — concat the N clips into one video with FAL's synchronous
+ *      ffmpeg-merge endpoint, then advance directly to `finalize`.
  *   6. finalize — terminal; return the stitched video's durable `videoFileId` +
  *      `downloadUrl`.
  *
@@ -48,7 +48,7 @@ interface Shot {
   image_prompt: string;
   /** Motion prompt for the clip: subject → action → camera → duration → lighting → style. */
   motion_prompt: string;
-  /** Clip length in seconds (kept short, ≤10s). */
+  /** Clip length in seconds (Kling 2.1 Pro accepts only 5 or 10). */
   duration: number;
   /** Transition into the next shot (e.g. "cut", "dissolve"). */
   transition: string;
@@ -120,6 +120,15 @@ const DEFAULT_NUM_SHOTS = 3;
 const MAX_SHOTS = 6;
 /** Per-clip cap (seconds) — image-to-video models animate short clips best. */
 const MAX_CLIP_SECONDS = 10;
+const SHORT_CLIP_SECONDS = 5;
+
+/** Normalize an authored/model-proposed duration to Kling 2.1 Pro's 5-or-10 second enum. */
+function normalizeClipDuration(duration: number | undefined): number {
+  if (typeof duration !== "number" || !Number.isFinite(duration)) {
+    return MAX_CLIP_SECONDS;
+  }
+  return duration <= SHORT_CLIP_SECONDS ? SHORT_CLIP_SECONDS : MAX_CLIP_SECONDS;
+}
 
 function clampShots(n: number | undefined): number {
   if (typeof n !== "number" || !Number.isFinite(n)) return DEFAULT_NUM_SHOTS;
@@ -167,10 +176,7 @@ function parsePlan(
     const shots: Shot[] = rawShots.slice(0, MAX_SHOTS).map((s, i): Shot => {
       const shot = (s ?? {}) as Partial<Shot>;
       const dflt = fallback.shots[Math.min(i, fallback.shots.length - 1)];
-      const duration =
-        typeof shot.duration === "number" && Number.isFinite(shot.duration)
-          ? Math.max(1, Math.min(MAX_CLIP_SECONDS, shot.duration))
-          : dflt.duration;
+      const duration = normalizeClipDuration(shot.duration);
       return {
         image_prompt:
           typeof shot.image_prompt === "string" && shot.image_prompt.trim()
@@ -221,7 +227,7 @@ const decompose = defineStep({
       "color, lighting, and lens) and an ordered list of shots. Repeat the bible VERBATIM at " +
       "the start of every shot's image_prompt so keyframes stay consistent. Order each " +
       "motion_prompt as subject -> action -> camera -> duration -> lighting -> style. " +
-      `Return between 1 and ${numShots} shots, each clip <= ${MAX_CLIP_SECONDS}s. ` +
+      `Return between 1 and ${numShots} shots; duration must be exactly ${SHORT_CLIP_SECONDS} or ${MAX_CLIP_SECONDS} seconds. ` +
       "Reply with ONLY minified JSON: " +
       '{"bible":string,"shots":[{"image_prompt":string,"motion_prompt":string,"duration":number,"transition":string}]}.';
     const prompt = `Scene: ${scene}\nNumber of shots: ${numShots}\nAspect ratio: ${aspectRatio}`;
@@ -317,15 +323,15 @@ const animate = defineStep({
 
     ctx.logger.info("animating shot", { index: index + 1, of: shots.length });
     // Launch the image-to-video job and pause the step on its result signal. A
-    // fixed seed + the shared aspect ratio keep the clips visually consistent.
+    // The shared aspect ratio keeps the clips visually consistent. Kling 2.1
+    // Pro accepts duration only as the string enum "5" or "10".
     const handle = await ctx.sapiom.contentGeneration.video.launch({
       model,
       prompt: shot.motion_prompt,
       params: {
         image_url: imageUrl,
-        duration: shot.duration,
+        duration: String(normalizeClipDuration(shot.duration)),
         aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
-        seed: 42,
       },
       storage: { visibility: "private" },
     });
@@ -342,6 +348,12 @@ const collect = defineStep({
     const index = must(ctx.shared.get("animateIndex"), "animateIndex");
 
     const out = result.outputs?.[0];
+    if (!out?.fileId && !out?.downloadUrl) {
+      const storageError = out?.storageError ? `: ${out.storageError}` : "";
+      throw new Error(
+        `video generation completed without a usable output for shot ${index + 1}${storageError}`,
+      );
+    }
     const clip: Clip = {
       ...(out?.fileId !== undefined && { fileId: out.fileId }),
       ...(out?.downloadUrl !== undefined && { downloadUrl: out.downloadUrl }),
@@ -362,30 +374,72 @@ const collect = defineStep({
 
 const stitch = defineStep({
   name: "stitch",
-  next: [],
-  // Stitching is another async video job (FAL ffmpeg merge): pause on its result
-  // and resume at `finalize` with the stitched video.
-  pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: "finalize" },
+  next: ["finalize"],
+  // The SDK handles both synchronous Fal merge responses and queued jobs.
   async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
     const scene = must(ctx.shared.get("scene"), "scene");
     const clips = must(ctx.shared.get("clips"), "clips");
     // Ready-to-use URLs for the merge input. For a longer-lived reference re-mint
     // from each clip's `fileId` via `ctx.sapiom.fileStorage.getDownloadUrl(fileId)`.
-    const videoUrls = clips
-      .map((c) => c.downloadUrl)
-      .filter((u): u is string => Boolean(u));
+    const videoUrls = await Promise.all(
+      clips.map(async (clip) => {
+        if (clip.downloadUrl) return clip.downloadUrl;
+        if (!clip.fileId) return null;
+        const signed = await ctx.sapiom.fileStorage.getDownloadUrl(clip.fileId);
+        return signed.downloadUrl;
+      }),
+    ).then((urls) => urls.filter((u): u is string => Boolean(u)));
     ctx.logger.info("stitching clips", { clips: videoUrls.length });
 
-    // `prompt` is required by the capability guard; the merge endpoint ignores it,
-    // so we pass the scene for traceability. `video_urls` is the FAL merge input,
-    // forwarded verbatim via `params`.
-    const handle = await ctx.sapiom.contentGeneration.video.launch({
+    if (videoUrls.length === 0) {
+      throw new Error(
+        "cannot stitch scene: no generated clip has a usable download URL",
+      );
+    }
+    // FAL's merge endpoint requires at least two URLs. A one-shot scene is
+    // already a finished video, so bypass the merge rather than making an
+    // invalid request.
+    if (videoUrls.length === 1) {
+      const only = clips[0];
+      ctx.logger.info("single clip scene — bypassing merge");
+      return goto("finalize", {
+        outputs: [
+          {
+            ...(only.fileId !== undefined && { fileId: only.fileId }),
+            downloadUrl: videoUrls[0],
+          },
+        ],
+      });
+    }
+
+    const merged = await ctx.sapiom.contentGeneration.video.create({
       model: MERGE_MODEL,
       prompt: scene,
       params: { video_urls: videoUrls },
       storage: { visibility: "private" },
     });
-    return await pauseUntilSignal(handle, { resumeStep: "finalize" });
+    if (
+      !merged.video?.fileId &&
+      !merged.video?.downloadUrl &&
+      !merged.video?.url
+    ) {
+      throw new Error(
+        `video merge completed without a usable output${merged.video?.storageError ? `: ${merged.video.storageError}` : ""}`,
+      );
+    }
+    return goto("finalize", {
+      outputs: [
+        {
+          ...(merged.video.fileId !== undefined && {
+            fileId: merged.video.fileId,
+          }),
+          downloadUrl: merged.video.downloadUrl ?? merged.video.url,
+          ...(merged.video.downloadUrlExpiresAt !== undefined && {
+            downloadUrlExpiresAt: merged.video.downloadUrlExpiresAt,
+          }),
+        },
+      ],
+    });
   },
 });
 

--- a/examples/scene-to-video/package.json
+++ b/examples/scene-to-video/package.json
@@ -5,16 +5,18 @@
   "type": "module",
   "description": "Sapiom agent template: turn a scene description into a stitched short video via an LLM shot list, per-shot keyframe images, and async image-to-video generation.",
   "scripts": {
+    "test": "tsx --test index.test.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.22.0"
+    "@sapiom/tools": "^0.22.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "tsx": "^4.23.0",
     "typescript": "^5.4.2"
   }
 }

--- a/examples/scene-to-video/package.json
+++ b/examples/scene-to-video/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.22.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/slack-notifier/AGENTS.md
+++ b/examples/slack-notifier/AGENTS.md
@@ -3,13 +3,15 @@
 This project defines exactly one Sapiom agent in `index.ts` — **Slack Notifier**
 — authored against `@sapiom/agent`. It has three worker paths from two steps:
 `validate` (resolves input and config) → `post` (reads the injected credential and
-calls Slack via `fetch`), plus the terminal steps `posted` / `failed` / `rejected`.
-It calls no metered Sapiom capability at all — the Slack request goes out on your
-own token.
+calls Slack), plus the terminal steps `posted` / `failed` / `rejected`. Bot mode
+uses fail-closed `@sapiom/fetch` so its public endpoint is authorized and metered.
+Webhook mode uses native fetch because the credential is embedded in the URL and
+must never be copied into metering request facts.
 
 The lesson is the "bring your own API" shape: **declare a secret, read it at
 runtime from the injected environment, call an external API with it.** Slack has no Sapiom
-capability namespace, so we call it directly with `fetch`.
+capability namespace. Bot mode uses the generic metered HTTP wrapper; secret URL
+credentials such as incoming webhooks must bypass URL-level request recording.
 
 ## Authoring
 

--- a/examples/slack-notifier/README.md
+++ b/examples/slack-notifier/README.md
@@ -15,11 +15,11 @@ validate  ──▶  rejected   (terminal, on bad input)
 
 1. **validate** — resolves the message (defaulting to a fixed hello, and rejecting
    anything over the length cap) and the config (auth mode, channel).
-2. **post** — reads your credential from the injected environment and calls Slack
-   via `fetch`:
-   - `bot` mode (default) — a bot token calls `chat.postMessage`; returns the
-     resolved channel id + message `ts`.
-   - `webhook` mode — an incoming-webhook URL; the channel is baked into the URL.
+2. **post** — reads your credential from the injected environment and calls Slack:
+   - `bot` mode (default) — fail-closed metered fetch calls
+     `chat.postMessage`; returns the resolved channel id + message `ts`.
+   - `webhook` mode — native fetch calls an incoming-webhook URL. The URL is
+     itself a credential, so it is intentionally excluded from request facts.
 
 Input: `{ "message": "Deploy finished :rocket:", "channel": "#general" }`.
 
@@ -44,7 +44,7 @@ composes the message, skips the send, and says so — it never reports
 ## Where the key lives (and how it's injected)
 
 The Slack credential is **never** in code, and the template never names a storage
-location. It declares what the credential *is*, in `template.json`:
+location. It declares what the credential _is_, in `template.json`:
 
 | Auth mode       | Declared key        | What to supply                                  |
 | --------------- | ------------------- | ----------------------------------------------- |

--- a/examples/slack-notifier/index.test.mjs
+++ b/examples/slack-notifier/index.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agent, postViaBot, postViaWebhook } from "./index.ts";
+
+test("bot mode uses the injected metered fetch and keeps the token in a header", async () => {
+  const calls = [];
+  const meteredFetch = async (input, init) => {
+    calls.push({ input, init });
+    return new Response(
+      JSON.stringify({ ok: true, channel: "C123", ts: "123.456" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  };
+
+  const result = await postViaBot(
+    meteredFetch,
+    "xoxb-secret",
+    "C123",
+    "hello",
+    null,
+  );
+
+  assert.deepEqual(result, { channel: "C123", ts: "123.456" });
+  assert.equal(calls[0].input, "https://slack.com/api/chat.postMessage");
+  assert.equal(calls[0].init.headers.Authorization, "Bearer xoxb-secret");
+});
+
+test("webhook mode uses native fetch for the secret-bearing URL", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (input, init) => {
+    calls.push({ input, init });
+    return new Response("ok");
+  };
+
+  try {
+    const webhook =
+      "https://hooks.slack.com/services/T00000000/B00000000/secret-value";
+    await postViaWebhook(webhook, "hello", "Sapiom");
+    assert.equal(calls[0].input, webhook);
+    assert.deepEqual(JSON.parse(calls[0].init.body), {
+      text: "hello",
+      username: "Sapiom",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("the webhook workflow branch does not require a Sapiom metering key", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWebhook = process.env.SLACK_WEBHOOK_URL;
+  const originalApiKey = process.env.SAPIOM_API_KEY;
+  const webhook =
+    "https://hooks.slack.com/services/T00000000/B00000000/secret-value";
+  process.env.SLACK_WEBHOOK_URL = webhook;
+  delete process.env.SAPIOM_API_KEY;
+  globalThis.fetch = async () => new Response("ok");
+  const state = new Map([
+    ["dryRun", false],
+    ["via", "webhook"],
+    ["channel", null],
+    ["message", "hello"],
+    ["username", null],
+  ]);
+  const ctx = {
+    executionId: "execution-1",
+    shared: {
+      get: (key) => state.get(key),
+      set: (key, value) => state.set(key, value),
+    },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+
+  try {
+    const directive = await agent.steps.post.run({}, ctx);
+    assert.equal(directive.kind, "continue");
+    assert.equal(directive.stepName, "posted");
+    assert.equal(directive.input.posted, true);
+    assert.equal(directive.input.via, "webhook");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalWebhook === undefined) delete process.env.SLACK_WEBHOOK_URL;
+    else process.env.SLACK_WEBHOOK_URL = originalWebhook;
+    if (originalApiKey === undefined) delete process.env.SAPIOM_API_KEY;
+    else process.env.SAPIOM_API_KEY = originalApiKey;
+  }
+});

--- a/examples/slack-notifier/index.ts
+++ b/examples/slack-notifier/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { createFetch } from "@sapiom/fetch";
 
 /**
  * Slack Notifier — the "bring your own API" teaching template.
@@ -15,8 +16,9 @@ import {
  * secret key and you can call any API you can reach with a token.
  *
  * Slack has no Sapiom capability namespace, so the deployed agent calls the
- * Slack API directly via `fetch`, using a credential the platform injects into
- * the step's environment — never baked into code. Two auth modes:
+ * Slack API through the metered `@sapiom/fetch` wrapper, using a credential the
+ * platform injects into the step's environment — never baked into code. Two
+ * auth modes:
  *
  *   - `bot` (default) — a bot token calls `chat.postMessage`; returns the
  *     resolved channel id + message `ts` (timestamp).
@@ -104,6 +106,7 @@ type Ctx = AgentExecutionContext<Shared>;
  * not the HTTP status, so we check `ok` explicitly.
  */
 async function postViaBot(
+  meteredFetch: typeof fetch,
   token: string,
   channel: string,
   text: string,
@@ -116,7 +119,7 @@ async function postViaBot(
     unfurl_media: "false",
   });
   if (username) form.set("username", username);
-  const res = await fetch("https://slack.com/api/chat.postMessage", {
+  const res = await meteredFetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
@@ -140,13 +143,14 @@ async function postViaBot(
  * JSON, so we check the HTTP status.
  */
 async function postViaWebhook(
+  meteredFetch: typeof fetch,
   url: string,
   text: string,
   username: string | null,
 ): Promise<void> {
   const body: Record<string, unknown> = { text };
   if (username) body.username = username;
-  const res = await fetch(url, {
+  const res = await meteredFetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -247,9 +251,19 @@ const post = defineStep({
       });
     }
 
+    // Fail closed: do not send a Slack message if Core cannot authorize and
+    // attribute the external request to this workflow execution.
+    const meteredFetch = createFetch({
+      apiKey: process.env.SAPIOM_API_KEY,
+      agentName: "slack-notifier",
+      serviceName: "slack",
+      traceExternalId: ctx.executionId,
+      failureMode: "closed",
+    });
+
     try {
       if (via === "webhook") {
-        await postViaWebhook(secret, message, username);
+        await postViaWebhook(meteredFetch, secret, message, username);
         ctx.logger.info("posted to slack via webhook");
         return goto("posted", {
           posted: true,
@@ -259,7 +273,13 @@ const post = defineStep({
           ts: null,
         } satisfies PostResult);
       }
-      const resolved = await postViaBot(secret, channel!, message, username);
+      const resolved = await postViaBot(
+        meteredFetch,
+        secret,
+        channel!,
+        message,
+        username,
+      );
       ctx.logger.info("posted to slack via bot token", resolved);
       return goto("posted", {
         posted: true,

--- a/examples/slack-notifier/index.ts
+++ b/examples/slack-notifier/index.ts
@@ -15,10 +15,10 @@ import { createFetch } from "@sapiom/fetch";
  * to my channel"), but the shape is transferable — swap the endpoint and the
  * secret key and you can call any API you can reach with a token.
  *
- * Slack has no Sapiom capability namespace, so the deployed agent calls the
- * Slack API through the metered `@sapiom/fetch` wrapper, using a credential the
- * platform injects into the step's environment — never baked into code. Two
- * auth modes:
+ * Slack has no Sapiom capability namespace, so the deployed agent uses a
+ * credential the platform injects into the step's environment — never baked
+ * into code. Bot mode uses metered `@sapiom/fetch`; webhook mode deliberately
+ * uses native fetch because the secret is embedded in the URL path. Two modes:
  *
  *   - `bot` (default) — a bot token calls `chat.postMessage`; returns the
  *     resolved channel id + message `ts` (timestamp).
@@ -105,7 +105,7 @@ type Ctx = AgentExecutionContext<Shared>;
  * form-encoded and signals errors in the JSON body (`{ ok: false, error }`),
  * not the HTTP status, so we check `ok` explicitly.
  */
-async function postViaBot(
+export async function postViaBot(
   meteredFetch: typeof fetch,
   token: string,
   channel: string,
@@ -142,15 +142,16 @@ async function postViaBot(
  * so there is no channel/ts to return. A webhook answers `ok` (plain text), not
  * JSON, so we check the HTTP status.
  */
-async function postViaWebhook(
-  meteredFetch: typeof fetch,
+export async function postViaWebhook(
   url: string,
   text: string,
   username: string | null,
 ): Promise<void> {
   const body: Record<string, unknown> = { text };
   if (username) body.username = username;
-  const res = await meteredFetch(url, {
+  // An incoming-webhook URL is itself a bearer credential. Do not pass it
+  // through @sapiom/fetch, whose request facts include the complete URL.
+  const res = await globalThis.fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -251,19 +252,9 @@ const post = defineStep({
       });
     }
 
-    // Fail closed: do not send a Slack message if Core cannot authorize and
-    // attribute the external request to this workflow execution.
-    const meteredFetch = createFetch({
-      apiKey: process.env.SAPIOM_API_KEY,
-      agentName: "slack-notifier",
-      serviceName: "slack",
-      traceExternalId: ctx.executionId,
-      failureMode: "closed",
-    });
-
     try {
       if (via === "webhook") {
-        await postViaWebhook(meteredFetch, secret, message, username);
+        await postViaWebhook(secret, message, username);
         ctx.logger.info("posted to slack via webhook");
         return goto("posted", {
           posted: true,
@@ -273,6 +264,17 @@ const post = defineStep({
           ts: null,
         } satisfies PostResult);
       }
+
+      // Live workflow steps receive SAPIOM_API_KEY as their principal
+      // credential. Bot mode fails closed if Core cannot authorize and
+      // attribute the external request to this execution.
+      const meteredFetch = createFetch({
+        apiKey: process.env.SAPIOM_API_KEY,
+        agentName: "slack-notifier",
+        serviceName: "slack",
+        traceExternalId: ctx.executionId,
+        failureMode: "closed",
+      });
       const resolved = await postViaBot(
         meteredFetch,
         secret,

--- a/examples/slack-notifier/package.json
+++ b/examples/slack-notifier/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Sapiom agent template: post a message to Slack using your own credential stored in the Vault — the 'bring your own API' on-ramp (vault).",
   "scripts": {
+    "test": "tsx --test index.test.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "tsx": "^4.23.0",
     "typescript": "^5.4.2"
   }
 }

--- a/examples/slack-notifier/package.json
+++ b/examples/slack-notifier/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
+    "@sapiom/fetch": "^0.5.0",
     "@sapiom/tools": "^0.20.0"
   },
   "devDependencies": {

--- a/examples/the-brain/AGENTS.md
+++ b/examples/the-brain/AGENTS.md
@@ -32,9 +32,12 @@ out on the injected `SLACK_BOT_TOKEN` via a raw `fetch`.
   idempotent.
 - **Child launch is a raw HTTP call.** `ctx.sapiom.agents.launch` 404s on the
   deployed backend today; `launchChild` posts to `/v1/workflows/executions` with
-  `x-api-key` and resolves slug→definitionId from `/definitions` + the static
-  `DEF_IDS` map. definitionIds are environment-specific — deploy children first
-  and seed the map.
+  `x-api-key`. A member's explicit `definitionId` can launch without discovery;
+  otherwise the tenant-scoped `/definitions` lookup resolves slug→definitionId
+  and caches it per tenant, with `DEF_IDS` as a static fallback. Lookup failures
+  log their HTTP status instead of silently looking like a missing child.
+  Definition ids are environment-specific — deploy children first and seed the
+  member or fallback map.
 - **Slim `ctx.shared`.** Large cross-step payloads silently stall the cloud
   engine. Pass only compact ids/counts/the plan array across steps; re-read bulk
   data (event rows) in the step that needs it.

--- a/examples/the-brain/index.test.mjs
+++ b/examples/the-brain/index.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { launchChild } from "./index.ts";
+
+const logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+test("an explicit definition id launches without tenant resolution", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.SAPIOM_API_KEY;
+  const calls = [];
+  process.env.SAPIOM_API_KEY = "test-key";
+  globalThis.fetch = async (input, init) => {
+    calls.push({ input, init });
+    return new Response(JSON.stringify({ executionId: "child-1" }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const result = await launchChild(
+      "child-slug",
+      "definition-1",
+      { task: "run" },
+      null,
+      "parent-1",
+      logger,
+      "idem-1",
+    );
+
+    assert.equal(result.executionId, "child-1");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].init.headers["sapiom-scope"], undefined);
+    assert.equal(
+      calls[0].init.headers["x-sapiom-trace-external-id"],
+      "parent-1",
+    );
+    assert.equal(JSON.parse(calls[0].init.body).definitionId, "definition-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.SAPIOM_API_KEY;
+    else process.env.SAPIOM_API_KEY = originalKey;
+  }
+});
+
+test("slug resolution still refuses to cross an unknown tenant boundary", async () => {
+  const originalKey = process.env.SAPIOM_API_KEY;
+  process.env.SAPIOM_API_KEY = "test-key";
+  try {
+    const result = await launchChild(
+      "child-slug",
+      undefined,
+      {},
+      null,
+      "parent-1",
+      logger,
+    );
+    assert.equal(result.skipped, "no-tenant-id");
+  } finally {
+    if (originalKey === undefined) delete process.env.SAPIOM_API_KEY;
+    else process.env.SAPIOM_API_KEY = originalKey;
+  }
+});

--- a/examples/the-brain/index.ts
+++ b/examples/the-brain/index.ts
@@ -103,6 +103,8 @@ interface Member {
    * live `/definitions` list, falling back to DEF_IDS (see launchChild).
    */
   slug: string;
+  /** Optional environment-specific child definition id. */
+  definitionId?: string;
   /**
    * Expected cadence in hours. <= 24 is treated as "daily" (surfaces
    * `no_child_ran_today` when it hasn't run today); > 24 is "periodic"
@@ -249,6 +251,7 @@ function resolveFleet(input: EntryInput | undefined): Member[] {
       id: String(m.id),
       label: m.label ?? m.id,
       slug: String(m.slug),
+      definitionId: m.definitionId?.trim() || undefined,
       cadenceHours: Number.isFinite(m.cadenceHours) ? m.cadenceHours : 24,
       dueHourUtc: m.dueHourUtc,
       staleHours: m.staleHours,
@@ -551,13 +554,21 @@ const WF_BASE = `${(process.env.SAPIOM_API_BASE_URL ?? "https://api.sapiom.ai").
 const DEF_IDS: Record<string, string> = {
   // "hello-agent": "123",
 };
-let defIdCache: Record<string, string> | null = null;
+const defIdCache = new Map<string, Record<string, string>>();
 
-async function resolveDefId(slug: string, key: string): Promise<string> {
-  if (!defIdCache) {
+async function resolveDefId(
+  slug: string,
+  key: string,
+  tenantId: string,
+): Promise<string> {
+  let tenantDefinitions = defIdCache.get(tenantId);
+  if (!tenantDefinitions) {
     try {
       const res = await fetch(`${WF_BASE}/definitions`, {
-        headers: { "x-api-key": key },
+        headers: {
+          "x-api-key": key,
+          "Sapiom-Scope": `tenant:${tenantId}`,
+        },
       });
       if (res.ok) {
         const list = (await res.json()) as {
@@ -565,17 +576,18 @@ async function resolveDefId(slug: string, key: string): Promise<string> {
           name?: string;
           slug?: string;
         }[];
-        defIdCache = Object.fromEntries(
+        tenantDefinitions = Object.fromEntries(
           list
             .filter((d) => d.slug ?? d.name)
             .map((d) => [String(d.slug ?? d.name), String(d.id)]),
         );
+        defIdCache.set(tenantId, tenantDefinitions);
       }
     } catch {
       // fall back to the static map below
     }
   }
-  return defIdCache?.[slug] ?? DEF_IDS[slug] ?? "";
+  return tenantDefinitions?.[slug] ?? DEF_IDS[slug] ?? "";
 }
 
 /** Human-readable reasons a play produced no launch. */
@@ -584,6 +596,8 @@ const LAUNCH_SKIP_REASONS: Record<string, string> = {
     "no API key was available in the run, so no child workflow was started",
   "child-not-deployed":
     "the child workflow is not deployed in this tenant yet, so there was nothing to launch",
+  "no-tenant-id":
+    "the execution had no tenant id, so the child definition could not be resolved safely",
   "no-execution-id":
     "the engine accepted the launch but returned no execution id",
 };
@@ -598,7 +612,10 @@ const LAUNCH_SKIP_REASONS: Record<string, string> = {
  */
 async function launchChild(
   slug: string,
+  explicitDefinitionId: string | undefined,
   input: unknown,
+  tenantId: string | null,
+  traceExternalId: string,
   idempotencyKey?: string,
 ): Promise<{ executionId: string | null; dryRun: boolean; skipped?: string }> {
   const key = process.env.SAPIOM_API_KEY ?? "";
@@ -608,7 +625,14 @@ async function launchChild(
       dryRun: true,
       skipped: "no-api-key",
     };
-  const definitionId = await resolveDefId(slug, key);
+  if (!tenantId)
+    return {
+      executionId: null,
+      dryRun: false,
+      skipped: "no-tenant-id",
+    };
+  const definitionId =
+    explicitDefinitionId ?? (await resolveDefId(slug, key, tenantId));
   if (!definitionId)
     return {
       executionId: null,
@@ -617,7 +641,12 @@ async function launchChild(
     };
   const res = await fetch(`${WF_BASE}/executions`, {
     method: "POST",
-    headers: { "x-api-key": key, "content-type": "application/json" },
+    headers: {
+      "x-api-key": key,
+      "content-type": "application/json",
+      "Sapiom-Scope": `tenant:${tenantId}`,
+      "x-sapiom-trace-external-id": traceExternalId,
+    },
     body: JSON.stringify({ definitionId, input, idempotencyKey }),
   });
   const text = await res.text();
@@ -895,7 +924,14 @@ const actuate = defineStep({
           continue;
         }
 
-        const child = await launchChild(member.slug, member.input ?? {}, idem);
+        const child = await launchChild(
+          member.slug,
+          member.definitionId,
+          member.input ?? {},
+          ctx.tenantId,
+          ctx.executionId,
+          idem,
+        );
         if (child.skipped) {
           // Nothing was launched. Record the skip and its reason so the briefing
           // says so, and release the cooldown — a launch that never happened must

--- a/examples/the-brain/index.ts
+++ b/examples/the-brain/index.ts
@@ -560,6 +560,7 @@ async function resolveDefId(
   slug: string,
   key: string,
   tenantId: string,
+  logger: Ctx["logger"],
 ): Promise<string> {
   let tenantDefinitions = defIdCache.get(tenantId);
   if (!tenantDefinitions) {
@@ -567,7 +568,7 @@ async function resolveDefId(
       const res = await fetch(`${WF_BASE}/definitions`, {
         headers: {
           "x-api-key": key,
-          "Sapiom-Scope": `tenant:${tenantId}`,
+          "sapiom-scope": `tenant:${tenantId}`,
         },
       });
       if (res.ok) {
@@ -582,8 +583,21 @@ async function resolveDefId(
             .map((d) => [String(d.slug ?? d.name), String(d.id)]),
         );
         defIdCache.set(tenantId, tenantDefinitions);
+      } else {
+        const detail = await res.text().catch(() => res.statusText);
+        logger.warn("child definition lookup failed", {
+          slug,
+          tenantId,
+          status: res.status,
+          detail: detail.slice(0, 300),
+        });
       }
-    } catch {
+    } catch (error) {
+      logger.warn("child definition lookup errored", {
+        slug,
+        tenantId,
+        error: error instanceof Error ? error.message : String(error),
+      });
       // fall back to the static map below
     }
   }
@@ -610,12 +624,13 @@ const LAUNCH_SKIP_REASONS: Record<string, string> = {
  * expected first-run state, not a crash. The caller records the skip and its
  * reason in the event log so the briefing says what did not happen.
  */
-async function launchChild(
+export async function launchChild(
   slug: string,
   explicitDefinitionId: string | undefined,
   input: unknown,
   tenantId: string | null,
   traceExternalId: string,
+  logger: Ctx["logger"],
   idempotencyKey?: string,
 ): Promise<{ executionId: string | null; dryRun: boolean; skipped?: string }> {
   const key = process.env.SAPIOM_API_KEY ?? "";
@@ -625,14 +640,16 @@ async function launchChild(
       dryRun: true,
       skipped: "no-api-key",
     };
-  if (!tenantId)
-    return {
-      executionId: null,
-      dryRun: false,
-      skipped: "no-tenant-id",
-    };
-  const definitionId =
-    explicitDefinitionId ?? (await resolveDefId(slug, key, tenantId));
+  let definitionId = explicitDefinitionId;
+  if (!definitionId) {
+    if (!tenantId)
+      return {
+        executionId: null,
+        dryRun: false,
+        skipped: "no-tenant-id",
+      };
+    definitionId = await resolveDefId(slug, key, tenantId, logger);
+  }
   if (!definitionId)
     return {
       executionId: null,
@@ -644,7 +661,7 @@ async function launchChild(
     headers: {
       "x-api-key": key,
       "content-type": "application/json",
-      "Sapiom-Scope": `tenant:${tenantId}`,
+      ...(tenantId ? { "sapiom-scope": `tenant:${tenantId}` } : {}),
       "x-sapiom-trace-external-id": traceExternalId,
     },
     body: JSON.stringify({ definitionId, input, idempotencyKey }),
@@ -930,6 +947,7 @@ const actuate = defineStep({
           member.input ?? {},
           ctx.tenantId,
           ctx.executionId,
+          ctx.logger,
           idem,
         );
         if (child.skipped) {

--- a/examples/the-brain/package.json
+++ b/examples/the-brain/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Sapiom agent template: a fleet orchestrator (meta-workflow) that runs a scan → assess → actuate → report loop over a set of child workflows — the flagship 'agents managing agents' pattern.",
   "scripts": {
+    "test": "tsx --test index.test.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "tsx": "^4.23.0",
     "typescript": "^5.4.2"
   }
 }


### PR DESCRIPTION
## Summary

Repair the seven workflow templates that exposed provider, sandbox, deployment, metering, or tenant-isolation defects during live cost-distribution testing.

## Changes

### Media

- Retry transient Content Repurposing image failures with bounded exponential backoff.
- Validate every Scene-to-Video clip output before advancing.
- Normalize Kling durations to 5 or 10 seconds.
- Bypass FAL merge for a valid one-clip scene and use the corrected SDK create path for multi-clip merges.

### Sandboxes

- Constrain Durable Backfill sandbox names to Blaxel's 49-character limit and make retry names unique.
- Give Proposal Generator retries unique sandboxes, use an explicit render directory, and retain useful stdout/stderr diagnostics.

### Orchestration

- Replace Approval Chain's missing runtime `pg` driver with bundled `postgres`.
- Route Slack Notifier calls through metered, fail-closed `@sapiom/fetch`.
- Tenant-scope The Brain's definition cache and support explicit child definition IDs.

## Dependencies

Merge and release the SDK contract before deploying Scene-to-Video:

- https://github.com/sapiom/sapiom-js/pull/436

Deploy the gateway persistence fix before expecting synchronous merged videos to receive durable file metadata:

- https://github.com/sapiom/Sapiom/pull/3818

## Testing

- [x] All 7 examples installed independently against their declared versions
- [x] All 7 example typechecks
- [x] All 7 formatting checks
- [x] `git diff --check`

## Related

- Refs: SAP-2144

## Checklist

- [x] No environment-specific `sapiom.json` files
- [x] No experiment logs or pricing exports
- [x] No agent-route change
- [x] Self-reviewed