### PR TITLE
fix(agent-core): sync scaffold VERSION_FALLBACK to published agent 0.7.1 + tools 0.23.0

### DIFF
--- a/.changeset/scaffold-version-fallback.md
+++ b/.changeset/scaffold-version-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Sync the scaffold `VERSION_FALLBACK` to the current published `@sapiom/agent` (0.7.1) and `@sapiom/tools` (0.23.0), so offline scaffolds pin real, published versions instead of stale ones.

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.7.0",
-  tools: "0.22.1",
+  agent: "0.7.1",
+  tools: "0.23.0",
 };
 
 /** The zod major the authoring SDK is built against. */


### PR DESCRIPTION
## Summary
The `@sapiom/tools@0.23.0` release (browserAutomation) + `@sapiom/agent@0.7.1` left the hand-maintained `VERSION_FALLBACK` snapshot in `scaffold.ts` stale (`0.7.0` / `0.22.1`), which fails the scaffold **offline-fallback regression test** on `main` (it asserts the fallback matches the workspace `package.json` versions). This syncs both to the published versions.

## Change
- `VERSION_FALLBACK`: `agent 0.7.0 → 0.7.1`, `tools 0.22.1 → 0.23.0`
- Patch changeset for `@sapiom/agent-core`

## Testing
- The failing test (`scaffold.test.ts › resolveVersions offline fallback › falls back to a version that is actually published`) now passes — the fallback equals the workspace `package.json` versions. (Other agent-core suites that fail locally do so only for the unrelated worktree missing-built-deps reason; they pass on CI.)

## Related
- Refs: SAP-2164 (the release that triggered the drift)

## Note
This is the recurring hand-maintained-snapshot drift the test is designed to catch — it will re-break on every `@sapiom/tools`/`@sapiom/agent` release. A durable fix (derive the fallback from `package.json` at build time) may be worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)