### PR TITLE
feat: resource-reuse wiring — database.list + runtime handle-read (SAP-2191)

### DIFF
--- a/.changeset/sap-2191-database-list.md
+++ b/.changeset/sap-2191-database-list.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+Add `database.list()` to the `database` capability — a thin, read-only listing over `GET /v1/databases` that returns every database you own, each with connection credentials. It never creates, mutates, or removes anything. Use it to discover a handle you (or another of your workflows) already provisioned before deciding whether to reuse it. Available on the client (`sapiom.database.list()`) and as an ambient function (`import { database } from "@sapiom/tools"`).

--- a/.changeset/sap-2191-resolve-resource-handle.md
+++ b/.changeset/sap-2191-resolve-resource-handle.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/agent": minor
+---
+
+Add `resolveResourceHandle(input, { fallback, key? })` — the single seam a step reads its chosen resource handle from.
+
+A template declares which managed resource it opens (its `resources[].handle` in `template.json`) and Sapiom provisions it at deploy, but that declaration is a build-time artifact that never reaches step code. Templates therefore hardcoded the handle (`const DEFAULT_DB_HANDLE = "…"`) and re-read it in every step, so the declared handle and the opened handle were two independent literals that could drift, and nothing let a run open a different one.
+
+`resolveResourceHandle` reads the handle injected into the run's entry input — the seam the setup panel's settings (and, later, its "use my own" resource picker) drive — falling back to the code-side default that keeps a zero-setup run working. It is read-only and never throws, so it is safe to call from an entry step. This is the mechanism a declared / provisioned / picked handle flows through to become the one the run actually opens.

--- a/.changeset/sap-2191-scaffold-version-fallback.md
+++ b/.changeset/sap-2191-scaffold-version-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Update the scaffold offline `VERSION_FALLBACK` to the currently published versions (`@sapiom/agent@0.7.1`, `@sapiom/tools@0.23.0`). The previous values had drifted behind the last release, which failed the "fallback matches the workspace version" regression test in `scaffold.test.ts`. Keeping the fallback current means an offline / registry-hiccup scaffold resolves to a version that actually exists on npm instead of failing with a silent ETARGET.

