### PR TITLE
feat(harness): move "New session…" into the Add menu

### DIFF
--- a/.changeset/harness-new-session-in-add-menu.md
+++ b/.changeset/harness-new-session-in-add-menu.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio: "New session…" moves from the Sessions menu to the Add menu.
+
+Starting a session is the most common thing the rail's `+` is pressed for, and it is unambiguously an *add* — but it lived in the History popover, one button over. That was an accident of order: the Sessions menu existed first, so the action was put where there was already a list to put it in. The result was the thing you do daily sitting behind the button for reviewing work that has already finished, and "start something new" split across two popovers that look identical and mean different things.
+
+It now leads the Add menu, above the three workspace doors, and is gone from the Sessions menu — one action, one home. The Sessions popover is left doing exactly one job: reopening a past session.
+
+The row is the same `DoorRow` component as the doors beside it rather than a hand-matched copy of the markup, so it cannot drift out of alignment with them; `DoorList` takes a `leading` slot for rows that belong to the menu but have no door in the dialog.

--- a/packages/harness/web/e2e/add-workspace.spec.ts
+++ b/packages/harness/web/e2e/add-workspace.spec.ts
@@ -45,10 +45,29 @@ test.describe("the resting state", () => {
     expect(Math.abs(panel.y - trigger.y)).toBeLessThan(2);
   });
 
