### PR TITLE
feat(tools): add browserAutomation capability (sessions / screenshot / identities) (SAP-2164)

### DIFF
--- a/.changeset/browser-automation.md
+++ b/.changeset/browser-automation.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `browserAutomation` capability with sessions, screenshots, and identity management:
+
+- `browserAutomation.sessions.create()` — open a browser session; returns a `BrowserSession` with a CDP WebSocket (`cdpUrl`) for Playwright/Puppeteer.
+- `browserAutomation.sessions.createWithIdentity({ identityId })` — open a session pre-authenticated with a stored identity.
+- `browserAutomation.sessions.close(sessionId)` — close a session and settle its billing; returns a `SessionSettlement` with `capturedAmountUsd` and `creditsUsed`.
+- `browserAutomation.screenshot(input)` — one-shot screenshot (`url` required, billed at `$0.01`) or session-mode screenshot (`sessionId` provided, no per-call charge). The returned `url` is an absolute hosted image URL.
+- `browserAutomation.withSession(fn, opts?)` — the recommended pattern: opens a session, invokes `fn(activeSession)`, and always closes in a `finally` block so sessions never leak at the $1.00 ceiling. The `activeSession` carries all `BrowserSession` fields plus a session-bound `screenshot` convenience.
+- `browserAutomation.identities.create(input)` — store credentials for automatic login during sessions (free).
+- `BrowserAutomationHttpError` (`{ status, body }`) — thrown on non-2xx responses; re-exported from the barrel.
+- `"./browser-automation"` subpath export added to `package.json`.
+- `createStubClient()` wires a deterministic `browserAutomation` stub for every operation, including `withSession` invoking `fn` with a stub `ActiveSession`.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -78,6 +78,11 @@
       "import": "./dist/esm/speech/index.js",
       "require": "./dist/cjs/speech/index.js"
     },
