### PR TITLE
fix(desktop): packaging, agent tooling, and in-app update checks

### DIFF
--- a/.changeset/desktop-update-check-button.md
+++ b/.changeset/desktop-update-check-button.md
@@ -2,10 +2,12 @@
 "@sapiom/harness": patch
 ---
 
-Add a desktop-only "Check for updates" control to the Settings popover, next to Disconnect.
+Add a desktop-only "Check for updates" item to the profile menu, alongside Disconnect.
 
 The Electron app (`@sapiom/harness-desktop`) now ships a minimal preload exposing `window.sapiomDesktop`, and the SPA feature-detects it: the row appears in the desktop app and is **absent** under `npx @sapiom/harness`, where there is no bundle to replace. New `web/src/lib/desktop.ts` owns that detection plus the outcome→copy mapping.
 
 The bridge contract is mirrored here rather than imported, because the dependency runs the other way (the desktop app depends on this package, never the reverse). `getDesktopBridge()` validates the shape rather than trusting a flag, so a desktop build older than a given SPA build reads as "no bridge" instead of throwing inside a click handler and leaving a dead button.
 
-Outcomes are distinguished rather than collapsed into one "checked!" message, because each has a different next step: downloading (wait), already downloaded (restart — offered as a button, warning that it ends running agent sessions), up to date (named with version *and* channel, since a beta and a stable install are up to date at different versions), updates disabled, or the check failed.
+The result arrives as a toast, because the menu closes on click and the outcome is the whole point of pressing it. Outcomes are distinguished rather than collapsed into one "checked!" message, because each has a different next step: downloading (wait), already downloaded (restart, via the native prompt described below), up to date (named with version *and* channel, since a beta and a stable install are up to date at different versions), updates disabled, or the check failed.
+
+Applying an update is confirmed by a **native dialog** raised by the desktop app, and the bridge exposes no way to trigger it. That is deliberate: a restart ends every running agent session, and the page asking for it shares an origin with the agent-authored files the harness serves at `/canvas/:sessionId/*`. Asking for a check when something is already downloaded re-raises that prompt.

--- a/.changeset/desktop-update-check-button.md
+++ b/.changeset/desktop-update-check-button.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness": patch
+---
+
+Add a desktop-only "Check for updates" control to the Settings popover, next to Disconnect.
+
+The Electron app (`@sapiom/harness-desktop`) now ships a minimal preload exposing `window.sapiomDesktop`, and the SPA feature-detects it: the row appears in the desktop app and is **absent** under `npx @sapiom/harness`, where there is no bundle to replace. New `web/src/lib/desktop.ts` owns that detection plus the outcome→copy mapping.
+
+The bridge contract is mirrored here rather than imported, because the dependency runs the other way (the desktop app depends on this package, never the reverse). `getDesktopBridge()` validates the shape rather than trusting a flag, so a desktop build older than a given SPA build reads as "no bridge" instead of throwing inside a click handler and leaving a dead button.
+
+Outcomes are distinguished rather than collapsed into one "checked!" message, because each has a different next step: downloading (wait), already downloaded (restart — offered as a button, warning that it ends running agent sessions), up to date (named with version *and* channel, since a beta and a stable install are up to date at different versions), updates disabled, or the check failed.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -79,10 +79,16 @@ jobs:
           #
           # Strip build metadata before looking for a pre-release tag: `0.1.2+pr-44`
           # is a FINAL release whose metadata happens to contain a hyphen.
+          #
+          # `*-?*`, not `*-*`: the hyphen must be FOLLOWED by something. A trailing
+          # hyphen (`0.1.2-`) is not a pre-release, and update-policy.ts's
+          # `/^\d+\.\d+\.\d+-\S/` agrees — matching on a bare `*-*` here made the
+          # two derivations disagree on that one input, which the metadata check
+          # below would catch as a confusing red build rather than a bad release.
           core="${version%%+*}"
           case "$core" in
-            *-*) channel=beta;    prerelease=true  ;;
-            *)   channel=latest;  prerelease=false ;;
+            *-?*) channel=beta;    prerelease=true  ;;
+            *)    channel=latest;  prerelease=false ;;
           esac
 
           # A tag that disagrees with package.json is the one mistake that breaks
@@ -468,6 +474,37 @@ jobs:
           for f in **/*.deb;      do cp "$f" "Sapiom-Linux-amd64.deb";      break; done
           for f in **/*.exe;      do cp "$f" "Sapiom-Windows-x64.exe";      break; done
           ls -la
+
+      # Refuse to publish a release that cannot update the apps already out there.
+      #
+      # The per-OS `Verify update metadata` step already fails a build with no
+      # manifest — but the Windows leg is `continue-on-error` while Phase 6 is open,
+      # and `fail_on_unmatched_files: false` below tolerates anything missing. Those
+      # two together route around that check: a final release could publish with no
+      # `latest.yml`, and every INSTALLED Windows app would then 404 on every check
+      # until the next release. Silent, and unfixable for anyone who already has it.
+      #
+      # So assert it once more here, where all three OSes' artifacts are together.
+      # Windows may still FAIL to build (that stays non-blocking) — this only says
+      # that whatever we attach must be internally consistent.
+      - name: Verify every platform's update manifest is present
+        run: |
+          set -euo pipefail
+          cd dist-artifacts
+          channel="${{ needs.prepare.outputs.channel }}"
+          missing=()
+          for suffix in ".yml" "-mac.yml" "-linux.yml"; do
+            # `find`, not a glob: download-artifact nests each OS in its own dir.
+            if [ -z "$(find . -name "${channel}${suffix}" -print -quit)" ]; then
+              missing+=("${channel}${suffix}")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing update manifest(s): ${missing[*]}. Publishing would leave already-installed apps unable to find any future update. Fix the failing platform, or cut the release without it deliberately."
+            find . -name "*.yml" -print
+            exit 1
+          fi
+          echo "All three channel manifests present for \"$channel\"."
 
       # Make the channels a hierarchy rather than two dead ends.
       #

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,10 +13,19 @@ name: Desktop Release
 # de-risking. Code signing + notarization (mac) and EV signing (win) come in
 # Phases 5–6 and layer on top of this same build.
 #
-# Trigger:
-#   - push a tag `harness-desktop-v1.2.3`  → build all OSes + publish a Release
-#   - workflow_dispatch (manual)           → build all OSes, artifacts only
-#     (no tag ⇒ no Release; download them from the run's Artifacts).
+# Trigger, and the tag convention that drives the update channel:
+#   - `harness-desktop-v1.2.3`        → FINAL release, `latest` channel. Every user
+#                                       gets it, and it becomes the target of the
+#                                       permanent /releases/latest/download/… links.
+#   - `harness-desktop-v1.2.3-beta.1` → PRE-release, `beta` channel. Only installs
+#                                       already following betas are offered it.
+#   - workflow_dispatch (manual)      → build all OSes, artifacts only
+#                                       (no tag ⇒ no Release; download them from
+#                                       the run's Artifacts).
+#
+# The tag must match `packages/harness-desktop/package.json`'s version exactly —
+# the `prepare` job enforces it, because that field is what names the artifacts and
+# what the installed app reports as its own version.
 
 on:
   push:
@@ -40,7 +49,64 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Resolve version/channel ONCE, and fail fast on a bad tag.
+  #
+  # Separate job on purpose: the guard below costs ~15 seconds, and catching a
+  # version mismatch here means we haven't already spent 40 minutes of macOS
+  # notarization on an artifact we're going to throw away. Three matrix legs
+  # computing the same thing three times would also be three chances to disagree.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      channel: ${{ steps.meta.outputs.channel }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version and update channel
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/harness-desktop/package.json').version")"
+
+          # THE source of truth is package.json, not the tag. electron-builder
+          # names every artifact from it, and the installed app derives its own
+          # channel from app.getVersion() — which is the same field (see
+          # src/main/update-policy.ts). Deriving the channel here from anything
+          # else would let the artifact and the app that runs it disagree.
+          #
+          # Strip build metadata before looking for a pre-release tag: `0.1.2+pr-44`
+          # is a FINAL release whose metadata happens to contain a hyphen.
+          core="${version%%+*}"
+          case "$core" in
+            *-*) channel=beta;    prerelease=true  ;;
+            *)   channel=latest;  prerelease=false ;;
+          esac
+
+          # A tag that disagrees with package.json is the one mistake that breaks
+          # updates permanently and silently: electron-builder writes the artifact
+          # names and `latest.yml` from package.json, so the release would advertise
+          # a version that no asset matches (or, worse, one the installed app
+          # already has) and every client would re-offer the same update forever.
+          # We have already tagged v0.1.0 against a package that later became
+          # 0.1.1 — this is a mistake we've made, not one we're imagining.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            expected="harness-desktop-v${version}"
+            if [ "${{ github.ref_name }}" != "$expected" ]; then
+              echo "::error::Tag '${{ github.ref_name }}' does not match packages/harness-desktop/package.json (${version}). Expected '${expected}'. Bump the package version or retag."
+              exit 1
+            fi
+          fi
+
+          echo "version=$version"       >> "$GITHUB_OUTPUT"
+          echo "channel=$channel"       >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "Building $version on the \"$channel\" channel (prerelease=$prerelease)."
+
   build:
+    needs: prepare
     strategy:
       # Build every OS even if one fails — a Linux failure must not hide the
       # macOS result (or vice-versa). Windows is additionally non-blocking below.
@@ -49,10 +115,24 @@ jobs:
         include:
           - os: ubuntu-latest
             packflag: "--linux"
-            # The shippable Linux installers.
+            # Suffix of the update manifest this OS produces; the channel is
+            # prefixed at check time (latest-linux.yml / beta-linux.yml).
+            metadata_suffix: "-linux.yml"
+            # The shippable Linux installers, PLUS the update manifest.
+            #
+            # The manifest globs are not optional extras: without them
+            # electron-builder generates the metadata and this step throws it
+            # away, producing a release that looks complete and silently breaks
+            # every future update. `latest*`/`beta*` rather than `*.yml` so
+            # builder-debug.yml doesn't get attached to a public release.
+            #
+            # No .blockmap on Linux — the AppImage embeds its own block map, so
+            # there is no separate file to collect (unlike the NSIS .exe).
             artifact_path: |
               packages/harness-desktop/release/*.AppImage
               packages/harness-desktop/release/*.deb
+              packages/harness-desktop/release/latest*.yml
+              packages/harness-desktop/release/beta*.yml
           - os: macos-14 # Apple Silicon; builds an arm64 .app → .dmg
             packflag: "--mac"
             # The .dmg is what a tester should get: signed + notarized, it opens
@@ -62,20 +142,34 @@ jobs:
             # unwrapping, at the cost of needing `chmod -R +x` + `xattr -dr
             # com.apple.quarantine` by hand — which signing exists to remove.)
             #
-            # .dmg ONLY — no .zip. electron-builder's macOS `zip` target is the
-            # auto-update artifact (Squirrel.Mac), a second full copy of the same
-            # .app; with no updater wired up yet it just doubled the download.
-            # It's no longer built (electron-builder.yml mac.target); re-add it
-            # here and there when auto-update ships in Phase 5+.
+            metadata_suffix: "-mac.yml"
+            # .dmg for humans, .zip for Squirrel.Mac. The zip is what the updater
+            # actually downloads — macOS auto-update cannot consume a dmg — and
+            # `latest-mac.yml` is only written when a zip target exists. It was
+            # deliberately dropped while there was no updater (it was just a second
+            # copy of the same .app); it is now load-bearing.
             artifact_path: |
               packages/harness-desktop/release/*.dmg
+              packages/harness-desktop/release/*.zip
+              packages/harness-desktop/release/latest*.yml
+              packages/harness-desktop/release/beta*.yml
+              packages/harness-desktop/release/*.blockmap
           # Pinned to windows-2022 (VS 2022 / v17). windows-latest rolled to an
           # image with Visual Studio 18, whose version node-gyp's VS detection
           # doesn't recognize ("unknown version undefined") → the node-pty
           # rebuild can't find a usable compiler. VS 2022 is fully supported.
           - os: windows-2022
             packflag: "--win"
-            artifact_path: packages/harness-desktop/release/*.exe
+            # Windows' manifest is unsuffixed: latest.yml / beta.yml.
+            metadata_suffix: ".yml"
+            # The .exe.blockmap is what makes differential updates work: without it
+            # attached, electron-updater silently falls back to downloading the
+            # whole ~100 MB installer instead of the few MB that changed.
+            artifact_path: |
+              packages/harness-desktop/release/*.exe
+              packages/harness-desktop/release/*.blockmap
+              packages/harness-desktop/release/latest*.yml
+              packages/harness-desktop/release/beta*.yml
 
     runs-on: ${{ matrix.os }}
     # Windows stays non-blocking while we bring it up (Phase 6). Keep it in the
@@ -203,6 +297,12 @@ jobs:
               notarize_flag="-c.mac.notarize=true"
             fi
           fi
+          # The channel is NOT passed from here. pack.mjs derives it from
+          # package.json using the app's own update-policy rule, so this workflow,
+          # the PR smoke job in test.yml, and a local `pnpm dist` all agree without
+          # three copies of "does this version have a pre-release tag?" in bash.
+          # The `prepare` job's channel output is then an independent expectation,
+          # and the metadata check below is what catches the two disagreeing.
           # shellcheck disable=SC2086 # intentional: empty must vanish
           node packages/harness-desktop/scripts/pack.mjs ${{ matrix.packflag }} $notarize_flag
 
@@ -243,6 +343,34 @@ jobs:
         # `shell: bash` runs under git-bash on the Windows runner too, so one ls works.
         shell: bash
         run: ls -la packages/harness-desktop/release
+
+      # Fail here rather than ship a release that can never update anything.
+      #
+      # The manifest is the entire auto-update contract, and its absence is
+      # invisible: the installers build, launch, and pass smoke. Every plausible
+      # way to lose it is a silent one — dropping the `publish` block from
+      # electron-builder.yml, a deploy dir that didn't receive the config, or
+      # electron-builder changing when it decides to emit metadata. So assert it
+      # exists, and assert the version inside it matches what we think we built
+      # (a mismatch makes clients re-offer the same update forever).
+      - name: Verify update metadata was generated
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest="packages/harness-desktop/release/${{ needs.prepare.outputs.channel }}${{ matrix.metadata_suffix }}"
+          if [ ! -f "$manifest" ]; then
+            echo "::error::$manifest is missing — auto-update would be dead in this build. Check the 'publish' block in electron-builder.yml."
+            ls -la packages/harness-desktop/release
+            exit 1
+          fi
+          echo "--- $manifest ---"
+          cat "$manifest"
+          expected="${{ needs.prepare.outputs.version }}"
+          if ! grep -qx "version: ${expected}" "$manifest"; then
+            echo "::error::$manifest does not advertise version ${expected}."
+            exit 1
+          fi
+          echo "Update manifest OK: $(basename "$manifest") advertises ${expected}."
 
       # Release gate: launch the packaged app on the OSes only this workflow builds.
       #
@@ -307,7 +435,7 @@ jobs:
   # Collect every OS's artifacts and attach them to the GitHub Release — only
   # on a real tag push (workflow_dispatch has no tag, so it stops at Artifacts).
   release:
-    needs: build
+    needs: [prepare, build]
     if: startsWith(github.ref, 'refs/tags/harness-desktop-v')
     runs-on: ubuntu-latest
     permissions:
@@ -341,25 +469,76 @@ jobs:
           for f in **/*.exe;      do cp "$f" "Sapiom-Windows-x64.exe";      break; done
           ls -la
 
+      # Make the channels a hierarchy rather than two dead ends.
+      #
+      # A beta install reads `beta.yml`. Final releases only publish `latest*.yml`,
+      # so without this a tester who installed a beta would be stranded the moment
+      # we stopped cutting betas: their manifest simply stops existing and every
+      # check 404s. Copying the stable manifest under the beta name means they roll
+      # forward onto the stable build — which is what "beta gets betas AND newer
+      # finals" has to mean in practice.
+      #
+      # The copy is sound because the manifest names no channel: it holds a version,
+      # the file list, and sha512s (verified in release/latest-linux.yml). Only the
+      # FILENAME distinguishes channels.
+      #
+      # Beta releases deliberately do not get the reverse treatment: they publish
+      # only `beta*.yml`, and a stable install (allowPrerelease=false) skips
+      # pre-releases outright, so it can never be offered one.
+      - name: Mirror stable manifests onto the beta channel
+        if: needs.prepare.outputs.channel == 'latest'
+        run: |
+          set -euo pipefail
+          cd dist-artifacts
+          shopt -s nullglob globstar
+          for f in **/latest.yml **/latest-mac.yml **/latest-linux.yml; do
+            base="$(basename "$f")"
+            cp "$f" "beta${base#latest}"
+            echo "mirrored $base → beta${base#latest}"
+          done
+          ls -la
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          # Pre-release while Windows is unsigned (and currently non-launching).
-          prerelease: true
+          # Driven by the version, not hardcoded: `0.1.2-beta.1` publishes a
+          # pre-release on the beta channel, `0.1.2` publishes a final one. This is
+          # also what makes the permanent /releases/latest/download/… links resolve
+          # — GitHub points "latest" at the newest NON-prerelease, so while every
+          # release was marked pre-release those links 404'd.
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
           fail_on_unmatched_files: false
-          # Every OS now uploads installer FILES only (macOS: .dmg, not the raw
+          # Every OS uploads installer FILES only (macOS: .dmg/.zip, not the raw
           # .app bundle), so this glob attaches a handful of assets rather than
-          # the hundreds of inner files an .app directory would produce.
+          # the hundreds of inner files an .app directory would produce. The
+          # `latest*.yml` / `beta*.yml` manifests and `.blockmap` files ride along —
+          # they are not optional decoration, they ARE the update mechanism.
           files: dist-artifacts/**/*
           body: |
             Desktop installers built by CI. Each one was **launched by CI before
             being attached** (`--smoke`: the app boots, serves the SPA from inside
-            the asar, spawns a PTY, and its preload bridge loads).
+            the asar, spawns a PTY, its preload bridge loads, and its auto-update
+            config is present).
+
+            Channel: **${{ needs.prepare.outputs.channel }}** (v${{ needs.prepare.outputs.version }}).
 
             | Platform | Status |
             | --- | --- |
             | macOS (Apple Silicon) | `.dmg` — signed + notarized when Apple credentials are configured; otherwise unsigned (Gatekeeper will ask for right-click → Open) |
             | Linux | `.AppImage` / `.deb` |
