### PR TITLE
feat(examples): populate zeroSetup on manifests from the B2 baseline (SAP-2080)

### DIFF
--- a/examples/approval-chain/template.json
+++ b/examples/approval-chain/template.json
@@ -96,5 +96,14 @@
         "compensated": 1
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "committed", "assert": "equals", "value": false },
+      { "path": "trail", "assert": "nonEmptyArray" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Runs the saga with no approvers supplied, so nothing is committed and it escalates."
+  }
 }

--- a/examples/cold-outreach-engine/template.json
+++ b/examples/cold-outreach-engine/template.json
@@ -63,5 +63,14 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "sent", "assert": "equals", "value": 0 },
+      { "path": "reason", "assert": "equals", "value": "no-deliverable-contacts" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Runs the outreach engine with no leads, so there is nobody to write to and nothing is sent."
+  }
 }

--- a/examples/content-repurposing-pipeline/template.json
+++ b/examples/content-repurposing-pipeline/template.json
@@ -82,5 +82,13 @@
         "messageId": "msg_789"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "pack.newsletter", "assert": "nonEmptyString" },
+      { "path": "pack.tweetThread", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Repurposes a built-in sample post into a newsletter, tweet thread, video script, and LinkedIn post."
+  }
 }

--- a/examples/dependency-upgrade/template.json
+++ b/examples/dependency-upgrade/template.json
@@ -54,5 +54,14 @@
         "summary": "Patch and minor bumps across dev dependencies; no major versions, narrow blast radius."
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "pushed", "assert": "equals", "value": false },
+      { "path": "reportFileId", "assert": "nonEmptyString" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Runs a coding agent to triage upgrades and writes a report; pushes nothing (no repo)."
+  }
 }

--- a/examples/durable-backfill/template.json
+++ b/examples/durable-backfill/template.json
@@ -73,5 +73,14 @@
         "resultFileIds": ["file_chunk0", "file_chunk1"]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "complete", "assert": "equals", "value": true },
+      { "path": "jobId", "assert": "nonEmptyString" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Runs the backfill offline over 3 chunks (25 records); persists nothing (no dbHandle)."
+  }
 }

--- a/examples/error-triage-digest/template.json
+++ b/examples/error-triage-digest/template.json
@@ -73,5 +73,14 @@
         "digest": "# Error triage digest\n\nTriaged **3** entries into **2** new and **0** recurring issue(s).\n\n## 🔴 New issues (2)\n- **[high] Undefined read in checkout** — Reading `id` off an undefined object in checkout.js. (2 this batch)\n  `TypeError: Cannot read properties of undefined (reading 'id') at checkout.js:42`\n- **[medium] Payment charge timeout** — payments.charge exceeds its 30s timeout. (1 this batch)\n  `Timeout after 30000ms calling payments.charge`\n\n## 🔁 Recurring issues (0)\n_None._"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "digest", "assert": "nonEmptyString" },
+      { "path": "delivered", "assert": "equals", "value": false },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Triages sample errors into a digest; emails nothing because no recipient is set."
+  }
 }

--- a/examples/eval-gate/template.json
+++ b/examples/eval-gate/template.json
@@ -50,5 +50,13 @@
         "rationale": "Does not mention privacy and reads as generic hype."
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "decision", "assert": "nonEmptyString" },
+      { "path": "rationale", "assert": "nonEmptyString" }
+    ],
+    "narrative": "Grades the built-in sample against a rubric and returns a decision with rationale."
+  }
 }

--- a/examples/hello-agent/template.json
+++ b/examples/hello-agent/template.json
@@ -30,5 +30,12 @@
         "greeting": "Hello, world!"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "greeting", "assert": "equals", "value": "Hello, world!" }
+    ],
+    "narrative": "Runs immediately with no setup and returns a greeting."
+  }
 }

--- a/examples/human-in-the-loop/template.json
+++ b/examples/human-in-the-loop/template.json
@@ -93,5 +93,14 @@
         "considered": 1
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "shortlist", "assert": "nonEmptyArray" },
+      { "path": "outcome", "assert": "equals", "value": "pending-approval" },
+      { "path": "committed", "assert": "equals", "value": false }
+    ],
+    "narrative": "Ranks the sample shortlist and stops at pending-approval; commits nothing (no approver)."
+  }
 }