-  test("offers exactly three doors and no path field", async ({ page }) => {
+  test("offers a session row, exactly three doors, and no path field", async ({ page }) => {
     const doors = page.getByTestId("aw-doors");
     await expect(doors).toBeVisible();
-    await expect(doors.locator(".aw-door")).toHaveCount(3);
+    // Four rows: one to start an agent, three to add a workspace. "New
+    // session…" leads, because it is the most common reason the + is pressed
+    // and it is an add — it sat in the Sessions menu only because that menu
+    // existed first, which put the daily action behind the button for
+    // reviewing finished work.
+    await expect(doors.locator(".aw-door")).toHaveCount(4);
+    await expect(doors.locator(".aw-door").first()).toHaveAttribute(
+      "data-testid",
+      "new-session-btn",
+    );
+    for (const door of ["have", "template", "idea"]) {
+      await expect(doors.getByTestId(`aw-door-${door}`)).toBeVisible();
+    }
+    // It is not left behind in the Sessions menu as well — one action, one home.
+    await page.keyboard.press("Escape");
+    await page.getByTestId("history-trigger").click();
+    await expect(page.getByTestId("history-menu")).toBeVisible();
+    await expect(page.getByTestId("new-session-btn")).toHaveCount(0);
+    await page.keyboard.press("Escape");
+    await page.getByTestId("add-workspace").click();
 
     // The point of the redesign: nothing is asked for until an intent is picked.
     await expect(page.locator(".dir-picker")).toBeHidden();

--- a/packages/harness/web/e2e/consent.spec.ts
+++ b/packages/harness/web/e2e/consent.spec.ts
@@ -197,7 +197,7 @@ test.describe("UI event tracking (track() calls)", () => {
 
   test("new session creation emits track('session.created')", async ({ page }) => {
     // Open new session modal.
-    await page.getByTestId("history-trigger").click();
+    await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     await expect(page.locator(".modal-new-session")).toBeVisible();
 

--- a/packages/harness/web/e2e/dismiss.spec.ts
+++ b/packages/harness/web/e2e/dismiss.spec.ts
@@ -71,7 +71,7 @@ test.describe("settings popover", () => {
 
 test.describe("new-session modal", () => {
   test("closes on Escape and returns focus to the history trigger that spawned it", async ({ page }) => {
-    await page.getByTestId("history-trigger").click();
+    await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     await expect(page.locator(".modal-new-session")).toBeVisible();
 
@@ -81,7 +81,7 @@ test.describe("new-session modal", () => {
   });
 
   test("still closes on a backdrop click, but not on clicks inside the panel", async ({ page }) => {
-    await page.getByTestId("history-trigger").click();
+    await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     await expect(page.locator(".modal-new-session")).toBeVisible();
 

--- a/packages/harness/web/e2e/popover-crop.spec.ts
+++ b/packages/harness/web/e2e/popover-crop.spec.ts
@@ -59,6 +59,14 @@ test("history menu opens uncropped off the rail header", async ({ page }) => {
   await expectUncropped(page, page.getByTestId("history-menu"));
 });
 
+test("add menu opens uncropped beside the rail header", async ({ page }) => {
+  // The only `right-start` placement in the app: it grows across the rail's
+  // right edge rather than down its inside, so it is the one most likely to be
+  // clipped by the rail's own scroller.
+  await page.getByTestId("add-workspace").click();
+  await expectUncropped(page, page.getByTestId("add-menu"));
+});
+
 test("profile menu opens uncropped off the rail footer", async ({ page }) => {
   await page.getByTestId("brand-identity").click();
   await expectUncropped(page, page.getByTestId("profile-menu"));
@@ -76,7 +84,7 @@ test("session bar menu opens uncropped at the header's right cluster", async ({ 
 });
 
 test("harness picker opens uncropped over the new-session dialog", async ({ page }) => {
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
   await page.getByTestId("harness-select").click();
   await expectUncropped(page, page.getByTestId("harness-select-menu"));

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -110,7 +110,7 @@ test("session header: compact identity (name only; path in the tooltip); New ses
 
   await page.screenshot({ path: "web/e2e/screenshots/session-header.png" });
 
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
   await expect(page.locator(".modal-new-session")).toBeVisible();
   await page.getByRole("button", { name: "Cancel" }).click();
@@ -492,7 +492,7 @@ test("add project: the rail's + registers a bare folder through the 'Open a fold
 });
 
 test("new-session modal: directory picker navigates and validates", async ({ page }) => {
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
   await expect(page.locator(".modal-new-session")).toBeVisible();
 
@@ -534,7 +534,7 @@ test("new-session modal: a failed directory read shows an error, not an empty li
   await page.goto("/?mockError=listDir&seed=0");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
   await expect(page.locator(".modal-new-session")).toBeVisible();
 
@@ -1600,7 +1600,7 @@ test.describe("session menu copy path", () => {
 });
 
 test("directory picker: arrow keys move the highlight and Enter drills into it", async ({ page }) => {
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
   const input = page.getByTestId("dir-picker-input");
   await expect(page.getByTestId("dir-picker-item-leasing")).toBeVisible();

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -140,7 +140,7 @@ test.describe("add workspace (three doors)", () => {
   });
 
   test("the harness picker renders from the adapter registry", async ({ page }) => {
-    await page.getByTestId("history-trigger").click();
+    await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     const trigger = page.getByTestId("harness-select");
     await expect(trigger).toBeVisible();
@@ -176,7 +176,7 @@ test.describe("add workspace (three doors)", () => {
 // ---------------------------------------------------------------------------
 
 test("recent-path chips middle-truncate long paths and keep the full path in the tooltip", async ({ page }) => {
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
 
   const chip = page.locator(".recent-dir-chip").first();
@@ -226,7 +226,7 @@ test("the directory picker's read failure carries its own Retry", async ({ page 
   await page.goto("/?mockError=listDir");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
-  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
 
   const err = page.getByTestId("dir-picker-error");

--- a/packages/harness/web/src/components/AddWorkspaceDialog.tsx
+++ b/packages/harness/web/src/components/AddWorkspaceDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { JSX, RefObject } from "react";
+import type { JSX, ReactNode, RefObject } from "react";
 import type { FsListResponse } from "../lib/api";
 import {
   isValidProjectName,
@@ -200,34 +200,72 @@ export function AddWorkspaceDialog({
 }
 
 /**
+ * One row of the add menu: icon · title · sub · chevron.
+ *
+ * Exported because the rail's Add popover leads with a row this dialog has no
+ * door for — "New session…", which starts an agent rather than adding a
+ * workspace. That row has to be indistinguishable from the doors beside it, so
+ * it is the same component rather than a hand-matched copy of the markup.
+ */
+export function DoorRow({
+  icon,
+  title,
+  sub,
+  testid,
+  onClick,
+}: {
+  icon: string;
+  title: string;
+  sub: string;
+  testid: string;
+  onClick: () => void;
+}): JSX.Element {
+  return (
+    <button type="button" className="aw-door" data-testid={testid} onClick={onClick}>
+      <span className="aw-door-icon" aria-hidden="true">
+        <Icon name={icon} size={15} />
+      </span>
+      <span className="aw-door-text">
+        <span className="aw-door-title">{title}</span>
+        <span className="aw-door-sub">{sub}</span>
+      </span>
+      <span className="aw-door-arrow" aria-hidden="true">
+        <Icon name="ArrowRight" size={14} />
+      </span>
+    </button>
+  );
+}
+
+/**
  * The resting state: three mutually exclusive intents, no path field in sight.
  *
  * Exported so the rail's Add popover can BE this list rather than restate it.
- * The row anatomy (icon · title · sub · chevron) is the same on both surfaces,
- * so it is one component and one stylesheet rule, not two that drift.
+ * The row anatomy is the same on both surfaces, so it is one component and one
+ * stylesheet rule, not two that drift.
+ *
+ * `leading` is for rows that belong to the MENU but not to this dialog — the
+ * rail passes "New session…". It rides inside the same `.aw-doors` wrapper so
+ * it inherits the list's spacing and separators instead of needing its own.
  */
-export function DoorList({ onPick }: { onPick: (door: Door) => void }): JSX.Element {
+export function DoorList({
+  onPick,
+  leading,
+}: {
+  onPick: (door: Door) => void;
+  leading?: ReactNode;
+}): JSX.Element {
   return (
     <div className="aw-doors" data-testid="aw-doors">
+      {leading}
       {DOORS.map((entry) => (
-        <button
+        <DoorRow
           key={entry.id}
-          type="button"
-          className="aw-door"
-          data-testid={`aw-door-${entry.id}`}
+          icon={entry.icon}
+          title={entry.title}
+          sub={entry.sub}
+          testid={`aw-door-${entry.id}`}
           onClick={() => onPick(entry.id)}
-        >
-          <span className="aw-door-icon" aria-hidden="true">
-            <Icon name={entry.icon} size={15} />
-          </span>
-          <span className="aw-door-text">
-            <span className="aw-door-title">{entry.title}</span>
-            <span className="aw-door-sub">{entry.sub}</span>
-          </span>
-          <span className="aw-door-arrow" aria-hidden="true">
-            <Icon name="ArrowRight" size={14} />
-          </span>
-        </button>
+        />
       ))}
     </div>
   );

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -16,7 +16,7 @@ import { BrandHeader } from "./BrandHeader";
 import { EmptyState } from "./EmptyState";
 import { HarnessBrandIcon } from "./HarnessBrandIcon";
 import { Icon } from "./Icon";
-import { AddWorkspaceDialog, DoorList } from "./AddWorkspaceDialog";
+import { AddWorkspaceDialog, DoorList, DoorRow } from "./AddWorkspaceDialog";
 import type { Door } from "./AddWorkspaceDialog";
 import { NewSessionModal } from "./NewSessionModal";
 import { SettingsPopover } from "./SettingsPopover";
@@ -527,6 +527,23 @@ export function WorkflowsRail({
           </div>
           <div className="connect-card-body">
             <DoorList
+              // "New session…" leads the menu: it is the most common thing the
+              // + is pressed for, and it is an ADD — it was only ever in the
+              // Sessions menu because that menu existed first. That put the
+              // one action you take daily behind the button for reviewing
+              // finished work, and split "start something" across two popovers.
+              leading={
+                <DoorRow
+                  icon="Plus"
+                  title="New session…"
+                  sub="Start an agent in a folder"
+                  testid="new-session-btn"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setAddDialogMode("session");
+                  }}
+                />
+              }
               onPick={(door) => {
                 setAddMenuOpen(false);
                 if (door === "template") {
@@ -560,22 +577,9 @@ export function WorkflowsRail({
             </button>
           </div>
           <div className="connect-card-body history-card-body">
-            <button
-              className="session-dropdown-item session-dropdown-new"
-              data-testid="new-session-btn"
-              onClick={() => {
-                setHistoryOpen(false);
-                setAddDialogMode("session");
-              }}
-            >
-              <span className="session-item-icon">
-                <Icon name="Plus" size={13} />
-              </span>
-              <span className="session-item-copy">
-                <span className="session-item-title">New session…</span>
-              </span>
-            </button>
-
+            {/* "New session…" used to lead this menu; it lives in the Add menu
+                now. This popover reviews work that already happened — the one
+                thing you do here is reopen a past session. */}
             <div className="session-dropdown-section">Past sessions</div>
             {pastRows.map((row) => {
               if (row.kind === "exited") {


### PR DESCRIPTION
## Summary

Starting a session is the most common thing the rail's `+` is pressed for, and it is unambiguously an **add** — but it lived in the History popover, one button over.

That was an accident of order: the Sessions menu existed first, so the action went where there was already a list to put it in. The result was the thing you do daily sitting behind the button for *reviewing work that has already finished*, and "start something new" split across two popovers that look identical and mean different things.

It now leads the Add menu, above the three workspace doors, and is gone from the Sessions menu — one action, one home. The Sessions popover is left doing exactly one job: reopening a past session.

This is the follow-up I flagged as deliberately deferred in #439.

## Changes

### The row is a shared component, not matched markup
`DoorRow` (icon · title · sub · chevron) is extracted from `DoorList` and exported, and `DoorList` takes a `leading` slot for rows that belong to the **menu** but have no door in the dialog. The session row is the same component as the doors beside it, so it cannot drift out of alignment with them, and it rides the same `.aw-doors` wrapper so it inherits the list's spacing and separators rather than needing its own rule.

### The Sessions popover keeps its shape
Only the row is removed. The "Past sessions" divider stays — `dismiss.spec.ts` uses it as a dead-space click target to prove an in-menu click does **not** dismiss, so deleting it would have cost a real test for a cosmetic tidy.

## Testing

- [x] **Full web e2e suite: 288 passed** (up from 287 — one new crop guard)
- [x] Web typecheck clean (`tsc --noEmit -p web/tsconfig.json`, exit 0)
- [x] Specs reach `new-session-btn` through the `+` rather than the history trigger — **11 call sites across 5 files** (`consent`, `dismiss`, `popover-crop`, `smoke`, `wave5`), rewritten only where `history-trigger` was immediately followed by `new-session-btn`, leaving the other 22 `history-trigger` uses untouched

### Assertions that now pin intent rather than a number
The door-count test asserted `toHaveCount(3)`. Rather than bump it to 4, it now pins what the change actually means: four rows, the session row **first**, all three doors present, and `new-session-btn` **absent from the Sessions menu** — so putting it back in two places fails.

### New crop guard
`popover-crop.spec.ts` gains an uncropped assertion for the Add menu. It is the app's only `right-start` placement (added in #439), so it is the one most likely to be clipped by the rail's own scroller — and nothing covered it.

## Checklist

- [x] Code follows project guidelines
- [x] All tests passing
- [x] Changeset added
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDanuiTBW7BnbQJ67couK4