-            | Windows | `.exe` — **unsigned, and a known launch bug is open**; SmartScreen will warn |
+            | Windows | `.exe` — **unsigned**; SmartScreen will warn |
+
+            **Updating:** an installed app checks for new releases on its own
+            channel and offers a restart when one has downloaded — you should not
+            need to reinstall again. Restarting ends any running agent sessions, so
+            it always asks first.
+
+            - `.zip` (macOS) and `.blockmap` (Windows) are update artifacts, not
+              downloads — take the `.dmg` / `.exe`.
+            - Windows updates run an unsigned installer until code signing lands,
+              so SmartScreen warns on each update.
+            - An `.AppImage` can only self-update while running as the AppImage;
+              `.deb` updates go through the system package manager and will ask for
+              your password.
 
             Intel Macs are not covered yet: CI builds arm64 only.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -12,6 +12,24 @@ CI cannot do (see [Bootstrapping a new package](#bootstrapping-a-new-package)).
 > quarantined out of the workspace (see `pnpm-workspace.yaml`) and are not
 > published by this flow.
 
+## Desktop installers are a separate flow
+
+`@sapiom/harness-desktop` is `private` and never goes to npm. It ships as signed
+installers attached to a GitHub Release by
+`.github/workflows/desktop-release.yml`, on its own tag namespace so it can never
+trigger the npm publish above:
+
+| Tag | Release | Update channel |
+| --- | --- | --- |
+| `harness-desktop-v1.2.3` | final | `latest` — every user |
+| `harness-desktop-v1.2.3-beta.1` | pre-release | `beta` — testers only |
+
+Bump `packages/harness-desktop/package.json` **first**: the tag must match it
+exactly or the build fails, by design — that field names the artifacts and drives
+auto-update. Installed apps then update themselves in place, so a release only
+has to reach people once. Details and pitfalls:
+`packages/harness-desktop/CLAUDE.md`.
+
 ## The normal flow (automated)
 
 1. **In your change PR, add a changeset** describing the bump:

--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -214,6 +214,36 @@ against a hand-written `dev-app-update.yml`. `SAPIOM_UPDATE_CHANNEL=latest|beta`
 `SAPIOM_DISABLE_UPDATER=1` turns it off. A smoke run ignores the force flag — CI must never depend on
 the network.
 
+## What the app installs for the user
+
+Three shims (`runtime-shims.ts`, PATH-prepended) plus two npm installs into
+`userData/npm-global` (`agent-install.ts`, on PATH via `agentBinDir()`):
+
+| Provided | Why |
+| --- | --- |
+| `node`, `npm`, **`npx`** shims | Electron bundles Node but not npm, and the machine may have neither |
+| Claude Code (if no agent on PATH) | the app is useless without an agent |
+| `@sapiom/cli` (if `sapiom` not on PATH) | macros and templates hand the agent `sapiom agents …` |
+
+`npx` and the CLI were both missing until they were added together, and both failed
+**silently**: the per-session MCP config launches the sapiom-dev server with
+`command: "npx"`, so a Node-less machine simply got no Sapiom tools, and the agent
+that was told to run `sapiom agents deploy` got `command not found` and improvised.
+Neither showed up as an error anywhere. If you add a door that shells out to a
+binary, it belongs in this table or in the doctor — the direct in-app actions
+(Deploy, Local Run) need none of it, which is why the gap survived so long.
+
+The CLI install is gated by `install-policy.ts`: never in `--smoke` (CI must not
+depend on the network), never in dev, and never when the user already has their own
+`sapiom` — that last one is also what makes it one-shot rather than once-per-launch,
+since the prefix is on PATH by the time the check runs.
+
+> `userData` is `$XDG_CONFIG_HOME/@sapiom/harness-desktop` on Linux (and
+> `~/Library/Application Support/@sapiom/harness-desktop` on macOS) — `app.getName()`
+> falls back to the *scoped npm name*, so the scope becomes a directory. It works,
+> but it litters, and changing it later orphans everything installed above. Decide
+> before wide release, not after.
+
 ## Before claiming an OS works
 
 Run the automated check first — it covers the packaging-specific layers and takes seconds:

--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -228,7 +228,10 @@ There are two ways an update reaches the user, and they are not interchangeable:
 - **Scheduled** (30 s after boot, then every 4 h) → silent, and only ever surfaces the native
   "restart to install" dialog. That dialog stays native because it fires whenever a background
   download finishes and must work regardless of what the window is showing.
-- **On demand** → the Settings popover's button, via `window.sapiomDesktop.checkForUpdates()`. It
+- **On demand** → the profile menu's "Check for updates" item, via
+  `window.sapiomDesktop.checkForUpdates()`. Note WHICH menu: the rail's profile drawer has a
+  Disconnect button and so does the Settings popover one level deeper — the item belongs in the
+  drawer, which is what users mean by "where Disconnect is". It
   differs in three ways that each matter: it *reports* an outcome (a button that appears to do
   nothing is broken), it clears the per-run "Later" set (asking is undeclining), and it answers
   `downloaded` for an update already on disk instead of the true-but-useless "up to date".
@@ -247,6 +250,11 @@ The main window carries a preload (`src/preload/desktop.mts`) — it did not bef
   agent prints. That made an agent-printed URL one click from a window holding `restartToUpdate()`,
   i.e. an agent could kill every live session. Local pop-outs go through `createPreviewWindow`
   (no preload, `sandbox: true`), which is explicit rather than dependent on override-merge semantics.
+- **There is no "apply the update" channel, and there must not be.** A restart ends every running
+  agent session, and page code shares an origin with agent-authored files. The confirmation is a
+  native dialog only; an on-demand check with something already downloaded re-raises it. The
+  `desktop-bridge` smoke check asserts the bridge exposes NOTHING beyond `appVersion` and
+  `checkForUpdates`, so a future addition has to be deliberate.
 - **Validate the IPC sender.** `isTrustedSender` requires the main window's `webContents` *and* a top
   frame at `/`, because the main window could itself navigate to agent content on the same origin. It
   reads the window from `host` (set every launch) and not from `active` (set only when updates are

--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -189,9 +189,16 @@ Things that will bite you:
   is a *getter*, invisible to `cjs-module-lexer`, so ESM link fails with
   `SyntaxError: Named export 'autoUpdater' not found`. Default-import and read the property — lazily,
   since the getter constructs a platform updater on first read.
-- **Close the harness server before `quitAndInstall()`.** It can hand off to the NSIS installer before
-  an async `before-quit` finishes, leaving live `claude` processes holding files the installer wants.
-  `index.ts` exposes a memoized `shutdownServer()` for exactly this; use it, don't add a second path.
+- **Close the harness server before `quitAndInstall()`** — it can hand off to the NSIS installer
+  before an async `before-quit` finishes, leaving live `claude` processes holding files the installer
+  wants. `index.ts` exposes a memoized `shutdownServer()`; use it, don't add a second path.
+- **…but check `isUpdaterActive()` FIRST.** Closing the server kills every agent session, and
+  `quitAndInstall` is not guaranteed to quit: Squirrel.Mac refuses an update it can't verify (and the
+  mac build is unsigned whenever `CSC_LINK` is absent), an extracted AppImage can't self-update, nor
+  can a `.deb` with no usable package manager. Doing the irreversible half first meant the user lost
+  their work *and* stayed on the old version, staring at a dead SPA. Refuse up front, and if the
+  handoff still doesn't happen within `HANDOFF_GRACE_MS`, `app.relaunch()` rather than leave a hollow
+  app. Clear `pending` on any failed apply, or the button wedges on "ready to install" forever.
 - **macOS needs the `zip` target and a valid signature.** Squirrel.Mac cannot consume a `.dmg`, and
   `latest-mac.yml` is only written when a zip target exists. It also refuses to apply an unsigned
   update — so auto-update on macOS depends on the Developer ID cert, not just on this code.
@@ -213,6 +220,51 @@ Dev loop without cutting tags: `SAPIOM_FORCE_UPDATER=1` runs the updater from an
 against a hand-written `dev-app-update.yml`. `SAPIOM_UPDATE_CHANNEL=latest|beta` repoints one machine;
 `SAPIOM_DISABLE_UPDATER=1` turns it off. A smoke run ignores the force flag — CI must never depend on
 the network.
+
+### The "Check for updates" button, and the main-window preload
+
+There are two ways an update reaches the user, and they are not interchangeable:
+
+- **Scheduled** (30 s after boot, then every 4 h) → silent, and only ever surfaces the native
+  "restart to install" dialog. That dialog stays native because it fires whenever a background
+  download finishes and must work regardless of what the window is showing.
+- **On demand** → the Settings popover's button, via `window.sapiomDesktop.checkForUpdates()`. It
+  differs in three ways that each matter: it *reports* an outcome (a button that appears to do
+  nothing is broken), it clears the per-run "Later" set (asking is undeclining), and it answers
+  `downloaded` for an update already on disk instead of the true-but-useless "up to date".
+
+The main window carries a preload (`src/preload/desktop.mts`) — it did not before. Watch out for:
+
+- **The SPA is not ours alone.** The identical bundle is served to a plain browser by
+  `npx @sapiom/harness`. Everything exposed here must be feature-detected on the SPA side
+  (`harness/web/src/lib/desktop.ts`), and the contract is *mirrored* there, not imported: the
+  dependency runs desktop → harness, never back.
+- **`sandbox: false` is required**, as for the setup window — Electron will not load an ESM preload
+  in a sandboxed renderer. `contextIsolation` stays on; the page never gets `ipcRenderer`.
+- **Never `{ action: "allow" }` a window from the main window.** An allowed child window INHERITS the
+  parent's `webPreferences`, preload included — and "local" is not "ours": the harness serves
+  agent-authored files at `/canvas/:sessionId/*` on the same origin, and xterm linkifies whatever the
+  agent prints. That made an agent-printed URL one click from a window holding `restartToUpdate()`,
+  i.e. an agent could kill every live session. Local pop-outs go through `createPreviewWindow`
+  (no preload, `sandbox: true`), which is explicit rather than dependent on override-merge semantics.
+- **Validate the IPC sender.** `isTrustedSender` requires the main window's `webContents` *and* a top
+  frame at `/`, because the main window could itself navigate to agent content on the same origin. It
+  reads the window from `host` (set every launch) and not from `active` (set only when updates are
+  on) — deriving it from `active` made a disabled build reject every sender and report
+  "not available here" instead of the real reason.
+- **The app version reaches the preload via `webPreferences.additionalArguments`**, not `process.env`.
+  Setting env in main and reading it in a renderer depends on inheriting a variable mutated after
+  startup. The `desktop-bridge` smoke check fails on an empty `appVersion` precisely so this stays
+  honest.
+- **Register `ipcMain` handlers regardless of the updater gate, and before any early return.**
+  `ipcRenderer.invoke` on an unhandled channel *rejects*, so a build with updates off must still
+  answer (with `{kind:"disabled"}`) rather than throw at the renderer. This was wrong once: `index.ts`
+  returned in `--smoke` before `initUpdater`, and the packaged check failed with
+  `No handler registered for 'update:check'` against an app that worked fine in production. Handler
+  registration must not depend on which branch of boot we exit through.
+- The `desktop-bridge` check **invokes** the channel, it doesn't just look for the function. Shape
+  alone would pass with no handler registered — and the only place that shows up otherwise is a user
+  clicking the button.
 
 ## What the app installs for the user
 

--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -68,6 +68,15 @@ touching this package, and how to tell whether a change actually works on the OS
 
 ### All platforms
 
+**`pnpm dist` does NOT rebuild the workspace packages it bundles.** It runs *this* package's `build`
+and then packs, and `pnpm deploy --prod` copies `@sapiom/harness`'s **`dist/`** — so a harness-side fix
+you have not built is silently absent from the artifact, and the app runs the old code. This is not
+hypothetical: two new smoke checks were written against fixed source, packaged, and both failed with
+the exact pre-fix errors (`spawn ENOTDIR`, the leaked esbuild pin) because only the desktop package had
+been rebuilt. Before packaging anything that depends on a harness change:
+`pnpm --filter @sapiom/harness build`. When a check fails on an artifact and the source looks right,
+verify the code is *in* the bundle before debugging the code (`grep -c <symbol> packages/harness/dist/...`).
+
 `pack.mjs` runs `pnpm deploy --prod --legacy` into a throwaway dir because electron-builder needs
 every packed file under the app dir, then runs electron-builder there. That deploy materializes
 node_modules with **relative** symlinks, which is why the deploy dir's *location* keeps breaking
@@ -75,6 +84,20 @@ things (see mac/Windows below). `asarUnpack: **/node_modules/**` is deliberate: 
 plain Node with no asar support, so their whole import tree must exist on disk. `npmRebuild`
 recompiles node-pty against the Electron ABI **on the packaging OS** — there is no cross-compiling
 here, each OS builds on its own runner.
+
+**A dependency that execs a sidecar binary needs more than `asarUnpack`.** Unpacking puts the file on
+disk but leaves every path `require.resolve` reports pointing at `app.asar`, and `spawn` — unlike
+`fs` — is not patched, so it fails with `ENOTDIR`. This shipped in 0.1.0: deploying a workflow died
+with `Failed to bundle the agent for deploy. (spawn ENOTDIR)` on macOS *and* Linux (Windows escaped it
+only because we set `asar: false` there), because the harness runs agent-core's esbuild bundler
+in-process. `configureEsbuildBinary()` (`env.ts`) points `ESBUILD_BINARY_PATH` at the unpacked twin —
+**from `index.ts`'s first import**, via `esbuild-binary.ts`. That ordering is the whole fix: esbuild
+snapshots the variable into a module-level constant when its own module is evaluated, so the first
+attempt at this — setting it inside `boot()` — logged the correct path and changed nothing, because
+`import … from "@sapiom/harness"` had already loaded agent-core → esbuild. `index.test.ts` pins the
+import order and the `deploy-bundle` smoke check catches it packaged. node-pty is the same class of
+problem solved a different way (its spawn-helper path comes from the module itself, already unpacked).
+Any new dependency of this shape needs its own path hook or a child process.
 
 ### macOS
 
@@ -135,12 +158,61 @@ here, each OS builds on its own runner.
 
 ## CI
 
-`.github/workflows/desktop-release.yml` — one job per OS (`ubuntu-latest`, `macos-14`,
-`windows-2022`), `fail-fast: false`, Windows `continue-on-error` while Phase 6 is open. Tag
-`harness-desktop-v*` builds all three and publishes a prerelease Release; `workflow_dispatch` builds
-artifacts only (14-day retention). There is a **TEMP branch trigger on `ewan/feat/harness-desktop`
-that must be removed before merge.** Keep the runner pins and the Python pin: each has a comment
-explaining the failure it prevents — don't "modernize" them without reproducing that failure.
+`.github/workflows/desktop-release.yml` — a `prepare` job (resolves version + channel, fails fast on
+a tag that disagrees with `package.json`), then one build job per OS (`ubuntu-latest`, `macos-14`,
+`windows-2022`), `fail-fast: false`, Windows `continue-on-error` while Phase 6 is open.
+`workflow_dispatch` builds artifacts only (14-day retention). Keep the runner pins and the Python
+pin: each has a comment explaining the failure it prevents — don't "modernize" them without
+reproducing that failure.
+
+Tag conventions, which drive everything downstream:
+
+| Tag | Release | Channel | Who gets it |
+| --- | --- | --- | --- |
+| `harness-desktop-v1.2.3` | final | `latest` | everyone, and `/releases/latest/download/…` resolves |
+| `harness-desktop-v1.2.3-beta.1` | pre-release | `beta` | only installs already following betas |
+
+The tag **must** equal `package.json`'s version. `prepare` enforces it, because that field is what
+names every artifact and what the app reports as its own version; a mismatch publishes a manifest
+advertising a version no asset matches, and clients then re-offer the same update forever.
+
+## Auto-update
+
+`electron-updater` replaces the whole app, so an update also carries Electron and node-pty — not just
+our JS. Policy lives in `src/main/update-policy.ts` (pure, unit-tested), wiring in
+`src/main/updater.ts` (electron-facing, covered by `--smoke`). That split is required: `vitest.config.ts`
+only tests modules that don't import `electron`.
+
+Things that will bite you:
+
+- **`import { autoUpdater } from "electron-updater"` does not work.** It's CommonJS and `autoUpdater`
+  is a *getter*, invisible to `cjs-module-lexer`, so ESM link fails with
+  `SyntaxError: Named export 'autoUpdater' not found`. Default-import and read the property — lazily,
+  since the getter constructs a platform updater on first read.
+- **Close the harness server before `quitAndInstall()`.** It can hand off to the NSIS installer before
+  an async `before-quit` finishes, leaving live `claude` processes holding files the installer wants.
+  `index.ts` exposes a memoized `shutdownServer()` for exactly this; use it, don't add a second path.
+- **macOS needs the `zip` target and a valid signature.** Squirrel.Mac cannot consume a `.dmg`, and
+  `latest-mac.yml` is only written when a zip target exists. It also refuses to apply an unsigned
+  update — so auto-update on macOS depends on the Developer ID cert, not just on this code.
+- **The `publish:` block in `electron-builder.yml` is load-bearing even though we never publish from
+  electron-builder** (`pack.mjs` passes `--publish never` so it can't race the release job). Without a
+  publish provider, no `latest*.yml` is generated and no `resources/app-update.yml` is baked in — the
+  app then runs perfectly and never updates. The `update-config` smoke check exists for that, and it
+  also cross-checks the *baked* channel against the one the app resolves at runtime.
+- **Don't derive the channel in a workflow.** `pack.mjs` imports `resolveUpdateChannel` from the built
+  `dist/` and passes the flag itself, so the release workflow, the PR smoke job and a local
+  `pnpm dist` cannot disagree.
+- **Artifact globs must include `latest*.yml` / `beta*.yml` / `*.blockmap`** (and macOS `*.zip`).
+  They're `latest*`/`beta*` rather than `*.yml` on purpose — `builder-debug.yml` also lands in
+  `release/`. Drop these and the metadata is built and then thrown away.
+- A build **before** this feature cannot update *to* anything: only installs from the first
+  auto-update-capable release onward will ever update themselves.
+
+Dev loop without cutting tags: `SAPIOM_FORCE_UPDATER=1` runs the updater from an unpackaged build
+against a hand-written `dev-app-update.yml`. `SAPIOM_UPDATE_CHANNEL=latest|beta` repoints one machine;
+`SAPIOM_DISABLE_UPDATER=1` turns it off. A smoke run ignores the force flag — CI must never depend on
+the network.
 
 ## Before claiming an OS works
 
@@ -152,10 +224,21 @@ HOME=$(mktemp -d) SAPIOM_TELEMETRY_DISABLED=1 \
 ```
 
 `--smoke` (`src/main/smoke.ts`) boots the app and asserts the SPA is served from inside the asar, the
-REST surface answers and rejects an untokened request, the setup window's preload bridge loaded,
-node-pty loads under Electron's ABI and can spawn, and the plain-Node subprocess's imports exist on
-disk. Exit code is the signal; CI runs it per OS after packaging. **Add a check here whenever you fix
-a packaging bug** — that's what stops it recurring silently.
+REST surface answers and rejects an untokened request, a real session spawns, the setup window's
+preload bridge loaded, node-pty loads under Electron's ABI and can spawn, the plain-Node subprocess's
+imports exist on disk, a deploy can bundle and a local run's child really starts (both spawn-from-asar
+bugs — see below), the agent inherits a clean environment, and the auto-update config is baked in. Exit
+code is the signal; CI runs it per OS after packaging.
+
+Two properties of the harness itself, learned the hard way:
+
+- **A check that cannot run must FAIL, not pass.** `--smoke` used to `app.quit()` — exit **0** — when it
+  lost the single-instance lock, so a stale app on the machine turned the packaging gate into a green
+  light over zero checks. `single-instance.ts` makes that a loud exit 1.
+- **Assert on what the child received, not on what the parent meant to send.** The esbuild-pin leak into
+  every agent process was invisible to every parent-side test; it took having the stub agent dump its own
+  environment (`SAPIOM_SMOKE_AGENT_ENV` in `scripts/smoke.sh`) for a check to see it. **Add a check here whenever you fix a packaging bug** — that's what stops it
+recurring silently.
 
 Then, for anything it can't cover (a real agent, a real workflow, a human flow):
 

--- a/packages/harness-desktop/electron-builder.yml
+++ b/packages/harness-desktop/electron-builder.yml
@@ -10,6 +10,24 @@ directories:
   output: release
   buildResources: assets
 
+# Auto-update metadata. This block is NOT here to upload anything — the release
+# workflow attaches assets itself (softprops/action-gh-release), and pack.mjs
+# passes `--publish never` so electron-builder never races it.
+#
+# It is here because a publish provider is what makes electron-builder
+#   (a) emit `latest.yml` / `latest-mac.yml` / `latest-linux.yml` — the manifests
+#       electron-updater reads to learn a newer version exists, and
+#   (b) bake `resources/app-update.yml` into the app — how the INSTALLED app knows
+#       where to look.
+# Without it the build succeeds, the app runs, and updates silently never happen.
+# The packaged `update-config` smoke check exists to catch exactly that.
+#
+# The repo is public, so the app needs no token to read releases.
+publish:
+  provider: github
+  owner: sapiom
+  repo: sapiom-js
+
 # Default file globbing packs production node_modules + package.json. We add
 # our built output explicitly and keep source/maps out of the bundle.
 files:
@@ -49,14 +67,20 @@ linux:
   synopsis: One-click Sapiom harness — run your coding agent on Sapiom.
 
 mac:
-  # dmg only. electron-builder also emits a `zip` for macOS auto-update
-  # (Squirrel.Mac consumes zips, not dmgs), but no updater is wired up yet
-  # (Phase 4: unsigned, no publish provider), so the zip was a second full copy
-  # of the same .app — doubling the artifact a tester downloads for nothing.
-  # Re-add `zip` here (and to the upload glob in desktop-release.yml) when macOS
-  # auto-update ships in Phase 5+.
+  # dmg AND zip. The zip is not a duplicate download for testers — it is the
+  # auto-update artifact: Squirrel.Mac consumes a zip, never a dmg, and
+  # `latest-mac.yml` is only written when a zip target exists. Without it the
+  # installed app fails every check with "Could not get latest version".
+  #
+  # (It genuinely was dead weight before — Phase 4 had no updater and no publish
+  # provider, so it was a second copy of the same .app. That is what changed.)
+  #
+  # Squirrel.Mac also requires the update to be validly SIGNED before it will
+  # apply it, so macOS auto-update only became possible once the Developer ID
+  # cert landed. An unsigned build still installs by hand; it just cannot update.
   target:
     - dmg
+    - zip
   category: public.app-category.developer-tools
   # macOS gets its own artwork: the same mark inset to ~82% of the canvas with a
   # transparent margin, per Apple's icon grid, so the app sits the same visual
@@ -90,3 +114,15 @@ nsis:
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true
+  # Differential updates: ship only the changed blocks instead of the whole
+  # installer. The app is ~100 MB and a typical harness fix touches a few MB of
+  # JS, so this is the difference between a background download nobody notices
+  # and one they do. Requires the generated `.exe.blockmap` to be attached to the
+  # release alongside the installer (see the artifact globs in
+  # desktop-release.yml) — without it electron-updater silently falls back to the
+  # full download.
+  #
+  # `perMachine: false` above matters here too: a per-user install updates without
+  # a UAC prompt. (The installer is still unsigned until the EV cert lands, so
+  # SmartScreen will warn regardless — Phase 6.)
+  differentialPackage: true

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@sapiom/harness": "workspace:^",
+    "electron-updater": "^6.8.9",
     "node-pty": "^1.1.0",
     "npm": "^10.9.0"
   },

--- a/packages/harness-desktop/scripts/pack.mjs
+++ b/packages/harness-desktop/scripts/pack.mjs
@@ -11,9 +11,9 @@
 //   (defaults to the HOST platform; any further args pass through, e.g.
 //   -c.mac.notarize=true)
 import { execFileSync } from "node:child_process";
-import { cpSync, realpathSync, rmSync } from "node:fs";
+import { cpSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as os from "node:os";
 
 const pkgDir = dirname(dirname(fileURLToPath(import.meta.url))); // packages/harness-desktop
@@ -38,6 +38,34 @@ const platform = process.argv[2] ?? HOST_PLATFORM_FLAG;
 // otherwise reach electron-builder as a bogus empty argument.
 const passthrough = process.argv.slice(3).filter((arg) => arg.length > 0);
 const isWindows = process.platform === "win32";
+
+// The update channel this artifact publishes to, derived HERE rather than by each
+// caller.
+//
+// It decides the manifest filename (`latest-linux.yml` vs `beta-linux.yml`), and it
+// must match the channel the packaged app resolves at runtime — otherwise the
+// release is published to one channel while the app that runs it looks at another,
+// and updates exist but are never found. The packaged `update-config` smoke check
+// asserts exactly that pair.
+//
+// So we reuse the app's OWN rule (`dist/main/update-policy.js`, which is pure and
+// unit-tested) instead of reimplementing "does this version have a pre-release
+// tag?" in every workflow that packages. Two workflows call this script, plus every
+// local `pnpm dist`; a copy of the rule in each one is three chances to disagree —
+// and the disagreement would only show up as updates quietly not arriving.
+//
+// `{}` for the env, deliberately: SAPIOM_UPDATE_CHANNEL is a per-machine RUNTIME
+// override for a tester, and letting it leak from a developer's shell into what
+// gets packaged would build a beta-channel artifact by accident.
+const { version } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+const { resolveUpdateChannel } = await import(
+  pathToFileURL(join(pkgDir, "dist", "main", "update-policy.js")).href
+);
+const { channel } = resolveUpdateChannel(version, {});
+// An explicit caller flag still wins — the passthrough args land after ours.
+const channelFlag = passthrough.some((arg) => arg.startsWith("-c.publish.channel"))
+  ? []
+  : [`-c.publish.channel=${channel}`];
 
 // Deploy-target base. `pnpm deploy` materializes the app's node_modules using
 // RELATIVE symlinks, so the base must satisfy two constraints:
@@ -77,7 +105,7 @@ cpSync(join(pkgDir, "dist"), join(deployDir, "dist"), { recursive: true });
 cpSync(join(pkgDir, "electron-builder.yml"), join(deployDir, "electron-builder.yml"));
 cpSync(join(pkgDir, "assets"), join(deployDir, "assets"), { recursive: true });
 
-console.log(`[pack] electron-builder ${platform} → ${outputDir}`);
+console.log(`[pack] electron-builder ${platform} → ${outputDir} (v${version}, channel "${channel}")`);
 // The `.bin` entry is `electron-builder.cmd` on Windows, `electron-builder` on POSIX.
 const electronBuilder = join(
   pkgDir,
@@ -85,6 +113,28 @@ const electronBuilder = join(
   ".bin",
   isWindows ? "electron-builder.cmd" : "electron-builder",
 );
-run(electronBuilder, [platform, `-c.directories.output=${outputDir}`, ...passthrough], deployDir);
+// `--publish never`, explicitly. electron-builder.yml declares a github publish
+// provider — it has to, or no auto-update metadata is generated at all — and
+// electron-builder's DEFAULT policy publishes when it detects CI plus a tag. That
+// is precisely our release condition, so left alone it would try to create the
+// GitHub release itself, in parallel with the workflow's own release job: two
+// writers on one release, and a build job that would need a write-scoped token it
+// currently does not have.
+//
+// Generating the metadata and uploading it are separate concerns; we want the
+// first and not the second. It comes BEFORE the passthrough args so a caller who
+// really wants to publish can still override it.
+run(
+  electronBuilder,
+  [
+    platform,
+    "--publish",
+    "never",
+    ...channelFlag,
+    `-c.directories.output=${outputDir}`,
+    ...passthrough,
+  ],
+  deployDir,
+);
 
 console.log(`[pack] done → ${outputDir}`);

--- a/packages/harness-desktop/scripts/smoke.sh
+++ b/packages/harness-desktop/scripts/smoke.sh
@@ -44,6 +44,14 @@ if [ -z "${CI:-}" ]; then
   # A Windows developer needs the real profile shape, not just the directory.
   mkdir -p "$smoke_home/AppData/Roaming" "$smoke_home/AppData/Local"
   export HOME="$app_home" USERPROFILE="$app_home" APPDATA="$(native "$smoke_home/AppData/Roaming")"
+  # HOME is NOT enough on Linux: Electron derives `userData` from XDG_CONFIG_HOME
+  # when it is set, so relocating only HOME left every local smoke run writing to
+  # the developer's real ~/.config/@sapiom/… — installing packages and app state
+  # into the very profile these lines exist to protect. Found while verifying the
+  # sapiom-CLI install: the app reported success and the files were nowhere near
+  # the temp HOME.
+  mkdir -p "$smoke_home/.config"
+  export XDG_CONFIG_HOME="$(native "$smoke_home/.config")"
 else
   echo "[smoke] CI detected — leaving HOME/USERPROFILE/APPDATA alone (ephemeral runner)"
 fi

--- a/packages/harness-desktop/scripts/smoke.sh
+++ b/packages/harness-desktop/scripts/smoke.sh
@@ -65,13 +65,22 @@ if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   # to see through. A stub that were a plain .cmd (or an .exe) would exercise a path
   # real agents never take, and is now correctly refused rather than shelled out.
   stub="$smoke_home/stub-agent.cmd"
-  printf 'setTimeout(() => process.exit(0), 3000);\n' > "$smoke_home/stub-agent.js"
+  # Dumps its own environment first — see SAPIOM_SMOKE_AGENT_ENV below.
+  printf 'const f = process.env.SAPIOM_SMOKE_AGENT_ENV;\nif (f) require("fs").writeFileSync(f, Object.entries(process.env).map(([k, v]) => k + "=" + v).join("\\n") + "\\n");\nsetTimeout(() => process.exit(0), 3000);\n' > "$smoke_home/stub-agent.js"
   printf '@echo off\r\n"%%dp0%%\\node.exe" "%%dp0%%\\stub-agent.js" %%*\r\n' > "$stub"
 else
   stub="$smoke_home/stub-agent.sh"
-  printf '#!/bin/sh\nsleep 3\nexit 0\n' > "$stub"
+  printf '#!/bin/sh\n[ -n "$SAPIOM_SMOKE_AGENT_ENV" ] && env > "$SAPIOM_SMOKE_AGENT_ENV"\nsleep 3\nexit 0\n' > "$stub"
   chmod +x "$stub"
 fi
+# Where the stub agent writes its environment, so a check can assert on what the
+# AGENT actually inherited rather than on what the main process meant to pass.
+# This caught a real regression: the desktop host pins ESBUILD_BINARY_PATH so its
+# own bundler can exec a binary outside app.asar, and the whole parent env is
+# copied into the pty — so every agent, and every tool it ran in the user's repo,
+# inherited a pin to OUR esbuild build ("Host version X does not match binary
+# version Y" on a project that builds fine outside the app).
+export SAPIOM_SMOKE_AGENT_ENV="$(native "$smoke_home/agent-env.txt")"
 # Native, because resolveSpawnTarget resolves this inside the app: a POSIX
 # path has no drive letter, so the Windows lookup would never find it.
 export SAPIOM_SMOKE_STUB_AGENT="$(native "$stub")"

--- a/packages/harness-desktop/src/main/agent-install.ts
+++ b/packages/harness-desktop/src/main/agent-install.ts
@@ -28,8 +28,24 @@ const require = createRequire(import.meta.url);
 /**
  * Absolute path to the bundled npm CLI. npm's `exports` map does NOT expose
  * `./bin/npm-cli.js`, so we resolve its (exported) `package.json`, read the
- * `bin.npm` field, and join it onto npm's dir — asar-safe (resolve returns the
- * unpacked path under Electron) and robust to npm changing its bin layout.
+ * `bin.npm` field, and join it onto npm's dir — robust to npm changing its bin
+ * layout.
+ *
+ * This path DOES name `app.asar` in a packaged build (measured:
+ * `…/resources/app.asar/node_modules/npm/bin/npm-cli.js`) — the previous comment
+ * here claimed `require.resolve` hands back the unpacked path, and that is simply
+ * false. It works regardless, for a different reason: the child below is spawned
+ * with `ELECTRON_RUN_AS_NODE`, so it is still the Electron binary and keeps the
+ * asar `fs` patch, and reading an in-archive file succeeds (real `node` would get
+ * ENOTDIR). Deliberately left as-is rather than "fixed", because first-run agent
+ * install is the highest-stakes path in the app and this is empirically working.
+ *
+ * What that does NOT cover: paths npm derives from this location and hands to a
+ * NON-Electron process — `npm_config_node_gyp` and the node-gyp bin dir it puts
+ * on PATH, consumed by python/make/cc when a dependency has a native addon.
+ * Unverified (it needs a real native-addon install to reproduce); see
+ * `unpackedPath()` in `@sapiom/harness`'s `core/asar-path.ts` if it turns out to
+ * need translating.
  */
 export function resolveNpmCli(): string {
   const pkgJsonPath = require.resolve("npm/package.json");

--- a/packages/harness-desktop/src/main/agent-install.ts
+++ b/packages/harness-desktop/src/main/agent-install.ts
@@ -17,11 +17,19 @@
  * the setup-window progress plumbing and the guided-install fallback.
  */
 import { app } from "electron";
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
+import { promisify } from "node:util";
 import { CLAUDE_INSTALL_COMMAND } from "@sapiom/harness";
+import {
+  SAPIOM_CLI_PACKAGE,
+  shouldInstallSapiomCli,
+  type SapiomCliDecision,
+} from "./install-policy.js";
+
+const isWindows = process.platform === "win32";
 
 const require = createRequire(import.meta.url);
 
@@ -47,13 +55,18 @@ const require = createRequire(import.meta.url);
  * `unpackedPath()` in `@sapiom/harness`'s `core/asar-path.ts` if it turns out to
  * need translating.
  */
-export function resolveNpmCli(): string {
+export function resolveNpmBin(name: "npm" | "npx"): string {
   const pkgJsonPath = require.resolve("npm/package.json");
   const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
-    bin?: { npm?: string };
+    bin?: Record<string, string | undefined>;
   };
-  const relBin = pkg.bin?.npm ?? "bin/npm-cli.js";
+  const relBin = pkg.bin?.[name] ?? `bin/${name}-cli.js`;
   return path.join(path.dirname(pkgJsonPath), relBin);
+}
+
+/** Back-compat alias: the npm CLI specifically. */
+export function resolveNpmCli(): string {
+  return resolveNpmBin("npm");
 }
 
 /**
@@ -107,9 +120,76 @@ const LOG_TAIL_LINES = 40;
 export function installClaudeCode(
   onLine: (line: string) => void,
 ): Promise<InstallResult> {
+  return installNpmGlobal(packageSpecFromInstallCommand(CLAUDE_INSTALL_COMMAND), onLine);
+}
+
+/**
+ * Install the `sapiom` CLI into the same per-user prefix, for the same reason and
+ * by the same mechanism as the agent: the app hands the coding agent
+ * `sapiom agents …` commands (macros, templates) and shipped nothing that
+ * provides them. `boot.ts` gates this on {@link shouldInstallSapiomCli} — never
+ * in smoke (no network in CI), never in dev, and never when the user already has
+ * their own `sapiom` on PATH.
+ *
+ * Non-fatal by contract: the app must still boot, and every direct in-app action
+ * (Deploy, Local Run) works without the CLI.
+ */
+export function installSapiomCli(
+  onLine: (line: string) => void,
+): Promise<InstallResult> {
+  return installNpmGlobal(SAPIOM_CLI_PACKAGE, onLine);
+}
+
+/**
+ * Is `sapiom` already on PATH, and where?
+ *
+ * Shells `which`/`where` — the same mechanism `harness/src/cli/doctor.ts` uses for
+ * claude/codex/git, mirrored rather than imported because that helper is private
+ * to the doctor. Deliberately NOT `resolveSpawnTarget`: on non-Windows that
+ * returns the command unchanged without touching the filesystem
+ * (`core/spawn-target.ts:187`), so it would report "found" for anything and the
+ * install would never run on macOS — the platform this is for.
+ */
+async function whichSapiom(): Promise<string | null> {
+  const exec = promisify(execFile);
+  try {
+    const { stdout } = await exec(isWindows ? "where" : "which", ["sapiom"]);
+    return stdout.trim().split("\n")[0]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install the `sapiom` CLI if this launch should. Returns the decision either way
+ * so the caller can log it — a silent skip is how the missing CLI stayed
+ * invisible. Never throws: a failed install is reported, not fatal.
+ */
+export async function ensureSapiomCli(
+  opts: { smoke: boolean; devMode: boolean },
+  onLine: (line: string) => void,
+): Promise<SapiomCliDecision & { result?: InstallResult }> {
+  const decision = shouldInstallSapiomCli({
+    // Skip the PATH probe entirely when we already know we won't install — it
+    // spawns a process on the boot path.
+    onPath: opts.smoke || opts.devMode ? null : await whichSapiom(),
+    smoke: opts.smoke,
+    devMode: opts.devMode,
+  });
+  if (!decision.install) return decision;
+  return { ...decision, result: await installSapiomCli(onLine) };
+}
+
+/**
+ * Drive the bundled npm to install one package into the per-user prefix.
+ * Streams npm's line-buffered output through `onLine`. Resolves (never rejects).
+ */
+function installNpmGlobal(
+  packageSpec: string,
+  onLine: (line: string) => void,
+): Promise<InstallResult> {
   const npmCli = resolveNpmCli();
   const prefix = agentPrefixDir();
-  const packageSpec = packageSpecFromInstallCommand(CLAUDE_INSTALL_COMMAND);
 
   // `--no-audit --no-fund` keep the run quiet/fast; `--loglevel=info` gives us
   // meaningful progress lines to stream. `--prefix` makes it a per-user install

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -33,7 +33,7 @@ import { augmentProcessPath } from "./env.js";
 import { esbuildBinaryPath } from "./esbuild-binary.js";
 import { resolveWebDir } from "./paths.js";
 import { createMainWindow } from "./windows.js";
-import { installClaudeCode } from "./agent-install.js";
+import { ensureSapiomCli, installClaudeCode } from "./agent-install.js";
 import { installRuntimeShims } from "./runtime-shims.js";
 import { BOOT_PROGRESS, BOOT_ERROR, CONSENT_SUBMIT, RETRY, type BootProgress, type BootErrorPayload } from "./ipc.js";
 
@@ -276,6 +276,29 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
     report = await ensureAgentAvailable(setupWin, report);
   }
   progress(setupWin, { phase: "doctor", message: `Found: ${report.availableHarnesses.join(", ")}`, status: "done" });
+
+  // 3b. The `sapiom` CLI. The agent is told to run `sapiom agents deploy` /
+  //     `run --target local|prod` (harness macros) and `sapiom agents init`
+  //     (templates), and nothing shipped that binary — so on a machine without a
+  //     global install the agent hit `command not found` and improvised. Install
+  //     it into the same per-user prefix as the agent; PATH already includes that
+  //     dir, so it resolves on this same launch.
+  //
+  //     Non-fatal on purpose, and NOT gated behind a doctor failure: every direct
+  //     in-app action (Deploy, Local Run) works without it, so a failed install
+  //     must never block boot — it just leaves the agent-driven doors degraded,
+  //     which is exactly the state we shipped. Skipped in smoke (no network on
+  //     CI) and in dev (workspace copy) — see install-policy.ts.
+  try {
+    const cli = await ensureSapiomCli({ smoke, devMode }, (line) => debug(`sapiom-cli: ${line}`));
+    debug(
+      cli.install
+        ? `sapiom CLI install ${cli.result?.ok ? "ok" : `FAILED (exit ${cli.result?.code ?? "?"})`} — ${cli.reason}`
+        : `sapiom CLI: ${cli.reason}`,
+    );
+  } catch (err) {
+    debug(`sapiom CLI install threw (ignored): ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   // 4. Machine id + first-run. "First run" means the user has never completed
   //    onboarding — i.e. no settings file has ever been persisted — NOT "has no

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -30,6 +30,7 @@ import {
   type DoctorReport,
 } from "@sapiom/harness";
 import { augmentProcessPath } from "./env.js";
+import { esbuildBinaryPath } from "./esbuild-binary.js";
 import { resolveWebDir } from "./paths.js";
 import { createMainWindow } from "./windows.js";
 import { installClaudeCode } from "./agent-install.js";
@@ -253,6 +254,11 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
   const runtimeShimDir = installRuntimeShims();
   augmentProcessPath(agentBinDir(), runtimeShimDir);
   resolveTargetEnvironment();
+
+  // 1b. esbuild's native binary was pinned by index.ts's first import — far
+  //     earlier than here, because esbuild reads the setting when its module
+  //     loads (esbuild-binary.ts). Only traced here, where the boot log is.
+  debug(`esbuild binary: ${esbuildBinaryPath ?? "left to esbuild's own resolution"}`);
 
   // 2. Doctor.
   progress(setupWin, { phase: "doctor", message: "Checking your environment…", status: "active" });

--- a/packages/harness-desktop/src/main/env.test.ts
+++ b/packages/harness-desktop/src/main/env.test.ts
@@ -7,9 +7,10 @@
  * every subprocess it spawned. These tests pin the ordering contract.
  */
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { existsSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { augmentProcessPath } from "./env.js";
+import { augmentProcessPath, configureEsbuildBinary, unpackedPath } from "./env.js";
 
 const AGENT_BIN = "/tmp/userData/npm-global/bin";
 const SHIMS = "/tmp/userData/runtime-bin";
@@ -107,5 +108,74 @@ describe("augmentProcessPath", () => {
     } finally {
       Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
     }
+  });
+});
+
+describe("unpackedPath", () => {
+  it("redirects an app.asar path to its on-disk twin", () => {
+    expect(unpackedPath("/Applications/Sapiom.app/Contents/Resources/app.asar/node_modules/esbuild/lib/main.js")).toBe(
+      "/Applications/Sapiom.app/Contents/Resources/app.asar.unpacked/node_modules/esbuild/lib/main.js",
+    );
+  });
+
+  it("handles Windows separators", () => {
+    expect(unpackedPath("C:\\Users\\u\\AppData\\Local\\Sapiom\\resources\\app.asar\\node_modules\\x")).toBe(
+      "C:\\Users\\u\\AppData\\Local\\Sapiom\\resources\\app.asar.unpacked\\node_modules\\x",
+    );
+  });
+
+  it("leaves an unpackaged path alone", () => {
+    const p = "/home/dev/repo/node_modules/esbuild/lib/main.js";
+    expect(unpackedPath(p)).toBe(p);
+  });
+
+  it("only rewrites app.asar as a whole path segment", () => {
+    // A directory that merely STARTS with "app.asar" is not the archive.
+    const p = "/opt/app.asarbackup/node_modules/x";
+    expect(unpackedPath(p)).toBe(p);
+  });
+});
+
+/**
+ * The regression these pin: deploying a workflow from the packaged app died with
+ * `Failed to bundle the agent for deploy. (spawn ENOTDIR)`. agent-core's
+ * `bundleForDeploy` runs esbuild IN-PROCESS (unlike the Canvas check, which
+ * already gets a child process with a translated cwd), and esbuild resolves its
+ * native binary with `require.resolve` — which under Electron reports the virtual
+ * `app.asar/…` path. Reads through it work (Electron patches fs); `spawn` does
+ * not (app.asar is a file), hence ENOTDIR. Only `npx` was unaffected.
+ */
+describe("configureEsbuildBinary", () => {
+  const saved = process.env.ESBUILD_BINARY_PATH;
+
+  beforeEach(() => {
+    delete process.env.ESBUILD_BINARY_PATH;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.ESBUILD_BINARY_PATH;
+    else process.env.ESBUILD_BINARY_PATH = saved;
+  });
+
+  it("points ESBUILD_BINARY_PATH at a real, on-disk esbuild binary", () => {
+    const result = configureEsbuildBinary();
+    expect(result).not.toBeNull();
+    expect(process.env.ESBUILD_BINARY_PATH).toBe(result);
+    // The whole point: whatever we set must be a file a spawn can actually exec.
+    // (Unpackaged that's the repo's own binary; packaged, the unpacked twin.)
+    expect(existsSync(result!)).toBe(true);
+    expect(result).not.toMatch(/app\.asar[\\/]/);
+  });
+
+  it("resolves esbuild through the harness, not this package", () => {
+    // esbuild is a transitive dep (harness → agent-core → esbuild) and pnpm's
+    // isolated node_modules make it invisible from harness-desktop. Resolving it
+    // from here would work in a hoisted tree and fail in the real one.
+    expect(configureEsbuildBinary()).toContain("esbuild");
+  });
+
+  it("never overrides a deliberate override", () => {
+    process.env.ESBUILD_BINARY_PATH = "/custom/esbuild";
+    expect(configureEsbuildBinary()).toBeNull();
+    expect(process.env.ESBUILD_BINARY_PATH).toBe("/custom/esbuild");
   });
 });

--- a/packages/harness-desktop/src/main/env.ts
+++ b/packages/harness-desktop/src/main/env.ts
@@ -1,5 +1,14 @@
 /**
- * PATH augmentation for a GUI-launched app.
+ * Environment fixups applied once, before `runDoctor()` / `startServer()`.
+ *
+ * Two unrelated things live here because they share that one requirement — both
+ * mutate `process.env` so that everything downstream (the doctor, node-pty, the
+ * in-process harness server) inherits the corrected value:
+ *
+ *   augmentProcessPath      — a GUI launch has no shell PATH (below)
+ *   configureEsbuildBinary  — esbuild can't exec a binary inside app.asar
+ *
+ * ## PATH augmentation for a GUI-launched app
  *
  * A double-clicked app (Finder / .desktop / Start menu) inherits a minimal
  * environment — NOT the user's shell PATH from `.zshrc`/`.bashrc`. So the
@@ -11,8 +20,12 @@
  * node-pty inherits `process.env` at spawn time, so mutating `process.env.PATH`
  * here is what makes the auto-installed agent (Phase 3) discoverable too.
  */
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 const isWindows = process.platform === "win32";
 
@@ -64,4 +77,88 @@ export function augmentProcessPath(agentBinDir: string, runtimeShimDir?: string)
   const next = merged.join(sep);
   process.env.PATH = next;
   return next;
+}
+
+/**
+ * Translate an `app.asar` path to its unpacked twin on disk. Electron patches
+ * `fs` so a *read* through the virtual path works, but `spawn`, `cpSync`,
+ * `opendir` and `chmod` go straight to the syscall and fail with `ENOTDIR` —
+ * app.asar is a file, not a directory. Same transformation the harness applies
+ * (`harness/src/core/canvas-manifest-check.ts`, `core/example-seed.ts`); it is a
+ * no-op on an unpackaged build and on Windows, where we ship `asar: false`.
+ */
+export function unpackedPath(p: string): string {
+  return p.replace(/([\\/])app\.asar([\\/])/, "$1app.asar.unpacked$2");
+}
+
+/**
+ * esbuild's platform binary package + the subpath of the executable inside it,
+ * mirroring esbuild's own `pkgAndSubpathForCurrentPlatform` for the platforms we
+ * ship. Deliberately a small allow-list rather than a copy of esbuild's full
+ * table: an unrecognized platform returns null and we leave esbuild to resolve
+ * the binary itself, which is exactly today's behaviour.
+ */
+function esbuildPlatformPackage(): { pkg: string; subpath: string } | null {
+  const key = `${process.platform}-${os.arch()}`;
+  const supported = [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64",
+    "win32-arm64",
+    "win32-x64",
+  ];
+  if (!supported.includes(key)) return null;
+  // Windows keeps the .exe at the package root; every other platform uses bin/.
+  return { pkg: `@esbuild/${key}`, subpath: isWindows ? "esbuild.exe" : "bin/esbuild" };
+}
+
+/**
+ * Point `ESBUILD_BINARY_PATH` at an esbuild binary that exists ON DISK.
+ *
+ * Why this is needed at all: `POST /api/workflows/:id/deploy` runs
+ * agent-core's `bundleForDeploy()` **in-process** (`harness/src/server/actions.ts`),
+ * and esbuild is not a JS bundler — it shells out to a native binary it locates
+ * with `require.resolve`. Under Electron that hands back the virtual
+ * `…/app.asar/node_modules/…/bin/esbuild` path, so the spawn dies with
+ * `spawn ENOTDIR` and the user sees "Failed to bundle the agent for deploy.".
+ * `asarUnpack` alone does NOT fix this: the file lands on disk, but every path
+ * derived from `require.resolve` still names the archive.
+ *
+ * esbuild honours this env var before doing any resolution of its own
+ * (`esbuild/lib/main.js`, `generateBinPath`), so setting it here fixes deploy and
+ * any future in-process esbuild caller in one place — no patching of a
+ * dependency's internals, and nothing about Electron leaking into agent-core
+ * (a published SDK that has no business knowing what app.asar is).
+ *
+ * Fail-soft by construction: an unknown platform, a failed resolve, or a missing
+ * file all return null and leave the variable unset, which is precisely the
+ * behaviour we have today. Never overrides a value already set — that is
+ * someone deliberately pinning a binary.
+ *
+ * @returns the path it set, or null if it left the environment untouched.
+ */
+export function configureEsbuildBinary(): string | null {
+  if ((process.env.ESBUILD_BINARY_PATH ?? "").trim() !== "") return null;
+
+  const platform = esbuildPlatformPackage();
+  if (!platform) return null;
+
+  let binPath: string;
+  try {
+    // Walk the same chain the harness does at runtime. esbuild is a TRANSITIVE
+    // dependency (harness → agent-core → esbuild) and pnpm's isolated
+    // node_modules make it invisible from this package, so resolving it from
+    // here would work in a hoisted tree and fail in the one we ship.
+    const fromHarness = createRequire(require.resolve("@sapiom/harness/package.json"));
+    const fromAgentCore = createRequire(fromHarness.resolve("@sapiom/agent-core"));
+    const fromEsbuild = createRequire(fromAgentCore.resolve("esbuild/package.json"));
+    binPath = unpackedPath(fromEsbuild.resolve(`${platform.pkg}/${platform.subpath}`));
+  } catch {
+    return null;
+  }
+  if (!existsSync(binPath)) return null;
+
+  process.env.ESBUILD_BINARY_PATH = binPath;
+  return binPath;
 }