--- a/examples/meeting-notes-crm/template.json
+++ b/examples/meeting-notes-crm/template.json
@@ -64,5 +64,14 @@
         "summary": "# Meeting notes → CRM\n\n**Contact:** Dana Ruiz — VP Eng, Northwind\n**Deal stage:** contract\n**Next step:** Send SOC 2 report, then security review before signing\n\nDana confirmed Q3 rollout budget and wants a security review before signing.\n\n## Action items (2 new, 0 already tracked)\n### New (2)\n- Send the SOC 2 report _(me, due Friday)_\n- Loop in the CISO _(Dana, due next week)_\n\n### Already tracked (0)\n_None._"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "summary", "assert": "nonEmptyString" },
+      { "path": "delivered", "assert": "equals", "value": false },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Turns sample meeting notes into a CRM update summary; emails nothing (no recipient)."
+  }
 }

--- a/examples/news-roundup/template.json
+++ b/examples/news-roundup/template.json
@@ -58,5 +58,14 @@
         "companyName": "Polsia"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "status", "assert": "equals", "value": "published" },
+      { "path": "articles", "assert": "nonEmptyArray" },
+      { "path": "pageUrl", "assert": "nonEmptyString" }
+    ],
+    "narrative": "Builds a news-roundup microsite from sample articles and publishes a live preview."
+  }
 }

--- a/examples/newsletter-autopilot/template.json
+++ b/examples/newsletter-autopilot/template.json
@@ -57,5 +57,14 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "body", "assert": "nonEmptyString" },
+      { "path": "sources", "assert": "nonEmptyArray" },
+      { "path": "delivered", "assert": "equals", "value": false }
+    ],
+    "narrative": "Writes a newsletter from researched sources; sends to nobody (empty subscriber list)."
+  }
 }

--- a/examples/nl-db-query-endpoint/template.json
+++ b/examples/nl-db-query-endpoint/template.json
@@ -62,5 +62,14 @@
         "sql": "DELETE FROM users"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "sampleSql", "assert": "nonEmptyString" },
+      { "path": "deployed", "assert": "equals", "value": false },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Translates a sample question to SQL and validates it; deploys no endpoint (needs a scoped key)."
+  }
 }

--- a/examples/personalized-media-at-scale/template.json
+++ b/examples/personalized-media-at-scale/template.json
@@ -69,5 +69,14 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "assets", "assert": "nonEmptyArray" },
+      { "path": "delivered", "assert": "equals", "value": 0 },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Renders personalized images; delivers nothing because no recipients are set."
+  }
 }

--- a/examples/pr-review-bot/template.json
+++ b/examples/pr-review-bot/template.json
@@ -67,5 +67,13 @@
         "verdict": "request_changes"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "verdict", "assert": "nonEmptyString" },
+      { "path": "posted", "assert": "equals", "value": false }
+    ],
+    "narrative": "Runs a coding agent to review the sample PR and returns a verdict; posts nothing (no webhook)."
+  }
 }

--- a/examples/scene-to-video/template.json
+++ b/examples/scene-to-video/template.json
@@ -58,5 +58,13 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "shots", "assert": "nonEmptyArray" },
+      { "path": "bible", "assert": "nonEmptyString" }
+    ],
+    "narrative": "Shoots the built-in sample scene into a shot list with a style bible (dry run)."
+  }
 }

--- a/examples/scheduled-compliance-audit/template.json
+++ b/examples/scheduled-compliance-audit/template.json
@@ -53,5 +53,14 @@
         "downloadUrl": null
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "attestation", "assert": "nonEmptyString" },
+      { "path": "filed", "assert": "equals", "value": false },
+      { "path": "checks", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Runs the audit checks and drafts an attestation; files nothing (nobody signed off)."
+  }
 }

--- a/examples/scheduled-research-brief/template.json
+++ b/examples/scheduled-research-brief/template.json
@@ -55,5 +55,14 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "brief", "assert": "nonEmptyString" },
+      { "path": "sources", "assert": "nonEmptyArray" },
+      { "path": "delivered", "assert": "equals", "value": false }
+    ],
+    "narrative": "Researches the topic and writes a brief with sources; emails nothing (no recipient)."
+  }
 }

--- a/examples/slack-notifier/template.json
+++ b/examples/slack-notifier/template.json
@@ -74,5 +74,14 @@
         "ts": "1717171717.000100"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "posted", "assert": "equals", "value": false },
+      { "path": "skipped", "assert": "equals", "value": "no-credential" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Composes the message and prints it; posts nothing to Slack (no bot token)."
+  }
 }

--- a/examples/wait-for-webhook/template.json
+++ b/examples/wait-for-webhook/template.json
@@ -44,5 +44,13 @@
         "reasons": ["status=\"failed\""]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed_partial",
+    "expect": [
+      { "path": "decision", "assert": "nonEmptyString" },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Evaluates the sample job and returns a decision; registers no external callback."
+  }
 }

--- a/examples/web-research-digest/template.json
+++ b/examples/web-research-digest/template.json
@@ -37,5 +37,13 @@
         ]
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "sources", "assert": "nonEmptyArray" },
+      { "path": "digest", "assert": "minLength", "value": 100 }
+    ],
+    "narrative": "Researches a default topic and returns a digest with cited sources."
+  }
 }


### PR DESCRIPTION
## Summary

Populates the `zeroSetup` manifest field — the one declaration that cannot be written from static reading, because it asserts what an *unconfigured* run actually emits. The values come **verbatim** from B2's measured `RunnabilityBaselineRecord` (SAP-2065 `proposedExpectation`) — traceable to a production run, not invented.

**21 templates populated.** Each `zeroSetup` is its record's `proposedExpectation` copied exactly; the injection asserted `deepStrictEqual(manifest.zeroSetup, record.proposedExpectation)` per file.

Linear: SAP-2080

## Traceability

Source of record: B2's baseline, kept in the **private** `plans/onboarding-templates/baseline-records/` (deliberately not in this public repo). Each manifest's `zeroSetup` equals `records/<id>.json` → `proposedExpectation`. Most records are `examplesSha 10834c0`; a few were re-run 2026-07-31.

## Deliberately absent (per ticket rules — no guessing)

| Template | Why absent |
| -- | -- |
| `the-brain` | Excluded from B2's measurement by design — launches child workflows via raw POST with the capability token, which the empty-vault safety property does not cover. Stays in the gallery; measure separately later. |
| `proposal-generator` | B2 recorded **hard-failed** (`render` exceeded retry cap) at `10834c0`. No `proposedExpectation`. The SAP-2201 fix has since merged — re-measure and it likely flips to meaningful, but that record is not committed, so deriving now would be guessing. |
| `research-to-microsite` | B2 recorded **meaningful** at `441c689` but authored **no** `proposedExpectation` (artifact `published: false`). Its honest-degrade is actively being reworked under SAP-2203 — defer the expectation to that work. |
| `scheduled-db-insight-report` | B2 recorded **not-forkable** at `441c689` (deploy build failed). No `proposedExpectation`. |
| `preview-keep-alive` | Has a baseline record, but the template was cut from the gallery (#455) — no manifest to write. |

`fan-out-and-combine` and `logged-in-screenshots` already carry `zeroSetup` (authored in SAP-2202) and are untouched.

## Acceptance criteria

- [x] Every measured template populated here has a `zeroSetup` with ≥1 `expect[]` entry
- [x] Every `expect[]` entry is derived from B2's record for that template — verbatim, verified by deep-equal
- [x] Every assertion uses only the closed vocabulary (`nonEmptyArray | nonEmptyString | minLength | matches | equals | absent`)
- [x] No `narrative` implies a delivery that did not happen (narratives say "posts nothing", "emails nothing", "sends to nobody")
- [x] `pnpm examples:check` passes — **27 manifests schema-valid**
- [x] Any template with no measurement/expectation has `zeroSetup` absent, listed above with reason

## Scope note: the registry half is not here

The ticket also asked to flip `setup.runsWithNoSetup` and re-run `pnpm examples:sync-setup`. Both belong to **SAP-2078** (registry `setup`-block migration + the codemod), which was **canceled** — that infrastructure was never built (there is no `setup` block in `registry.json` and no `examples:sync-setup` script on any branch). This change is therefore manifest-only, matching the `zeroSetup` convention SAP-2202 established. `runsWithNoSetup` can be derived downstream from each record's `classification === "meaningful"` if/when the registry setup surface is built.

## Test plan

- `pnpm examples:check` → OK, 27 template.json manifests schema-valid
- Diff is byte-preserving: only a trailing `,` on the previous last key + the new `zeroSetup` block; no existing content reformatted (verified on the non-canonical `slack-notifier.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)