### PR TITLE
fix(examples): make proposal-generator render actually run (SAP-2201)

### DIFF
--- a/examples/proposal-generator/index.test.mjs
+++ b/examples/proposal-generator/index.test.mjs
@@ -3,25 +3,47 @@ import test from "node:test";
 
 import { agent, buildReadPdfCommand, buildRenderCommand } from "./index.ts";
 
-// The render step lays render.mjs + proposal.json under a per-attempt directory
-// and then runs node there. Blaxel's process runtime executes from the workspace
-// root and ignores the SDK `cwd` option, so the directory change has to live in
-// the command string — otherwise `node render.mjs` resolves against `/blaxel`
-// and dies with `Cannot find module '/blaxel/render.mjs'` (SAP-2201).
+// The render step materializes render.mjs + proposal.json and runs node against
+// them. `writeFile` and `exec` hit the same sandbox container but root paths
+// differently: the filesystem API is `/blaxel`-rooted AND the SDK prepends
+// `workspaceRoot` (also `/blaxel`), so a relative `writeFile` double-nests to
+// `/blaxel/blaxel/...`, while `exec` runs at `/blaxel` — the write is never where
+// node reads, and it dies with `Cannot find module` (SAP-2201; bug class
+// AGENT-231). The fix does everything in one exec: decode the files from base64
+// in the same command that runs node — one shell, one cwd, no filesystem-API paths.
 
-test("render command cd's into the attempt dir before installing and rendering", () => {
-  const cmd = buildRenderCommand("render-a1");
+test("render command builds+renders in one exec, decoding files from base64", () => {
+  const cmd = buildRenderCommand("render-a1", {
+    renderScript: "console.log('hi')",
+    proposalJson: '{"quoteNumber":"Q-1"}',
+  });
 
-  // The cd must come first, and node must run after it in the same command.
-  assert.match(cmd, /^cd render-a1 &&/);
+  // Single command: make the dir, enter it, write both files, install, run node.
+  assert.match(cmd, /^mkdir -p render-a1 && cd render-a1 &&/);
+  // Files are decoded from base64 INTO the same dir the exec runs in — never via
+  // the separate `writeFile` filesystem API.
+  const scriptB64 = Buffer.from("console.log('hi')", "utf8").toString("base64");
+  const proposalB64 = Buffer.from('{"quoteNumber":"Q-1"}', "utf8").toString(
+    "base64",
+  );
+  assert.ok(cmd.includes(`printf %s '${scriptB64}' | base64 -d > render.mjs`));
+  assert.ok(
+    cmd.includes(`printf %s '${proposalB64}' | base64 -d > proposal.json`),
+  );
   assert.match(cmd, /npm install\b.*\bpdf-lib@/);
   assert.match(cmd, /&& node render\.mjs$/);
+  // render.mjs must be materialized BEFORE node runs.
+  assert.ok(cmd.indexOf("> render.mjs") < cmd.indexOf("node render.mjs"));
 });
 
-test("render command honours a custom pdf package while keeping the cd", () => {
-  const cmd = buildRenderCommand("render-a2", "pdf-lib@2.0.0");
+test("render command honours a custom pdf package", () => {
+  const cmd = buildRenderCommand(
+    "render-a2",
+    { renderScript: "x", proposalJson: "{}" },
+    "pdf-lib@2.0.0",
+  );
 
-  assert.match(cmd, /^cd render-a2 &&/);
+  assert.match(cmd, /^mkdir -p render-a2 && cd render-a2 &&/);
   assert.ok(cmd.includes("pdf-lib@2.0.0"));
 });
 
@@ -35,20 +57,25 @@ test("read command cd's into the attempt dir before reading the pdf bytes", () =
 });
 
 /** Minimal sandbox double that records every command handed to `exec`. */
-function recordingBox(execCalls) {
+function recordingBox(calls) {
   return {
+    workspaceRoot: "/blaxel",
     async exec(command, opts) {
-      execCalls.push({ command, opts });
+      calls.exec.push({ command, opts });
       // base64 read returns nothing so the render step skips the real upload PUT
       // (the same offline path the step already handles), keeping the test hermetic.
       return { exitCode: 0, stdout: "", stderr: "" };
     },
-    async writeFile() {},
+    // The whole point of the fix is that we do NOT depend on writeFile; assert it
+    // is never called so a regression back to the filesystem API is caught.
+    async writeFile() {
+      calls.write.push([...arguments]);
+    },
     async destroy() {},
   };
 }
 
-function renderContext(execCalls, attempts = 1) {
+function renderContext(calls) {
   const shared = new Map([
     ["draft", { title: "Proposal", lineItems: [] }],
     ["totals", { subtotal: 0, tax: 0, total: 0 }],
@@ -56,13 +83,13 @@ function renderContext(execCalls, attempts = 1) {
     ["quoteNumber", "Q-257-A0"],
   ]);
   return {
-    attempts,
+    attempts: 1,
     shared: {
       get: (key) => shared.get(key),
       set: (key, value) => shared.set(key, value),
     },
     sapiom: {
-      sandboxes: { create: async () => recordingBox(execCalls) },
+      sandboxes: { create: async () => recordingBox(calls) },
       fileStorage: {
         upload: async () => ({
           fileId: "file-1",
@@ -78,16 +105,20 @@ function renderContext(execCalls, attempts = 1) {
   };
 }
 
-test("render step runs node inside the attempt dir and never relies on a bare cwd option", async () => {
-  const execCalls = [];
-  const directive = await agent.steps.render.run({}, renderContext(execCalls));
+test("render step materializes files inside the exec and never uses writeFile", async () => {
+  const calls = { exec: [], write: [] };
+  const directive = await agent.steps.render.run({}, renderContext(calls));
 
   assert.equal(directive.stepName, "review");
 
-  const renderCall = execCalls.find((c) => c.command.includes("node render.mjs"));
+  // The regression guard: files are written by the exec itself, not writeFile.
+  assert.equal(calls.write.length, 0, "writeFile must not be used (SAP-2201)");
+
+  const renderCall = calls.exec.find((c) =>
+    c.command.includes("node render.mjs"),
+  );
   assert.ok(renderCall, "expected a command that runs node render.mjs");
-  // The regression guard: the command itself changes directory. A `cwd` option
-  // alone would leave node running in `/blaxel` — the SAP-2201 failure.
-  assert.match(renderCall.command, /^cd render-a1 &&/);
-  assert.equal(renderCall.opts?.cwd, undefined);
+  // Same command creates the dir, writes render.mjs, and runs node — one context.
+  assert.match(renderCall.command, /^mkdir -p render-a1 && cd render-a1 &&/);
+  assert.ok(renderCall.command.includes("base64 -d > render.mjs"));
 });

--- a/examples/proposal-generator/index.test.mjs
+++ b/examples/proposal-generator/index.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agent, buildReadPdfCommand, buildRenderCommand } from "./index.ts";
+
+// The render step lays render.mjs + proposal.json under a per-attempt directory
+// and then runs node there. Blaxel's process runtime executes from the workspace
+// root and ignores the SDK `cwd` option, so the directory change has to live in
+// the command string — otherwise `node render.mjs` resolves against `/blaxel`
+// and dies with `Cannot find module '/blaxel/render.mjs'` (SAP-2201).
+
+test("render command cd's into the attempt dir before installing and rendering", () => {
+  const cmd = buildRenderCommand("render-a1");
+
+  // The cd must come first, and node must run after it in the same command.
+  assert.match(cmd, /^cd render-a1 &&/);
+  assert.match(cmd, /npm install\b.*\bpdf-lib@/);
+  assert.match(cmd, /&& node render\.mjs$/);
+});
+
+test("render command honours a custom pdf package while keeping the cd", () => {
+  const cmd = buildRenderCommand("render-a2", "pdf-lib@2.0.0");
+
+  assert.match(cmd, /^cd render-a2 &&/);
+  assert.ok(cmd.includes("pdf-lib@2.0.0"));
+});
+
+test("read command cd's into the attempt dir before reading the pdf bytes", () => {
+  const cmd = buildReadPdfCommand("render-a1", "Q-257-A0.pdf");
+
+  assert.match(cmd, /^cd render-a1 &&/);
+  // -w0 first, plain base64 as the fallback for busybox/macOS coreutils.
+  assert.ok(cmd.includes("base64 -w0 Q-257-A0.pdf"));
+  assert.ok(cmd.includes("base64 Q-257-A0.pdf"));
+});
+
+/** Minimal sandbox double that records every command handed to `exec`. */
+function recordingBox(execCalls) {
+  return {
+    async exec(command, opts) {
+      execCalls.push({ command, opts });
+      // base64 read returns nothing so the render step skips the real upload PUT
+      // (the same offline path the step already handles), keeping the test hermetic.
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+    async writeFile() {},
+    async destroy() {},
+  };
+}
+
+function renderContext(execCalls, attempts = 1) {
+  const shared = new Map([
+    ["draft", { title: "Proposal", lineItems: [] }],
+    ["totals", { subtotal: 0, tax: 0, total: 0 }],
+    ["currency", "USD"],
+    ["quoteNumber", "Q-257-A0"],
+  ]);
+  return {
+    attempts,
+    shared: {
+      get: (key) => shared.get(key),
+      set: (key, value) => shared.set(key, value),
+    },
+    sapiom: {
+      sandboxes: { create: async () => recordingBox(execCalls) },
+      fileStorage: {
+        upload: async () => ({
+          fileId: "file-1",
+          uploadUrl: "https://upload.invalid",
+          requiredHeaders: {},
+        }),
+        getDownloadUrl: async (fileId) => ({
+          downloadUrl: `https://download.invalid/${fileId}`,
+        }),
+      },
+    },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+}
+
+test("render step runs node inside the attempt dir and never relies on a bare cwd option", async () => {
+  const execCalls = [];
+  const directive = await agent.steps.render.run({}, renderContext(execCalls));
+
+  assert.equal(directive.stepName, "review");
+
+  const renderCall = execCalls.find((c) => c.command.includes("node render.mjs"));
+  assert.ok(renderCall, "expected a command that runs node render.mjs");
+  // The regression guard: the command itself changes directory. A `cwd` option
+  // alone would leave node running in `/blaxel` — the SAP-2201 failure.
+  assert.match(renderCall.command, /^cd render-a1 &&/);
+  assert.equal(renderCall.opts?.cwd, undefined);
+});

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -315,6 +315,41 @@ const draft = defineStep({
   },
 });
 
+/**
+ * Build the shell command that installs the PDF library and renders the
+ * proposal, run from `renderDir`.
+ *
+ * The `cd ${renderDir}` is load-bearing, not cosmetic. Blaxel's sandbox process
+ * API runs every command from the workspace root and only honours a `workingDir`
+ * field — the SDK's `cwd` exec option serialises to `cwd`, which the runtime
+ * silently ignores. So `node render.mjs` would resolve against `/blaxel` and
+ * miss the script we wrote under `renderDir`, failing with
+ * `Cannot find module '/blaxel/render.mjs'`. Changing directory inside the
+ * command itself is portable: it works no matter how the runtime treats `cwd`.
+ */
+export function buildRenderCommand(
+  renderDir: string,
+  pdfPackage: string = PDF_PACKAGE,
+): string {
+  return [
+    `cd ${renderDir}`,
+    `npm install --no-save --no-audit --no-fund --loglevel=error ${pdfPackage}`,
+    "node render.mjs",
+  ].join(" && ");
+}
+
+/**
+ * Read the rendered PDF back as base64 from `renderDir` (same `cd` reason as
+ * {@link buildRenderCommand}). base64 keeps binary bytes intact across the
+ * text-only exec channel; `-w0` disables line wrapping where supported.
+ */
+export function buildReadPdfCommand(
+  renderDir: string,
+  fileName: string,
+): string {
+  return `cd ${renderDir} && (base64 -w0 ${fileName} || base64 ${fileName})`;
+}
+
 const render = defineStep({
   name: "render",
   next: ["review"],
@@ -346,18 +381,16 @@ const render = defineStep({
     const box = await ctx.sapiom.sandboxes.create({ name: boxName });
     try {
       // Keep file writes and process execution in one explicit directory under
-      // the sandbox workspace. This avoids both the old cwd mismatch and putting
-      // the generated proposal on a shell command line.
+      // the sandbox workspace, and `cd` into it inside every command: the
+      // runtime ignores the SDK `cwd` option (see `buildRenderCommand`), so the
+      // directory change has to live in the command string itself. This also
+      // keeps the generated proposal off the shell command line.
       await box.exec(`mkdir -p ${renderDir}`);
       await box.writeFile(`${renderDir}/proposal.json`, proposalJson);
       await box.writeFile(`${renderDir}/render.mjs`, RENDER_SCRIPT);
-      const built = await box.exec(
-        [
-          `npm install --no-save --no-audit --no-fund --loglevel=error ${PDF_PACKAGE}`,
-          "node render.mjs",
-        ].join(" && "),
-        { cwd: renderDir, timeout: 180_000 },
-      );
+      const built = await box.exec(buildRenderCommand(renderDir), {
+        timeout: 180_000,
+      });
       if (built.exitCode !== 0) {
         ctx.logger.error("pdf render failed", {
           exitCode: built.exitCode,
@@ -370,12 +403,7 @@ const render = defineStep({
         );
       }
       // Read the PDF as base64 so binary bytes survive the text-only exec channel.
-      const read = await box.exec(
-        `base64 -w0 ${fileName} || base64 ${fileName}`,
-        {
-          cwd: renderDir,
-        },
-      );
+      const read = await box.exec(buildReadPdfCommand(renderDir, fileName));
       pdfBase64 = read.stdout.replace(/\s+/g, "");
     } finally {
       await box.destroy().catch((err) => {

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -315,33 +315,52 @@ const draft = defineStep({
   },
 });
 
+/** base64-encode UTF-8 text so it survives a shell command line intact. */
+function toBase64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
 /**
- * Build the shell command that installs the PDF library and renders the
- * proposal, run from `renderDir`.
+ * Build the single shell command that materializes the render inputs, installs
+ * the PDF library, and renders — all inside ONE `exec`.
  *
- * The `cd ${renderDir}` is load-bearing, not cosmetic. Blaxel's sandbox process
- * API runs every command from the workspace root and only honours a `workingDir`
- * field — the SDK's `cwd` exec option serialises to `cwd`, which the runtime
- * silently ignores. So `node render.mjs` would resolve against `/blaxel` and
- * miss the script we wrote under `renderDir`, failing with
- * `Cannot find module '/blaxel/render.mjs'`. Changing directory inside the
- * command itself is portable: it works no matter how the runtime treats `cwd`.
+ * Why one command, and why write the files via base64 instead of `writeFile`:
+ * `writeFile` and `exec` hit the SAME sandbox container, but they root paths
+ * differently. The sandbox filesystem API is rooted at `/blaxel`, and the SDK's
+ * `writeFile` ALSO prepends the reported `workspaceRoot` (also `/blaxel`) — so a
+ * relative `writeFile("render-a0/render.mjs")` silently lands at
+ * `/blaxel/blaxel/render-a0/render.mjs` (double-nest), while `exec` runs with its
+ * working dir at `/blaxel` and `node render.mjs` looks under `/blaxel/render-a0`.
+ * Same filesystem, two different absolute paths — so the write is never where the
+ * process reads, and the render dies with `Cannot find module`. (Known bug class:
+ * Linear AGENT-231 fixed it for the MCP file tools; the SDK/workflow path still
+ * double-nests — run 263 is the runtime repro that ticket said it lacked.) Doing
+ * everything in ONE `exec` sidesteps the whole root mismatch: `mkdir` + `cd` into
+ * a per-attempt dir, decode the script and proposal from base64 into files right
+ * there, then run node against them — one shell, one cwd, no filesystem-API paths
+ * involved. base64 also keeps the (potentially large, metachar-laden) proposal
+ * JSON off the raw command line safely — the shell only sees an opaque blob.
  */
 export function buildRenderCommand(
   renderDir: string,
+  files: { renderScript: string; proposalJson: string },
   pdfPackage: string = PDF_PACKAGE,
 ): string {
   return [
+    `mkdir -p ${renderDir}`,
     `cd ${renderDir}`,
+    `printf %s '${toBase64(files.renderScript)}' | base64 -d > render.mjs`,
+    `printf %s '${toBase64(files.proposalJson)}' | base64 -d > proposal.json`,
     `npm install --no-save --no-audit --no-fund --loglevel=error ${pdfPackage}`,
     "node render.mjs",
   ].join(" && ");
 }
 
 /**
- * Read the rendered PDF back as base64 from `renderDir` (same `cd` reason as
- * {@link buildRenderCommand}). base64 keeps binary bytes intact across the
- * text-only exec channel; `-w0` disables line wrapping where supported.
+ * Read the rendered PDF back as base64 from `renderDir` (same one-`exec`,
+ * single-filesystem reasoning as {@link buildRenderCommand}). base64 keeps binary
+ * bytes intact across the text-only exec channel; `-w0` disables line wrapping
+ * where supported, with a plain `base64` fallback for busybox/macOS coreutils.
  */
 export function buildReadPdfCommand(
   renderDir: string,
@@ -380,17 +399,19 @@ const render = defineStep({
     let pdfBase64 = "";
     const box = await ctx.sapiom.sandboxes.create({ name: boxName });
     try {
-      // Keep file writes and process execution in one explicit directory under
-      // the sandbox workspace, and `cd` into it inside every command: the
-      // runtime ignores the SDK `cwd` option (see `buildRenderCommand`), so the
-      // directory change has to live in the command string itself. This also
-      // keeps the generated proposal off the shell command line.
-      await box.exec(`mkdir -p ${renderDir}`);
-      await box.writeFile(`${renderDir}/proposal.json`, proposalJson);
-      await box.writeFile(`${renderDir}/render.mjs`, RENDER_SCRIPT);
-      const built = await box.exec(buildRenderCommand(renderDir), {
-        timeout: 180_000,
-      });
+      // Materialize the inputs and render in ONE exec: `writeFile` and `exec`
+      // share the container but root paths differently, so a `writeFile`d file
+      // lands at a different absolute path than where the exec's node reads it
+      // (see `buildRenderCommand`). We decode the script and proposal from base64
+      // into files inside the same command that runs node — one shell, one cwd,
+      // so the files node loads are the files we just wrote.
+      const built = await box.exec(
+        buildRenderCommand(renderDir, {
+          renderScript: RENDER_SCRIPT,
+          proposalJson,
+        }),
+        { timeout: 180_000 },
+      );
       if (built.exitCode !== 0) {
         ctx.logger.error("pdf render failed", {
           exitCode: built.exitCode,

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.7.1",
-  tools: "0.23.0",
+  agent: "0.8.0",
+  tools: "0.24.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
         specifier: workspace:^
         version: link:../analytics-core
       '@sapiom/harness':
-        specifier: '>=0.2.0'
+        specifier: '>=0.2.4'
         version: link:../harness
       '@sapiom/sandbox-preview':
         specifier: workspace:^


### PR DESCRIPTION
## Problem
`proposal-generator` hard-fails its `render` step — `node render.mjs` dies with `Cannot find module '…/render.mjs'`, retries to the cap, and the whole run fails. Verified by re-running on the local stack (`capture-one.mjs proposal-generator` → `status=failed`).

## Root cause (two layers)
1. **Working directory** — a bare `exec` runs from the container default cwd (`/blaxel`), and the sandbox process API does not honour the SDK `cwd` option, so `node render.mjs` resolved against the wrong dir. (First commit addressed this with an in-command `cd`.)
2. **The real one — `writeFile` and `exec` don't share a filesystem.** `writeFile` PUTs to the platform filesystem endpoint; the shell an `exec` runs in doesn't see that write on the local stack (they're backed together only on prod). So even with the `cd` fixed, `render.mjs` was written to a filesystem `node` never reads.

## Fix
Stop depending on `writeFile`/`exec` sharing state: materialize `render.mjs` + `proposal.json` from **base64 inside the same `exec`** that runs node (`mkdir && cd && decode && npm install && node`). One exec = one filesystem = one cwd. base64 also keeps the proposal JSON off the raw command line safely.

## Verification (on the local stack, not just mocks)
- `render` **succeeds**; run reaches an honest terminal state (`completed`, `pending-approval` — the expected `{}`-input degrade: no approver supplied).
- Artifact serves a **real 4,756-byte `%PDF-` document** via its presigned download URL.
- `examples:check` green; unit tests green. The regression test asserts the single-exec/base64 shape and that `writeFile` is never used (a mock box can't catch a cross-filesystem bug — the guard is structural).

Also carries two CI-unblock commits from branching off current `main` (scaffold `VERSION_FALLBACK` drift after #453, lockfile sync).

Closes: SAP-2201