+    "./browser-automation": {
+      "types": "./dist/cjs/browser-automation/index.d.ts",
+      "import": "./dist/esm/browser-automation/index.js",
+      "require": "./dist/cjs/browser-automation/index.js"
+    },
     "./stub": {
       "types": "./dist/cjs/stub/index.d.ts",
       "import": "./dist/esm/stub/index.js",

--- a/packages/tools/src/browser-automation/README.md
+++ b/packages/tools/src/browser-automation/README.md
@@ -1,0 +1,141 @@
+# browserAutomation
+
+Programmatic browser sessions, screenshots, and identity management. The same
+browser automation tools your agents call over MCP, callable directly from your
+code.
+
+```typescript
+import { createClient } from "@sapiom/tools";
+const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+
+// One-shot screenshot — no session required:
+const shot = await sapiom.browserAutomation.screenshot({
+  url: "https://example.com",
+});
+shot.url;        // absolute hosted image URL
+shot.expiresAt;  // ISO-8601 expiry (~1 hour)
+```
+
+Ambient import works too:
+
+```typescript
+import { browserAutomation } from "@sapiom/tools";
+const shot = await browserAutomation.screenshot({ url: "https://example.com" });
+```
+
+## Sessions
+
+A session gives you a CDP WebSocket (`cdpUrl`) that you can connect to with
+Playwright or Puppeteer. Screenshots taken inside a session carry no per-call
+charge — billing settles when you close the session.
+
+```typescript
+// Option A — withSession (recommended): opens + auto-closes in a finally block.
+const result = await sapiom.browserAutomation.withSession(async (session) => {
+  session.cdpUrl;          // pass to Playwright's browser.connectOverCDP(...)
+  session.expiresAt;       // ISO-8601 max lifetime
+
+  // session-bound screenshot — sessionId injected automatically:
+  const shot = await session.screenshot({ url: "https://example.com" });
+  return shot.url;
+});
+
+// Option B — manual open/close:
+const session = await sapiom.browserAutomation.sessions.create();
+try {
+  const shot = await sapiom.browserAutomation.screenshot({
+    url: "https://example.com",
+    sessionId: session.sessionId,  // no per-call charge
+  });
+} finally {
+  const settlement = await sapiom.browserAutomation.sessions.close(session.sessionId);
+  settlement.settled;           // true on success
+  settlement.capturedAmountUsd; // exact amount charged (≤ $1.00)
+}
+```
+
+`withSession` is strongly recommended: it guarantees the session is always
+closed — preventing the auto-expiry $1.00 ceiling charge if the session leaks.
+
+## Sessions with identity
+
+When you have a stored identity, open a session pre-authenticated:
+
+```typescript
+const result = await sapiom.browserAutomation.withSession(
+  async (session) => {
+    // browser starts logged in to the identity's site
+    const shot = await session.screenshot({ url: "https://app.example.com/dashboard" });
+    return shot;
+  },
+  { identityId: "id_abc123" },
+);
+```
+
+## Screenshot options
+
+```typescript
+const shot = await sapiom.browserAutomation.screenshot({
+  url: "https://example.com",
+  width: 1280,           // viewport width in pixels
+  height: 800,           // viewport height in pixels
+  fullPage: true,        // capture full scrollable height
+  format: "jpeg",        // "png" (default) or "jpeg"
+  imageQuality: 85,      // JPEG quality 0–100 (only for format: "jpeg")
+  waitMs: 1000,          // wait 1 s after load before capturing
+});
+```
+
+## Identities
+
+Store credentials once; reuse them across sessions:
+
+```typescript
+const identity = await sapiom.browserAutomation.identities.create({
+  source: "https://app.example.com/login",   // login page URL (required)
+  name: "My App Account",                    // optional label
+  credentials: [
+    { type: "username_password", username: "user@example.com", password: "secret" },
+  ],
+  shouldCache: true,
+});
+
+identity.id;      // pass as identityId to sessions.createWithIdentity / withSession
+identity.status;  // lifecycle status
+```
+
+Supported credential types: `"profile"`, `"username_password"`, `"authenticator"`,
+`"custom"`.
+
+## Error handling
+
+Failed requests throw `BrowserAutomationHttpError` (carries `status` + parsed
+`body`), exported from `@sapiom/tools`.
+
+```typescript
+import { BrowserAutomationHttpError } from "@sapiom/tools";
+
+try {
+  await sapiom.browserAutomation.screenshot({ url: "https://example.com" });
+} catch (err) {
+  if (err instanceof BrowserAutomationHttpError) {
+    console.error(err.status, err.body);
+    // 401 — missing or invalid API key
+    // 400 — bad parameters
+    // 404 — session not found or expired
+  }
+}
+```
+
+## Billing
+
+| Operation | Charge |
+|---|---|
+| `sessions.create` / `sessions.createWithIdentity` | `upto $1.00` (pre-authorized; settled on close) |
+| `sessions.close` | Settles actual cost (≤ $1.00) |
+| `screenshot` (one-shot) | `$0.01` per call |
+| `screenshot` (in-session) | No per-call charge |
+| `identities.create` | Free |
+
+Sessions auto-expire after ~20 minutes; if never explicitly closed, billing
+settles at the $1.00 ceiling. Use `withSession` to guarantee close-on-exit.

--- a/packages/tools/src/browser-automation/errors.ts
+++ b/packages/tools/src/browser-automation/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error thrown by the `browserAutomation` capability when a request fails
+ * (non-2xx response). Exposes `status` (HTTP status code) and `body` (parsed
+ * JSON body, or raw text when the body isn't JSON) for programmatic inspection.
+ */
+export class BrowserAutomationHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "BrowserAutomationHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link BrowserAutomationHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new BrowserAutomationHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/browser-automation/index.spec.ts
+++ b/packages/tools/src/browser-automation/index.spec.ts
@@ -1,0 +1,994 @@
+import { createClient } from "../index.js";
+import { Transport } from "../_client/index.js";
+import * as browserAutomation from "./index.js";
+import { BrowserAutomationHttpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+// ---------------------------------------------------------------------------
+// sessions.create / createSession()
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.sessions.create()", () => {
+  it("POSTs /v1/sessions with empty body, sends credential, returns mapped BrowserSession", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          sessionId: "sess-123",
+          cdpUrl: "ws://cdp.example.com/session/sess-123",
+          liveViewUrl: "https://live.example.com/sess-123",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        }),
+    ]);
+
+    const result = await browserAutomation.createSession(transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/sessions`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({});
+
+    expect(result.sessionId).toBe("sess-123");
+    expect(result.cdpUrl).toBe("ws://cdp.example.com/session/sess-123");
+    expect(result.liveViewUrl).toBe("https://live.example.com/sess-123");
+    expect(result.expiresAt).toBe("2099-01-01T00:00:00Z");
+    expect(result.maxDurationSec).toBe(1200);
+  });
+
+  it("maps snake_case response fields to camelCase", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          session_id: "sess-snake",
+          cdp_url: "ws://cdp.example.com/snake",
+          live_view_url: "https://live.example.com/snake",
+          expires_at: "2099-01-01T00:00:00Z",
+          max_duration_sec: 600,
+        }),
+    ]);
+
+    const result = await browserAutomation.createSession(transport, BASE);
+
+    expect(result.sessionId).toBe("sess-snake");
+    expect(result.cdpUrl).toBe("ws://cdp.example.com/snake");
+    expect(result.liveViewUrl).toBe("https://live.example.com/snake");
+    expect(result.expiresAt).toBe("2099-01-01T00:00:00Z");
+    expect(result.maxDurationSec).toBe(600);
+  });
+
+  it("omits liveViewUrl when not in the response", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          sessionId: "sess-nolive",
+          cdpUrl: "ws://cdp.example.com/nolive",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        }),
+    ]);
+
+    const result = await browserAutomation.createSession(transport, BASE);
+    expect(result.liveViewUrl).toBeUndefined();
+  });
+
+  it("passes extra response fields through via [k: string]: unknown", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          sessionId: "sess-extra",
+          cdpUrl: "ws://cdp.example.com/extra",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+          someNewField: "hello",
+        }),
+    ]);
+
+    const result = await browserAutomation.createSession(transport, BASE);
+    expect((result as Record<string, unknown>)["someNewField"]).toBe("hello");
+  });
+
+  it("throws BrowserAutomationHttpError on a non-2xx response", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "unauthorized" }), {
+          status: 401,
+        }),
+    ]);
+
+    await expect(
+      browserAutomation.createSession(transport, BASE),
+    ).rejects.toMatchObject({
+      name: "BrowserAutomationHttpError",
+      status: 401,
+      body: { message: "unauthorized" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessions.createWithIdentity / createSessionWithIdentity()
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.sessions.createWithIdentity()", () => {
+  it("POSTs /v1/sessions/with-identity with identityId in body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          sessionId: "sess-ident",
+          cdpUrl: "ws://cdp.example.com/ident",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        }),
+    ]);
+
+    const result = await browserAutomation.createSessionWithIdentity(
+      { identityId: "id-abc" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/sessions/with-identity`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      identityId: "id-abc",
+    });
+    expect(result.sessionId).toBe("sess-ident");
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when identityId is empty", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.createSessionWithIdentity(
+        { identityId: "" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when identityId is missing", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.createSessionWithIdentity(
+        { identityId: undefined as unknown as string },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError on a non-2xx response", async () => {
+    const { transport } = makeTransport([
+      () => new Response(JSON.stringify({ message: "not found" }), { status: 404 }),
+    ]);
+
+    await expect(
+      browserAutomation.createSessionWithIdentity(
+        { identityId: "id-gone" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessions.close / closeSession()
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.sessions.close()", () => {
+  it("DELETEs /v1/sessions/:sessionId and returns mapped SessionSettlement", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          sessionId: "sess-123",
+          settled: true,
+          capturedAmountUsd: "0.05",
+          creditsUsed: 5,
+        }),
+    ]);
+
+    const result = await browserAutomation.closeSession(
+      "sess-123",
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/sessions/sess-123`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+
+    expect(result.sessionId).toBe("sess-123");
+    expect(result.settled).toBe(true);
+    expect(result.capturedAmountUsd).toBe("0.05");
+    expect(result.creditsUsed).toBe(5);
+  });
+
+  it("URL-encodes the sessionId in the path", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ sessionId: "sess/slash", settled: true }),
+    ]);
+
+    await browserAutomation.closeSession("sess/slash", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/sessions/sess%2Fslash`);
+  });
+
+  it("maps snake_case settlement fields to camelCase", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          session_id: "sess-snake",
+          settled: true,
+          captured_amount_usd: "0.10",
+          credits_used: 10,
+        }),
+    ]);
+
+    const result = await browserAutomation.closeSession(
+      "sess-snake",
+      transport,
+      BASE,
+    );
+
+    expect(result.sessionId).toBe("sess-snake");
+    expect(result.capturedAmountUsd).toBe("0.10");
+    expect(result.creditsUsed).toBe(10);
+    expect((result as Record<string, unknown>)["captured_amount_usd"]).toBeUndefined();
+    expect((result as Record<string, unknown>)["credits_used"]).toBeUndefined();
+  });
+
+  it("omits capturedAmountUsd and creditsUsed when not in the response", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ sessionId: "sess-min", settled: false }),
+    ]);
+
+    const result = await browserAutomation.closeSession(
+      "sess-min",
+      transport,
+      BASE,
+    );
+    expect(result.capturedAmountUsd).toBeUndefined();
+    expect(result.creditsUsed).toBeUndefined();
+  });
+
+  it("throws BrowserAutomationHttpError on 404 (session not found)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "session not found" }), {
+          status: 404,
+        }),
+    ]);
+
+    await expect(
+      browserAutomation.closeSession("no-such-session", transport, BASE),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// screenshot() — one-shot and session modes
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.screenshot() — one-shot mode", () => {
+  it("POSTs /v1/tools/screenshot with url and returns mapped Screenshot", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          url: "/v1/tools/screenshots/abc123.png",
+          expiresAt: "2099-01-01T00:00:00Z",
+        }),
+    ]);
+
+    const result = await browserAutomation.screenshot(
+      { url: "https://example.com" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/tools/screenshot`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.url).toBe("https://example.com");
+
+    // Relative URL resolved to absolute:
+    expect(result.url).toBe(`${BASE}/v1/tools/screenshots/abc123.png`);
+    expect(result.expiresAt).toBe("2099-01-01T00:00:00Z");
+  });
+
+  it("passes an already-absolute url through unchanged", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          url: "https://cdn.example.com/screenshots/abc123.png",
+          expiresAt: "2099-01-01T00:00:00Z",
+        }),
+    ]);
+
+    const result = await browserAutomation.screenshot(
+      { url: "https://example.com" },
+      transport,
+      BASE,
+    );
+    expect(result.url).toBe("https://cdn.example.com/screenshots/abc123.png");
+  });
+
+  it("maps fullPage → scroll_all_content + capture_full_height in the request body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      { url: "https://example.com", fullPage: true },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.scroll_all_content).toBe(true);
+    expect(body.capture_full_height).toBe(true);
+    expect(body).not.toHaveProperty("fullPage");
+  });
+
+  it("does NOT send scroll_all_content when fullPage is false/omitted", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      { url: "https://example.com", fullPage: false },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).not.toHaveProperty("scroll_all_content");
+    expect(body).not.toHaveProperty("capture_full_height");
+  });
+
+  it("maps imageQuality → image_quality in the request body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      { url: "https://example.com", imageQuality: 85, format: "jpeg" },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.image_quality).toBe(85);
+    expect(body).not.toHaveProperty("imageQuality");
+  });
+
+  it("maps waitMs → wait in the request body", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      { url: "https://example.com", waitMs: 500 },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.wait).toBe(500);
+    expect(body).not.toHaveProperty("waitMs");
+  });
+
+  it("passes width, height, format through as-is", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      {
+        url: "https://example.com",
+        width: 1280,
+        height: 800,
+        format: "jpeg",
+      },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.width).toBe(1280);
+    expect(body.height).toBe(800);
+    expect(body.format).toBe("jpeg");
+  });
+
+  it("spreads params FIRST so they cannot clobber the url field", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      {
+        url: "https://real.example.com",
+        params: { url: "https://injected.example.com", extraFlag: true },
+      },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.url).toBe("https://real.example.com");
+    expect(body.extraFlag).toBe(true);
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when url is missing in one-shot mode", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.screenshot({}, transport, BASE),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when url is empty in one-shot mode", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.screenshot({ url: "" }, transport, BASE),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError on a non-2xx response", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "bad url" }), { status: 400 }),
+    ]);
+
+    await expect(
+      browserAutomation.screenshot({ url: "https://example.com" }, transport, BASE),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+  });
+});
+
+describe("browserAutomation.screenshot() — session mode", () => {
+  it("sends sessionId in the body and does NOT require url", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          url: "/v1/tools/screenshots/session-shot.png",
+          expiresAt: "2099-01-01T00:00:00Z",
+        }),
+    ]);
+
+    const result = await browserAutomation.screenshot(
+      { sessionId: "sess-123" },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.sessionId).toBe("sess-123");
+    expect(body.url).toBeUndefined();
+    expect(result.url).toBe(`${BASE}/v1/tools/screenshots/session-shot.png`);
+  });
+
+  it("sends both sessionId and url when both are provided", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({ url: "/v1/tools/screenshots/abc.png", expiresAt: "2099-01-01T00:00:00Z" }),
+    ]);
+
+    await browserAutomation.screenshot(
+      { sessionId: "sess-123", url: "https://example.com/page" },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.sessionId).toBe("sess-123");
+    expect(body.url).toBe("https://example.com/page");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// identities.create / createIdentity()
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.identities.create()", () => {
+  it("POSTs /v1/identities with the input and returns mapped Identity", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          id: "ident-abc",
+          status: "active",
+          name: "My Account",
+        }),
+    ]);
+
+    const result = await browserAutomation.createIdentity(
+      {
+        source: "https://app.example.com/login",
+        name: "My Account",
+        credentials: [
+          {
+            type: "username_password",
+            username: "user@example.com",
+            password: "secret",
+          },
+        ],
+      },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/identities`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.source).toBe("https://app.example.com/login");
+    expect(body.name).toBe("My Account");
+    expect(body.credentials).toHaveLength(1);
+
+    expect(result.id).toBe("ident-abc");
+    expect(result.status).toBe("active");
+    expect(result.name).toBe("My Account");
+  });
+
+  it("omits optional fields from the body when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ id: "ident-min", status: "pending" }),
+    ]);
+
+    await browserAutomation.createIdentity(
+      {
+        source: "https://app.example.com/login",
+        credentials: [{ type: "profile", name: "default" }],
+      },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).not.toHaveProperty("name");
+    expect(body).not.toHaveProperty("shouldCache");
+    expect(body).not.toHaveProperty("metadata");
+  });
+
+  it("includes optional fields when provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ id: "ident-full", status: "active" }),
+    ]);
+
+    await browserAutomation.createIdentity(
+      {
+        source: "https://app.example.com/login",
+        credentials: [{ type: "profile", name: "default" }],
+        shouldCache: true,
+        metadata: { env: "test" },
+      },
+      transport,
+      BASE,
+    );
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.shouldCache).toBe(true);
+    expect(body.metadata).toEqual({ env: "test" });
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when source is empty", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.createIdentity(
+        { source: "", credentials: [] },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError (before fetch) when source is missing", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      browserAutomation.createIdentity(
+        { source: undefined as unknown as string, credentials: [] },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+    expect(calls.length).toBe(0);
+  });
+
+  it("throws BrowserAutomationHttpError on a non-2xx response", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "bad request" }), { status: 400 }),
+    ]);
+
+    await expect(
+      browserAutomation.createIdentity(
+        {
+          source: "https://app.example.com/login",
+          credentials: [{ type: "profile", name: "default" }],
+        },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ name: "BrowserAutomationHttpError", status: 400 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withSession()
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation.withSession()", () => {
+  function makeSessionTransport(sessionId = "sess-ws") {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      calls.push({ url, init });
+
+      if (url.endsWith("/v1/sessions") && init.method === "POST") {
+        return jsonResponse({
+          sessionId,
+          cdpUrl: `ws://cdp.example.com/${sessionId}`,
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        });
+      }
+      if (url.includes("/v1/sessions/") && init.method === "DELETE") {
+        return jsonResponse({ sessionId, settled: true, capturedAmountUsd: "0.05" });
+      }
+      if (url.endsWith("/v1/tools/screenshot") && init.method === "POST") {
+        return jsonResponse({
+          url: "/v1/tools/screenshots/shot.png",
+          expiresAt: "2099-01-01T00:00:00Z",
+        });
+      }
+      throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+    }) as typeof globalThis.fetch;
+
+    return {
+      transport: new Transport({ apiKey: "test-key", fetch: fetchMock }),
+      calls,
+    };
+  }
+
+  it("opens a session, calls fn with an ActiveSession, closes on success", async () => {
+    const { transport, calls } = makeSessionTransport("sess-ws-ok");
+
+    const result = await browserAutomation.withSession(
+      async (session) => {
+        expect(session.sessionId).toBe("sess-ws-ok");
+        expect(typeof session.screenshot).toBe("function");
+        return "done";
+      },
+      undefined,
+      transport,
+      BASE,
+    );
+
+    expect(result).toBe("done");
+    // open + close
+    expect(calls.some((c) => c.url.endsWith("/v1/sessions") && c.init.method === "POST")).toBe(true);
+    expect(calls.some((c) => c.url.includes("/v1/sessions/") && c.init.method === "DELETE")).toBe(true);
+  });
+
+  it("closes the session even when fn throws", async () => {
+    const { transport, calls } = makeSessionTransport("sess-ws-throw");
+
+    await expect(
+      browserAutomation.withSession(
+        async () => {
+          throw new Error("step failed");
+        },
+        undefined,
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow("step failed");
+
+    // close was still called
+    expect(calls.some((c) => c.url.includes("/v1/sessions/sess-ws-throw") && c.init.method === "DELETE")).toBe(true);
+  });
+
+  it("session-bound screenshot injects sessionId automatically", async () => {
+    const { transport, calls } = makeSessionTransport("sess-ws-shot");
+
+    await browserAutomation.withSession(
+      async (session) => {
+        await session.screenshot({ url: "https://example.com" });
+      },
+      undefined,
+      transport,
+      BASE,
+    );
+
+    const shotCall = calls.find((c) => c.url.endsWith("/v1/tools/screenshot"));
+    expect(shotCall).toBeDefined();
+    const body = JSON.parse(shotCall!.init.body as string);
+    expect(body.sessionId).toBe("sess-ws-shot");
+  });
+
+  it("uses createSessionWithIdentity when identityId is provided", async () => {
+    let createUrl: string | undefined;
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      calls.push({ url, init });
+
+      if (url.includes("/v1/sessions") && init.method === "POST") {
+        createUrl = url;
+        return jsonResponse({
+          sessionId: "sess-ident",
+          cdpUrl: "ws://cdp.example.com/ident",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        });
+      }
+      if (url.includes("/v1/sessions/") && init.method === "DELETE") {
+        return jsonResponse({ sessionId: "sess-ident", settled: true });
+      }
+      throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+
+    await browserAutomation.withSession(
+      async (session) => {
+        expect(session.sessionId).toBe("sess-ident");
+      },
+      { identityId: "id-xyz" },
+      transport,
+      BASE,
+    );
+
+    expect(createUrl).toBe(`${BASE}/v1/sessions/with-identity`);
+  });
+
+  it("propagates the original error even if close also fails", async () => {
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      if (url.endsWith("/v1/sessions") && init.method === "POST") {
+        return jsonResponse({
+          sessionId: "sess-err",
+          cdpUrl: "ws://cdp.example.com/err",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        });
+      }
+      if (url.includes("/v1/sessions/") && init.method === "DELETE") {
+        return new Response("server error", { status: 500 });
+      }
+      throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+
+    await expect(
+      browserAutomation.withSession(
+        async () => {
+          throw new Error("original error");
+        },
+        undefined,
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow("original error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client wiring + credential
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation — client wiring + credential", () => {
+  it("createClient().browserAutomation routes all operations with the credential", async () => {
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      calls.push({ url, init });
+      if (url.endsWith("/v1/sessions") && init.method === "POST") {
+        return jsonResponse({
+          sessionId: "s",
+          cdpUrl: "ws://x",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        });
+      }
+      if (url.includes("/v1/sessions/") && init.method === "DELETE") {
+        return jsonResponse({ sessionId: "s", settled: true });
+      }
+      if (url.includes("/v1/sessions/with-identity")) {
+        return jsonResponse({
+          sessionId: "s",
+          cdpUrl: "ws://x",
+          expiresAt: "2099-01-01T00:00:00Z",
+          maxDurationSec: 1200,
+        });
+      }
+      if (url.endsWith("/v1/tools/screenshot")) {
+        return jsonResponse({
+          url: "/v1/tools/screenshots/abc.png",
+          expiresAt: "2099-01-01T00:00:00Z",
+        });
+      }
+      if (url.endsWith("/v1/identities")) {
+        return jsonResponse({ id: "ident", status: "active" });
+      }
+      throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
+    await sapiom.browserAutomation.sessions.create();
+    await sapiom.browserAutomation.sessions.createWithIdentity({ identityId: "id-1" });
+    await sapiom.browserAutomation.sessions.close("s");
+    await sapiom.browserAutomation.screenshot({ url: "https://example.com" });
+    await sapiom.browserAutomation.identities.create({
+      source: "https://app.example.com/login",
+      credentials: [{ type: "profile", name: "default" }],
+    });
+
+    expect(calls.length).toBeGreaterThanOrEqual(5);
+    for (const c of calls) {
+      expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
+    }
+
+    expect(calls.some((c) => c.url.includes("/v1/sessions"))).toBe(true);
+    expect(calls.some((c) => c.url.includes("/v1/tools/screenshot"))).toBe(true);
+    expect(calls.some((c) => c.url.includes("/v1/identities"))).toBe(true);
+  });
+
+  it("throws a clear error when no tenant credential is configured", async () => {
+    const saved = process.env["SAPIOM_API_KEY"];
+    delete process.env["SAPIOM_API_KEY"];
+    try {
+      const transport = new Transport({
+        fetch: (async () => new Response("{}")) as typeof globalThis.fetch,
+      });
+      await expect(
+        browserAutomation.createSession(transport, BASE),
+      ).rejects.toThrow(/no tenant credential/i);
+    } finally {
+      if (saved !== undefined) process.env["SAPIOM_API_KEY"] = saved;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Namespace exports
+// ---------------------------------------------------------------------------
+
+describe("browserAutomation — namespace exports", () => {
+  it("sessions.create is the same function as createSession", () => {
+    expect(browserAutomation.sessions.create).toBe(
+      browserAutomation.createSession,
+    );
+  });
+
+  it("sessions.createWithIdentity is the same function as createSessionWithIdentity", () => {
+    expect(browserAutomation.sessions.createWithIdentity).toBe(
+      browserAutomation.createSessionWithIdentity,
+    );
+  });
+
+  it("sessions.close is the same function as closeSession", () => {
+    expect(browserAutomation.sessions.close).toBe(
+      browserAutomation.closeSession,
+    );
+  });
+
+  it("identities.create is the same function as createIdentity", () => {
+    expect(browserAutomation.identities.create).toBe(
+      browserAutomation.createIdentity,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BrowserAutomationHttpError
+// ---------------------------------------------------------------------------
+
+describe("BrowserAutomationHttpError", () => {
+  it("carries status and body and is instanceof Error", () => {
+    const err = new BrowserAutomationHttpError("something went wrong", 422, {
+      message: "invalid",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(BrowserAutomationHttpError);
+    expect(err.status).toBe(422);
+    expect(err.body).toEqual({ message: "invalid" });
+    expect(err.name).toBe("BrowserAutomationHttpError");
+  });
+});

--- a/packages/tools/src/browser-automation/index.ts
+++ b/packages/tools/src/browser-automation/index.ts
@@ -1,0 +1,535 @@
+/**
+ * `browserAutomation` capability — sessions, screenshots, and identity management.
+ * The same browser automation tools your agents call over MCP, callable directly
+ * from code.
+ *
+ *   import { createClient } from "@sapiom/tools";
+ *   const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
+ *
+ *   // One-shot screenshot (no session needed):
+ *   const shot = await sapiom.browserAutomation.screenshot({ url: "https://example.com" });
+ *   shot.url;        // absolute hosted URL
+ *   shot.expiresAt;  // ISO-8601 expiry
+ *
+ *   // Session + auto-close helper:
+ *   const result = await sapiom.browserAutomation.withSession(async (session) => {
+ *     session.cdpUrl;  // CDP WebSocket — connect Playwright/Puppeteer here
+ *     const shot = await session.screenshot({ url: "https://example.com" });
+ *     return shot;
+ *   });
+ *
+ * Or via an explicit client:
+ *   `createClient({ apiKey }).browserAutomation.sessions.create()`
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, BrowserAutomationHttpError } from "./errors.js";
+
+export { BrowserAutomationHttpError };
+
+// The ONLY occurrence of the backing provider subdomain — NOT in type names,
+// method names, comments, or docs.
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "anchor-browser",
+  process.env.SAPIOM_BROWSER_AUTOMATION_URL,
+);
+
+// ----- Types -----
+
+export interface BrowserSession {
+  /** Unique session identifier. */
+  sessionId: string;
+  /** CDP WebSocket URL — connect Playwright or Puppeteer here. */
+  cdpUrl: string;
+  /** Optional hosted live-view URL. */
+  liveViewUrl?: string;
+  /** ISO-8601 timestamp when this session expires. */
+  expiresAt: string;
+  /** Maximum session duration in seconds. */
+  maxDurationSec: number;
+  /** Additional fields returned by the capability, passed through as-is. */
+  [k: string]: unknown;
+}
+
+export interface SessionSettlement {
+  /** The session that was closed. */
+  sessionId: string;
+  /** Whether the session was settled successfully. */
+  settled: boolean;
+  /** Actual USD amount captured (present when settled). */
+  capturedAmountUsd?: string;
+  /** Credits consumed during the session. */
+  creditsUsed?: number;
+  /** Additional fields returned by the capability, passed through as-is. */
+  [k: string]: unknown;
+}
+
+export interface ScreenshotInput {
+  /**
+   * URL to screenshot. Required when no `sessionId` is provided (one-shot mode).
+   * Optional when a `sessionId` is given.
+   */
+  url?: string;
+  /**
+   * Session mode — attach this screenshot to an existing session. No per-call
+   * charge; billing settles with the session when it is closed.
+   */
+  sessionId?: string;
+  /** Viewport width in pixels. */
+  width?: number;
+  /** Viewport height in pixels. */
+  height?: number;
+  /**
+   * Capture the full scrollable page height. Maps to `scroll_all_content` +
+   * `capture_full_height` in the gateway request.
+   */
+  fullPage?: boolean;
+  /**
+   * JPEG quality (0–100). Maps to `image_quality` in the gateway request.
+   * Only meaningful when `format` is `"jpeg"`.
+   */
+  imageQuality?: number;
+  /**
+   * Milliseconds to wait after page load before capturing. Maps to `wait` in
+   * the gateway request.
+   */
+  waitMs?: number;
+  /** Output format. Defaults to `"png"` when omitted. */
+  format?: "png" | "jpeg";
+  /**
+   * Advanced: extra parameters forwarded verbatim to the gateway (spread FIRST
+   * so they cannot override the guard-validated fields above).
+   */
+  params?: Record<string, unknown>;
+}
+
+export interface Screenshot {
+  /** Absolute hosted URL of the captured image. */
+  url: string;
+  /** ISO-8601 timestamp when `url` expires. */
+  expiresAt: string;
+  /** Additional fields returned by the capability, passed through as-is. */
+  [k: string]: unknown;
+}
+
+export type IdentityCredential =
+  | { type: "profile"; name: string }
+  | { type: "username_password"; username: string; password: string }
+  | { type: "authenticator"; secret: string }
+  | { type: "custom"; fields: Array<{ name: string; value: string }> };
+
+export interface IdentityCreateInput {
+  /** Login page URL (required). */
+  source: string;
+  /** Optional display name for this identity. */
+  name?: string;
+  /** Credentials the session should log in with. */
+  credentials: IdentityCredential[];
+  /** Whether to cache the authenticated session state. */
+  shouldCache?: boolean;
+  /** Arbitrary metadata to attach to this identity. */
+  metadata?: Record<string, unknown>;
+}
+
+export interface Identity {
+  /** Unique identity identifier. */
+  id: string;
+  /** Current lifecycle status. */
+  status: string;
+  /** Display name of this identity. */
+  name?: string;
+  /** Additional fields returned by the capability, passed through as-is. */
+  [k: string]: unknown;
+}
+
+export interface WithSessionOptions {
+  /**
+   * When provided, opens the session with the given identity so it starts with
+   * a pre-authenticated browser context.
+   */
+  identityId?: string;
+}
+
+/**
+ * An open browser session with a session-bound `screenshot` convenience.
+ * The `screenshot` method injects `sessionId` automatically — no per-call charge.
+ */
+export interface ActiveSession extends BrowserSession {
+  /**
+   * Capture a screenshot inside this session. `sessionId` is injected
+   * automatically. `url` is optional when the session already has an active page.
+   */
+  screenshot(
+    input?: Omit<ScreenshotInput, "sessionId" | "url"> & { url?: string },
+  ): Promise<Screenshot>;
+}
+
+// ----- Internal response shapes -----
+
+interface RawBrowserSession {
+  session_id?: string;
+  sessionId?: string;
+  cdp_url?: string;
+  cdpUrl?: string;
+  live_view_url?: string;
+  liveViewUrl?: string;
+  expires_at?: string;
+  expiresAt?: string;
+  max_duration_sec?: number;
+  maxDurationSec?: number;
+  [k: string]: unknown;
+}
+
+interface RawSessionSettlement {
+  session_id?: string;
+  sessionId?: string;
+  settled?: boolean;
+  captured_amount_usd?: string;
+  capturedAmountUsd?: string;
+  credits_used?: number;
+  creditsUsed?: number;
+  [k: string]: unknown;
+}
+
+interface RawScreenshot {
+  url?: string;
+  expires_at?: string;
+  expiresAt?: string;
+  [k: string]: unknown;
+}
+
+interface RawIdentity {
+  id?: string;
+  status?: string;
+  name?: string;
+  [k: string]: unknown;
+}
+
+// ----- Response mappers (accept snake_case OR camelCase, spread the rest) -----
+
+function mapBrowserSession(raw: RawBrowserSession): BrowserSession {
+  const {
+    session_id,
+    sessionId,
+    cdp_url,
+    cdpUrl,
+    live_view_url,
+    liveViewUrl,
+    expires_at,
+    expiresAt,
+    max_duration_sec,
+    maxDurationSec,
+    ...rest
+  } = raw;
+  const resolvedLiveViewUrl = liveViewUrl ?? live_view_url;
+  return {
+    sessionId: (sessionId ?? session_id ?? "") as string,
+    cdpUrl: (cdpUrl ?? cdp_url ?? "") as string,
+    ...(resolvedLiveViewUrl !== undefined && {
+      liveViewUrl: resolvedLiveViewUrl,
+    }),
+    expiresAt: (expiresAt ?? expires_at ?? "") as string,
+    maxDurationSec: (maxDurationSec ?? max_duration_sec ?? 0) as number,
+    ...rest,
+  };
+}
+
+function mapSessionSettlement(raw: RawSessionSettlement): SessionSettlement {
+  const {
+    session_id,
+    sessionId,
+    settled,
+    captured_amount_usd,
+    capturedAmountUsd,
+    credits_used,
+    creditsUsed,
+    ...rest
+  } = raw;
+  const resolvedCaptured = capturedAmountUsd ?? captured_amount_usd;
+  const resolvedCredits = creditsUsed ?? credits_used;
+  return {
+    sessionId: (sessionId ?? session_id ?? "") as string,
+    settled: settled ?? false,
+    ...(resolvedCaptured !== undefined && {
+      capturedAmountUsd: resolvedCaptured,
+    }),
+    ...(resolvedCredits !== undefined && { creditsUsed: resolvedCredits }),
+    ...rest,
+  };
+}
+
+function mapScreenshot(raw: RawScreenshot, baseUrl: string): Screenshot {
+  const { url, expires_at, expiresAt, ...rest } = raw;
+  // The gateway may return a relative path — resolve it to absolute.
+  const resolvedUrl = url
+    ? url.startsWith("/")
+      ? `${baseUrl}${url}`
+      : url
+    : "";
+  return {
+    url: resolvedUrl,
+    expiresAt: (expiresAt ?? expires_at ?? "") as string,
+    ...rest,
+  };
+}
+
+function mapIdentity(raw: RawIdentity): Identity {
+  const { id, status, name, ...rest } = raw;
+  return {
+    id: id ?? "",
+    status: status ?? "",
+    ...(name !== undefined && { name }),
+    ...rest,
+  };
+}
+
+// ----- Guards -----
+
+function assertIdentityId(identityId: unknown): void {
+  if (typeof identityId !== "string" || identityId.trim() === "") {
+    throw new BrowserAutomationHttpError(
+      "identityId is required and must be a non-empty string",
+      400,
+      { error: "invalid_identity_id" },
+    );
+  }
+}
+
+function assertSource(source: unknown): void {
+  if (typeof source !== "string" || source.trim() === "") {
+    throw new BrowserAutomationHttpError(
+      "source is required and must be a non-empty string (the login page URL)",
+      400,
+      { error: "invalid_source" },
+    );
+  }
+}
+
+function assertUrl(url: unknown): void {
+  if (typeof url !== "string" || url.trim() === "") {
+    throw new BrowserAutomationHttpError(
+      "url is required and must be a non-empty string for one-shot screenshots",
+      400,
+      { error: "invalid_url" },
+    );
+  }
+}
+
+// ----- Capability operations -----
+
+/**
+ * Open a new browser session. Returns a `BrowserSession` with a CDP WebSocket
+ * you can pass to Playwright or Puppeteer. The session is billed at `upto $1.00`;
+ * call `sessions.close` (or use `withSession`) to settle the exact cost.
+ * Failed requests throw {@link BrowserAutomationHttpError}.
+ */
+export async function createSession(
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<BrowserSession> {
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/sessions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({}),
+    }),
+    "Failed to create session",
+  );
+  return mapBrowserSession((await res.json()) as RawBrowserSession);
+}
+
+/**
+ * Open a new browser session with an existing identity, starting the browser
+ * already authenticated. Returns a `BrowserSession`. Failed requests throw
+ * {@link BrowserAutomationHttpError}.
+ */
+export async function createSessionWithIdentity(
+  input: { identityId: string },
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<BrowserSession> {
+  assertIdentityId(input.identityId);
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/sessions/with-identity`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({ identityId: input.identityId }),
+    }),
+    "Failed to create session with identity",
+  );
+  return mapBrowserSession((await res.json()) as RawBrowserSession);
+}
+
+/**
+ * Close a session and settle its billing. Returns a `SessionSettlement` with
+ * `capturedAmountUsd` (the exact amount charged, never more than $1.00) and
+ * `creditsUsed`. Always call this or use `withSession` to avoid the auto-expiry
+ * $1.00 ceiling. Failed requests throw {@link BrowserAutomationHttpError}.
+ */
+export async function closeSession(
+  sessionId: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SessionSettlement> {
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/sessions/${encodeURIComponent(sessionId)}`,
+      {
+        method: "DELETE",
+        headers: { accept: "application/json" },
+      },
+    ),
+    "Failed to close session",
+  );
+  return mapSessionSettlement((await res.json()) as RawSessionSettlement);
+}
+
+/**
+ * Capture a screenshot of a URL or an in-session page. In one-shot mode (`url`
+ * required, no `sessionId`) the call is billed at `$0.01`. In session mode
+ * (`sessionId` provided) there is no per-call charge; billing settles with the
+ * session. The returned `url` is an absolute, short-lived hosted image URL.
+ * Failed requests throw {@link BrowserAutomationHttpError}.
+ */
+export async function screenshot(
+  input: ScreenshotInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Screenshot> {
+  // One-shot mode requires a url; session mode makes url optional.
+  if (!input.sessionId) {
+    assertUrl(input.url);
+  }
+
+  // `params` is spread first so it cannot clobber the guard-validated fields.
+  const body: Record<string, unknown> = {
+    ...input.params,
+    ...(input.url !== undefined && { url: input.url }),
+    ...(input.sessionId !== undefined && { sessionId: input.sessionId }),
+    ...(input.width !== undefined && { width: input.width }),
+    ...(input.height !== undefined && { height: input.height }),
+    ...(input.fullPage === true && {
+      scroll_all_content: true,
+      capture_full_height: true,
+    }),
+    ...(input.imageQuality !== undefined && {
+      image_quality: input.imageQuality,
+    }),
+    ...(input.waitMs !== undefined && { wait: input.waitMs }),
+    ...(input.format !== undefined && { format: input.format }),
+  };
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/tools/screenshot`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    "Failed to capture screenshot",
+  );
+  return mapScreenshot((await res.json()) as RawScreenshot, baseUrl);
+}
+
+/**
+ * Create a browser identity that stores credentials for automatic login.
+ * Pass the returned `id` to `sessions.createWithIdentity` to open a
+ * pre-authenticated session. Identity creation is free.
+ * Failed requests throw {@link BrowserAutomationHttpError}.
+ */
+export async function createIdentity(
+  input: IdentityCreateInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Identity> {
+  assertSource(input.source);
+
+  const body: Record<string, unknown> = {
+    source: input.source,
+    credentials: input.credentials,
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.shouldCache !== undefined && { shouldCache: input.shouldCache }),
+    ...(input.metadata !== undefined && { metadata: input.metadata }),
+  };
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/identities`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    "Failed to create identity",
+  );
+  return mapIdentity((await res.json()) as RawIdentity);
+}
+
+/**
+ * Open a browser session, invoke `fn` with an `ActiveSession` (which includes a
+ * session-bound `screenshot` convenience), and **always** close the session in a
+ * `finally` block — even when `fn` throws.
+ *
+ * This is the recommended way to run a browser automation task: it prevents the
+ * session from leaking at the $1.00 ceiling charge if you forget to close it.
+ * Failed requests throw {@link BrowserAutomationHttpError}.
+ *
+ * @example
+ * const result = await sapiom.browserAutomation.withSession(async (session) => {
+ *   const shot = await session.screenshot({ url: "https://example.com" });
+ *   return shot.url;
+ * });
+ */
+export async function withSession<T>(
+  fn: (session: ActiveSession) => Promise<T>,
+  opts?: WithSessionOptions,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<T> {
+  const browserSession = opts?.identityId
+    ? await createSessionWithIdentity({ identityId: opts.identityId }, transport, baseUrl)
+    : await createSession(transport, baseUrl);
+
+  const activeSession: ActiveSession = {
+    ...browserSession,
+    screenshot: (input?) =>
+      screenshot(
+        { ...input, sessionId: browserSession.sessionId },
+        transport,
+        baseUrl,
+      ),
+  };
+
+  try {
+    return await fn(activeSession);
+  } finally {
+    // Always close — swallow errors so the original result/throw propagates.
+    await closeSession(browserSession.sessionId, transport, baseUrl).catch(
+      () => undefined,
+    );
+  }
+}
+
+// ----- Namespace exports -----
+
+/** Browser session lifecycle operations. */
+export const sessions = {
+  create: createSession,
+  createWithIdentity: createSessionWithIdentity,
+  close: closeSession,
+};
+
+/** Browser identity management. */
+export const identities = {
+  create: createIdentity,
+};

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -148,6 +148,17 @@ import type {
   SoundEffectInput,
   VoicesResult,
 } from "./speech/index.js";
+import * as browserAutomation from "./browser-automation/index.js";
+import type {
+  BrowserSession,
+  SessionSettlement,
+  ScreenshotInput,
+  Screenshot,
+  IdentityCreateInput,
+  Identity,
+  WithSessionOptions,
+  ActiveSession,
+} from "./browser-automation/index.js";
 import * as vault from "./vault/index.js";
 
 export interface Sapiom {
@@ -426,6 +437,40 @@ export interface Sapiom {
     };
   };
   /**
+   * Browser automation — sessions, screenshots, and identity management.
+   * Use `withSession` for the safe auto-close pattern; use `sessions` +
+   * `screenshot` + `identities` for direct control.
+   */
+  readonly browserAutomation: {
+    /** Open and close browser sessions. */
+    sessions: {
+      /** Open a new browser session. */
+      create(): Promise<BrowserSession>;
+      /** Open a new browser session pre-authenticated with an identity. */
+      createWithIdentity(input: { identityId: string }): Promise<BrowserSession>;
+      /** Close a session and settle its billing. */
+      close(sessionId: string): Promise<SessionSettlement>;
+    };
+    /**
+     * Capture a screenshot. Pass `url` only for a one-shot capture ($0.01);
+     * pass `sessionId` to capture inside an existing session (no per-call charge).
+     */
+    screenshot(input: ScreenshotInput): Promise<Screenshot>;
+    /**
+     * Open a session, run `fn` with an `ActiveSession`, and always close in a
+     * `finally` block — the recommended way to avoid leaked-session charges.
+     */
+    withSession<T>(
+      fn: (session: ActiveSession) => Promise<T>,
+      opts?: WithSessionOptions,
+    ): Promise<T>;
+    /** Create and manage browser identities for authenticated sessions. */
+    identities: {
+      /** Store credentials for automatic login during sessions. */
+      create(input: IdentityCreateInput): Promise<Identity>;
+    };
+  };
+  /**
    * Derive a client that attributes its calls to a different agent/trace. For the
    * router case (one process acting for many agents); step-authoring code doesn't
    * need this — attribution is set once when the client is constructed.
@@ -587,6 +632,20 @@ function bind(transport: Transport): Sapiom {
       },
       voices: {
         list: () => speech.listVoices(transport),
+      },
+    },
+    browserAutomation: {
+      sessions: {
+        create: () => browserAutomation.createSession(transport),
+        createWithIdentity: (input) =>
+          browserAutomation.createSessionWithIdentity(input, transport),
+        close: (sessionId) => browserAutomation.closeSession(sessionId, transport),
+      },
+      screenshot: (input) => browserAutomation.screenshot(input, transport),
+      withSession: (fn, opts) =>
+        browserAutomation.withSession(fn, opts, transport),
+      identities: {
+        create: (input) => browserAutomation.createIdentity(input, transport),
       },
     },
     withAttribution: (attribution) =>

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -120,5 +120,8 @@ export { MemoryHttpError } from "./memory/index.js";
 export * as speech from "./speech/index.js";
 export { SpeechHttpError } from "./speech/index.js";
 
+export * as browserAutomation from "./browser-automation/index.js";
+export { BrowserAutomationHttpError } from "./browser-automation/index.js";
+
 export * as vault from "./vault/index.js";
 export { VaultHttpError } from "./vault/index.js";

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -16,11 +16,13 @@ import {
   search,
   memory,
   speech,
+  browserAutomation,
   Sandbox,
   Repository,
   SearchHttpError,
   MemoryHttpError,
   SpeechHttpError,
+  BrowserAutomationHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -62,6 +64,14 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.speech.soundEffects.create).toBe("function");
     expect(typeof sapiom.speech.voices.list).toBe("function");
 
+    expect(typeof sapiom.browserAutomation).toBe("object");
+    expect(typeof sapiom.browserAutomation.sessions.create).toBe("function");
+    expect(typeof sapiom.browserAutomation.sessions.createWithIdentity).toBe("function");
+    expect(typeof sapiom.browserAutomation.sessions.close).toBe("function");
+    expect(typeof sapiom.browserAutomation.screenshot).toBe("function");
+    expect(typeof sapiom.browserAutomation.withSession).toBe("function");
+    expect(typeof sapiom.browserAutomation.identities.create).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -79,9 +89,11 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof search).toBe("object");
     expect(typeof memory).toBe("object");
     expect(typeof speech).toBe("object");
+    expect(typeof browserAutomation).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");
+    expect(typeof BrowserAutomationHttpError).toBe("function");
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -102,6 +102,13 @@ import type {
   MemoryMetadataValue,
 } from "../memory/index.js";
 import type { SpeechResult, VoicesResult } from "../speech/index.js";
+import type {
+  BrowserSession,
+  SessionSettlement,
+  Screenshot,
+  Identity,
+  ActiveSession,
+} from "../browser-automation/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -1659,6 +1666,97 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             r("speech.voices.list", [], () => ({
               voices: [{ voiceId: "stub-voice", name: "Stub Voice" }],
             })) as VoicesResult,
+          ),
+      },
+    },
+    browserAutomation: {
+      sessions: {
+        create: () =>
+          Promise.resolve(
+            r("browserAutomation.sessions.create", [], () => ({
+              sessionId: "stub-session",
+              cdpUrl: "ws://stub.local/session/stub-session",
+              expiresAt: "2099-01-01T00:00:00Z",
+              maxDurationSec: 1200,
+            })) as BrowserSession,
+          ),
+        createWithIdentity: (input) =>
+          Promise.resolve(
+            r("browserAutomation.sessions.createWithIdentity", [input], () => ({
+              sessionId: "stub-session",
+              cdpUrl: "ws://stub.local/session/stub-session",
+              expiresAt: "2099-01-01T00:00:00Z",
+              maxDurationSec: 1200,
+            })) as BrowserSession,
+          ),
+        close: (sessionId) =>
+          Promise.resolve(
+            r("browserAutomation.sessions.close", [sessionId], () => ({
+              sessionId,
+              settled: true,
+              capturedAmountUsd: "0.00",
+              creditsUsed: 0,
+            })) as SessionSettlement,
+          ),
+      },
+      screenshot: (input) =>
+        Promise.resolve(
+          r("browserAutomation.screenshot", [input], () => ({
+            url: "https://cdn.example.com/stub-screenshot.png",
+            expiresAt: "2099-01-01T00:00:00Z",
+          })) as Screenshot,
+        ),
+      withSession: async <T>(
+        fn: (session: ActiveSession) => Promise<T>,
+        sessionOpts?: { identityId?: string },
+      ) => {
+        const stubSession = r(
+          "browserAutomation.withSession",
+          [fn, sessionOpts],
+          () => ({
+            sessionId: "stub-session",
+            cdpUrl: "ws://stub.local/session/stub-session",
+            expiresAt: "2099-01-01T00:00:00Z",
+            maxDurationSec: 1200,
+          }),
+        ) as BrowserSession;
+        const activeSession: ActiveSession = {
+          ...stubSession,
+          screenshot: (screenshotInput?) =>
+            Promise.resolve(
+              r(
+                "browserAutomation.screenshot",
+                [{ ...screenshotInput, sessionId: stubSession.sessionId }],
+                () => ({
+                  url: "https://cdn.example.com/stub-screenshot.png",
+                  expiresAt: "2099-01-01T00:00:00Z",
+                }),
+              ) as Screenshot,
+            ),
+        };
+        try {
+          return await fn(activeSession);
+        } finally {
+          // Stub close — swallow (mirrors the real withSession finally).
+          r(
+            "browserAutomation.sessions.close",
+            [stubSession.sessionId],
+            () => ({
+              sessionId: stubSession.sessionId,
+              settled: true,
+              capturedAmountUsd: "0.00",
+              creditsUsed: 0,
+            }),
+          );
+        }
+      },
+      identities: {
+        create: (input) =>
+          Promise.resolve(
+            r("browserAutomation.identities.create", [input], () => ({
+              id: "stub-identity",
+              status: "active",
+            })) as Identity,
           ),
       },
     },

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -1712,7 +1712,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       ) => {
         const stubSession = r(
           "browserAutomation.withSession",
-          [fn, sessionOpts],
+          // Only the serializable opts are recorded; `fn` (a closure) has no
+          // useful JSON form and would show as null in the calls-sink trace.
+          [sessionOpts],
           () => ({
             sessionId: "stub-session",
             cdpUrl: "ws://stub.local/session/stub-session",


### PR DESCRIPTION
## Summary
Adds the `browserAutomation` capability to `@sapiom/tools` — typed functions wrapping the live browser gateway, callable from code now and (after the workflow-engine `@sapiom/tools` bump, SAP-2165) from workflow steps. Mirrors the `speech` capability pattern. **No provider name in the user-facing surface.**

## Surface
- `browserAutomation.sessions.create()` / `createWithIdentity({ identityId })` / `close(sessionId)`
- `browserAutomation.screenshot({ url, sessionId?, width?, height?, fullPage?, imageQuality?, waitMs?, format? })` — one-shot (`$0.01`) or session-mode (no per-call charge); returns an absolute hosted URL
- `browserAutomation.identities.create({ source, credentials, ... })` (free)
- `browserAutomation.withSession(fn, opts?)` — opens a session, runs `fn(activeSession)`, and **always closes in a `finally`** (prevents the `$1` auto-expiry-ceiling leak); `activeSession` carries the session fields + a session-bound `screenshot`
- `BrowserAutomationHttpError` re-exported from the barrel; `./browser-automation` subpath export; stub + smoke wired

## Base URL / cross-env
`resolveServiceUrl("anchor-browser", process.env.SAPIOM_BROWSER_AUTOMATION_URL)` — honors `SAPIOM_SERVICES_BASE` for local/dev/prod. The backing provider name appears **only** in that subdomain string; nowhere user-facing.

## Testing
- **50 pass** (46 unit via mock transport + 4 smoke)
- Covers request shaping / headers / snake↔camel mapping, error wrapping, screenshot input→gateway-param mapping + relative-URL resolution + session mode, required-field guards, and **`withSession` closes on success AND on throw**
- `typecheck` ✓ · `lint` ✓

## Related
- Refs: SAP-2164 (Epic E1). Unblocks SAP-2165 (workflow-engine bump) → SAP-2166 (E2E).

## Checklist
- [x] No provider-name leak (only the `anchor-browser` subdomain)
- [x] Changeset added (minor)
- [x] Self-reviewed; verified typecheck/lint/tests green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)