--- a/packages/harness-desktop/src/main/esbuild-binary.ts
+++ b/packages/harness-desktop/src/main/esbuild-binary.ts
@@ -1,0 +1,33 @@
+/**
+ * Side-effect module — **must be the FIRST import in `index.ts`**, before
+ * anything pulls in `@sapiom/harness`.
+ *
+ * `configureEsbuildBinary()` points `ESBUILD_BINARY_PATH` at an on-disk binary,
+ * because esbuild cannot exec one from inside `app.asar` (see env.ts for the
+ * full story). The catch is *when* it has to happen: esbuild snapshots the
+ * variable into a module-level constant the first time its module is evaluated
+ *
+ *   var ESBUILD_BINARY_PATH = process.env.ESBUILD_BINARY_PATH || …   (lib/main.js)
+ *
+ * and `generateBinPath()` reads that constant, not `process.env`. So setting it
+ * even one module too late is silently ignored — which is exactly what happened
+ * on the first attempt at this fix: `boot()` set it correctly (the boot trace
+ * showed the right unpacked path) and the packaged app still failed to bundle,
+ * because `import { startServer } from "@sapiom/harness"` at the top of boot.ts
+ * had already evaluated agent-core → esbuild.
+ *
+ * ESM evaluates a module's imports depth-first in declaration order, and the
+ * importing module's own body runs after all of them. That leaves exactly one
+ * place this can live: a module with no harness in its own import graph, pulled
+ * in ahead of every other import of the entry point. Hence a file whose entire
+ * job is one statement.
+ *
+ * Do not "tidy" this into a call inside `boot()` or `app.whenReady()`, and do not
+ * let an import sorter move it down the list. Two things will catch you if you
+ * do: `index.test.ts` asserts the import order, and the packaged `deploy-bundle`
+ * smoke check fails with `spawn ENOTDIR`.
+ */
+import { configureEsbuildBinary } from "./env.js";
+
+/** The binary we pinned, or null if we left esbuild to its own resolution. */
+export const esbuildBinaryPath: string | null = configureEsbuildBinary();

