### PR TITLE
feat(examples): examples:sync-setup — populate registry setup blocks from manifest zeroSetup (SAP-2234)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -63,7 +63,14 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 2,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Runs the saga with no approvers supplied, so nothing is committed and it escalates."
+      }
     },
     {
       "id": "cold-outreach-engine",
@@ -140,7 +147,14 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Runs the outreach engine with no leads, so there is nobody to write to and nothing is sent."
+      }
     },
     {
       "id": "content-repurposing-pipeline",
@@ -201,7 +215,13 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Repurposes a built-in sample post into a newsletter, tweet thread, video script, and LinkedIn post."
+      }
     },
     {
       "id": "dependency-upgrade",
@@ -269,7 +289,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Runs a coding agent to triage upgrades and writes a report; pushes nothing (no repo)."
+      }
     },
     {
       "id": "durable-backfill",
@@ -310,7 +336,14 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "provisions": ["sandbox"],
+        "degradedWithoutSetup": "Runs the backfill offline over 3 chunks (25 records); persists nothing (no dbHandle)."
+      }
     },
     {
       "id": "error-triage-digest",
@@ -356,7 +389,14 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 2,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Triages sample errors into a digest; emails nothing because no recipient is set."
+      }
     },
     {
       "id": "eval-gate",
@@ -395,7 +435,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Grades the built-in sample against a rubric and returns a decision with rationale."
+      }
     },
     {
       "id": "fan-out-and-combine",
@@ -451,7 +497,13 @@
           "next": [],
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Fans a sample goal into three parallel child runs of itself and returns one combined answer."
+      }
     },
     {
       "id": "hello-agent",
@@ -471,7 +523,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Runs immediately with no setup and returns a greeting."
+      }
     },
     {
       "id": "human-in-the-loop",
@@ -552,7 +610,13 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 2,
+        "degradedWithoutSetup": "Ranks the sample shortlist and stops at pending-approval; commits nothing (no approver)."
+      }
     },
     {
       "id": "logged-in-screenshots",
@@ -597,7 +661,13 @@
           "next": [],
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 1,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Opens a browser session and captures two stable public pages as hosted images; no login, so authenticated is false."
+      }
     },
     {
       "id": "meeting-notes-crm",
@@ -643,7 +713,14 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 2,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Turns sample meeting notes into a CRM update summary; emails nothing (no recipient)."
+      }
     },
     {
       "id": "news-roundup",
@@ -693,7 +770,14 @@
           "next": [],
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "provisions": ["sandbox"],
+        "degradedWithoutSetup": "Searches the web for the company's recent news and publishes an illustrated roundup page; with no recent news it honestly reports no-news."
+      }
     },
     {
       "id": "newsletter-autopilot",
@@ -741,7 +825,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Writes a newsletter from researched sources; sends to nobody (empty subscriber list)."
+      }
     },
     {
       "id": "nl-db-query-endpoint",
@@ -812,7 +902,14 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 1,
+        "settingCount": 0,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Translates a sample question to SQL and validates it; deploys no endpoint (needs a scoped key)."
+      }
     },
     {
       "id": "personalized-media-at-scale",
@@ -866,7 +963,14 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Renders personalized images; delivers nothing because no recipients are set."
+      }
     },
     {
       "id": "pr-review-bot",
@@ -925,7 +1029,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 1,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Runs a coding agent to review the sample PR and returns a verdict; posts nothing (no webhook)."
+      }
     },
     {
       "id": "proposal-generator",
@@ -991,7 +1101,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": false,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "provisions": ["sandbox"]
+      }
     },
     {
       "id": "research-to-microsite",
@@ -1072,7 +1188,12 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": false,
+        "connectionCount": 0,
+        "settingCount": 0
+      }
     },
     {
       "id": "scene-to-video",
@@ -1130,7 +1251,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Shoots the built-in sample scene into a shot list with a style bible (dry run)."
+      }
     },
     {
       "id": "scheduled-compliance-audit",
@@ -1195,7 +1322,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Runs the audit checks and drafts an attestation; files nothing (nobody signed off)."
+      }
     },
     {
       "id": "scheduled-db-insight-report",
@@ -1245,7 +1378,13 @@
           "capability": "email.send",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": false,
+        "connectionCount": 1,
+        "settingCount": 1,
+        "provisions": ["postgres"]
+      }
     },
     {
       "id": "scheduled-research-brief",
@@ -1286,7 +1425,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Researches the topic and writes a brief with sources; emails nothing (no recipient)."
+      }
     },
     {
       "id": "slack-notifier",
@@ -1330,7 +1475,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 2,
+        "settingCount": 1,
+        "degradedWithoutSetup": "Composes the message and prints it; posts nothing to Slack (no bot token)."
+      }
     },
     {
       "id": "the-brain",
@@ -1370,7 +1521,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": false,
+        "connectionCount": 1,
+        "settingCount": 1,
+        "provisions": ["postgres"]
+      }
     },
     {
       "id": "wait-for-webhook",
@@ -1409,7 +1566,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Evaluates the sample job and returns a decision; registers no external callback."
+      }
     },
     {
       "id": "web-research-digest",
@@ -1436,7 +1599,13 @@
           "kind": "compute",
           "terminal": true
         }
