### PR TITLE
fix(ci): stop publishing the unmaintained langchain packages

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -8,9 +8,22 @@ npm via **OIDC Trusted Publishing** — no long-lived `NPM_TOKEN`, no interactiv
 The one exception is the **first-ever publish of a brand-new package**, which
 CI cannot do (see [Bootstrapping a new package](#bootstrapping-a-new-package)).
 
-> The `@sapiom/langchain` and `@sapiom/langchain-classic` packages are
-> quarantined out of the workspace (see `pnpm-workspace.yaml`) and are not
-> published by this flow.
+> **`@sapiom/langchain` and `@sapiom/langchain-classic` are no longer
+> maintained and are not published.** Both are `"private": true`, so
+> `changeset publish` skips them (it only considers non-private packages) and
+> `npm`/`pnpm` refuse them outright. They stay in the workspace and are still
+> built and tested by `-r` — this stops them SHIPPING, nothing else. npm keeps
+> serving the last release, 0.5.0.
+>
+> This note previously claimed they were "quarantined out of the workspace (see
+> `pnpm-workspace.yaml`)". That was true from 2026-06-16 until 2026-07-08, when
+> the exclusions were removed. For the three weeks after, the two packages were
+> live in the release flow with no Trusted Publisher configured — so every
+> `Publish` run failed on them with `ENEEDAUTH` while this note said they were
+> not published by this flow at all, which is a large part of why a red job went
+> unexamined. If they are ever revived, the fix is to drop `"private"` AND
+> configure a Trusted Publisher for each on npmjs.com; both already exist there,
+> so no manual bootstrap publish is needed.
 
 ## The normal flow (automated)
 

--- a/packages/langchain-classic/package.json
+++ b/packages/langchain-classic/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sapiom/langchain-classic",
   "version": "0.5.1",
+  "private": true,
   "description": "LangChain v0.x integration for Sapiom SDK (legacy)",
   "keywords": [
     "sapiom",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sapiom/langchain",
   "version": "0.5.1",
+  "private": true,
   "description": "LangChain v1.x integration for Sapiom SDK",
   "keywords": [
     "sapiom",


### PR DESCRIPTION
## Summary

`Publish` has failed on **every push to `main` for three weeks**. The lockfile and `VERSION_FALLBACK` fixes in #438 cleared the install and test failures; this is the last one.

`changeset publish` reaches `@sapiom/langchain` and `@sapiom/langchain-classic` at 0.5.1, and both die:

```
error an error occurred while publishing @sapiom/langchain: ENEEDAUTH
This command requires you to be logged in to https://registry.npmjs.org
error an error occurred while publishing @sapiom/langchain-classic: ENEEDAUTH
```

Every other package publishes fine around them, which is why `harness@0.2.0` still shipped — the run is red but partially published, and has been for weeks.

## Why they can't authenticate

Neither package has a **Trusted Publisher** configured on npmjs.com, so the runner's OIDC token buys no publish auth for them. That's a gap rather than a regression:

| when | what |
|---|---|
| 2026-06-16 (`0301dfa`) | Both quarantined **out of the workspace** over a real `@langchain/*` dep conflict |
| 2026-06-23 (`5b3495b`) | OIDC trusted publishing configured **per package** — these two, being outside the workspace, were skipped |
| 2026-07-08 (`2a97d64`) | Exclusions removed to add analytics; the dep conflict was resolved |
| 2026-07-09 07:34 | 0.5.0 published **by hand** — the last CI publish before it *failed*, and the two packages' npm timestamps are 2s apart |
| since | Every automated publish fails `ENEEDAUTH` |

## Why `private` and not credentials

Both packages are **healthy** — I verified they build clean and their tests pass (**183 + 36**) once workspace deps are built. So this isn't a broken-package problem, and re-quarantining them out of the workspace would be the wrong tool.

They're simply **no longer maintained**, so the fix is to stop shipping them rather than to grant them credentials.

`"private": true` is the entire mechanism. `changeset publish` filters on exactly this — `packages.filter(pkg => !pkg.packageJson.private)` (`@changesets/cli` 2.31.0, `changesets-cli.esm.js:1004`) — and `npm`/`pnpm` refuse a private package outright. There's no second switch to keep in sync, and no config that can drift out of agreement with it.

They stay in the workspace and are still built and tested by `-r`; this stops them **shipping**, nothing else. npm keeps serving 0.5.0.

## Docs

`PUBLISHING.md` still described the 06-16 workspace quarantine as current, telling readers these packages were *"not published by this flow"* — while they were in fact in the flow and failing it. That's a large part of why a red job went unexamined for three weeks, so the note is corrected and the history recorded, along with what to do if the packages are ever revived (drop `private` **and** configure a Trusted Publisher for each; both already exist on npm, so no manual bootstrap publish is needed).

## Testing

- [x] `pnpm --filter @sapiom/langchain publish --dry-run` → **"There are no new packages that should be published"** (was attempting to publish)
- [x] Confirmed changesets' publish path filters private packages, read from the installed `@changesets/cli` rather than assumed
- [x] `pnpm install --frozen-lockfile` → **exit 0**, no lockfile change needed (`private` isn't part of resolution)
- [x] `pnpm build` (full workspace, all 18 packages) → **exit 0**, zero errors — the langchain packages still build, they just won't ship
- [x] Verified no workspace package depends on either

## Checklist

- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed

No changeset: this changes no published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDanuiTBW7BnbQJ67couK4