### PR TITLE
fix(deps,agent-core): unstick main after the 0.2.0 version bump

### DIFF
--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.6.7",
-  tools: "0.22.0",
+  agent: "0.7.0",
+  tools: "0.22.1",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
         specifier: workspace:^
         version: link:../analytics-core
       '@sapiom/harness':
-        specifier: '>=0.1.2'
+        specifier: '>=0.2.0'
         version: link:../harness
       '@sapiom/sandbox-preview':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

Merging #417 versioned `@sapiom/harness` to 0.2.0 on `main`, but **both** the Publish and Test workflows have failed on every push since — so 0.2.0 was never published. `npx @sapiom/harness@latest` still resolves to 0.1.6.

The release PR bumped versions and left **two hand-maintained mirrors of those versions stale**. Changesets updates neither, and both are load-bearing.

## Changes

### 1. `pnpm-lock.yaml` — the lockfile specifier

#417 bumped `packages/cli`'s `@sapiom/harness` peerDependency `>=0.1.2` → `>=0.2.0` without regenerating the lockfile. Both workflows install with `--frozen-lockfile`, so both died at step 4:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
  * 1 dependencies are mismatched:
    - @sapiom/harness (lockfile: >=0.1.2, manifest: >=0.2.0)
```

One specifier line, from `pnpm install --lockfile-only`. No dependency versions change — `version: link:../harness` is a workspace link either way.

### 2. `VERSION_FALLBACK` — the offline scaffold pin

`packages/agent-core/src/scaffold.ts` carries a hand-maintained snapshot of the last published `@sapiom/agent` / `@sapiom/tools`, used when the live npm lookup fails. `scaffold.test.ts` asserts it matches the workspace's own `package.json` precisely so a version bump can't leave it behind — and it caught this one:

```
● resolveVersions offline fallback › falls back to a version that is
  actually published (matches the workspace's own package.json)
  Expected: "0.7.0"
  Received: "0.6.7"
```

agent `0.6.7` → `0.7.0`, tools `0.22.0` → `0.22.1`, matching what this same commit's publish puts on npm. Left stale, every offline or registry-hiccup scaffold fails with a silent ETARGET — which is what the pin's own comment warns about ("Bump alongside notable releases").

**This second failure was latent on main, not new.** Test also installs with `--frozen-lockfile`, so it died at install for the same reason Publish did and never reached the suite. Fixing the lockfile is what let CI get far enough to surface it. Test was green on every main push before the #417 merge and red on it.

## Testing

- [x] Reproduced CI's exact install step: `pnpm install --frozen-lockfile` → **exit 0** (was `ERR_PNPM_OUTDATED_LOCKFILE`)
- [x] `pnpm --filter @sapiom/agent-core test` → **129 passed, 14 suites**, including the `resolveVersions offline fallback` test that failed in CI

## Known follow-up — NOT fixed here

This gets `main` green and lets the publish run. But `changeset publish` has a **third, independent failure** that predates #417 entirely. The `fix(tools)` push before the merge got past install and failed inside publish:

```
error an error occurred while publishing @sapiom/langchain: ENEEDAUTH
This command requires you to be logged in to https://registry.npmjs.org
```

`@sapiom/langchain` is 0.5.1 in-repo, npm has 0.5.0, and 0.5.1 404s — that package has no per-package **Trusted Publisher** on npmjs.com, exactly the case `publish.yml`'s header comment warns about. Changesets publishes packages independently, so harness 0.2.0 should still land once this merges, but the job will stay red until someone with npm org admin adds the Trusted Publisher (repo `sapiom/sapiom-js`, workflow `.github/workflows/publish.yml`). That's a web-UI action; it can't be done from CI or a PR.

## Checklist

- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDanuiTBW7BnbQJ67couK4