### PR TITLE
fix(agent): manifest schema was stripping authored description + capabilities

### DIFF
--- a/.changeset/manifest-schema-description.md
+++ b/.changeset/manifest-schema-description.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/agent": patch
+---
+
+Fix: authored `description` (on `defineStep` and `defineAgent`) and step `capabilities` were silently dropped during manifest validation.
+
+`agentManifestSchema` is a `z.object()`, which strips keys it doesn't declare. The previous release added `description`/`capabilities` to the TS types and to `buildManifest`'s output, but not to the runtime schema — so `agentManifestSchema.parse()` (which `@sapiom/agent-core`'s `check()` runs on every manifest) discarded them. The result: tooling that reads the validated manifest — the harness canvas — always saw empty descriptions, no matter what the source authored.
+
+Adds `description` (step + workflow) and `capabilities` (step) to the schema as optional fields, so they survive validation and reach consumers. No behavior change for manifests that don't use them.

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -359,6 +359,43 @@ describe("buildManifest", () => {
     expect(parsed.steps.entry.inputSchema).not.toBeNull();
     expect(parsed.steps.exit.timeoutMs).toBe(5000);
   });
+
+  it("preserves authored description + capabilities through schema validation (regression: they were stripped)", () => {
+    const def = defineAgent({
+      name: "described-wf",
+      description: "Triages incoming tickets end to end.",
+      entry: "classify",
+      steps: {
+        classify: defineStep({
+          name: "classify",
+          next: [],
+          terminal: true,
+          description: "Tags the ticket with a category for routing.",
+          capabilities: ["rules.classify"],
+          async run() {
+            return terminate(null);
+          },
+        }),
+      },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    // buildManifest emits the authored fields...
+    expect(manifest.description).toBe("Triages incoming tickets end to end.");
+    expect(manifest.steps.classify.description).toBe("Tags the ticket with a category for routing.");
+    expect(manifest.steps.classify.capabilities).toEqual(["rules.classify"]);
+
+    // ...and the schema must NOT strip them on parse. This is the exact bug the
+    // canvas hit: z.object() drops keys absent from the schema, so an authored
+    // description silently vanished on `agentManifestSchema.parse` and never
+    // reached the renderer — even though the TS type and buildManifest had it.
+    const parsed = agentManifestSchema.parse(manifest);
+    expect(parsed.description).toBe("Triages incoming tickets end to end.");
+    expect(parsed.steps.classify.description).toBe("Tags the ticket with a category for routing.");
+    expect(parsed.steps.classify.capabilities).toEqual(["rules.classify"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/manifest.ts
+++ b/packages/agent/src/manifest.ts
@@ -94,6 +94,11 @@ const workflowStepManifestSchema = z.object({
   timeoutMs: z.union([z.number().int().positive(), z.null()]),
   inputSchema: z.union([z.record(z.string(), z.unknown()), z.null()]),
   transitions: z.array(manifestTransitionSchema),
+  // Optional authoring fields — must be in the SCHEMA, not just the TS type and
+  // buildManifest output, or z.object() strips them on parse and the canvas
+  // (which reads the validated manifest) never sees an authored description.
+  description: z.union([z.string(), z.null()]).optional(),
+  capabilities: z.array(z.string()).optional(),
 });
 
 /**
@@ -110,4 +115,7 @@ export const agentManifestSchema = z.object({
     entryFile: z.string().min(1),
   }),
   steps: z.record(z.string(), workflowStepManifestSchema),
+  // Optional workflow-level description (Option A) — same reason as the step
+  // field above: absent from the schema means stripped on parse.
+  description: z.union([z.string(), z.null()]).optional(),
 });


### PR DESCRIPTION
## The bug

Authored `description` (on `defineStep` / `defineAgent`) and step `capabilities` have **never rendered on the harness canvas** since they were introduced — because manifest validation silently drops them.

`agentManifestSchema` is a `z.object()`, which strips any key it doesn't declare. The introducing PR added `description`/`capabilities` to the **TS types** and to **`buildManifest`'s output**, but not to the **runtime Zod schema**. And `@sapiom/agent-core`'s `check()` — the exact pipeline the canvas uses to build a graph — runs `agentManifestSchema.parse()` on every manifest. So:

```
source authors `description`  →  buildManifest emits it  →  schema.parse() STRIPS it  →  canvas gets ""
```

Discovered while testing "Describe with AI": the agent wrote correct `description:` fields into a workflow's source, the workflow's own SDK read them, but the canvas stayed blank. Running the real extraction (`extractWorkflowGraph`) returned every description as `""`; adding the fields to the schema made all of them flow through.

## The fix

Add `description` (step + workflow) and `capabilities` (step) to `workflowStepManifestSchema` / `agentManifestSchema` as optional fields, so they survive validation and reach consumers.

## Test

New regression in `manifest.spec.ts`: build a manifest with an authored workflow + step `description` and step `capabilities`, `agentManifestSchema.parse()` it, and assert they're **preserved** (the previous schema silently dropped them). The existing suite only ever parsed manifests without these fields, which is how it slipped through.

Verified: `@sapiom/agent` unit **84 pass**. Changeset included (patch → publish).

## Impact / sequencing

This unblocks authored descriptions **and** the "Describe with AI" feature (PR #421), both of which were non-functional end-to-end without it. Needs a **publish** (like the field itself did) before the shipped harness renders authored descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
