### PR TITLE
fix(harness): deploy links or creates the remote agent a template clone never had

### DIFF
--- a/.changeset/deploy-auto-link.md
+++ b/.changeset/deploy-auto-link.md
@@ -1,0 +1,33 @@
+---
+"@sapiom/harness": patch
+---
+
+Deploy now links (or creates) the remote agent for a project that has never
+been linked, instead of failing.
+
+A gallery-template clone lands with `sapiom.json` carrying its fork provenance
+and no `definitionId` — by design, since the definition was always meant to be
+created at deploy. That half was missing, so `POST /api/workflows/:id/deploy`
+answered 409 "workflow is not linked to a Sapiom agent" and the Deploy button
+could not succeed on a fresh template.
+
+The route now resolves-or-creates the agent first (`link({ create: true })`,
+which matches an existing definition by name/slug before creating one, so
+re-deploying never duplicates it), caches the id in `sapiom.json`, and continues
+into the build. The stream gains a non-terminal `linking` line so the UI can say
+what it is doing; terminal lines are unchanged. The agent is named after its
+declared `defineAgent({ name })` where resolvable, falling back to the cached
+name or the workflow's own name. An unparseable `sapiom.json` still 409s — now
+with a message that says so, because creating a remote agent we could not
+record would orphan it.
+
+Caching the newly-linked id in `sapiom.json` is best-effort: the file is a
+re-resolvable cache and `link` re-resolves the same agent by name, so a failed
+write (read-only checkout, a permissions error, the config turning invalid
+between the initial check and this write) must not cost the user their build.
+On that path the stream emits a non-terminal `warning` line instead of failing
+— the agent was created on Sapiom but not recorded locally, so the Deployed
+chip will not flip and the next deploy re-links, but nothing is duplicated
+because `link` resolves the same agent again. The SPA renders both the
+`linking` and `warning` lines, and a double-click on Deploy can no longer
+create two remote agents for the same project.

--- a/.changeset/deploy-auto-link.md
+++ b/.changeset/deploy-auto-link.md
@@ -31,3 +31,9 @@ chip will not flip and the next deploy re-links, but nothing is duplicated
 because `link` resolves the same agent again. The SPA renders both the
 `linking` and `warning` lines, and a double-click on Deploy can no longer
 create two remote agents for the same project.
+
+Because linking matches by name, two gallery clones of the same template —
+which share the same declared `defineAgent({ name })` — resolve to the same
+remote agent, so deploying the second one replaces the first's build; this is
+inherent to link-by-name (unchanged from `sapiom agents link --create`), not
+a new bug, but it's now reachable from a single button click.

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Thumbs.db
 # Local Verdaccio registry (SDK dev loop) — storage + runtime auth, never committed
 .verdaccio/storage/
 .verdaccio/.npmrc
+
+# Subagent-driven-development scratch (ledger, briefs, review packages) — never committed
+.superpowers/