--- a/packages/harness-desktop/src/main/index.test.ts
+++ b/packages/harness-desktop/src/main/index.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The entry point has ONE ordering contract, and it is invisible at runtime
+ * until a user tries to deploy: `./esbuild-binary.js` must be imported before
+ * anything that reaches `@sapiom/harness`, because esbuild snapshots
+ * `ESBUILD_BINARY_PATH` when its module is evaluated and ignores it afterwards
+ * (see esbuild-binary.ts). Getting this wrong is silent — the app boots, every
+ * other smoke check passes, and only a deploy fails, with `spawn ENOTDIR`.
+ *
+ * The packaged `deploy-bundle` smoke check is the real guard; this one just fails
+ * in seconds instead of after a 100 MB package, and names the reason.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "index.ts"), "utf8");
+const imports = [...source.matchAll(/^import\s.*?["'](.+?)["'];$/gm)].map((m) => m[1]);
+
+describe("main entry import order", () => {
+  it("imports ./esbuild-binary.js before anything else", () => {
+    expect(imports.length).toBeGreaterThan(1);
+    expect(imports[0]).toBe("./esbuild-binary.js");
+  });
+
+  it("imports it ahead of every module that reaches @sapiom/harness", () => {
+    // boot.ts and smoke.ts both import @sapiom/harness at their top level, so
+    // either one evaluating first would load esbuild too early.
+    for (const mod of ["./boot.js", "./smoke.js"]) {
+      expect(imports).toContain(mod);
+      expect(imports.indexOf(mod)).toBeGreaterThan(imports.indexOf("./esbuild-binary.js"));
+    }
+  });
+});

--- a/packages/harness-desktop/src/main/index.ts
+++ b/packages/harness-desktop/src/main/index.ts
@@ -5,10 +5,19 @@
  * Lifecycle mirrors bin.ts's SIGINT path: on quit we `server.close()` so all
  * live claude/codex PTYs are killed rather than orphaned.
  */
+// FIRST, and it has to stay first: this pins esbuild's native binary to a path
+// outside app.asar, and esbuild reads that setting once, when its own module is
+// evaluated. Every import below reaches @sapiom/harness → agent-core → esbuild,
+// so anything ahead of this line makes a packaged deploy fail with
+// `spawn ENOTDIR`. See esbuild-binary.ts.
+import "./esbuild-binary.js";
+import { writeFileSync } from "node:fs";
 import { app, dialog, Menu } from "electron";
+import { resolveInstanceLockAction } from "./single-instance.js";
 import { createSetupWindow } from "./windows.js";
 import { boot, type BootResult } from "./boot.js";
 import { runSmokeChecks, reportSmoke } from "./smoke.js";
+import { initUpdater } from "./updater.js";
 
 const devMode = process.argv.includes("--dev");
 /** `--smoke`: boot, verify the packaged bundle, print results, exit. See smoke.ts. */
@@ -23,10 +32,48 @@ app.commandLine.appendSwitch("enable-features", "OverlayScrollbar");
 
 let bootResult: BootResult | null = null;
 let quitting = false;
+/**
+ * Memoized server shutdown, shared by the quit hook and the updater.
+ *
+ * Both paths need the PTYs dead, and they can race: applying an update calls this
+ * directly (see updater.ts — `quitAndInstall` can hand off to the NSIS installer
+ * before an async `before-quit` completes), and `quitAndInstall` then quits, which
+ * fires `before-quit`. Memoizing means the second caller awaits the first close
+ * instead of starting a second one against an already-closing server.
+ */
+let shuttingDown: Promise<void> | null = null;
+function shutdownServer(): Promise<void> {
+  if (!bootResult) return Promise.resolve();
+  // Set synchronously, before any await: the quit hook reads it to decide whether
+  // to intercept, and a later assignment would let it intercept its own re-quit.
+  quitting = true;
+  shuttingDown ??= bootResult.server.close().catch(() => {
+    /* close() is internally race-bounded to 5s; ignore errors on shutdown */
+  });
+  return shuttingDown;
+}
 
-// Single-instance: focus the existing window instead of booting twice.
-const gotLock = app.requestSingleInstanceLock();
-if (!gotLock) {
+// Single-instance: focus the existing window instead of booting twice — except
+// under --smoke, where losing the lock means the run verified NOTHING and must
+// say so instead of exiting 0. See single-instance.ts.
+const lock = resolveInstanceLockAction({
+  gotLock: app.requestSingleInstanceLock(),
+  smokeMode: smokeMode,
+});
+if (lock.action === "fail") {
+  console.log(lock.message);
+  const outFile = process.env.SAPIOM_SMOKE_OUT;
+  if (outFile) {
+    // Same reason reportSmoke writes this file: on Windows a GUI-subsystem exe
+    // has no console to print to, so stdout alone loses the diagnostic.
+    try {
+      writeFileSync(outFile, lock.message + "\n", "utf8");
+    } catch {
+      /* nothing better to do — the exit code still fails the run */
+    }
+  }
+  app.exit(lock.exitCode);
+} else if (lock.action === "quit") {
   app.quit();
 } else {
   app.on("second-instance", () => {
@@ -58,10 +105,19 @@ if (!gotLock) {
         // windows first, or window-all-closed → quit → before-quit would close
         // the server a second time.
         const code = reportSmoke(await runSmokeChecks(bootResult));
-        await bootResult.server.close().catch(() => {});
+        await shutdownServer();
         app.exit(code);
         return;
       }
+      // Last, and only for a real launch: initUpdater gates itself on
+      // packaged/!dev/!smoke, but starting it after the window is up also keeps a
+      // network round-trip off the boot path entirely.
+      initUpdater({
+        mainWindow: bootResult.mainWindow,
+        devMode,
+        smoke: smokeMode,
+        shutdown: shutdownServer,
+      });
     } catch (err) {
       if (smokeMode) {
         // A boot failure IS the smoke result — report it as one and fail fast
@@ -89,13 +145,7 @@ if (!gotLock) {
 app.on("before-quit", (event) => {
   if (quitting || !bootResult) return;
   event.preventDefault();
-  quitting = true;
-  void bootResult.server
-    .close()
-    .catch(() => {
-      /* close() is internally race-bounded to 5s; ignore errors on shutdown */
-    })
-    .finally(() => app.quit());
+  void shutdownServer().finally(() => app.quit());
 });
 
 app.on("window-all-closed", () => {

--- a/packages/harness-desktop/src/main/index.ts
+++ b/packages/harness-desktop/src/main/index.ts
@@ -98,6 +98,20 @@ if (lock.action === "fail") {
         // server booted without driving the GUI.
         console.log(`[harness-desktop] ready: ${bootResult.url}`);
       }
+      // BEFORE the smoke branch, deliberately. initUpdater gates itself on
+      // packaged/!dev/!smoke — it starts no timers and touches no network under
+      // --smoke — but it also registers the IPC handlers the SPA's "Check for
+      // updates" button invokes. Calling it only on the non-smoke path left the
+      // smoke run with no handler, so the packaged check could not exercise the
+      // real wiring: it failed with "No handler registered for 'update:check'"
+      // against an app that works fine in production. Handler registration must
+      // not depend on where in this sequence we happen to return.
+      initUpdater({
+        mainWindow: bootResult.mainWindow,
+        devMode,
+        smoke: smokeMode,
+        shutdown: shutdownServer,
+      });
       if (smokeMode) {
         // Verify the packaged bundle, then leave — never wait for a user. The
         // exit code is the CI signal. `app.exit` skips the before-quit handler,
@@ -109,15 +123,6 @@ if (lock.action === "fail") {
         app.exit(code);
         return;
       }
-      // Last, and only for a real launch: initUpdater gates itself on
-      // packaged/!dev/!smoke, but starting it after the window is up also keeps a
-      // network round-trip off the boot path entirely.
-      initUpdater({
-        mainWindow: bootResult.mainWindow,
-        devMode,
-        smoke: smokeMode,
-        shutdown: shutdownServer,
-      });
     } catch (err) {
       if (smokeMode) {
         // A boot failure IS the smoke result — report it as one and fail fast

--- a/packages/harness-desktop/src/main/install-policy.test.ts
+++ b/packages/harness-desktop/src/main/install-policy.test.ts
@@ -1,0 +1,43 @@
+/**
+ * When may the app install the `sapiom` CLI for the user? Pure, because the
+ * wrong answer is either a broken flow (never install) or a network call on
+ * every launch and a hijacked `sapiom` for developers (always install).
+ */
+import { describe, expect, it } from "vitest";
+
+import { SAPIOM_CLI_PACKAGE, shouldInstallSapiomCli } from "./install-policy.js";
+
+describe("shouldInstallSapiomCli", () => {
+  it("installs when the CLI is nowhere on PATH", () => {
+    expect(shouldInstallSapiomCli({ onPath: null, smoke: false, devMode: false })).toEqual({
+      install: true,
+      reason: "sapiom is not on PATH",
+    });
+  });
+
+  it("does nothing when the CLI is already resolvable — never shadow a user's own install", () => {
+    // A developer with a global or workspace-linked `sapiom` must keep theirs;
+    // the app's prefix is on PATH too, so this is also what makes the install
+    // one-shot instead of once-per-launch.
+    const outcome = shouldInstallSapiomCli({ onPath: "/usr/local/bin/sapiom", smoke: false, devMode: false });
+    expect(outcome.install).toBe(false);
+    expect(outcome.reason).toContain("/usr/local/bin/sapiom");
+  });
+
+  it("never installs during --smoke — CI must not depend on the network", () => {
+    const outcome = shouldInstallSapiomCli({ onPath: null, smoke: true, devMode: false });
+    expect(outcome.install).toBe(false);
+    expect(outcome.reason).toMatch(/smoke/i);
+  });
+
+  it("does not install in dev either — a dev tree has its own workspace copy", () => {
+    const outcome = shouldInstallSapiomCli({ onPath: null, smoke: false, devMode: true });
+    expect(outcome.install).toBe(false);
+    expect(outcome.reason).toMatch(/dev/i);
+  });
+
+  it("pins nothing surprising: the spec is the published package", () => {
+    // `@latest` is deliberate — see install-policy.ts.
+    expect(SAPIOM_CLI_PACKAGE).toBe("@sapiom/cli@latest");
+  });
+});

--- a/packages/harness-desktop/src/main/install-policy.ts
+++ b/packages/harness-desktop/src/main/install-policy.ts
@@ -1,0 +1,55 @@
+/**
+ * Whether to install the `sapiom` CLI on this launch.
+ *
+ * Why the app installs it at all: three macro prompts (`harness/src/core/macros.ts`)
+ * and the templates door (`harness/web/src/lib/templates.ts`) hand the coding
+ * agent commands like `sapiom agents deploy` and `sapiom agents init . -t <id>`.
+ * Nothing shipped that binary — `installClaudeCode()` installs the *agent* only,
+ * and `runDoctor()` never checked for it — so on a machine without a global
+ * install the agent got `command not found` and improvised. That reads as "the
+ * app is broken in a strange way" rather than "a dependency is missing".
+ *
+ * (The direct in-app Deploy / Local Run buttons never needed the CLI: they call
+ * agent-core in-process or via the bootstrap child. Only the agent-driven doors
+ * shell out to it.)
+ *
+ * Pure so the three refusals are pinned by tests, because each one is a bug we
+ * would otherwise ship: installing when the user already has their own copy
+ * (hijacking it), installing during `--smoke` (making CI depend on the network,
+ * which `harness-desktop/CLAUDE.md` forbids), and installing on every launch
+ * (a network round-trip in the boot path).
+ */
+
+/**
+ * The published package, dist-tagged for the same reason the generated MCP config
+ * pins `@sapiom/mcp@latest`: a bare name resolves a LOCAL workspace copy when the
+ * app runs from inside the monorepo, whose bin is not linked.
+ */
+export const SAPIOM_CLI_PACKAGE = "@sapiom/cli@latest";
+
+export interface SapiomCliDecision {
+  install: boolean;
+  /** Human-readable, and logged either way — a silent skip is how this class of
+   *  gap stayed invisible in the first place. */
+  reason: string;
+}
+
+export function shouldInstallSapiomCli(input: {
+  /** Absolute path if `sapiom` already resolves on PATH, else null. PATH already
+   *  includes the app's own npm prefix at this point, so a previous launch's
+   *  install lands here — that is what makes this one-shot. */
+  onPath: string | null;
+  smoke: boolean;
+  devMode: boolean;
+}): SapiomCliDecision {
+  if (input.onPath) {
+    return { install: false, reason: `already on PATH at ${input.onPath}` };
+  }
+  if (input.smoke) {
+    return { install: false, reason: "skipped in --smoke (CI must not depend on the network)" };
+  }
+  if (input.devMode) {
+    return { install: false, reason: "skipped in dev (use the workspace CLI)" };
+  }
+  return { install: true, reason: "sapiom is not on PATH" };
+}

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -55,8 +55,13 @@ export const APP_VERSION_ARG = "--sapiom-app-version=";
 
 /** SPA → main (invoke): check for an update now. Returns `UpdateCheckOutcome`. */
 export const UPDATE_CHECK = "update:check";
-/** SPA → main (invoke): apply a downloaded update and relaunch. Returns void. */
-export const UPDATE_RESTART = "update:restart";
+/*
+ * There is deliberately NO "apply the update" channel. The restart is destructive —
+ * it ends every running agent session — and the page that would call it is the same
+ * origin as the agent-authored files the harness serves at `/canvas/:sessionId/*`.
+ * Rather than exposing that and guarding it, the confirmation lives in a native
+ * dialog the main process raises: page content cannot reach it at all.
+ */
 
 /**
  * The result of an on-demand check.

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -1,6 +1,13 @@
 /**
- * IPC contract between the main process and the setup window (the pre-SPA
- * onboarding UI). Channel names live here so main, preload, and renderer agree.
+ * IPC contract between the main process and its renderers. Channel names live
+ * here so main, preload, and renderer agree.
+ *
+ * Two renderers, and they are very different:
+ *  - the **setup window**, our own onboarding UI (BOOT_* / CONSENT_SUBMIT / RETRY);
+ *  - the **main window**, which loads the harness SPA — code that also runs in a
+ *    plain browser under `npx @sapiom/harness`, where none of this exists. Anything
+ *    exposed to it must therefore be feature-detected on the SPA side, never
+ *    assumed (see `harness/web/src/lib/desktop.ts`).
  */
 
 /** main → renderer: a step of the boot sequence changed state. */
@@ -35,3 +42,41 @@ export interface BootErrorPayload {
   /** When true the renderer shows a "Retry" button wired to RETRY. */
   retryable: boolean;
 }
+
+/**
+ * Prefix of the argv flag carrying the app version into the main window's preload.
+ *
+ * `webPreferences.additionalArguments` is Electron's documented way to hand a
+ * preload a value at window-creation time. The obvious alternative — setting
+ * `process.env` in main and reading it in the preload — depends on a renderer
+ * inheriting an env var mutated after startup, which is not something to rely on.
+ */
+export const APP_VERSION_ARG = "--sapiom-app-version=";
+
+/** SPA → main (invoke): check for an update now. Returns `UpdateCheckOutcome`. */
+export const UPDATE_CHECK = "update:check";
+/** SPA → main (invoke): apply a downloaded update and relaunch. Returns void. */
+export const UPDATE_RESTART = "update:restart";
+
+/**
+ * The result of an on-demand check.
+ *
+ * Deliberately STRUCTURED rather than a ready-made sentence: the renderer owns
+ * the wording (it's the only side that knows the surrounding UI), and a
+ * discriminated union means a new state can't be silently rendered as a stale
+ * string. The scheduled 4-hour check ignores all of this — it only ever surfaces
+ * the native "restart to update" dialog.
+ */
+export type UpdateCheckOutcome =
+  /** A newer version exists and is downloading now (autoDownload is on). */
+  | { kind: "available"; version: string }
+  /**
+   * Already downloaded and waiting — either the user chose "Later" earlier, or a
+   * background check finished while they weren't looking. Distinct from
+   * "available" because the honest next step is "restart", not "wait".
+   */
+  | { kind: "downloaded"; version: string }
+  | { kind: "up-to-date"; version: string; channel: string }
+  /** Updates are off for this build (unpackaged, or an env opt-out). */
+  | { kind: "disabled"; reason: string }
+  | { kind: "failed"; message: string };

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -82,6 +82,13 @@ export type UpdateCheckOutcome =
    */
   | { kind: "downloaded"; version: string }
   | { kind: "up-to-date"; version: string; channel: string }
+  /**
+   * The channel has nothing to offer yet. Distinct from `failed` on purpose: a
+   * stable install correctly ignores pre-releases, so before the first final
+   * release this is the CORRECT answer, and dressing it up as an error teaches
+   * users to distrust the feature.
+   */
+  | { kind: "no-release"; channel: string }
   /** Updates are off for this build (unpackaged, or an env opt-out). */
   | { kind: "disabled"; reason: string }
   | { kind: "failed"; message: string };

--- a/packages/harness-desktop/src/main/paths.ts
+++ b/packages/harness-desktop/src/main/paths.ts
@@ -28,3 +28,9 @@ export function setupHtmlPath(): string {
 export function setupPreloadPath(): string {
   return path.join(mainDir, "..", "preload", "setup.mjs");
 }
+
+/** Preload for the MAIN window (the harness SPA) — exposes `window.sapiomDesktop`.
+ *  Same `.mjs` + sandbox-off requirement as the setup preload. */
+export function desktopPreloadPath(): string {
+  return path.join(mainDir, "..", "preload", "desktop.mjs");
+}

--- a/packages/harness-desktop/src/main/runtime-shims.ts
+++ b/packages/harness-desktop/src/main/runtime-shims.ts
@@ -15,7 +15,7 @@
 import { app } from "electron";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
-import { resolveNpmCli } from "./agent-install.js";
+import { resolveNpmBin } from "./agent-install.js";
 
 const isWindows = process.platform === "win32";
 
@@ -34,28 +34,34 @@ export function installRuntimeShims(): string {
   const dir = shimDir();
   mkdirSync(dir, { recursive: true });
   const exec = process.execPath;
-  const npmCli = resolveNpmCli();
 
-  if (isWindows) {
-    // `%*` forwards args; ELECTRON_RUN_AS_NODE makes Electron behave as Node.
-    writeFileSync(
-      path.join(dir, "node.cmd"),
-      `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${exec}" %*\r\n`,
-    );
-    writeFileSync(
-      path.join(dir, "npm.cmd"),
-      `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${exec}" "${npmCli}" %*\r\n`,
-    );
-    return dir;
+  // node, npm AND npx. npx was the one missing, and its absence was silent: the
+  // per-session MCP config launches the sapiom-dev server with `command: "npx"`
+  // (`harness/src/core/inject/mcp-config.ts`), so on a machine with no system
+  // Node that server simply never started and the agent quietly lacked every
+  // Sapiom tool. The bundled npm package ships an `npx` bin, so this is the same
+  // one-line shim as the other two — it just was not written.
+  const clis: Array<[name: string, cli: string | null]> = [
+    ["node", null],
+    ["npm", resolveNpmBin("npm")],
+    ["npx", resolveNpmBin("npx")],
+  ];
+
+  for (const [name, cli] of clis) {
+    if (isWindows) {
+      // `%*` forwards args; ELECTRON_RUN_AS_NODE makes Electron behave as Node.
+      const body = cli
+        ? `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${exec}" "${cli}" %*\r\n`
+        : `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${exec}" %*\r\n`;
+      writeFileSync(path.join(dir, `${name}.cmd`), body);
+      continue;
+    }
+    const body = cli
+      ? `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec "${exec}" "${cli}" "$@"\n`
+      : `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec "${exec}" "$@"\n`;
+    const shimPath = path.join(dir, name);
+    writeFileSync(shimPath, body);
+    chmodSync(shimPath, 0o755);
   }
-
-  const nodeShim = `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec "${exec}" "$@"\n`;
-  const npmShim = `#!/bin/sh\nexport ELECTRON_RUN_AS_NODE=1\nexec "${exec}" "${npmCli}" "$@"\n`;
-  const nodePath = path.join(dir, "node");
-  const npmPath = path.join(dir, "npm");
-  writeFileSync(nodePath, nodeShim);
-  writeFileSync(npmPath, npmShim);
-  chmodSync(nodePath, 0o755);
-  chmodSync(npmPath, 0o755);
   return dir;
 }

--- a/packages/harness-desktop/src/main/single-instance.test.ts
+++ b/packages/harness-desktop/src/main/single-instance.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The contract that keeps the packaging gate honest: a smoke run that cannot
+ * verify anything must FAIL, not exit 0. See single-instance.ts.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveInstanceLockAction } from "./single-instance.js";
+
+describe("resolveInstanceLockAction", () => {
+  it("boots when it owns the lock", () => {
+    expect(resolveInstanceLockAction({ gotLock: true, smokeMode: false })).toEqual({ action: "boot" });
+    expect(resolveInstanceLockAction({ gotLock: true, smokeMode: true })).toEqual({ action: "boot" });
+  });
+
+  it("quits quietly on a second real launch — the running window gets focus", () => {
+    expect(resolveInstanceLockAction({ gotLock: false, smokeMode: false })).toEqual({ action: "quit" });
+  });
+
+  it("FAILS a smoke run that lost the lock, rather than exiting 0 having checked nothing", () => {
+    const outcome = resolveInstanceLockAction({ gotLock: false, smokeMode: true });
+    expect(outcome).toMatchObject({ action: "fail", exitCode: 1 });
+    // The line has to be greppable alongside the other results, or CI shows a
+    // non-zero exit with no explanation.
+    expect(outcome.action === "fail" && outcome.message).toMatch(/^\[smoke\] FAILED/);
+    expect(outcome.action === "fail" && outcome.message).toMatch(/single-instance lock/);
+  });
+});

--- a/packages/harness-desktop/src/main/single-instance.ts
+++ b/packages/harness-desktop/src/main/single-instance.ts
@@ -1,0 +1,39 @@
+/**
+ * What to do when the single-instance lock is already held.
+ *
+ * Pure, because the interesting case is invisible in production and used to be
+ * invisible in CI too: `--smoke` called `app.quit()` when it lost the lock,
+ * which exits **0**. A packaging gate whose whole job is "did this artifact
+ * actually work?" would then report success having run **zero checks** — the
+ * worst failure mode a verification harness can have, because it is
+ * indistinguishable from a green run in the log. (Found by auditing the smoke
+ * harness itself, after it had already been used to sign off a release.)
+ *
+ * A real launch still just focuses the running window and quits quietly; only
+ * the smoke path turns a lost lock into a loud failure.
+ */
+
+export type InstanceLockAction =
+  /** Boot normally — we own the lock. */
+  | { action: "boot" }
+  /** A second real launch: hand off to the running instance, exit 0. */
+  | { action: "quit" }
+  /** A smoke run that cannot verify anything: exit non-zero, loudly. */
+  | { action: "fail"; exitCode: number; message: string };
+
+export function resolveInstanceLockAction(input: {
+  gotLock: boolean;
+  smokeMode: boolean;
+}): InstanceLockAction {
+  if (input.gotLock) return { action: "boot" };
+  if (!input.smokeMode) return { action: "quit" };
+  return {
+    action: "fail",
+    exitCode: 1,
+    // Phrased as a smoke report line so it lands in the same grep as every other
+    // result, and names the fix — a stale instance is the usual cause locally.
+    message:
+      "[smoke] FAILED — another Sapiom instance holds the single-instance lock, so nothing was verified. " +
+      "Quit the running app (or kill the stale process) and re-run.",
+  };
+}

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -20,6 +20,8 @@
  *                   (covers the rebuild AND the +x spawn-helper) — no agent needed
  *   unpacked-deps   what the plain-Node Canvas subprocess imports exists ON DISK,
  *                   not just inside the archive
+ *   runtime-shims   node/npm/npx shims exist AND execute (npx was missing for the
+ *                   app's whole life, silently breaking the sapiom-dev MCP server)
  *   run-local       POST /api/runs/local's child process really starts (its cwd,
  *                   its script path and ELECTRON_RUN_AS_NODE were all wrong, so
  *                   every local run answered `spawn ENOTDIR`)
@@ -32,15 +34,18 @@
  * Exit code is 0 only if every check passes; each result is printed as one line
  * so a CI log shows exactly which layer broke.
  */
+import { execFile } from "node:child_process";
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { app } from "electron";
 import { resolveSpawnTarget } from "@sapiom/harness";
 import { createSetupWindow } from "./windows.js";
 import { resolveWebDir } from "./paths.js";
+import { shimDir } from "./runtime-shims.js";
 import { CHANNEL_ENV_VAR, resolveUpdateChannel } from "./update-policy.js";
 import type { BootResult } from "./boot.js";
 
@@ -404,6 +409,41 @@ async function loadBundleForDeploy(): Promise<BundleForDeploy> {
 }
 
 /**
+ * Do the runtime shims exist AND run?
+ *
+ * The app bundles Node (as Electron) and npm, and exposes them to the agent as
+ * `node`/`npm`/`npx` shims on PATH so a machine with no system Node can still
+ * work. `npx` was missing for the app's whole life, and nothing noticed: the
+ * per-session MCP config launches the sapiom-dev server with `command: "npx"`, so
+ * on a Node-less machine that server silently never started and the agent quietly
+ * had none of the Sapiom tools. Existence is not enough — a shim that points at
+ * the wrong CLI path or lost its +x bit is equally dead — so each one is executed.
+ *
+ * Offline and deterministic: `--version` on all three touches no network.
+ */
+async function checkRuntimeShims(): Promise<string> {
+  const dir = shimDir();
+  const exec = promisify(execFile);
+  const suffix = process.platform === "win32" ? ".cmd" : "";
+  const reports: string[] = [];
+
+  for (const name of ["node", "npm", "npx"] as const) {
+    const shim = path.join(dir, `${name}${suffix}`);
+    if (!existsSync(shim)) throw new Error(`no ${name} shim at ${shim}`);
+    try {
+      // shell on Windows: a .cmd cannot be spawned directly (CVE-2024-27980).
+      const { stdout } = await exec(shim, ["--version"], { shell: process.platform === "win32" });
+      const version = stdout.trim().split("\n")[0] ?? "";
+      if (!version) throw new Error("no version output");
+      reports.push(`${name} ${version}`);
+    } catch (err) {
+      throw new Error(`${name} shim did not run: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return reports.join(", ");
+}
+
+/**
  * Can `POST /api/runs/local` actually reach its child process?
  *
  * The "Local Run" button was dead in every packaged build, answering with
@@ -620,6 +660,7 @@ export async function runSmokeChecks(boot: BootResult): Promise<SmokeCheck[]> {
     await check("preload-bridge", checkPreloadBridge),
     await check("node-pty", checkNodePty),
     await check("unpacked-deps", checkUnpackedDeps),
+    await check("runtime-shims", checkRuntimeShims),
     await check("run-local", () => checkRunLocal(base, token)),
     await check("deploy-bundle", checkDeployBundle),
     await check("update-config", checkUpdateConfig),

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -605,15 +605,23 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
   const shape = (await win.webContents.executeJavaScript(
     "({ bridge: typeof window.sapiomDesktop," +
       " check: typeof window.sapiomDesktop?.checkForUpdates," +
-      " restart: typeof window.sapiomDesktop?.restartToUpdate," +
       " version: window.sapiomDesktop?.appVersion })",
-  )) as { bridge: string; check: string; restart: string; version: unknown };
+  )) as { bridge: string; check: string; version: unknown };
 
   if (shape.bridge !== "object") {
     throw new Error("window.sapiomDesktop is missing — the main window's preload did not run");
   }
-  if (shape.check !== "function" || shape.restart !== "function") {
+  if (shape.check !== "function") {
     throw new Error(`bridge incomplete: ${JSON.stringify(shape)}`);
+  }
+  // The bridge must stay MINIMAL as well as present. A restart method would let
+  // same-origin agent-authored content end every running session, which is why
+  // applying an update is a native dialog and has no channel (ipc.ts).
+  const extra = (await win.webContents.executeJavaScript(
+    "Object.keys(window.sapiomDesktop).filter((k) => k !== 'appVersion' && k !== 'checkForUpdates')",
+  )) as string[];
+  if (extra.length > 0) {
+    throw new Error(`bridge exposes unexpected members to page code: ${extra.join(", ")}`);
   }
   // Not cosmetic-only: the version arrives via `additionalArguments`, which is the
   // documented way to pass a value to a preload precisely because reading a
@@ -660,7 +668,7 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
   }
 
   return (
-    `window.sapiomDesktop exposes checkForUpdates + restartToUpdate (v${shape.version}); ` +
+    `window.sapiomDesktop exposes checkForUpdates only (v${shape.version}); ` +
     `trusted-sender round-trip returned "${outcome.kind}: ${outcome.reason}"`
   );
 }

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -20,17 +20,28 @@
  *                   (covers the rebuild AND the +x spawn-helper) — no agent needed
  *   unpacked-deps   what the plain-Node Canvas subprocess imports exists ON DISK,
  *                   not just inside the archive
+ *   run-local       POST /api/runs/local's child process really starts (its cwd,
+ *                   its script path and ELECTRON_RUN_AS_NODE were all wrong, so
+ *                   every local run answered `spawn ENOTDIR`)
+ *   deploy-bundle   agent-core's in-process bundler can actually SPAWN esbuild's
+ *                   native binary (a path inside app.asar gave `spawn ENOTDIR`,
+ *                   so every deploy from the packaged app failed)
+ *   update-config   the auto-update metadata is baked in and electron-updater
+ *                   loads — otherwise the app runs fine and never updates again
  *
  * Exit code is 0 only if every check passes; each result is printed as one line
  * so a CI log shows exactly which layer broke.
  */
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { app } from "electron";
 import { resolveSpawnTarget } from "@sapiom/harness";
 import { createSetupWindow } from "./windows.js";
 import { resolveWebDir } from "./paths.js";
+import { CHANNEL_ENV_VAR, resolveUpdateChannel } from "./update-policy.js";
 import type { BootResult } from "./boot.js";
 
 const require = createRequire(import.meta.url);
@@ -258,7 +269,8 @@ async function checkSessionCreate(base: string, token: string | null): Promise<s
     const found = state.sessions?.find((s) => s.id === session.id);
     if (!found) throw new Error(`session ${session.id} missing from /api/state`);
 
-    return `spawned a session in ${path.basename(cwd)} (status ${found.status ?? session.status ?? "?"})`;
+    const inherited = await checkAgentEnvironment(session.id);
+    return `spawned a session in ${path.basename(cwd)} (status ${found.status ?? session.status ?? "?"}); ${inherited}`;
   } finally {
     // Best-effort ONLY, and deliberately so: this directory is the live pty's
     // cwd, and Windows refuses to delete a directory that is a running
@@ -271,6 +283,56 @@ async function checkSessionCreate(base: string, token: string | null): Promise<s
       /* the pty still holds it; nothing to do and nothing worth reporting */
     }
   }
+}
+
+/**
+ * What did the AGENT actually inherit?
+ *
+ * Asserting on what the main process *meant* to pass is not the same as asserting
+ * on what arrived: `SessionManager.spawn` copies the whole parent environment into
+ * the pty, and the desktop host puts `ESBUILD_BINARY_PATH` in that environment so
+ * its own in-process bundler can exec a binary outside app.asar. The agent — and
+ * every tool the agent runs in the USER'S repo — inherited a pin to our esbuild
+ * build, so any project on a different version died with
+ * `Cannot start service: Host version "0.25.12" does not match binary version
+ * "0.28.1"` on a repo that builds fine outside the app. A fix in the harness is
+ * invisible from here unless the check reads the child's real environment.
+ *
+ * The stub agent writes it (scripts/smoke.sh). Skips loudly when run without that
+ * harness rather than passing silently, and keys on the new session's own id so a
+ * stale file from an earlier run can never be mistaken for this one's.
+ */
+async function checkAgentEnvironment(sessionId: string): Promise<string> {
+  const file = process.env.SAPIOM_SMOKE_AGENT_ENV;
+  if (!file) return "agent env NOT CHECKED (no SAPIOM_SMOKE_AGENT_ENV — run via scripts/smoke.sh)";
+
+  // The pty spawns asynchronously; give the stub a moment to write.
+  const deadline = Date.now() + 5_000;
+  let lines: string[] = [];
+  for (;;) {
+    if (existsSync(file)) {
+      lines = readFileSync(file, "utf8").split("\n");
+      if (lines.some((l) => l === `SAPIOM_HARNESS_SESSION_ID=${sessionId}`)) break;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        existsSync(file)
+          ? `agent env dump is not this session's (no SAPIOM_HARNESS_SESSION_ID=${sessionId})`
+          : `agent never wrote ${file} — the stub did not run`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  const leaked = lines.filter((l) => /^ESBUILD_BINARY_PATH=/.test(l));
+  if (leaked.length) {
+    throw new Error(`agent inherited the host's esbuild pin: ${leaked[0]!.slice(0, 160)}`);
+  }
+  // PATH must still be there — this is a targeted strip, not a clean env.
+  if (!lines.some((l) => /^PATH=/.test(l))) {
+    throw new Error("agent inherited no PATH — the env strip took too much");
+  }
+  return `agent env clean (${lines.length} vars, no esbuild pin)`;
 }
 
 /**
@@ -301,6 +363,227 @@ async function checkUnpackedDeps(): Promise<string> {
   const missing = targets.filter(([, p]) => !existsSync(p)).map(([name, p]) => `${name} (${p})`);
   if (missing.length) throw new Error(`not on disk: ${missing.join(", ")}`);
   return `${targets.length} entry points present on disk (asar-translated)`;
+}
+
+type BundleForDeploy = (sourceDir: string) => Promise<{
+  code: string;
+  dependencies: Record<string, string>;
+}>;
+
+/**
+ * Load agent-core's `bundleForDeploy` the way the harness server loads it.
+ *
+ * agent-core is the HARNESS's dependency, not ours — under pnpm's isolated
+ * node_modules it isn't visible from this package at all, hence the two-step
+ * resolve and the structural type above rather than an `import type`. It also
+ * ships dual CJS/ESM, and the harness (ESM) gets the `import` condition while
+ * `createRequire().resolve` would hand back the CJS copy — a different module
+ * instance, and named-export interop we don't want to be testing here. So read
+ * the ESM entry out of the exports map and import that.
+ */
+async function loadBundleForDeploy(): Promise<BundleForDeploy> {
+  const fromHarness = createRequire(require.resolve("@sapiom/harness/package.json"));
+  const pkgPath = fromHarness.resolve("@sapiom/agent-core/package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+    exports?: { ".": { import?: string } };
+    module?: string;
+    main?: string;
+  };
+  const rel = pkg.exports?.["."]?.import ?? pkg.module ?? pkg.main;
+  if (!rel) throw new Error(`@sapiom/agent-core (${pkgPath}) declares no entry point`);
+  const entry = path.resolve(path.dirname(pkgPath), rel);
+
+  const mod = (await import(pathToFileURL(entry).href)) as Record<string, unknown> & {
+    default?: Record<string, unknown>;
+  };
+  const fn = mod.bundleForDeploy ?? mod.default?.bundleForDeploy;
+  if (typeof fn !== "function") {
+    throw new Error(`${entry} exports no bundleForDeploy (got ${Object.keys(mod).join(", ") || "nothing"})`);
+  }
+  return fn as BundleForDeploy;
+}
+
+/**
+ * Can `POST /api/runs/local` actually reach its child process?
+ *
+ * The "Local Run" button was dead in every packaged build, answering with
+ * `{"kind":"error","error":"spawn ENOTDIR"}` — three packaging defects in one
+ * four-line spawn (asar cwd, asar script path, and no `ELECTRON_RUN_AS_NODE`, so
+ * `process.execPath` would have booted a SECOND COPY OF THE APP). Unit tests pin
+ * the path math; only a packaged launch proves the child really starts.
+ *
+ * The trick is asserting on a child that we can make fail *for a known domain
+ * reason*: point it at an empty directory and agent-core answers "No index.ts
+ * found". That single line proves the whole chain — cwd valid, bootstrap script
+ * readable off disk, the child ran as Node rather than relaunching the app, and
+ * its `import "@sapiom/agent-core"` resolved unpacked. No workflow project, no
+ * dependencies, no network, and deterministic. A packaging regression cannot
+ * produce that error; it produces ENOTDIR, ERR_MODULE_NOT_FOUND, or silence.
+ */
+async function checkRunLocal(base: string, token: string | null): Promise<string> {
+  if (!token) throw new Error("boot url carried no token");
+
+  const dir = mkdtempSync(path.join(tmpdir(), "sapiom-smoke-runlocal-"));
+  try {
+    const res = await fetch(`${base}/api/runs/local`, {
+      method: "POST",
+      headers: { "X-Harness-Token": token, "content-type": "application/json" },
+      body: JSON.stringify({ sourceDir: dir }),
+    });
+    const body = await res.text();
+    if (res.status !== 200) throw new Error(`POST /api/runs/local → ${res.status}: ${body.slice(0, 200)}`);
+
+    const lines = body.trim().split("\n").filter(Boolean);
+    if (lines.length === 0) {
+      // No NDJSON at all is the signature of the child never running — e.g. the
+      // app relaunching itself instead of executing the bootstrap.
+      throw new Error("no NDJSON from the run-local child (did it spawn at all?)");
+    }
+    const terminal = JSON.parse(lines[lines.length - 1]) as { kind?: string; error?: string };
+    const message = terminal.error ?? "";
+    if (/ENOTDIR|ENOENT|ERR_MODULE_NOT_FOUND|Cannot find (module|package)/i.test(message)) {
+      throw new Error(`packaging failure reached the child: ${message.slice(0, 300)}`);
+    }
+    if (!/index\.ts/i.test(message)) {
+      throw new Error(
+        `expected agent-core's "No index.ts found" from a real child, got ${terminal.kind}: ${message.slice(0, 300)}`,
+      );
+    }
+    return `child ran and answered from agent-core (${lines.length} NDJSON line(s), terminal kind "${terminal.kind}")`;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Can a deploy bundle anything?
+ *
+ * `POST /api/workflows/:id/deploy` runs agent-core's `bundleForDeploy()` in the
+ * main process, and esbuild shells out to a native binary it locates with
+ * `require.resolve` — which under Electron names the virtual `app.asar/…` path.
+ * Reads through it work (Electron patches fs), `spawn` does not, so every deploy
+ * from the packaged app died with `Failed to bundle the agent for deploy.
+ * (spawn ENOTDIR)` while `npx` was fine. `esbuild-binary.ts` is the fix — and it
+ * only works because of WHERE it is imported, which no unit test can see, so this
+ * is the only thing that proves it against a real artifact.
+ *
+ * Bundles a throwaway two-file project rather than calling esbuild directly: the
+ * relative import means a pass also covers the resolution esbuild does on the
+ * author's behalf, and it exercises the exact entry point deploy uses. Network-
+ * free — `bundleForDeploy` only reads the local tree.
+ */
+async function checkDeployBundle(): Promise<string> {
+  const bundleForDeploy = await loadBundleForDeploy();
+
+  const dir = mkdtempSync(path.join(tmpdir(), "sapiom-smoke-bundle-"));
+  try {
+    writeFileSync(path.join(dir, "shared.ts"), "export const answer: number = 42;\n");
+    writeFileSync(
+      path.join(dir, "index.ts"),
+      'import { answer } from "./shared.js";\nexport default { answer };\n',
+    );
+    // agent-core puts the real cause in `hint` (esbuild's own message) and keeps
+    // `message` generic, so a bare rethrow reports "Failed to bundle the agent
+    // for deploy." and nothing else — which is precisely the useless diagnostic
+    // this check produced on its first run. Flatten both, plus the binary we
+    // pinned, since that is the next thing anyone would ask.
+    const { code } = await bundleForDeploy(dir).catch((err: unknown) => {
+      const hint = (err as { hint?: unknown }).hint;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `${message}${typeof hint === "string" ? ` (${hint})` : ""} ` +
+          `[ESBUILD_BINARY_PATH=${process.env.ESBUILD_BINARY_PATH ?? "unset"}]`,
+      );
+    });
+    // The relative import must have been INLINED — that's the whole job.
+    if (!code.includes("42")) {
+      throw new Error(`bundle did not inline ./shared.ts: ${code.slice(0, 200)}`);
+    }
+    const binPath = process.env.ESBUILD_BINARY_PATH;
+    return `bundled a 2-file project (${code.length} bytes) via ${binPath ? path.basename(path.dirname(binPath)) + "/" + path.basename(binPath) : "esbuild's own resolution"}`;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Is this build actually capable of updating itself?
+ *
+ * This is the archetypal packaged-only invariant: nothing observable goes wrong
+ * when it's broken. `resources/app-update.yml` is written by electron-builder ONLY
+ * when a publish provider is configured, so dropping that config (or building with
+ * a config the deploy dir didn't receive) produces an app that installs, launches,
+ * passes every other check here — and then never updates, silently, forever. The
+ * failure surfaces weeks later as "why is that tester still on 0.1.1?".
+ *
+ * It also loads electron-updater for real. That module is CommonJS inside an ESM
+ * app whose `node_modules` are asar-unpacked, and `autoUpdater` is a getter that
+ * constructs a platform-specific updater on first read — three things that can
+ * only be confirmed against a packaged artifact on the platform in question.
+ */
+async function checkUpdateConfig(): Promise<string> {
+  if (!app.isPackaged) {
+    return "SKIPPED — unpackaged build has no app-update.yml (run scripts/smoke.sh)";
+  }
+
+  const configPath = path.join(process.resourcesPath, "app-update.yml");
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `no ${configPath} — electron-builder writes it only when a publish provider is ` +
+        `configured, so auto-update is dead in this build`,
+    );
+  }
+  // Read the few fields we care about directly rather than pulling in a YAML
+  // parser: js-yaml is only a TRANSITIVE dependency here (via electron-updater),
+  // and depending on one of those is how an unrelated upgrade breaks a build.
+  const raw = readFileSync(configPath, "utf8");
+  const field = (key: string): string | undefined =>
+    raw.match(new RegExp(`^${key}:\\s*(\\S+)`, "m"))?.[1];
+
+  const provider = field("provider");
+  const owner = field("owner");
+  const repo = field("repo");
+  if (provider !== "github") {
+    throw new Error(`app-update.yml provider is "${provider ?? "(none)"}", expected "github"`);
+  }
+  if (!owner || !repo) {
+    throw new Error(`app-update.yml names no owner/repo (owner="${owner}", repo="${repo}")`);
+  }
+
+  // Reading the getter is the test: it constructs the updater for THIS packaging
+  // format (MacUpdater / NsisUpdater / AppImageUpdater / DebUpdater), which is
+  // where a CJS-in-ESM or unpacked-module problem would surface.
+  const { autoUpdater } = (await import("electron-updater")).default;
+  const kind = autoUpdater.constructor.name;
+
+  // Two independent things decide which manifest this install reads: the channel
+  // electron-builder BAKED IN at package time (from `-c.publish.channel`, absent
+  // meaning "latest") and the one the app RESOLVES at runtime from its own version.
+  // They must agree, or the artifact was published to one channel while the app
+  // that runs it looks at another — updates that exist and are never found.
+  //
+  // They agree by construction: CI derives the pack flag from package.json's
+  // version, and update-policy.ts derives the runtime channel from the same field
+  // by the same rule. This asserts that construction actually held, which is
+  // exactly the kind of two-sided invariant no unit test can see.
+  const bakedChannel = field("channel") ?? "latest";
+  const { channel } = resolveUpdateChannel(app.getVersion(), process.env);
+  // An env override is a deliberate disagreement (pin this machine to another
+  // channel), so it suspends the check rather than failing it.
+  const overridden = (process.env[CHANNEL_ENV_VAR] ?? "").trim() !== "";
+  if (!overridden && bakedChannel !== channel) {
+    throw new Error(
+      `channel mismatch: packaged for "${bakedChannel}" but v${app.getVersion()} resolves to ` +
+        `"${channel}" — this build would publish to one channel and look for updates on another`,
+    );
+  }
+
+  // Report the channel so a CI log answers "which channel did this artifact ship
+  // on?" without anyone having to reason about the tag.
+  return (
+    `${kind} → ${provider}:${owner}/${repo}, channel "${channel}"` +
+    `${overridden ? " (env override)" : ""} (v${app.getVersion()})`
+  );
 }
 
 /**
@@ -337,6 +620,9 @@ export async function runSmokeChecks(boot: BootResult): Promise<SmokeCheck[]> {
     await check("preload-bridge", checkPreloadBridge),
     await check("node-pty", checkNodePty),
     await check("unpacked-deps", checkUnpackedDeps),
+    await check("run-local", () => checkRunLocal(base, token)),
+    await check("deploy-bundle", checkDeployBundle),
+    await check("update-config", checkUpdateConfig),
   ];
 }
 

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -28,6 +28,9 @@
  *   deploy-bundle   agent-core's in-process bundler can actually SPAWN esbuild's
  *                   native binary (a path inside app.asar gave `spawn ENOTDIR`,
  *                   so every deploy from the packaged app failed)
+ *   desktop-bridge  the main window's preload exposed window.sapiomDesktop — the
+ *                   SPA feature-detects it, so a broken preload just makes the
+ *                   "Check for updates" button silently absent
  *   update-config   the auto-update metadata is baked in and electron-updater
  *                   loads — otherwise the app runs fine and never updates again
  *
@@ -561,6 +564,107 @@ async function checkDeployBundle(): Promise<string> {
  * constructs a platform-specific updater on first read — three things that can
  * only be confirmed against a packaged artifact on the platform in question.
  */
+/**
+ * Does the SPA actually get the desktop bridge?
+ *
+ * The "Check for updates" button in the Settings popover is rendered only when
+ * `window.sapiomDesktop` exists, and the SPA feature-detects it because the same
+ * bundle also runs in a plain browser. That makes a broken preload *invisible*:
+ * no error, no blank screen — the button silently isn't there, and looks like a
+ * missing feature rather than a bug. The setup window had exactly this failure
+ * once (an ESM preload won't load in a sandboxed renderer, and onboarding hung
+ * with nothing in any log).
+ *
+ * Asserted against the REAL main window, and asserted through the same shape check
+ * the SPA uses, so a bridge that loads but is incomplete still fails here.
+ */
+async function checkDesktopBridge(boot: BootResult): Promise<string> {
+  const win = boot.mainWindow;
+  if (win.isDestroyed()) throw new Error("main window is gone");
+
+  // `boot()` does NOT await the main window's load — it only registers a
+  // `did-finish-load` handler to close the setup window (boot.ts) — so without
+  // this we can execute against the initial empty document and report "the
+  // preload did not run" as a pure race. It passes today only because the checks
+  // ahead of this one happen to take long enough, which is not a guarantee.
+  if (win.webContents.isLoading()) {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("main window did not finish loading in 15s")), 15_000);
+      const done = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      win.webContents.once("did-finish-load", done);
+      win.webContents.once("did-fail-load", (_e, code, desc) => {
+        clearTimeout(timer);
+        reject(new Error(`main window failed to load: ${desc} (${code})`));
+      });
+    });
+  }
+
+  const shape = (await win.webContents.executeJavaScript(
+    "({ bridge: typeof window.sapiomDesktop," +
+      " check: typeof window.sapiomDesktop?.checkForUpdates," +
+      " restart: typeof window.sapiomDesktop?.restartToUpdate," +
+      " version: window.sapiomDesktop?.appVersion })",
+  )) as { bridge: string; check: string; restart: string; version: unknown };
+
+  if (shape.bridge !== "object") {
+    throw new Error("window.sapiomDesktop is missing — the main window's preload did not run");
+  }
+  if (shape.check !== "function" || shape.restart !== "function") {
+    throw new Error(`bridge incomplete: ${JSON.stringify(shape)}`);
+  }
+  // Not cosmetic-only: the version arrives via `additionalArguments`, which is the
+  // documented way to pass a value to a preload precisely because reading a
+  // mutated `process.env` from a renderer is not dependable. An empty string here
+  // means that mechanism silently failed.
+  if (typeof shape.version !== "string" || shape.version.length === 0) {
+    throw new Error(
+      `bridge exposes no appVersion (${JSON.stringify(shape.version)}) — the ` +
+        `additionalArguments hand-off did not reach the preload`,
+    );
+  }
+
+  // Now actually CALL it. Shape alone would still pass if no `ipcMain` handler were
+  // registered — `ipcRenderer.invoke` on an unhandled channel rejects, and the only
+  // place that shows up is a user clicking the button in a real build.
+  //
+  // Hermetic on purpose: a smoke run has updates gated off, so this returns
+  // `disabled` and short-circuits before any network call. That still exercises the
+  // whole path — preload → invoke → handler → structured outcome back across the
+  // boundary — which is exactly why the handlers are registered regardless of the
+  // gate rather than only when updates are on.
+  const outcome = (await win.webContents.executeJavaScript(
+    "window.sapiomDesktop.checkForUpdates().then(" +
+      "(o) => ({ ok: true, kind: o && o.kind, reason: o && o.reason })," +
+      "(e) => ({ ok: false, kind: String((e && e.message) || e) }))",
+  )) as { ok: boolean; kind?: string; reason?: string };
+  if (!outcome.ok) {
+    throw new Error(`checkForUpdates() rejected: ${outcome.kind} (is the ipcMain handler registered?)`);
+  }
+  if (outcome.kind !== "disabled") {
+    // A smoke run must never reach the network; any other outcome means the gate
+    // leaked and CI would start depending on GitHub.
+    throw new Error(`expected a "disabled" outcome under --smoke, got "${outcome.kind}"`);
+  }
+  // The REASON is what makes this check meaningful now that senders are validated.
+  // A rejected sender also answers `disabled`, so matching on the kind alone could
+  // not tell "the gate is off" (correct) from "the main window is not trusted"
+  // (broken button in every real build). Only the gate says "smoke run".
+  if (outcome.reason !== "smoke run") {
+    throw new Error(
+      `expected the gate's reason ("smoke run"), got "${outcome.reason}" — ` +
+        `the main window was not accepted as a trusted IPC sender`,
+    );
+  }
+
+  return (
+    `window.sapiomDesktop exposes checkForUpdates + restartToUpdate (v${shape.version}); ` +
+    `trusted-sender round-trip returned "${outcome.kind}: ${outcome.reason}"`
+  );
+}
+
 async function checkUpdateConfig(): Promise<string> {
   if (!app.isPackaged) {
     return "SKIPPED — unpackaged build has no app-update.yml (run scripts/smoke.sh)";
@@ -663,6 +767,7 @@ export async function runSmokeChecks(boot: BootResult): Promise<SmokeCheck[]> {
     await check("runtime-shims", checkRuntimeShims),
     await check("run-local", () => checkRunLocal(base, token)),
     await check("deploy-bundle", checkDeployBundle),
+    await check("desktop-bridge", () => checkDesktopBridge(boot)),
     await check("update-config", checkUpdateConfig),
   ];
 }

--- a/packages/harness-desktop/src/main/update-policy.test.ts
+++ b/packages/harness-desktop/src/main/update-policy.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Channel resolution has no failure mode that looks like a failure. Get it
+ * wrong and the app updates perfectly — to the wrong build, for the wrong
+ * people. The two ways that plays out:
+ *
+ *  - a stable install offered a pre-release ships an unvalidated build to every
+ *    real user, which is the entire reason the beta channel exists;
+ *  - a beta install with `allowPrerelease: false` never sees anything, because
+ *    the GitHub provider filters pre-releases out of the feed BEFORE it looks
+ *    for `beta.yml` — the channel name alone does nothing.
+ *
+ * The gate is here for a narrower reason: if it ever returns `enabled` during a
+ * `--smoke` run, the packaging gate starts depending on the network and on the
+ * state of our published releases, and a deterministic check becomes a flaky one.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  CHANNEL_ENV_VAR,
+  DISABLE_ENV_VAR,
+  FORCE_ENV_VAR,
+  STABLE_ACCEPTS_PRERELEASE,
+  resolveUpdateChannel,
+  shouldEnableUpdater,
+} from "./update-policy.js";
+
+const noEnv: NodeJS.ProcessEnv = {};
+
+describe("resolveUpdateChannel", () => {
+  it("follows stable for a final version", () => {
+    expect(resolveUpdateChannel("0.1.2", noEnv)).toEqual({
+      channel: "latest",
+      allowPrerelease: STABLE_ACCEPTS_PRERELEASE,
+    });
+  });
+
+  it("follows beta for a pre-release version, and accepts pre-releases", () => {
+    // Both halves matter: the channel picks the file, allowPrerelease is what
+    // lets the provider consider the release that file lives on.
+    expect(resolveUpdateChannel("0.1.2-beta.1", noEnv)).toEqual({
+      channel: "beta",
+      allowPrerelease: true,
+    });
+  });
+
+  it("treats build metadata as a final release, not a pre-release", () => {
+    // `+ci.44` is metadata; the `-` inside `pr-44` must not read as a tag.
+    expect(resolveUpdateChannel("0.1.2+ci.44", noEnv).channel).toBe("latest");
+    expect(resolveUpdateChannel("0.1.2+pr-44", noEnv).channel).toBe("latest");
+  });
+
+  it("does not offer a stable install a pre-release by default", () => {
+    // The safety property. If this ever flips, every user is on the beta line.
+    expect(resolveUpdateChannel("0.1.2", noEnv).allowPrerelease).toBe(false);
+  });
+
+  it("honours the env override in both directions", () => {
+    expect(resolveUpdateChannel("0.1.2", { [CHANNEL_ENV_VAR]: "beta" })).toEqual({
+      channel: "beta",
+      allowPrerelease: true,
+    });
+    // A tester on a beta build can be pinned back to stable without reinstalling.
+    expect(resolveUpdateChannel("0.1.2-beta.1", { [CHANNEL_ENV_VAR]: "latest" })).toEqual({
+      channel: "latest",
+      allowPrerelease: STABLE_ACCEPTS_PRERELEASE,
+    });
+  });
+
+  it("accepts a sloppily-typed override", () => {
+    // It is set by hand in a shell, so " BETA\n" is the normal case, not an edge one.
+    expect(resolveUpdateChannel("0.1.2", { [CHANNEL_ENV_VAR]: " BETA\n" }).channel).toBe("beta");
+  });
+
+  it("reports an unusable override instead of silently ignoring it", () => {
+    const decision = resolveUpdateChannel("0.1.2", { [CHANNEL_ENV_VAR]: "nightly" });
+    expect(decision.channel).toBe("latest"); // falls back, never throws
+    expect(decision.ignoredOverride).toBe("nightly");
+  });
+
+  it("says nothing when the override is absent or empty", () => {
+    expect(resolveUpdateChannel("0.1.2", noEnv).ignoredOverride).toBeUndefined();
+    expect(resolveUpdateChannel("0.1.2", { [CHANNEL_ENV_VAR]: "  " }).ignoredOverride).toBeUndefined();
+  });
+
+  it("treats an unparseable version as stable rather than throwing", () => {
+    // app.getVersion() is whatever package.json says; a bad value must not be
+    // able to stop the app from starting.
+    for (const version of ["", "not-a-version", "0.1", "v0.1.2"]) {
+      expect(resolveUpdateChannel(version, noEnv).channel).toBe("latest");
+    }
+  });
+});
+
+describe("shouldEnableUpdater", () => {
+  const packaged = { isPackaged: true, devMode: false, smoke: false, env: noEnv };
+
+  it("is on for a plain packaged launch", () => {
+    expect(shouldEnableUpdater(packaged)).toEqual({ enabled: true });
+  });
+
+  it("is off during a smoke run, so CI never depends on GitHub", () => {
+    const gate = shouldEnableUpdater({ ...packaged, smoke: true });
+    expect(gate.enabled).toBe(false);
+    expect(gate.reason).toBe("smoke run");
+  });
+
+  it("is off unpackaged — there is no app-update.yml to read", () => {
+    expect(shouldEnableUpdater({ ...packaged, isPackaged: false }).enabled).toBe(false);
+  });
+
+  it("is off in --dev, including against a packaged build", () => {
+    expect(shouldEnableUpdater({ ...packaged, devMode: true }).enabled).toBe(false);
+  });
+
+  it("can be switched off outright", () => {
+    const gate = shouldEnableUpdater({ ...packaged, env: { [DISABLE_ENV_VAR]: "1" } });
+    expect(gate.enabled).toBe(false);
+    expect(gate.reason).toContain(DISABLE_ENV_VAR);
+  });
+
+  it("can be forced on from an unpackaged build, and says so", () => {
+    // The dev loop for this feature: without `forced`, the caller wouldn't set
+    // forceDevUpdateConfig and electron-updater would throw looking for the
+    // app-update.yml that only packaging writes.
+    const gate = shouldEnableUpdater({
+      ...packaged,
+      isPackaged: false,
+      devMode: true,
+      env: { [FORCE_ENV_VAR]: "1" },
+    });
+    expect(gate).toEqual({ enabled: true, forced: true });
+  });
+
+  it("keeps a smoke run hermetic even when the updater is forced on", () => {
+    // CI hermeticity outranks the developer convenience: no combination of env
+    // vars may make the packaging gate depend on the network.
+    const gate = shouldEnableUpdater({ ...packaged, smoke: true, env: { [FORCE_ENV_VAR]: "1" } });
+    expect(gate.enabled).toBe(false);
+    expect(gate.reason).toBe("smoke run");
+  });
+
+  it("lets the opt-out beat the force override", () => {
+    // A user who asked for no update traffic gets none, whatever else is set.
+    const gate = shouldEnableUpdater({
+      ...packaged,
+      env: { [DISABLE_ENV_VAR]: "1", [FORCE_ENV_VAR]: "1" },
+    });
+    expect(gate.enabled).toBe(false);
+  });
+
+  it("always reports a reason when disabled", () => {
+    // The reason is the only thing a user's log will show; an empty one turns
+    // "updates aren't working" into an unanswerable question.
+    for (const input of [
+      { ...packaged, smoke: true },
+      { ...packaged, isPackaged: false },
+      { ...packaged, devMode: true },
+      { ...packaged, env: { [DISABLE_ENV_VAR]: "1" } },
+    ]) {
+      const gate = shouldEnableUpdater(input);
+      expect(gate.enabled).toBe(false);
+      expect(gate.reason).toBeTruthy();
+    }
+  });
+});

--- a/packages/harness-desktop/src/main/update-policy.test.ts
+++ b/packages/harness-desktop/src/main/update-policy.test.ts
@@ -16,6 +16,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANNEL_ENV_VAR,
+  classifyUpdateError,
   DISABLE_ENV_VAR,
   FORCE_ENV_VAR,
   STABLE_ACCEPTS_PRERELEASE,
@@ -159,6 +160,55 @@ describe("shouldEnableUpdater", () => {
       const gate = shouldEnableUpdater(input);
       expect(gate.enabled).toBe(false);
       expect(gate.reason).toBeTruthy();
+    }
+  });
+});
+
+describe("classifyUpdateError", () => {
+  // The real thing, abbreviated: electron-updater appends the ENTIRE releases Atom
+  // feed after ", XML:", plus a full stack trace. Forwarding this to the UI put
+  // kilobytes of XML into a toast.
+  const REAL_NO_RELEASE = [
+    "Unable to find latest version on GitHub (https://github.com/sapiom/sapiom-js/releases.atom),",
+    " please ensure a production release exists: HttpError: 404",
+    '\n    at GitHubProvider.getLatestTagName (/Applications/Sapiom.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:173:55)',
+    "\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+    ', XML: <?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom">',
+    "<title>Release notes from sapiom-js</title><entry><id>tag:github.com,2008:Repository/1094593670/harness-desktop-v0.1.0</id></entry></feed>",
+  ].join("");
+
+  it("recognises an empty channel, and drops the feed and the stack", () => {
+    const { kind, summary } = classifyUpdateError(REAL_NO_RELEASE);
+    expect(kind).toBe("no-release");
+    expect(summary).not.toMatch(/<\?xml|<feed|GitHubProvider|app\.asar/);
+    expect(summary.length).toBeLessThan(120);
+  });
+
+  it("never lets a message through long enough to wreck a toast", () => {
+    // The property that actually matters, independent of classification.
+    for (const raw of [REAL_NO_RELEASE, `Boom${"x".repeat(5000)}`, `a\n${"y".repeat(5000)}`]) {
+      expect(classifyUpdateError(raw).summary.length).toBeLessThanOrEqual(160);
+    }
+  });
+
+  it("names an offline machine as such", () => {
+    expect(classifyUpdateError("request to https://github.com failed, reason: getaddrinfo ENOTFOUND github.com").kind).toBe(
+      "offline",
+    );
+    expect(classifyUpdateError("connect ECONNREFUSED 140.82.121.3:443").kind).toBe("offline");
+  });
+
+  it("keeps an unrecognised message, bounded, rather than replacing it", () => {
+    // A truncated real message still beats a generic one when diagnosing from a
+    // screenshot.
+    const { kind, summary } = classifyUpdateError("ENOSPC: no space left on device, write");
+    expect(kind).toBe("other");
+    expect(summary).toContain("ENOSPC");
+  });
+
+  it("always produces something to show", () => {
+    for (const raw of ["", "   ", "\n\n"]) {
+      expect(classifyUpdateError(raw).summary.length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/harness-desktop/src/main/update-policy.ts
+++ b/packages/harness-desktop/src/main/update-policy.ts
@@ -1,0 +1,166 @@
+/**
+ * Update policy — the decisions about WHICH build an install follows and WHETHER
+ * it checks at all. Deliberately pure: no `electron`, no `electron-updater`.
+ *
+ * That split is required, not stylistic. `vitest.config.ts` unit-tests only the
+ * main-process modules that don't import `electron`, on the stated grounds that
+ * mocking it would re-assert the same assumptions the packaged `--smoke` run
+ * exists to check. These two functions are exactly the parts that can be wrong
+ * *silently* — a mis-resolved channel doesn't crash, it just quietly ships the
+ * wrong build to the wrong people — so they belong on the testable side of that
+ * line. The `electron`-facing wiring lives in `updater.ts`.
+ */
+
+export type UpdateChannel = "latest" | "beta";
+
+export interface ChannelDecision {
+  /** The channel file the updater reads: `latest*.yml` or `beta*.yml`. */
+  channel: UpdateChannel;
+  /**
+   * Whether pre-release GitHub Releases are considered at all. The GitHub
+   * provider filters pre-releases out of the release feed *before* looking for a
+   * channel file, so a beta install needs this on or it never sees the beta
+   * release the channel name points at.
+   */
+  allowPrerelease: boolean;
+  /**
+   * Set when SAPIOM_UPDATE_CHANNEL held something unusable, so the caller can
+   * warn. A silently-ignored override is a support trap: the user believes they
+   * switched channels and nothing happens, with no evidence either way.
+   */
+  ignoredOverride?: string;
+}
+
+/**
+ * The one genuinely discretionary knob. False means a stable install is NEVER
+ * offered a pre-release — the safe default, since pre-release is precisely the
+ * build nobody has validated yet.
+ *
+ * Flip it to true only if you want "ship the fix to everyone immediately" to be
+ * the standing behaviour rather than a deliberate act. Note there is already a
+ * per-machine escape hatch that doesn't require this: SAPIOM_UPDATE_CHANNEL=beta
+ * moves one install onto betas without changing policy for everybody.
+ */
+export const STABLE_ACCEPTS_PRERELEASE = false;
+
+/** Env var a tester (or a dev) sets to follow a different channel. */
+export const CHANNEL_ENV_VAR = "SAPIOM_UPDATE_CHANNEL";
+/** Env var that turns update checking off entirely. */
+export const DISABLE_ENV_VAR = "SAPIOM_DISABLE_UPDATER";
+/**
+ * Env var that runs the updater against a hand-written `dev-app-update.yml` from
+ * an unpackaged build. Without it the dev loop for this feature is "cut a tag and
+ * wait for CI", which is not a loop.
+ */
+export const FORCE_ENV_VAR = "SAPIOM_FORCE_UPDATER";
+
+const CHANNELS: readonly UpdateChannel[] = ["latest", "beta"];
+
+/**
+ * True when the version carries a semver pre-release component (`0.1.2-beta.1`),
+ * which is how a beta artifact is distinguished from a final one.
+ *
+ * Build metadata is stripped first: `0.1.2+ci.44` is a *final* release, and the
+ * `-` inside a build tag like `0.1.2+pr-44` would otherwise read as one.
+ *
+ * Hand-rolled rather than importing `semver`: it isn't a declared dependency of
+ * this package (only a transitive one of electron-updater), and relying on a
+ * transitive dep is how a working build breaks on an unrelated upgrade.
+ */
+function hasPrereleaseTag(version: string): boolean {
+  const [core = ""] = version.trim().split("+", 1);
+  return /^\d+\.\d+\.\d+-\S/.test(core);
+}
+
+/**
+ * Which channel this install follows.
+ *
+ * The version is the source of truth, because it is the one thing that is
+ * unambiguously baked into the artifact the user is actually running: a build
+ * tagged `-beta.N` follows betas, a final build follows finals. We cannot let
+ * electron-builder infer this — `detectUpdateChannel` is documented as not
+ * applying to GitHub publishing — so the app decides for itself.
+ *
+ * Channels are a hierarchy, not a partition: a beta install accepts betas AND
+ * newer finals, so a tester is pulled back onto the stable line as soon as one
+ * ships rather than being stranded on a branch nobody publishes to any more.
+ * (The release job's `latest*.yml` → `beta*.yml` copy is the other half of that;
+ * without it the beta channel file simply vanishes at the next final release.)
+ *
+ * The env override is honoured even in a packaged build, on purpose. It is the
+ * only way to say "put this one machine on betas" before there is any settings
+ * UI — a tester who hits a bug we already fixed can get the fix today, and it
+ * costs a restart with an env var rather than a release.
+ */
+export function resolveUpdateChannel(version: string, env: NodeJS.ProcessEnv): ChannelDecision {
+  const fromVersion: UpdateChannel = hasPrereleaseTag(version) ? "beta" : "latest";
+
+  const raw = env[CHANNEL_ENV_VAR];
+  const requested = raw?.trim().toLowerCase();
+  const override = CHANNELS.find((c) => c === requested);
+
+  const channel = override ?? fromVersion;
+  const decision: ChannelDecision = {
+    channel,
+    // A beta install must accept pre-releases or the channel name is inert.
+    allowPrerelease: channel !== "latest" || STABLE_ACCEPTS_PRERELEASE,
+  };
+
+  // Something was set but wasn't a channel — report it rather than swallow it.
+  if (raw !== undefined && raw.trim() !== "" && !override) {
+    decision.ignoredOverride = raw;
+  }
+  return decision;
+}
+
+export interface UpdaterGateInput {
+  /** `app.isPackaged`. */
+  isPackaged: boolean;
+  /** `--dev` was passed. */
+  devMode: boolean;
+  /** `--smoke` was passed. */
+  smoke: boolean;
+  env: NodeJS.ProcessEnv;
+}
+
+export interface UpdaterGate {
+  enabled: boolean;
+  /** Why it's off, for the log. Absent when enabled. */
+  reason?: string;
+  /**
+   * Enabled only because of the force override, so the caller must also set
+   * `autoUpdater.forceDevUpdateConfig` — otherwise electron-updater looks for the
+   * `app-update.yml` that only packaging writes and throws instead of reading the
+   * `dev-app-update.yml` the developer just wrote.
+   */
+  forced?: boolean;
+}
+
+/**
+ * Whether to run update checks at all.
+ *
+ * Each exclusion is load-bearing:
+ *  - **unpackaged**: electron-updater throws without the `app-update.yml` that
+ *    only packaging writes, so a dev run would surface a boot error for nothing.
+ *  - **smoke**: a CI smoke run must not reach out to GitHub. It would make the
+ *    packaging gate depend on network + the state of our releases, turning a
+ *    deterministic check into a flaky one.
+ *  - **dev**: same as unpackaged in practice, but explicit, so `--dev` against a
+ *    packaged build (which happens) is also quiet.
+ *  - **env opt-out**: the answer to "how do I stop it phoning home", asked once
+ *    per privacy-conscious user, and useful when bisecting a boot problem.
+ *
+ * Order is deliberate. The opt-out wins over everything, including the force
+ * override, because a user who asked for no update traffic must get none whatever
+ * else is set. `smoke` is checked BEFORE the force override so no combination of
+ * env vars can make the packaging gate hit the network — the force override is a
+ * developer convenience, and CI hermeticity outranks it.
+ */
+export function shouldEnableUpdater(input: UpdaterGateInput): UpdaterGate {
+  if (input.env[DISABLE_ENV_VAR] === "1") return { enabled: false, reason: `${DISABLE_ENV_VAR}=1` };
+  if (input.smoke) return { enabled: false, reason: "smoke run" };
+  if (input.env[FORCE_ENV_VAR] === "1") return { enabled: true, forced: true };
+  if (!input.isPackaged) return { enabled: false, reason: "not a packaged build" };
+  if (input.devMode) return { enabled: false, reason: "--dev" };
+  return { enabled: true };
+}

--- a/packages/harness-desktop/src/main/update-policy.ts
+++ b/packages/harness-desktop/src/main/update-policy.ts
@@ -164,3 +164,44 @@ export function shouldEnableUpdater(input: UpdaterGateInput): UpdaterGate {
   if (input.devMode) return { enabled: false, reason: "--dev" };
   return { enabled: true };
 }
+
+/** What went wrong with a check, in terms a user can act on. */
+export type UpdateErrorKind =
+  /** The channel has no release to offer — not a fault, just nothing published. */
+  | "no-release"
+  /** We could not reach GitHub. */
+  | "offline"
+  | "other";
+
+/**
+ * Turn electron-updater's error into one short, human line.
+ *
+ * This exists because the raw message is unusable in a UI: for a channel with no
+ * published release, GitHubProvider appends the **entire releases Atom feed** plus
+ * a full stack trace, so `error.message` is kilobytes of XML. Rendering that in a
+ * toast is what happens if you trust it (it did).
+ *
+ * Also separates "nothing is published yet" from "something broke". The first is a
+ * normal state — a stable install correctly ignores pre-releases, so before the
+ * first final release there is genuinely nothing to find — and calling it an error
+ * teaches users to distrust the feature.
+ */
+export function classifyUpdateError(raw: string): { kind: UpdateErrorKind; summary: string } {
+  // Cut the appended feed first: everything from `, XML:` on is the Atom document.
+  const withoutXml = raw.split(/,\s*XML:/)[0] ?? raw;
+  // Then the first line, because the rest is a stack trace.
+  const firstLine = (withoutXml.split(/\r?\n/)[0] ?? "").trim();
+  const collapsed = firstLine.replace(/\s+/g, " ");
+
+  if (/unable to find latest version|ensure a production release exists|no published versions/i.test(collapsed)) {
+    return { kind: "no-release", summary: "no release has been published on this channel yet" };
+  }
+  if (/ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|ENETUNREACH|net::ERR/i.test(collapsed)) {
+    return { kind: "offline", summary: "could not reach GitHub" };
+  }
+  // Unknown: keep it, but bounded. A truncated real message still beats a generic
+  // one when someone has to diagnose it from a screenshot.
+  const MAX = 160;
+  const summary = collapsed.length > MAX ? `${collapsed.slice(0, MAX - 1).trimEnd()}…` : collapsed;
+  return { kind: "other", summary: summary || "the update check failed" };
+}

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -36,6 +36,7 @@ import type { UpdateInfo } from "electron-updater";
 import { UPDATE_CHECK, type UpdateCheckOutcome } from "./ipc.js";
 import {
   CHANNEL_ENV_VAR,
+  classifyUpdateError,
   resolveUpdateChannel,
   shouldEnableUpdater,
 } from "./update-policy.js";
@@ -296,9 +297,13 @@ async function runCheck(current: NonNullable<typeof active>): Promise<UpdateChec
     }
     return { kind: "up-to-date", version: app.getVersion(), channel: current.channel };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log(`on-demand check failed: ${message}`);
-    return { kind: "failed", message };
+    // NEVER forward the raw message: for a channel with no published release,
+    // electron-updater appends the whole releases Atom feed and a stack trace, so
+    // it is kilobytes of XML — which went straight into a toast once.
+    const { kind, summary } = classifyUpdateError(err instanceof Error ? err.message : String(err));
+    log(`on-demand check failed (${kind}): ${summary}`);
+    if (kind === "no-release") return { kind: "no-release", channel: current.channel };
+    return { kind: "failed", message: summary };
   }
 }
 
@@ -439,14 +444,14 @@ function startUpdater(deps: UpdaterDeps): void {
     // Expected in the field, and never fatal: no network, a release without
     // metadata, an AppImage the user extracted, a .deb with no working package
     // manager. The app keeps working on the version it has.
-    log(`check failed: ${err.message}`);
+    log(`check failed: ${classifyUpdateError(err.message).summary}`);
   });
 
   const check = (): void => {
     autoUpdater.checkForUpdates().catch((err: unknown) => {
       // checkForUpdates rejects AND emits "error"; swallow here so the
       // rejection can't surface as an unhandled promise.
-      log(`check rejected: ${err instanceof Error ? err.message : String(err)}`);
+      log(`check rejected: ${classifyUpdateError(err instanceof Error ? err.message : String(err)).summary}`);
     });
   };
 

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -29,10 +29,11 @@
  *    installer is trying to replace. So the update path calls the caller's
  *    `shutdown()` and awaits it, rather than relying on the quit hook.
  */
-import { BrowserWindow, app, dialog } from "electron";
+import { BrowserWindow, app, dialog, ipcMain, type IpcMainInvokeEvent } from "electron";
 // CJS: default-import then read the property. See trap 1 above.
 import electronUpdater from "electron-updater";
 import type { UpdateInfo } from "electron-updater";
+import { UPDATE_CHECK, UPDATE_RESTART, type UpdateCheckOutcome } from "./ipc.js";
 import {
   CHANNEL_ENV_VAR,
   resolveUpdateChannel,
@@ -77,17 +78,114 @@ const declined = new Set<string>();
 let promptOpen = false;
 
 /**
+ * Who we serve, set on every launch regardless of the gate.
+ *
+ * Separate from `active` on purpose: sender validation and the failure dialogs
+ * need the main window even when updates are switched off. Deriving the window
+ * from `active` instead made `isTrustedSender` reject *everything* in a build with
+ * updates disabled, so the SPA reported the useless "not available here" in place
+ * of the real reason ("not a packaged build").
+ */
+let host: UpdaterDeps | null = null;
+/** Live updater, once initialised. Null means checks are off — `disabledReason` says why. */
+let active: { autoUpdater: typeof electronUpdater.autoUpdater; channel: string; deps: UpdaterDeps } | null = null;
+let disabledReason: string | null = null;
+/**
+ * An update that has finished downloading and is waiting for a restart. Held so
+ * an on-demand check can answer "ready — restart" instead of "up to date", which
+ * is what it would otherwise say: electron-updater reports the *installed*
+ * version, and a downloaded-but-unapplied update doesn't change that.
+ */
+let pending: UpdateInfo | null = null;
+/** In-flight on-demand check, so a double-click doesn't start two. */
+let checkInFlight: Promise<UpdateCheckOutcome> | null = null;
+
+/**
+ * How long to wait for `quitAndInstall` to actually end the process before
+ * concluding the handoff failed. It normally quits within a second; 15s is slack
+ * for Squirrel.Mac's staging step, not a guess at a happy path.
+ */
+const HANDOFF_GRACE_MS = 15 * 1_000;
+
+/**
+ * Hand off to the platform installer, having first closed the harness server.
+ *
+ * Two hard-won constraints pull in opposite directions here:
+ *
+ *  - The server MUST close before the installer runs (trap 2 at the top): an
+ *    orphaned pty holding the install directory is a failed update on Windows,
+ *    and an orphaned `claude` everywhere.
+ *  - But closing it kills every agent session, and `quitAndInstall` is NOT
+ *    guaranteed to quit. Squirrel.Mac refuses an update it cannot verify, and the
+ *    mac build is unsigned whenever `CSC_LINK` is absent; an extracted AppImage
+ *    and a `.deb` with no usable package manager can't self-install either. This
+ *    file's own error handler lists all three as things that happen in the field.
+ *
+ * Doing the irreversible half first meant that in every one of those cases the
+ * user lost their work AND stayed on the old version, looking at a dead SPA, with
+ * one stderr line as the only evidence. So: refuse up front when the updater
+ * cannot install, and if the handoff still doesn't happen, relaunch rather than
+ * leave a hollow app.
+ */
+async function applyUpdate(version: string): Promise<{ ok: boolean; reason?: string }> {
+  if (!active) return { ok: false, reason: "updates are not initialised" };
+
+  // Checked BEFORE touching the server, because this is the whole point: no
+  // installer, no reason to take anything away from the user.
+  if (!active.autoUpdater.isUpdaterActive()) {
+    log(`refusing to apply ${version}: the updater is not active for this install`);
+    return {
+      ok: false,
+      reason:
+        "This build can't install updates itself — it's unsigned, or installed in a format " +
+        "that can't self-update. Download the new version instead; your sessions are untouched.",
+    };
+  }
+
+  log(`applying ${version} — closing the harness server first`);
+  await active.deps.shutdown();
+  try {
+    // (true, true) = install without the NSIS wizard, then relaunch. Both are
+    // Windows-only knobs; macOS always relaunches and Linux ignores them. Without
+    // isForceRunAfter a "Restart now" would quit and NOT come back, which is not
+    // what the button says.
+    active.autoUpdater.quitAndInstall(true, true);
+  } catch (err) {
+    log(`quitAndInstall threw: ${err instanceof Error ? err.message : String(err)}`);
+    relaunchAfterFailedHandoff();
+    return { ok: false, reason: "The installer could not be started; restarting Sapiom." };
+  }
+
+  // Still running after the grace period means the handoff silently failed — and
+  // the server is already closed, so there is nothing to go back to. Relaunching
+  // on the OLD version is a worse outcome than updating and a much better one than
+  // an app with no server behind it.
+  setTimeout(() => {
+    log("quitAndInstall did not quit — relaunching on the current version");
+    relaunchAfterFailedHandoff();
+  }, HANDOFF_GRACE_MS).unref();
+  return { ok: true };
+}
+
+function relaunchAfterFailedHandoff(): void {
+  // `pending` is cleared by the caller; this process is about to be replaced.
+  app.relaunch();
+  app.exit(0);
+}
+
+/**
  * Offer the update, and apply it only if the user agrees.
  *
- * A native dialog rather than something injected into the page: the main window
- * shows the harness SPA, served by the harness itself, and reaching into it would
- * couple this app to a UI another person is actively refactoring. It also matches
- * how the rest of onboarding already talks to the user.
+ * A native dialog, not something injected into the page: this fires whenever a
+ * background download finishes, and it must work regardless of what the main
+ * window happens to be showing. (The SPA's Settings popover has its own,
+ * *user-initiated* path — see `checkForUpdatesNow`.)
  *
  * Declining is remembered per version FOR THIS RUN only. Re-prompting on every
  * check would nag someone who already said no; forgetting entirely across
  * launches would mean a deferred update is never mentioned again. Prompting once
- * per launch is the middle that needs no extra state on disk.
+ * per launch is the middle that needs no extra state on disk — and an explicit
+ * "check for updates" clears it, because asking IS undeclining.
  */
 async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
   const { version } = info;
@@ -95,6 +193,9 @@ async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
   if (deps.mainWindow.isDestroyed()) return;
 
   promptOpen = true;
+  // Held across the apply, not just the dialog: shutdown takes seconds, and
+  // releasing early let a second `update-downloaded` stack another dialog on top
+  // of an app that was already installing.
   try {
     const { response } = await dialog.showMessageBox(deps.mainWindow, {
       type: "info",
@@ -114,19 +215,112 @@ async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
       log(`user deferred ${version}`);
       return;
     }
+
+    const result = await applyUpdate(version);
+    if (!result.ok) {
+      // Never silently: the user pressed "Restart now" and nothing happened, so
+      // say what and why. Their sessions are still alive in the refuse-up-front
+      // case, which is exactly what the message needs to tell them.
+      pending = null;
+      await dialog.showMessageBox(deps.mainWindow, {
+        type: "warning",
+        buttons: ["OK"],
+        message: `Sapiom ${version} could not be installed.`,
+        detail: result.reason ?? "The update could not be applied.",
+      });
+    }
   } finally {
     promptOpen = false;
   }
+}
 
-  log(`applying ${version} — closing the harness server first`);
-  // Await it: see trap 2. An orphaned pty holding the install directory is a
-  // failed update on Windows, and an orphaned `claude` on every platform.
-  await deps.shutdown();
-  // (true, true) = install without the NSIS wizard, then relaunch. Both are
-  // Windows-only knobs; macOS always relaunches and Linux ignores them. Without
-  // isForceRunAfter a "Restart now" would quit and NOT come back, which is not
-  // what the button says.
-  electronUpdater.autoUpdater.quitAndInstall(true, true);
+/**
+ * Check right now, on the user's behalf, and describe what happened.
+ *
+ * This is the Settings popover's "Check for updates" button. It differs from the
+ * scheduled check in three ways, and each one is a thing users notice:
+ *  - it REPORTS an outcome. A silent background check is fine; a button that
+ *    appears to do nothing is broken.
+ *  - it clears the declined set, so someone who chose "Later" can change their
+ *    mind without restarting the app.
+ *  - it answers "downloaded" for an update already waiting, rather than the
+ *    literally-true-but-useless "you're up to date".
+ *
+ * Never throws: every failure becomes a `failed` outcome the UI can render.
+ */
+export async function checkForUpdatesNow(): Promise<UpdateCheckOutcome> {
+  if (!active) {
+    return { kind: "disabled", reason: disabledReason ?? "updates are not available in this build" };
+  }
+  // Asking is undeclining — and it has to happen BEFORE the `pending` shortcut
+  // below, or it never happens in the one case that matters: choosing "Later"
+  // sets `pending`, so returning early would leave the version declined for the
+  // rest of the run and the native prompt would never come back.
+  declined.clear();
+  // Something already downloaded and waiting to be applied: report that instead
+  // of asking GitHub again. Note this is checked AFTER undeclining, and that
+  // `pending` is cleared whenever an apply fails — otherwise one failed install
+  // would wedge the button on "ready to install" forever, with the restart doing
+  // nothing and a genuinely newer version never being offered.
+  if (pending) return { kind: "downloaded", version: pending.version };
+  // Coalesce concurrent asks rather than firing two requests at GitHub.
+  checkInFlight ??= runCheck(active);
+  try {
+    return await checkInFlight;
+  } finally {
+    checkInFlight = null;
+  }
+}
+
+async function runCheck(current: NonNullable<typeof active>): Promise<UpdateCheckOutcome> {
+  try {
+    const result = await current.autoUpdater.checkForUpdates();
+    if (!result) {
+      // electron-updater returns null when it declines to check at all (no
+      // update config, or a check already running). Not an error, but not an
+      // answer either — don't dress it up as "up to date".
+      return { kind: "failed", message: "The update check did not run." };
+    }
+    if (result.isUpdateAvailable) {
+      log(`on-demand check: ${result.updateInfo.version} available`);
+      return { kind: "available", version: result.updateInfo.version };
+    }
+    return { kind: "up-to-date", version: app.getVersion(), channel: current.channel };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log(`on-demand check failed: ${message}`);
+    return { kind: "failed", message };
+  }
+}
+
+/**
+ * Apply an update the user asked to install from the SPA. No-op if none is waiting.
+ *
+ * On failure `pending` is cleared so the button recovers: it goes back to being a
+ * real check instead of permanently re-offering an install that cannot happen.
+ */
+export async function restartToUpdate(): Promise<void> {
+  if (!pending) {
+    log("restart requested with no downloaded update — ignoring");
+    return;
+  }
+  const version = pending.version;
+  const result = await applyUpdate(version);
+  if (!result.ok) {
+    pending = null;
+    log(`could not apply ${version}: ${result.reason ?? "unknown"}`);
+    // The SPA gets a void back, so tell the user here — this is the same dead-end
+    // the native path reports, and silence would look like a broken button.
+    const win = host?.mainWindow;
+    if (win && !win.isDestroyed()) {
+      await dialog.showMessageBox(win, {
+        type: "warning",
+        buttons: ["OK"],
+        message: `Sapiom ${version} could not be installed.`,
+        detail: result.reason ?? "The update could not be applied.",
+      });
+    }
+  }
 }
 
 /**
@@ -139,11 +333,73 @@ async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
  * must never cost someone their app.
  */
 export function initUpdater(deps: UpdaterDeps): void {
+  host = deps;
+  // Registered BEFORE (and regardless of) the gate. The SPA's button is wired to
+  // these channels, and `ipcRenderer.invoke` on a channel with no handler REJECTS
+  // — so skipping registration for a build with updates disabled would turn a
+  // clear "updates are off in this build" into an opaque renderer-side error.
+  registerHandlers();
   try {
     startUpdater(deps);
   } catch (err) {
+    disabledReason = `initialisation failed: ${err instanceof Error ? err.message : String(err)}`;
     log(`could not initialise: ${err instanceof Error ? err.message : String(err)}`);
   }
+}
+
+/**
+ * Only the harness SPA, in the main window's top frame, may drive these.
+ *
+ * `restartToUpdate` kills every running agent session, so "which renderer asked?"
+ * is a security question, not bookkeeping. Two things could otherwise ask:
+ *  - another window — a pop-out inherits webPreferences unless we prevent it
+ *    (windows.ts does now, and this is the check that still holds if that ever
+ *    regresses);
+ *  - the main window itself after navigating to agent-authored content, which the
+ *    harness serves at `/canvas/:sessionId/*` on this same origin.
+ *
+ * Hence both an identity check and a path check. The SPA lives at `/` and never
+ * navigates the top frame over http (its one `location.href` is an editor scheme,
+ * which `will-navigate` sends to the OS), so requiring `/` is exact today. If the
+ * SPA ever adopts routing this fails CLOSED and says why, rather than quietly
+ * widening.
+ */
+function isTrustedSender(event: IpcMainInvokeEvent): boolean {
+  const win = host?.mainWindow ?? null;
+  if (!win || win.isDestroyed()) return false;
+  if (event.sender !== win.webContents) {
+    log("rejected an update IPC from a non-main-window renderer");
+    return false;
+  }
+  // The top frame, not the calling frame: a subframe must never qualify even if
+  // `nodeIntegrationInSubFrames` is switched on later.
+  const frameUrl = event.sender.mainFrame.url;
+  try {
+    if (new URL(frameUrl).pathname !== "/") {
+      log(`rejected an update IPC from ${frameUrl} — only the SPA root may ask`);
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+/** Idempotent: `ipcMain.handle` throws if a channel is registered twice. */
+let handlersRegistered = false;
+function registerHandlers(): void {
+  if (handlersRegistered) return;
+  handlersRegistered = true;
+  ipcMain.handle(UPDATE_CHECK, async (event): Promise<UpdateCheckOutcome> => {
+    // Answer, rather than throw, so an unexpected caller gets a dead end instead
+    // of a stack trace to probe.
+    if (!isTrustedSender(event)) return { kind: "disabled", reason: "not available here" };
+    return checkForUpdatesNow();
+  });
+  ipcMain.handle(UPDATE_RESTART, async (event): Promise<void> => {
+    if (!isTrustedSender(event)) return;
+    await restartToUpdate();
+  });
 }
 
 function startUpdater(deps: UpdaterDeps): void {
@@ -154,6 +410,7 @@ function startUpdater(deps: UpdaterDeps): void {
     env: process.env,
   });
   if (!gate.enabled) {
+    disabledReason = gate.reason ?? "updates are disabled";
     log(`disabled — ${gate.reason}`);
     return;
   }
@@ -193,6 +450,10 @@ function startUpdater(deps: UpdaterDeps): void {
     log(`up to date on "${decision.channel}" (${app.getVersion()})`);
   });
   autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    // Recorded before we prompt: whatever the user answers, this version is now
+    // on disk and applying it is a restart away — which is what the SPA's button
+    // needs to know to say "restart" instead of "up to date".
+    pending = info;
     void offerUpdate(info, deps).catch((err: unknown) => {
       log(`failed to apply ${info.version}: ${err instanceof Error ? err.message : String(err)}`);
     });
@@ -216,6 +477,10 @@ function startUpdater(deps: UpdaterDeps): void {
     `enabled — channel "${decision.channel}", allowPrerelease=${decision.allowPrerelease}` +
       `${gate.forced ? ", forced (dev config)" : ""}`,
   );
+  // Last: publishing `active` is what enables the on-demand path, so it happens
+  // only once everything above has been configured without throwing.
+  active = { autoUpdater, channel: decision.channel, deps };
+  disabledReason = null;
   // .unref() so a pending check can't hold the process alive during quit.
   setTimeout(check, FIRST_CHECK_DELAY_MS).unref();
   setInterval(check, CHECK_INTERVAL_MS).unref();

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -33,7 +33,7 @@ import { BrowserWindow, app, dialog, ipcMain, type IpcMainInvokeEvent } from "el
 // CJS: default-import then read the property. See trap 1 above.
 import electronUpdater from "electron-updater";
 import type { UpdateInfo } from "electron-updater";
-import { UPDATE_CHECK, UPDATE_RESTART, type UpdateCheckOutcome } from "./ipc.js";
+import { UPDATE_CHECK, type UpdateCheckOutcome } from "./ipc.js";
 import {
   CHANNEL_ENV_VAR,
   resolveUpdateChannel,
@@ -257,12 +257,21 @@ export async function checkForUpdatesNow(): Promise<UpdateCheckOutcome> {
   // sets `pending`, so returning early would leave the version declined for the
   // rest of the run and the native prompt would never come back.
   declined.clear();
-  // Something already downloaded and waiting to be applied: report that instead
-  // of asking GitHub again. Note this is checked AFTER undeclining, and that
-  // `pending` is cleared whenever an apply fails — otherwise one failed install
-  // would wedge the button on "ready to install" forever, with the restart doing
-  // nothing and a genuinely newer version never being offered.
-  if (pending) return { kind: "downloaded", version: pending.version };
+  // Something already downloaded and waiting to be applied: report that instead of
+  // asking GitHub again, and RE-RAISE the native prompt. That prompt is the only
+  // way to actually apply an update — the SPA has no restart channel, by design —
+  // and it already carries the wording that matters ("this ends running agent
+  // sessions"). Re-offering here is what `declined.clear()` above exists for: a
+  // user who chose "Later" and then asked again gets asked again.
+  if (pending) {
+    const info = pending;
+    if (host) {
+      void offerUpdate(info, host).catch((err: unknown) => {
+        log(`re-offer failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    }
+    return { kind: "downloaded", version: info.version };
+  }
   // Coalesce concurrent asks rather than firing two requests at GitHub.
   checkInFlight ??= runCheck(active);
   try {
@@ -294,36 +303,6 @@ async function runCheck(current: NonNullable<typeof active>): Promise<UpdateChec
 }
 
 /**
- * Apply an update the user asked to install from the SPA. No-op if none is waiting.
- *
- * On failure `pending` is cleared so the button recovers: it goes back to being a
- * real check instead of permanently re-offering an install that cannot happen.
- */
-export async function restartToUpdate(): Promise<void> {
-  if (!pending) {
-    log("restart requested with no downloaded update — ignoring");
-    return;
-  }
-  const version = pending.version;
-  const result = await applyUpdate(version);
-  if (!result.ok) {
-    pending = null;
-    log(`could not apply ${version}: ${result.reason ?? "unknown"}`);
-    // The SPA gets a void back, so tell the user here — this is the same dead-end
-    // the native path reports, and silence would look like a broken button.
-    const win = host?.mainWindow;
-    if (win && !win.isDestroyed()) {
-      await dialog.showMessageBox(win, {
-        type: "warning",
-        buttons: ["OK"],
-        message: `Sapiom ${version} could not be installed.`,
-        detail: result.reason ?? "The update could not be applied.",
-      });
-    }
-  }
-}
-
-/**
  * Wire up update checking. Safe to call unconditionally — it decides for itself
  * whether to do anything, and NEVER throws.
  *
@@ -350,8 +329,10 @@ export function initUpdater(deps: UpdaterDeps): void {
 /**
  * Only the harness SPA, in the main window's top frame, may drive these.
  *
- * `restartToUpdate` kills every running agent session, so "which renderer asked?"
- * is a security question, not bookkeeping. Two things could otherwise ask:
+ * A check reaches the network and reveals that this machine runs Sapiom, so "which
+ * renderer asked?" is a security question, not bookkeeping. (The destructive half —
+ * applying an update — has no channel at all; see ipc.ts.) Two things could
+ * otherwise ask:
  *  - another window — a pop-out inherits webPreferences unless we prevent it
  *    (windows.ts does now, and this is the check that still holds if that ever
  *    regresses);
@@ -395,10 +376,6 @@ function registerHandlers(): void {
     // of a stack trace to probe.
     if (!isTrustedSender(event)) return { kind: "disabled", reason: "not available here" };
     return checkForUpdatesNow();
-  });
-  ipcMain.handle(UPDATE_RESTART, async (event): Promise<void> => {
-    if (!isTrustedSender(event)) return;
-    await restartToUpdate();
   });
 }
 

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -1,0 +1,222 @@
+/**
+ * In-place app updates.
+ *
+ * The harness ships *inside* this bundle, so without this module a harness fix
+ * reaches a desktop user only if they find, download and run a new installer —
+ * which testers do not do. They sit on a broken build and re-report bugs we
+ * already fixed. electron-updater replaces the whole app, which means an update
+ * also carries Electron and node-pty (and their security fixes), not just our JS.
+ *
+ * The policy decisions — which channel, whether to check at all — live in
+ * `update-policy.ts`, which imports neither `electron` nor `electron-updater` so
+ * it can be unit-tested (see `vitest.config.ts` on why nothing here is mocked).
+ * This module is the wiring, and is covered by the packaged `--smoke` run.
+ *
+ * ## Two traps encoded below
+ *
+ * 1. `import { autoUpdater } from "electron-updater"` does not work. The package
+ *    is CommonJS and exposes `autoUpdater` as a getter, which `cjs-module-lexer`
+ *    cannot see statically, so ESM link fails outright:
+ *      SyntaxError: Named export 'autoUpdater' not found.
+ *    A default import and a property read is the supported form. The read is also
+ *    kept LAZY: the getter constructs a platform updater (and pulls in electron),
+ *    so touching it at module scope would run that work during import, before we
+ *    know whether the updater is even enabled.
+ *
+ * 2. Applying an update must close the harness server FIRST. `quitAndInstall`
+ *    can hand off to the NSIS installer before an async `before-quit` handler has
+ *    finished, which would leave live `claude` processes holding files the
+ *    installer is trying to replace. So the update path calls the caller's
+ *    `shutdown()` and awaits it, rather than relying on the quit hook.
+ */
+import { BrowserWindow, app, dialog } from "electron";
+// CJS: default-import then read the property. See trap 1 above.
+import electronUpdater from "electron-updater";
+import type { UpdateInfo } from "electron-updater";
+import {
+  CHANNEL_ENV_VAR,
+  resolveUpdateChannel,
+  shouldEnableUpdater,
+} from "./update-policy.js";
+
+/**
+ * How often to look for a new build. Four hours: the app is a long-lived desktop
+ * session, and an update that lands during the working day should be offered the
+ * same day without turning into a poll loop.
+ */
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
+
+/**
+ * Delay before the first check. The boot sequence has just finished and the user
+ * is looking at a freshly-loaded SPA; a network round-trip and a possible dialog
+ * belong after that, not during it.
+ */
+const FIRST_CHECK_DELAY_MS = 30 * 1_000;
+
+export interface UpdaterDeps {
+  mainWindow: BrowserWindow;
+  devMode: boolean;
+  smoke: boolean;
+  /**
+   * Closes the harness server, killing every live PTY. Supplied by `index.ts`,
+   * which owns app lifecycle and memoizes it so the quit hook and this module
+   * cannot close it twice.
+   */
+  shutdown: () => Promise<void>;
+}
+
+function log(message: string): void {
+  // Unconditional and on stderr: these lines are rare, and they are the only
+  // evidence available when a user reports "it never updates". Gating them behind
+  // a debug flag would mean the one time we need them, they aren't there.
+  console.error(`[updater] ${message}`);
+}
+
+/** Versions the user has already said "Later" to during this run — see below. */
+const declined = new Set<string>();
+let promptOpen = false;
+
+/**
+ * Offer the update, and apply it only if the user agrees.
+ *
+ * A native dialog rather than something injected into the page: the main window
+ * shows the harness SPA, served by the harness itself, and reaching into it would
+ * couple this app to a UI another person is actively refactoring. It also matches
+ * how the rest of onboarding already talks to the user.
+ *
+ * Declining is remembered per version FOR THIS RUN only. Re-prompting on every
+ * check would nag someone who already said no; forgetting entirely across
+ * launches would mean a deferred update is never mentioned again. Prompting once
+ * per launch is the middle that needs no extra state on disk.
+ */
+async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
+  const { version } = info;
+  if (declined.has(version) || promptOpen) return;
+  if (deps.mainWindow.isDestroyed()) return;
+
+  promptOpen = true;
+  try {
+    const { response } = await dialog.showMessageBox(deps.mainWindow, {
+      type: "info",
+      buttons: ["Restart now", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+      message: `Sapiom ${version} is ready to install.`,
+      // The session warning is the point of this dialog, not a footnote: the
+      // user may have an agent mid-task, and restarting ends it. Burying that is
+      // how a well-meaning update destroys someone's work.
+      detail:
+        "Restarting will end any running agent sessions. " +
+        "Choose Later to keep working — Sapiom stays on the current version until you restart.",
+    });
+    if (response !== 0) {
+      declined.add(version);
+      log(`user deferred ${version}`);
+      return;
+    }
+  } finally {
+    promptOpen = false;
+  }
+
+  log(`applying ${version} — closing the harness server first`);
+  // Await it: see trap 2. An orphaned pty holding the install directory is a
+  // failed update on Windows, and an orphaned `claude` on every platform.
+  await deps.shutdown();
+  // (true, true) = install without the NSIS wizard, then relaunch. Both are
+  // Windows-only knobs; macOS always relaunches and Linux ignores them. Without
+  // isForceRunAfter a "Restart now" would quit and NOT come back, which is not
+  // what the button says.
+  electronUpdater.autoUpdater.quitAndInstall(true, true);
+}
+
+/**
+ * Wire up update checking. Safe to call unconditionally — it decides for itself
+ * whether to do anything, and NEVER throws.
+ *
+ * That last part is structural, not a promise: the call site sits inside boot's
+ * own try/catch, so an escaping error here would be reported to the user as
+ * "Sapiom failed to start". Updates are a convenience; failing to arrange them
+ * must never cost someone their app.
+ */
+export function initUpdater(deps: UpdaterDeps): void {
+  try {
+    startUpdater(deps);
+  } catch (err) {
+    log(`could not initialise: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function startUpdater(deps: UpdaterDeps): void {
+  const gate = shouldEnableUpdater({
+    isPackaged: app.isPackaged,
+    devMode: deps.devMode,
+    smoke: deps.smoke,
+    env: process.env,
+  });
+  if (!gate.enabled) {
+    log(`disabled — ${gate.reason}`);
+    return;
+  }
+
+  const decision = resolveUpdateChannel(app.getVersion(), process.env);
+  if (decision.ignoredOverride) {
+    log(`ignoring ${CHANNEL_ENV_VAR}="${decision.ignoredOverride}" — expected "latest" or "beta"`);
+  }
+
+  // Reading the getter constructs a platform-specific updater and can throw
+  // outright (an unsupported packaging format, for one) — which is one of the
+  // reasons initUpdater wraps this whole function.
+  const { autoUpdater } = electronUpdater;
+
+  autoUpdater.channel = decision.channel;
+  autoUpdater.allowPrerelease = decision.allowPrerelease;
+  autoUpdater.autoDownload = true;
+  // We own the restart (the user asked to be notified, not surprised), so an
+  // ordinary quit must NOT install. Leaving this at its default would apply the
+  // update on quit — silently — which is the behaviour we deliberately declined.
+  autoUpdater.autoInstallOnAppQuit = false;
+  // Only when forced on from an unpackaged build: read dev-app-update.yml
+  // instead of the app-update.yml that only packaging writes.
+  if (gate.forced) autoUpdater.forceDevUpdateConfig = true;
+
+  autoUpdater.logger = {
+    info: (m) => log(String(m)),
+    warn: (m) => log(`warn: ${String(m)}`),
+    error: (m) => log(`error: ${String(m)}`),
+    debug: () => {},
+  };
+
+  autoUpdater.on("update-available", (info: UpdateInfo) => {
+    log(`${info.version} available on "${decision.channel}" — downloading`);
+  });
+  autoUpdater.on("update-not-available", () => {
+    log(`up to date on "${decision.channel}" (${app.getVersion()})`);
+  });
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    void offerUpdate(info, deps).catch((err: unknown) => {
+      log(`failed to apply ${info.version}: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
+  autoUpdater.on("error", (err) => {
+    // Expected in the field, and never fatal: no network, a release without
+    // metadata, an AppImage the user extracted, a .deb with no working package
+    // manager. The app keeps working on the version it has.
+    log(`check failed: ${err.message}`);
+  });
+
+  const check = (): void => {
+    autoUpdater.checkForUpdates().catch((err: unknown) => {
+      // checkForUpdates rejects AND emits "error"; swallow here so the
+      // rejection can't surface as an unhandled promise.
+      log(`check rejected: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  };
+
+  log(
+    `enabled — channel "${decision.channel}", allowPrerelease=${decision.allowPrerelease}` +
+      `${gate.forced ? ", forced (dev config)" : ""}`,
+  );
+  // .unref() so a pending check can't hold the process alive during quit.
+  setTimeout(check, FIRST_CHECK_DELAY_MS).unref();
+  setInterval(check, CHECK_INTERVAL_MS).unref();
+}

--- a/packages/harness-desktop/src/main/windows.ts
+++ b/packages/harness-desktop/src/main/windows.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, shell } from "electron";
-import { setupHtmlPath, setupPreloadPath } from "./paths.js";
+import { BrowserWindow, app, shell } from "electron";
+import { APP_VERSION_ARG } from "./ipc.js";
+import { desktopPreloadPath, setupHtmlPath, setupPreloadPath } from "./paths.js";
 
 /**
  * The setup/onboarding window shown BEFORE the harness SPA — drives the boot
@@ -37,9 +38,14 @@ export function createSetupWindow(): BrowserWindow {
 
 /**
  * The main window: loads the harness SPA from the local server at its
- * boot-token URL. No preload — it is just the harness web app. External
- * (non-localhost) links open in the system browser; in-app navigation is
- * confined to the local server.
+ * boot-token URL. External (non-localhost) links open in the system browser;
+ * in-app navigation is confined to the local server.
+ *
+ * It carries a preload — a deliberately minimal one. The SPA is the same bundle
+ * `npx @sapiom/harness` serves to a plain browser, so this window is the only
+ * place it can offer anything desktop-specific (today: "Check for updates" in the
+ * Settings popover). The SPA feature-detects `window.sapiomDesktop` and simply
+ * omits those affordances in a browser — see `harness/web/src/lib/desktop.ts`.
  */
 export function createMainWindow(loadUrl: string): BrowserWindow {
   const win = new BrowserWindow({
@@ -48,17 +54,46 @@ export function createMainWindow(loadUrl: string): BrowserWindow {
     show: false, // show on ready-to-show to avoid a white flash
     title: "Sapiom",
     webPreferences: {
+      preload: desktopPreloadPath(),
       contextIsolation: true,
       nodeIntegration: false,
+      // Same constraint as the setup window: Electron will not load an ESM
+      // preload in a sandboxed renderer. contextIsolation stays ON, so the page
+      // still gets only the frozen bridge and never `ipcRenderer` itself.
+      sandbox: false,
+      // How the preload learns the app version. `process.env` would mean relying
+      // on a renderer inheriting a variable mutated after startup; this is the
+      // documented channel. See APP_VERSION_ARG.
+      additionalArguments: [`${APP_VERSION_ARG}${app.getVersion()}`],
     },
+  });
+
+  // A silently-failing preload is the exact bug the setup window once had: the
+  // window looks fine and the bridge is just absent. Here it would mean the
+  // update button vanishing with no error anywhere, so say so.
+  win.webContents.on("preload-error", (_e, preloadPath, error) => {
+    console.error(`[main] preload failed to load: ${preloadPath}\n${error?.stack ?? error}`);
   });
 
   win.once("ready-to-show", () => win.show());
 
   // Anything that isn't our local server opens in the user's real browser
   // (OAuth continuations, docs links, agent-opened URLs).
+  //
+  // Local URLs get a window we build ourselves rather than `{ action: "allow" }`.
+  // A window opened by `allow` INHERITS the parent's webPreferences — including
+  // this window's preload — and "local" is not the same as "ours": the harness
+  // serves agent-authored files at `/canvas/:sessionId/*` from
+  // `<cwd>/.sapiom/canvas/`, on this very origin. xterm linkifies whatever the
+  // agent prints, so a URL in the terminal is one click from a window holding
+  // `window.sapiomDesktop` — i.e. an agent could call `restartToUpdate()` and kill
+  // every live session. Denying and opening explicitly is deterministic; it
+  // doesn't depend on override-merge semantics.
   win.webContents.setWindowOpenHandler(({ url }) => {
-    if (isLocalUrl(url)) return { action: "allow" };
+    if (isLocalUrl(url)) {
+      createPreviewWindow(url);
+      return { action: "deny" };
+    }
     void shell.openExternal(url);
     return { action: "deny" };
   });
@@ -70,6 +105,36 @@ export function createMainWindow(loadUrl: string): BrowserWindow {
   });
 
   void win.loadURL(loadUrl);
+  return win;
+}
+
+/**
+ * A plain window for a local page the SPA or the agent asked to pop out (a canvas
+ * preview, a dev server). Deliberately has NO preload and IS sandboxed: this is
+ * where agent-authored content ends up, and it must not reach the main process.
+ *
+ * Everything the main window needs and this one must not have is absent by
+ * construction rather than by override, which is the point — see the window-open
+ * handler above.
+ */
+export function createPreviewWindow(url: string): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    title: "Sapiom",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  // A preview window is a leaf: it gets no bridge, and it cannot spawn further
+  // windows that might. Off-origin links still go to the real browser.
+  win.webContents.setWindowOpenHandler(({ url: next }) => {
+    if (!isLocalUrl(next)) void shell.openExternal(next);
+    return { action: "deny" };
+  });
+  void win.loadURL(url);
   return win;
 }
 

--- a/packages/harness-desktop/src/preload/desktop.mts
+++ b/packages/harness-desktop/src/preload/desktop.mts
@@ -1,0 +1,39 @@
+/**
+ * Preload for the MAIN window — the one running the harness SPA.
+ *
+ * The SPA is not ours alone: the identical bundle is served to a plain browser by
+ * `npx @sapiom/harness`, where none of this exists. So this bridge is strictly
+ * additive and the SPA must feature-detect it (`harness/web/src/lib/desktop.ts`)
+ * rather than assume it. Presence of `window.sapiomDesktop` IS the answer to "am I
+ * running inside the desktop app?", which is why `appVersion` is included even
+ * though nothing needs it yet: it makes the object self-describing in a bug report.
+ *
+ * Kept deliberately tiny. This is the only channel from remote-ish page code into
+ * the main process, so every addition is attack surface — `contextIsolation` stays
+ * on and `ipcRenderer` is never handed to the page.
+ */
+import { contextBridge, ipcRenderer } from "electron";
+import {
+  APP_VERSION_ARG,
+  UPDATE_CHECK,
+  UPDATE_RESTART,
+  type UpdateCheckOutcome,
+} from "../main/ipc.js";
+
+const api = {
+  /** The desktop app's version — NOT the harness's (the SPA already knows that one). */
+  appVersion:
+    process.argv.find((arg) => arg.startsWith(APP_VERSION_ARG))?.slice(APP_VERSION_ARG.length) ?? "",
+  /** Check now, on the user's behalf. Resolves with what happened; never rejects. */
+  checkForUpdates(): Promise<UpdateCheckOutcome> {
+    return ipcRenderer.invoke(UPDATE_CHECK) as Promise<UpdateCheckOutcome>;
+  },
+  /** Apply a downloaded update: closes sessions, installs, relaunches. */
+  restartToUpdate(): Promise<void> {
+    return ipcRenderer.invoke(UPDATE_RESTART) as Promise<void>;
+  },
+};
+
+export type DesktopBridge = typeof api;
+
+contextBridge.exposeInMainWorld("sapiomDesktop", api);

--- a/packages/harness-desktop/src/preload/desktop.mts
+++ b/packages/harness-desktop/src/preload/desktop.mts
@@ -13,12 +13,7 @@
  * on and `ipcRenderer` is never handed to the page.
  */
 import { contextBridge, ipcRenderer } from "electron";
-import {
-  APP_VERSION_ARG,
-  UPDATE_CHECK,
-  UPDATE_RESTART,
-  type UpdateCheckOutcome,
-} from "../main/ipc.js";
+import { APP_VERSION_ARG, UPDATE_CHECK, type UpdateCheckOutcome } from "../main/ipc.js";
 
 const api = {
   /** The desktop app's version — NOT the harness's (the SPA already knows that one). */
@@ -28,10 +23,9 @@ const api = {
   checkForUpdates(): Promise<UpdateCheckOutcome> {
     return ipcRenderer.invoke(UPDATE_CHECK) as Promise<UpdateCheckOutcome>;
   },
-  /** Apply a downloaded update: closes sessions, installs, relaunches. */
-  restartToUpdate(): Promise<void> {
-    return ipcRenderer.invoke(UPDATE_RESTART) as Promise<void>;
-  },
+  // No restart method, on purpose — see ipc.ts. An update that is ready to install
+  // is confirmed through a native dialog, so nothing the page can call ends a
+  // user's sessions.
 };
 
 export type DesktopBridge = typeof api;

--- a/packages/harness/CLAUDE.md
+++ b/packages/harness/CLAUDE.md
@@ -48,13 +48,57 @@ dir.replace(/([\\/])app\.asar([\\/])/, "$1app.asar.unpacked$2");
 
 Any **new** code that resolves a path relative to this package (templates, fixtures, scaffolds,
 binaries) needs that translation, or the file has to be covered by
-`packages/harness-desktop/electron-builder.yml`'s `asarUnpack`.
+`packages/harness-desktop/electron-builder.yml`'s `asarUnpack`. Use the shared
+`core/asar-path.ts` helper — this was four hand-written copies of the same regex, and the fifth call
+site that needed one (`POST /api/runs/local`) simply didn't have it.
+
+**Spawning a child is three separate hazards, not one.** `core/canvas-manifest-check.ts` gets all three
+right and is the model; `server/actions.ts`'s run-local spawn got none, so every local run in the
+packaged app answered `spawn ENOTDIR` (and ENOTDIR is not in Node's deferred-error list, so `spawn`
+throws *synchronously*):
+
+1. **`cwd`** — translate it. **This is the one that actually bit.** A cwd is applied by `exec` itself,
+   so no `fs` patch can ever cover it, and `spawn` **throws synchronously** (ENOTDIR is not in Node's
+   deferred-error list) rather than reporting on the child. Measured, both children:
+   `spawn(…, {cwd: "<app.asar>/node_modules/@sapiom/harness"})` → `THREW ENOTDIR: spawn ENOTDIR`.
+2. **every path in `argv`** — translate those too, but know why. Measured: reading a file inside
+   `app.asar` **succeeds** in an `ELECTRON_RUN_AS_NODE` child (it is still the Electron binary, so the
+   `fs` patch is retained) and **fails with ENOTDIR under real `node`**. So an in-archive path is safe
+   only while the consumer happens to be Electron — it breaks the moment that argument reaches the CLI's
+   real `node`, a compiler, `git`, or any other third-party binary. Translate by default; do not rely on
+   the patch to cover for you.
+3. **`ELECTRON_RUN_AS_NODE: "1"`** — set it (guarded on `process.versions.electron`, so the CLI is
+   untouched). `process.execPath` is the Electron binary; without the flag you launch a second copy of
+   the app instead of running your script, and the parent waits forever for output that never comes.
+
+And what you *don't* pass matters: the env you hand a child is inherited wholesale by everything it
+spawns. `HOST_ESBUILD_PIN` (`core/asar-path.ts`) has to be stripped from every child environment —
+`session-manager`, `task-manager` and the run-local spec all do — or the user's own repo builds against
+our esbuild binary and dies with a version mismatch.
+
+**`asarUnpack` alone is not the fix.** It puts the file on disk; it does not change the path
+`require.resolve` reports. This is what broke deploy: `server/actions.ts` runs agent-core's
+`bundleForDeploy()` **in this process**, esbuild locates its native binary with `require.resolve` and
+`spawn`s it, and the user got `Failed to bundle the agent for deploy. (spawn ENOTDIR)` in the desktop
+app while `npx` was fine. So a **dependency** that execs a sidecar binary is subject to this rule too,
+not just our own code — and the fix has to reach inside that dependency's resolution. esbuild takes
+`ESBUILD_BINARY_PATH`, which the desktop host sets from its entry point's **first** import
+(`harness-desktop/src/main/esbuild-binary.ts`) — esbuild snapshots that variable when its module is
+evaluated, so setting it any later, including inside `startServer`'s caller, is silently ignored.
+Adding another dependency of this shape means finding its equivalent hook, or moving the work into a
+child process the way `core/canvas-manifest-check.ts` does.
 
 ### 3. `process.execPath` is Electron, not `node`
 
 Spawning "node" means spawning the Electron binary. It only behaves like Node with
 `ELECTRON_RUN_AS_NODE: "1"`, and that subprocess is **plain Node with no asar support** — so
 everything it imports must exist unpacked on disk (this is why `asarUnpack` is `**/node_modules/**`).
+
+> Measured nuance, since it changes what you may rely on: such a child *can* in fact read paths inside
+> `app.asar` (it is the Electron binary, patch included — `readFileSync` of an in-archive file returns
+> its bytes, while real `node` gets ENOTDIR). Keep unpacking and keep translating anyway: `cwd` is
+> unpatchable in every child, and any path that escapes to a non-Electron consumer breaks immediately.
+> The rule survives; the reason is narrower than "it cannot see the archive at all".
 Guard on `process.versions.electron` so the CLI path stays untouched; see
 `core/canvas-manifest-check.ts:99`.
 

--- a/packages/harness/src/core/asar-path.test.ts
+++ b/packages/harness/src/core/asar-path.test.ts
@@ -1,0 +1,40 @@
+/**
+ * One regex, four call sites, and every one of them was written from scratch —
+ * which is how `POST /api/runs/local` shipped without it and died with
+ * `spawn ENOTDIR` in the packaged app. These tests pin the shared helper the
+ * call sites now share.
+ */
+import { describe, expect, it } from "vitest";
+
+import { unpackedPath } from "./asar-path.js";
+
+describe("unpackedPath", () => {
+  it("redirects an app.asar path to its unpacked twin", () => {
+    expect(unpackedPath("/Applications/Sapiom.app/Contents/Resources/app.asar/node_modules/@sapiom/harness")).toBe(
+      "/Applications/Sapiom.app/Contents/Resources/app.asar.unpacked/node_modules/@sapiom/harness",
+    );
+  });
+
+  it("handles Windows separators", () => {
+    expect(unpackedPath("C:\\Users\\u\\AppData\\Local\\Sapiom\\resources\\app.asar\\node_modules\\x")).toBe(
+      "C:\\Users\\u\\AppData\\Local\\Sapiom\\resources\\app.asar.unpacked\\node_modules\\x",
+    );
+  });
+
+  it("is a no-op for the CLI, where there is no archive", () => {
+    const p = "/home/dev/repo/packages/harness/dist/core/run-local-bootstrap.js";
+    expect(unpackedPath(p)).toBe(p);
+  });
+
+  it("only rewrites app.asar as a whole path segment", () => {
+    // A directory that merely starts with "app.asar" is not the archive.
+    expect(unpackedPath("/opt/app.asarbackup/x")).toBe("/opt/app.asarbackup/x");
+  });
+
+  it("leaves an already-unpacked path alone (idempotent)", () => {
+    // Callers compose freely — translating twice must not produce
+    // app.asar.unpacked.unpacked.
+    const once = unpackedPath("/app/resources/app.asar/node_modules/x");
+    expect(unpackedPath(once)).toBe(once);
+  });
+});

--- a/packages/harness/src/core/asar-path.ts
+++ b/packages/harness/src/core/asar-path.ts
@@ -1,0 +1,44 @@
+/**
+ * The one asar path translation, shared.
+ *
+ * Packaged inside Electron, this package lives in `app.asar` and every path
+ * derived from `require.resolve` / `import.meta.url` names that archive.
+ * Electron patches `fs`, so reads through the virtual path work — but the
+ * syscalls it does NOT patch (a child process's `cwd`, an argv path handed to a
+ * plain-Node child, `cpSync`, `opendir`, `chmod`, `spawn` of a binary) hit
+ * `app.asar` as a path component, and it is a regular file: `ENOTDIR`.
+ *
+ * `asarUnpack` (see `harness-desktop/electron-builder.yml`) puts the real file
+ * on disk next door in `app.asar.unpacked`, but does NOT change the path the
+ * resolver reports — so the translation has to be applied explicitly, every
+ * time. This existed as four hand-written copies of the same regex, and
+ * `POST /api/runs/local` shipped without one: `spawn ENOTDIR` on every local
+ * run in the desktop app. One helper, so a fifth call site can reuse instead of
+ * remember.
+ *
+ * A no-op under the CLI (no archive in the path) and idempotent, so composing
+ * translations is safe.
+ *
+ * The one env var that exists for the same reason lives here too — see
+ * {@link HOST_ESBUILD_PIN}.
+ */
+
+/** Redirect an `app.asar` path to its unpacked twin on disk. */
+export function unpackedPath(path: string): string {
+  return path.replace(/([\\/])app\.asar([\\/])/, "$1app.asar.unpacked$2");
+}
+
+/**
+ * The env var the desktop host sets for the same reason (see
+ * `harness-desktop/src/main/esbuild-binary.ts`): esbuild cannot exec its native
+ * binary from inside `app.asar`, so the host pins it to the unpacked twin.
+ *
+ * It must never cross a process boundary. In-process callers read the pin; a
+ * child does not need it (plain Node resolves real on-disk paths itself) and
+ * inheriting it breaks any project whose own esbuild is a different version —
+ * `Cannot start service: Host version "X" does not match binary version "Y"` on
+ * a repo that builds fine outside the app. Named here, once, because the two
+ * environment-copying spawners (`session-manager`, `task-manager`) and the
+ * run-local child spec all have to strip the same key.
+ */
+export const HOST_ESBUILD_PIN = "ESBUILD_BINARY_PATH";

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -1116,6 +1116,34 @@ describe("SessionManager", () => {
     delete process.env["HARNESS_TEST_UNSET_ME"];
   });
 
+  /**
+   * The desktop host pins `ESBUILD_BINARY_PATH` at an esbuild binary outside
+   * app.asar, because it cannot exec one from inside the archive. That pin must
+   * not reach the agent: this loop copies the WHOLE parent environment into the
+   * pty, so the agent — and everything the agent spawns in the user's own repo —
+   * inherited a pin to OUR esbuild build. Any project on a different esbuild
+   * version (vite, vitest, tsup, tsx, astro…) then dies with
+   * `Cannot start service: Host version "0.25.12" does not match binary version
+   * "0.28.1"` on a project that builds fine outside the app.
+   */
+  it("never leaks the host's ESBUILD_BINARY_PATH pin into the agent's environment", async () => {
+    process.env["ESBUILD_BINARY_PATH"] = "/app/resources/app.asar.unpacked/node_modules/@esbuild/linux-x64/bin/esbuild";
+    const capturedEnvs: Record<string, string | undefined>[] = [];
+    const spawnPty: PtySpawnFn = (_file, _args, options) => {
+      capturedEnvs.push(options.env ?? {});
+      const fake = createFakePty();
+      return fake.pty as unknown as ReturnType<PtySpawnFn>;
+    };
+    const { manager } = makeManager({ spawnPty });
+    await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+    expect(capturedEnvs[0]?.["ESBUILD_BINARY_PATH"]).toBeUndefined();
+    // Everything else still comes through — this is a targeted strip, not a
+    // switch to a clean environment (the agent needs PATH, HOME, the lot).
+    expect(capturedEnvs[0]?.["PATH"]).toBe(process.env["PATH"]);
+    delete process.env["ESBUILD_BINARY_PATH"];
+  });
+
   describe("awaitable kill — liveness-fallback resolution", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -22,6 +22,7 @@ import {
   type SpawnSpec,
 } from "../shared/types.js";
 import { expandHome } from "./paths.js";
+import { HOST_ESBUILD_PIN } from "./asar-path.js";
 import { resolveSpawnTarget } from "./spawn-target.js";
 import {
   AdapterNotFoundError,
@@ -882,6 +883,7 @@ export class SessionManager {
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) env[key] = value;
     }
+    delete env[HOST_ESBUILD_PIN];
     for (const [key, value] of Object.entries(spec.env)) {
       if (value === null) delete env[key];
       else env[key] = value;

--- a/packages/harness/src/core/task-manager.test.ts
+++ b/packages/harness/src/core/task-manager.test.ts
@@ -108,6 +108,26 @@ describe("TaskManager", () => {
     expect(manager.list()).toHaveLength(1);
   });
 
+  /**
+   * The same leak SessionManager.spawn had: this manager copies the whole parent
+   * environment into the child, so the desktop host's `ESBUILD_BINARY_PATH` pin
+   * (set because it cannot exec a binary from inside app.asar) reached background
+   * agent tasks too, breaking any project on a different esbuild version.
+   */
+  it("never leaks the host's ESBUILD_BINARY_PATH pin into a background task", async () => {
+    process.env["ESBUILD_BINARY_PATH"] = "/app/resources/app.asar.unpacked/node_modules/@esbuild/linux-x64/bin/esbuild";
+    try {
+      const { manager, spawned } = makeManager();
+      await manager.run(runRequest);
+      expect(spawned).toHaveLength(1);
+      expect("ESBUILD_BINARY_PATH" in spawned[0].options.env).toBe(false);
+      // Targeted strip, not a clean environment — the agent still needs the rest.
+      expect(spawned[0].options.env.PATH).toBe(process.env["PATH"]);
+    } finally {
+      delete process.env["ESBUILD_BINARY_PATH"];
+    }
+  });
+
   it("appends parsed status lines from stdout and re-broadcasts the task on each", async () => {
     const { manager, spawned, statuses } = makeManager();
     const task = await manager.run(runRequest);

--- a/packages/harness/src/core/task-manager.ts
+++ b/packages/harness/src/core/task-manager.ts
@@ -32,6 +32,7 @@ import {
   type SpawnSpec,
 } from "../shared/types.js";
 import type { LaunchOptsBuilder } from "./session-manager.js";
+import { HOST_ESBUILD_PIN } from "./asar-path.js";
 import { resolveSpawnTarget } from "./spawn-target.js";
 import { parseTaskStreamLine } from "./task-stream.js";
 import { AdapterNotFoundError, ExternalHarnessError } from "./errors.js";
@@ -280,6 +281,7 @@ export class TaskManager {
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) env[key] = value;
     }
+    delete env[HOST_ESBUILD_PIN];
     for (const [key, value] of Object.entries(spec.env)) {
       if (value === null) delete env[key];
       else env[key] = value;

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createActionsRouter,
   resolveRunLocalBootstrapPath,
+  resolveRunLocalChildSpec,
   type ActionsRouterOpts,
   type RunLocalChildProcess,
 } from "./actions.js";
@@ -988,6 +989,79 @@ describe("createActionsRouter", () => {
         "file:///app/packages/harness/src/server/actions.ts",
       );
       expect(p).toBe("/app/packages/harness/src/core/run-local-bootstrap.ts");
+    });
+  });
+
+  // ── run-local child spec (pure) ───────────────────────────────────────────
+
+  /**
+   * `POST /api/runs/local` shipped in the desktop app answering every request
+   * with `{"kind":"error","error":"spawn ENOTDIR"}` — three separate packaging
+   * defects in one four-line spawn, none of which the CLI can see:
+   *
+   *   1. `cwd` was `…/app.asar/node_modules/@sapiom/harness`. Electron patches
+   *      `fs` but nothing translates a child process's cwd, so chdir → ENOTDIR
+   *      (and ENOTDIR is not in Node's deferred-error list, so `spawn` THROWS).
+   *   2. the bootstrap SCRIPT path was inside the archive too — and the child is
+   *      plain Node, which has no asar support and cannot read it.
+   *   3. no `ELECTRON_RUN_AS_NODE=1`, so `process.execPath` (the Sapiom binary
+   *      under Electron) would have booted A SECOND COPY OF THE APP.
+   *
+   * `canvas-manifest-check.ts` already got all three right; this call site got
+   * none. These tests pin each one independently.
+   */
+  describe("resolveRunLocalChildSpec", () => {
+    const PACKAGED = "file:///Applications/Sapiom.app/Contents/Resources/app.asar/node_modules/@sapiom/harness/dist/server/actions.js";
+    const CLI = "file:///home/u/.npm/_npx/abc/node_modules/@sapiom/harness/dist/server/actions.js";
+
+    it("points the child's cwd at the unpacked twin, never into the archive", () => {
+      const spec = resolveRunLocalChildSpec(PACKAGED, { execPath: "/Applications/Sapiom.app/Contents/MacOS/Sapiom", env: {}, isElectron: true });
+      expect(spec.cwd).toBe("/Applications/Sapiom.app/Contents/Resources/app.asar.unpacked/node_modules/@sapiom/harness");
+      expect(spec.cwd).not.toContain("app.asar/");
+    });
+
+    it("points the bootstrap script at the unpacked twin — a plain-Node child cannot read the archive", () => {
+      const spec = resolveRunLocalChildSpec(PACKAGED, { execPath: "/x/Sapiom", env: {}, isElectron: true });
+      const script = spec.args.at(-1)!;
+      expect(script).toBe("/Applications/Sapiom.app/Contents/Resources/app.asar.unpacked/node_modules/@sapiom/harness/dist/core/run-local-bootstrap.js");
+      expect(spec.args.join(" ")).not.toContain("app.asar/");
+    });
+
+    it("sets ELECTRON_RUN_AS_NODE under Electron, so execPath runs the script instead of booting the app", () => {
+      const spec = resolveRunLocalChildSpec(PACKAGED, { execPath: "/x/Sapiom", env: { PATH: "/usr/bin" }, isElectron: true });
+      expect(spec.env["ELECTRON_RUN_AS_NODE"]).toBe("1");
+      expect(spec.env["PATH"]).toBe("/usr/bin"); // inherits the rest
+    });
+
+    it("leaves the CLI path untouched — no flag, no rewriting, real node", () => {
+      const spec = resolveRunLocalChildSpec(CLI, { execPath: "/usr/bin/node", env: { PATH: "/usr/bin" }, isElectron: false });
+      expect(spec.env["ELECTRON_RUN_AS_NODE"]).toBeUndefined();
+      expect(spec.cwd).toBe("/home/u/.npm/_npx/abc/node_modules/@sapiom/harness");
+      expect(spec.args).toEqual(["/home/u/.npm/_npx/abc/node_modules/@sapiom/harness/dist/core/run-local-bootstrap.js"]);
+      expect(spec.command).toBe("/usr/bin/node");
+    });
+
+    it("keeps the tsx register hook for a .ts bootstrap (dev server)", () => {
+      const spec = resolveRunLocalChildSpec("file:///repo/packages/harness/src/server/actions.ts", {
+        execPath: "/usr/bin/node",
+        env: {},
+        isElectron: false,
+      });
+      expect(spec.args).toEqual(["--import", "tsx", "/repo/packages/harness/src/core/run-local-bootstrap.ts"]);
+    });
+
+    it("does not leak the desktop host's esbuild pin into the child", () => {
+      // The pin exists ONLY so in-process (Electron main) esbuild can exec a
+      // binary outside app.asar. No child needs it — a child is plain Node and
+      // resolves real on-disk paths itself — and a workflow step body that
+      // shells out to the project's own toolchain would hit a version mismatch.
+      // So the rule is uniform: the pin never crosses a process boundary.
+      const spec = resolveRunLocalChildSpec(PACKAGED, {
+        execPath: "/x/Sapiom",
+        env: { ESBUILD_BINARY_PATH: "/app/resources/app.asar.unpacked/node_modules/@esbuild/darwin-arm64/bin/esbuild" },
+        isElectron: true,
+      });
+      expect(spec.env["ESBUILD_BINARY_PATH"]).toBeUndefined();
     });
   });
 });

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -42,7 +42,7 @@ import {
 } from "@sapiom/agent-core";
 
 import { resolveCoreBaseUrl } from "../core/definition-slug-resolver.js";
-import { unpackedPath } from "../core/asar-path.js";
+import { HOST_ESBUILD_PIN, unpackedPath } from "../core/asar-path.js";
 import type { RunLocalRequest } from "../core/run-local-bootstrap.js";
 import {
   type ApiKeyProvider,
@@ -168,7 +168,14 @@ export function resolveRunLocalChildSpec(
   const args = bootstrap.endsWith(".ts")
     ? ["--import", "tsx", bootstrap]
     : [bootstrap];
-  const { ESBUILD_BINARY_PATH: _pin, ...inherited } = runtime.env;
+  // Via the constant, not the literal name. `HOST_ESBUILD_PIN`'s whole purpose is
+  // to be the ONE place that key is written, and its doc names this spec as one of
+  // the three strippers — but a rest-destructure needs a literal, so renaming the
+  // constant would have silently left this child inheriting the pin and hitting
+  // `Host version "X" does not match binary version "Y"`.
+  const inherited = Object.fromEntries(
+    Object.entries(runtime.env).filter(([key]) => key !== HOST_ESBUILD_PIN),
+  );
   return {
     command: runtime.execPath,
     args,

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -42,6 +42,7 @@ import {
 } from "@sapiom/agent-core";
 
 import { resolveCoreBaseUrl } from "../core/definition-slug-resolver.js";
+import { unpackedPath } from "../core/asar-path.js";
 import type { RunLocalRequest } from "../core/run-local-bootstrap.js";
 import {
   type ApiKeyProvider,
@@ -122,20 +123,73 @@ export function resolveRunLocalBootstrapPath(moduleUrl: string): string {
   return join(dirname(here), "..", "core", `run-local-bootstrap${ext}`);
 }
 
+/** Everything needed to launch the run-local child, resolved but not yet spawned
+ *  — so the packaging-sensitive path math is unit-testable. */
+export interface RunLocalChildSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
 /**
- * The default spawn: `node <bootstrap>` with `cwd` set to this package's root
- * so the bootstrap's `import "@sapiom/agent-core"` resolves against the
- * harness's real dependency (same technique as canvas-manifest-check). A `.ts`
- * bootstrap (dev only) is loaded through the `tsx` register hook; the built
- * `.js` runs on bare node. stdin is piped so the route can write the request.
+ * Resolve how to launch the run-local bootstrap child: `node <bootstrap>` with
+ * `cwd` at this package's root, so the bootstrap's `import "@sapiom/agent-core"`
+ * resolves against the harness's real dependency. A `.ts` bootstrap (dev only)
+ * goes through the `tsx` register hook; the built `.js` runs on bare node.
+ *
+ * Three things here exist ONLY for the packaged desktop app, and their absence
+ * is why every local run failed there with `spawn ENOTDIR` while the CLI was
+ * fine. `canvas-manifest-check.ts` already does all three; this call site did
+ * none of them:
+ *
+ *  1. **cwd must be the unpacked twin.** `import.meta.url` reports a path inside
+ *     `app.asar`; nothing translates a child's cwd, so `chdir` fails. ENOTDIR is
+ *     not in Node's deferred-error list, so `spawn` throws SYNCHRONOUSLY and the
+ *     route answers `{"kind":"error","error":"spawn ENOTDIR"}`.
+ *  2. **the script path must be the unpacked twin too.** The child is plain Node
+ *     with no asar support whatsoever — it cannot read a file inside the archive,
+ *     however well Electron's own `fs` copes.
+ *  3. **`ELECTRON_RUN_AS_NODE=1` under Electron.** `process.execPath` is the
+ *     Sapiom binary there; without the flag it boots a SECOND COPY OF THE APP
+ *     instead of running the script. Only set when actually inside Electron, so
+ *     the CLI (real node) is untouched.
+ *
+ * `ESBUILD_BINARY_PATH` is dropped: the desktop host pins it so its in-process
+ * bundler can exec a binary outside app.asar, but no child needs it (a child
+ * resolves real on-disk paths itself) and a workflow step body that shells out
+ * to the project's own toolchain would hit an esbuild version mismatch.
  */
-function defaultRunLocalSpawn(): RunLocalChildProcess {
-  const bootstrap = resolveRunLocalBootstrapPath(import.meta.url);
-  const nodeArgs = bootstrap.endsWith(".ts")
+export function resolveRunLocalChildSpec(
+  moduleUrl: string,
+  runtime: { execPath: string; env: NodeJS.ProcessEnv; isElectron: boolean },
+): RunLocalChildSpec {
+  const bootstrap = unpackedPath(resolveRunLocalBootstrapPath(moduleUrl));
+  const args = bootstrap.endsWith(".ts")
     ? ["--import", "tsx", bootstrap]
     : [bootstrap];
-  return spawnChildProcess(process.execPath, nodeArgs, {
-    cwd: join(dirname(fileURLToPath(import.meta.url)), "..", ".."),
+  const { ESBUILD_BINARY_PATH: _pin, ...inherited } = runtime.env;
+  return {
+    command: runtime.execPath,
+    args,
+    cwd: unpackedPath(join(dirname(fileURLToPath(moduleUrl)), "..", "..")),
+    env: {
+      ...inherited,
+      ...(runtime.isElectron ? { ELECTRON_RUN_AS_NODE: "1" } : {}),
+    },
+  };
+}
+
+/** The default spawn. stdin is piped so the route can write the request. */
+function defaultRunLocalSpawn(): RunLocalChildProcess {
+  const spec = resolveRunLocalChildSpec(import.meta.url, {
+    execPath: process.execPath,
+    env: process.env,
+    isElectron: Boolean(process.versions.electron),
+  });
+  return spawnChildProcess(spec.command, spec.args, {
+    cwd: spec.cwd,
+    env: spec.env,
     stdio: ["pipe", "pipe", "pipe"],
   });
 }

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -6,6 +6,11 @@ import { HARNESS_PATHS } from "@shared/types";
 import type { AuthStartResponse } from "../lib/api";
 import { Icon } from "./Icon";
 import { track } from "../lib/track";
+import {
+  describeUpdateOutcome,
+  getDesktopBridge,
+  type UpdateStatusView,
+} from "../lib/desktop";
 
 /** Sign-in progress state in the Settings popover. */
 type AuthProgress =
@@ -45,6 +50,13 @@ export function SettingsPopover({
 }: SettingsPopoverProps): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [authProgress, setAuthProgress] = useState<AuthProgress>({ status: "idle" });
+  // Null in a browser (`npx @sapiom/harness`), where there is nothing to update —
+  // the whole update section is then absent rather than disabled. Read once per
+  // render; the preload either injected it before first paint or never will.
+  const desktop = getDesktopBridge();
+  const [updateChecking, setUpdateChecking] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatusView | null>(null);
+  const [restarting, setRestarting] = useState(false);
   // An env override outranks any stored preference; flipping the toggle here
   // would silently lose to it on the next boot, so the control locks instead.
   const envForced = consentSource === "env-forced-off";
@@ -93,6 +105,46 @@ export function SettingsPopover({
       await onDisconnect();
     } finally {
       setBusy(false);
+    }
+  };
+
+  const handleCheckForUpdates = async (): Promise<void> => {
+    if (!desktop) return;
+    setUpdateChecking(true);
+    // Clear the previous result first: leaving "Up to date" on screen while a new
+    // check runs makes the button look like it did nothing.
+    setUpdateStatus(null);
+    try {
+      setUpdateStatus(describeUpdateOutcome(await desktop.checkForUpdates()));
+    } catch (err) {
+      // The bridge is documented as never rejecting, but it crosses a process
+      // boundary — if that contract ever breaks, the user gets a message rather
+      // than a spinner that never stops.
+      setUpdateStatus({
+        text: err instanceof Error ? err.message : "The update check failed.",
+        tone: "error",
+      });
+    } finally {
+      setUpdateChecking(false);
+    }
+  };
+
+  const handleRestartToUpdate = async (): Promise<void> => {
+    if (!desktop || restarting) return;
+    // Latched, and never released on success: the app is about to be replaced, so
+    // the button must not come back and invite a second install. A double-click
+    // would otherwise call quitAndInstall twice.
+    setRestarting(true);
+    try {
+      await desktop.restartToUpdate();
+    } catch (err) {
+      // Reaching here means the install did not happen — the app would be gone
+      // otherwise. Re-arm the button and say so.
+      setRestarting(false);
+      setUpdateStatus({
+        text: err instanceof Error ? err.message : "The update could not be installed.",
+        tone: "error",
+      });
     }
   };
 
@@ -155,6 +207,56 @@ export function SettingsPopover({
             <Icon name="LogOut" size={13} />
             {busy ? "Signing out…" : "Disconnect"}
           </button>
+        </div>
+      )}
+
+      {/* Desktop app only. In a browser there is no bundle to replace, so the
+          whole section is absent rather than present-and-disabled — a control that
+          can never work is worse than no control. */}
+      {desktop && (
+        <div className="settings-auth-row" data-testid="settings-update-row">
+          <button
+            type="button"
+            className="settings-update-btn"
+            data-testid="settings-update-btn"
+            disabled={updateChecking}
+            onClick={() => void handleCheckForUpdates()}
+          >
+            <Icon name={updateChecking ? "Loader" : "RefreshCw"} size={13} />
+            {updateChecking ? "Checking…" : "Check for updates"}
+          </button>
+          {updateStatus && (
+            <p
+              className="settings-note settings-update-status"
+              data-testid="settings-update-status"
+              // Announced, because the outcome is the entire point of pressing
+              // the button and it appears without any focus change.
+              role="status"
+            >
+              {updateStatus.text}
+            </p>
+          )}
+          {updateStatus?.tone === "action" && (
+            <button
+              type="button"
+              className="settings-update-restart-btn"
+              data-testid="settings-update-restart-btn"
+              disabled={restarting}
+              onClick={() => void handleRestartToUpdate()}
+              // Same warning the native prompt gives. The user may have an agent
+              // mid-task, and this button ends it — so it says so before the click,
+              // not after.
+              title="Ends any running agent sessions"
+            >
+              <Icon name={restarting ? "Loader" : "RefreshCw"} size={13} />
+              {restarting ? "Installing…" : "Restart now — ends running sessions"}
+            </button>
+          )}
+          {desktop.appVersion && (
+            <p className="settings-note settings-update-version" data-testid="settings-app-version">
+              Sapiom {desktop.appVersion}
+            </p>
+          )}
         </div>
       )}
 

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -6,11 +6,6 @@ import { HARNESS_PATHS } from "@shared/types";
 import type { AuthStartResponse } from "../lib/api";
 import { Icon } from "./Icon";
 import { track } from "../lib/track";
-import {
-  describeUpdateOutcome,
-  getDesktopBridge,
-  type UpdateStatusView,
-} from "../lib/desktop";
 
 /** Sign-in progress state in the Settings popover. */
 type AuthProgress =
@@ -50,13 +45,6 @@ export function SettingsPopover({
 }: SettingsPopoverProps): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [authProgress, setAuthProgress] = useState<AuthProgress>({ status: "idle" });
-  // Null in a browser (`npx @sapiom/harness`), where there is nothing to update —
-  // the whole update section is then absent rather than disabled. Read once per
-  // render; the preload either injected it before first paint or never will.
-  const desktop = getDesktopBridge();
-  const [updateChecking, setUpdateChecking] = useState(false);
-  const [updateStatus, setUpdateStatus] = useState<UpdateStatusView | null>(null);
-  const [restarting, setRestarting] = useState(false);
   // An env override outranks any stored preference; flipping the toggle here
   // would silently lose to it on the next boot, so the control locks instead.
   const envForced = consentSource === "env-forced-off";
@@ -105,46 +93,6 @@ export function SettingsPopover({
       await onDisconnect();
     } finally {
       setBusy(false);
-    }
-  };
-
-  const handleCheckForUpdates = async (): Promise<void> => {
-    if (!desktop) return;
-    setUpdateChecking(true);
-    // Clear the previous result first: leaving "Up to date" on screen while a new
-    // check runs makes the button look like it did nothing.
-    setUpdateStatus(null);
-    try {
-      setUpdateStatus(describeUpdateOutcome(await desktop.checkForUpdates()));
-    } catch (err) {
-      // The bridge is documented as never rejecting, but it crosses a process
-      // boundary — if that contract ever breaks, the user gets a message rather
-      // than a spinner that never stops.
-      setUpdateStatus({
-        text: err instanceof Error ? err.message : "The update check failed.",
-        tone: "error",
-      });
-    } finally {
-      setUpdateChecking(false);
-    }
-  };
-
-  const handleRestartToUpdate = async (): Promise<void> => {
-    if (!desktop || restarting) return;
-    // Latched, and never released on success: the app is about to be replaced, so
-    // the button must not come back and invite a second install. A double-click
-    // would otherwise call quitAndInstall twice.
-    setRestarting(true);
-    try {
-      await desktop.restartToUpdate();
-    } catch (err) {
-      // Reaching here means the install did not happen — the app would be gone
-      // otherwise. Re-arm the button and say so.
-      setRestarting(false);
-      setUpdateStatus({
-        text: err instanceof Error ? err.message : "The update could not be installed.",
-        tone: "error",
-      });
     }
   };
 
@@ -207,56 +155,6 @@ export function SettingsPopover({
             <Icon name="LogOut" size={13} />
             {busy ? "Signing out…" : "Disconnect"}
           </button>
-        </div>
-      )}
-
-      {/* Desktop app only. In a browser there is no bundle to replace, so the
-          whole section is absent rather than present-and-disabled — a control that
-          can never work is worse than no control. */}
-      {desktop && (
-        <div className="settings-auth-row" data-testid="settings-update-row">
-          <button
-            type="button"
-            className="settings-update-btn"
-            data-testid="settings-update-btn"
-            disabled={updateChecking}
-            onClick={() => void handleCheckForUpdates()}
-          >
-            <Icon name={updateChecking ? "Loader" : "RefreshCw"} size={13} />
-            {updateChecking ? "Checking…" : "Check for updates"}
-          </button>
-          {updateStatus && (
-            <p
-              className="settings-note settings-update-status"
-              data-testid="settings-update-status"
-              // Announced, because the outcome is the entire point of pressing
-              // the button and it appears without any focus change.
-              role="status"
-            >
-              {updateStatus.text}
-            </p>
-          )}
-          {updateStatus?.tone === "action" && (
-            <button
-              type="button"
-              className="settings-update-restart-btn"
-              data-testid="settings-update-restart-btn"
-              disabled={restarting}
-              onClick={() => void handleRestartToUpdate()}
-              // Same warning the native prompt gives. The user may have an agent
-              // mid-task, and this button ends it — so it says so before the click,
-              // not after.
-              title="Ends any running agent sessions"
-            >
-              <Icon name={restarting ? "Loader" : "RefreshCw"} size={13} />
-              {restarting ? "Installing…" : "Restart now — ends running sessions"}
-            </button>
-          )}
-          {desktop.appVersion && (
-            <p className="settings-note settings-update-version" data-testid="settings-app-version">
-              Sapiom {desktop.appVersion}
-            </p>
-          )}
         </div>
       )}
 

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -19,6 +19,7 @@ import { Icon } from "./Icon";
 import { AddWorkspaceDialog } from "./AddWorkspaceDialog";
 import { NewSessionModal } from "./NewSessionModal";
 import { SettingsPopover } from "./SettingsPopover";
+import { describeUpdateOutcome, getDesktopBridge } from "../lib/desktop";
 import { WorkflowRow } from "./WorkflowRow";
 import { isMockMode } from "../lib/api";
 import { HARNESS_LABELS, historyDirs, historyRowMeta, sessionRowState } from "../lib/history-meta";
@@ -661,6 +662,7 @@ export function WorkflowsRail({
 
       <div className="rail-footer">
         <ProfileRow
+          onToast={onToast}
           authenticated={authenticated}
           organizationName={organizationName}
           telemetryOptIn={telemetryOptIn}
@@ -745,6 +747,7 @@ function ProfileRow({
   onSetSettingsOpen,
   overviewSelected,
   onSelectOverview,
+  onToast,
 }: {
   authenticated: boolean;
   organizationName: string | null;
@@ -760,6 +763,7 @@ function ProfileRow({
   onSetSettingsOpen: (open: boolean) => void;
   overviewSelected: boolean;
   onSelectOverview: () => void;
+  onToast: (message: string) => void;
 }): JSX.Element {
   const [menuOpen, setMenuOpen] = useState(false);
   const [authProgress, setAuthProgress] = useState<ProfileAuthProgress>({ status: "idle" });
@@ -769,6 +773,28 @@ function ProfileRow({
 
   const demo = isMockMode();
   const isPending = authProgress.status === "pending";
+  // Null in a browser (`npx @sapiom/harness`), where there is nothing to update —
+  // the item is then absent rather than present-and-dead.
+  const desktop = getDesktopBridge();
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+
+  const handleCheckForUpdates = async (): Promise<void> => {
+    if (!desktop || checkingUpdate) return;
+    setCheckingUpdate(true);
+    closeMenu();
+    try {
+      // A toast, because the menu closes on click and the outcome is the entire
+      // point of pressing this. When an update is already downloaded the main
+      // process ALSO re-raises its native "Restart now / Later" prompt — that
+      // dialog is the only way to apply one, deliberately (see the desktop app's
+      // ipc.ts: page code has no restart channel).
+      onToast(describeUpdateOutcome(await desktop.checkForUpdates()).text);
+    } catch {
+      onToast("Couldn't check for updates.");
+    } finally {
+      setCheckingUpdate(false);
+    }
+  };
 
   // When auth.changed arrives and authenticated flips to true, clear pending.
   if (authenticated && authProgress.status === "pending") {
@@ -895,6 +921,18 @@ function ProfileRow({
           <Icon name="Settings" size={13} />
           Settings
         </button>
+        {desktop && (
+          <button
+            role="menuitem"
+            className="profile-menu-item"
+            data-testid="profile-check-updates"
+            disabled={checkingUpdate}
+            onClick={() => void handleCheckForUpdates()}
+          >
+            <Icon name={checkingUpdate ? "Loader" : "RefreshCw"} size={13} />
+            {checkingUpdate ? "Checking…" : "Check for updates"}
+          </button>
+        )}
         {!demo && !authenticated && (
           <button
             role="menuitem"

--- a/packages/harness/web/src/lib/desktop.test.ts
+++ b/packages/harness/web/src/lib/desktop.test.ts
@@ -29,20 +29,20 @@ describe("getDesktopBridge", () => {
 
   it("returns the bridge when the desktop preload injected a complete one", () => {
     const bridge = getDesktopBridge({
-      sapiomDesktop: { appVersion: "0.1.2", checkForUpdates: noop, restartToUpdate: noop },
+      sapiomDesktop: { appVersion: "0.1.2", checkForUpdates: noop },
     });
     expect(bridge).not.toBeNull();
     expect(bridge?.appVersion).toBe("0.1.2");
   });
 
-  it("rejects a bridge missing a method — an older desktop build must read as a browser", () => {
-    const host = { sapiomDesktop: { appVersion: "0.1.0", checkForUpdates: noop } };
+  it("rejects a bridge missing its method — an older desktop build must read as a browser", () => {
+    const host = { sapiomDesktop: { appVersion: "0.1.0" } };
     expect(getDesktopBridge(host)).toBeNull();
   });
 
   it("tolerates a missing appVersion rather than refusing the bridge", () => {
     // Cosmetic field; losing it must not cost the user the button.
-    const host = { sapiomDesktop: { checkForUpdates: noop, restartToUpdate: noop } };
+    const host = { sapiomDesktop: { checkForUpdates: noop } };
     expect(getDesktopBridge(host)?.appVersion).toBe("");
   });
 
@@ -84,8 +84,9 @@ describe("describeUpdateOutcome", () => {
   });
 
   it("offers a restart for exactly one outcome", () => {
-    // The Settings row keys its restart button off `tone === "action"`, so an
-    // extra one here would offer a restart with nothing downloaded.
+    // Exactly one outcome means "you must restart" — the desktop app raises that
+    // prompt itself, so a second actionable state here would be a claim nothing
+    // acts on.
     const outcomes: Parameters<typeof describeUpdateOutcome>[0][] = [
       { kind: "available", version: "1.0.0" },
       { kind: "downloaded", version: "1.0.0" },

--- a/packages/harness/web/src/lib/desktop.test.ts
+++ b/packages/harness/web/src/lib/desktop.test.ts
@@ -75,6 +75,14 @@ describe("describeUpdateOutcome", () => {
     expect(view.tone).toBe("info");
   });
 
+  it("reports an empty channel as a state, not a failure", () => {
+    // This is the normal answer before the first final release ships, and calling
+    // it an error teaches users to distrust the feature.
+    const view = describeUpdateOutcome({ kind: "no-release", channel: "latest" });
+    expect(view.tone).toBe("info");
+    expect(view.text).toContain("latest");
+  });
+
   it("surfaces why updates are off, and the failure reason", () => {
     expect(describeUpdateOutcome({ kind: "disabled", reason: "not a packaged build" })).toEqual({
       text: "Updates are off: not a packaged build.",
@@ -91,6 +99,7 @@ describe("describeUpdateOutcome", () => {
       { kind: "available", version: "1.0.0" },
       { kind: "downloaded", version: "1.0.0" },
       { kind: "up-to-date", version: "1.0.0", channel: "latest" },
+      { kind: "no-release", channel: "latest" },
       { kind: "disabled", reason: "x" },
       { kind: "failed", message: "x" },
     ];
@@ -103,6 +112,7 @@ describe("describeUpdateOutcome", () => {
       { kind: "available" as const, version: "1.0.0" },
       { kind: "downloaded" as const, version: "1.0.0" },
       { kind: "up-to-date" as const, version: "1.0.0", channel: "latest" },
+      { kind: "no-release" as const, channel: "latest" },
       { kind: "disabled" as const, reason: "x" },
       { kind: "failed" as const, message: "x" },
     ]) {

--- a/packages/harness/web/src/lib/desktop.test.ts
+++ b/packages/harness/web/src/lib/desktop.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Two properties matter here, and both are about NOT breaking the browser build.
+ *
+ * `getDesktopBridge` is the only thing standing between a browser user and a
+ * button that cannot work. It validates the shape rather than trusting a flag,
+ * because a desktop build older than the SPA can expose a bridge missing a newer
+ * method — and reading that inside a click handler is a dead button with a console
+ * error nobody sees. Anything unrecognised must read as "browser".
+ *
+ * `describeUpdateOutcome` must give every outcome its own next step. Collapsing
+ * them into one cheerful message would make the button as uninformative as no
+ * message at all — especially "downloaded", where the user has to restart and
+ * nothing else will tell them.
+ */
+import { describe, expect, it } from "vitest";
+
+import { describeUpdateOutcome, getDesktopBridge } from "./desktop";
+
+const noop = (): Promise<never> => Promise.reject(new Error("not called"));
+
+describe("getDesktopBridge", () => {
+  it("returns null when there is no host at all (the unit runner, or SSR)", () => {
+    expect(getDesktopBridge(undefined)).toBeNull();
+  });
+
+  it("returns null in a browser — nothing was injected", () => {
+    expect(getDesktopBridge({})).toBeNull();
+  });
+
+  it("returns the bridge when the desktop preload injected a complete one", () => {
+    const bridge = getDesktopBridge({
+      sapiomDesktop: { appVersion: "0.1.2", checkForUpdates: noop, restartToUpdate: noop },
+    });
+    expect(bridge).not.toBeNull();
+    expect(bridge?.appVersion).toBe("0.1.2");
+  });
+
+  it("rejects a bridge missing a method — an older desktop build must read as a browser", () => {
+    const host = { sapiomDesktop: { appVersion: "0.1.0", checkForUpdates: noop } };
+    expect(getDesktopBridge(host)).toBeNull();
+  });
+
+  it("tolerates a missing appVersion rather than refusing the bridge", () => {
+    // Cosmetic field; losing it must not cost the user the button.
+    const host = { sapiomDesktop: { checkForUpdates: noop, restartToUpdate: noop } };
+    expect(getDesktopBridge(host)?.appVersion).toBe("");
+  });
+
+  it("ignores junk", () => {
+    for (const junk of [null, 0, "yes", true, {}, []]) {
+      expect(getDesktopBridge({ sapiomDesktop: junk })).toBeNull();
+    }
+  });
+});
+
+describe("describeUpdateOutcome", () => {
+  it("distinguishes downloading from ready-to-install", () => {
+    // The distinction IS the information: one means wait, the other means restart.
+    expect(describeUpdateOutcome({ kind: "available", version: "0.2.0" })).toEqual({
+      text: "Downloading 0.2.0…",
+      tone: "info",
+    });
+    expect(describeUpdateOutcome({ kind: "downloaded", version: "0.2.0" })).toEqual({
+      text: "0.2.0 is ready to install.",
+      tone: "action",
+    });
+  });
+
+  it("names the version AND channel when up to date", () => {
+    // "Up to date" is only trustworthy if it says up to date with WHAT — a beta
+    // install and a stable one are up to date at different versions.
+    const view = describeUpdateOutcome({ kind: "up-to-date", version: "0.1.2", channel: "beta" });
+    expect(view.text).toContain("0.1.2");
+    expect(view.text).toContain("beta");
+    expect(view.tone).toBe("info");
+  });
+
+  it("surfaces why updates are off, and the failure reason", () => {
+    expect(describeUpdateOutcome({ kind: "disabled", reason: "not a packaged build" })).toEqual({
+      text: "Updates are off: not a packaged build.",
+      tone: "error",
+    });
+    expect(describeUpdateOutcome({ kind: "failed", message: "network down" }).tone).toBe("error");
+  });
+
+  it("offers a restart for exactly one outcome", () => {
+    // The Settings row keys its restart button off `tone === "action"`, so an
+    // extra one here would offer a restart with nothing downloaded.
+    const outcomes: Parameters<typeof describeUpdateOutcome>[0][] = [
+      { kind: "available", version: "1.0.0" },
+      { kind: "downloaded", version: "1.0.0" },
+      { kind: "up-to-date", version: "1.0.0", channel: "latest" },
+      { kind: "disabled", reason: "x" },
+      { kind: "failed", message: "x" },
+    ];
+    const actionable = outcomes.filter((o) => describeUpdateOutcome(o).tone === "action");
+    expect(actionable).toEqual([{ kind: "downloaded", version: "1.0.0" }]);
+  });
+
+  it("always produces non-empty text", () => {
+    for (const o of [
+      { kind: "available" as const, version: "1.0.0" },
+      { kind: "downloaded" as const, version: "1.0.0" },
+      { kind: "up-to-date" as const, version: "1.0.0", channel: "latest" },
+      { kind: "disabled" as const, reason: "x" },
+      { kind: "failed" as const, message: "x" },
+    ]) {
+      expect(describeUpdateOutcome(o).text.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/harness/web/src/lib/desktop.ts
+++ b/packages/harness/web/src/lib/desktop.ts
@@ -1,0 +1,103 @@
+/**
+ * Desktop-app integration, from the SPA's side.
+ *
+ * This same bundle is served two ways: by `npx @sapiom/harness` into a plain
+ * browser, and by the Electron app (`@sapiom/harness-desktop`) into its main
+ * window. The desktop build injects a preload that exposes `window.sapiomDesktop`;
+ * a browser has nothing. So **presence of the bridge is how we know where we are**,
+ * and every desktop-only affordance must be feature-detected through here rather
+ * than assumed — a browser user must never see a button that cannot work.
+ *
+ * The bridge type is DECLARED here rather than imported, on purpose: the
+ * dependency runs the other way (the desktop app depends on this package, never
+ * the reverse), so importing its types would be a cycle. That makes this a mirror
+ * of `harness-desktop/src/main/ipc.ts`, which is the source of truth — if you
+ * change the contract there, change it here. The runtime guard below is what keeps
+ * a mismatch from becoming a crash: an older desktop build simply reads as
+ * "no bridge".
+ */
+
+/** Result of an on-demand update check. Mirrors the desktop app's `UpdateCheckOutcome`. */
+export type UpdateCheckOutcome =
+  | { kind: "available"; version: string }
+  | { kind: "downloaded"; version: string }
+  | { kind: "up-to-date"; version: string; channel: string }
+  | { kind: "disabled"; reason: string }
+  | { kind: "failed"; message: string };
+
+export interface DesktopBridge {
+  /** The desktop app's own version (may be empty on older builds). */
+  appVersion: string;
+  checkForUpdates: () => Promise<UpdateCheckOutcome>;
+  restartToUpdate: () => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    sapiomDesktop?: unknown;
+  }
+}
+
+/** Where the bridge is looked for. Injectable so this is testable in the
+ *  Node-environment unit runner, which has no `window` at all. */
+export interface DesktopHost {
+  sapiomDesktop?: unknown;
+}
+
+/** The real host, or undefined outside a browser. */
+function defaultHost(): DesktopHost | undefined {
+  return typeof window === "undefined" ? undefined : window;
+}
+
+/**
+ * The desktop bridge, or null when running in a browser.
+ *
+ * Validates the shape instead of trusting the flag. A desktop build older than a
+ * given SPA build can expose a bridge without a newer method, and reading it would
+ * throw inside a click handler — the kind of failure that surfaces as a dead
+ * button. Anything unrecognised degrades to "browser", which is always safe.
+ */
+export function getDesktopBridge(host: DesktopHost | undefined = defaultHost()): DesktopBridge | null {
+  const candidate = host?.sapiomDesktop;
+  if (!candidate || typeof candidate !== "object") return null;
+  const bridge = candidate as Partial<DesktopBridge>;
+  if (typeof bridge.checkForUpdates !== "function") return null;
+  if (typeof bridge.restartToUpdate !== "function") return null;
+  return {
+    appVersion: typeof bridge.appVersion === "string" ? bridge.appVersion : "",
+    checkForUpdates: bridge.checkForUpdates,
+    restartToUpdate: bridge.restartToUpdate,
+  };
+}
+
+/** How the Settings popover should render a check result. */
+export interface UpdateStatusView {
+  text: string;
+  /** `action` means "offer the restart button" — the only outcome with a next step. */
+  tone: "info" | "action" | "error";
+}
+
+/**
+ * Turn an outcome into something worth reading.
+ *
+ * The wording lives on this side because only the UI knows its own context, and
+ * because each state has a genuinely different next step: wait, restart, nothing,
+ * or fix something. A single "checked!" message for all of them would be the same
+ * as no message.
+ */
+export function describeUpdateOutcome(outcome: UpdateCheckOutcome): UpdateStatusView {
+  switch (outcome.kind) {
+    case "available":
+      return { text: `Downloading ${outcome.version}…`, tone: "info" };
+    case "downloaded":
+      // Deliberately distinct from "available": it's on disk already, so the only
+      // thing standing between the user and the new version is the restart.
+      return { text: `${outcome.version} is ready to install.`, tone: "action" };
+    case "up-to-date":
+      return { text: `Up to date (${outcome.version}, ${outcome.channel}).`, tone: "info" };
+    case "disabled":
+      return { text: `Updates are off: ${outcome.reason}.`, tone: "error" };
+    case "failed":
+      return { text: `Couldn't check: ${outcome.message}`, tone: "error" };
+  }
+}

--- a/packages/harness/web/src/lib/desktop.ts
+++ b/packages/harness/web/src/lib/desktop.ts
@@ -29,7 +29,9 @@ export interface DesktopBridge {
   /** The desktop app's own version (may be empty on older builds). */
   appVersion: string;
   checkForUpdates: () => Promise<UpdateCheckOutcome>;
-  restartToUpdate: () => Promise<void>;
+  // No restart method: applying an update is confirmed by a native dialog in the
+  // desktop app, so page code — which shares an origin with agent-authored files
+  // the harness serves — has no way to end a user's sessions.
 }
 
 declare global {
@@ -62,18 +64,16 @@ export function getDesktopBridge(host: DesktopHost | undefined = defaultHost()):
   if (!candidate || typeof candidate !== "object") return null;
   const bridge = candidate as Partial<DesktopBridge>;
   if (typeof bridge.checkForUpdates !== "function") return null;
-  if (typeof bridge.restartToUpdate !== "function") return null;
   return {
     appVersion: typeof bridge.appVersion === "string" ? bridge.appVersion : "",
     checkForUpdates: bridge.checkForUpdates,
-    restartToUpdate: bridge.restartToUpdate,
   };
 }
 
 /** How the Settings popover should render a check result. */
 export interface UpdateStatusView {
   text: string;
-  /** `action` means "offer the restart button" — the only outcome with a next step. */
+  /** `action` means the user must restart — the desktop app raises that prompt itself. */
   tone: "info" | "action" | "error";
 }
 

--- a/packages/harness/web/src/lib/desktop.ts
+++ b/packages/harness/web/src/lib/desktop.ts
@@ -22,6 +22,7 @@ export type UpdateCheckOutcome =
   | { kind: "available"; version: string }
   | { kind: "downloaded"; version: string }
   | { kind: "up-to-date"; version: string; channel: string }
+  | { kind: "no-release"; channel: string }
   | { kind: "disabled"; reason: string }
   | { kind: "failed"; message: string };
 
@@ -95,6 +96,11 @@ export function describeUpdateOutcome(outcome: UpdateCheckOutcome): UpdateStatus
       return { text: `${outcome.version} is ready to install.`, tone: "action" };
     case "up-to-date":
       return { text: `Up to date (${outcome.version}, ${outcome.channel}).`, tone: "info" };
+    case "no-release":
+      // Not an error, and must not read like one: a stable install correctly
+      // ignores pre-releases, so before the first final release this is simply the
+      // truth.
+      return { text: `No ${outcome.channel} release published yet.`, tone: "info" };
     case "disabled":
       return { text: `Updates are off: ${outcome.reason}.`, tone: "error" };
     case "failed":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,6 +453,9 @@ importers:
       '@sapiom/harness':
         specifier: workspace:^
         version: link:../harness
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1102,7 +1105,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -2595,6 +2598,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -2988,6 +2995,9 @@ packages:
 
   electron-to-chromium@1.5.374:
     resolution: {integrity: sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==}
+
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron@33.4.11:
     resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
@@ -3999,11 +4009,18 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -5106,6 +5123,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -7672,6 +7692,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.7.0:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -8090,6 +8117,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.374: {}
+
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.2.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron@33.4.11:
     dependencies:
@@ -9428,9 +9468,13 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
 
   lodash.groupby@4.6.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -10424,6 +10468,8 @@ snapshots:
       minimatch: 3.1.5
 
   text-table@0.2.0: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
Three commits on top of the packaging work already on this branch. The headline is that a desktop user can now **ask** for an update instead of waiting on a 4-hour timer — and that the update path can no longer cost them their work.

## What's here

**`feat(desktop)` — check for updates from the Settings popover, next to Disconnect.**
Same place on every platform. A menu bar was the obvious alternative and is wrong here: macOS would be fine, but the main content is a terminal, and an Alt-revealed menu bar on Windows/Linux would eat `Alt+B`/`Alt+F`.

An on-demand check is not the scheduled one with a button on top:
- it **reports an outcome** — a silent background check is fine, a button that appears to do nothing is broken;
- it **clears the per-run "Later" set**, because asking is undeclining (and that must happen *before* the pending shortcut, or it never happens in the one case that matters);
- it answers **"ready to install"** for an update already on disk, rather than the true-but-useless "up to date".

The main window now carries a preload, which it did not before. The SPA is not ours alone — `npx @sapiom/harness` serves the identical bundle to a plain browser — so `window.sapiomDesktop` is feature-detected and the row is **absent** in a browser rather than present-and-dead.

**`fix(harness)` — strip the esbuild pin via `HOST_ESBUILD_PIN`.** The constant exists to be the single place that key is written, and its doc names this spec as a stripper, but the code destructured the literal. No behaviour change; it makes the claim true.

**`ci(desktop)` — refuse to publish a release that cannot update anyone.** Windows `continue-on-error` plus `fail_on_unmatched_files: false` let a final release publish with **no `latest.yml`**, which would 404 every check for everyone already installed, forever. Now gated on all three channel manifests.

## Two defects found in review, both fixed here

**A real vulnerability I introduced.** A window opened with `{ action: "allow" }` **inherits the parent's `webPreferences`, preload included** — and "local" is not "ours": the harness serves agent-authored files at `/canvas/:sessionId/*` on the same origin, and xterm linkifies whatever the agent prints. An agent-printed URL was one click from a window holding `restartToUpdate()`, i.e. an agent could kill every live session. Local pop-outs now go through `createPreviewWindow` (no preload, sandboxed), and both IPC handlers validate the sender — main window's `webContents` *and* a top frame at `/`, since the main window could itself navigate to same-origin agent content.

**The apply order could destroy work for nothing.** `applyUpdate` closed the server (killing every agent session) and *then* called `quitAndInstall`, which is **not guaranteed to quit**: Squirrel.Mac refuses an update it can't verify and the mac build is unsigned without `CSC_LINK`; an extracted AppImage can't self-update; nor can a `.deb` with no package manager — all three already listed in that file's own error handler. The user lost their sessions *and* stayed on the old version, looking at a dead SPA. Now `isUpdaterActive()` is checked before anything is taken away, a failure explains itself with sessions intact, and a handoff that doesn't happen within 15s relaunches rather than leaving a hollow app. `pending` is cleared on any failed apply, or the button wedges on "ready to install" for good.

## Test plan

- [x] Typecheck clean, both packages
- [x] Harness unit tests — 1602 (+11)
- [x] Desktop unit tests — 48 (+17)
- [x] Playwright mock mode — 285, confirming the row is invisible in a browser
- [x] Packaged Linux smoke — 12 passed / 1 skipped
- [x] Manifest generation for both channels; CI release gate simulated pass *and* fail
- [x] macOS: signed artifact launches, button appears and responds
- [x] Windows: same
- [ ] A real update, installed → offered → applied. **Needs two consecutive releases; nothing local proves it.**

The new `desktop-bridge` smoke check **invokes** the channel rather than just looking for the function, and earned it: it caught that no handler was registered under `--smoke` (`index.ts` returned before `initUpdater`), and — once senders were validated — that a rejected sender and a disabled gate both answer `disabled`, so it now asserts the gate's own reason.

## Known, unchanged

Windows is unsigned (SmartScreen will warn on each update) and macOS is arm64-only. A build **without** this feature cannot be updated *to* anything — only installs from the first auto-update-capable release onward will ever update themselves, so anyone on v0.1.0 reinstalls once.