### PR TITLE
feat(examples): declare an entry inputSchema on scaffolds + every gallery example that reads input (SAP-2226)

### DIFF
--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Multi-Party Approval Chain (Saga) — a durable, sequential sign-off flow.
@@ -339,8 +340,64 @@ async function persistTransition(
 const DEFAULT_SUBJECT = "Sample: renew the annual analytics contract ($18,000)";
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `subject` carries the sample as
+ * its `.default(...)`; an empty `approvers` chain escalates rather than pausing
+ * on a gate that does not exist.
+ */
+const entryInput = z.object({
+  subject: z
+    .string()
+    .default(DEFAULT_SUBJECT)
+    .describe("What is being signed off (contract, budget, policy…)."),
+  approvers: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        email: z.string().optional(),
+      }),
+    )
+    .optional()
+    .describe(
+      "The ordered chain of approvers — each must approve before the next is asked.",
+    ),
+  escalateTo: z
+    .string()
+    .optional()
+    .describe(
+      "Human channel to escalate to on timeout. Falls back to config.ESCALATION_EMAIL.",
+    ),
+  ledgerHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Handle of a durable Postgres to append the audit trail to. Falls back to config.LEDGER_HANDLE.",
+    ),
+  reminderMs: z
+    .number()
+    .optional()
+    .describe(
+      "Pause timeout per gate in ms (best-effort auto-reminder). Default 24h.",
+    ),
+  maxReminders: z
+    .number()
+    .default(DEFAULT_MAX_REMINDERS)
+    .describe("Reminders before a silent gate escalates."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Skip the irreversible finalize action and live DB writes."),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("String-only config bag (escalation / ledger fallbacks)."),
+});
+
 const start = defineStep({
   name: "start",
+  inputSchema: entryInput,
   next: ["present", "escalate"],
   async run(input: EntryInput, ctx: Ctx) {
     const config = input.config ?? {};

--- a/examples/approval-chain/package.json
+++ b/examples/approval-chain/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
     "@sapiom/tools": "^0.20.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/cold-outreach-engine/index.ts
+++ b/examples/cold-outreach-engine/index.ts
@@ -8,6 +8,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Cold Outreach Personalization Engine — turn a raw lead list into a
@@ -277,8 +278,61 @@ async function resolveSenderInbox(
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: a
+ * zero-input run works a sample batch through a default three-touch sequence.
+ */
+const entryInput = z.object({
+  leads: z
+    .array(
+      z.object({
+        domain: z.string().optional(),
+        company: z.string().optional(),
+        fullName: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+      }),
+    )
+    .optional()
+    .describe("The leads to work through on this run."),
+  campaign: z
+    .string()
+    .optional()
+    .describe("Campaign name — also the key for the dedup/log store."),
+  sequence: z
+    .array(z.object({ subject: z.string(), body: z.string() }))
+    .optional()
+    .describe("The drip sequence; defaults to a three-touch sequence."),
+  dripIntervalDays: z
+    .number()
+    .optional()
+    .describe("Days to wait between touches (default 3)."),
+  senderName: z
+    .string()
+    .optional()
+    .describe("Display name signed on the outgoing mail."),
+  schedule: z
+    .string()
+    .optional()
+    .describe("Cron cadence this engine runs on (documentation only)."),
+  dbHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Postgres handle for the campaign store; defaults to the template handle.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Compute the plan and openers but skip the send, the DB, and the drip.",
+    ),
+});
+
 const enrich = defineStep({
   name: "enrich",
+  inputSchema: entryInput,
   next: ["scrape"],
   async run(input: EntryInput, ctx: Ctx) {
     const leads = normalizeLeads(input.leads);

--- a/examples/cold-outreach-engine/package.json
+++ b/examples/cold-outreach-engine/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.24.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /**
  * Content Repurposing Pipeline — one long-form source into a multi-channel pack.
@@ -76,8 +77,8 @@ interface Clip {
 
 /** Trigger input. Only `source` is required. */
 interface RepurposeInput {
-  /** The blog post or transcript to repurpose (raw text). */
-  source: string;
+  /** The blog post or transcript to repurpose (raw text). Omit ⇒ the sample. */
+  source?: string;
   /** Optional title/topic for context in the generated copy. */
   title?: string;
   /** Who the content is for; steers tone (default a general professional audience). */
@@ -381,8 +382,60 @@ function renderPackMarkdown(
   ].join("\n");
 }
 
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `source` stays optional so the
+ * tri-state holds: omitted ⇒ repurpose the built-in sample, explicitly empty ⇒
+ * a reported mistake, present ⇒ repurpose it.
+ */
+const entryInput = z.object({
+  source: z
+    .string()
+    .optional()
+    .describe(
+      "The blog post or transcript to repurpose (raw text). Omit to use the built-in sample.",
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe("Optional title/topic for context in the generated copy."),
+  audience: z
+    .string()
+    .optional()
+    .describe(
+      "Who the content is for; steers tone (default a general professional audience).",
+    ),
+  numQuotes: z
+    .number()
+    .default(2)
+    .describe("How many quote graphics to make (clamped 1–4)."),
+  deliverTo: z
+    .string()
+    .optional()
+    .describe(
+      "Recipient email. Omit it and the pack is returned inline instead of emailed.",
+    ),
+  schedule: z
+    .string()
+    .optional()
+    .describe("Cron cadence this pipeline runs on (carried + reported)."),
+  model: z
+    .string()
+    .optional()
+    .describe(
+      "Optional image-to-video model id, passed through to video.launch.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Generate the copy only — skip graphics, clip, upload, and email.",
+    ),
+});
+
 const repurpose = defineStep({
   name: "repurpose",
+  inputSchema: entryInput,
   next: ["graphics"],
   terminal: true,
   async run(input: RepurposeInput, ctx: Ctx) {
@@ -397,7 +450,8 @@ const repurpose = defineStep({
       });
     }
     const usedSampleSource = input.source === undefined;
-    const source = usedSampleSource ? SAMPLE_SOURCE : input.source.trim();
+    const source =
+      input.source === undefined ? SAMPLE_SOURCE : input.source.trim();
     if (usedSampleSource) {
       ctx.shared.set(
         "note",

--- a/examples/content-repurposing-pipeline/package.json
+++ b/examples/content-repurposing-pipeline/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/dependency-upgrade/index.ts
+++ b/examples/dependency-upgrade/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /**
  * dependency-upgrade — a scheduled "Dependabot triage" that only opens a PR when
@@ -103,8 +104,61 @@ interface Assessment {
 // ──────────────────────────────────────────────────────────────── steps ──
 
 /** Resolve the repo + commands into shared and validate the input. */
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. The instruction and command
+ * knobs carry their runtime fallbacks as `.default(...)`; `repoSlug` has no
+ * default on purpose — a repository must exist, so an empty slug is a clean
+ * rejection rather than a plausible-but-missing one.
+ */
+const entryInput = z.object({
+  repoSlug: z
+    .string()
+    .optional()
+    .describe(
+      "In-network repo slug the coding agent clones and upgrades. Required for a real run.",
+    ),
+  task: z
+    .string()
+    .default(DEFAULT_TASK)
+    .describe("Plain-words upgrade instruction for the coding agent."),
+  installCommand: z
+    .string()
+    .default("npm install")
+    .describe("Command that installs dependencies in the checkout."),
+  testCommand: z
+    .string()
+    .default("npm test")
+    .describe("Command that runs the test suite in the checkout."),
+  workingDirectory: z
+    .string()
+    .optional()
+    .describe("Checkout subdirectory to run tests in. Defaults to the slug."),
+  maxAutoRisk: z
+    .enum(["low", "medium", "high"])
+    .default("medium")
+    .describe(
+      "Risk at/below which a green build auto-pushes; anything above is held.",
+    ),
+  allowRisky: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Push even when risk is above maxAutoRisk (skip the human hold).",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Assemble everything but skip the push + report upload."),
+  schedule: z
+    .string()
+    .optional()
+    .describe("Cron cadence when deployed as a schedule (documentation only)."),
+});
+
 const plan = defineStep({
   name: "plan",
+  inputSchema: entryInput,
   next: ["bump", "rejected"],
   async run(input: DependencyUpgradeInput, ctx: Ctx) {
     const repoSlug = (input?.repoSlug ?? "").trim();

--- a/examples/dependency-upgrade/package.json
+++ b/examples/dependency-upgrade/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/durable-backfill/index.ts
+++ b/examples/durable-backfill/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Durable Backfill / Long-Job Runner — process a huge dataset in resumable
@@ -312,8 +313,50 @@ async function processChunk(
 }
 
 // ---- steps -----------------------------------------------------------------
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. The sizing + command knobs carry
+ * their runtime fallbacks as `.default(...)`; `dbHandle` stays optional (absent
+ * ⇒ the loop runs offline).
+ */
+const entryInput = z.object({
+  total: z
+    .number()
+    .default(DEFAULT_TOTAL)
+    .describe("Total items in the dataset to back-fill."),
+  chunkSize: z
+    .number()
+    .default(DEFAULT_CHUNK_SIZE)
+    .describe("Items per chunk — the unit of work between heartbeats."),
+  jobId: z
+    .string()
+    .optional()
+    .describe(
+      "Stable id / checkpoint key. Pass the same jobId to resume an interrupted job. Defaults to the execution id.",
+    ),
+  dbHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Postgres handle whose connection string is injected as DATABASE_URL. Absent ⇒ offline.",
+    ),
+  command: z
+    .string()
+    .default(DEFAULT_COMMAND)
+    .describe("Shell command run once per chunk inside the sandbox."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Process chunks in-process and skip all external calls."),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Reserved for extra string config."),
+});
+
 const plan = defineStep({
   name: "plan",
+  inputSchema: entryInput,
   next: ["process"],
   async run(input: BackfillInput, ctx: Ctx) {
     const total = Math.max(0, Math.floor(input.total ?? DEFAULT_TOTAL));
@@ -434,7 +477,8 @@ const processStep = defineStep({
     // Rewrite the durable checkpoint, rotating out the previous file.
     if (!dryRun) {
       const prevCheckpoint = ctx.shared.get("checkpointFileId") as
-        string | null;
+        | string
+        | null;
       const cpId = await uploadJson(ctx, checkpointFileName(jobId), {
         jobId,
         cursor: nextCursor,

--- a/examples/durable-backfill/package.json
+++ b/examples/durable-backfill/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/error-triage-digest/index.ts
+++ b/examples/error-triage-digest/index.ts
@@ -8,6 +8,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Error / Log Triage Digest — turn a noisy stream of errors into one daily
@@ -235,8 +236,62 @@ function toIso(v: unknown): string {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: pass an
+ * `errors` batch directly, a `pullUrl` to fetch one, or set `webhook` to wait
+ * for a batch to be pushed.
+ */
+const entryInput = z.object({
+  errors: z
+    .array(
+      z
+        .object({
+          message: z.string(),
+          level: z.string().optional(),
+          service: z.string().optional(),
+          stack: z.string().optional(),
+          timestamp: z.string().optional(),
+        })
+        .catchall(z.unknown()),
+    )
+    .optional()
+    .describe("The error batch to triage (the scheduled-pull / direct path)."),
+  pullUrl: z
+    .string()
+    .optional()
+    .describe(
+      "Optional URL to GET the batch from (a JSON array, or { errors: [] }).",
+    ),
+  webhook: z
+    .boolean()
+    .optional()
+    .describe("Wait for a webhook to push the batch instead of pulling one."),
+  schedule: z
+    .string()
+    .optional()
+    .describe("Cron cadence this digest runs on (documentation only)."),
+  dbHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Postgres handle for the dedup store; defaults to the template handle.",
+    ),
+  deliverTo: z
+    .string()
+    .optional()
+    .describe(
+      "Recipient email. Omit it and the digest is returned inline instead of emailed.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Compute the digest but skip the DB writes and the real send."),
+});
+
 const collect = defineStep({
   name: "collect",
+  inputSchema: entryInput,
   next: ["triage"],
   // Static graph edge: on SIGNAL, resume at `triage`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "triage" },

--- a/examples/error-triage-digest/package.json
+++ b/examples/error-triage-digest/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.24.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/fan-out-and-combine/index.ts
+++ b/examples/fan-out-and-combine/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Fan Out and Combine — split a goal into parts, run each part as its own child
@@ -158,13 +159,58 @@ function readAnalysis(output: unknown): string | null {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `goal` and `items` carry the
+ * sample set as their `.default(...)` so a zero-input run really fans out;
+ * `mode`/`item` are what the coordinator sets on each child.
+ */
+const entryInput = z.object({
+  goal: z
+    .string()
+    .default(DEFAULT_GOAL)
+    .describe(
+      "What to accomplish. Split across the items on the coordinate path.",
+    ),
+  items: z
+    .array(z.string())
+    .default(DEFAULT_ITEMS)
+    .describe("The sub-parts to fan out — one child run per item."),
+  childDefinition: z
+    .string()
+    .optional()
+    .describe(
+      "Slug of the deployed orchestration to run per item. Defaults to this agent's own slug.",
+    ),
+  mode: z
+    .enum(["coordinate", "leaf"])
+    .default("coordinate")
+    .describe(
+      'Which role this execution plays; a "leaf" does one item and never fans out.',
+    ),
+  item: z
+    .string()
+    .optional()
+    .describe(
+      "The single item a leaf works on. Set by the coordinator on each child.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Resolve and return the fan-out plan without dispatching any child runs.",
+    ),
+});
+
 const plan = defineStep({
   name: "plan",
+  inputSchema: entryInput,
   next: ["solve", "fanOut", "planned"],
   async run(input: EntryInput, ctx: Ctx) {
     const mode: Mode = input.mode === "leaf" ? "leaf" : "coordinate";
-    const suppliedGoal = input.goal?.trim() ?? "";
-    const goal = suppliedGoal || DEFAULT_GOAL;
+    // The schema fills `goal` with DEFAULT_GOAL on a zero-input run, so the
+    // value — not its absence — is what tells us the default goal was used.
+    const goal = input.goal?.trim() || DEFAULT_GOAL;
     // Default to composing THIS deployment. `ctx.agentName` is the run's own slug,
     // so a forked+deployed copy dispatches leaf runs of itself with no other setup.
     const childDefinition = input.childDefinition?.trim() || ctx.agentName;
@@ -183,7 +229,7 @@ const plan = defineStep({
     // Coordinate path.
     const items = normalizeItems(input.items, DEFAULT_ITEMS);
     ctx.shared.set("itemCount", items.length);
-    if (!suppliedGoal) {
+    if (goal === DEFAULT_GOAL) {
       ctx.shared.set(
         "note",
         `Coordinated the default goal. Pass a \`goal\` and \`items\` to fan out your own.`,

--- a/examples/fan-out-and-combine/package.json
+++ b/examples/fan-out-and-combine/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.7.1",
-    "@sapiom/tools": "^0.23.0"
+    "@sapiom/tools": "^0.23.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/hello-agent/index.ts
+++ b/examples/hello-agent/index.ts
@@ -1,8 +1,5 @@
-import {
-  defineAgent,
-  defineStep,
-  terminate,
-} from "@sapiom/agent";
+import { defineAgent, defineStep, terminate } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Hello Agent — the minimal single-step Sapiom agent.
@@ -14,8 +11,18 @@ import {
  * Each step declares its allowed transitions (`next` / `terminal`); the return
  * type is derived from them, so an undeclared transition is a compile error.
  */
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `name` defaults to the greeting
+ * this scaffold ships with, so a zero-input run still produces a real result.
+ */
+const entryInput = z.object({
+  name: z.string().default("world").describe("Who to greet."),
+});
+
 const greet = defineStep({
   name: "greet",
+  inputSchema: entryInput,
   next: [],
   terminal: true,
   async run(input: { name?: string }, ctx) {

--- a/examples/hello-agent/package.json
+++ b/examples/hello-agent/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.5.0",
-    "@sapiom/tools": "^0.16.0"
+    "@sapiom/tools": "^0.16.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Human-in-the-Loop Approval — the "ask before you commit/spend" pattern.
@@ -88,10 +89,10 @@ interface ParsedRequest {
 }
 
 interface EntryInput {
-  /** The natural-language request to fulfil (parsed by the model). */
-  request: string;
-  /** The pool of candidates to rank and offer to, in any order. */
-  candidates: Candidate[];
+  /** The natural-language request to fulfil (parsed by the model). Omit ⇒ the sample. */
+  request?: string;
+  /** The pool of candidates to rank and offer to, in any order. Omit ⇒ the sample. */
+  candidates?: Candidate[];
   /** Who approves before anything commits. Falls back to `config.APPROVER_EMAIL`. */
   approver?: string;
   /** Human channel to escalate to when the ranked list is exhausted. Falls back to `config.ESCALATION_EMAIL`. */
@@ -244,8 +245,55 @@ const SAMPLE_CANDIDATES: Candidate[] = [
 ];
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `request` and `candidates` stay
+ * optional so a zero-input run falls back to the built-in sample (and says so),
+ * rather than being rejected for missing fields.
+ */
+const entryInput = z.object({
+  request: z
+    .string()
+    .optional()
+    .describe(
+      "The natural-language request to fulfil (parsed by the model). Omit to use the built-in sample.",
+    ),
+  candidates: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        email: z.string().optional(),
+        attributes: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .optional()
+    .describe("The pool of candidates to rank and offer to, in any order."),
+  approver: z
+    .string()
+    .optional()
+    .describe(
+      "Who approves before anything commits. Falls back to config.APPROVER_EMAIL.",
+    ),
+  escalateTo: z
+    .string()
+    .optional()
+    .describe(
+      "Human channel to escalate to when the ranked list is exhausted. Falls back to config.ESCALATION_EMAIL.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Compute + notify but never perform the irreversible commit."),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("String-only config bag (approver / escalation fallbacks)."),
+});
+
 const parse = defineStep({
   name: "parse",
+  inputSchema: entryInput,
   next: ["rank"],
   async run(input: EntryInput, ctx: Ctx) {
     const suppliedRequest = input.request?.trim() ?? "";

--- a/examples/human-in-the-loop/package.json
+++ b/examples/human-in-the-loop/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/logged-in-screenshots/index.ts
+++ b/examples/logged-in-screenshots/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Logged-In Page Screenshots — open a real browser, optionally log in, visit the
@@ -120,8 +121,40 @@ function missedShot(url: string, error: string): Shot {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `urls` defaults to two stable
+ * public pages so a zero-input run captures something real; the login fields
+ * stay optional (public capture when omitted).
+ */
+const entryInput = z.object({
+  urls: z
+    .array(z.string())
+    .default(DEFAULT_URLS)
+    .describe("The pages to capture."),
+  loginUrl: z
+    .string()
+    .optional()
+    .describe(
+      "Login page URL — set it with loginUsername and the BROWSER_LOGIN_PASSWORD secret to capture behind a login.",
+    ),
+  loginUsername: z
+    .string()
+    .optional()
+    .describe(
+      "Username to log in with, paired with the BROWSER_LOGIN_PASSWORD secret.",
+    ),
+  fullPage: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Capture the full scrollable page height instead of just the viewport.",
+    ),
+});
+
 const start = defineStep({
   name: "start",
+  inputSchema: entryInput,
   next: ["login", "capture"],
   async run(input: EntryInput, ctx: Ctx) {
     const urls = normalizeUrls(input.urls, DEFAULT_URLS);

--- a/examples/logged-in-screenshots/package.json
+++ b/examples/logged-in-screenshots/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.7.1",
-    "@sapiom/tools": "^0.23.0"
+    "@sapiom/tools": "^0.23.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/meeting-notes-crm/index.ts
+++ b/examples/meeting-notes-crm/index.ts
@@ -8,6 +8,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Meeting-Notes → CRM Updater — turn a raw meeting transcript into a clean CRM
@@ -238,8 +239,49 @@ async function initSchema(sql: Sql): Promise<void> {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: pass a
+ * `transcript` directly, or set `webhook` to wait for a note-taker to push one.
+ */
+const entryInput = z.object({
+  transcript: z
+    .string()
+    .optional()
+    .describe("The meeting transcript / notes to process (the direct path)."),
+  webhook: z
+    .boolean()
+    .optional()
+    .describe(
+      "Wait for a note-taker to push the transcript instead of passing one.",
+    ),
+  deliverTo: z
+    .string()
+    .optional()
+    .describe(
+      "Recipient email. Omit it and the recap is returned inline instead of emailed.",
+    ),
+  dbHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Postgres handle for the CRM store; defaults to the template handle.",
+    ),
+  meetingDate: z
+    .string()
+    .optional()
+    .describe(
+      "When the meeting happened (ISO); defaults to now on the DB side.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Compute the update but skip the DB writes and the real send."),
+});
+
 const intake = defineStep({
   name: "intake",
+  inputSchema: entryInput,
   next: ["extract"],
   // Static graph edge: on SIGNAL, resume at `extract`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "extract" },

--- a/examples/meeting-notes-crm/package.json
+++ b/examples/meeting-notes-crm/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.24.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/newsletter-autopilot/index.ts
+++ b/examples/newsletter-autopilot/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Newsletter Autopilot — a standing, self-writing newsletter.
@@ -218,12 +219,47 @@ function renderHtml(issue: Issue, headerImageUrl: string | null): string {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `niche` carries the sample as
+ * its `.default(...)` so a zero-input tick writes a real issue instead of being
+ * rejected for a missing field.
+ */
+const entryInput = z.object({
+  niche: z
+    .string()
+    .default(DEFAULT_NICHE)
+    .describe("The niche / topic to research and write about on each tick."),
+  newsletterName: z
+    .string()
+    .default(DEFAULT_NEWSLETTER_NAME)
+    .describe("Masthead shown in the subject and header."),
+  schedule: z
+    .string()
+    .optional()
+    .describe(
+      "Cron cadence this newsletter runs on (default weekly Monday 08:00).",
+    ),
+  subscribers: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Subscriber emails. Omit them and the issue is returned inline instead of sent.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Write + render the issue but skip the real send."),
+});
+
 const search = defineStep({
   name: "search",
+  inputSchema: entryInput,
   next: ["scrape"],
   async run(input: EntryInput, ctx: Ctx) {
-    const suppliedNiche = input.niche?.trim() ?? "";
-    const niche = suppliedNiche || DEFAULT_NICHE;
+    // The schema fills `niche` with DEFAULT_NICHE on a zero-input tick, so the
+    // value — not its absence — is what tells us the default niche was used.
+    const niche = input.niche?.trim() || DEFAULT_NICHE;
     ctx.shared.set("niche", niche);
     ctx.shared.set(
       "newsletterName",
@@ -237,7 +273,7 @@ const search = defineStep({
         : [],
     );
     ctx.shared.set("dryRun", input.dryRun === true);
-    if (!suppliedNiche) {
+    if (niche === DEFAULT_NICHE) {
       ctx.shared.set(
         "note",
         `Wrote about the default niche ("${DEFAULT_NICHE}"). Pass a \`niche\` to write about yours.`,

--- a/examples/newsletter-autopilot/package.json
+++ b/examples/newsletter-autopilot/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Natural-Language DB Query Endpoint — deploy a live HTTP endpoint that turns a
@@ -349,8 +350,62 @@ const SERVER_PACKAGE_JSON = JSON.stringify(
 // ──────────────────────────────────────────────────────────────── steps ──
 
 /** Validate the input and resolve config. Missing DB target → rejected. */
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: with no
+ * `dbHandle`/`connectionString` the run uses the managed demo database and its
+ * seeded read-only dataset.
+ */
+const entryInput = z.object({
+  dbHandle: z
+    .string()
+    .optional()
+    .describe(
+      "Sapiom-managed Postgres handle; its connection string is injected as DATABASE_URL.",
+    ),
+  connectionString: z
+    .string()
+    .optional()
+    .describe("Explicit Postgres connection string (overrides dbHandle)."),
+  sandboxName: z
+    .string()
+    .optional()
+    .describe(
+      "Sandbox name to host the endpoint (default nl-db-query-endpoint).",
+    ),
+  sampleQuestion: z
+    .string()
+    .optional()
+    .describe(
+      "A question used to preview the translate → guard path before deploying.",
+    ),
+  model: z
+    .string()
+    .optional()
+    .describe("LLM model / routing alias override for the translation."),
+  maxRows: z
+    .number()
+    .optional()
+    .describe("Max rows the endpoint returns per query (default 100)."),
+  port: z
+    .number()
+    .optional()
+    .describe("Port the endpoint listens on (default 3000)."),
+  sapiomApiKey: z
+    .string()
+    .optional()
+    .describe(
+      "Dev-only fallback: inject the server's SAPIOM_API_KEY directly.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Assemble everything but skip the real deployPreview."),
+});
+
 const validate = defineStep({
   name: "validate",
+  inputSchema: entryInput,
   next: ["resolve", "rejected"],
   async run(input: EntryInput, ctx: Ctx) {
     const config = resolveConfig(input);

--- a/examples/nl-db-query-endpoint/package.json
+++ b/examples/nl-db-query-endpoint/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -9,6 +9,7 @@ import {
 } from "@sapiom/agent";
 import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Personalized Media at Scale — one custom image or short clip per row, stored
@@ -261,8 +262,56 @@ async function resolveSenderInbox(ctx: Ctx): Promise<string> {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. The rendering knobs carry their
+ * runtime fallbacks as `.default(...)`; the database handle and creative
+ * overrides stay optional.
+ */
+const entryInput = z.object({
+  dbHandle: z
+    .string()
+    .optional()
+    .describe("Database handle holding the recipient table."),
+  medium: z
+    .enum(["image", "video"])
+    .default("image")
+    .describe('"image" (sync, cheaper) or "video" (async, pricier).'),
+  schedule: z
+    .string()
+    .optional()
+    .describe('Cron cadence this batch runs on (e.g. "0 9 * * *").'),
+  limit: z
+    .number()
+    .default(3)
+    .describe("How many rows to render this run (clamped 1–25)."),
+  style: z
+    .string()
+    .optional()
+    .describe(
+      'A creative direction folded into every prompt (e.g. "warm, editorial").',
+    ),
+  aspectRatio: z
+    .string()
+    .default("16:9")
+    .describe(
+      "Aspect ratio for generated video; images use the model default.",
+    ),
+  videoModel: z
+    .string()
+    .optional()
+    .describe("Video model alias or raw id, passed through to video.launch."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Plan only — read the rows and prompts, generate and send nothing.",
+    ),
+});
+
 const fetch = defineStep({
   name: "fetch",
+  inputSchema: entryInput,
   next: ["renderImages", "renderClip"],
   terminal: true,
   async run(input: EntryInput, ctx: Ctx) {

--- a/examples/personalized-media-at-scale/package.json
+++ b/examples/personalized-media-at-scale/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.24.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/pr-review-bot/index.ts
+++ b/examples/pr-review-bot/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * PR Review Bot — a coding agent reviews a pull request, then posts feedback.
@@ -268,8 +269,55 @@ function renderReview(pr: PrEvent, review: Review): string {
 }
 
 // ───────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `via` carries its default; the
+ * rest are optional (the resume payload — a PR webhook — supplies the PR).
+ */
+const repoRefSchema = z.object({
+  owner: z.string(),
+  name: z.string(),
+  cloneUrl: z.string().optional(),
+});
+const entryInput = z.object({
+  repo: repoRefSchema
+    .optional()
+    .describe("Repo the webhook watches and the agent reviews."),
+  via: z
+    .enum(["email", "slack"])
+    .default("email")
+    .describe("Where to deliver the review."),
+  to: z
+    .string()
+    .optional()
+    .describe("email: recipient address. slack: channel (#reviews or C0123)."),
+  samplePr: z
+    .object({
+      repo: repoRefSchema.optional(),
+      number: z.number().optional(),
+      title: z.string().optional(),
+      branch: z.string().optional(),
+      baseBranch: z.string().optional(),
+      author: z.string().optional(),
+      diff: z.string().optional(),
+      diffUrl: z.string().optional(),
+    })
+    .catchall(z.unknown())
+    .optional()
+    .describe(
+      "Optional sample PR used when the resume payload is empty (local runs).",
+    ),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "Absent (or DRY_RUN) ⇒ offline: skip registration and the real send.",
+    ),
+});
+
 const watch = defineStep({
   name: "watch",
+  inputSchema: entryInput,
   next: ["review"],
   // Static graph edge: on `SIGNAL`, resume at `review`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "review" },

--- a/examples/pr-review-bot/package.json
+++ b/examples/pr-review-bot/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Proposal / Quote Generator — requirements in, a signed-off PDF quote out.
@@ -75,8 +76,8 @@ interface Party {
 }
 
 interface EntryInput {
-  /** The free-text requirement / RFP / brief to quote against. */
-  request: string;
+  /** The free-text requirement / RFP / brief to quote against. Omit ⇒ the sample. */
+  request?: string;
   /** The client the proposal is for. `email` is where the final PDF is sent. */
   client?: Party;
   /** Who the proposal is from (your company). Shown on the PDF. */
@@ -256,8 +257,67 @@ async function draftProposal(
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `request` stays optional so the
+ * tri-state holds: omitted ⇒ quote the built-in sample brief, explicitly empty
+ * ⇒ a rejection, present ⇒ quote it.
+ */
+const partySchema = z.object({
+  name: z.string().optional(),
+  company: z.string().optional(),
+  email: z.string().optional(),
+});
+const entryInput = z.object({
+  request: z
+    .string()
+    .optional()
+    .describe(
+      "The free-text requirement / RFP / brief to quote against. Omit to use the built-in sample.",
+    ),
+  client: partySchema
+    .optional()
+    .describe(
+      "The client the proposal is for. `email` is where the final PDF is sent.",
+    ),
+  from: partySchema
+    .optional()
+    .describe("Who the proposal is from (your company). Shown on the PDF."),
+  currency: z
+    .string()
+    .default("USD")
+    .describe("ISO 4217 currency code for the quote."),
+  taxRate: z
+    .number()
+    .default(0)
+    .describe("Tax rate as a fraction, e.g. 0.08 for 8% (0 ⇒ no tax line)."),
+  approver: z
+    .string()
+    .optional()
+    .describe(
+      "Who signs off before the client sees it. Falls back to config.APPROVER_EMAIL.",
+    ),
+  recipientEmail: z
+    .string()
+    .optional()
+    .describe(
+      "Where to send the approved proposal. Falls back to client.email / config.CLIENT_EMAIL.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Draft + render + get sign-off, but never send the client email.",
+    ),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("String-only config bag (approver / client fallbacks)."),
+});
+
 const draft = defineStep({
   name: "draft",
+  inputSchema: entryInput,
   next: ["render", "rejected"],
   async run(input: EntryInput, ctx: Ctx) {
     // An omitted request drafts against the sample brief, so a zero-input run
@@ -268,7 +328,8 @@ const draft = defineStep({
       });
     }
     const usedSampleRequest = input.request === undefined;
-    const request = usedSampleRequest ? SAMPLE_REQUEST : input.request.trim();
+    const request =
+      input.request === undefined ? SAMPLE_REQUEST : input.request.trim();
     if (usedSampleRequest) {
       ctx.shared.set(
         "note",

--- a/examples/proposal-generator/package.json
+++ b/examples/proposal-generator/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/research-to-microsite/index.ts
+++ b/examples/research-to-microsite/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /**
  * Research → Micro-Site Publisher — deep multi-source research that ends in a
@@ -235,12 +236,49 @@ function hostOf(url: string): string | null {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `topic` carries the sample as
+ * its `.default(...)` so a zero-input run builds a real site instead of being
+ * rejected for a missing field.
+ */
+const entryInput = z.object({
+  topic: z
+    .string()
+    .default(DEFAULT_TOPIC)
+    .describe("What to research and publish a site about."),
+  audience: z
+    .string()
+    .optional()
+    .describe(
+      'Who the site is for — tunes the report tone (e.g. "investors", "developers").',
+    ),
+  customDomain: z
+    .string()
+    .optional()
+    .describe(
+      "A domain you already own in Sapiom to map the site onto. Omit to publish at the preview URL only.",
+    ),
+  subdomain: z
+    .string()
+    .default(DEFAULT_SUBDOMAIN)
+    .describe('Host on the custom domain, e.g. "report" → report.your.dev.'),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Compute the report and return it as a preview, skipping the build, deploy, and DNS.",
+    ),
+});
+
 const search = defineStep({
   name: "search",
+  inputSchema: entryInput,
   next: ["scrape"],
   async run(input: EntryInput, ctx: Ctx) {
-    const suppliedTopic = input.topic?.trim() ?? "";
-    const topic = suppliedTopic || DEFAULT_TOPIC;
+    // The schema fills `topic` with DEFAULT_TOPIC on a zero-input run, so the
+    // value — not its absence — is what tells us the sample topic was used.
+    const topic = input.topic?.trim() || DEFAULT_TOPIC;
     ctx.shared.set("topic", topic);
     ctx.shared.set("audience", input.audience?.trim() || "a general audience");
     ctx.shared.set("customDomain", input.customDomain?.trim() || null);
@@ -248,7 +286,7 @@ const search = defineStep({
     ctx.shared.set("dryRun", input.dryRun === true);
     ctx.shared.set("sandboxName", null);
     ctx.shared.set("liveUrl", null);
-    if (!suppliedTopic) {
+    if (topic === DEFAULT_TOPIC) {
       ctx.shared.set(
         "note",
         `Researched the default topic ("${DEFAULT_TOPIC}"). Pass a \`topic\` to build a site about yours.`,

--- a/examples/research-to-microsite/package.json
+++ b/examples/research-to-microsite/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /**
  * Scene → Images → Video — a real multi-step generative pipeline.
@@ -75,8 +76,8 @@ export interface Clip {
 
 /** Trigger input. Only `scene` is required. */
 interface SceneInput {
-  /** The scene / story to turn into a short video. */
-  scene: string;
+  /** The scene / story to turn into a short video. Omit ⇒ the sample scene. */
+  scene?: string;
   /** How many shots to plan (default 3, clamped 1–6). */
   numShots?: number;
   /** Aspect ratio passed to image + video generation (default "16:9"). */
@@ -222,8 +223,42 @@ function parsePlan(
   }
 }
 
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `scene` stays optional so the
+ * tri-state holds: omitted ⇒ shoot the built-in sample scene, explicitly empty
+ * ⇒ a reported mistake, present ⇒ shoot it.
+ */
+const entryInput = z.object({
+  scene: z
+    .string()
+    .optional()
+    .describe(
+      "The scene / story to turn into a short video. Omit to use the built-in sample.",
+    ),
+  numShots: z
+    .number()
+    .default(3)
+    .describe("How many shots to plan (clamped 1–6)."),
+  aspectRatio: z
+    .string()
+    .default("16:9")
+    .describe("Aspect ratio passed to image + video generation."),
+  model: z
+    .string()
+    .optional()
+    .describe("Optional video model id, passed through to video.launch."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Plan only — skip all image/video generation and return the plan.",
+    ),
+});
+
 const decompose = defineStep({
   name: "decompose",
+  inputSchema: entryInput,
   next: ["keyframes"],
   terminal: true,
   async run(input: SceneInput, ctx: AgentExecutionContext<Shared>) {
@@ -236,7 +271,7 @@ const decompose = defineStep({
       });
     }
     const usedSampleScene = input.scene === undefined;
-    const scene = usedSampleScene ? SAMPLE_SCENE : input.scene.trim();
+    const scene = input.scene === undefined ? SAMPLE_SCENE : input.scene.trim();
     if (usedSampleScene) {
       ctx.shared.set(
         "note",

--- a/examples/scene-to-video/package.json
+++ b/examples/scene-to-video/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.22.1"
+    "@sapiom/tools": "^0.22.1",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/scheduled-compliance-audit/index.ts
+++ b/examples/scheduled-compliance-audit/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Scheduled Compliance Audit + Attestation — the recurring "prove we're still
@@ -219,8 +220,54 @@ const SAMPLE_RESOURCES: ResourceRef[] = [
 ];
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `policy` carries the sample as
+ * its `.default(...)` and `resources` defaults to an empty set, so a zero-input
+ * run audits the built-in sample policy and evidence.
+ */
+const entryInput = z.object({
+  resources: z
+    .array(
+      z.object({
+        id: z.string(),
+        url: z.string(),
+        label: z.string().optional(),
+      }),
+    )
+    .default([])
+    .describe("The resources/config to collect and audit on each tick."),
+  policy: z
+    .string()
+    .default(SAMPLE_POLICY)
+    .describe(
+      "The policy the collected state is checked against (free text or rules).",
+    ),
+  schedule: z
+    .string()
+    .optional()
+    .describe('Cron cadence this audit runs on (e.g. "0 6 * * 1").'),
+  framework: z
+    .string()
+    .optional()
+    .describe(
+      'Compliance framework label for the attestation title (e.g. "SOC 2 CC6").',
+    ),
+  signOffBy: z
+    .string()
+    .optional()
+    .describe(
+      "Who is expected to sign off; recorded in the attestation. Informational.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Compute + pause but never perform the real archive upload."),
+});
+
 const collect = defineStep({
   name: "collect",
+  inputSchema: entryInput,
   next: ["audit"],
   async run(input: EntryInput, ctx: Ctx) {
     const suppliedPolicy = input.policy?.trim() ?? "";

--- a/examples/scheduled-compliance-audit/package.json
+++ b/examples/scheduled-compliance-audit/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * Scheduled DB Snapshot to Insight Report — on a cron cadence, take a snapshot of
@@ -308,8 +309,44 @@ async function resolveSenderInbox(ctx: Ctx): Promise<string> {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: a
+ * zero-input run reports on sample metrics (see `dryRun`) and the template
+ * handle backs `dbHandle`.
+ */
+const entryInput = z.object({
+  queries: z
+    .array(z.object({ name: z.string(), sql: z.string() }))
+    .optional()
+    .describe(
+      "Queries to snapshot; defaults to catalog introspection when omitted.",
+    ),
+  schedule: z
+    .string()
+    .optional()
+    .describe("Cron cadence this report runs on (documentation only)."),
+  dbHandle: z
+    .string()
+    .optional()
+    .describe("Postgres handle to snapshot; defaults to the template handle."),
+  deliverTo: z
+    .string()
+    .optional()
+    .describe(
+      "Recipient email. Omit it and the report is returned inline instead of emailed.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Report on sample metrics and skip the DB query and the real send.",
+    ),
+});
+
 const snapshot = defineStep({
   name: "snapshot",
+  inputSchema: entryInput,
   next: ["narrate"],
   async run(input: EntryInput, ctx: Ctx) {
     const dryRun = truthy(input.dryRun);

--- a/examples/scheduled-db-insight-report/package.json
+++ b/examples/scheduled-db-insight-report/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.24.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/scheduled-research-brief/index.ts
+++ b/examples/scheduled-research-brief/index.ts
@@ -6,6 +6,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import type { Sapiom } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /**
  * Scheduled Research Brief — the scheduled, LLM-curated, delivered sibling of
@@ -116,17 +117,47 @@ async function resolveSenderInbox(ctx: Ctx): Promise<string> {
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `topic` carries the sample as
+ * its `.default(...)` so the declared default and the runtime default are the
+ * same value: a zero-input tick researches the sample topic instead of being
+ * rejected for a missing field.
+ */
+const entryInput = z.object({
+  topic: z
+    .string()
+    .default(DEFAULT_TOPIC)
+    .describe("What to research on each tick."),
+  schedule: z
+    .string()
+    .optional()
+    .describe('Cron cadence this brief runs on (e.g. "0 8 * * *").'),
+  deliverTo: z
+    .string()
+    .optional()
+    .describe(
+      "Recipient email. Omit it and the brief is returned inline instead of emailed.",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Compute the brief but skip the real send."),
+});
+
 const search = defineStep({
   name: "search",
+  inputSchema: entryInput,
   next: ["scrape"],
   async run(input: EntryInput, ctx: Ctx) {
-    const supplied = input.topic?.trim() ?? "";
-    const topic = supplied || DEFAULT_TOPIC;
+    // The schema fills `topic` with DEFAULT_TOPIC on a zero-input tick, so the
+    // value — not its absence — is what tells us the sample topic was used.
+    const topic = input.topic?.trim() || DEFAULT_TOPIC;
     ctx.shared.set("topic", topic);
     ctx.shared.set("schedule", input.schedule?.trim() || DEFAULT_SCHEDULE);
     ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
     ctx.shared.set("dryRun", input.dryRun === true);
-    if (!supplied) {
+    if (topic === DEFAULT_TOPIC) {
       ctx.shared.set(
         "note",
         `Researched the default topic ("${DEFAULT_TOPIC}"). Pass a \`topic\` to research yours.`,

--- a/examples/scheduled-research-brief/package.json
+++ b/examples/scheduled-research-brief/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.6.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/slack-notifier/index.ts
+++ b/examples/slack-notifier/index.ts
@@ -6,6 +6,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import { createFetch } from "@sapiom/fetch";
+import { z } from "zod/v4";
 
 /**
  * Slack Notifier — the "bring your own API" teaching template.
@@ -165,8 +166,40 @@ export async function postViaWebhook(
 // ──────────────────────────────────────────────────────────────── steps ──
 
 /** Validate inputs and resolve config before any network call. */
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. `message` and `via` carry their
+ * runtime fallbacks as `.default(...)`, so a zero-input run posts the sample
+ * message via the `bot` credential.
+ */
+const entryInput = z.object({
+  message: z
+    .string()
+    .default(DEFAULT_MESSAGE)
+    .describe("The message text to post."),
+  channel: z
+    .string()
+    .optional()
+    .describe(
+      "Target channel for `bot` mode — a name (#general) or id (C0123). Ignored by `webhook` mode.",
+    ),
+  via: z
+    .enum(["bot", "webhook"])
+    .default("bot")
+    .describe("Which credential to use."),
+  username: z
+    .string()
+    .optional()
+    .describe("Override the bot's display name for this post."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Skip the real Slack call (network I/O)."),
+});
+
 const validate = defineStep({
   name: "validate",
+  inputSchema: entryInput,
   next: ["post", "rejected"],
   async run(input: EntryInput, ctx: Ctx) {
     const dryRun = input?.dryRun === true;

--- a/examples/slack-notifier/package.json
+++ b/examples/slack-notifier/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
     "@sapiom/fetch": "^0.5.0",
-    "@sapiom/tools": "^0.20.0"
+    "@sapiom/tools": "^0.20.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/the-brain/index.ts
+++ b/examples/the-brain/index.ts
@@ -6,6 +6,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import postgres from "postgres";
+import { z } from "zod/v4";
 
 /**
  * the-brain — a fleet orchestrator ("central nervous system") over a set of
@@ -741,8 +742,54 @@ function parsePlan(
 
 // ───────────────────────────────────────────────────────────────────── steps ──
 
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Every field is optional: a
+ * zero-input run reads the bus for the DEFAULT_FLEET and briefs on it.
+ */
+const entryInput = z.object({
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("Skip all external I/O (Slack + Postgres + child launch)."),
+  observeOnly: z
+    .boolean()
+    .optional()
+    .describe(
+      "Do everything real but launch no child — the briefing shows what it WOULD launch.",
+    ),
+  briefingChannelId: z
+    .string()
+    .optional()
+    .describe(
+      "Low-noise channel the brain posts its briefing into. Empty ⇒ log only.",
+    ),
+  fleet: z
+    .array(
+      z.object({
+        id: z.string(),
+        label: z.string(),
+        slug: z.string(),
+        definitionId: z.string().optional(),
+        cadenceHours: z.number(),
+        dueHourUtc: z.number().optional(),
+        staleHours: z.number().optional(),
+        input: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .optional()
+    .describe(
+      "Override the fleet the brain orchestrates (defaults to DEFAULT_FLEET).",
+    ),
+  now: z
+    .string()
+    .optional()
+    .describe("Pin the clock for deterministic testing (ISO string)."),
+});
+
 const scan = defineStep({
   name: "scan",
+  inputSchema: entryInput,
   next: ["assess"],
   async run(input: EntryInput, ctx: Ctx) {
     const dryRun = input.dryRun ?? false;

--- a/examples/the-brain/package.json
+++ b/examples/the-brain/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@sapiom/agent": "^0.6.5",
     "@sapiom/tools": "^0.20.0",
-    "postgres": "^3.4.5"
+    "postgres": "^3.4.5",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/wait-for-webhook/index.ts
+++ b/examples/wait-for-webhook/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { z } from "zod/v4";
 
 /**
  * Wait-for-Webhook — durable pause/resume around any slow external callback.
@@ -155,8 +156,27 @@ async function registerJob(
 }
 
 // ---- steps -----------------------------------------------------------------
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its labelled fields from. Both fields are optional: absent
+ * `config` (or `DRY_RUN`) runs offline; a `CALLBACK_TIMEOUT_MS` caps the wait.
+ */
+const entryInput = z.object({
+  job: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Arbitrary parameters handed to the external async job."),
+  config: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "Config bag. CALLBACK_REGISTER_URL points at the external job; CALLBACK_TIMEOUT_MS caps the wait.",
+    ),
+});
+
 const kickoff = defineStep({
   name: "kickoff",
+  inputSchema: entryInput,
   next: ["decide"],
   // Static graph edge: on `SIGNAL`, resume at `decide`. Must match the directive.
   pause: { signal: SIGNAL, resumeStep: "decide" },

--- a/examples/wait-for-webhook/package.json
+++ b/examples/wait-for-webhook/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.5.0",
-    "@sapiom/tools": "^0.16.0"
+    "@sapiom/tools": "^0.16.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/examples/web-research-digest/index.ts
+++ b/examples/web-research-digest/index.ts
@@ -6,6 +6,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import type { Sapiom } from "@sapiom/tools";
+import { z } from "zod/v4";
 
 /** The web-search response shape, derived from the capability client. */
 type WebSearchResponse = Awaited<ReturnType<Sapiom["search"]["webSearch"]>>;
@@ -31,15 +32,29 @@ interface Shared extends Record<string, unknown> {
  */
 const DEFAULT_TOPIC = "what is an LLM agent?";
 
+/**
+ * The entry contract — this agent's public API, and what the dashboard "Run
+ * once" form renders its fields from. `topic` carries the sample as its
+ * `.default(...)` so the declared default and the runtime default are the same
+ * value: a zero-input run performs a real search instead of being rejected for
+ * a missing field.
+ */
+const entryInput = z.object({
+  topic: z
+    .string()
+    .default(DEFAULT_TOPIC)
+    .describe("The subject to research and summarize into a sourced digest."),
+});
+
 const search = defineStep({
   name: "search",
   next: ["summarize"],
-  async run(
-    input: { topic: string },
-    ctx: AgentExecutionContext<Shared>,
-  ) {
+  inputSchema: entryInput,
+  async run(input: { topic: string }, ctx: AgentExecutionContext<Shared>) {
     const topic = input.topic?.trim() || DEFAULT_TOPIC;
-    if (topic === DEFAULT_TOPIC && input.topic?.trim() !== DEFAULT_TOPIC) {
+    // The schema fills `topic` with DEFAULT_TOPIC on a zero-input run, so the
+    // value — not its absence — is what tells us the sample was used.
+    if (topic === DEFAULT_TOPIC) {
       ctx.shared.set(
         "note",
         `Researched the default topic ("${DEFAULT_TOPIC}"). Pass a \`topic\` to research yours.`,
@@ -61,10 +76,7 @@ const summarize = defineStep({
   name: "summarize",
   next: [],
   terminal: true,
-  async run(
-    response: WebSearchResponse,
-    ctx: AgentExecutionContext<Shared>,
-  ) {
+  async run(response: WebSearchResponse, ctx: AgentExecutionContext<Shared>) {
     const topic = ctx.shared.get("topic") ?? response.query;
     const sources = response.results.map((r) => ({
       title: r.title,

--- a/examples/web-research-digest/package.json
+++ b/examples/web-research-digest/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "^0.5.0",
-    "@sapiom/tools": "^0.16.0"
+    "@sapiom/tools": "^0.16.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/packages/agent-core/templates/coding-pause/index.ts
+++ b/packages/agent-core/templates/coding-pause/index.ts
@@ -7,6 +7,24 @@ import {
   pauseUntilSignal,
 } from "@sapiom/agent";
 import { CODING_RESULT_SIGNAL, type CodingResultPayload } from "@sapiom/tools";
+import { z } from "zod/v4";
+
+/**
+ * The entry contract — your agent's PUBLIC API. This schema is what the Sapiom
+ * dashboard's "Run once" form renders its fields from (one labelled field per
+ * property, using its `.describe(...)`), and every run's input is validated
+ * against it before `prepare` runs. The `.default(...)` is the same value the
+ * code sees on a zero-input run, so the template runs as-is and stays editable.
+ */
+const entryInput = z.object({
+  task: z
+    .string()
+    .default(
+      "Make a small, self-contained change to this repository and commit it.",
+    )
+    .describe("What the coding agent should do in the cloned repository."),
+});
+type EntryInput = z.infer<typeof entryInput>;
 
 /**
  * __PROJECT_NAME__ — a non-blocking coding-agent workflow.
@@ -30,13 +48,17 @@ const REPO_SLUG = "__PROJECT_NAME__-notes";
 interface Shared extends Record<string, unknown> {
   slug: string;
   cloneUrl: string;
+  /** The coding instruction, stashed by `prepare` so `kickoff` can launch it. */
+  task: string;
 }
 
 /** Find the repo, or create it on the first run. */
 const prepare = defineStep({
   name: "prepare",
   next: ["kickoff"],
-  async run(_input, ctx) {
+  inputSchema: entryInput,
+  async run(input: EntryInput, ctx) {
+    ctx.shared.set("task", input.task);
     const existing = await ctx.sapiom.repositories.list();
     const repo =
       existing.find((r) => r.slug === REPO_SLUG) ??
@@ -58,7 +80,7 @@ const kickoff = defineStep({
       ctx.shared.get("cloneUrl") as string,
     );
     const run = await ctx.sapiom.models.coding.launch({
-      task: "Make a small, self-contained change to this repository and commit it.",
+      task: ctx.shared.get("task") as string,
       gitRepository: repo, // auto-cloned into the sandbox at /workspace/<slug>
     });
     ctx.logger.info("agent launched; suspending until it finishes", {
@@ -102,7 +124,7 @@ const finalize = defineStep({
   },
 });
 
-export const agent = defineAgent<unknown, Shared>({
+export const agent = defineAgent<EntryInput, Shared>({
   name: "__PROJECT_NAME__",
   entry: "prepare",
   steps: { prepare, kickoff, finalize },

--- a/packages/agent-core/templates/default/index.ts
+++ b/packages/agent-core/templates/default/index.ts
@@ -1,12 +1,29 @@
 import { defineAgent, defineStep, goto, terminate } from '@sapiom/agent';
+import { z } from 'zod/v4';
+
+/**
+ * The entry contract — your agent's PUBLIC API. This schema is what the Sapiom
+ * dashboard's "Run once" form renders its fields from (one labelled field per
+ * property, using its `.describe(...)`), and every run's input is validated
+ * against it before `start` runs. Give a field a `.default(...)` so a zero-input
+ * run still works and the declared default is the same value the code sees.
+ * Replace `name` with your agent's real input.
+ */
+const entryInput = z.object({
+  name: z
+    .string()
+    .default('world')
+    .describe('Who to greet — the sample field this scaffold ships with.'),
+});
 
 const start = defineStep({
   name: 'start',
   next: ['finish'],
+  inputSchema: entryInput,
   async run(input, ctx) {
     ctx.logger.info('starting', { input });
     // Sapiom capabilities: ctx.sapiom.sandboxes.create(), ctx.sapiom.repositories.create()
-    return goto('finish', { greeting: 'hello from Sapiom' });
+    return goto('finish', { greeting: `hello from Sapiom, ${input.name}` });
   },
 });
 

--- a/packages/cli/templates/default/index.ts
+++ b/packages/cli/templates/default/index.ts
@@ -1,12 +1,29 @@
 import { defineAgent, defineStep, goto, terminate } from '@sapiom/agent';
+import { z } from 'zod/v4';
+
+/**
+ * The entry contract — your agent's PUBLIC API. This schema is what the Sapiom
+ * dashboard's "Run once" form renders its fields from (one labelled field per
+ * property, using its `.describe(...)`), and every run's input is validated
+ * against it before `start` runs. Give a field a `.default(...)` so a zero-input
+ * run still works and the declared default is the same value the code sees.
+ * Replace `name` with your agent's real input.
+ */
+const entryInput = z.object({
+  name: z
+    .string()
+    .default('world')
+    .describe('Who to greet — the sample field this scaffold ships with.'),
+});
 
 const start = defineStep({
   name: 'start',
   next: ['finish'],
+  inputSchema: entryInput,
   async run(input, ctx) {
     ctx.logger.info('starting', { input });
     // Sapiom capabilities: ctx.sapiom.sandboxes.create(), ctx.sapiom.repositories.create()
-    return goto('finish', { greeting: 'hello from Sapiom' });
+    return goto('finish', { greeting: `hello from Sapiom, ${input.name}` });
   },
 });
 

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -17,6 +17,10 @@
 //   5. every template.json validates against examples/template.schema.json,
 //      including the declaration surface (requiredSecrets, settings,
 //      defaultInput, zeroSetup) — see scripts/examples-manifest-check.mjs.
+//   5b. the manifest's renderable projection (defaultInput / settings) only
+//      names paths the code's entry `inputSchema` declares — a projection onto
+//      a field the schema never declares is the drift SAP-2226 exists to catch.
+//      See scripts/examples-entry-schema-check.mjs.
 //   6. house-style copy rules the schemas cannot express — see
 //      scripts/examples-copy-check.mjs. (The length caps ARE in the schemas,
 //      as `maxLength`, so they surface through checks 1 and 5.)
@@ -42,6 +46,7 @@ import {
 } from "./examples-manifest-check.mjs";
 import { checkCopy } from "./examples-copy-check.mjs";
 import { checkDiscipline } from "./examples-discipline-check.mjs";
+import { checkEntrySchemaCoverage } from "./examples-entry-schema-check.mjs";
 import {
   complexityBandScore,
   scoreTemplateComplexity,
@@ -122,6 +127,16 @@ for (const t of templates) {
       existsSync(path.join(dir, seed)),
     ),
   );
+
+  // 5b. The manifest's renderable projection (defaultInput / settings) may only
+  // name paths the code's entry `inputSchema` declares — otherwise the shelf
+  // paints a field the run drops. The entry schema is read statically from
+  // index.ts; a template without one is read as `null` (source absent) below.
+  const indexPath = path.join(dir, "index.ts");
+  const indexSource = existsSync(indexPath)
+    ? readFileSync(indexPath, "utf8")
+    : null;
+  errors.push(...checkEntrySchemaCoverage(t.id, manifest, indexSource));
 
   manifests.set(t.id, manifest);
   manifestsChecked++;

--- a/scripts/examples-entry-schema-check.mjs
+++ b/scripts/examples-entry-schema-check.mjs
@@ -1,0 +1,191 @@
+// =============================================================================
+// scripts/examples-entry-schema-check.mjs
+//
+// The `entry-schema` half of `pnpm examples:check`: the manifest's renderable
+// projection of the entry input (`defaultInput` / `settings`) may only name
+// paths the code's entry `inputSchema` actually declares.
+//
+// Why this is a check and not a convention: `defaultInput` / `settings` are the
+// SHELF's projection of the entry contract — the UI cannot introspect a zod
+// schema fetched from GitHub, so it renders from these instead (see
+// examples/template.schema.json). The schema description states outright that
+// this projection "NEVER overrides code": if it names a `deliverTo` the entry
+// schema never declares, the form paints a field the run silently drops. That
+// is exactly the class of bug SAP-2226 fixed by declaring the schema in the
+// first place; this keeps the projection from drifting back off it.
+//
+// The entry step's inputSchema lives in TypeScript, and this check runs on the
+// source tree with no compiler, so it reads the `z.object({ … })` literal's
+// top-level keys statically. That is deliberately conservative:
+//   - Entry step with NO `inputSchema` but a manifest that declares
+//     `defaultInput`/`settings` → FAIL. A projection with nothing to project
+//     onto is the drift this exists to catch.
+//   - `inputSchema` present but not a plain `z.object({ … })` literal we can
+//     read (built from a variable, a merge, a `z.union`, …) → SKIP coverage.
+//     A parser limitation must never fail a valid template.
+//   - Object literal read → every `settings[].path` root and every
+//     `defaultInput` top-level key must be one of its keys.
+//
+// Exported (rather than inlined into examples-check.mjs) so the extraction and
+// the rule are testable against fixtures without shelling out to the whole gate.
+// =============================================================================
+
+/**
+ * Read the top-level keys of the entry step's `z.object({ … })` inputSchema.
+ *
+ * @param source  the example's `index.ts` contents
+ * @returns
+ *   - `null` — the file could not be analyzed (no `entry`, no matching step):
+ *     the caller skips it.
+ *   - `{ hasInputSchema: false, keys: null }` — the entry step declares no
+ *     `inputSchema`.
+ *   - `{ hasInputSchema: true, keys: null }` — an `inputSchema` is declared but
+ *     its object literal could not be read (built from a variable / merge / …).
+ *   - `{ hasInputSchema: true, keys: Set<string> }` — the declared keys.
+ */
+export function extractEntrySchema(source) {
+  const entryMatch = source.match(/entry:\s*["']([^"']+)["']/);
+  if (!entryMatch) return null;
+  const entry = entryMatch[1];
+
+  // The entry step's `defineStep({ … })` — matched up to its `name:` so the
+  // slice that follows is that step's body, not another step's.
+  const stepMatch = source.match(
+    new RegExp(
+      `const\\s+\\w+\\s*=\\s*defineStep\\(\\{[\\s\\S]*?name:\\s*["']${entry}["']`,
+    ),
+  );
+  if (!stepMatch) return null;
+
+  // Read forward only to the next step declaration, so an `inputSchema` on a
+  // LATER step is never misattributed to the entry step.
+  const rest = source.slice(stepMatch.index + stepMatch[0].length);
+  const nextStep = rest.search(/\n\s*const\s+\w+\s*=\s*defineStep\(\{/);
+  const stepBody = nextStep === -1 ? rest : rest.slice(0, nextStep);
+
+  const schemaMatch = stepBody.match(/inputSchema:\s*([A-Za-z_$][\w$]*)/);
+  if (!schemaMatch) return { hasInputSchema: false, keys: null };
+  const ident = schemaMatch[1];
+
+  // `const <ident> = … .object({` — allows `z.object`, `z\n  .object`, and a
+  // schema that opens with `.meta(...)` etc. before `.object`.
+  const declMatch = source.match(
+    new RegExp(`const\\s+${ident}\\s*=[\\s\\S]*?\\.object\\(\\{`),
+  );
+  if (!declMatch) return { hasInputSchema: true, keys: null };
+
+  const braceStart = declMatch.index + declMatch[0].length - 1; // at the `{`
+  const inner = sliceBalanced(source, braceStart);
+  if (inner === null) return { hasInputSchema: true, keys: null };
+
+  return { hasInputSchema: true, keys: topLevelKeys(inner) };
+}
+
+/**
+ * Given the index of an opening `{`, return the substring strictly between it
+ * and its matching `}`, or null if the braces never balance.
+ */
+function sliceBalanced(source, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    const c = source[i];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return source.slice(openIndex + 1, i);
+    }
+  }
+  return null;
+}
+
+/**
+ * Top-level `key:` names inside an object-literal body — the identifiers that
+ * sit at brace/paren/bracket depth 0, i.e. direct properties of the object.
+ * Keys nested inside a field's own value (`z.object({ … })`, arrays, calls) are
+ * at depth > 0 and are ignored.
+ */
+function topLevelKeys(inner) {
+  const keys = new Set();
+  let depth = 0;
+  let token = "";
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === "{" || c === "(" || c === "[") {
+      depth++;
+      token = "";
+    } else if (c === "}" || c === ")" || c === "]") {
+      depth--;
+      token = "";
+    } else if (depth === 0) {
+      if (/[A-Za-z0-9_$]/.test(c)) {
+        token += c;
+      } else if (c === ":") {
+        if (token) keys.add(token);
+        token = "";
+      } else {
+        token = "";
+      }
+    }
+  }
+  return keys;
+}
+
+/**
+ * Verify a template's manifest projection against its entry schema.
+ *
+ * @param templateId  registry id, for the message
+ * @param manifest    parsed template.json
+ * @param source      the example's index.ts contents, or null if unreadable
+ * @returns string[] of human-readable problems (empty when consistent or when
+ *          conservatively skipped)
+ */
+export function checkEntrySchemaCoverage(templateId, manifest, source) {
+  const settings = Array.isArray(manifest?.settings) ? manifest.settings : [];
+  const defaultInput =
+    manifest?.defaultInput && typeof manifest.defaultInput === "object"
+      ? Object.keys(manifest.defaultInput)
+      : [];
+  if (settings.length === 0 && defaultInput.length === 0) return [];
+
+  if (source == null) return [];
+  const schema = extractEntrySchema(source);
+  if (schema === null) return []; // could not analyze — skip, never false-fail.
+
+  const where = `"${templateId}"`;
+  if (!schema.hasInputSchema) {
+    return [
+      `entry-schema: ${where} declares ${describeProjection(settings, defaultInput)} but its entry step declares no \`inputSchema\` for them to project onto — the shelf would render fields the run drops. Add a zod \`inputSchema\` to the entry step (see SAP-2226).`,
+    ];
+  }
+  if (schema.keys === null) return []; // schema not a readable literal — skip.
+
+  const errors = [];
+  for (const s of settings) {
+    if (typeof s?.path !== "string") continue;
+    const root = s.path.split(".")[0];
+    if (!schema.keys.has(root)) {
+      errors.push(
+        `entry-schema: ${where} settings path "${s.path}" is not declared by the entry \`inputSchema\` (has: ${listKeys(schema.keys)}). The shelf would render a field the run drops.`,
+      );
+    }
+  }
+  for (const key of defaultInput) {
+    if (!schema.keys.has(key)) {
+      errors.push(
+        `entry-schema: ${where} defaultInput key "${key}" is not declared by the entry \`inputSchema\` (has: ${listKeys(schema.keys)}). A default that projects onto no field is dead data.`,
+      );
+    }
+  }
+  return errors;
+}
+
+function listKeys(keys) {
+  return [...keys].sort().join(", ") || "(none)";
+}
+
+function describeProjection(settings, defaultInput) {
+  const parts = [];
+  if (settings.length) parts.push(`${settings.length} setting(s)`);
+  if (defaultInput.length) parts.push("a defaultInput");
+  return parts.join(" and ");
+}

--- a/scripts/examples-entry-schema-check.test.mjs
+++ b/scripts/examples-entry-schema-check.test.mjs
@@ -1,0 +1,157 @@
+// =============================================================================
+// scripts/examples-entry-schema-check.test.mjs
+//
+// Fixture tests for the `entry-schema` gate. The rule: a manifest's renderable
+// projection (`defaultInput` / `settings`) may only name paths the code's entry
+// `inputSchema` declares. These fixtures pin both the static key extraction and
+// the conservative skip behaviour (a parser limitation must never false-fail).
+//
+// Run:  pnpm examples:check:test   (node --test)
+// =============================================================================
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  checkEntrySchemaCoverage,
+  extractEntrySchema,
+} from "./examples-entry-schema-check.mjs";
+
+/** A source file whose entry step `run` declares an object-literal inputSchema. */
+const source = (schemaBody, { entry = "start", withSchema = true } = {}) => `
+import { defineAgent, defineStep, goto, terminate } from "@sapiom/agent";
+import { z } from "zod/v4";
+
+const entryInput = z.object({${schemaBody}});
+
+const ${entry} = defineStep({
+  name: "${entry}",
+  next: ["finish"],
+${withSchema ? "  inputSchema: entryInput,\n" : ""}  async run(input, ctx) {
+    return goto("finish", {});
+  },
+});
+
+export const agent = defineAgent({ name: "x", entry: "${entry}", steps: { ${entry} } });
+`;
+
+test("extractEntrySchema reads top-level keys of the entry z.object", () => {
+  const s = extractEntrySchema(
+    source(`
+      topic: z.string().default("x"),
+      deliverTo: z.string().optional(),
+      client: z.object({ email: z.string().optional() }).optional(),
+    `),
+  );
+  assert.equal(s.hasInputSchema, true);
+  assert.deepEqual([...s.keys].sort(), ["client", "deliverTo", "topic"]);
+});
+
+test("nested object keys are NOT treated as top-level", () => {
+  const s = extractEntrySchema(
+    source(
+      `client: z.object({ email: z.string(), name: z.string() }).optional(),`,
+    ),
+  );
+  assert.deepEqual([...s.keys], ["client"]);
+  assert.ok(!s.keys.has("email"));
+});
+
+test("no inputSchema on the entry step → hasInputSchema false", () => {
+  const s = extractEntrySchema(
+    source(`topic: z.string(),`, { withSchema: false }),
+  );
+  assert.equal(s.hasInputSchema, false);
+  assert.equal(s.keys, null);
+});
+
+test("settings + defaultInput covered by the schema → no errors", () => {
+  const src = source(`
+    topic: z.string().default("x"),
+    deliverTo: z.string().optional(),
+    client: z.object({ email: z.string().optional() }).optional(),
+  `);
+  const manifest = {
+    settings: [
+      { path: "deliverTo", label: "To", type: "email", default: "" },
+      { path: "client.email", label: "Client", type: "email", default: "" },
+    ],
+    defaultInput: { topic: "hello" },
+  };
+  assert.deepEqual(checkEntrySchemaCoverage("fixture", manifest, src), []);
+});
+
+test("settings path not declared by the schema → error", () => {
+  const src = source(`topic: z.string().default("x"),`);
+  const manifest = {
+    settings: [{ path: "deliverTo", label: "To", type: "email", default: "" }],
+  };
+  const errors = checkEntrySchemaCoverage("fixture", manifest, src);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /settings path "deliverTo" is not declared/);
+});
+
+test("defaultInput key not declared by the schema → error", () => {
+  const src = source(`topic: z.string().default("x"),`);
+  const manifest = { defaultInput: { topic: "hi", ghost: 1 } };
+  const errors = checkEntrySchemaCoverage("fixture", manifest, src);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /defaultInput key "ghost" is not declared/);
+});
+
+test("nested settings path checks its ROOT segment only", () => {
+  // `client` is declared; `client.email` is fine even though the schema does not
+  // spell out the nested `email` — the projection targets the `client` field.
+  const src = source(
+    `client: z.object({ email: z.string().optional() }).optional(),`,
+  );
+  const manifest = {
+    settings: [
+      { path: "client.email", label: "C", type: "email", default: "" },
+    ],
+  };
+  assert.deepEqual(checkEntrySchemaCoverage("fixture", manifest, src), []);
+});
+
+test("manifest with a projection but NO entry inputSchema → fails", () => {
+  const src = source(`topic: z.string(),`, { withSchema: false });
+  const manifest = { defaultInput: { topic: "hi" } };
+  const errors = checkEntrySchemaCoverage("fixture", manifest, src);
+  assert.equal(errors.length, 1);
+  assert.match(
+    errors[0],
+    /declares a defaultInput but its entry step declares no `inputSchema`/,
+  );
+});
+
+test("no settings and no defaultInput → nothing to check", () => {
+  const src = source(`topic: z.string(),`, { withSchema: false });
+  assert.deepEqual(checkEntrySchemaCoverage("fixture", {}, src), []);
+});
+
+test("unreadable source → conservatively skipped", () => {
+  const manifest = { defaultInput: { topic: "hi" } };
+  assert.deepEqual(checkEntrySchemaCoverage("fixture", manifest, null), []);
+});
+
+test("inputSchema built from a non-literal → coverage skipped, never false-fails", () => {
+  // A schema assembled by a call (not a readable `z.object({…})` literal) must
+  // not fail the gate — the parser cannot see its keys, so it declines to judge.
+  const src = `
+import { defineAgent, defineStep, goto } from "@sapiom/agent";
+const entryInput = buildSchema();
+const start = defineStep({
+  name: "start",
+  next: ["finish"],
+  inputSchema: entryInput,
+  async run(input, ctx) { return goto("finish", {}); },
+});
+export const agent = defineAgent({ name: "x", entry: "start", steps: { start } });
+`;
+  const s = extractEntrySchema(src);
+  assert.equal(s.hasInputSchema, true);
+  assert.equal(s.keys, null);
+  const manifest = {
+    settings: [{ path: "whatever", label: "W", type: "string", default: "" }],
+  };
+  assert.deepEqual(checkEntrySchemaCoverage("fixture", manifest, src), []);
+});


### PR DESCRIPTION
## Summary

Almost no shipped agent declared a runtime entry contract, so the dashboard had nothing to render a Run form from — the manifest recorded `inputSchema: null` while the same template's `template.json` still told users to "pass a `topic`". Input was expressed **twice, neither at runtime**: TS annotations on `run(input)` (erased by esbuild) and `template.json` `defaultInput`/`settings` (pre-deploy metadata only). `examples/template.schema.json` already described the intended split — *"The runtime guarantee lives in code … this is its declared, renderable projection … and it NEVER overrides code"* — but the code half was never written. This writes it.

Closes SAP-2226.

## What changed

- **Scaffolds (2/2 → done):** `packages/agent-core/templates/{default,coding-pause}` + the mirrored `packages/cli/templates/default` get a zod entry `inputSchema` with a comment naming it the agent's public API and what the dashboard Run form renders from. `coding-pause` now threads its `task` field through so the scaffold demonstrates input actually flowing to a step.
- **Gallery (2/27 → 27/27):** every gallery example whose entry step reads input now declares a zod `inputSchema` (imported from `zod/v4`) on the entry step — 25 new (eval-gate + news-roundup already had one).
  - `.default(...)` carries the runtime default where a zero-interaction run is expected, so the declared default and the runtime default are the same value.
  - Credentials / webhooks / dynamic values, and the tri-state "sample" fields (`source`/`scene`/`request`/`candidates`), stay `.optional()` so their existing sample-fallback behavior is preserved exactly.
  - Where a field gained a default, the "used the default" note detection switches from an `undefined` check to value-equality against the default (matching `eval-gate`), so the honest note still fires on a zero-input run.
- **`template.json` unchanged, still consistent:** `defaultInput`/`settings` remain the renderable projection — every declared path is now backed by a schema field.
- **Nice: examples-check extended.** New `scripts/examples-entry-schema-check.mjs` fails the gate when `defaultInput`/`settings` name a path the entry `inputSchema` does not declare (statically reading the entry `z.object` literal's keys; conservative — a parser limitation never false-fails). Fixture tests in `scripts/examples-entry-schema-check.test.mjs`.

## Acceptance criteria

- ✅ Every gallery example that consumes entry input has a zod entry schema; the built manifest's entry step has a **non-null `inputSchema`** (verified by building the manifest via `buildManifest` and inspecting `steps[entry].inputSchema`).
- ✅ `workflowInputContract` renders **labelled fields** (not a JSON blob) for the converted templates.
- ✅ A **zero-input run still validates** for every template — `{}` parses through all 27 entry schemas (every field is optional or defaulted).

## Testing

- Per-example `tsc --noEmit` clean for all 25 converted examples + both scaffolds.
- Monorepo `pnpm build && pnpm typecheck && pnpm lint` green.
- `pnpm examples:check` (27 templates, incl. the new entry-schema gate) + `pnpm examples:check:test` (84 tests) pass.
- Built each converted example's manifest and confirmed a non-null entry `inputSchema` + rendered fields; confirmed `{}` parses through every entry schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