--- a/docs/superpowers/plans/2026-07-30-deploy-auto-link.md
+++ b/docs/superpowers/plans/2026-07-30-deploy-auto-link.md
@@ -1,0 +1,1121 @@
+# Deploy Auto-Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clicking Deploy on a template-cloned agent that has no remote counterpart resolves-or-creates the remote agent first, then builds — instead of failing with a 409.
+
+**Architecture:** One new branch inside `POST /api/workflows/:id/deploy` in `packages/harness/src/server/actions.ts`. When `sapiom.json` carries no `definitionId`, the route emits a new non-terminal `linking` NDJSON line, calls agent-core's `link({ name, create: true })` (which matches an existing remote definition by name/slug before creating one), caches the result in `sapiom.json`, and continues into the existing build path. `link` and `writeConfig` arrive as injected core deps so no test touches the network or the filesystem. The agent's name comes from an optional `resolveDefinitionName` seam, wired in `server/index.ts` to the already-warm canvas extraction cache.
+
+**Tech Stack:** TypeScript (ESM, NodeNext), Express, Vitest, pnpm workspaces, `@sapiom/agent-core`, React (SPA).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-30-deploy-auto-link-design.md`. Read it before Task 1.
+- Package under change: `@sapiom/harness`. `@sapiom/agent-core` is **not** modified — its `deploy()` must keep never writing `sapiom.json`.
+- Scope is the harness HTTP route only. Do **not** change `packages/cli/src/commands/agents/deploy.ts` or the MCP deploy tool; their `NOT_LINKED` behaviour is intentional.
+- The already-linked path must stay byte-identical on the wire: `building` → `ready`/`error`, with no `link` call. Every existing test in `src/server/actions.test.ts` except the two named in Task 1 and Task 2 must pass untouched.
+- `actions.ts` must not import from `core/canvas-*` or the workflow registry. It stays decoupled via injected deps and seams (this mirrors the existing `resolveWorkflow` / `coreDeps` / `runLocalSpawn` seams).
+- Terminal stream lines stay exactly one per stream: `ready` or `error`. `linking` is non-terminal.
+- Run every command **from the repo root** — never `cd` (see `packages/harness/CLAUDE.md`).
+- No new desktop-packaging hazard is permitted or expected: `link` is a plain network call, and the only subprocess involved is the existing `runManifestCheck`, which already translates asar paths and sets `ELECTRON_RUN_AS_NODE`. Do not add a new `asarUnpack` entry or a `smoke.ts` check — if you find yourself needing one, stop and re-read the spec.
+- Test command shape: `pnpm --filter @sapiom/harness exec vitest run <path> -t "<name>"`.
+- Baseline for this worktree: 102 files / 1578 tests, all passing. Any other failure you see is yours.
+- Commit after each task. Conventional-commit prefixes (`feat:`, `fix:`, `test:`, `refactor:`, `docs:`).
+- Do not add attribution/co-author trailers to commits (disabled globally for this repo).
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `packages/harness/src/server/actions.ts` | Modify: three-way config read, `linking` event, auto-link branch, `link`/`writeConfig` deps, `resolveDefinitionName` seam, `ActionWorkflow.name` | 1, 2 |
+| `packages/harness/src/server/actions.test.ts` | Modify: rewrite the two tests that assert the old 409, add auto-link coverage | 1, 2 |
+| `packages/harness/src/core/definition-name.ts` | **Create**: `resolveManifestName(projectDir, extract?)` — reads `graph.manifestName` from the canvas extraction cache, null on any failure | 3 |
+| `packages/harness/src/core/definition-name.test.ts` | **Create**: unit tests for the above with an injected fake extractor | 3 |
+| `packages/harness/src/server/index.ts:1166-1177` | Modify: pass `resolveDefinitionName` + `name` into `createActionsRouter` | 3 |
+| `packages/harness/web/src/lib/api.ts` | Modify: mirror the `linking` member in the SPA's `DeployStreamEvent`; emit it from `MockApi.deploy` | 4 |
+| `packages/harness/web/src/lib/api.test.ts` | Modify: `linking` parses and stays non-terminal | 4 |
+| `packages/harness/web/src/lib/use-harness-state.ts:941-943` | Modify: toast for the `linking` phase | 4 |
+| `.changeset/deploy-auto-link.md` | **Create**: patch changeset | 5 |
+
+---
+
+### Task 1: Tell "unlinked" apart from "broken config"
+
+`readDefinitionId` currently collapses both an unlinked project and an unparseable
+`sapiom.json` into `null`. Task 2 needs those separated: auto-linking on a broken
+config would create a remote agent and then die, because `writeConfig` calls
+`readConfig`, which throws `BAD_CONFIG` on invalid JSON — leaving an orphaned
+remote agent that nothing records. This task only splits the read and gives
+bad-config its own message; the unlinked 409 still stands, and Task 2 removes it.
+
+**Files:**
+- Modify: `packages/harness/src/server/actions.ts:253-272` (the `readDefinitionId` helper) and `:401-407` (its call site)
+- Test: `packages/harness/src/server/actions.test.ts:301-321` (the existing bad-config test)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  ```ts
+  type ProjectConfigState =
+    | { kind: "linked"; definitionId: string }
+    | { kind: "unlinked"; name?: string }
+    | { kind: "bad-config" };
+
+  function readProjectConfigState(
+    readConfig: typeof coreReadConfig,
+    projectDir: string,
+  ): ProjectConfigState;
+  ```
+  Task 2 consumes both. The `name` on `unlinked` is `sapiom.json`'s cached `name` — step 2 of Task 2's fallback chain.
+
+- [ ] **Step 1: Strengthen the existing bad-config test to assert the message**
+
+In `packages/harness/src/server/actions.test.ts`, find the test named
+`"returns 409 when sapiom.json is unreadable/unparseable"` (around line 301). It
+currently asserts only the status. Add the message assertion, so the two 409s are
+distinguishable from the outside:
+
+```ts
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("sapiom.json is not valid JSON");
+      expect(coreDeps.deploy).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/server/actions.test.ts -t "unreadable/unparseable"
+```
+
+Expected: FAIL — received `"workflow is not linked to a Sapiom agent"`, expected
+`"sapiom.json is not valid JSON"`.
+
+- [ ] **Step 3: Replace the helper with the three-way read**
+
+In `packages/harness/src/server/actions.ts`, replace the whole
+`readDefinitionId` function (and its doc comment) with:
+
+```ts
+/**
+ * What a project's `sapiom.json` says about its server-side identity. Three
+ * states, not two: an unlinked project is fixable by linking on the spot (the
+ * deploy route does exactly that), while an unparseable file is not — and
+ * telling them apart matters, because `writeConfig` re-reads the file and
+ * throws BAD_CONFIG on invalid JSON. Auto-linking on a broken config would
+ * create a remote agent and then fail to record it, orphaning it.
+ *
+ * `name` on the unlinked state is the cached agent name a previous `link`
+ * wrote, if any — the deploy route uses it to name the agent it creates.
+ */
+type ProjectConfigState =
+  | { kind: "linked"; definitionId: string }
+  | { kind: "unlinked"; name?: string }
+  | { kind: "bad-config" };
+
+function readProjectConfigState(
+  readConfig: typeof coreReadConfig,
+  projectDir: string,
+): ProjectConfigState {
+  let config: SapiomConfig | null;
+  try {
+    config = readConfig(projectDir);
+  } catch {
+    return { kind: "bad-config" };
+  }
+  const definitionId = config?.definitionId;
+  if (definitionId) return { kind: "linked", definitionId };
+  return config?.name ? { kind: "unlinked", name: config.name } : { kind: "unlinked" };
+}
+```
+
+- [ ] **Step 4: Update the call site**
+
+In the same file, replace these lines in the deploy route (currently `:401-407`):
+
+```ts
+    const definitionId = readDefinitionId(deps.readConfig, workflow.path);
+    if (!definitionId) {
+      res
+        .status(409)
+        .json({ error: "workflow is not linked to a Sapiom agent" });
+      return;
+    }
+```
+
+with:
+
+```ts
+    const configState = readProjectConfigState(deps.readConfig, workflow.path);
+    if (configState.kind === "bad-config") {
+      res.status(409).json({ error: "sapiom.json is not valid JSON" });
+      return;
+    }
+    if (configState.kind === "unlinked") {
+      res
+        .status(409)
+        .json({ error: "workflow is not linked to a Sapiom agent" });
+      return;
+    }
+    const definitionId = configState.definitionId;
+```
+
+- [ ] **Step 5: Run the full actions suite**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/server/actions.test.ts
+```
+
+Expected: PASS, all tests. The unlinked-409 test still passes (Task 2 rewrites it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/harness/src/server/actions.ts packages/harness/src/server/actions.test.ts
+git commit -m "refactor(harness): tell an unlinked project apart from an unparseable sapiom.json"
+```
+
+---
+
+### Task 2: Deploy links (or creates) the agent when the project isn't linked
+
+The behaviour change. Note that **you are deleting a passing test's premise**:
+`"returns 409 when the workflow has no linked definitionId"` asserts exactly the
+bug we are fixing. Rewrite it as specified below — do not preserve the old
+assertion, and do not weaken the new code to keep it green.
+
+**Files:**
+- Modify: `packages/harness/src/server/actions.ts` — `ActionWorkflow`, `DeployStreamEvent`, `ActionsCoreDeps`, `DEFAULT_CORE_DEPS`, `ActionsRouterOpts`, the deploy route body, the `node:path` import
+- Test: `packages/harness/src/server/actions.test.ts` — `makeCoreDeps`, the rewritten test, five new tests
+
+**Interfaces:**
+- Consumes: `ProjectConfigState` / `readProjectConfigState` from Task 1.
+- Produces:
+  ```ts
+  interface ActionWorkflow { path: string; name?: string }
+
+  type DeployStreamEvent =
+    | { phase: "linking"; name: string }
+    | { phase: "building"; definitionId: string }
+    | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
+    | { phase: "error"; code: string; message: string; hint?: string };
+
+  interface ActionsCoreDeps {
+    createClient: typeof createClient;
+    deploy: typeof coreDeploy;
+    run: typeof coreRun;
+    readConfig: typeof coreReadConfig;
+    link: typeof coreLink;         // new
+    writeConfig: typeof coreWriteConfig;  // new
+  }
+
+  // on ActionsRouterOpts:
+  resolveDefinitionName?: (workflow: ActionWorkflow) => Promise<string | null>;
+  ```
+  Task 3 implements `resolveDefinitionName`; Task 4 mirrors `DeployStreamEvent`.
+  `name` on `ActionWorkflow` is **optional** — 30 existing test call sites build
+  `{ path: "/proj/agent" }` literals, and a required field would break them all
+  for no behavioural gain. The route falls back to `basename(path)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/harness/src/server/actions.test.ts`, first extend the fake-deps
+factory so the two new deps exist on every test (find `makeCoreDeps`, around
+line 26, and add the two entries before the `...overrides` spread):
+
+```ts
+    readConfig: vi.fn().mockReturnValue({ definitionId: "def_123" }),
+    link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+    writeConfig: vi.fn(),
+    ...overrides,
+```
+
+Then **replace** the test named `"returns 409 when the workflow has no linked
+definitionId"` (around line 281) with these six tests:
+
+```ts
+    it("links (creating the agent) then deploys when the project is not linked yet", async () => {
+      // A fresh gallery-template clone: sapiom.json carries the fork
+      // provenance and no definitionId. This is the case that used to 409.
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({ forkId: "fork_7", templateId: "order-triage" }),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // The linking line precedes building, and the stream still ends with
+      // exactly one terminal line.
+      expect(parseNdjson(await res.text())).toEqual([
+        { phase: "linking", name: "order-triage" },
+        { phase: "building", definitionId: "def_new" },
+        { phase: "ready", definitionId: "def_new", buildRunId: "build_1", status: "ready" },
+      ]);
+
+      // create: true is what makes this work on an agent that does not exist
+      // remotely yet; link() itself matches an existing one by name/slug first.
+      expect(coreDeps.link).toHaveBeenCalledWith(
+        { name: "order-triage", create: true },
+        expect.anything(),
+      );
+      // The id is cached under the name the SERVER returned, and writeConfig
+      // merges, so the clone's forkId/templateId survive.
+      expect(coreDeps.writeConfig).toHaveBeenCalledWith("/proj/agent", {
+        definitionId: "def_new",
+        name: "order-triage",
+      });
+      // The build then runs against the freshly linked id.
+      expect(coreDeps.deploy).toHaveBeenCalledWith(
+        { projectDir: "/proj/agent", definitionId: "def_new" },
+        expect.anything(),
+      );
+    });
+
+    it("does not link when the project is already linked", async () => {
+      // Regression guard for the common path: a linked project must never pay
+      // for a definitions round-trip, and its stream shape is unchanged.
+      const coreDeps = makeCoreDeps({
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_123",
+          buildRunId: "build_9",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      const events = parseNdjson(await res.text());
+
+      expect(coreDeps.link).not.toHaveBeenCalled();
+      expect(coreDeps.writeConfig).not.toHaveBeenCalled();
+      expect(events[0]).toEqual({ phase: "building", definitionId: "def_123" });
+    });
+
+    it("ends the stream with one terminal error when linking fails, without building", async () => {
+      const { AgentOperationError } = await import("@sapiom/agent-core");
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockRejectedValue(
+          new AgentOperationError({
+            code: "HTTP_404",
+            message: "Could not create the agent.",
+            hint: "The tenant deploy routes may not be enabled.",
+          }),
+        ),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "agent" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // A link failure is reported as itself — never disguised as a build
+      // failure — and nothing is written or built.
+      expect(parseNdjson(await res.text())).toEqual([
+        { phase: "linking", name: "agent" },
+        {
+          phase: "error",
+          code: "HTTP_404",
+          message: "Could not create the agent.",
+          hint: "The tenant deploy routes may not be enabled.",
+        },
+      ]);
+      expect(coreDeps.deploy).not.toHaveBeenCalled();
+      expect(coreDeps.writeConfig).not.toHaveBeenCalled();
+    });
+
+    it("refreshes the key once and retries when linking is rejected as unauthorized", async () => {
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi
+          .fn()
+          .mockRejectedValueOnce(await makeAuthRejection(401))
+          .mockResolvedValue({ definitionId: "def_new", name: "agent" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      const provider = refreshingProvider("sk-stale", "sk-fresh");
+      start({
+        apiKey: provider,
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "agent" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      const events = parseNdjson(await res.text());
+
+      expect(provider.refreshCalls).toBe(1);
+      expect(coreDeps.link).toHaveBeenCalledTimes(2);
+      // The retry is transparent: no extra linking line, normal terminal.
+      expect(events.filter((e) => e.phase === "linking")).toHaveLength(1);
+      expect(events.at(-1)).toMatchObject({ phase: "ready", definitionId: "def_new" });
+    });
+
+    it("names the created agent from the resolveDefinitionName seam when it resolves", async () => {
+      // The seam supplies the agent's declared manifest name, which wins over
+      // both sapiom.json's cached name and the registry name.
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({ name: "cached-name" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "b",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "registry-name" }),
+        resolveDefinitionName: () => Promise.resolve("manifest-name"),
+        coreDeps,
+      });
+
+      await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+
+      expect(coreDeps.link).toHaveBeenCalledWith(
+        { name: "manifest-name", create: true },
+        expect.anything(),
+      );
+    });
+
+    it("falls back to the cached name, then the registry name, then the folder", async () => {
+      // The seam is absent or fails (no node_modules yet, a bundle error) —
+      // each fallback in turn must still yield a usable name.
+      const cases: Array<{
+        config: Record<string, unknown>;
+        workflow: { path: string; name?: string };
+        seam?: () => Promise<string | null>;
+        expected: string;
+      }> = [
+        // Seam rejects → sapiom.json's cached name.
+        {
+          config: { name: "cached-name" },
+          workflow: { path: "/proj/agent", name: "registry-name" },
+          seam: () => Promise.reject(new Error("no node_modules")),
+          expected: "cached-name",
+        },
+        // No seam, no cached name → the registry name.
+        {
+          config: {},
+          workflow: { path: "/proj/agent", name: "registry-name" },
+          expected: "registry-name",
+        },
+        // Nothing at all → the project folder's basename.
+        {
+          config: {},
+          workflow: { path: "/proj/my-agent" },
+          seam: () => Promise.resolve(null),
+          expected: "my-agent",
+        },
+      ];
+
+      for (const testCase of cases) {
+        const coreDeps = makeCoreDeps({
+          readConfig: vi.fn().mockReturnValue(testCase.config),
+          deploy: vi.fn().mockResolvedValue({
+            definitionId: "def_new",
+            buildRunId: "b",
+            status: "ready",
+          }),
+        });
+        start({
+          apiKey: "sk-test-key",
+          resolveWorkflow: () => testCase.workflow,
+          ...(testCase.seam ? { resolveDefinitionName: testCase.seam } : {}),
+          coreDeps,
+        });
+
+        await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+
+        expect(coreDeps.link).toHaveBeenCalledWith(
+          { name: testCase.expected, create: true },
+          expect.anything(),
+        );
+        // Each iteration starts its own server; close it before the next.
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+```
+
+Note on the last test: `start()` assigns the suite-level `server`, and `afterEach`
+closes it — closing an already-closed server would throw, so the loop closes each
+iteration's server itself and the final one is left for `afterEach`. If that
+proves awkward in practice, split the loop into three separate `it()` blocks
+rather than weakening the assertions.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/server/actions.test.ts
+```
+
+Expected: FAIL. The new tests fail on the 409 (no `linking` line, `link` never
+called); TypeScript also reports `resolveDefinitionName` and `name` as unknown
+properties. Both are the point.
+
+- [ ] **Step 3: Import the new core ops and `basename`**
+
+In `packages/harness/src/server/actions.ts`, extend the two existing imports.
+`node:path` (line 29) becomes:
+
+```ts
+import { basename, dirname, join } from "node:path";
+```
+
+and the `@sapiom/agent-core` import block (lines 33-42) gains three entries:
+
+```ts
+import {
+  AgentOperationError,
+  createClient,
+  deploy as coreDeploy,
+  link as coreLink,
+  run as coreRun,
+  readConfig as coreReadConfig,
+  writeConfig as coreWriteConfig,
+  type DeployResult,
+  type LinkResult,
+  type RunResult,
+  type SapiomConfig,
+} from "@sapiom/agent-core";
+```
+
+- [ ] **Step 4: Widen the types**
+
+Add `name` to `ActionWorkflow` (line 57):
+
+```ts
+export interface ActionWorkflow {
+  /** Absolute path to the agent project directory (deploy's `projectDir`). */
+  path: string;
+  /**
+   * Registry display name (`package.json`'s `name`, else the folder basename).
+   * Optional so a host that only knows the path still works; used as a
+   * mid-priority fallback when naming an agent this route has to create.
+   */
+  name?: string;
+}
+```
+
+Add the `linking` member to `DeployStreamEvent` and refresh its doc comment
+(lines 63-72):
+
+```ts
+/**
+ * One line of the deploy NDJSON stream. `linking` is emitted only when the
+ * project had no `definitionId` and the route is resolving-or-creating its
+ * remote agent; `building` is emitted once the build is triggered; exactly one
+ * terminal line (`ready` | `error`) closes the stream. `capability`-agnostic
+ * and credential-free by construction.
+ */
+export type DeployStreamEvent =
+  | { phase: "linking"; name: string }
+  | { phase: "building"; definitionId: string }
+  | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
+  | { phase: "error"; code: string; message: string; hint?: string };
+```
+
+Add the two deps to `ActionsCoreDeps` and `DEFAULT_CORE_DEPS` (lines 78-90):
+
+```ts
+export interface ActionsCoreDeps {
+  createClient: typeof createClient;
+  deploy: typeof coreDeploy;
+  run: typeof coreRun;
+  readConfig: typeof coreReadConfig;
+  /** Resolve-or-create the server-side agent for an unlinked project. */
+  link: typeof coreLink;
+  /** Cache the linked id back into `sapiom.json` (merges; never clobbers). */
+  writeConfig: typeof coreWriteConfig;
+}
+
+const DEFAULT_CORE_DEPS: ActionsCoreDeps = {
+  createClient,
+  deploy: coreDeploy,
+  run: coreRun,
+  readConfig: coreReadConfig,
+  link: coreLink,
+  writeConfig: coreWriteConfig,
+};
+```
+
+- [ ] **Step 5: Add the name seam to the router options**
+
+In `ActionsRouterOpts`, directly after the `resolveWorkflow` field
+(currently ending at line 241), add:
+
+```ts
+  /**
+   * The agent's DECLARED name (`defineAgent({ name })`) for a project the route
+   * has to link on the fly, or null when it cannot be determined. Optional: the
+   * route falls back to `sapiom.json`'s cached name, then
+   * {@link ActionWorkflow.name}, then the project folder's basename.
+   *
+   * A seam rather than a direct call so this router keeps knowing nothing about
+   * the canvas extraction cache (see core/definition-name.ts, which
+   * `server/index.ts` wires in here). Never expected to throw — a rejection is
+   * treated as "could not determine".
+   */
+  resolveDefinitionName?: (workflow: ActionWorkflow) => Promise<string | null>;
+```
+
+- [ ] **Step 6: Implement the auto-link branch in the route**
+
+Two edits in the deploy route.
+
+First, replace Task 1's whole config block — keeping the bad-config 409, dropping
+the unlinked 409 so that case falls through, **and deleting the
+`const definitionId = configState.definitionId;` line** (it must go: `configState`
+is no longer narrowed to `linked` here, so that line would not compile, and the
+id is now produced by `ensureDefinitionId` below). The block becomes exactly:
+
+```ts
+    const configState = readProjectConfigState(deps.readConfig, workflow.path);
+    if (configState.kind === "bad-config") {
+      res.status(409).json({ error: "sapiom.json is not valid JSON" });
+      return;
+    }
+```
+
+Second, replace everything from `write({ phase: "building", definitionId });`
+through the end of the `try/catch/finally` (currently lines 418-440) with:
+
+```ts
+    /**
+     * The definition id to build against: the linked one, or a freshly
+     * resolved-or-created one for a project that has never been linked (a
+     * gallery-template clone lands exactly this way — `clone` writes the fork
+     * provenance and leaves `definitionId` for deploy to fill in).
+     *
+     * `link({ create: true })` matches an existing remote agent by name/slug
+     * BEFORE creating one, so this is resync-or-create: re-deploying never
+     * duplicates an agent, and a template already deployed from another machine
+     * re-attaches to the same definition.
+     */
+    const ensureDefinitionId = async (): Promise<string> => {
+      if (configState.kind === "linked") return configState.definitionId;
+
+      const fromSeam = opts.resolveDefinitionName
+        ? await opts.resolveDefinitionName(workflow).catch(() => null)
+        : null;
+      const name =
+        fromSeam?.trim() ||
+        configState.name?.trim() ||
+        workflow.name?.trim() ||
+        basename(workflow.path);
+
+      write({ phase: "linking", name });
+      // Same refresh-on-rejected-key recovery the build gets; the retry is
+      // transparent to the stream (no second linking line).
+      const linked: LinkResult = await withKeyRefreshRetry(
+        provider,
+        clientFor,
+        (client) => deps.link({ name, create: true }, client),
+      );
+      // Cache under the name the SERVER settled on, matching what
+      // `sapiom agents link` writes. writeConfig merges, so the clone's
+      // forkId/templateId/repoFullName survive.
+      deps.writeConfig(workflow.path, {
+        definitionId: linked.definitionId,
+        name: linked.name,
+      });
+      return linked.definitionId;
+    };
+
+    try {
+      // A link failure throws out of here and is mapped by the same
+      // toDeployErrorEvent below — reported as itself, never as a build
+      // failure, and `deploy` is never reached.
+      const definitionId = await ensureDefinitionId();
+      write({ phase: "building", definitionId });
+      // Auth against the live key, refreshing + retrying once on a rejected key
+      // (same recovery the runs router gets). The building/terminal streaming
+      // shape is unchanged — the retry is transparent to the NDJSON stream.
+      const result: DeployResult = await withKeyRefreshRetry(
+        provider,
+        clientFor,
+        (client) =>
+          deps.deploy({ projectDir: workflow.path, definitionId }, client),
+      );
+      write({
+        phase: "ready",
+        definitionId: result.definitionId,
+        buildRunId: result.buildRunId,
+        status: result.status,
+      });
+    } catch (err) {
+      write(toDeployErrorEvent(err));
+    } finally {
+      res.end();
+    }
+```
+
+Also update the route's JSDoc (lines 369-383): the `409` line now reads
+`409  sapiom.json is unparseable`, and add a sentence saying an unlinked project
+is linked on the fly (`linking` line) rather than rejected.
+
+- [ ] **Step 7: Run the tests until green**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/server/actions.test.ts
+```
+
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 8: Typecheck**
+
+```bash
+pnpm --filter @sapiom/harness exec tsc --noEmit
+```
+
+Expected: no errors. (`server/index.ts` still compiles — the new option is
+optional; Task 3 wires it.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/harness/src/server/actions.ts packages/harness/src/server/actions.test.ts
+git commit -m "feat(harness): deploy links or creates the remote agent when the project isn't linked"
+```
+
+---
+
+### Task 3: Name the created agent after its declared manifest name
+
+Without this, an agent created from a clone is named after the folder it landed
+in. `graph.manifestName` is the agent's own `defineAgent({ name })` — the value
+this codebase already treats as authoritative (the registry stores it as
+`definitionSlug`; `sapiom.json`'s `name` is documented as a cache of it). It is
+usually free: the canvas renders on bind, so the extraction is already cached.
+
+**Files:**
+- Create: `packages/harness/src/core/definition-name.ts`
+- Create: `packages/harness/src/core/definition-name.test.ts`
+- Modify: `packages/harness/src/server/index.ts:1166-1177`
+
+**Interfaces:**
+- Consumes: `ActionsRouterOpts.resolveDefinitionName` from Task 2.
+- Produces:
+  ```ts
+  function resolveManifestName(
+    projectDir: string,
+    extract?: typeof extractWorkflowGraphCached,
+  ): Promise<string | null>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/harness/src/core/definition-name.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveManifestName } from "./definition-name.js";
+
+/** A cached-extraction result shaped like canvas-cache's, with just the field
+ *  under test populated. */
+function extraction(manifestName: string) {
+  return {
+    result: {
+      ok: true as const,
+      graph: {
+        manifestName,
+        entry: "start",
+        nodes: [],
+        edges: [],
+        warnings: [],
+      },
+    },
+    cached: true,
+    fingerprint: "1:1",
+  };
+}
+
+describe("resolveManifestName", () => {
+  it("returns the agent's declared manifest name", async () => {
+    const extract = vi.fn().mockResolvedValue(extraction("order-triage"));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBe("order-triage");
+    expect(extract).toHaveBeenCalledWith("/proj/agent");
+  });
+
+  it("returns null when extraction failed", async () => {
+    // The usual cause: node_modules isn't installed yet, so the check process
+    // cannot bundle. The caller falls back to another name source.
+    const extract = vi.fn().mockResolvedValue({
+      result: { ok: false as const, reason: "run npm install first" },
+      cached: false,
+      fingerprint: "0:0",
+    });
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+
+  it("returns null when extraction throws", async () => {
+    const extract = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+
+  it("returns null for a blank manifest name", async () => {
+    const extract = vi.fn().mockResolvedValue(extraction("   "));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/core/definition-name.test.ts
+```
+
+Expected: FAIL — cannot resolve `./definition-name.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/harness/src/core/definition-name.ts`:
+
+```ts
+/**
+ * The name to give a server-side agent the deploy route has to create for a
+ * project that was never linked (a gallery-template clone).
+ *
+ * The honest answer is the agent's own `defineAgent({ name })`, which the
+ * canvas extraction already surfaces as `graph.manifestName` — and which the
+ * registry stores as `definitionSlug` and `sapiom.json` caches as `name`. Read
+ * through the fingerprint cache (core/canvas-cache.ts), so this is normally
+ * free: the canvas renders on bind, so the extraction is already warm.
+ *
+ * Never throws and never blocks a deploy: any failure (no `node_modules` yet,
+ * a bundle error, the check process timing out) comes back as null and the
+ * caller falls back to a weaker name source.
+ */
+import { extractWorkflowGraphCached } from "./canvas-cache.js";
+
+export async function resolveManifestName(
+  projectDir: string,
+  extract: typeof extractWorkflowGraphCached = extractWorkflowGraphCached,
+): Promise<string | null> {
+  try {
+    const { result } = await extract(projectDir);
+    if (!result.ok) return null;
+    return result.graph.manifestName.trim() || null;
+  } catch {
+    // Extraction is best-effort here — a name is a nicety, a deploy is not.
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run src/core/definition-name.test.ts
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Wire it into the server**
+
+In `packages/harness/src/server/index.ts`, add the import next to the other
+`../core/*` imports:
+
+```ts
+import { resolveManifestName } from "../core/definition-name.js";
+```
+
+Then extend the `createActionsRouter` call (currently lines 1166-1177) so the
+router also gets the registry name and the seam:
+
+```ts
+  app.use(
+    createActionsRouter({
+      // Pass the provider (not a static key) so deploy/prod-run authenticate
+      // with the live key and can refresh + retry on a rejected key, recovering
+      // instead of locking — matching the runs router above.
+      apiKey: apiKeyProvider,
+      // coreBaseUrl omitted: the router self-defaults via resolveCoreBaseUrl()
+      // (see actions.ts), which derives the core host from the agents env.
+      resolveWorkflow: (id) => {
+        const workflow = workflowsCache.find((w) => w.path === id);
+        // `name` is the registry's display name — a fallback for naming an
+        // agent the deploy route has to create.
+        return workflow ? { path: workflow.path, name: workflow.name } : null;
+      },
+      // Prefer the agent's DECLARED name when deploy has to create it, read
+      // from the same warm extraction cache the canvas renders from.
+      resolveDefinitionName: (workflow) => resolveManifestName(workflow.path),
+    }),
+  );
+```
+
+- [ ] **Step 6: Typecheck and run the server suite**
+
+```bash
+pnpm --filter @sapiom/harness exec tsc --noEmit
+pnpm --filter @sapiom/harness exec vitest run src/server src/core/definition-name.test.ts
+```
+
+Expected: no type errors; all tests pass.
+
+Note: this step's wiring is covered by types plus Task 2's seam-precedence tests
+rather than by a test of its own — asserting it end-to-end would need a real
+project with installed `node_modules` and an esbuild run. If you can do that
+cheaply in this repo (e.g. against the bundled example project), adding it is
+welcome; do not fake it with a test that asserts nothing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/harness/src/core/definition-name.ts packages/harness/src/core/definition-name.test.ts packages/harness/src/server/index.ts
+git commit -m "feat(harness): name an auto-created agent after its declared manifest name"
+```
+
+---
+
+### Task 4: The SPA reports the linking step
+
+The server can now emit a phase the browser's type union does not know about.
+Mirror it, give it a toast, and teach the mock API to emit it so mock mode and
+real mode behave alike (the mock's own comment already promises to "mirror the
+real server" on this).
+
+**Files:**
+- Modify: `packages/harness/web/src/lib/api.ts:80-88` (the mirrored union) and `:1160-1198` (`MockApi.deploy`)
+- Modify: `packages/harness/web/src/lib/use-harness-state.ts:941-943`
+- Test: `packages/harness/web/src/lib/api.test.ts`
+
+**Interfaces:**
+- Consumes: `DeployStreamEvent`'s `linking` member from Task 2.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/harness/web/src/lib/api.test.ts`, inside the existing
+`describe("terminalDeployEvent")` block:
+
+```ts
+  it("treats a linking line as non-terminal", async () => {
+    // The server emits `linking` before `building` when it has to create the
+    // agent; only ready/error may end the stream.
+    const events: DeployStreamEvent[] = [
+      { phase: "linking", name: "order-triage" },
+      { phase: "building", definitionId: "42" },
+    ];
+    expect(terminalDeployEvent(events)).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
+  });
+```
+
+and add a new top-level describe block:
+
+```ts
+describe("parseNdjsonLine of a linking event", () => {
+  it("parses the linking phase and its name", () => {
+    expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"linking","name":"order-triage"}')).toEqual({
+      phase: "linking",
+      name: "order-triage",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run web/src/lib/api.test.ts
+```
+
+Expected: FAIL — TypeScript rejects `{ phase: "linking", … }`, which is not
+assignable to the SPA's `DeployStreamEvent`.
+
+- [ ] **Step 3: Mirror the union member**
+
+In `packages/harness/web/src/lib/api.ts`, replace the `DeployStreamEvent`
+declaration and its doc comment (lines 80-88) with:
+
+```ts
+/**
+ * One line of the `POST /api/workflows/:id/deploy` NDJSON stream (mirrors
+ * `DeployStreamEvent` in src/server/actions.ts): an optional `linking` line
+ * when the server has to resolve-or-create the remote agent first, a `building`
+ * line, then exactly one terminal `ready` | `error` line closing the stream.
+ */
+export type DeployStreamEvent =
+  | { phase: "linking"; name: string }
+  | { phase: "building"; definitionId: string }
+  | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
+  | { phase: "error"; code: string; message: string; hint?: string };
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run web/src/lib/api.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Toast the linking phase**
+
+In `packages/harness/web/src/lib/use-harness-state.ts`, replace the `onEvent`
+handler inside `deploy` (line 942):
+
+```ts
+        const terminal = await api.deploy(workflowPath, (event) => {
+          // A never-linked project (a fresh template clone) gets its agent
+          // created first — say so, rather than claiming we're building.
+          if (event.phase === "linking") {
+            setToast(`Deploying — creating the agent "${event.name}" on Sapiom…`);
+          } else if (event.phase === "building") {
+            setToast("Deploying — building on Sapiom…");
+          }
+        });
+```
+
+- [ ] **Step 6: Teach the mock API to emit it**
+
+In `packages/harness/web/src/lib/api.ts`, in `MockApi.deploy`, insert before the
+existing `building` line (line 1166):
+
+```ts
+    this.recordDirectAction("deploy", { workflowPath });
+    // Mirror the real server: an unlinked workflow is linked (agent created)
+    // before the build, so mock mode exercises the same two-phase stream.
+    const target = this.workflows.find((w) => w.path === workflowPath);
+    if (target && target.definitionId == null) {
+      const linking: DeployStreamEvent = { phase: "linking", name: target.name };
+      onEvent?.(linking);
+      await delay(200);
+    }
+    const building: DeployStreamEvent = { phase: "building", definitionId: "mock-def" };
+```
+
+- [ ] **Step 7: Run the whole web suite plus a typecheck**
+
+```bash
+pnpm --filter @sapiom/harness exec vitest run web/src
+pnpm --filter @sapiom/harness exec tsc --noEmit -p web/tsconfig.json
+```
+
+Expected: all pass, no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/harness/web/src/lib/api.ts packages/harness/web/src/lib/api.test.ts packages/harness/web/src/lib/use-harness-state.ts
+git commit -m "feat(harness): surface the linking step in the deploy stream UI"
+```
+
+---
+
+### Task 5: Changeset and full verification
+
+**Files:**
+- Create: `.changeset/deploy-auto-link.md`
+
+**Interfaces:**
+- Consumes: everything above. Produces: nothing.
+
+- [ ] **Step 1: Write the changeset**
+
+Create `.changeset/deploy-auto-link.md`:
+
+```markdown
+---
+"@sapiom/harness": patch
+---
+
+Deploy now links (or creates) the remote agent for a project that has never been
+linked, instead of failing.
+
+A gallery-template clone lands with `sapiom.json` carrying its fork provenance
+and no `definitionId` — by design, since the definition was always meant to be
+created at deploy. That half was missing, so `POST /api/workflows/:id/deploy`
+answered 409 "workflow is not linked to a Sapiom agent" and the Deploy button
+could not succeed on a fresh template.
+
+The route now resolves-or-creates the agent first (`link({ create: true })`,
+which matches an existing definition by name/slug before creating one, so
+re-deploying never duplicates it), caches the id in `sapiom.json`, and continues
+into the build. The stream gains a non-terminal `linking` line so the UI can say
+what it is doing; terminal lines are unchanged. An unparseable `sapiom.json`
+still 409s — now with a message that says so, because creating a remote agent we
+could not record would orphan it.
+```
+
+- [ ] **Step 2: Run the full harness suite**
+
+```bash
+pnpm --filter @sapiom/harness test
+```
+
+Expected: PASS. Baseline was 102 files / 1578 tests; you should now have ~1590
+(the tests added here, minus the one rewritten in Task 2).
+
+- [ ] **Step 3: Lint and typecheck both projects**
+
+```bash
+pnpm --filter @sapiom/harness lint
+pnpm --filter @sapiom/harness typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Build, to prove the desktop host still consumes this**
+
+```bash
+pnpm --filter @sapiom/harness build
+```
+
+Expected: exit 0. (`harness-desktop` builds from this `dist/`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .changeset/deploy-auto-link.md
+git commit -m "docs: changeset for deploy auto-link"
+```
+
+---
+
+## Verification Notes for the Reviewer
+
+Two things this plan deliberately does **not** claim:
+
+1. **The backend `POST /definitions` route may not exist.**
+   `packages/cli/src/commands/agents/link.ts:12` records that the `--create`
+   path depended on tenant deploy routes added in a parallel effort. If that
+   route is not live, the user now sees a named failure with a hint
+   (`HTTP_404` + "Could not create the agent") instead of an opaque 409 — an
+   improvement, but not a working button. Confirm against a real tenant before
+   calling the feature done; the unit tests cover our side of the contract only.
+
+2. **`server/index.ts`'s seam wiring has no test of its own** (Task 3, Step 6).
+   Its correctness rests on the type system plus Task 2's seam-precedence tests.
+
+Out of scope, per the spec: `sapiom agents init` writes no `sapiom.json`, so a
+scaffolded (non-gallery) project is never discovered by the registry and never
+gets a Deploy button to click. Separate bug, separate fix.

--- a/docs/superpowers/specs/2026-07-30-deploy-auto-link-design.md
+++ b/docs/superpowers/specs/2026-07-30-deploy-auto-link-design.md
@@ -1,0 +1,209 @@
+# Deploy links (or creates) the remote agent when the project isn't linked yet
+
+Date: 2026-07-30
+Status: approved, ready for implementation plan
+
+## The bug
+
+Apply a gallery template, click **Deploy**, and nothing ships. The button is live —
+it is only auth-gated — but the request always fails.
+
+`clone()` writes `sapiom.json` with the fork provenance and no `definitionId`
+(`packages/agent-core/src/clone.ts:202`):
+
+```js
+...(definitionId ? { definitionId } : { forkId: resolvedForkId }),
+```
+
+That is deliberate. `packages/agent-core/src/config.ts:17` documents the intent:
+
+> Absent right after a template `clone` (the definition is created at `deploy`, D6)
+> and filled in by `link`.
+
+**The "created at `deploy`" half was never built.** So:
+
+1. The SPA routes the `deploy` macro to the direct server action, not the pty
+   (`web/src/lib/macro-actions.ts`).
+2. `POST /api/workflows/:id/deploy` reads the config
+   (`src/server/actions.ts:401`) and gets `null`.
+3. The route answers **409 `"workflow is not linked to a Sapiom agent"`**
+   (`src/server/actions.ts:402-407`).
+
+The Deploy button carries no `needsDeploy` gate (`web/src/components/SessionStepsBar.tsx:114-123`),
+so a fresh template offers a button that cannot succeed. `sapiom agents deploy`
+fails the same way, via `requireConfig()` → `NOT_LINKED`.
+
+The missing mechanism already exists: `link({ name, create: true })`
+(`packages/agent-core/src/link.ts`) lists `/definitions`, matches on name **or**
+slug, and only `POST /definitions` when nothing matched. That single call is both
+halves of what we need — resync to an existing remote agent, or create one.
+
+## Scope
+
+The harness deploy route only. The CLI and the agent-facing MCP deploy tool keep
+their current `NOT_LINKED` behaviour and their existing remedy
+(`sapiom agents link --create`); a scripted or CI deploy must not silently create
+a remote agent because it ran in the wrong directory.
+
+`agent-core`'s `deploy()` is not touched. It deliberately never writes
+`sapiom.json` — `link` is the only config writer — and that separation stays.
+
+## Design
+
+### Flow
+
+```
+POST /api/workflows/:id/deploy
+  400 id missing · 503 not signed in · 404 unknown workflow      [unchanged]
+
+  config = readDefinitionId(workflow.path)
+  ├─ bad-config → 409 "sapiom.json is not valid JSON"            [new]
+  ├─ linked     → straight to the build, no link call            [unchanged]
+  └─ unlinked   → commit 200 + NDJSON headers, then:
+         name = await resolveDefinitionName(workflow)
+         write { phase: "linking", name }
+         result = link({ name, create: true })
+         writeConfig(workflow.path, { definitionId: result.definitionId,
+                                      name: result.name })
+
+  write { phase: "building", definitionId }
+  deploy({ projectDir, definitionId }) → terminal ready | error
+```
+
+`link()` matching by name/slug before creating is what makes this "resync **or**
+create": re-deploying never duplicates an agent, and a template already deployed
+from another machine re-attaches to the existing definition instead of forking
+the user's cloud state.
+
+`writeConfig()` merges over the existing file (`agent-core/src/config.ts:70`), so
+the clone's `forkId`, `templateId`, `repoFullName` and `defaultBranch` all
+survive the write.
+
+Both the `link` and the `deploy` call go through the existing
+`withKeyRefreshRetry` helper, so a rejected key refreshes and retries once — the
+same recovery the build already gets.
+
+### Bad config must not create an orphan
+
+`readDefinitionId` currently swallows an unparseable `sapiom.json` as `null`
+(`src/server/actions.ts:267`, deliberately: "treat as not linked"). Under
+auto-link that becomes a defect — we would create a remote definition and only
+then fail, because `writeConfig` calls `readConfig`, which throws `BAD_CONFIG` on
+invalid JSON. The remote agent would exist with nothing recording it.
+
+So the helper returns a three-way result:
+
+```ts
+type ConfigState =
+  | { kind: "linked"; definitionId: string }
+  | { kind: "unlinked" }
+  | { kind: "bad-config" };
+```
+
+`bad-config` keeps a 409, with a message naming the real problem. No remote
+resource is created on a path that cannot record it.
+
+### Name of the created agent
+
+Fallback chain, first hit wins:
+
+1. **`graph.manifestName`** — the agent's own `defineAgent({ name })`, read via
+   `extractWorkflowGraphCached(path)` (`src/core/canvas-cache.ts`). Usually a
+   cache hit, because the canvas renders on bind. This is the name the codebase
+   already treats as authoritative: the registry stores it as `definitionSlug`
+   (`src/core/workflow-registry.ts:31`) and `config.ts:22` calls `sapiom.json`'s
+   `name` a cache of it.
+2. **`sapiom.json`'s `name`** — present for a project a previous `link` touched.
+3. **The registry name** — `package.json`'s `name`, else the folder basename
+   (`workflow-registry.ts:51-62`).
+
+Step 1 fails cheaply and silently when extraction cannot run (no `node_modules`
+yet, a bundle error), which is exactly when steps 2 and 3 apply.
+
+The name written back to `sapiom.json` is `link()`'s **returned** `name`, not the
+requested one — the server may normalize it, and the CLI's `link` command already
+caches the returned value (`cli/src/commands/agents/link.ts:28`). The `linking`
+stream line carries the requested name, since it is emitted before the call.
+
+Steps 1-3 live behind `resolveDefinitionName`, which is optional: when a host
+does not supply it the router falls back to steps 2 and 3 only (config name, then
+`ActionWorkflow.name`). That keeps the router's default free of any canvas
+dependency, and `src/server/index.ts` supplies the manifest-name implementation.
+
+### Seams
+
+The actions router reaches neither the registry nor the canvas today, and that
+does not change:
+
+| Where | Addition |
+| --- | --- |
+| `ActionsCoreDeps` | `link`, `writeConfig` — so no test touches network or fs |
+| `ActionsRouterOpts` | `resolveDefinitionName?: (w: ActionWorkflow) => Promise<string>` |
+| `ActionWorkflow` | `name: string` — the registry already carries it |
+| `src/server/index.ts:1174` | wires `resolveDefinitionName` to the canvas cache |
+
+### Stream shape
+
+`DeployStreamEvent` gains one non-terminal line:
+
+```ts
+| { phase: "linking"; name: string }
+```
+
+Emitted only on the unlinked path, before the `link` call. The union's mirror in
+`web/src/lib/api.ts` gains the same member, and `use-harness-state.ts`'s deploy
+handler gives it its own toast ("Creating the agent on Sapiom…") alongside the
+existing `building` toast. Terminal lines are unchanged: still exactly one
+`ready` or `error`.
+
+### Errors
+
+A link failure ends the stream with one terminal `error` line carrying its own
+code — never disguised as a build failure, and `deploy()` is never called.
+`toDeployErrorEvent` already maps an `AgentOperationError` to `{ code, message,
+hint }`, so a `NOT_FOUND`/`HTTP_*`/`NETWORK` from `link` surfaces as-is.
+
+**Known risk:** `cli/src/commands/agents/link.ts:12` records that the `--create`
+backend route (`POST /definitions`) was parallel work that may not have landed.
+If it 404s, the user sees a named failure with a hint instead of today's opaque
+409 — better, but the button will not fully work until that route is live. This
+is a backend dependency, not something this change can resolve. Verify against a
+real tenant before calling the feature done.
+
+### Desktop host
+
+No new packaging hazard (`packages/harness/CLAUDE.md`): `link` is a plain network
+call, and the only subprocess involved is the existing `runManifestCheck`, which
+already translates asar paths and sets `ELECTRON_RUN_AS_NODE`. Nothing new needs
+`asarUnpack`, and `smoke.ts` needs no new check.
+
+## Tests
+
+TDD — each test written and seen failing before the code that satisfies it.
+
+`src/server/actions.test.ts` (fakes for `link` / `writeConfig` / `deploy`):
+
+- unlinked project → stream is `linking` → `building` → `ready`; `link` called
+  once with `{ name, create: true }`; `definitionId` written to `sapiom.json`
+  with `forkId` and `templateId` preserved.
+- already-linked project → `link` never called, stream unchanged. Regression
+  guard for the common path.
+- `link` rejects → exactly one terminal `error` line with the operation's code;
+  `deploy` never called; nothing written.
+- unparseable `sapiom.json` → 409, `link` never called, no write.
+- rejected key on the `link` call → refresh + retry once, then proceed.
+- name resolution: manifest name wins; falls back to config name; falls back to
+  the registry name.
+
+`web/src/lib/api.test.ts` + the deploy handler: a `linking` line parses and sets
+its own toast without disturbing the terminal-event contract.
+
+Plus a changeset (patch, `@sapiom/harness`).
+
+## Out of scope, deliberately
+
+`sapiom agents init` writes no `sapiom.json` at all, so a scaffolded
+(non-gallery) project is never discovered by the registry
+(`workflow-registry.ts:43` scans for that marker) and therefore never gets a
+Deploy button to click. That is a separate bug with a separate fix; it is not
+addressed here.

--- a/packages/harness/src/core/definition-name.test.ts
+++ b/packages/harness/src/core/definition-name.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveManifestName } from "./definition-name.js";
+
+/** A cached-extraction result shaped like canvas-cache's, with just the field
+ *  under test populated. */
+function extraction(manifestName: string) {
+  return {
+    result: {
+      ok: true as const,
+      graph: {
+        manifestName,
+        entry: "start",
+        nodes: [],
+        edges: [],
+        warnings: [],
+      },
+    },
+    cached: true,
+    fingerprint: "1:1",
+  };
+}
+
+describe("resolveManifestName", () => {
+  it("returns the agent's declared manifest name", async () => {
+    const extract = vi.fn().mockResolvedValue(extraction("order-triage"));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBe("order-triage");
+    expect(extract).toHaveBeenCalledWith("/proj/agent");
+  });
+
+  it("returns null when extraction failed", async () => {
+    // The usual cause: node_modules isn't installed yet, so the check process
+    // cannot bundle. The caller falls back to another name source.
+    const extract = vi.fn().mockResolvedValue({
+      result: { ok: false as const, reason: "run npm install first" },
+      cached: false,
+      fingerprint: "0:0",
+    });
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+
+  it("returns null when extraction throws", async () => {
+    const extract = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+
+  it("returns null for a blank manifest name", async () => {
+    const extract = vi.fn().mockResolvedValue(extraction("   "));
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+  });
+});

--- a/packages/harness/src/core/definition-name.ts
+++ b/packages/harness/src/core/definition-name.ts
@@ -1,0 +1,29 @@
+/**
+ * The name to give a server-side agent the deploy route has to create for a
+ * project that was never linked (a gallery-template clone).
+ *
+ * The honest answer is the agent's own `defineAgent({ name })`, which the
+ * canvas extraction already surfaces as `graph.manifestName` — and which the
+ * registry stores as `definitionSlug` and `sapiom.json` caches as `name`. Read
+ * through the fingerprint cache (core/canvas-cache.ts), so this is normally
+ * free: the canvas renders on bind, so the extraction is already warm.
+ *
+ * Never throws and never blocks a deploy: any failure (no `node_modules` yet,
+ * a bundle error, the check process timing out) comes back as null and the
+ * caller falls back to a weaker name source.
+ */
+import { extractWorkflowGraphCached } from "./canvas-cache.js";
+
+export async function resolveManifestName(
+  projectDir: string,
+  extract: typeof extractWorkflowGraphCached = extractWorkflowGraphCached,
+): Promise<string | null> {
+  try {
+    const { result } = await extract(projectDir);
+    if (!result.ok) return null;
+    return result.graph.manifestName.trim() || null;
+  } catch {
+    // Extraction is best-effort here — a name is a nicety, a deploy is not.
+    return null;
+  }
+}

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -329,6 +329,129 @@ describe("createActionsRouter", () => {
       );
     });
 
+    it("calls onLinked exactly once with the workflow, after writeConfig, on a first-time link", async () => {
+      // The registry's list() never re-reads sapiom.json and the workspace
+      // watcher ignores a content-only edit, so the host needs telling that a
+      // project just went from unlinked to linked in order to rescan it.
+      const order: string[] = [];
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        writeConfig: vi.fn().mockImplementation(() => {
+          order.push("writeConfig");
+        }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      const onLinked = vi.fn().mockImplementation(async () => {
+        order.push("onLinked");
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+        onLinked,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      await res.text();
+
+      expect(onLinked).toHaveBeenCalledTimes(1);
+      expect(onLinked).toHaveBeenCalledWith({ path: "/proj/agent", name: "order-triage" });
+      expect(order).toEqual(["writeConfig", "onLinked"]);
+    });
+
+    it("does not call onLinked when the project is already linked", async () => {
+      const coreDeps = makeCoreDeps({
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_123",
+          buildRunId: "build_9",
+          status: "ready",
+        }),
+      });
+      const onLinked = vi.fn().mockResolvedValue(undefined);
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent" }),
+        coreDeps,
+        onLinked,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      await res.text();
+
+      expect(onLinked).not.toHaveBeenCalled();
+    });
+
+    it("still calls onLinked when writeConfig failed (the warning path)", async () => {
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        writeConfig: vi.fn().mockImplementation(() => {
+          throw new Error("EACCES: permission denied, open '/proj/agent/sapiom.json'");
+        }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      const onLinked = vi.fn().mockResolvedValue(undefined);
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+        onLinked,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      await res.text();
+
+      // A rescan is harmless whether or not the cache write succeeded, and
+      // there's nothing new to re-read when it failed either way.
+      expect(onLinked).toHaveBeenCalledTimes(1);
+      expect(onLinked).toHaveBeenCalledWith({ path: "/proj/agent", name: "order-triage" });
+    });
+
+    it("still produces a normal ready terminal and still deploys when onLinked rejects", async () => {
+      // onLinked is never expected to throw, but a rejection must not cost the
+      // user their build — it is awaited only for ordering, then swallowed.
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      const onLinked = vi.fn().mockRejectedValue(new Error("rescan blew up"));
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+        onLinked,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+      const events = parseNdjson(await res.text());
+
+      expect(events).toEqual([
+        { phase: "linking", name: "order-triage" },
+        { phase: "building", definitionId: "def_new" },
+        { phase: "ready", definitionId: "def_new", buildRunId: "build_1", status: "ready" },
+      ]);
+      expect(coreDeps.deploy).toHaveBeenCalledWith(
+        { projectDir: "/proj/agent", definitionId: "def_new" },
+        expect.anything(),
+      );
+      expect(onLinked).toHaveBeenCalledTimes(1);
+    });
+
     it("warns (but still builds) when linking succeeds but caching it to sapiom.json fails", async () => {
       // sapiom.json is a re-resolvable cache (agent-core/src/config.ts) and link()
       // re-resolves the same agent by name — so a failed cache write (read-only

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -363,6 +363,14 @@ describe("createActionsRouter", () => {
       expect(events[1].message).toEqual(
         expect.stringContaining("def_new"),
       );
+      // The project itself is still unlinked locally — only the remote agent
+      // exists — so the message must not read as "your project is linked".
+      expect(events[1].message).toEqual(
+        expect.stringContaining("was created on Sapiom"),
+      );
+      expect(events[1].message).toEqual(
+        expect.stringContaining("not recorded locally"),
+      );
       expect(events[1].message).toEqual(
         expect.stringContaining("nothing is duplicated"),
       );

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -495,7 +495,7 @@ describe("createActionsRouter", () => {
         expect.stringContaining("not recorded locally"),
       );
       expect(events[1].message).toEqual(
-        expect.stringContaining("nothing is duplicated"),
+        expect.stringContaining("re-deploying re-resolves it by name"),
       );
       expect(events[2]).toEqual({ phase: "building", definitionId: "def_new" });
       expect(events[3]).toEqual({

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -318,6 +318,8 @@ describe("createActionsRouter", () => {
         method: "POST",
       });
       expect(res.status).toBe(409);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("sapiom.json is not valid JSON");
       expect(coreDeps.deploy).not.toHaveBeenCalled();
     });
 

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -29,6 +29,8 @@ function makeCoreDeps(overrides: Partial<ActionsRouterOpts["coreDeps"]> = {}) {
     deploy: vi.fn(),
     run: vi.fn(),
     readConfig: vi.fn().mockReturnValue({ definitionId: "def_123" }),
+    link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+    writeConfig: vi.fn(),
     ...overrides,
   } as NonNullable<ActionsRouterOpts["coreDeps"]> & { __client?: unknown };
 }
@@ -278,10 +280,63 @@ describe("createActionsRouter", () => {
       expect(coreDeps.deploy).not.toHaveBeenCalled();
     });
 
-    it("returns 409 when the workflow has no linked definitionId", async () => {
+    it("links (creating the agent) then deploys when the project is not linked yet", async () => {
+      // A fresh gallery-template clone: sapiom.json carries the fork
+      // provenance and no definitionId. This is the case that used to 409.
       const coreDeps = makeCoreDeps({
-        // sapiom.json present but not linked (no definitionId).
-        readConfig: vi.fn().mockReturnValue({}),
+        readConfig: vi.fn().mockReturnValue({ forkId: "fork_7", templateId: "order-triage" }),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // The linking line precedes building, and the stream still ends with
+      // exactly one terminal line.
+      expect(parseNdjson(await res.text())).toEqual([
+        { phase: "linking", name: "order-triage" },
+        { phase: "building", definitionId: "def_new" },
+        { phase: "ready", definitionId: "def_new", buildRunId: "build_1", status: "ready" },
+      ]);
+
+      // create: true is what makes this work on an agent that does not exist
+      // remotely yet; link() itself matches an existing one by name/slug first.
+      expect(coreDeps.link).toHaveBeenCalledWith(
+        { name: "order-triage", create: true },
+        expect.anything(),
+      );
+      // The id is cached under the name the SERVER returned, and writeConfig
+      // merges, so the clone's forkId/templateId survive.
+      expect(coreDeps.writeConfig).toHaveBeenCalledWith("/proj/agent", {
+        definitionId: "def_new",
+        name: "order-triage",
+      });
+      // The build then runs against the freshly linked id.
+      expect(coreDeps.deploy).toHaveBeenCalledWith(
+        { projectDir: "/proj/agent", definitionId: "def_new" },
+        expect.anything(),
+      );
+    });
+
+    it("does not link when the project is already linked", async () => {
+      // Regression guard for the common path: a linked project must never pay
+      // for a definitions round-trip, and its stream shape is unchanged.
+      const coreDeps = makeCoreDeps({
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_123",
+          buildRunId: "build_9",
+          status: "ready",
+        }),
       });
       start({
         apiKey: "sk-test-key",
@@ -289,13 +344,162 @@ describe("createActionsRouter", () => {
         coreDeps,
       });
 
-      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, {
-        method: "POST",
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      const events = parseNdjson(await res.text());
+
+      expect(coreDeps.link).not.toHaveBeenCalled();
+      expect(coreDeps.writeConfig).not.toHaveBeenCalled();
+      expect(events[0]).toEqual({ phase: "building", definitionId: "def_123" });
+    });
+
+    it("ends the stream with one terminal error when linking fails, without building", async () => {
+      const { AgentOperationError } = await import("@sapiom/agent-core");
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockRejectedValue(
+          new AgentOperationError({
+            code: "HTTP_404",
+            message: "Could not create the agent.",
+            hint: "The tenant deploy routes may not be enabled.",
+          }),
+        ),
       });
-      expect(res.status).toBe(409);
-      const body = (await res.json()) as Record<string, unknown>;
-      expect(body.error).toBe("workflow is not linked to a Sapiom agent");
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "agent" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // A link failure is reported as itself — never disguised as a build
+      // failure — and nothing is written or built.
+      expect(parseNdjson(await res.text())).toEqual([
+        { phase: "linking", name: "agent" },
+        {
+          phase: "error",
+          code: "HTTP_404",
+          message: "Could not create the agent.",
+          hint: "The tenant deploy routes may not be enabled.",
+        },
+      ]);
       expect(coreDeps.deploy).not.toHaveBeenCalled();
+      expect(coreDeps.writeConfig).not.toHaveBeenCalled();
+    });
+
+    it("refreshes the key once and retries when linking is rejected as unauthorized", async () => {
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi
+          .fn()
+          .mockRejectedValueOnce(await makeAuthRejection(401))
+          .mockResolvedValue({ definitionId: "def_new", name: "agent" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      const provider = refreshingProvider("sk-stale", "sk-fresh");
+      start({
+        apiKey: provider,
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "agent" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      const events = parseNdjson(await res.text());
+
+      expect(provider.refreshCalls).toBe(1);
+      expect(coreDeps.link).toHaveBeenCalledTimes(2);
+      // The retry is transparent: no extra linking line, normal terminal.
+      expect(events.filter((e) => e.phase === "linking")).toHaveLength(1);
+      expect(events.at(-1)).toMatchObject({ phase: "ready", definitionId: "def_new" });
+    });
+
+    it("names the created agent from the resolveDefinitionName seam when it resolves", async () => {
+      // The seam supplies the agent's declared manifest name, which wins over
+      // both sapiom.json's cached name and the registry name.
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({ name: "cached-name" }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "b",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "registry-name" }),
+        resolveDefinitionName: () => Promise.resolve("manifest-name"),
+        coreDeps,
+      });
+
+      await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+
+      expect(coreDeps.link).toHaveBeenCalledWith(
+        { name: "manifest-name", create: true },
+        expect.anything(),
+      );
+    });
+
+    it("falls back to the cached name, then the registry name, then the folder", async () => {
+      // The seam is absent or fails (no node_modules yet, a bundle error) —
+      // each fallback in turn must still yield a usable name.
+      const cases: Array<{
+        config: Record<string, unknown>;
+        workflow: { path: string; name?: string };
+        seam?: () => Promise<string | null>;
+        expected: string;
+      }> = [
+        // Seam rejects → sapiom.json's cached name.
+        {
+          config: { name: "cached-name" },
+          workflow: { path: "/proj/agent", name: "registry-name" },
+          seam: () => Promise.reject(new Error("no node_modules")),
+          expected: "cached-name",
+        },
+        // No seam, no cached name → the registry name.
+        {
+          config: {},
+          workflow: { path: "/proj/agent", name: "registry-name" },
+          expected: "registry-name",
+        },
+        // Nothing at all → the project folder's basename.
+        {
+          config: {},
+          workflow: { path: "/proj/my-agent" },
+          seam: () => Promise.resolve(null),
+          expected: "my-agent",
+        },
+      ];
+
+      for (const testCase of cases) {
+        const coreDeps = makeCoreDeps({
+          readConfig: vi.fn().mockReturnValue(testCase.config),
+          deploy: vi.fn().mockResolvedValue({
+            definitionId: "def_new",
+            buildRunId: "b",
+            status: "ready",
+          }),
+        });
+        start({
+          apiKey: "sk-test-key",
+          resolveWorkflow: () => testCase.workflow,
+          ...(testCase.seam ? { resolveDefinitionName: testCase.seam } : {}),
+          coreDeps,
+        });
+
+        await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+
+        expect(coreDeps.link).toHaveBeenCalledWith(
+          { name: testCase.expected, create: true },
+          expect.anything(),
+        );
+        // Each iteration starts its own server; close it before the next.
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
 
     it("returns 409 when sapiom.json is unreadable/unparseable", async () => {

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -285,7 +285,7 @@ describe("createActionsRouter", () => {
       // provenance and no definitionId. This is the case that used to 409.
       const coreDeps = makeCoreDeps({
         readConfig: vi.fn().mockReturnValue({ forkId: "fork_7", templateId: "order-triage" }),
-        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage-canonical" }),
         deploy: vi.fn().mockResolvedValue({
           definitionId: "def_new",
           buildRunId: "build_1",
@@ -315,13 +315,67 @@ describe("createActionsRouter", () => {
         { name: "order-triage", create: true },
         expect.anything(),
       );
-      // The id is cached under the name the SERVER returned, and writeConfig
-      // merges, so the clone's forkId/templateId survive.
+      // The id is cached under the name the SERVER returned (not the requested
+      // name — they differ here on purpose, to prove which one wins), and
+      // writeConfig merges, so the clone's forkId/templateId survive.
       expect(coreDeps.writeConfig).toHaveBeenCalledWith("/proj/agent", {
         definitionId: "def_new",
-        name: "order-triage",
+        name: "order-triage-canonical",
       });
       // The build then runs against the freshly linked id.
+      expect(coreDeps.deploy).toHaveBeenCalledWith(
+        { projectDir: "/proj/agent", definitionId: "def_new" },
+        expect.anything(),
+      );
+    });
+
+    it("warns (but still builds) when linking succeeds but caching it to sapiom.json fails", async () => {
+      // sapiom.json is a re-resolvable cache (agent-core/src/config.ts) and link()
+      // re-resolves the same agent by name — so a failed cache write (read-only
+      // checkout, EACCES, config gone invalid between the 409 check and the
+      // write) must not cost the user their deploy. It's best-effort: warn, and
+      // carry on with the id already in hand.
+      const coreDeps = makeCoreDeps({
+        readConfig: vi.fn().mockReturnValue({}),
+        link: vi.fn().mockResolvedValue({ definitionId: "def_new", name: "order-triage" }),
+        writeConfig: vi.fn().mockImplementation(() => {
+          throw new Error("EACCES: permission denied, open '/proj/agent/sapiom.json'");
+        }),
+        deploy: vi.fn().mockResolvedValue({
+          definitionId: "def_new",
+          buildRunId: "build_1",
+          status: "ready",
+        }),
+      });
+      start({
+        apiKey: "sk-test-key",
+        resolveWorkflow: () => ({ path: "/proj/agent", name: "order-triage" }),
+        coreDeps,
+      });
+
+      const res = await fetch(`${baseUrl}/api/workflows/wf-1/deploy`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      const events = parseNdjson(await res.text());
+      expect(events).toHaveLength(4);
+      expect(events[0]).toEqual({ phase: "linking", name: "order-triage" });
+      expect(events[1].phase).toBe("warning");
+      expect(events[1].message).toEqual(
+        expect.stringContaining("def_new"),
+      );
+      expect(events[1].message).toEqual(
+        expect.stringContaining("nothing is duplicated"),
+      );
+      expect(events[2]).toEqual({ phase: "building", definitionId: "def_new" });
+      expect(events[3]).toEqual({
+        phase: "ready",
+        definitionId: "def_new",
+        buildRunId: "build_1",
+        status: "ready",
+      });
+
+      // The whole point of the override: the build still runs against the
+      // linked id even though the cache write failed.
       expect(coreDeps.deploy).toHaveBeenCalledWith(
         { projectDir: "/proj/agent", definitionId: "def_new" },
         expect.anything(),
@@ -349,7 +403,10 @@ describe("createActionsRouter", () => {
 
       expect(coreDeps.link).not.toHaveBeenCalled();
       expect(coreDeps.writeConfig).not.toHaveBeenCalled();
-      expect(events[0]).toEqual({ phase: "building", definitionId: "def_123" });
+      expect(events).toEqual([
+        { phase: "building", definitionId: "def_123" },
+        { phase: "ready", definitionId: "def_123", buildRunId: "build_9", status: "ready" },
+      ]);
     });
 
     it("ends the stream with one terminal error when linking fails, without building", async () => {
@@ -525,6 +582,10 @@ describe("createActionsRouter", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.error).toBe("sapiom.json is not valid JSON");
       expect(coreDeps.deploy).not.toHaveBeenCalled();
+      // An unparseable config must never reach link() — the entire reason
+      // "bad-config" is a distinct state from "unlinked".
+      expect(coreDeps.link).not.toHaveBeenCalled();
+      expect(coreDeps.writeConfig).not.toHaveBeenCalled();
     });
 
     it("returns 503 (no network) when the harness has no API key", async () => {

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -71,12 +71,15 @@ export interface ActionWorkflow {
 /**
  * One line of the deploy NDJSON stream. `linking` is emitted only when the
  * project had no `definitionId` and the route is resolving-or-creating its
- * remote agent; `building` is emitted once the build is triggered; exactly one
- * terminal line (`ready` | `error`) closes the stream. `capability`-agnostic
- * and credential-free by construction.
+ * remote agent; `warning` is non-terminal and advisory — it never replaces a
+ * terminal line and may appear alongside either outcome (e.g. linking
+ * succeeded but caching the id in `sapiom.json` failed); `building` is emitted
+ * once the build is triggered; exactly one terminal line (`ready` | `error`)
+ * closes the stream. `capability`-agnostic and credential-free by construction.
  */
 export type DeployStreamEvent =
   | { phase: "linking"; name: string }
+  | { phase: "warning"; message: string }
   | { phase: "building"; definitionId: string }
   | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
   | { phase: "error"; code: string; message: string; hint?: string };
@@ -435,10 +438,24 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
       // Cache under the name the SERVER settled on, matching what
       // `sapiom agents link` writes. writeConfig merges, so the clone's
       // forkId/templateId/repoFullName survive.
-      deps.writeConfig(workflow.path, {
-        definitionId: linked.definitionId,
-        name: linked.name,
-      });
+      //
+      // Best-effort: sapiom.json is a re-resolvable cache (agent-core's
+      // config.ts) and `link` re-resolves the same agent by name, so a failed
+      // write here (read-only checkout, EACCES, a config that turned invalid
+      // between the 409 check above and this write) must not cost the user
+      // their deploy — warn and carry on with the id already in hand.
+      try {
+        deps.writeConfig(workflow.path, {
+          definitionId: linked.definitionId,
+          name: linked.name,
+        });
+      } catch (cacheErr) {
+        write({
+          phase: "warning",
+          message:
+            `The agent "${linked.name}" is linked (${linked.definitionId}) but could not be recorded in sapiom.json: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves the same agent, so nothing is duplicated.`,
+        });
+      }
       return linked.definitionId;
     };
 

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -197,24 +197,34 @@ export interface ActionsRouterOpts {
 }
 
 /**
- * Extract the linked `definitionId` from a project's `sapiom.json`. The config
- * file — not the registry — is the source of truth for a project's server-side
- * definition id, so both deploy and (a future) resolve path read it here. Never
- * throws: an unlinked/unreadable project returns null and the route maps that to
- * a 409.
+ * What a project's `sapiom.json` says about its server-side identity. Three
+ * states, not two: an unlinked project is fixable by linking on the spot (the
+ * deploy route does exactly that), while an unparseable file is not — and
+ * telling them apart matters, because `writeConfig` re-reads the file and
+ * throws BAD_CONFIG on invalid JSON. Auto-linking on a broken config would
+ * create a remote agent and then fail to record it, orphaning it.
+ *
+ * `name` on the unlinked state is the cached agent name a previous `link`
+ * wrote, if any — the deploy route uses it to name the agent it creates.
  */
-function readDefinitionId(
+type ProjectConfigState =
+  | { kind: "linked"; definitionId: string }
+  | { kind: "unlinked"; name?: string }
+  | { kind: "bad-config" };
+
+function readProjectConfigState(
   readConfig: typeof coreReadConfig,
   projectDir: string,
-): string | null {
+): ProjectConfigState {
   let config: SapiomConfig | null;
   try {
     config = readConfig(projectDir);
   } catch {
-    // BAD_CONFIG (unparseable sapiom.json) — treat as "not linked" for the route.
-    return null;
+    return { kind: "bad-config" };
   }
-  return config?.definitionId ?? null;
+  const definitionId = config?.definitionId;
+  if (definitionId) return { kind: "linked", definitionId };
+  return config?.name ? { kind: "unlinked", name: config.name } : { kind: "unlinked" };
 }
 
 /**
@@ -344,13 +354,18 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
       return;
     }
 
-    const definitionId = readDefinitionId(deps.readConfig, workflow.path);
-    if (!definitionId) {
+    const configState = readProjectConfigState(deps.readConfig, workflow.path);
+    if (configState.kind === "bad-config") {
+      res.status(409).json({ error: "sapiom.json is not valid JSON" });
+      return;
+    }
+    if (configState.kind === "unlinked") {
       res
         .status(409)
         .json({ error: "workflow is not linked to a Sapiom agent" });
       return;
     }
+    const definitionId = configState.definitionId;
 
     // From here the outcome is streamed in-band as NDJSON — status is 200 and
     // headers are committed before the (potentially long) build runs.

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -467,7 +467,7 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
         write({
           phase: "warning",
           message:
-            `The agent "${linked.name}" was created on Sapiom (${linked.definitionId}) but not recorded locally: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves the same agent, so nothing is duplicated.`,
+            `The agent "${linked.name}" was created on Sapiom (${linked.definitionId}) but not recorded locally: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves it by name.`,
         });
       }
       // Best-effort, same as the cache write above, and run whether or not it

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -26,7 +26,7 @@
 
 import { spawn as spawnChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Router } from "express";
@@ -34,9 +34,12 @@ import {
   AgentOperationError,
   createClient,
   deploy as coreDeploy,
+  link as coreLink,
   run as coreRun,
   readConfig as coreReadConfig,
+  writeConfig as coreWriteConfig,
   type DeployResult,
+  type LinkResult,
   type RunResult,
   type SapiomConfig,
 } from "@sapiom/agent-core";
@@ -57,14 +60,23 @@ import {
 export interface ActionWorkflow {
   /** Absolute path to the agent project directory (deploy's `projectDir`). */
   path: string;
+  /**
+   * Registry display name (`package.json`'s `name`, else the folder basename).
+   * Optional so a host that only knows the path still works; used as a
+   * mid-priority fallback when naming an agent this route has to create.
+   */
+  name?: string;
 }
 
 /**
- * One line of the deploy NDJSON stream. `building` is emitted once the build is
- * triggered; exactly one terminal line (`ready` | `error`) closes the stream.
- * `capability`-agnostic and credential-free by construction.
+ * One line of the deploy NDJSON stream. `linking` is emitted only when the
+ * project had no `definitionId` and the route is resolving-or-creating its
+ * remote agent; `building` is emitted once the build is triggered; exactly one
+ * terminal line (`ready` | `error`) closes the stream. `capability`-agnostic
+ * and credential-free by construction.
  */
 export type DeployStreamEvent =
+  | { phase: "linking"; name: string }
   | { phase: "building"; definitionId: string }
   | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
   | { phase: "error"; code: string; message: string; hint?: string };
@@ -79,6 +91,10 @@ export interface ActionsCoreDeps {
   deploy: typeof coreDeploy;
   run: typeof coreRun;
   readConfig: typeof coreReadConfig;
+  /** Resolve-or-create the server-side agent for an unlinked project. */
+  link: typeof coreLink;
+  /** Cache the linked id back into `sapiom.json` (merges; never clobbers). */
+  writeConfig: typeof coreWriteConfig;
 }
 
 const DEFAULT_CORE_DEPS: ActionsCoreDeps = {
@@ -86,6 +102,8 @@ const DEFAULT_CORE_DEPS: ActionsCoreDeps = {
   deploy: coreDeploy,
   run: coreRun,
   readConfig: coreReadConfig,
+  link: coreLink,
+  writeConfig: coreWriteConfig,
 };
 
 /**
@@ -185,6 +203,18 @@ export interface ActionsRouterOpts {
    * registry — the router does not read the registry directly.
    */
   resolveWorkflow: (id: string) => ActionWorkflow | null;
+  /**
+   * The agent's DECLARED name (`defineAgent({ name })`) for a project the route
+   * has to link on the fly, or null when it cannot be determined. Optional: the
+   * route falls back to `sapiom.json`'s cached name, then
+   * {@link ActionWorkflow.name}, then the project folder's basename.
+   *
+   * A seam rather than a direct call so this router keeps knowing nothing about
+   * the canvas extraction cache (see core/definition-name.ts, which
+   * `server/index.ts` wires in here). Never expected to throw — a rejection is
+   * treated as "could not determine".
+   */
+  resolveDefinitionName?: (workflow: ActionWorkflow) => Promise<string | null>;
   /** Injectable core operations. Test seam; defaults to the real exports. */
   coreDeps?: Partial<ActionsCoreDeps>;
   /**
@@ -329,12 +359,14 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
    * pushes the synthesized tree, triggers a build, and polls to a terminal
    * status — all inside @sapiom/agent-core's {@link deploy}. Streams NDJSON: a
    * `building` line up front, then exactly one terminal `ready`/`error` line.
+   * A project with no `definitionId` yet is linked on the fly first (a
+   * `linking` line precedes `building`) rather than rejected.
    *
    * 200  NDJSON stream (even a build failure is a 200 with a terminal `error`
    *      line — the request itself succeeded; the build outcome is in-band).
    * 400  id missing/empty
    * 404  workflow id not registered
-   * 409  workflow is not linked to a Sapiom agent (no definitionId)
+   * 409  sapiom.json is unparseable
    * 503  harness is not signed in to Sapiom
    */
   router.post("/api/workflows/:id/deploy", async (req, res) => {
@@ -359,13 +391,6 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
       res.status(409).json({ error: "sapiom.json is not valid JSON" });
       return;
     }
-    if (configState.kind === "unlinked") {
-      res
-        .status(409)
-        .json({ error: "workflow is not linked to a Sapiom agent" });
-      return;
-    }
-    const definitionId = configState.definitionId;
 
     // From here the outcome is streamed in-band as NDJSON — status is 200 and
     // headers are committed before the (potentially long) build runs.
@@ -376,9 +401,53 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
       res.write(JSON.stringify(event) + "\n");
     };
 
-    write({ phase: "building", definitionId });
+    /**
+     * The definition id to build against: the linked one, or a freshly
+     * resolved-or-created one for a project that has never been linked (a
+     * gallery-template clone lands exactly this way — `clone` writes the fork
+     * provenance and leaves `definitionId` for deploy to fill in).
+     *
+     * `link({ create: true })` matches an existing remote agent by name/slug
+     * BEFORE creating one, so this is resync-or-create: re-deploying never
+     * duplicates an agent, and a template already deployed from another machine
+     * re-attaches to the same definition.
+     */
+    const ensureDefinitionId = async (): Promise<string> => {
+      if (configState.kind === "linked") return configState.definitionId;
+
+      const fromSeam = opts.resolveDefinitionName
+        ? await opts.resolveDefinitionName(workflow).catch(() => null)
+        : null;
+      const name =
+        fromSeam?.trim() ||
+        configState.name?.trim() ||
+        workflow.name?.trim() ||
+        basename(workflow.path);
+
+      write({ phase: "linking", name });
+      // Same refresh-on-rejected-key recovery the build gets; the retry is
+      // transparent to the stream (no second linking line).
+      const linked: LinkResult = await withKeyRefreshRetry(
+        provider,
+        clientFor,
+        (client) => deps.link({ name, create: true }, client),
+      );
+      // Cache under the name the SERVER settled on, matching what
+      // `sapiom agents link` writes. writeConfig merges, so the clone's
+      // forkId/templateId/repoFullName survive.
+      deps.writeConfig(workflow.path, {
+        definitionId: linked.definitionId,
+        name: linked.name,
+      });
+      return linked.definitionId;
+    };
 
     try {
+      // A link failure throws out of here and is mapped by the same
+      // toDeployErrorEvent below — reported as itself, never as a build
+      // failure, and `deploy` is never reached.
+      const definitionId = await ensureDefinitionId();
+      write({ phase: "building", definitionId });
       // Auth against the live key, refreshing + retrying once on a rejected key
       // (same recovery the runs router gets). The building/terminal streaming
       // shape is unchanged — the retry is transparent to the NDJSON stream.

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -218,6 +218,18 @@ export interface ActionsRouterOpts {
    * treated as "could not determine".
    */
   resolveDefinitionName?: (workflow: ActionWorkflow) => Promise<string | null>;
+  /**
+   * Called after the route has linked a previously-unlinked project and cached
+   * its new `definitionId`, so the host can refresh whatever it derives from
+   * `sapiom.json`. The registry's `list()` never re-reads the file and the
+   * workspace watcher ignores a content-only edit, so without this a
+   * first-time deploy leaves the SPA showing "Draft" with Prod Run gated.
+   *
+   * A seam rather than a direct call so this router keeps knowing nothing about
+   * the workflow registry (`server/index.ts` wires it). Never expected to
+   * throw — a rejection must not cost the user their build.
+   */
+  onLinked?: (workflow: ActionWorkflow) => Promise<void>;
   /** Injectable core operations. Test seam; defaults to the real exports. */
   coreDeps?: Partial<ActionsCoreDeps>;
   /**
@@ -458,6 +470,13 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
             `The agent "${linked.name}" was created on Sapiom (${linked.definitionId}) but not recorded locally: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves the same agent, so nothing is duplicated.`,
         });
       }
+      // Best-effort, same as the cache write above, and run whether or not it
+      // succeeded: a rescan is harmless either way, and there is nothing new to
+      // re-read when the write failed. Without this, the registry's list()
+      // never re-reads sapiom.json and the workspace watcher ignores a
+      // content-only edit, so the SPA would keep showing "Draft" after the
+      // very first successful deploy of a project.
+      if (opts.onLinked) await opts.onLinked(workflow).catch(() => undefined);
       return linked.definitionId;
     };
 

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -363,7 +363,9 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
    * status — all inside @sapiom/agent-core's {@link deploy}. Streams NDJSON: a
    * `building` line up front, then exactly one terminal `ready`/`error` line.
    * A project with no `definitionId` yet is linked on the fly first (a
-   * `linking` line precedes `building`) rather than rejected.
+   * `linking` line precedes `building`) rather than rejected; if the resolved
+   * agent's id could not be cached in `sapiom.json`, a non-terminal `warning`
+   * line follows before `building` continues.
    *
    * 200  NDJSON stream (even a build failure is a 200 with a terminal `error`
    *      line — the request itself succeeded; the build outcome is in-band).
@@ -453,7 +455,7 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
         write({
           phase: "warning",
           message:
-            `The agent "${linked.name}" is linked (${linked.definitionId}) but could not be recorded in sapiom.json: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves the same agent, so nothing is duplicated.`,
+            `The agent "${linked.name}" was created on Sapiom (${linked.definitionId}) but not recorded locally: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. The build continues; re-deploying re-resolves the same agent, so nothing is duplicated.`,
         });
       }
       return linked.definitionId;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1181,6 +1181,12 @@ export const startServer = async (
       // Prefer the agent's DECLARED name when deploy has to create it, read
       // from the same warm extraction cache the canvas renders from.
       resolveDefinitionName: (workflow) => resolveManifestName(workflow.path),
+      // A first-time deploy writes definitionId into an existing sapiom.json,
+      // which the watcher's directory-set diff cannot see — rescan that project
+      // so the Draft→Deployed chip and the deploy-gated actions update.
+      onLinked: async (workflow) => {
+        await scanWorkflowsAndBroadcast(workflow.path);
+      },
     }),
   );
   app.use(

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -98,6 +98,7 @@ import {
   createDefinitionSlugResolver,
   resolveAgentsBaseUrl,
 } from "../core/definition-slug-resolver.js";
+import { resolveManifestName } from "../core/definition-name.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createApiKeyProvider } from "../core/api-key-provider.js";
 import { createRestRouter } from "./rest.js";
@@ -1171,8 +1172,15 @@ export const startServer = async (
       apiKey: apiKeyProvider,
       // coreBaseUrl omitted: the router self-defaults via resolveCoreBaseUrl()
       // (see actions.ts), which derives the core host from the agents env.
-      resolveWorkflow: (id) =>
-        workflowsCache.find((w) => w.path === id) ?? null,
+      resolveWorkflow: (id) => {
+        const workflow = workflowsCache.find((w) => w.path === id);
+        // `name` is the registry's display name — a fallback for naming an
+        // agent the deploy route has to create.
+        return workflow ? { path: workflow.path, name: workflow.name } : null;
+      },
+      // Prefer the agent's DECLARED name when deploy has to create it, read
+      // from the same warm extraction cache the canvas renders from.
+      resolveDefinitionName: (workflow) => resolveManifestName(workflow.path),
     }),
   );
   app.use(

--- a/packages/harness/web/e2e/direct-actions.spec.ts
+++ b/packages/harness/web/e2e/direct-actions.spec.ts
@@ -176,6 +176,30 @@ test.describe("Deploy button — direct route, NDJSON build stream, no pty write
     // updates its local workflow copy, and refreshWorkflows re-reads it.
     await expect(page.getByTestId("session-lifecycle-chip")).toContainText("Deployed", { timeout: 3_000 });
   });
+
+  test("double-clicking Deploy on an undeployed workflow only creates the agent once", async ({ page }) => {
+    // rfq is unlinked (definitionId=null), so each deploy would call
+    // link({ create: true }) — a read-then-write with no uniqueness guard.
+    // Two concurrent deploys must not create two remote agents: the state
+    // layer's inFlightDeploys guard should collapse the second click into the
+    // first call's in-flight promise.
+    await page.getByTestId("workflow-rfq").locator(".workflow-item-trigger").click();
+    await page.getByTestId("open-agent-start-session").click();
+    await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");
+
+    const deployBtn = page.getByTestId("session-step-deploy");
+    await expect(deployBtn).toBeEnabled();
+
+    // Click twice in immediate succession, before the first deploy settles.
+    await deployBtn.click();
+    await deployBtn.click();
+
+    await expect(page.getByTestId("toast")).toContainText("Deployed to Sapiom.", { timeout: 5_000 });
+
+    const hook = await readTestHook(page);
+    const deploys = (hook?.directActions as Array<{ action: string }>).filter((a) => a.action === "deploy");
+    expect(deploys).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -57,6 +57,17 @@ describe("terminalDeployEvent", () => {
     ];
     expect(terminalDeployEvent(events)).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
   });
+
+  it("treats a warning line as non-terminal", async () => {
+    // `warning` is advisory (the agent was created but its id couldn't be
+    // written to sapiom.json) — it never closes the stream on its own.
+    const events: DeployStreamEvent[] = [
+      { phase: "linking", name: "order-triage" },
+      { phase: "warning", message: "Couldn't save the agent id to sapiom.json." },
+      { phase: "building", definitionId: "42" },
+    ];
+    expect(terminalDeployEvent(events)).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
+  });
 });
 
 describe("parseNdjsonLine of a linking event", () => {
@@ -64,6 +75,17 @@ describe("parseNdjsonLine of a linking event", () => {
     expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"linking","name":"order-triage"}')).toEqual({
       phase: "linking",
       name: "order-triage",
+    });
+  });
+});
+
+describe("parseNdjsonLine of a warning event", () => {
+  it("parses the warning phase and its message", () => {
+    expect(
+      parseNdjsonLine<DeployStreamEvent>('{"phase":"warning","message":"Couldn\'t save the agent id."}'),
+    ).toEqual({
+      phase: "warning",
+      message: "Couldn't save the agent id.",
     });
   });
 });

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -70,26 +70,6 @@ describe("terminalDeployEvent", () => {
   });
 });
 
-describe("parseNdjsonLine of a linking event", () => {
-  it("parses the linking phase and its name", () => {
-    expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"linking","name":"order-triage"}')).toEqual({
-      phase: "linking",
-      name: "order-triage",
-    });
-  });
-});
-
-describe("parseNdjsonLine of a warning event", () => {
-  it("parses the warning phase and its message", () => {
-    expect(
-      parseNdjsonLine<DeployStreamEvent>('{"phase":"warning","message":"Couldn\'t save the agent id."}'),
-    ).toEqual({
-      phase: "warning",
-      message: "Couldn't save the agent id.",
-    });
-  });
-});
-
 describe("parseNdjsonLine (deploy stream)", () => {
   it("parses a well-formed deploy event line", () => {
     expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"building","definitionId":"42"}')).toEqual({

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -47,6 +47,25 @@ describe("terminalDeployEvent", () => {
   it("synthesizes an error for an empty stream", () => {
     expect(terminalDeployEvent([])).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
   });
+
+  it("treats a linking line as non-terminal", async () => {
+    // The server emits `linking` before `building` when it has to create the
+    // agent; only ready/error may end the stream.
+    const events: DeployStreamEvent[] = [
+      { phase: "linking", name: "order-triage" },
+      { phase: "building", definitionId: "42" },
+    ];
+    expect(terminalDeployEvent(events)).toMatchObject({ phase: "error", code: "NO_OUTPUT" });
+  });
+});
+
+describe("parseNdjsonLine of a linking event", () => {
+  it("parses the linking phase and its name", () => {
+    expect(parseNdjsonLine<DeployStreamEvent>('{"phase":"linking","name":"order-triage"}')).toEqual({
+      phase: "linking",
+      name: "order-triage",
+    });
+  });
 });
 
 describe("parseNdjsonLine (deploy stream)", () => {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -80,11 +80,14 @@ export type RunLocalLine =
 /**
  * One line of the `POST /api/workflows/:id/deploy` NDJSON stream (mirrors
  * `DeployStreamEvent` in src/server/actions.ts): an optional `linking` line
- * when the server has to resolve-or-create the remote agent first, a `building`
- * line, then exactly one terminal `ready` | `error` line closing the stream.
+ * when the server has to resolve-or-create the remote agent first, an
+ * optional `warning` line (non-terminal, advisory — the agent was created but
+ * its id couldn't be written back to sapiom.json), a `building` line, then
+ * exactly one terminal `ready` | `error` line closing the stream.
  */
 export type DeployStreamEvent =
   | { phase: "linking"; name: string }
+  | { phase: "warning"; message: string }
   | { phase: "building"; definitionId: string }
   | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
   | { phase: "error"; code: string; message: string; hint?: string };

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -79,10 +79,12 @@ export type RunLocalLine =
 
 /**
  * One line of the `POST /api/workflows/:id/deploy` NDJSON stream (mirrors
- * `DeployStreamEvent` in src/server/actions.ts): a `building` line up front,
- * then exactly one terminal `ready` | `error` line closing the stream.
+ * `DeployStreamEvent` in src/server/actions.ts): an optional `linking` line
+ * when the server has to resolve-or-create the remote agent first, a `building`
+ * line, then exactly one terminal `ready` | `error` line closing the stream.
  */
 export type DeployStreamEvent =
+  | { phase: "linking"; name: string }
   | { phase: "building"; definitionId: string }
   | { phase: "ready"; definitionId: string; buildRunId: string; status: string }
   | { phase: "error"; code: string; message: string; hint?: string };
@@ -1162,6 +1164,14 @@ class MockApi implements HarnessApi {
     onEvent?: StreamLineHandler<DeployStreamEvent>,
   ): Promise<DeployStreamEvent> {
     this.recordDirectAction("deploy", { workflowPath });
+    // Mirror the real server: an unlinked workflow is linked (agent created)
+    // before the build, so mock mode exercises the same two-phase stream.
+    const target = this.workflows.find((w) => w.path === workflowPath);
+    if (target && target.definitionId == null) {
+      const linking: DeployStreamEvent = { phase: "linking", name: target.name };
+      onEvent?.(linking);
+      await delay(200);
+    }
     const building: DeployStreamEvent = { phase: "building", definitionId: "mock-def" };
     onEvent?.(building);
     await delay(400);

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -939,7 +939,13 @@ export function useHarnessState(): HarnessStateHook {
       setToast("Deploying — building on Sapiom…");
       try {
         const terminal = await api.deploy(workflowPath, (event) => {
-          if (event.phase === "building") setToast("Deploying — building on Sapiom…");
+          // A never-linked project (a fresh template clone) gets its agent
+          // created first — say so, rather than claiming we're building.
+          if (event.phase === "linking") {
+            setToast(`Deploying — creating the agent "${event.name}" on Sapiom…`);
+          } else if (event.phase === "building") {
+            setToast("Deploying — building on Sapiom…");
+          }
         });
         if (terminal.phase === "ready") {
           setToast("Deployed to Sapiom.");

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -254,6 +254,12 @@ export function useHarnessState(): HarnessStateHook {
   // affects the render, and both are read/written within a single call.
   const inFlightHistory = useRef<Map<string, Promise<SessionSummary[]>>>(new Map());
   const historyLoads = useRef(0);
+  // Deploys in flight, keyed by workflow path. A second click while one is
+  // running must not start another: for an UNLINKED project each deploy calls
+  // link({ create: true }), which is a read-then-write with no uniqueness
+  // guard, so two concurrent deploys create two remote agents. Same shape as
+  // inFlightHistory above.
+  const inFlightDeploys = useRef<Map<string, Promise<void>>>(new Map());
   const [lastMessage, setLastMessage] = useState<BusMessage | null>(null);
   const [busySessionIds, setBusySessionIds] = useState<Set<string>>(new Set());
   const [tasks, setTasks] = useState<BackgroundTask[]>([]);
@@ -935,51 +941,78 @@ export function useHarnessState(): HarnessStateHook {
   // the registry so a linked/rebuilt workflow's Deployed chip flips. Swallows
   // failures into the toast (like runMacro) — its caller fires it unawaited.
   const deploy = useCallback(
-    async (workflowPath: string): Promise<void> => {
-      setToast("Deploying — building on Sapiom…");
-      try {
-        const terminal = await api.deploy(workflowPath, (event) => {
-          // A never-linked project (a fresh template clone) gets its agent
-          // created first — say so, rather than claiming we're building.
-          if (event.phase === "linking") {
-            setToast(`Deploying — creating the agent "${event.name}" on Sapiom…`);
-          } else if (event.phase === "building") {
-            setToast("Deploying — building on Sapiom…");
-          }
-        });
-        if (terminal.phase === "ready") {
-          setToast("Deployed to Sapiom.");
-          // Clear any prior deploy error for this workflow — it succeeded.
-          setLastDeployErrorByPath((prev) => {
-            if (!prev.has(workflowPath)) return prev;
-            const next = new Map(prev);
-            next.delete(workflowPath);
-            return next;
+    (workflowPath: string): Promise<void> => {
+      // A second click while one is running returns the SAME in-flight
+      // promise instead of starting another — see inFlightDeploys above.
+      const existing = inFlightDeploys.current.get(workflowPath);
+      if (existing) return existing;
+
+      const run = (async (): Promise<void> => {
+        setToast("Deploying — building on Sapiom…");
+        // Which non-terminal phase was last seen, so a terminal `error` can
+        // say whether linking or building failed — both are the same wire
+        // shape, told apart only by what preceded them.
+        let lastNonTerminalPhase: "linking" | "building" | null = null;
+        try {
+          const terminal = await api.deploy(workflowPath, (event) => {
+            // A never-linked project (a fresh template clone) gets its agent
+            // created first — say so, rather than claiming we're building.
+            if (event.phase === "linking") {
+              lastNonTerminalPhase = "linking";
+              setToast(`Deploying — creating the agent "${event.name}" on Sapiom…`);
+            } else if (event.phase === "warning") {
+              // Non-terminal and advisory: the agent was created but its id
+              // couldn't be written back to sapiom.json. The message is
+              // already a complete, user-facing sentence composed
+              // server-side — pass it through verbatim. A later `building`
+              // legitimately replaces this toast.
+              setToast(event.message);
+            } else if (event.phase === "building") {
+              lastNonTerminalPhase = "building";
+              setToast("Deploying — building on Sapiom…");
+            }
           });
-          // A successful deploy links/rebuilds the agent — re-read the registry
-          // so definitionId (the Draft→Deployed truth) and the deploy-gated
-          // actions update without waiting on a bus refresh.
-          await refreshWorkflows();
-        } else if (terminal.phase === "error") {
-          const msg = terminal.hint
-            ? `Deploy failed: ${terminal.message} (${terminal.hint})`
-            : `Deploy failed: ${terminal.message}`;
+          if (terminal.phase === "ready") {
+            setToast("Deployed to Sapiom.");
+            // Clear any prior deploy error for this workflow — it succeeded.
+            setLastDeployErrorByPath((prev) => {
+              if (!prev.has(workflowPath)) return prev;
+              const next = new Map(prev);
+              next.delete(workflowPath);
+              return next;
+            });
+            // A successful deploy links/rebuilds the agent — re-read the registry
+            // so definitionId (the Draft→Deployed truth) and the deploy-gated
+            // actions update without waiting on a bus refresh.
+            await refreshWorkflows();
+          } else if (terminal.phase === "error") {
+            // Same error shape for a link failure and a build failure —
+            // distinguish them by whichever non-terminal phase preceded it.
+            const prefix = lastNonTerminalPhase === "linking" ? "Couldn't create the agent" : "Deploy failed";
+            const msg = terminal.hint
+              ? `${prefix}: ${terminal.message} (${terminal.hint})`
+              : `${prefix}: ${terminal.message}`;
+            setToast(msg);
+            // Persist the failure so the action bar can distinguish "last deploy
+            // failed" from "never deployed" after the toast is dismissed.
+            setLastDeployErrorByPath((prev) => new Map(prev).set(workflowPath, msg));
+          }
+        } catch (err) {
+          const msg = err instanceof ApiError && err.reason ? err.reason : (err as Error).message;
           setToast(msg);
-          // Persist the failure so the action bar can distinguish "last deploy
-          // failed" from "never deployed" after the toast is dismissed.
+          // An exception from the deploy stream (e.g. network error) also counts
+          // as a deploy failure — persist so the action bar reflects it.
           setLastDeployErrorByPath((prev) => new Map(prev).set(workflowPath, msg));
+        } finally {
+          // Signal that a deploy action settled (success or failure) so the
+          // SessionStepsBar can clear its pending ring for this button.
+          bumpDirectActionSettleSeq();
+          inFlightDeploys.current.delete(workflowPath);
         }
-      } catch (err) {
-        const msg = err instanceof ApiError && err.reason ? err.reason : (err as Error).message;
-        setToast(msg);
-        // An exception from the deploy stream (e.g. network error) also counts
-        // as a deploy failure — persist so the action bar reflects it.
-        setLastDeployErrorByPath((prev) => new Map(prev).set(workflowPath, msg));
-      } finally {
-        // Signal that a deploy action settled (success or failure) so the
-        // SessionStepsBar can clear its pending ring for this button.
-        bumpDirectActionSettleSeq();
-      }
+      })();
+
+      inFlightDeploys.current.set(workflowPath, run);
+      return run;
     },
     [refreshWorkflows, bumpDirectActionSettleSeq],
   );

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -948,11 +948,18 @@ export function useHarnessState(): HarnessStateHook {
       if (existing) return existing;
 
       const run = (async (): Promise<void> => {
-        setToast("Deploying — building on Sapiom…");
+        setToast("Deploying…");
         // Which non-terminal phase was last seen, so a terminal `error` can
         // say whether linking or building failed — both are the same wire
         // shape, told apart only by what preceded them.
         let lastNonTerminalPhase: "linking" | "building" | null = null;
+        // The warning line (if any), remembered the same way — NOT a ref, NOT
+        // shared state, just a per-call local — so it survives the `building`
+        // toast that follows it in the same chunk (the server writes `warning`
+        // then `building` back to back; without this the warning is
+        // overwritten before it's ever seen) and gets folded into the success
+        // toast instead.
+        let pendingWarning: string | null = null;
         try {
           const terminal = await api.deploy(workflowPath, (event) => {
             // A never-linked project (a fresh template clone) gets its agent
@@ -965,7 +972,9 @@ export function useHarnessState(): HarnessStateHook {
               // couldn't be written back to sapiom.json. The message is
               // already a complete, user-facing sentence composed
               // server-side — pass it through verbatim. A later `building`
-              // legitimately replaces this toast.
+              // legitimately replaces this toast, so it's also remembered
+              // above to resurface on success.
+              pendingWarning = event.message;
               setToast(event.message);
             } else if (event.phase === "building") {
               lastNonTerminalPhase = "building";
@@ -973,7 +982,7 @@ export function useHarnessState(): HarnessStateHook {
             }
           });
           if (terminal.phase === "ready") {
-            setToast("Deployed to Sapiom.");
+            setToast(pendingWarning ? `Deployed to Sapiom. ${pendingWarning}` : "Deployed to Sapiom.");
             // Clear any prior deploy error for this workflow — it succeeded.
             setLastDeployErrorByPath((prev) => {
               if (!prev.has(workflowPath)) return prev;


### PR DESCRIPTION
## The bug

Apply a gallery template, click **Deploy**, and nothing ships.

`clone()` writes `sapiom.json` with the fork provenance and no `definitionId` (`agent-core/src/clone.ts:202`). That is deliberate — `agent-core/src/config.ts:17` already documents it:

> Absent right after a template `clone` (the definition is created at `deploy`, D6) and filled in by `link`.

**The "created at `deploy`" half was never built.** So `POST /api/workflows/:id/deploy` read the config, got `null`, and answered `409 "workflow is not linked to a Sapiom agent"`. The Deploy button carries no deploy-gate (only an auth gate), so a fresh template offered a live button that could not succeed.

## The fix

The route now resolves-or-creates the remote agent before building, via agent-core's existing `link({ name, create: true })` — which matches an existing definition by **name or slug before creating one**, so this is resync-*or*-create: re-deploying never duplicates, and a template already deployed from another machine re-attaches to the same definition.

```
POST /api/workflows/:id/deploy
  unparseable sapiom.json → 409 (now with a message that says so)
  unlinked → linking → [warning] → building → ready|error
  linked   →                       building → ready|error   (unchanged)
```

- **`linking`** (new, non-terminal) — the agent is being resolved or created.
- **`warning`** (new, non-terminal) — the agent was created but its id could not be written to `sapiom.json`. The build continues; the message says so verbatim.
- Terminal lines are unchanged: exactly one `ready` or `error` per stream.

The agent is named after its own declared `defineAgent({ name })` — read from the canvas extraction cache, which is normally already warm — falling back to `sapiom.json`'s cached name, the registry name, then the folder basename.

Scope is the harness route only. `agent-core` and `cli` are untouched, and `deploy()` still never writes `sapiom.json`. `sapiom agents deploy` keeps its `NOT_LINKED` behavior on purpose: a scripted or CI deploy must not silently create a remote agent because it ran in the wrong directory.

## Four things the review chain caught beyond the original bug

1. **Splitting "unlinked" from "unparseable config."** The old helper collapsed both into `null`. Under auto-link that orphans a resource: we would create the remote agent, then die when `writeConfig` re-read the invalid file. Bad config now 409s before anything is created.
2. **A failed `sapiom.json` write no longer costs you the deploy.** The file is a re-resolvable cache and `link` re-resolves by name, so a read-only checkout or EACCES emits the `warning` line and continues rather than throwing away a successful link.
3. **Double-clicking Deploy could create two remote agents.** `link({ create: true })` is a read-then-write with no uniqueness guard, and the button is not disabled while pending. An in-flight guard now lives at the state layer (following the existing `inFlightHistory` precedent), covered by a Playwright test that was mutation-verified: disabling the guard makes it fail.
4. **A successful first deploy still showed "Draft."** The registry's `list()` never re-reads `sapiom.json`, and the workspace watcher fires only when the *set* of marker directories changes — not on a content edit to an existing file. So the chip stayed **Draft** and Prod Run stayed disabled reading "Not deployed yet" until you opened a new session or restarted. A new `onLinked` seam rescans that one project and broadcasts `workflows.changed`, keeping the registry out of `actions.ts` the same way `resolveDefinitionName` does.

## Test plan

Verified on this tree:

- [x] `pnpm --filter @sapiom/harness test` — **103 files / 1594 tests**, plus perf config 1 file / 4 tests, all green
- [x] `pnpm --filter @sapiom/harness lint` — 0 errors (1 pre-existing warning in an untouched file)
- [x] `pnpm --filter @sapiom/harness typecheck` — clean on both projects
- [x] `pnpm --filter @sapiom/harness build` — exit 0
- [x] Playwright `direct-actions.spec.ts` — 7/7, including the new double-click guard test

New coverage: 8 deploy-route tests (linked, unlinked, bad-config, link failure, key-refresh-and-retry, seam name precedence, a 3-case name-fallback table, the warning path), 4 `onLinked` seam tests, 4 `resolveManifestName` unit tests, and the e2e double-click test.

Worth a manual pass before merge, since no automated test can reach a real tenant:

- [ ] Apply a gallery template into a fresh folder, click **Deploy**, confirm the agent is created, the build runs, and the chip flips to **Deployed** with Prod Run enabled
- [ ] Deploy that same project again — confirm it re-attaches to the same agent rather than creating a second one
- [ ] Confirm the same flow in the packaged desktop app (`pnpm --filter @sapiom/harness-desktop dist`)

## Known limitations, stated deliberately

- **Backend dependency.** `cli/src/commands/agents/link.ts:12` records that the `--create` path (`POST /definitions`) depended on tenant routes added in a parallel effort. If that route is not live, you now get a named failure with a hint instead of an opaque 409 — better diagnostics, but the button will not fully work until it is. **This is the one thing that could not be verified without a real tenant.**
- **Two clones of one template share a remote agent.** `link` matches by name/slug tenant-wide and both clones carry an identical `defineAgent({ name })`, so the second deploy replaces the first's build. Inherent to link-by-name and unchanged from `sapiom agents link --create`, but now reachable from one click. Recorded in the changeset.
- **The double-click guard is per-tab.** Two browser tabs, or a reload mid-deploy, could still race two `link` calls. Desktop is single-window so exposure is small; the real fix would be a server-side map around `ensureDefinitionId`.
- **The `warning` toast is only guaranteed visible at the end.** It is appended to the terminal toast, because the single toast slot is last-write-wins and `building` follows it in the same tick.
- **Out of scope:** `sapiom agents init` writes no `sapiom.json` at all, so a scaffolded (non-gallery) project is never discovered by the scanner and never gets a Deploy button. Separate bug, separate fix. (A `+ Connect`'d project with no marker *does* work end to end — `writeConfig` creates the file.)

Design and plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
