### PR TITLE
fix(examples): render db-insight chart in one exec, not via writeFile (SAP-2209)

### DIFF
--- a/examples/scheduled-db-insight-report/index.test.mjs
+++ b/examples/scheduled-db-insight-report/index.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agent } from "./index.ts";
+
+// The chart step materializes render.mjs + data.json and runs node against them.
+// `writeFile` and `exec` root paths differently on the Blaxel sandbox (SAP-2209:
+// the filesystem API and the SDK both prepend the workspace root, so a `writeFile`d
+// file double-nests to `/blaxel/blaxel/...` while `exec` runs at `/blaxel`) — the
+// write is never where node reads it, and the chart silently degrades out. The fix
+// materializes the files from base64 inside the same exec that runs node, and reads
+// the SVG back over the exec channel too (readFile would double-nest identically).
+
+const SERIES_METRICS = [
+  {
+    name: "Rows per table",
+    kind: "series",
+    points: [
+      { label: "events", value: 81_300 },
+      { label: "users", value: 12_840 },
+    ],
+  },
+];
+
+/**
+ * Sandbox double that records exec commands and flags any writeFile/readFile use.
+ * The render exec returns success; the read exec returns a base64 SVG so the step
+ * walks the upload path (proving the read is decoded, not `readFile`d).
+ */
+function recordingBox(calls) {
+  return {
+    workspaceRoot: "/blaxel",
+    async exec(command) {
+      calls.exec.push(command);
+      if (command.includes("base64 -w0 chart.svg")) {
+        // the read-back: hand back a base64-encoded SVG over the exec channel.
+        const svg = "<svg xmlns='http://www.w3.org/2000/svg'></svg>";
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(svg, "utf8").toString("base64"),
+          stderr: "",
+        };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+    // The fix must not touch the filesystem API — assert these are never called.
+    async writeFile() {
+      calls.write.push([...arguments]);
+    },
+    async readFile() {
+      calls.read.push([...arguments]);
+    },
+    async destroy() {},
+  };
+}
+
+function chartContext(calls) {
+  return {
+    executionId: "test-exec-1",
+    sapiom: {
+      sandboxes: { create: async () => recordingBox(calls) },
+      fileStorage: {
+        upload: async () => ({
+          fileId: "file-1",
+          uploadUrl: "https://upload.invalid",
+          requiredHeaders: {},
+        }),
+        getDownloadUrl: async (fileId) => ({
+          downloadUrl: `https://download.invalid/${fileId}`,
+        }),
+      },
+    },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+}
+
+test("chart step materializes files + reads the SVG entirely over exec, never the FS API", async () => {
+  const calls = { exec: [], write: [], read: [] };
+  const directive = await agent.steps.chart.run(
+    { metrics: SERIES_METRICS },
+    chartContext(calls),
+  );
+
+  // It reached deliver with a hosted chart URL (the render + read round-tripped).
+  assert.equal(directive.stepName, "deliver");
+  assert.ok(
+    directive.input?.chartUrl,
+    "expected a chartUrl from the rendered SVG",
+  );
+
+  // The regression guard: no filesystem-API calls — everything goes through exec.
+  assert.equal(calls.write.length, 0, "writeFile must not be used (SAP-2209)");
+  assert.equal(calls.read.length, 0, "readFile must not be used (SAP-2209)");
+
+  // The render exec decodes both inputs from base64, in one command, before node.
+  const renderCmd = calls.exec.find((c) => c.includes("node render.mjs"));
+  assert.ok(renderCmd, "expected an exec that runs node render.mjs");
+  assert.ok(renderCmd.includes("base64 -d > render.mjs"));
+  assert.ok(renderCmd.includes("base64 -d > data.json"));
+  assert.ok(
+    renderCmd.indexOf("> render.mjs") < renderCmd.indexOf("node render.mjs"),
+    "render.mjs must be materialized before node runs",
+  );
+
+  // The SVG is read back over the exec channel, not readFile.
+  assert.ok(calls.exec.some((c) => c.includes("base64 -w0 chart.svg")));
+});
+
+test("chart step skips the sandbox entirely when there is nothing chartable", async () => {
+  const calls = { exec: [], write: [], read: [] };
+  const directive = await agent.steps.chart.run(
+    { metrics: [{ name: "count", kind: "scalar", value: 5 }] },
+    chartContext(calls),
+  );
+  assert.equal(directive.stepName, "deliver");
+  assert.equal(directive.input?.chartUrl, null);
+  assert.equal(calls.exec.length, 0, "no sandbox work when no series metric");
+});

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -502,6 +502,11 @@ writeFileSync(outPath, svg);
 process.stdout.write(String(svg.length));
 `;
 
+/** base64-encode UTF-8 text so it survives a shell command line intact. */
+function toBase64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
 const chart = defineStep({
   name: "chart",
   next: ["deliver"],
@@ -529,15 +534,35 @@ const chart = defineStep({
         name: sandboxName,
         ttl: "15m",
       });
-      await box.writeFile("render.mjs", CHART_SCRIPT);
-      await box.writeFile("data.json", JSON.stringify({ charts }));
-
-      const res = await box.exec("node render.mjs data.json chart.svg");
+      // Materialize the renderer + data and run it in ONE exec. `writeFile` and
+      // `exec` root paths differently on the Blaxel sandbox (SAP-2209: the
+      // filesystem API and the SDK both prepend the workspace root, so a
+      // `writeFile`d file double-nests to `/blaxel/blaxel/...` while `exec` runs
+      // at `/blaxel`) — a written file is never where `node` reads it. Decoding
+      // from base64 inside the same command keeps one shell and one cwd, so the
+      // renderer sees the files we just wrote; base64 also keeps the chart data
+      // off the raw command line safely.
+      const res = await box.exec(
+        [
+          `printf %s '${toBase64(CHART_SCRIPT)}' | base64 -d > render.mjs`,
+          `printf %s '${toBase64(JSON.stringify({ charts }))}' | base64 -d > data.json`,
+          "node render.mjs data.json chart.svg",
+        ].join(" && "),
+      );
       if (res.exitCode !== 0) {
         throw new Error(`renderer exited ${res.exitCode}: ${res.stderr}`);
       }
 
-      const svg = await box.readFile("chart.svg");
+      // Read the SVG back over the exec channel too — `readFile` would double-nest
+      // exactly like the writes did. base64 keeps bytes intact across the text-only
+      // channel (`-w0` disables wrapping where supported, plain `base64` fallback).
+      const read = await box.exec("(base64 -w0 chart.svg || base64 chart.svg)");
+      const svg =
+        read.exitCode === 0
+          ? Buffer.from(read.stdout.replace(/\s+/g, ""), "base64").toString(
+              "utf8",
+            )
+          : "";
       // An empty read is the stubbed (`run_local`) path — no bytes to host.
       if (svg.trim().length > 0) {
         const bytes = new TextEncoder().encode(svg);

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -83,8 +83,8 @@ const DEFAULT_REGISTRY = "https://registry.npmjs.org";
  * @sapiom/tools without updating this). Bump alongside notable releases.
  */
 const VERSION_FALLBACK = {
-  agent: "0.7.1",
-  tools: "0.23.0",
+  agent: "0.8.0",
+  tools: "0.24.0",
 };
 
 /** The zod major the authoring SDK is built against. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
         specifier: workspace:^
         version: link:../analytics-core
       '@sapiom/harness':
-        specifier: '>=0.2.0'
+        specifier: '>=0.2.4'
         version: link:../harness
       '@sapiom/sandbox-preview':
         specifier: workspace:^


### PR DESCRIPTION
## Problem
`scheduled-db-insight-report`'s `chart` step uses the `writeFile → exec node → readFile` pattern (`index.ts:532-540`), which fails on the Blaxel sandbox for the same reason as SAP-2201: the filesystem API and the exec working dir root relative paths differently, so a `writeFile`d file double-nests to `/blaxel/blaxel/...` while `node` reads `/blaxel/...`. Its try/catch degrades the failure into a **chart-less report**, so the run still "succeeds" — the chart silently never renders. (The baseline missed this because `{}` input degrades before charting; the dry-run `SAMPLE_METRICS` path does reach it.)

Root cause + platform/SDK fix tracked in **SAP-2209**. This is the template-side stopgap.

## Fix
Materialize `render.mjs` + `data.json` from base64 inside the **one** `exec` that runs node, and read `chart.svg` back over the exec channel (`readFile` double-nests identically). One shell, one cwd, no filesystem-API paths. Same approach as proposal-generator (PR #454). Adds a unit test asserting the single-exec/base64 shape and that `writeFile`/`readFile` are never used.

## Verification
⚠️ **Not verified on the local stack** — this template pins `@sapiom/agent@^0.8.0` (uses `resolveResourceHandle`) and the local registry only has ≤0.7.x, so it can't build/test locally. **CI (with the published 0.8.0 SDK) is the verification path.** The fix is mechanically identical to SAP-2201, which was verified end-to-end on-stack (real 4,756-byte PDF from run 263).

Refs: SAP-2209

🤖 Generated with [Claude Code](https://claude.com/claude-code)