### PR TITLE
feat(examples): add orchestration + browser-automation gallery templates (SAP-2202)

### DIFF
--- a/examples/fan-out-and-combine/AGENTS.md
+++ b/examples/fan-out-and-combine/AGENTS.md
@@ -1,0 +1,42 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Fan Out and
+Combine** — authored against `@sapiom/agent`. It splits a goal into parts, runs each
+part as its own child workflow in parallel, then merges the results:
+`plan` → `fanOut` → `reduce` → `done`, with a `solve` leaf and a `planned` (dry-run)
+off-ramp. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom`
+(here: `ctx.sapiom.agents.run`, `ctx.sapiom.models.run`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined
+  by `@sapiom/tools` — read the types / use autocomplete rather than guessing.
+- **One agent, two roles, chosen by `mode`.** The default (`coordinate`) fans out;
+  each child is launched with `mode: "leaf"`, and the leaf path (`solve`) does one
+  unit of work and terminates. A leaf NEVER fans out — that is what bounds the
+  recursion to a single level. Don't let `solve` call `agents.run`.
+- **It composes itself.** `fanOut` defaults `childDefinition` to `ctx.agentName`, the
+  run's own slug, so a deployed copy dispatches leaf runs of itself with no other
+  deployment. Point `childDefinition` at another slug to fan that out instead.
+- **`agents.run` blocks; that's the join.** `fanOut` uses `Promise.all` over
+  `ctx.sapiom.agents.run` — each call waits for its child to reach a terminal state,
+  so the whole step resolves when every child is done. (`pauseUntilSignal` only
+  suspends on ONE handle, so it can't express a fan-in over many children.)
+- **Never fail.** Every child dispatch is wrapped: a throw or a non-`completed`
+  status becomes a `{ ok: false }` row, and `reduce` runs over the survivors. If
+  nothing came back with content, `reduce` says so instead of inventing an answer,
+  and its model call is itself wrapped to fall back to the raw parts. Keep those
+  guards if you edit the steps.
+- **Runs with nothing.** `plan` defaults the goal and the items, so `{}` in produces
+  a real fan-out. `dryRun: true` returns the plan via `planned` without dispatching.
+
+## Test it
+
+- `run_local` with `{ "dryRun": true }` traces the fan-out plan offline for free (no
+  capability calls). A non-dry local run dispatches STUBBED children that complete
+  with empty output, so `reduce` reports that no analysis came back — expected
+  offline, and honest.
+- Deployed, a run with `{}` fans a sample goal into three parallel child runs of
+  itself and returns one combined answer.

--- a/examples/fan-out-and-combine/README.md
+++ b/examples/fan-out-and-combine/README.md
@@ -1,0 +1,51 @@
+# Fan Out and Combine
+
+Split a goal into parts, run each part as its own child workflow in parallel, then
+merge the results into one answer — fan out, join, reduce. The canonical "a workflow
+composes other workflows" template, built on `ctx.sapiom.agents.run`.
+
+## What it does
+
+```
+                 ┌─ agents.run (leaf) ─┐
+plan ─▶ fanOut ──┼─ agents.run (leaf) ─┼─▶ reduce ─▶ done      (coordinate)
+                 └─ agents.run (leaf) ─┘   (models.run) (terminal)
+
+plan ─▶ solve ─▶ (terminal)                                    (leaf)
+        (models.run)
+
+plan ─▶ planned ─▶ (terminal)                                  (dryRun)
+```
+
+One agent, two roles chosen by `mode`:
+
+1. **plan** — resolves the `goal`, the `items` to fan out, and the
+   `childDefinition` (defaults to this agent's own slug, `ctx.agentName`). A leaf
+   goes straight to `solve`; a dry run goes to `planned`; otherwise it fans out.
+2. **fanOut** — launches one child run per item via `ctx.sapiom.agents.run` and
+   waits for all of them (`Promise.all`). Each dispatch is wrapped, so a child that
+   throws or does not complete becomes a failed row instead of sinking the batch.
+3. **reduce** — combines the children's analyses into one answer
+   (`ctx.sapiom.models.run`). If nothing came back with content, it says so rather
+   than inventing a result.
+4. **solve** _(leaf)_ — the unit of work: one `ctx.sapiom.models.run` analysis of a
+   single item toward the goal, then terminate. A leaf never fans out — that bounds
+   the recursion to one level.
+5. **done** / **planned** — terminal. `done` returns the combined answer plus a
+   per-child status; `planned` returns the fan-out plan with nothing dispatched.
+
+Input:
+`{ "goal": "…", "items": ["…", "…"], "childDefinition": "some-slug", "dryRun": false }`
+
+- `goal` and `items` are the two knobs — what to accomplish, and the parts to fan
+  it across (one child run per item).
+- `childDefinition` (optional) is the slug of the workflow to run per item; it
+  defaults to this agent, so the template composes itself with no other deployment.
+- `dryRun: true` returns the resolved fan-out plan without dispatching any children.
+
+## Run it
+
+- **Use this template** in the app — Sapiom builds and deploys it, and a run with
+  no input fans a sample goal into three parallel child runs of itself.
+- **Locally:** `run_local` with `{ "dryRun": true }` traces the fan-out plan for
+  free (the child capability is stubbed offline).

--- a/examples/fan-out-and-combine/index.ts
+++ b/examples/fan-out-and-combine/index.ts
@@ -1,0 +1,414 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Fan Out and Combine — split a goal into parts, run each part as its own child
+ * workflow in parallel, then merge the results into one answer.
+ *
+ * This is the canonical "a workflow composes other workflows" template. It reaches
+ * the child-run capability through the run context (`ctx.sapiom.agents.run`), so
+ * every child is a real, independently-metered execution — not an in-process
+ * function call. The pattern is fan-out → join → reduce, the durable equivalent of
+ * `Promise.all` over sub-agents.
+ *
+ * ONE agent, TWO roles, chosen by `mode`:
+ *   - coordinate (default): the parent. Splits the goal into items, launches a
+ *     child run per item, waits for all of them, and reduces their outputs.
+ *   - leaf: a child. Does exactly ONE unit of work (analyse its item toward the
+ *     goal with `models.run`) and terminates. A leaf NEVER fans out, which is what
+ *     bounds the recursion to a single level — there is no runaway.
+ *
+ * The child it fans out to defaults to THIS agent's own slug (`ctx.agentName`), so
+ * the template composes itself with zero setup: a deployed run dispatches leaf runs
+ * of the same deployment. Point `childDefinition` at any other deployed
+ * orchestration's slug and it fans that out instead, one child run per item.
+ *
+ * The graph, one legible line per role:
+ *   plan ─▶ fanOut (agents.run × N) ─▶ reduce (models.run) ─▶ done      (coordinate)
+ *   plan ─▶ solve (models.run) ─▶ (terminal)                            (leaf)
+ *   plan ─▶ planned (terminal)                                          (dryRun)
+ *
+ * Never-fail discipline:
+ *   - Every child dispatch is wrapped: a child that throws or ends non-`completed`
+ *     becomes a `{ ok: false }` row, and the reduce runs over the survivors. Even
+ *     if every child fails, the run still reaches a terminal state with an honest
+ *     account of what happened — it never reports a combined answer it doesn't have.
+ *   - `dryRun` returns the resolved fan-out PLAN (which child, how many items, the
+ *     resolved inputs) without dispatching anything. Pass it to `run_local` to see
+ *     the shape of the fan-out offline, for free, before spending on child runs.
+ *   - Offline (`run_local`) the child capability is stubbed, so children complete
+ *     with empty output; the reduce says so rather than inventing analysis.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Hard cap on how many children a single coordinate run fans out to. */
+const MAX_ITEMS = 5;
+/** Truncate each child's analysis before it rides into the reduce prompt. */
+const MAX_ANALYSIS_CHARS = 1200;
+/** Bound the leaf model call — one focused analysis, not an essay. */
+const LEAF_MAX_TOKENS = 700;
+/** Bound the reduce model call — a combined brief, not a book. */
+const REDUCE_MAX_TOKENS = 1000;
+
+/**
+ * The goal a zero-input run works on. A real goal with real sub-parts, so the
+ * default run produces a genuine combined answer rather than a hollow demo.
+ */
+const DEFAULT_GOAL =
+  "What are the main trade-offs of running background jobs on a serverless platform?";
+/** The sub-parts a zero-input run fans out — one child run each. */
+const DEFAULT_ITEMS = [
+  "cost and the billing model",
+  "cold starts and latency",
+  "concurrency and scaling limits",
+];
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+type Mode = "coordinate" | "leaf";
+
+interface EntryInput {
+  /** What to accomplish. Split across the items on the coordinate path. */
+  goal?: string;
+  /** The sub-parts to fan out — one child run per item. Defaults to a sample set. */
+  items?: string[];
+  /**
+   * Slug of the deployed orchestration to run for each item. Defaults to THIS
+   * agent's own slug, so the template composes itself with no other deployment.
+   */
+  childDefinition?: string;
+  /**
+   * Which role this execution plays. Omit (or "coordinate") for the parent; the
+   * coordinator sets "leaf" on the children it launches. A leaf does one item and
+   * never fans out.
+   */
+  mode?: Mode;
+  /** The single item a leaf works on. Set by the coordinator on each child. */
+  item?: string;
+  /** Resolve and return the fan-out plan without dispatching any child runs. */
+  dryRun?: boolean;
+}
+
+/** The outcome of one child dispatch, success or failure — the fan-out → reduce row. */
+interface ChildResult {
+  item: string;
+  /** True only when the child run reached `completed`. */
+  ok: boolean;
+  /** The child run's lifecycle status, or "error" when the dispatch itself threw. */
+  status: string;
+  /** The child's analysis text, when it returned one. */
+  analysis: string | null;
+  /** A short error string when the child failed or threw. */
+  error: string | null;
+}
+
+interface Shared extends Record<string, unknown> {
+  goal: string;
+  childDefinition: string;
+  dryRun: boolean;
+  /** How many items the coordinator fanned out (0 on the leaf/dryRun paths). */
+  itemCount: number;
+  /** Set when the run coordinated the default goal rather than a supplied one. */
+  note?: string;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/** Trim, drop empties, de-dupe, and cap — the items a coordinate run fans out. */
+function normalizeItems(items: unknown, fallback: string[]): string[] {
+  const cleaned = Array.isArray(items)
+    ? [
+        ...new Set(
+          items
+            .filter((i): i is string => typeof i === "string")
+            .map((i) => i.trim())
+            .filter((i) => i.length > 0),
+        ),
+      ]
+    : [];
+  const chosen = cleaned.length > 0 ? cleaned : fallback;
+  return chosen.slice(0, MAX_ITEMS);
+}
+
+/** A short, human-readable reason a child run did not complete. */
+function describeChildError(error: unknown, status: string): string {
+  if (error == null) return `child ended in status "${status}"`;
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  return JSON.stringify(error);
+}
+
+/**
+ * Pull the leaf's analysis text out of a child run's output. A leaf terminates with
+ * `{ analysis }`, but a custom `childDefinition` may shape its output differently
+ * (and the offline stub returns `{}`), so read defensively and return null rather
+ * than throw when there is nothing to read.
+ */
+function readAnalysis(output: unknown): string | null {
+  if (!output || typeof output !== "object") return null;
+  const value = (output as Record<string, unknown>).analysis;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim().slice(0, MAX_ANALYSIS_CHARS)
+    : null;
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const plan = defineStep({
+  name: "plan",
+  next: ["solve", "fanOut", "planned"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const mode: Mode = input.mode === "leaf" ? "leaf" : "coordinate";
+    const suppliedGoal = input.goal?.trim() ?? "";
+    const goal = suppliedGoal || DEFAULT_GOAL;
+    // Default to composing THIS deployment. `ctx.agentName` is the run's own slug,
+    // so a forked+deployed copy dispatches leaf runs of itself with no other setup.
+    const childDefinition = input.childDefinition?.trim() || ctx.agentName;
+
+    ctx.shared.set("goal", goal);
+    ctx.shared.set("childDefinition", childDefinition);
+    ctx.shared.set("dryRun", input.dryRun === true);
+    ctx.shared.set("itemCount", 0);
+
+    // Leaf path: one item, one analysis, no fan-out. This is what each child runs.
+    if (mode === "leaf") {
+      const item = input.item?.trim() || goal;
+      return goto("solve", { goal, item });
+    }
+
+    // Coordinate path.
+    const items = normalizeItems(input.items, DEFAULT_ITEMS);
+    ctx.shared.set("itemCount", items.length);
+    if (!suppliedGoal) {
+      ctx.shared.set(
+        "note",
+        `Coordinated the default goal. Pass a \`goal\` and \`items\` to fan out your own.`,
+      );
+    }
+
+    // Dry run: describe the fan-out without dispatching a single child.
+    if (input.dryRun === true) {
+      return goto("planned", { goal, childDefinition, items });
+    }
+
+    ctx.logger.info("fanning out", {
+      goal,
+      childDefinition,
+      items: items.length,
+    });
+    return goto("fanOut", { goal, childDefinition, items });
+  },
+});
+
+const solve = defineStep({
+  name: "solve",
+  next: [],
+  terminal: true,
+  async run(input: { goal: string; item: string }, ctx: Ctx) {
+    // The unit of work a child does. One model call, one focused result. A leaf
+    // deliberately does NOT fan out — that is what keeps the recursion one level deep.
+    const res = await ctx.sapiom.models.run({
+      system:
+        "You are one worker in a parallel team, each analysing a different facet " +
+        "of the same goal. Analyse ONLY your assigned facet, concretely and " +
+        "self-containedly, in 3-5 sentences. Do not restate the goal or the other " +
+        "facets — another step combines everyone's work.",
+      prompt: `GOAL: ${input.goal}\n\nYOUR FACET: ${input.item}`,
+      maxTokens: LEAF_MAX_TOKENS,
+    });
+    const analysis = (res?.output ?? "").trim();
+    ctx.logger.info("leaf solved its facet", {
+      item: input.item,
+      chars: analysis.length,
+    });
+    return terminate({ ok: true, item: input.item, analysis });
+  },
+});
+
+const fanOut = defineStep({
+  name: "fanOut",
+  next: ["reduce"],
+  async run(
+    input: { goal: string; childDefinition: string; items: string[] },
+    ctx: Ctx,
+  ) {
+    const { goal, childDefinition, items } = input;
+
+    // Launch one child run per item and wait for all of them — the durable
+    // equivalent of Promise.all over sub-agents. `agents.run` blocks until the
+    // child reaches a terminal state, so a rejected promise here is a genuine
+    // dispatch failure, caught per-item so one bad child never sinks the batch.
+    const results = await Promise.all(
+      items.map(async (item): Promise<ChildResult> => {
+        try {
+          const run = await ctx.sapiom.agents.run({
+            definition: childDefinition,
+            // A self-child reads `mode`; a custom child just gets goal + item.
+            input: { mode: "leaf", goal, item },
+          });
+          const ok = run.status === "completed";
+          return {
+            item,
+            ok,
+            status: run.status,
+            analysis: ok ? readAnalysis(run.output) : null,
+            error: ok ? null : describeChildError(run.error, run.status),
+          };
+        } catch (err) {
+          // A dispatch that throws (unknown slug, transport fault) is data, not a
+          // crash: record it and let the survivors carry the run.
+          ctx.logger.warn("child dispatch failed", {
+            item,
+            childDefinition,
+            err: String(err),
+          });
+          return {
+            item,
+            ok: false,
+            status: "error",
+            analysis: null,
+            error: String(err),
+          };
+        }
+      }),
+    );
+
+    const succeeded = results.filter((r) => r.ok).length;
+    ctx.logger.info("fan-out joined", {
+      total: results.length,
+      succeeded,
+    });
+    return goto("reduce", { results });
+  },
+});
+
+const reduce = defineStep({
+  name: "reduce",
+  next: ["done"],
+  async run(input: { results: ChildResult[] }, ctx: Ctx) {
+    const results = input.results ?? [];
+    const goal = ctx.shared.get("goal") || DEFAULT_GOAL;
+    const withAnalysis = results.filter((r) => r.ok && r.analysis);
+
+    // Nothing came back with content — the honest combined answer says so, no
+    // model call needed. Reached when every child failed, or offline where the
+    // child capability is stubbed and returns empty output.
+    if (withAnalysis.length === 0) {
+      const combined =
+        `No child run returned analysis for "${goal}" ` +
+        `(${results.length} dispatched, ${results.filter((r) => r.ok).length} completed). ` +
+        `Offline this is expected — the child capability is stubbed.`;
+      return goto("done", { combined, results });
+    }
+
+    const parts = withAnalysis
+      .map((r, i) => `[${i + 1}] FACET: ${r.item}\n${r.analysis}`)
+      .join("\n\n");
+
+    // Combine the children's independent analyses into one answer. Wrapped so a
+    // reduce failure still terminates with the raw parts rather than sinking a run
+    // whose expensive fan-out already succeeded.
+    let combined: string;
+    try {
+      const res = await ctx.sapiom.models.run({
+        system:
+          "You are combining several workers' independent analyses, each covering " +
+          "a different facet of one goal, into a single coherent answer. Integrate " +
+          "them — resolve overlaps, keep the concrete detail, and note any tension " +
+          "between facets. Do not just concatenate. Output prose, no preamble.",
+        prompt: `GOAL: ${goal}\n\nFACET ANALYSES:\n${parts}`,
+        maxTokens: REDUCE_MAX_TOKENS,
+      });
+      combined = (res?.output ?? "").trim();
+      if (!combined) throw new Error("empty reduce output");
+    } catch (err) {
+      ctx.logger.warn("reduce model call failed; returning the raw facets", {
+        err: String(err),
+      });
+      combined =
+        `Combined ${withAnalysis.length} facet analyses (synthesis step ` +
+        `unavailable, so they are listed as-is):\n\n${parts}`;
+    }
+
+    ctx.logger.info("reduced", { facets: withAnalysis.length });
+    return goto("done", { combined, results });
+  },
+});
+
+const done = defineStep({
+  name: "done",
+  next: [],
+  terminal: true,
+  async run(input: { combined: string; results: ChildResult[] }, ctx: Ctx) {
+    const results = input.results ?? [];
+    const succeeded = results.filter((r) => r.ok).length;
+    return terminate({
+      coordinated: true,
+      dispatched: results.length > 0,
+      goal: ctx.shared.get("goal") || DEFAULT_GOAL,
+      childDefinition: ctx.shared.get("childDefinition") || null,
+      combined: input.combined,
+      children: results.map((r) => ({
+        item: r.item,
+        ok: r.ok,
+        status: r.status,
+        error: r.error,
+      })),
+      succeeded,
+      total: results.length,
+      note: ctx.shared.get("note"),
+    });
+  },
+});
+
+const planned = defineStep({
+  name: "planned",
+  next: [],
+  terminal: true,
+  async run(
+    input: { goal: string; childDefinition: string; items: string[] },
+    ctx: Ctx,
+  ) {
+    // The off-ramp: describe exactly what a real run WOULD dispatch, having spent
+    // nothing. Honest — `dispatched: false` — and real: a concrete fan-out plan.
+    return terminate({
+      coordinated: false,
+      dispatched: false,
+      dryRun: true,
+      goal: input.goal,
+      childDefinition: input.childDefinition,
+      plan: {
+        childRuns: input.items.length,
+        items: input.items,
+        inputs: input.items.map((item) => ({
+          mode: "leaf",
+          goal: input.goal,
+          item,
+        })),
+      },
+      note: [
+        "`dryRun` was set, so no child runs were dispatched.",
+        ctx.shared.get("note"),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "fan-out-and-combine",
+  entry: "plan",
+  steps: {
+    plan,
+    solve,
+    fanOut,
+    reduce,
+    done,
+    planned,
+  },
+});

--- a/examples/fan-out-and-combine/package.json
+++ b/examples/fan-out-and-combine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-fan-out-and-combine",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: split a goal into parts, run each part as its own child workflow in parallel via ctx.sapiom.agents.run, then merge the results into one answer.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.7.1",
+    "@sapiom/tools": "^0.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/fan-out-and-combine/template.json
+++ b/examples/fan-out-and-combine/template.json
@@ -36,6 +36,16 @@
               "mode": "leaf",
               "goal": "Draft a launch plan for a new API product",
               "item": "pricing"
+            },
+            {
+              "mode": "leaf",
+              "goal": "Draft a launch plan for a new API product",
+              "item": "docs and developer experience"
+            },
+            {
+              "mode": "leaf",
+              "goal": "Draft a launch plan for a new API product",
+              "item": "go-to-market"
             }
           ]
         }

--- a/examples/fan-out-and-combine/template.json
+++ b/examples/fan-out-and-combine/template.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "whatItDoes": "Split a goal into parts, run each part as its own child workflow in parallel, then merge the results into one answer. Each child is a real, separately-metered run reached through `ctx.sapiom.agents.run` — fan out, join, reduce. It composes itself by default, or fans out any workflow whose slug you pass.",
+  "longDescription": "You give it a goal and the parts to break it into. It launches one child run per part, all at once, waits for every one to finish, and combines their outputs into a single answer. It is the durable version of running sub-agents with `Promise.all` — except each child is its own metered, independently-retryable run, not a function call.\n\nThe same template plays both roles. By default it fans out to its OWN slug (`ctx.sapiom.agents.run` with `ctx.agentName`), so a deployed copy dispatches child runs of itself with nothing else to set up. Each child runs in leaf mode — one part, one model analysis, then it terminates — and a leaf never fans out, so the recursion is exactly one level deep. Point `childDefinition` at another deployed workflow and it fans that out instead, one child per item.\n\nA child that throws or ends without completing becomes a failed row and the merge runs over the survivors, so a single bad child never sinks the batch — and if every child fails it still terminates with an honest account rather than a combined answer it doesn't have. Set `dryRun` to get the fan-out plan back without dispatching anything.\n\nYou pay for the child runs and the model call that merges them — the plan path and the joining are free.",
+  "useCases": [
+    "Fan a job across parallel child runs",
+    "Map-reduce over sub-agents",
+    "Compose many workflows into one"
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nRun it with nothing and it fans a sample goal into three parallel child runs of itself and merges them. Pass your own `goal` and `items` (one child run per item) to fan out your own work, or set `childDefinition` to another deployed workflow's slug to fan THAT out — each child receives `{ goal, item }`. Pass `dryRun: true` to see exactly what it would dispatch without spending on child runs.\n\nPrefer to work from the code? Run it locally with `run_local` and `{ \"dryRun\": true }` to trace the fan-out plan for free (the child capability is stubbed offline), or edit and deploy it with the Sapiom MCP.",
+  "defaultInput": {},
+  "examples": [
+    {
+      "title": "Preview the fan-out plan without dispatching",
+      "input": {
+        "goal": "Draft a launch plan for a new API product",
+        "items": ["pricing", "docs and developer experience", "go-to-market"],
+        "dryRun": true
+      },
+      "output": {
+        "coordinated": false,
+        "dispatched": false,
+        "dryRun": true,
+        "goal": "Draft a launch plan for a new API product",
+        "childDefinition": "fan-out-and-combine",
+        "plan": {
+          "childRuns": 3,
+          "items": ["pricing", "docs and developer experience", "go-to-market"],
+          "inputs": [
+            {
+              "mode": "leaf",
+              "goal": "Draft a launch plan for a new API product",
+              "item": "pricing"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "title": "Fan out and combine",
+      "input": {
+        "goal": "What are the main trade-offs of running background jobs on a serverless platform?",
+        "items": [
+          "cost and the billing model",
+          "cold starts and latency",
+          "concurrency and scaling limits"
+        ]
+      },
+      "output": {
+        "coordinated": true,
+        "dispatched": true,
+        "goal": "What are the main trade-offs of running background jobs on a serverless platform?",
+        "childDefinition": "fan-out-and-combine",
+        "combined": "Serverless background jobs trade operational simplicity for three coupled costs...",
+        "children": [
+          {
+            "item": "cost and the billing model",
+            "ok": true,
+            "status": "completed",
+            "error": null
+          },
+          {
+            "item": "cold starts and latency",
+            "ok": true,
+            "status": "completed",
+            "error": null
+          },
+          {
+            "item": "concurrency and scaling limits",
+            "ok": true,
+            "status": "completed",
+            "error": null
+          }
+        ],
+        "succeeded": 3,
+        "total": 3
+      }
+    }
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "coordinated", "assert": "equals", "value": true },
+      { "path": "children", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Fans a sample goal into three parallel child runs of itself and returns one combined answer."
+  }
+}

--- a/examples/fan-out-and-combine/tsconfig.json
+++ b/examples/fan-out-and-combine/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/logged-in-screenshots/AGENTS.md
+++ b/examples/logged-in-screenshots/AGENTS.md
@@ -1,0 +1,40 @@
+# Working in this agent
+
+This project defines exactly one Sapiom agent in `index.ts` — **Logged-In Page
+Screenshots** — authored against `@sapiom/agent`. It drives a real hosted browser to
+(optionally) log in and capture the pages you list as hosted images:
+`start` → `login` → `capture` → `done`, where `login` is skipped for public capture.
+Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapiom` (here:
+`ctx.sapiom.browserAutomation.identities.create`,
+`ctx.sapiom.browserAutomation.withSession`, and the session-bound `session.screenshot`).
+
+## Authoring
+
+- An agent is `defineAgent({ entry, steps })`; each step is
+  `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined
+  by `@sapiom/tools` — read the types / use autocomplete rather than guessing.
+- **One session captures every page.** `capture` uses
+  `ctx.sapiom.browserAutomation.withSession` and calls `session.screenshot({ url })`
+  per page inside it. In-session screenshots carry no per-shot charge — billing
+  settles once when the session closes — so don't replace them with per-URL one-shot
+  `browserAutomation.screenshot({ url })` calls, which bill each time.
+- **`withSession` always closes.** It runs your `fn` and closes the session in a
+  `finally`, so the session can't leak at the $1.00 ceiling. Keep the capture loop
+  inside the `withSession` callback.
+- **Login is optional and honest.** A login needs `loginUrl`, `loginUsername`, and
+  the `BROWSER_LOGIN_PASSWORD` secret (read from `process.env`, never an input). Miss
+  any of them, or let `identities.create` fail, and the run captures the PUBLIC view
+  and reports `authenticated: false` — it must never claim a logged-in capture it
+  didn't make.
+- **Every URL yields a row.** A page that fails to capture becomes a
+  `{ ok: false }` row, and if the session itself can't open, every requested URL is
+  recorded as a miss. That keeps the run terminal and the account complete — keep it.
+- **Runs with nothing.** `start` defaults `urls` to two stable public pages, so `{}`
+  in produces real screenshots with no login.
+
+## Test it
+
+- `run_local` traces the flow offline for free — the browser capability is stubbed,
+  so `session.screenshot` returns a stub image URL.
+- Deployed, a run with `{}` opens a session and captures two public pages.

--- a/examples/logged-in-screenshots/README.md
+++ b/examples/logged-in-screenshots/README.md
@@ -1,0 +1,39 @@
+# Logged-In Page Screenshots
+
+Open a real hosted browser, optionally log in, visit the pages you list, and capture
+each one as a hosted image — the rendered view a signed-in user sees, which a scraper
+can't reach. Built on `ctx.sapiom.browserAutomation`.
+
+## What it does
+
+```
+start ─▶ login (browser.identity) ─▶ capture (browser.session) ─▶ done
+start ─────────────────────────────▶ capture (browser.session) ─▶ done
+```
+
+1. **start** — resolves the `urls` to capture and decides whether to log in. A login
+   needs `loginUrl`, `loginUsername`, and the `BROWSER_LOGIN_PASSWORD` secret; miss
+   any and it captures the public view and says so.
+2. **login** — stores the credentials as a browser identity
+   (`ctx.sapiom.browserAutomation.identities.create`, free) so the session opens
+   signed in. If it fails, it degrades to a public capture rather than failing.
+3. **capture** — opens ONE browser session (`ctx.sapiom.browserAutomation.withSession`)
+   and screenshots every page in it. In-session screenshots have no per-shot charge,
+   and the session always closes in a `finally`, so it never leaks. A page that fails
+   becomes a failed row; the rest are still captured.
+4. **done** — terminal; returns one row per requested URL (image URL or the failure),
+   plus `authenticated` and the captured count.
+
+Input:
+`{ "urls": ["https://…"], "loginUrl": "https://…/login", "loginUsername": "you@…", "fullPage": false }`
+
+- `urls` — the pages to capture. Defaults to two stable public pages.
+- `loginUrl` + `loginUsername` + the `BROWSER_LOGIN_PASSWORD` secret — set all three
+  to capture behind a login. Omit them for public capture.
+- `fullPage: true` — capture the full scrollable height instead of the viewport.
+
+## Run it
+
+- **Use this template** in the app — Sapiom builds and deploys it, and a run with no
+  input captures two public pages.
+- **Locally:** `run_local` traces the flow for free (the browser capability is stubbed).

--- a/examples/logged-in-screenshots/index.ts
+++ b/examples/logged-in-screenshots/index.ts
@@ -1,0 +1,291 @@
+import {
+  defineAgent,
+  defineStep,
+  goto,
+  terminate,
+  type AgentExecutionContext,
+} from "@sapiom/agent";
+
+/**
+ * Logged-In Page Screenshots — open a real browser, optionally log in, visit the
+ * pages you list, and capture each one as a hosted image.
+ *
+ * A plain scraper can't see a page that lives behind a login, and it never sees
+ * what the page actually LOOKS like. This drives a real hosted browser
+ * (`ctx.sapiom.browserAutomation`), so it can sign in with credentials you supply
+ * and capture the rendered page — the exact view a logged-in user gets. Use it to
+ * archive a dashboard, verify a deploy renders right, or keep a visual record of a
+ * page behind auth.
+ *
+ * The graph, one legible line per capability:
+ *   start ─▶ login (browser.identity) ─▶ capture (browser.session) ─▶ done
+ *   start ─────────────────────────────▶ capture (browser.session) ─▶ done
+ *
+ * One browser session captures EVERY page in a single sitting. In-session
+ * screenshots carry no per-shot charge — billing settles once when the session
+ * closes — so visiting five pages costs one session, not five one-shots. The
+ * session is always closed in a `finally` (that is what `withSession` guarantees),
+ * so it can never leak at the ceiling charge.
+ *
+ * Never-fail discipline:
+ *   - Runs with nothing: no login, it captures a couple of stable public pages and
+ *     returns their image URLs. `authenticated` is honestly `false`.
+ *   - Login is optional and degrades honestly. Ask for a login without setting the
+ *     password secret, or let identity creation fail, and it captures the PUBLIC
+ *     view and reports `authenticated: false` with a reason — it never claims a
+ *     logged-in capture it didn't make.
+ *   - Every requested URL yields a row whether its shot succeeded or not, so one
+ *     unreachable page never sinks the run and the result is always a full account.
+ */
+
+// ─────────────────────────────────────────────────────────────── config ──
+/** Cap how many pages one session captures, to bound session time and cost. */
+const MAX_URLS = 8;
+/**
+ * The pages a zero-input run captures. Both are IANA reserved example domains —
+ * about the most stable public pages there are — so the default run always has
+ * something real to shoot.
+ */
+const DEFAULT_URLS = ["https://example.com", "https://example.org"];
+
+/** The env var the login password is read from (never an input field). */
+const PASSWORD_ENV = "BROWSER_LOGIN_PASSWORD";
+
+// ─────────────────────────────────────────────────────────────── shapes ──
+interface EntryInput {
+  /** The pages to capture. Defaults to two stable public pages. */
+  urls?: string[];
+  /**
+   * The login page URL. Set it (with `loginUsername` and the `BROWSER_LOGIN_PASSWORD`
+   * secret) to capture pages behind a login. Omit for public capture.
+   */
+  loginUrl?: string;
+  /** The username to log in with. Paired with the `BROWSER_LOGIN_PASSWORD` secret. */
+  loginUsername?: string;
+  /** Capture the full scrollable page height instead of just the viewport. */
+  fullPage?: boolean;
+}
+
+/** One captured page — always present per requested URL, success or not. */
+interface Shot {
+  url: string;
+  /** Hosted image URL, or null when the capture failed. */
+  imageUrl: string | null;
+  /** ISO-8601 expiry of the hosted image, when captured. */
+  expiresAt: string | null;
+  ok: boolean;
+  /** A short reason when the capture failed. */
+  error: string | null;
+}
+
+interface Shared extends Record<string, unknown> {
+  urlCount: number;
+  fullPage: boolean;
+  /** Whether the session ran with a logged-in identity. */
+  authenticated: boolean;
+  /** Why a run isn't authenticated, when a login was expected. */
+  note?: string;
+}
+
+type Ctx = AgentExecutionContext<Shared>;
+
+/** The payload carried from `start`/`login` into `capture`. */
+interface CapturePlan {
+  urls: string[];
+  /** The identity to open the session with, or null for a public session. */
+  identityId: string | null;
+  fullPage: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────── helpers ──
+/** Trim, drop non-http(s), de-dupe, and cap — the pages a run will capture. */
+function normalizeUrls(urls: unknown, fallback: string[]): string[] {
+  const cleaned = Array.isArray(urls)
+    ? [
+        ...new Set(
+          urls
+            .filter((u): u is string => typeof u === "string")
+            .map((u) => u.trim())
+            .filter((u) => /^https?:\/\//i.test(u)),
+        ),
+      ]
+    : [];
+  const chosen = cleaned.length > 0 ? cleaned : fallback;
+  return chosen.slice(0, MAX_URLS);
+}
+
+/** A row for a page that was never shot (session never opened). */
+function missedShot(url: string, error: string): Shot {
+  return { url, imageUrl: null, expiresAt: null, ok: false, error };
+}
+
+// ─────────────────────────────────────────────────────────────── steps ──
+const start = defineStep({
+  name: "start",
+  next: ["login", "capture"],
+  async run(input: EntryInput, ctx: Ctx) {
+    const urls = normalizeUrls(input.urls, DEFAULT_URLS);
+    const fullPage = input.fullPage === true;
+    ctx.shared.set("urlCount", urls.length);
+    ctx.shared.set("fullPage", fullPage);
+    ctx.shared.set("authenticated", false);
+
+    const loginUrl = input.loginUrl?.trim() || "";
+    const username = input.loginUsername?.trim() || "";
+    const password = (process.env[PASSWORD_ENV] ?? "").trim();
+
+    // No login asked for — capture the public view.
+    if (!loginUrl && !username) {
+      return goto("capture", { urls, identityId: null, fullPage });
+    }
+
+    // Login asked for but under-configured — capture public, say what was missing.
+    const missing: string[] = [];
+    if (!loginUrl) missing.push("loginUrl");
+    if (!username) missing.push("loginUsername");
+    if (!password) missing.push(`${PASSWORD_ENV} secret`);
+    if (missing.length > 0) {
+      ctx.shared.set(
+        "note",
+        `Captured the public view — login needs ${missing.join(", ")}. Set them to capture behind the login.`,
+      );
+      ctx.logger.info("login under-configured; capturing public view", {
+        missing,
+      });
+      return goto("capture", { urls, identityId: null, fullPage });
+    }
+
+    return goto("login", { urls, loginUrl, username, password, fullPage });
+  },
+});
+
+const login = defineStep({
+  name: "login",
+  next: ["capture"],
+  async run(
+    input: {
+      urls: string[];
+      loginUrl: string;
+      username: string;
+      password: string;
+      fullPage: boolean;
+    },
+    ctx: Ctx,
+  ) {
+    // Store the credentials as a browser identity; the session opens pre-logged-in.
+    // Creating an identity is free. If it fails, degrade to a public capture rather
+    // than failing the run — a public shot beats no shot.
+    try {
+      const identity = await ctx.sapiom.browserAutomation.identities.create({
+        source: input.loginUrl,
+        name: "logged-in-screenshots",
+        credentials: [
+          {
+            type: "username_password",
+            username: input.username,
+            password: input.password,
+          },
+        ],
+      });
+      ctx.logger.info("created login identity", { identityId: identity.id });
+      return goto("capture", {
+        urls: input.urls,
+        identityId: identity.id,
+        fullPage: input.fullPage,
+      });
+    } catch (err) {
+      ctx.shared.set(
+        "note",
+        "Captured the public view — the login identity could not be created.",
+      );
+      ctx.logger.warn("identity creation failed; capturing public view", {
+        err: String(err),
+      });
+      return goto("capture", {
+        urls: input.urls,
+        identityId: null,
+        fullPage: input.fullPage,
+      });
+    }
+  },
+});
+
+const capture = defineStep({
+  name: "capture",
+  next: ["done"],
+  async run(input: CapturePlan, ctx: Ctx) {
+    const { urls, identityId, fullPage } = input;
+    const authenticated = identityId !== null;
+    ctx.shared.set("authenticated", authenticated);
+
+    ctx.logger.info("opening browser session", {
+      pages: urls.length,
+      authenticated,
+    });
+
+    let shots: Shot[];
+    try {
+      // One session, every page. `withSession` always closes in a `finally`, so
+      // the session settles even if a capture throws.
+      shots = await ctx.sapiom.browserAutomation.withSession(
+        async (session) => {
+          const out: Shot[] = [];
+          for (const url of urls) {
+            try {
+              const shot = await session.screenshot({ url, fullPage });
+              out.push({
+                url,
+                imageUrl: shot.url,
+                expiresAt: shot.expiresAt ?? null,
+                ok: true,
+                error: null,
+              });
+            } catch (err) {
+              // A single unreachable page degrades to a failed row; the session
+              // stays open and the remaining pages are still captured.
+              ctx.logger.warn("page capture failed", { url, err: String(err) });
+              out.push(missedShot(url, String(err)));
+            }
+          }
+          return out;
+        },
+        identityId ? { identityId } : undefined,
+      );
+    } catch (err) {
+      // The session itself could not open — record every requested page as missed
+      // so the run still terminates with a complete, honest account.
+      ctx.logger.error("browser session failed to open", { err: String(err) });
+      shots = urls.map((url) => missedShot(url, String(err)));
+    }
+
+    return goto("done", { shots });
+  },
+});
+
+const done = defineStep({
+  name: "done",
+  next: [],
+  terminal: true,
+  async run(input: { shots: Shot[] }, ctx: Ctx) {
+    const shots = input.shots ?? [];
+    const captured = shots.filter((s) => s.ok).length;
+    return terminate({
+      authenticated: ctx.shared.get("authenticated") ?? false,
+      requested: shots.length,
+      captured,
+      screenshots: shots,
+      note: ctx.shared.get("note"),
+    });
+  },
+});
+
+export const agent = defineAgent<EntryInput, Shared>({
+  name: "logged-in-screenshots",
+  entry: "start",
+  steps: {
+    start,
+    login,
+    capture,
+    done,
+  },
+});

--- a/examples/logged-in-screenshots/index.ts
+++ b/examples/logged-in-screenshots/index.ts
@@ -155,7 +155,9 @@ const start = defineStep({
       return goto("capture", { urls, identityId: null, fullPage });
     }
 
-    return goto("login", { urls, loginUrl, username, password, fullPage });
+    // Route with a flag, not the secret: the password is re-read from env in the
+    // `login` step so it never rides in a persisted step transition.
+    return goto("login", { urls, loginUrl, username, fullPage });
   },
 });
 
@@ -167,11 +169,31 @@ const login = defineStep({
       urls: string[];
       loginUrl: string;
       username: string;
-      password: string;
       fullPage: boolean;
     },
     ctx: Ctx,
   ) {
+    // Re-read the password from the injected env at the point of use rather than
+    // carrying it in the step transition: a step's input is persisted in the durable
+    // execution record, and a login secret must never land there. The secret is
+    // injected into every step's env, so reading it here keeps it out of the trace.
+    const password = (process.env[PASSWORD_ENV] ?? "").trim();
+    if (!password) {
+      // Shouldn't happen — `start` only routes here when the secret was present —
+      // but if the env changed under us, degrade to a public capture rather than
+      // sending an empty credential.
+      ctx.shared.set(
+        "note",
+        `Captured the public view — the ${PASSWORD_ENV} secret was not set.`,
+      );
+      ctx.logger.info("password secret absent at login; capturing public view");
+      return goto("capture", {
+        urls: input.urls,
+        identityId: null,
+        fullPage: input.fullPage,
+      });
+    }
+
     // Store the credentials as a browser identity; the session opens pre-logged-in.
     // Creating an identity is free. If it fails, degrade to a public capture rather
     // than failing the run — a public shot beats no shot.
@@ -183,7 +205,7 @@ const login = defineStep({
           {
             type: "username_password",
             username: input.username,
-            password: input.password,
+            password,
           },
         ],
       });

--- a/examples/logged-in-screenshots/package.json
+++ b/examples/logged-in-screenshots/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sapiom/example-logged-in-screenshots",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sapiom agent template: drive a real hosted browser to log in with credentials you supply and capture the rendered pages you list as hosted images, all in one session.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"**/*.ts\""
+  },
+  "dependencies": {
+    "@sapiom/agent": "^0.7.1",
+    "@sapiom/tools": "^0.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/logged-in-screenshots/template.json
+++ b/examples/logged-in-screenshots/template.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "../template.schema.json",
+  "manifestVersion": 1,
+  "author": {
+    "name": "Sapiom",
+    "url": "https://sapiom.ai/"
+  },
+  "whatItDoes": "Open a real hosted browser, optionally log in with credentials you supply, visit the pages you list, and capture each one as a hosted image. It captures every page in a single session — the rendered view a logged-in user sees, which a scraper can't reach. With no login it captures public pages.",
+  "longDescription": "You give it a list of pages. It opens one real browser session, visits each page, and captures it as a hosted image you get a URL back for. Because it drives an actual browser rather than fetching HTML, it captures what the page really looks like — and, if you hand it a login, what it looks like to a signed-in user.\n\nEverything happens in a single session. In-session screenshots carry no per-shot charge — billing settles once when the session closes — so capturing five pages costs one session, not five one-shots. The session is always closed for you, even if a capture fails, so it can never leak at the ceiling charge.\n\nThe login is optional and honest. Set `loginUrl`, `loginUsername`, and the `BROWSER_LOGIN_PASSWORD` secret and it stores them as a browser identity and opens the session already signed in. Leave any of them out — or let the login fail — and it captures the public view instead and tells you `authenticated: false`, rather than claiming a logged-in capture it didn't make. Every requested URL comes back as a row whether its shot worked or not.\n\nYou pay for the browser session; creating the login identity is free.",
+  "useCases": [
+    "Archive a dashboard behind a login",
+    "Verify a deploy renders correctly",
+    "Record a page behind authentication"
+  ],
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nRun it with nothing and it captures two stable public pages. Pass `urls` (the pages to capture) and `fullPage: true` for full-height captures. To capture behind a login, pass `loginUrl` and `loginUsername` and set the `BROWSER_LOGIN_PASSWORD` secret — the session opens signed in. Miss any of the three and it captures the public view and says so.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the flow for free (the browser capability is stubbed), or edit and deploy it with the Sapiom MCP.",
+  "requiredSecrets": [
+    {
+      "key": "BROWSER_LOGIN_PASSWORD",
+      "label": "Login password",
+      "provider": "custom",
+      "credentialKind": "basic",
+      "description": "The password for the login you want to capture behind, paired with `loginUsername`. Only needed for authenticated capture — without it the run captures the public view.",
+      "optional": true
+    }
+  ],
+  "defaultInput": {
+    "urls": ["https://example.com", "https://example.org"]
+  },
+  "examples": [
+    {
+      "title": "Capture public pages",
+      "input": {
+        "urls": ["https://example.com"]
+      },
+      "output": {
+        "authenticated": false,
+        "requested": 1,
+        "captured": 1,
+        "screenshots": [
+          {
+            "url": "https://example.com",
+            "imageUrl": "https://cdn.sapiom.ai/screenshots/abc123.png",
+            "expiresAt": "2026-08-01T00:00:00Z",
+            "ok": true,
+            "error": null
+          }
+        ]
+      }
+    },
+    {
+      "title": "Capture a page behind a login",
+      "input": {
+        "urls": ["https://app.example.com/dashboard"],
+        "loginUrl": "https://app.example.com/login",
+        "loginUsername": "you@example.com"
+      },
+      "output": {
+        "authenticated": true,
+        "requested": 1,
+        "captured": 1,
+        "screenshots": [
+          {
+            "url": "https://app.example.com/dashboard",
+            "imageUrl": "https://cdn.sapiom.ai/screenshots/def456.png",
+            "expiresAt": "2026-08-01T00:00:00Z",
+            "ok": true,
+            "error": null
+          }
+        ]
+      }
+    }
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "screenshots", "assert": "nonEmptyArray" },
+      { "path": "authenticated", "assert": "equals", "value": false }
+    ],
+    "narrative": "Opens a browser session and captures two stable public pages as hosted images; no login, so authenticated is false."
+  }
+}

--- a/examples/logged-in-screenshots/tsconfig.json
+++ b/examples/logged-in-screenshots/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -398,6 +398,62 @@
       ]
     },
     {
+      "id": "fan-out-and-combine",
+      "name": "Fan Out and Combine",
+      "description": "Split a goal into parts, run each part as its own child workflow in parallel, then merge the results into one answer.",
+      "tags": ["orchestration", "fan-out", "map-reduce", "agents"],
+      "category": "reliability-governance",
+      "discipline": "Reliability",
+      "cadence": "on-demand",
+      "complexity": "involved",
+      "sourcePath": "examples/fan-out-and-combine",
+      "capabilities": ["agents.run", "models.run"],
+      "steps": [
+        {
+          "name": "plan",
+          "description": "Resolve the goal, the parts to fan out, and the child workflow to run for each — this agent itself by default. A leaf handles one part; a dry run returns the plan.",
+          "kind": "compute",
+          "next": ["solve", "fanOut", "planned"]
+        },
+        {
+          "name": "solve",
+          "description": "Leaf role: analyse one part toward the goal with a model, then finish. A leaf never fans out, which bounds the recursion to one level.",
+          "kind": "llm",
+          "capability": "models.run",
+          "next": [],
+          "terminal": true
+        },
+        {
+          "name": "fanOut",
+          "description": "Launch one child run per part in parallel and wait for all of them; a child that fails becomes a row, not a crash.",
+          "kind": "capability",
+          "capability": "agents.run",
+          "next": ["reduce"]
+        },
+        {
+          "name": "reduce",
+          "description": "Merge the children's analyses into one answer. If nothing came back with content, say so rather than invent it.",
+          "kind": "llm",
+          "capability": "models.run",
+          "next": ["done"]
+        },
+        {
+          "name": "done",
+          "description": "Return the combined answer and each child's status.",
+          "kind": "compute",
+          "next": [],
+          "terminal": true
+        },
+        {
+          "name": "planned",
+          "description": "Off-ramp for a dry run: return the fan-out plan with nothing dispatched.",
+          "kind": "compute",
+          "next": [],
+          "terminal": true
+        }
+      ]
+    },
+    {
       "id": "hello-agent",
       "name": "Hello Agent",
       "description": "The smallest working Sapiom agent — one step that returns a greeting, so you can confirm build, deploy, and run before adding a real capability.",
@@ -494,6 +550,51 @@
           "description": "The ranked list ran out, or nobody could be contacted — hand off to a person.",
           "kind": "capability",
           "capability": "email.send",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "id": "logged-in-screenshots",
+      "name": "Logged-In Page Screenshots",
+      "description": "Open a real browser, optionally log in, and capture the pages you list as hosted images — the view a signed-in user sees.",
+      "tags": ["browser", "screenshot", "authenticated", "visual"],
+      "category": "reliability-governance",
+      "discipline": "Reliability",
+      "cadence": "on-demand",
+      "complexity": "simple",
+      "sourcePath": "examples/logged-in-screenshots",
+      "capabilities": [
+        "browser.identity",
+        "browser.session",
+        "browser.screenshot"
+      ],
+      "steps": [
+        {
+          "name": "start",
+          "description": "Resolve the pages to capture and decide whether to log in — a login needs a URL, a username, and the password secret; miss any and it captures the public view.",
+          "kind": "compute",
+          "next": ["login", "capture"]
+        },
+        {
+          "name": "login",
+          "description": "Store the supplied credentials as a browser identity so the session opens signed in. If it fails, fall back to a public capture.",
+          "kind": "capability",
+          "capability": "browser.identity",
+          "next": ["capture"]
+        },
+        {
+          "name": "capture",
+          "description": "Open one browser session and screenshot every page in it; a page that fails becomes a row, the rest are still captured.",
+          "kind": "capability",
+          "capability": "browser.session",
+          "next": ["done"]
+        },
+        {
+          "name": "done",
+          "description": "Return one row per requested page — its image URL or its failure — with the captured count and whether it was authenticated.",
+          "kind": "compute",
+          "next": [],
           "terminal": true
         }
       ]


### PR DESCRIPTION
## What & why

[SAP-2202](https://linear.app/sapiom/issue/SAP-2202) quantified that the onboarding template gallery under-represents Sapiom's differentiated capabilities. Two capabilities had **zero** gallery presence:

- **Durable workflow orchestration** (`ctx.sapiom.agents.run` — "a workflow composes other workflows") — the one existing multi-workflow example (`the-brain`) uses raw child-launches and is being reduced, so there was no clean exemplar of the core differentiator.
- **Browser automation** (`ctx.sapiom.browserAutomation`, new in `@sapiom/tools@0.23.0`) — brand-new capability, no template.

This PR adds one flagship template for each gap.

## Templates added

### `fan-out-and-combine` — Fan Out and Combine
The canonical **workflow-composes-workflow** exemplar: split a goal into parts, run each part as its own child workflow in parallel via `ctx.sapiom.agents.run`, then merge the results (fan out → join → reduce).

- **Composes itself** by default — `childDefinition` defaults to `ctx.agentName`, so a deployed copy dispatches child runs of itself with no other setup. Point it at any other deployed slug to fan that out instead.
- **Bounded recursion** — children run in a `leaf` mode that does one unit of work and never fans out (depth is exactly one).
- **Never-fail** — a child that throws or doesn't complete becomes a `{ ok: false }` row and the reduce runs over the survivors; if nothing comes back it terminates with an honest account rather than a fabricated answer. `dryRun` returns the fan-out plan without dispatching.
- Runnable with `{}`.

### `logged-in-screenshots` — Logged-In Page Screenshots
The gallery's **first browser-automation** template: drive a real hosted browser to (optionally) log in and capture the pages you list as hosted images — the view a signed-in user sees, which a scraper can't reach.

- One `withSession` captures every page in a single session (in-session shots have no per-shot charge; the session always closes in a `finally`).
- The login (`identities.create` + `withSession({ identityId })`) is **optional and honest** — miss the `loginUrl`/`loginUsername`/`BROWSER_LOGIN_PASSWORD`, or let it fail, and it captures the public view and reports `authenticated: false`.
- Every requested URL yields a row (success or failure). Runnable with `{}`.

## Out of scope (deliberate)
SAP-2202 also suggested a flagship coding-agent template and de-emphasizing near-duplicate digest templates. Coding agents already have three gallery templates, and "de-emphasize" is a product/composition decision (and destructive), so both are left for a product call — this PR lands the two genuine zero-coverage gaps.

## Validation
- `pnpm examples:check` — passes (28 templates, schema-valid, sorted, all manifests valid; both new bands match the derived complexity score).
- `tsc --noEmit` — passes for both templates against the **published** SDKs (`@sapiom/agent@^0.7.1`, `@sapiom/tools@^0.23.0`), which is what the one-click build installs.
- Not run: a live deployed run (needs a live tenant) — the offline `run_local` paths and stub behavior were traced from the SDK stub client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJuaJmQAwcKqvXqtoQUCRK