### PR TITLE
feat(agent): make the agent input contract first-class via defineAgent({ inputSchema }) (SAP-2228)

### DIFF
--- a/.changeset/agent-level-input-schema.md
+++ b/.changeset/agent-level-input-schema.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/agent": minor
+---
+
+Make the agent input contract first-class: `defineAgent({ inputSchema })`.
+
+`defineAgent` now accepts an optional agent-level `inputSchema` — one obvious place to declare "what this agent takes". When the entry step declares no `inputSchema` of its own, `defineAgent` folds the agent-level schema onto it, so the built manifest's entry step carries the JSON Schema (and the dashboard renders its fields) without any downstream change. Declaring a *different* schema at both the agent level and on the entry step is now a build error with a clear message; declaring the identical schema object in both places is allowed.
+
+The schema is typed `ZodType<TInput>`, so the `defineAgent<TInput>` generic (hence the `run(def, input)` call site) is inferred from the same runtime schema that becomes the contract — the TS annotation and the runtime validation can no longer drift apart (SAP-2226).
+
+Existing agents that declare the schema on the entry step keep working unchanged.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,3 +1,7 @@
+// `zod/v4` subpath (present in zod 3.25.x AND zod 4.x): the v4 `ZodType` surface
+// while the `zod` peer can resolve to v3 or v4. See step.ts / introspection.ts.
+import type { ZodType } from 'zod/v4';
+
 import { UnknownStepError } from './errors.js';
 import type { StepDefinition } from './step.js';
 
@@ -33,6 +37,17 @@ export const AGENT_DEFINITION_BRAND = Symbol.for('sapiom.models.definition');
  *     steps: { gather, summarize, ... },
  *   });
  *
+ * The input contract can instead be declared once, at the agent level, via
+ * `inputSchema` — `TInput` is then inferred from it (no explicit generic
+ * needed) and `defineAgent` folds it onto the entry step:
+ *
+ *   export const cycleAgent = defineAgent({
+ *     name: 'cycle',
+ *     entry: 'gather',
+ *     inputSchema: z.object({ companyId: z.number() }),
+ *     steps: { gather, summarize, ... },
+ *   });
+ *
  * Steps inside `steps` are typed Step<unknown, unknown, TShared>. The
  * primitive doesn't (and can't) statically enforce that each step's TIn
  * matches its predecessor's TOut — that's a design tradeoff for the
@@ -49,6 +64,20 @@ export interface AgentDefinition<
    *  deterministic, no LLM). */
   readonly description?: string;
   readonly entry: string;
+  /**
+   * Optional agent-level input contract — the one obvious place to declare
+   * "what this agent takes". When the entry step declares no `inputSchema`,
+   * `defineAgent` folds this schema onto it, so the manifest's entry step
+   * carries the JSON Schema and the dashboard renders its fields. Declaring it
+   * here AND on the entry step (as a *different* schema) is a build error —
+   * declare the contract once.
+   *
+   * Typed `ZodType<TInput>` so the `defineAgent<TInput>` generic (hence the
+   * `run(def, input)` call site) is inferred from the same runtime schema that
+   * becomes the contract — the TS annotation and the runtime validation cannot
+   * drift apart (SAP-2226).
+   */
+  readonly inputSchema?: ZodType<TInput>;
   readonly steps: Readonly<Record<string, StepDefinition<TShared>>>;
   /**
    * Phantom marker that carries the entry-step input type so `runner.run(def, input)`
@@ -99,6 +128,16 @@ export function isLegacyOrchestrationDefinition(val: unknown): val is AgentDefin
  *   1. `name` is non-empty
  *   2. `entry` exists in `steps`
  *   3. Every step in `steps` is non-null and the map key matches `step.name`
+ *   4. If an agent-level `inputSchema` is declared, fold it onto the entry step
+ *      (build error if the entry step declares a *different* one) — see below.
+ *
+ * When `inputSchema` is declared at the agent level and the entry step declares
+ * none, the agent-level schema BECOMES the entry step's `inputSchema`. This
+ * keeps a single source of truth for the input contract while leaving every
+ * downstream consumer (`buildManifest`, `workflowInputContract`,
+ * `stepInputContract`) unchanged — they still read `steps[entry].inputSchema`,
+ * which now carries it. Declaring a *different* schema in both places is a
+ * conflict and throws; declaring the identical schema object in both is allowed.
  *
  * Attaches a non-enumerable brand symbol (`AGENT_DEFINITION_BRAND`) so
  * the object can be detected by `isAgentDefinition` after bundling +
@@ -126,6 +165,26 @@ export function defineAgent<TInput = unknown, TShared extends Record<string, unk
     }
     if (step.name !== key) {
       throw new Error(`Agent '${def.name}' step name mismatch at key '${key}': step.name='${step.name}'`);
+    }
+  }
+  // Fold the agent-level input contract onto the entry step (see the doc above).
+  if (def.inputSchema) {
+    const entryStep = def.steps[def.entry];
+    if (entryStep.inputSchema && entryStep.inputSchema !== def.inputSchema) {
+      throw new Error(
+        `Agent '${def.name}' declares an inputSchema at both the agent level and on its entry step '${def.entry}'. ` +
+          `Declare the input contract in one place — remove it from whichever is not the source of truth.`,
+      );
+    }
+    if (!entryStep.inputSchema) {
+      // The entry step declared no schema: the agent-level contract becomes it.
+      // Replace the step in the map (not a deep clone — the step's `run` and
+      // routing declarations are carried over by the spread) so downstream
+      // readers of `steps[entry].inputSchema` pick it up without special-casing.
+      (def.steps as Record<string, StepDefinition<TShared>>)[def.entry] = {
+        ...entryStep,
+        inputSchema: def.inputSchema as ZodType<unknown>,
+      };
     }
   }
   // Attach the brand as a non-enumerable property so it:

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -172,18 +172,22 @@ export function defineAgent<TInput = unknown, TShared extends Record<string, unk
     const entryStep = def.steps[def.entry];
     if (entryStep.inputSchema && entryStep.inputSchema !== def.inputSchema) {
       throw new Error(
-        `Agent '${def.name}' declares an inputSchema at both the agent level and on its entry step '${def.entry}'. ` +
-          `Declare the input contract in one place — remove it from whichever is not the source of truth.`,
+        `Agent '${def.name}' declares a different inputSchema at the agent level and on its entry step '${def.entry}'. ` +
+          `Declare the input contract once and reference that single schema object in both places (or remove one).`,
       );
     }
     if (!entryStep.inputSchema) {
       // The entry step declared no schema: the agent-level contract becomes it.
-      // Replace the step in the map (not a deep clone — the step's `run` and
-      // routing declarations are carried over by the spread) so downstream
-      // readers of `steps[entry].inputSchema` pick it up without special-casing.
-      (def.steps as Record<string, StepDefinition<TShared>>)[def.entry] = {
-        ...entryStep,
-        inputSchema: def.inputSchema as ZodType<unknown>,
+      // Copy-on-write — build a FRESH steps map with a fresh entry step rather
+      // than mutating the caller's (Readonly) `steps` object in place. Mutating
+      // it would corrupt a `steps` literal shared across two `defineAgent` calls
+      // (the first fold would rewrite the second's entry step) and would throw on
+      // an `Object.freeze()`d map. The step's `run` and routing declarations are
+      // carried over by the spread, so downstream readers of
+      // `steps[entry].inputSchema` pick up the contract without special-casing.
+      (def as { steps: Record<string, StepDefinition<TShared>> }).steps = {
+        ...def.steps,
+        [def.entry]: { ...entryStep, inputSchema: def.inputSchema as ZodType<unknown> },
       };
     }
   }

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -338,6 +338,34 @@ describe("buildManifest", () => {
     expect(stepSchema.required).toContain("runId");
   });
 
+  it("agent-level inputSchema is carried on the entry step's manifest schema", () => {
+    // An agent that declares only `defineAgent({ inputSchema })` — the entry
+    // step declares no schema of its own. The manifest's entry step must still
+    // carry the JSON Schema so the dashboard can render its fields (SAP-2228).
+    const schema = z.object({ companyId: z.number(), region: z.string() });
+    const def = defineAgent({
+      name: "wf",
+      entry: "gather",
+      inputSchema: schema,
+      steps: { gather: makeStep("gather") },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    const stepSchema = manifest.steps.gather.inputSchema;
+    expect(stepSchema).not.toBeNull();
+    expect(stepSchema?.type).toBe("object");
+    expect(
+      (stepSchema?.properties as Record<string, unknown>)?.companyId,
+    ).toBeDefined();
+    expect(
+      (stepSchema?.properties as Record<string, unknown>)?.region,
+    ).toBeDefined();
+    // Produces a manifest that still validates against the schema.
+    expect(() => agentManifestSchema.parse(manifest)).not.toThrow();
+  });
+
   it("manifest validates against agentManifestSchema", () => {
     const inputSchema = z.object({ input: z.string() });
     const def = defineAgent({

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -10,6 +10,8 @@
  *      StepLogger interface is accepted (validates the structural design)
  */
 
+import { z } from 'zod/v4';
+
 import {
   DIRECTIVE_KIND,
   InMemoryContextStore,
@@ -159,6 +161,100 @@ describe('defineAgent', () => {
     // A plain-JSON copy (simulating what JSON.stringify/parse produces) lacks the brand.
     const copy = JSON.parse(JSON.stringify({ name: def.name, entry: def.entry, steps: {} }));
     expect(isAgentDefinition(copy)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1b. defineAgent — agent-level inputSchema (the first-class input contract)
+// ---------------------------------------------------------------------------
+
+describe('defineAgent agent-level inputSchema', () => {
+  const contract = z.object({ companyId: z.number() });
+
+  /** An entry step that declares no inputSchema of its own. */
+  function entryWithoutSchema(name: string) {
+    return defineStep({
+      name,
+      next: [],
+      terminal: true,
+      async run() {
+        return terminate(null);
+      },
+    });
+  }
+
+  /** An entry step that declares its own inputSchema. */
+  function entryWithSchema(name: string, schema: z.ZodType) {
+    return defineStep({
+      name,
+      next: [],
+      terminal: true,
+      inputSchema: schema,
+      async run() {
+        return terminate(null);
+      },
+    });
+  }
+
+  it('folds the agent-level schema onto an entry step that declares none', () => {
+    const entry = entryWithoutSchema('start');
+    const def = defineAgent({
+      name: 'wf',
+      entry: 'start',
+      inputSchema: contract,
+      steps: { start: entry },
+    });
+    // The entry step now carries the agent-level schema.
+    expect(def.steps.start.inputSchema).toBe(contract);
+  });
+
+  it('leaves an entry step that declares the identical schema object untouched (no conflict)', () => {
+    const entry = entryWithSchema('start', contract);
+    const def = defineAgent({
+      name: 'wf',
+      entry: 'start',
+      inputSchema: contract,
+      steps: { start: entry },
+    });
+    expect(def.steps.start).toBe(entry);
+    expect(def.steps.start.inputSchema).toBe(contract);
+  });
+
+  it('throws a clear error when agent-level and entry-step schemas conflict', () => {
+    const entrySchema = z.object({ topic: z.string() });
+    expect(() =>
+      defineAgent({
+        name: 'wf',
+        entry: 'start',
+        inputSchema: contract,
+        steps: { start: entryWithSchema('start', entrySchema) },
+      }),
+    ).toThrow(/declares an inputSchema at both the agent level and on its entry step 'start'/);
+  });
+
+  it('does not touch non-entry steps', () => {
+    const entry = entryWithoutSchema('start');
+    const second = entryWithoutSchema('second');
+    const def = defineAgent({
+      name: 'wf',
+      entry: 'start',
+      inputSchema: contract,
+      steps: { start: entry, second },
+    });
+    expect(def.steps.second.inputSchema).toBeUndefined();
+    expect(def.steps.second).toBe(second);
+  });
+
+  it('is a no-op when no agent-level schema is declared (back-compat)', () => {
+    const entry = entryWithSchema('start', contract);
+    const def = defineAgent({
+      name: 'wf',
+      entry: 'start',
+      steps: { start: entry },
+    });
+    // Entry step reference and its own schema are preserved unchanged.
+    expect(def.steps.start).toBe(entry);
+    expect(def.steps.start.inputSchema).toBe(contract);
   });
 });
 

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -229,7 +229,45 @@ describe('defineAgent agent-level inputSchema', () => {
         inputSchema: contract,
         steps: { start: entryWithSchema('start', entrySchema) },
       }),
-    ).toThrow(/declares an inputSchema at both the agent level and on its entry step 'start'/);
+    ).toThrow(/declares a different inputSchema at the agent level and on its entry step 'start'/);
+  });
+
+  it('does not mutate a steps object shared across two defineAgent calls', () => {
+    // Both agents are built from the SAME steps object literal. Folding the
+    // agent-level schema onto the first must NOT rewrite the entry step the
+    // second reads (copy-on-write, not in-place mutation).
+    const start = entryWithoutSchema('start');
+    const shared = { start };
+    const withSchema = defineAgent({
+      name: 'with',
+      entry: 'start',
+      inputSchema: contract,
+      steps: shared,
+    });
+    const without = defineAgent({
+      name: 'without',
+      entry: 'start',
+      steps: shared,
+    });
+    // The first agent folded the contract onto its own (fresh) entry step...
+    expect(withSchema.steps.start.inputSchema).toBe(contract);
+    // ...but the shared object and the second agent are untouched.
+    expect(shared.start).toBe(start);
+    expect(shared.start.inputSchema).toBeUndefined();
+    expect(without.steps.start.inputSchema).toBeUndefined();
+  });
+
+  it('does not mutate a frozen steps map (folds via copy, no TypeError)', () => {
+    const frozen = Object.freeze({ start: entryWithoutSchema('start') });
+    const def = defineAgent({
+      name: 'wf',
+      entry: 'start',
+      inputSchema: contract,
+      steps: frozen,
+    });
+    expect(def.steps.start.inputSchema).toBe(contract);
+    // The original frozen map is left as-is.
+    expect(frozen.start.inputSchema).toBeUndefined();
   });
 
   it('does not touch non-entry steps', () => {

--- a/packages/agent/src/type-enforcement.spec.ts
+++ b/packages/agent/src/type-enforcement.spec.ts
@@ -12,7 +12,9 @@
  *     through to the `run` return constraint end-to-end.
  */
 
-import { defineStep, fail, goto, pauseUntilSignal, retry, terminate } from './index.js';
+import { z } from 'zod/v4';
+
+import { defineAgent, defineStep, fail, goto, pauseUntilSignal, retry, terminate } from './index.js';
 import type { Allowed, Goto, Pause, Retry, Terminate } from './index.js';
 
 type Extends<A, B> = A extends B ? true : false;
@@ -102,9 +104,32 @@ function _smoke() {
   });
 }
 
+// ---- 3. defineAgent inputSchema → TInput inference -----------------------
+// Declaring the input contract at the agent level infers TInput from the zod
+// schema (no explicit generic), so the run(def, input) type is tied to the same
+// runtime schema that becomes the contract (SAP-2228). Checked by tsc via the
+// __inputType phantom that carries TInput.
+
+function _agentInputInference() {
+  const def = defineAgent({
+    name: 'wf',
+    entry: 'start',
+    inputSchema: z.object({ companyId: z.number() }),
+    steps: {
+      start: defineStep({ name: 'start', next: [], terminal: true, run: async () => terminate(null) }),
+    },
+  });
+  type Inferred = NonNullable<typeof def.__inputType>;
+  // TInput is inferred as exactly the schema's output type (both directions).
+  const _forward: Extends<Inferred, { companyId: number }> = true;
+  const _backward: Extends<{ companyId: number }, Inferred> = true;
+  return [_forward, _backward];
+}
+
 describe('type enforcement', () => {
   it('assignability table + defineStep smoke checks are validated by tsc --noEmit', () => {
     expect(TABLE).toHaveLength(9);
     expect(typeof _smoke).toBe('function');
+    expect(typeof _agentInputInference).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary

Makes the agent input contract a first-class construct instead of a convention. `defineAgent` now accepts an optional agent-level `inputSchema` — **one obvious place** to declare "what this agent takes" — closing the drift described in SAP-2228/SAP-2226 where authors had to *know* that "the entry step's schema is the agent's contract" and hand-mirror it.

## What changed (`packages/agent`)

- **`agent.ts`**
  - `AgentDefinition` gains an optional `inputSchema?: ZodType<TInput>`.
  - `defineAgent` **folds** the agent-level schema onto the entry step when the entry step declares none. Everything downstream (`buildManifest`, `workflowInputContract`, `stepInputContract`, and therefore the engine + dashboard) keeps reading `steps[entry].inputSchema` unchanged — it now simply carries the contract.
  - Declaring a **different** schema at both the agent level and the entry step is a **build error** with a clear message. Declaring the *identical* schema object in both places is allowed (no-op).
  - Typing `inputSchema` as `ZodType<TInput>` infers `TInput` from the schema, tying the `defineAgent<TInput>` generic (hence the `run(def, input)` call site) to the same runtime schema that becomes the contract — the TS annotation and runtime validation can no longer diverge.

## Design note — scope

The manifest **shape is intentionally unchanged**: folding onto the entry step satisfies the acceptance criteria ("manifest whose entry step carries that JSON Schema") without a manifest schema bump, so **no `apps/workflows-engine` change is required** and existing agents keep working byte-for-byte. The two *Nice-to-have* items in the ticket (an explicit manifest-level input contract field to remove the ordinal-vs-entry dependency, and a `template.json` `defaultInput` generator) are deliberately left as follow-ups — each is additive and carries its own cross-repo/tooling surface.

## Acceptance criteria

- ✅ An agent declaring only `defineAgent({ inputSchema })` builds a manifest whose entry step carries that JSON Schema (dashboard renders its fields).
- ✅ A conflicting agent-level + entry-step schema fails the build with a clear message.
- ✅ Existing agents that declare the schema on the entry step keep working unchanged.

## Testing

- `sdk.spec.ts` — fold onto schemaless entry, identical-schema no-op, conflict throws, non-entry steps untouched, back-compat no-op.
- `manifest.spec.ts` — manifest's entry step carries the folded JSON Schema and still validates against `agentManifestSchema`.
- `type-enforcement.spec.ts` — `TInput` is inferred exactly from `inputSchema` (checked by `tsc --noEmit`).
- Verified locally: `pnpm --filter @sapiom/agent build`, `pnpm typecheck`, `pnpm lint`, and the three specs (66 tests pass).

A `minor` changeset is included (`@sapiom/agent`).

Closes SAP-2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dbrv98JjCQ1wXbvmpTsR4