--- a/examples/cold-outreach-engine/index.ts
+++ b/examples/cold-outreach-engine/index.ts
@@ -3,6 +3,7 @@ import {
   defineStep,
   goto,
   pauseUntilSignal,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -291,7 +292,10 @@ const enrich = defineStep({
         : DEFAULT_DRIP_DAYS;
 
     ctx.shared.set("campaign", input.campaign?.trim() || "cold-outreach");
-    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set(
+      "dbHandle",
+      resolveResourceHandle(input, { fallback: DEFAULT_DB_HANDLE }),
+    );
     ctx.shared.set("dryRun", truthy(input.dryRun));
     ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
     ctx.shared.set("senderName", input.senderName?.trim() || "The team");

--- a/examples/cold-outreach-engine/package.json
+++ b/examples/cold-outreach-engine/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.8.0",
+    "@sapiom/tools": "^0.24.0",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/examples/error-triage-digest/index.ts
+++ b/examples/error-triage-digest/index.ts
@@ -3,6 +3,7 @@ import {
   defineStep,
   goto,
   pauseUntilSignal,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -240,7 +241,10 @@ const collect = defineStep({
   // Static graph edge: on SIGNAL, resume at `triage`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "triage" },
   async run(input: EntryInput, ctx: Ctx) {
-    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set(
+      "dbHandle",
+      resolveResourceHandle(input, { fallback: DEFAULT_DB_HANDLE }),
+    );
     ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
     ctx.shared.set("dryRun", truthy(input.dryRun));
     ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);

--- a/examples/error-triage-digest/package.json
+++ b/examples/error-triage-digest/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.8.0",
+    "@sapiom/tools": "^0.24.0",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/examples/meeting-notes-crm/index.ts
+++ b/examples/meeting-notes-crm/index.ts
@@ -3,6 +3,7 @@ import {
   defineStep,
   goto,
   pauseUntilSignal,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -243,7 +244,10 @@ const intake = defineStep({
   // Static graph edge: on SIGNAL, resume at `extract`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "extract" },
   async run(input: EntryInput, ctx: Ctx) {
-    ctx.shared.set("dbHandle", input.dbHandle?.trim() || DEFAULT_DB_HANDLE);
+    ctx.shared.set(
+      "dbHandle",
+      resolveResourceHandle(input, { fallback: DEFAULT_DB_HANDLE }),
+    );
     ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
     ctx.shared.set("dryRun", truthy(input.dryRun));
     ctx.shared.set("meetingDate", input.meetingDate?.trim() || null);

--- a/examples/meeting-notes-crm/package.json
+++ b/examples/meeting-notes-crm/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.8.0",
+    "@sapiom/tools": "^0.24.0",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -3,6 +3,7 @@ import {
   defineStep,
   goto,
   pauseUntilSignal,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -265,7 +266,9 @@ const fetch = defineStep({
   next: ["renderImages", "renderClip"],
   terminal: true,
   async run(input: EntryInput, ctx: Ctx) {
-    const dbHandle = input.dbHandle?.trim() || DEFAULT_DB_HANDLE;
+    const dbHandle = resolveResourceHandle(input, {
+      fallback: DEFAULT_DB_HANDLE,
+    });
     const medium: Medium = input.medium === "video" ? "video" : "image";
     const dryRun = input.dryRun === true;
     const style = input.style?.trim() ?? "";

--- a/examples/personalized-media-at-scale/package.json
+++ b/examples/personalized-media-at-scale/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.8.0",
+    "@sapiom/tools": "^0.24.0",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -2,6 +2,7 @@ import {
   defineAgent,
   defineStep,
   goto,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -312,7 +313,9 @@ const snapshot = defineStep({
   next: ["narrate"],
   async run(input: EntryInput, ctx: Ctx) {
     const dryRun = truthy(input.dryRun);
-    const handle = input.dbHandle?.trim() || DEFAULT_DB_HANDLE;
+    const handle = resolveResourceHandle(input, {
+      fallback: DEFAULT_DB_HANDLE,
+    });
     ctx.shared.set("dbHandle", handle);
     ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
     ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);

--- a/examples/scheduled-db-insight-report/package.json
+++ b/examples/scheduled-db-insight-report/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.8.0",
+    "@sapiom/tools": "^0.24.0",
     "postgres": "^3.4.5"
   },
   "devDependencies": {

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.7.0",
-  tools: "0.22.1",
+  agent: "0.7.1",
+  tools: "0.23.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/packages/agent/src/config.spec.ts
+++ b/packages/agent/src/config.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * resolveResourceHandle — the seam a step reads its chosen resource handle from.
+ * The injected entry-input value wins when present and non-empty; otherwise the
+ * code-side fallback (the runtime guarantee) is used. It never throws.
+ */
+
+import { resolveResourceHandle } from "./index.js";
+
+const FALLBACK = "meeting-notes-crm";
+
+describe("resolveResourceHandle", () => {
+  it("returns the fallback when the input carries no handle", () => {
+    expect(resolveResourceHandle({}, { fallback: FALLBACK })).toBe(FALLBACK);
+    expect(resolveResourceHandle({ other: "x" }, { fallback: FALLBACK })).toBe(
+      FALLBACK,
+    );
+  });
+
+  it("returns the injected handle when present and non-empty", () => {
+    expect(
+      resolveResourceHandle({ dbHandle: "my-own-db" }, { fallback: FALLBACK }),
+    ).toBe("my-own-db");
+  });
+
+  it("trims surrounding whitespace on the injected handle", () => {
+    expect(
+      resolveResourceHandle(
+        { dbHandle: "  my-own-db  " },
+        { fallback: FALLBACK },
+      ),
+    ).toBe("my-own-db");
+  });
+
+  it("falls back when the injected handle is blank / whitespace-only", () => {
+    expect(
+      resolveResourceHandle({ dbHandle: "   " }, { fallback: FALLBACK }),
+    ).toBe(FALLBACK);
+    expect(
+      resolveResourceHandle({ dbHandle: "" }, { fallback: FALLBACK }),
+    ).toBe(FALLBACK);
+  });
+
+  it("reads a custom key when given", () => {
+    expect(
+      resolveResourceHandle(
+        { targetDb: "picked" },
+        { fallback: FALLBACK, key: "targetDb" },
+      ),
+    ).toBe("picked");
+    // The default key is ignored when a custom key is supplied.
+    expect(
+      resolveResourceHandle(
+        { dbHandle: "ignored" },
+        { fallback: FALLBACK, key: "targetDb" },
+      ),
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back on non-string or non-object inputs without throwing", () => {
+    expect(
+      resolveResourceHandle({ dbHandle: 123 }, { fallback: FALLBACK }),
+    ).toBe(FALLBACK);
+    expect(
+      resolveResourceHandle({ dbHandle: null }, { fallback: FALLBACK }),
+    ).toBe(FALLBACK);
+    expect(resolveResourceHandle(undefined, { fallback: FALLBACK })).toBe(
+      FALLBACK,
+    );
+    expect(resolveResourceHandle(null, { fallback: FALLBACK })).toBe(FALLBACK);
+    expect(resolveResourceHandle("a string", { fallback: FALLBACK })).toBe(
+      FALLBACK,
+    );
+  });
+});

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -1,0 +1,66 @@
+/**
+ * Injected run configuration a step reads from its entry input.
+ *
+ * A template declares which managed resource it opens — its `resources[].handle`
+ * in `template.json` — and Sapiom provisions it at deploy. But that declaration is
+ * a build-time artifact: it never reaches step code. So a run needs the chosen
+ * handle *injected*, and the injection seam is the entry input. The setup panel's
+ * settings (and, later, its "use my own" resource picker) write the chosen handle
+ * into the entry input under a declared key, which the engine merges into
+ * `ctx.input` per run.
+ *
+ * Historically templates hardcoded the handle (`const DEFAULT_DB_HANDLE = "…"`)
+ * and re-read it in every step, so the *declared* handle and the *opened* handle
+ * were two independent literals that could drift, and nothing let a run open a
+ * different one. {@link resolveResourceHandle} is the single seam that reads the
+ * injected handle, so a declared / provisioned / picked handle finally becomes
+ * the one the run opens.
+ */
+
+/** Options for {@link resolveResourceHandle}. */
+export interface ResolveResourceHandleOptions {
+  /**
+   * The code-side default handle — the value used when the entry input carries
+   * none. This is the runtime guarantee that keeps a zero-setup run working; the
+   * manifest declares the same value as the setting's `default` (its renderable
+   * projection). Required, because a run must always open *some* handle.
+   */
+  readonly fallback: string;
+  /**
+   * The top-level key in the entry input that carries the injected handle — the
+   * field a declared `settings[]` entry's `path` targets, and what the picker
+   * writes. Defaults to `"dbHandle"`, the convention the templates already use.
+   */
+  readonly key?: string;
+}
+
+/**
+ * Resolve the resource handle a run should open from its injected entry input,
+ * falling back to the code-side default.
+ *
+ * Read-only and side-effect-free: it inspects `input` and never provisions,
+ * mutates, or opens anything. Safe to call from an entry step — it never throws
+ * on a missing, empty, or malformed value; it simply falls back. An injected
+ * handle wins only when it is a non-empty string once trimmed.
+ *
+ * @example
+ * ```ts
+ * const DEFAULT_DB_HANDLE = "meeting-notes-crm";
+ * const handle = resolveResourceHandle(input, { fallback: DEFAULT_DB_HANDLE });
+ * ctx.shared.set("dbHandle", handle);
+ * ```
+ */
+export function resolveResourceHandle(
+  input: unknown,
+  opts: ResolveResourceHandleOptions,
+): string {
+  const key = opts.key ?? "dbHandle";
+  if (input && typeof input === "object") {
+    const raw = (input as Record<string, unknown>)[key];
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return opts.fallback;
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -54,6 +54,11 @@ export {
 // Errors that are part of the public contract surface
 export { AgentError, UnknownStepError, StepInputValidationError, DisallowedTransitionError } from './errors.js';
 
+// Injected run configuration — the seam a step reads a chosen resource handle
+// from (the entry input the setup panel's settings / resource picker drive).
+export { resolveResourceHandle } from './config.js';
+export type { ResolveResourceHandleOptions } from './config.js';
+
 // Introspection — zod→JSON-Schema conversion + step/workflow input contracts.
 // Shared by engine tooling and the build phase (runs outside the engine).
 export { zodToJsonSchema, exampleFromJsonSchema, stepInputContract, workflowInputContract } from './introspection.js';

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -287,6 +287,8 @@ export interface Sapiom {
     create(input: CreateDatabaseInput): Promise<Database>;
     /** Retrieve a database by its id or handle. */
     get(idOrHandle: string): Promise<Database>;
+    /** List every database you own, each with connection credentials (read-only). */
+    list(): Promise<Database[]>;
     /** Delete a database by its id or handle. */
     delete(idOrHandle: string): Promise<void>;
   };
@@ -558,6 +560,7 @@ function bind(transport: Transport): Sapiom {
     database: {
       create: (input) => database.create(input, transport),
       get: (idOrHandle) => database.get(idOrHandle, transport),
+      list: () => database.list(transport),
       delete: (idOrHandle) => database.delete(idOrHandle, transport),
     },
     email: {

--- a/packages/tools/src/database/README.md
+++ b/packages/tools/src/database/README.md
@@ -22,10 +22,17 @@ db.connection?.username;
 db.connection?.password;
 db.connection?.databaseName;
 
-// 3. Retrieve it later by id or handle, then delete it.
+// 3. Retrieve it later by id or handle, or list everything you own.
 const again = await sapiom.database.get(db.id); // or get("analytics")
+const all = await sapiom.database.list(); // read-only; every database you own
+
+// 4. Delete it by id or handle.
 await sapiom.database.delete(db.id); // or delete("analytics")
 ```
+
+`list()` is **read-only** — it never creates, mutates, or removes anything. Use it
+to discover a handle you (or another of your workflows) already provisioned before
+deciding whether to reuse it.
 
 Ambient import works too: `import { database } from "@sapiom/tools"`.
 

--- a/packages/tools/src/database/index.spec.ts
+++ b/packages/tools/src/database/index.spec.ts
@@ -313,6 +313,52 @@ describe("database.get()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// list()
+// ---------------------------------------------------------------------------
+
+describe("database.list()", () => {
+  it("GETs /v1/databases and maps each row", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse([
+          rawDatabase(),
+          rawDatabase({ id: "db_def456", handle: "reporting" }),
+        ]),
+    ]);
+
+    const dbs = await database.list(transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/databases`);
+    expect(calls[0]!.init.method).toBeUndefined(); // default GET
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(dbs).toHaveLength(2);
+    expect(dbs[0]!.id).toBe("db_abc123");
+    expect(dbs[0]!.connection?.host).toBe("db.example.com");
+    expect(dbs[1]!.handle).toBe("reporting");
+  });
+
+  it("returns [] for an empty list", async () => {
+    const { transport } = makeTransport([() => jsonResponse([])]);
+    await expect(database.list(transport, BASE)).resolves.toEqual([]);
+  });
+
+  it("tolerates a non-array body by returning []", async () => {
+    const { transport } = makeTransport([() => jsonResponse({})]);
+    await expect(database.list(transport, BASE)).resolves.toEqual([]);
+  });
+
+  it("throws DatabaseHttpError on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () => new Response("boom", { status: 500 }),
+    ]);
+
+    await expect(database.list(transport, BASE)).rejects.toBeInstanceOf(
+      DatabaseHttpError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // delete()
 // ---------------------------------------------------------------------------
 
@@ -374,13 +420,15 @@ describe("database — client wiring + credential", () => {
     const sapiom = createClient({ apiKey: "my-key", fetch: fetchMock });
     await sapiom.database.create({ duration: "1h" });
     await sapiom.database.get("db_abc123");
+    await sapiom.database.list();
     await sapiom.database.delete("db_abc123");
 
-    expect(calls).toHaveLength(3);
+    expect(calls).toHaveLength(4);
     for (const c of calls) {
       expect(headerOf(c, "x-sapiom-api-key")).toBe("my-key");
     }
     expect(calls[0]!.url).toBe("https://neon.services.sapiom.ai/v1/databases");
+    expect(calls[2]!.url).toBe("https://neon.services.sapiom.ai/v1/databases");
   });
 
   it("throws a clear error when no tenant credential is configured", async () => {

--- a/packages/tools/src/database/index.ts
+++ b/packages/tools/src/database/index.ts
@@ -8,6 +8,7 @@
  *   db.connection?.connectionString;                      // a ready-to-use Postgres URI
  *
  *   const again = await database.get(db.id);              // or get("analytics") by handle
+ *   const all = await database.list();                    // every database you own (read-only)
  *   await database.delete(db.id);                         // or delete("analytics")
  *
  * Or via an explicit client: `createClient({ apiKey }).database.create(...)`.
@@ -222,6 +223,25 @@ export async function get(
     `Failed to get database '${idOrHandle}'`,
   );
   return mapDatabase((await res.json()) as RawDatabaseResponse);
+}
+
+/**
+ * List your active and provisioning databases, each with connection credentials.
+ * Read-only — it never creates, mutates, or removes anything. Useful for
+ * discovering a handle you (or another of your workflows) already provisioned
+ * before deciding whether to reuse it. Failed requests throw
+ * {@link DatabaseHttpError}.
+ */
+export async function list(
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<Database[]> {
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/databases`),
+    "Failed to list databases",
+  );
+  const raw = (await res.json()) as RawDatabaseResponse[];
+  return Array.isArray(raw) ? raw.map(mapDatabase) : [];
 }
 
 /**

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -1236,6 +1236,8 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             createdAt: "2099-01-01T00:00:00Z",
           })) as Database,
         ),
+      list: () =>
+        Promise.resolve(r("database.list", [], () => []) as Database[]),
       delete: (idOrHandle) =>
         Promise.resolve(
           r("database.delete", [idOrHandle], () => undefined) as void,


### PR DESCRIPTION
## What & why

The safe, load-bearing half of the reuse picker ([SAP-2191](https://linear.app/sapiom/issue/SAP-2191)). This half carries **no delete risk** and is **not gated on the [SAP-2190](https://linear.app/sapiom/issue/SAP-2190) delete decision**: making step code read an injected handle instead of a hardcoded one creates no sharing (provisioning still gives each workflow its own DB). The selection/attachment UI — where two workflows share one handle — lives in **SAP-2191b**, blocked on the delete decision.

Design of record: `plans/onboarding-templates/design-v2.md` §C1 (and `auto-detection-and-reuse.md` §Q3).

## Changes

**1. `@sapiom/tools` — `database.list()` (read-only).** The `database` namespace exposed only create/get/delete. `list()` is a thin, read-only listing over the existing `GET /v1/databases` (the neon gateway route the backend already surfaces as `sapiom_database_list`), returning every database you own with connection credentials. It never creates, mutates, or removes anything, so it's safe ahead of the delete decision. Wired through the client type, the ambient factory, and the **stub client** (returns `[]` under `run_local`).

**2. `@sapiom/agent` — `resolveResourceHandle(input, { fallback, key? })`.** *The deepest gap:* a template declares which DB it opens (its `resources[].handle`) and Sapiom provisions it at deploy, but that declaration is a build-time artifact that never reaches step code — so templates re-hardcoded the handle as `DEFAULT_DB_HANDLE` and nothing at runtime let a run open a different one. This is the single seam a step reads its chosen handle from: it reads the handle **injected into the entry input** (the seam the setup panel's settings, and later the resource picker, drive), falling back to the code-side default that keeps a zero-setup run working. Read-only and never throws, so it's safe in an entry step. This is the mechanism the picker later drives; it's useful on its own — a declared/provisioned handle finally becomes the one the run opens.

**3. Templates migrated** to read the handle via the new seam (behaviour-preserving; `DEFAULT_DB_HANDLE` stays as the code-side fallback): `meeting-notes-crm`, `cold-outreach-engine`, `error-triage-digest`, `personalized-media-at-scale`, `scheduled-db-insight-report`. `nl-db-query-endpoint` is intentionally left as-is (its demo-vs-`connectionString` resolution has different semantics the generic seam would flatten).

## Explicitly NOT here
Selecting/attaching an **existing** (possibly another workflow's) handle — that introduces sharing + delete risk and lives in **SAP-2191b**.

## Release ordering note for reviewers
`examples/` sits outside the pnpm workspace and pins **published** SDK versions (it's validated in CI only by the static `examples:check`, never built). The migrated templates therefore bump `@sapiom/agent` → `^0.8.0` (the minor this PR's changeset cuts, which carries `resolveResourceHandle`) and `@sapiom/tools` → `^0.24.0` to stay in lockstep. The `@sapiom/agent` authoring surface has been stable since 0.6.0, so the pin bump is API-safe. Changesets included for both packages.

## Verification
- `pnpm build` / `pnpm typecheck` / `pnpm lint` — green on `@sapiom/tools` + `@sapiom/agent` (incl. their dep chain).
- `pnpm examples:check` — green (26 manifests schema-valid, sorted).
- `database/index.spec.ts` (23 tests) and `config.spec.ts` (6 tests) — green (`--maxWorkers=1`).

Closes SAP-2191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)