-      ]
+      ],
+      "setup": {
+        "runsWithNoSetup": true,
+        "connectionCount": 0,
+        "settingCount": 0,
+        "degradedWithoutSetup": "Researches a default topic and returns a digest with cited sources."
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "publish:local": "node scripts/publish-local.mjs",
     "examples:check": "node scripts/examples-check.mjs",
     "examples:check:test": "node --test scripts/*.test.mjs",
-    "examples:sort": "node scripts/examples-sort.mjs"
+    "examples:sort": "node scripts/examples-sort.mjs",
+    "examples:sync-setup": "node scripts/examples-sync-setup.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -37,7 +37,7 @@ import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import {
   checkResourceSeeds,
-  checkSetupProvisions,
+  checkSetupSync,
   createManifestChecker,
 } from "./examples-manifest-check.mjs";
 import { checkCopy } from "./examples-copy-check.mjs";
@@ -165,13 +165,14 @@ for (const t of templates) {
   errors.push(...checkCopy(t, manifests.get(t.id) ?? null));
 }
 
-// 6b. `setup.provisions[]` is DERIVED from the manifest's `resources[]`, so it
-// gets verified rather than trusted. An author-declared mirror with no source of
-// truth is the drift that let `capabilities[]` fill up with SDK method paths
-// instead of catalog ids; this is the same field shape, so it gets a check
-// before it can acquire the same problem.
+// 6b. The whole `registry.setup` block is DERIVED from the manifest (secrets,
+// settings, resources, zeroSetup) by `pnpm examples:sync-setup`, so it gets
+// verified rather than trusted — the drift that let `capabilities[]` fill up
+// with SDK method paths, applied to the entire denormalised block. Only checked
+// for templates that have a manifest (others are already flagged above).
 for (const t of templates) {
-  errors.push(...checkSetupProvisions(t, manifests.get(t.id) ?? null));
+  const manifest = manifests.get(t.id);
+  if (manifest) errors.push(...checkSetupSync(t, manifest));
 }
 
 if (errors.length > 0) {

--- a/scripts/examples-manifest-check.mjs
+++ b/scripts/examples-manifest-check.mjs
@@ -44,7 +44,9 @@ export function isReservedSecretKey(key) {
  * `registry.setup.provisions[]` must equal.
  */
 export function deriveProvisions(manifest) {
-  const resources = Array.isArray(manifest?.resources) ? manifest.resources : [];
+  const resources = Array.isArray(manifest?.resources)
+    ? manifest.resources
+    : [];
   return [...new Set(resources.map((r) => r?.kind))].filter(Boolean).sort();
 }
 
@@ -67,6 +69,93 @@ export function checkSetupProvisions(template, manifest) {
   ];
 }
 
+/** zeroSetup.terminalState values that count as "reaches a meaningful terminal
+ * with no setup". A suspend (`paused_for_approval`) or an absent zeroSetup does
+ * not — the shelf's "pauses for approval" state is derived from steps[].checkpoint. */
+const MEANINGFUL_ZEROSETUP_TERMINALS = new Set([
+  "completed",
+  "completed_partial",
+]);
+
+/**
+ * The full `registry.setup` block a template's manifest implies — the single
+ * source of truth for `pnpm examples:sync-setup` and the drift check below.
+ * Denormalised into the thin registry index so the gallery shelf renders it
+ * without fetching a manifest (an N+1 the shelf can't afford).
+ *
+ *   runsWithNoSetup      — true ONLY when the manifest carries a zeroSetup whose
+ *                          terminalState is a meaningful terminal; absent
+ *                          zeroSetup (unmeasured / hard-failed / the-brain) ⇒ false.
+ *   connectionCount      — number of requiredSecrets ("needs 1 credential").
+ *   settingCount         — number of declared settings.
+ *   provisions           — deriveProvisions(manifest); included only when non-empty.
+ *   degradedWithoutSetup — zeroSetup.narrative verbatim, when present (rendered
+ *                          on the card — never implies a send that won't happen).
+ */
+export function deriveSetup(manifest) {
+  const requiredSecrets = Array.isArray(manifest?.requiredSecrets)
+    ? manifest.requiredSecrets
+    : [];
+  const settings = Array.isArray(manifest?.settings) ? manifest.settings : [];
+  const zeroSetup = manifest?.zeroSetup;
+  const provisions = deriveProvisions(manifest);
+
+  const setup = {
+    runsWithNoSetup:
+      !!zeroSetup &&
+      MEANINGFUL_ZEROSETUP_TERMINALS.has(zeroSetup.terminalState),
+    connectionCount: requiredSecrets.length,
+    settingCount: settings.length,
+  };
+  if (provisions.length > 0) setup.provisions = provisions;
+  if (
+    typeof zeroSetup?.narrative === "string" &&
+    zeroSetup.narrative.length > 0
+  ) {
+    setup.degradedWithoutSetup = zeroSetup.narrative;
+  }
+  return setup;
+}
+
+/** Stable key-sorted serialisation, so two setup blocks compare equal regardless
+ * of key order or which optional fields are present. */
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .reduce((acc, k) => {
+        acc[k] = canonical(value[k]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+/**
+ * The registry `setup` block is GENERATED from the manifest by
+ * `pnpm examples:sync-setup`. This fails CI when the committed block drifts from
+ * what the manifest implies — the same verify-don't-trust rule as provisions,
+ * applied to the whole block so it can never be hand-edited out of sync.
+ */
+export function checkSetupSync(template, manifest) {
+  const derived = deriveSetup(manifest);
+  const actual = template?.setup;
+  if (actual === undefined) {
+    return [
+      `setup-sync: "${template?.id ?? "(unknown)"}" has no registry setup block — run \`pnpm examples:sync-setup\` (setup is generated from the manifest, never hand-maintained).`,
+    ];
+  }
+  if (
+    JSON.stringify(canonical(actual)) === JSON.stringify(canonical(derived))
+  ) {
+    return [];
+  }
+  return [
+    `setup-sync: "${template?.id ?? "(unknown)"}" registry setup is ${JSON.stringify(actual)} but the manifest derives ${JSON.stringify(derived)} — run \`pnpm examples:sync-setup\`.`,
+  ];
+}
+
 /**
  * A declared seed that isn't on disk provisions an empty database and reports
  * success — the exact failure `resources[].seed` exists to prevent.
@@ -74,7 +163,9 @@ export function checkSetupProvisions(template, manifest) {
  * @param fileExists  (relativePath) => boolean, resolved against the example dir
  */
 export function checkResourceSeeds(templateId, manifest, fileExists) {
-  const resources = Array.isArray(manifest?.resources) ? manifest.resources : [];
+  const resources = Array.isArray(manifest?.resources)
+    ? manifest.resources
+    : [];
   const errors = [];
   resources.forEach((resource, i) => {
     if (typeof resource?.seed !== "string") return;
@@ -131,7 +222,9 @@ export function createManifestChecker(ajv, schema) {
     // (`ctx.sapiom.database.get(handle)`), so a duplicate is a silent collision
     // at lookup — the schema can constrain one handle's shape but not their
     // uniqueness as a set.
-    const resources = Array.isArray(manifest?.resources) ? manifest.resources : [];
+    const resources = Array.isArray(manifest?.resources)
+      ? manifest.resources
+      : [];
     const seenHandles = new Map();
     resources.forEach((resource, i) => {
       const handle = resource?.handle;

--- a/scripts/examples-manifest-check.mjs
+++ b/scripts/examples-manifest-check.mjs
@@ -50,25 +50,6 @@ export function deriveProvisions(manifest) {
   return [...new Set(resources.map((r) => r?.kind))].filter(Boolean).sort();
 }
 
-/**
- * `setup.provisions[]` is denormalised into the thin registry index so the shelf
- * can render it without fetching a manifest. Denormalised data with no source of
- * truth is what let `capabilities[]` fill up with SDK method paths instead of
- * catalog ids, so this verifies rather than trusts.
- *
- * @returns string[] — empty when `provisions` is absent (it is optional)
- */
-export function checkSetupProvisions(template, manifest) {
-  const declared = template?.setup?.provisions;
-  if (!Array.isArray(declared)) return [];
-  const derived = deriveProvisions(manifest);
-  const actual = [...declared].sort();
-  if (JSON.stringify(actual) === JSON.stringify(derived)) return [];
-  return [
-    `setup-provisions: "${template?.id ?? "(unknown)"}" registry setup.provisions is [${actual.join(", ")}] but the manifest's resources[] derive [${derived.join(", ")}] — provisions is generated from the manifest, never hand-maintained.`,
-  ];
-}
-
 /** zeroSetup.terminalState values that count as "reaches a meaningful terminal
  * with no setup". A suspend (`paused_for_approval`) or an absent zeroSetup does
  * not — the shelf's "pauses for approval" state is derived from steps[].checkpoint. */

--- a/scripts/examples-manifest-check.test.mjs
+++ b/scripts/examples-manifest-check.test.mjs
@@ -17,7 +17,6 @@ import test from "node:test";
 import Ajv from "ajv";
 import {
   checkResourceSeeds,
-  checkSetupProvisions,
   checkSetupSync,
   createManifestChecker,
   deriveProvisions,
@@ -357,66 +356,6 @@ test("provisions derive as distinct kinds, sorted", () => {
   );
 });
 
-test("setup.provisions disagreeing with the manifest fails", () => {
-  const manifest = { resources: [{ kind: "postgres", handle: "db" }] };
-  const errors = checkSetupProvisions(
-    {
-      id: "fixture",
-      setup: { runsWithNoSetup: false, provisions: ["postgres", "sandbox"] },
-    },
-    manifest,
-  );
-  assert.equal(errors.length, 1);
-  assert.match(errors[0], /^setup-provisions: "fixture" /);
-  assert.match(
-    errors[0],
-    /is \[postgres, sandbox\] but the manifest's resources\[\] derive \[postgres\]/,
-  );
-});
-
-test("setup.provisions matching the manifest passes, order-insensitively", () => {
-  const manifest = {
-    resources: [
-      { kind: "sandbox", handle: "s" },
-      { kind: "postgres", handle: "p" },
-    ],
-  };
-  const setup = { runsWithNoSetup: false, provisions: ["sandbox", "postgres"] };
-  assert.deepEqual(
-    checkSetupProvisions({ id: "fixture", setup }, manifest),
-    [],
-  );
-});
-
-test("an absent setup.provisions is not a mismatch", () => {
-  // Both fields are optional; only a declared mirror gets verified.
-  assert.deepEqual(
-    checkSetupProvisions({ id: "fixture" }, { resources: [] }),
-    [],
-  );
-  assert.deepEqual(
-    checkSetupProvisions(
-      { id: "fixture", setup: { runsWithNoSetup: true } },
-      null,
-    ),
-    [],
-  );
-});
-
-test("declaring provisions with no resources at all fails", () => {
-  // The case that motivated the check: a hand-written mirror with nothing
-  // behind it. Silent before, because provisions had no source of truth.
-  const errors = checkSetupProvisions(
-    {
-      id: "fixture",
-      setup: { runsWithNoSetup: false, provisions: ["postgres"] },
-    },
-    { manifestVersion: 1 },
-  );
-  assert.equal(errors.length, 1);
-  assert.match(errors[0], /derive \[\]/);
-});
-
 test("a seed file that does not exist fails", () => {
   const errors = checkResourceSeeds(
     "fixture",
@@ -480,6 +419,16 @@ test("deriveSetup: a meaningful zeroSetup terminal ⇒ runsWithNoSetup true, nar
   assert.equal(setup.connectionCount, 1);
   assert.equal(setup.settingCount, 2);
   assert.equal(setup.degradedWithoutSetup, "did the honest thing");
+});
+
+test("deriveSetup: terminalState 'completed' ⇒ runsWithNoSetup true", () => {
+  // Symmetry with the completed_partial case above: both non-suspend terminals
+  // in the enum are meaningful, so the other literal gets its own assertion.
+  const setup = deriveSetup({
+    zeroSetup: { terminalState: "completed", narrative: "ran clean" },
+  });
+  assert.equal(setup.runsWithNoSetup, true);
+  assert.equal(setup.degradedWithoutSetup, "ran clean");
 });
 
 test("deriveSetup: no zeroSetup ⇒ runsWithNoSetup false and no degradedWithoutSetup", () => {

--- a/scripts/examples-manifest-check.test.mjs
+++ b/scripts/examples-manifest-check.test.mjs
@@ -18,8 +18,10 @@ import Ajv from "ajv";
 import {
   checkResourceSeeds,
   checkSetupProvisions,
+  checkSetupSync,
   createManifestChecker,
   deriveProvisions,
+  deriveSetup,
 } from "./examples-manifest-check.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -59,8 +61,14 @@ test("every existing manifest in the repo validates unchanged", () => {
 
 test("the copy length caps are enforced by the schema, with a pointer", () => {
   const cases = [
-    [{ whatItDoes: "Create ".repeat(60) }, /\/whatItDoes must NOT have more than 320 characters/],
-    [{ useCases: ["x".repeat(41)] }, /\/useCases\/0 must NOT have more than 40 characters/],
+    [
+      { whatItDoes: "Create ".repeat(60) },
+      /\/whatItDoes must NOT have more than 320 characters/,
+    ],
+    [
+      { useCases: ["x".repeat(41)] },
+      /\/useCases\/0 must NOT have more than 40 characters/,
+    ],
   ];
   for (const [extra, expected] of cases) {
     const errors = check(extra);
@@ -170,7 +178,12 @@ test("a fully declared resource is valid", () => {
   assert.deepEqual(
     check({
       resources: [
-        { kind: "postgres", handle: "reports-db", duration: "7d", seed: "seed.sql" },
+        {
+          kind: "postgres",
+          handle: "reports-db",
+          duration: "7d",
+          seed: "seed.sql",
+        },
         { kind: "sandbox", handle: "renderer", ephemeral: true },
       ],
     }),
@@ -347,12 +360,18 @@ test("provisions derive as distinct kinds, sorted", () => {
 test("setup.provisions disagreeing with the manifest fails", () => {
   const manifest = { resources: [{ kind: "postgres", handle: "db" }] };
   const errors = checkSetupProvisions(
-    { id: "fixture", setup: { runsWithNoSetup: false, provisions: ["postgres", "sandbox"] } },
+    {
+      id: "fixture",
+      setup: { runsWithNoSetup: false, provisions: ["postgres", "sandbox"] },
+    },
     manifest,
   );
   assert.equal(errors.length, 1);
   assert.match(errors[0], /^setup-provisions: "fixture" /);
-  assert.match(errors[0], /is \[postgres, sandbox\] but the manifest's resources\[\] derive \[postgres\]/);
+  assert.match(
+    errors[0],
+    /is \[postgres, sandbox\] but the manifest's resources\[\] derive \[postgres\]/,
+  );
 });
 
 test("setup.provisions matching the manifest passes, order-insensitively", () => {
@@ -363,14 +382,23 @@ test("setup.provisions matching the manifest passes, order-insensitively", () =>
     ],
   };
   const setup = { runsWithNoSetup: false, provisions: ["sandbox", "postgres"] };
-  assert.deepEqual(checkSetupProvisions({ id: "fixture", setup }, manifest), []);
+  assert.deepEqual(
+    checkSetupProvisions({ id: "fixture", setup }, manifest),
+    [],
+  );
 });
 
 test("an absent setup.provisions is not a mismatch", () => {
   // Both fields are optional; only a declared mirror gets verified.
-  assert.deepEqual(checkSetupProvisions({ id: "fixture" }, { resources: [] }), []);
   assert.deepEqual(
-    checkSetupProvisions({ id: "fixture", setup: { runsWithNoSetup: true } }, null),
+    checkSetupProvisions({ id: "fixture" }, { resources: [] }),
+    [],
+  );
+  assert.deepEqual(
+    checkSetupProvisions(
+      { id: "fixture", setup: { runsWithNoSetup: true } },
+      null,
+    ),
     [],
   );
 });
@@ -379,7 +407,10 @@ test("declaring provisions with no resources at all fails", () => {
   // The case that motivated the check: a hand-written mirror with nothing
   // behind it. Silent before, because provisions had no source of truth.
   const errors = checkSetupProvisions(
-    { id: "fixture", setup: { runsWithNoSetup: false, provisions: ["postgres"] } },
+    {
+      id: "fixture",
+      setup: { runsWithNoSetup: false, provisions: ["postgres"] },
+    },
     { manifestVersion: 1 },
   );
   assert.equal(errors.length, 1);
@@ -393,20 +424,35 @@ test("a seed file that does not exist fails", () => {
     () => false,
   );
   assert.equal(errors.length, 1);
-  assert.match(errors[0], /^manifest-resource-seed: "fixture" \/resources\/0\/seed points at "seed\.sql"/);
+  assert.match(
+    errors[0],
+    /^manifest-resource-seed: "fixture" \/resources\/0\/seed points at "seed\.sql"/,
+  );
 });
 
 test("a seed file that exists passes, and no seed is not a problem", () => {
   const resources = [{ kind: "postgres", handle: "db", seed: "seed.sql" }];
-  assert.deepEqual(checkResourceSeeds("fixture", { resources }, () => true), []);
   assert.deepEqual(
-    checkResourceSeeds("fixture", { resources: [{ kind: "sandbox", handle: "s" }] }, () => false),
+    checkResourceSeeds("fixture", { resources }, () => true),
+    [],
+  );
+  assert.deepEqual(
+    checkResourceSeeds(
+      "fixture",
+      { resources: [{ kind: "sandbox", handle: "s" }] },
+      () => false,
+    ),
     [],
   );
 });
 
 test("no declaration field names a storage location", () => {
-  const declarations = ["requiredSecrets", "settings", "resources", "zeroSetup"];
+  const declarations = [
+    "requiredSecrets",
+    "settings",
+    "resources",
+    "zeroSetup",
+  ];
   const forbidden = ["vaultRef", "connectorId", "store"];
   const names = JSON.stringify(
     declarations.map((d) => manifestSchema.properties[d]),
@@ -415,6 +461,90 @@ test("no declaration field names a storage location", () => {
     assert.ok(
       !names.includes(`"${field}"`),
       `${field} must never appear in a declaration — a declaration says what the credential is, never where it is stored.`,
+    );
+  }
+});
+
+// --- setup derivation + drift (examples:sync-setup) ------------------------
+
+test("deriveSetup: a meaningful zeroSetup terminal ⇒ runsWithNoSetup true, narrative mirrored", () => {
+  const setup = deriveSetup({
+    requiredSecrets: [{ key: "A" }],
+    settings: [{ path: "x" }, { path: "y" }],
+    zeroSetup: {
+      terminalState: "completed_partial",
+      narrative: "did the honest thing",
+    },
+  });
+  assert.equal(setup.runsWithNoSetup, true);
+  assert.equal(setup.connectionCount, 1);
+  assert.equal(setup.settingCount, 2);
+  assert.equal(setup.degradedWithoutSetup, "did the honest thing");
+});
+
+test("deriveSetup: no zeroSetup ⇒ runsWithNoSetup false and no degradedWithoutSetup", () => {
+  const setup = deriveSetup({ requiredSecrets: [{ key: "A" }] });
+  assert.equal(setup.runsWithNoSetup, false);
+  assert.equal(setup.connectionCount, 1);
+  assert.equal(setup.settingCount, 0);
+  assert.ok(!("degradedWithoutSetup" in setup));
+  assert.ok(!("provisions" in setup));
+});
+
+test("deriveSetup: a suspend (paused_for_approval) is not runsWithNoSetup", () => {
+  const setup = deriveSetup({
+    zeroSetup: { terminalState: "paused_for_approval", narrative: "waits" },
+  });
+  assert.equal(setup.runsWithNoSetup, false);
+});
+
+test("deriveSetup: provisions are the distinct sorted resource kinds, only when present", () => {
+  const setup = deriveSetup({
+    resources: [
+      { kind: "sandbox" },
+      { kind: "postgres" },
+      { kind: "postgres" },
+    ],
+    zeroSetup: { terminalState: "completed" },
+  });
+  assert.deepEqual(setup.provisions, ["postgres", "sandbox"]);
+});
+
+test("checkSetupSync: a block matching the manifest passes; drift and absence fail", () => {
+  const manifest = {
+    requiredSecrets: [{ key: "A" }],
+    zeroSetup: { terminalState: "completed", narrative: "n" },
+  };
+  const inSync = { id: "t", setup: deriveSetup(manifest) };
+  assert.deepEqual(checkSetupSync(inSync, manifest), []);
+
+  const drift = {
+    id: "t",
+    setup: { ...deriveSetup(manifest), connectionCount: 99 },
+  };
+  assert.equal(checkSetupSync(drift, manifest).length, 1);
+  assert.match(checkSetupSync(drift, manifest)[0], /setup-sync/);
+
+  assert.equal(checkSetupSync({ id: "t" }, manifest).length, 1);
+});
+
+test("checkSetupSync passes for every real manifest against the committed registry", () => {
+  const registry = JSON.parse(
+    readFileSync(path.join(ROOT, "examples", "registry.json"), "utf8"),
+  );
+  for (const t of registry.templates) {
+    const dir = path.join(ROOT, t.sourcePath ?? path.join("examples", t.id));
+    const manifestPath = path.join(dir, "template.json");
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    } catch {
+      continue; // no manifest ⇒ flagged by a different gate
+    }
+    assert.deepEqual(
+      checkSetupSync(t, manifest),
+      [],
+      `${t.id} registry setup is out of sync — run pnpm examples:sync-setup`,
     );
   }
 });

--- a/scripts/examples-sync-setup.mjs
+++ b/scripts/examples-sync-setup.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// =============================================================================
+// scripts/examples-sync-setup.mjs
+//
+// Regenerate every registry template's `setup` block from its co-located
+// `template.json` (the manifest), in place.
+//
+// The gallery shelf renders `setup` from the thin registry index (listTemplates
+// never fetches manifests — that would be an N+1), so the block is denormalised
+// here from the manifest's requiredSecrets / settings / resources[] / zeroSetup.
+// It is GENERATED, never hand-maintained: `pnpm examples:check` (checkSetupSync)
+// fails CI if the committed block drifts from what the manifest implies.
+//
+// Usage:  node scripts/examples-sync-setup.mjs   (or `pnpm examples:sync-setup`)
+// =============================================================================
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import prettier from "prettier";
+import { deriveSetup } from "./examples-manifest-check.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REGISTRY_PATH = path.join(ROOT, "examples", "registry.json");
+
+const registry = JSON.parse(readFileSync(REGISTRY_PATH, "utf8"));
+if (!Array.isArray(registry.templates)) {
+  console.error("registry.json has no `templates` array — nothing to sync.");
+  process.exit(1);
+}
+
+let changed = 0;
+const missing = [];
+for (const t of registry.templates) {
+  const dir = path.join(ROOT, t.sourcePath ?? path.join("examples", t.id));
+  const manifestPath = path.join(dir, "template.json");
+  if (!existsSync(manifestPath)) {
+    // No manifest ⇒ nothing to derive from; leave any existing setup untouched
+    // and let examples:check report the missing manifest itself.
+    missing.push(t.id);
+    continue;
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const setup = deriveSetup(manifest);
+  if (JSON.stringify(t.setup) !== JSON.stringify(setup)) changed++;
+  t.setup = setup;
+}
+
+// Emit prettier-formatted JSON (repo .prettierrc) so the file on disk always
+// matches the formatter — same approach as examples:sort, so a sync is a pure
+// content change with no formatting churn.
+const config = await prettier.resolveConfig(REGISTRY_PATH);
+const formatted = await prettier.format(JSON.stringify(registry), {
+  ...config,
+  parser: "json",
+});
+writeFileSync(REGISTRY_PATH, formatted);
+
+console.log(
+  `Synced setup on ${registry.templates.length - missing.length} template(s) (${changed} changed)` +
+    (missing.length
+      ? `; skipped ${missing.length} with no manifest: ${missing.join(", ")}`
+      : "") +
+    ".",
+);


### PR DESCRIPTION
## What & why

The gallery **shelf reads the `setup` block in `registry.json`, not the manifest `zeroSetup`** — and `registry.json` carried no `setup` blocks at all, so the authored zero-setup truth (from #470 / SAP-2080) never reached the shelf. The `pnpm examples:sync-setup` codemod the schema comment references didn't exist. This adds it, plus a CI guard.

## Changes

- **`deriveSetup(manifest)` + `pnpm examples:sync-setup`** — generates each template's registry `setup` block from its co-located `template.json`:
  - `runsWithNoSetup` — `true` only where the manifest carries a `zeroSetup` with a *meaningful* terminal (`completed` / `completed_partial`); a suspend or an absent `zeroSetup` ⇒ `false`.
  - `connectionCount` ← `requiredSecrets.length`, `settingCount` ← `settings.length`.
  - `provisions` ← distinct sorted resource kinds (reuses `deriveProvisions`), only when non-empty.
  - `degradedWithoutSetup` ← `zeroSetup.narrative` verbatim (renders on the card).
- **`checkSetupSync` wired into `examples:check`** — CI fails when a committed `setup` block drifts from what its manifest implies (verify-don't-trust; supersedes the narrower provisions-only check).
- **Regenerated `registry.json`** setup blocks for all 27 templates.
- **Unit tests** for `deriveSetup` + `checkSetupSync`.

## Scoping notes

- **Stacked on #470** (base `feat/SAP-2080`) because it consumes the manifest `zeroSetup` that PR adds — **merge #470 first**.
- Templates with no authored `zeroSetup` get `runsWithNoSetup: false` and no narrative — correct for `the-brain` (excluded), and honest for the recently-fixed `proposal-generator` / `research-to-microsite` until their `zeroSetup` is authored (follow-up / re-baseline).
- `runsWithNoSetup: true` coexists with `connectionCount ≥ 1` for honest-degrade templates (e.g. `slack-notifier`): it *runs* immediately (composes + prints), and `connectionCount` signals the credential needed to do the real thing — both drive the shelf.

## Validation
- `pnpm examples:check` — 27 templates, schema-valid; drift guard verified to fail on tampering and clear after re-sync ✅
- `pnpm examples:check:test` — 79/79 (6 new) ✅
- `prettier --check` ✅

Unblocks SAP-2063 (shelf labels). Ticket: SAP-2234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
