### PR TITLE
feat(harness): instrument the Studio with client PostHog + tier consent

### DIFF
--- a/packages/harness-desktop/src/renderer/setup.html
+++ b/packages/harness-desktop/src/renderer/setup.html
@@ -44,8 +44,8 @@
 
       <section id="consent" class="consent" hidden>
         <label class="consent-row">
-          <input type="checkbox" id="telemetry" checked />
-          <span>Share anonymous usage data to help improve Sapiom (optional).</span>
+          <input type="checkbox" id="telemetry" />
+          <span>Share your session details with Sapiom so we can optimize your experience (optional, off by default).</span>
         </label>
         <button id="consent-continue" class="btn-primary">Continue</button>
       </section>

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -88,6 +88,7 @@
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.23.0",
+    "posthog-js": "^1.363.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsx": "^4.19.0",

--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -57,17 +57,19 @@ describe("ensureConsent", () => {
     expect(settings.telemetryOptIn).toBe(false);
   });
 
-  it("defaults to ON and persists on first run when stdin is not a TTY", async () => {
+  it("defaults to OFF (opt-out) and persists on first run when stdin is not a TTY", async () => {
+    // SAP-1988: the invasive Sapiom→BQ tier is opt-out by default — a non-TTY
+    // first run (CI/Docker/headless) must never silently opt the user in.
     const wasTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
     try {
       const result = await ensureConsent({ noTelemetry: false });
-      expect(result.telemetryOptIn).toBe(true);
+      expect(result.telemetryOptIn).toBe(false);
       expect(result.source).toBe("default-silent");
 
       const settings = await loadSettings();
-      expect(settings.telemetryOptIn).toBe(true);
+      expect(settings.telemetryOptIn).toBe(false);
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
@@ -78,31 +80,31 @@ describe("ensureConsent", () => {
     Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
 
     try {
-      await ensureConsent({ noTelemetry: false }); // first run persists the default (true)
+      await ensureConsent({ noTelemetry: false }); // first run persists the default (false)
       const settings = await loadSettings();
       // Overwrite with a non-default value to prove the second call reuses
       // whatever was persisted rather than just returning the default again.
       await fs.writeFile(
         path.join(tmpDir, ".sapiom", "harness", "settings.json"),
-        JSON.stringify({ ...settings, telemetryOptIn: false }),
+        JSON.stringify({ ...settings, telemetryOptIn: true }),
       );
 
       const result = await ensureConsent({ noTelemetry: false });
-      expect(result.telemetryOptIn).toBe(false);
+      expect(result.telemetryOptIn).toBe(true);
       expect(result.source).toBe("stored-explicit");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
     }
   });
 
-  it("interactive prompt: a blank answer accepts the default (on)", async () => {
+  it("interactive prompt: a blank answer accepts the default (off)", async () => {
     const wasTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
     nextAnswer = "";
 
     try {
       const result = await ensureConsent({ noTelemetry: false });
-      expect(result.telemetryOptIn).toBe(true);
+      expect(result.telemetryOptIn).toBe(false);
       expect(result.source).toBe("prompted");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
@@ -177,9 +179,11 @@ describe("ensureConsent", () => {
     });
 
     it("overrides a previously persisted opt-in for this run, without rewriting it", async () => {
-      // Establish a stored opt-in from an earlier, env-free run.
+      // Establish a stored opt-in from an earlier, env-free run — an explicit
+      // 'y' at the prompt (the default is now off, so blank would not opt in).
       const wasTTY = process.stdin.isTTY;
-      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      nextAnswer = "y";
       try {
         const firstResult = await ensureConsent({ noTelemetry: false });
         expect(firstResult.telemetryOptIn).toBe(true);
@@ -188,6 +192,9 @@ describe("ensureConsent", () => {
       }
       expect((await loadSettings()).telemetryOptIn).toBe(true);
 
+      // Reset the prompt counter so the assertion below measures only the
+      // env-forced run (the setup above prompted once to store the opt-in).
+      questionCallCount = 0;
       process.env.DO_NOT_TRACK = "1";
       const result = await ensureConsent({ noTelemetry: false });
 
@@ -211,9 +218,13 @@ describe("ensureConsent", () => {
 
       try {
         const result = await ensureConsent({ noTelemetry: false });
-        expect(result.telemetryOptIn).toBe(true);
-        // env var present but not an opt-out value → "default-silent" (non-TTY)
+        // The env value is not a valid opt-out flag, so it does NOT force
+        // telemetry off via the env path — consent falls through to the normal
+        // first-run flow (default-silent, envReason null). The value itself is
+        // now the opt-out default, but the point of this test is that the env
+        // var was ignored, which source/envReason prove.
         expect(result.source).toBe("default-silent");
+        expect(result.envReason).toBeNull();
       } finally {
         Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
       }

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -1,29 +1,27 @@
 import * as readline from "node:readline/promises";
 import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 
-// Early-access phase: default to opted in (matches the on-by-default prompt
-// below and the non-TTY fallback) — intentional for the early-access phase;
-// flip for a wider release.
-//
-// Pre-wider-release checklist: revisit the non-TTY silent opt-in below.
-// The current default (true) is intentional for the early-access phase;
-// for a wider/public release the conservative choice is false (opt-out by
-// default) so users who never see a TTY (CI, Docker, headless environments)
-// are not silently opted in.
-// See also the first-run UI notice wiring in web/src/components/TelemetryNotice.tsx,
-// which surfaces this path to interactive users who did get the default.
-const DEFAULT_TELEMETRY_OPT_IN = true;
+// Opt-OUT by default (SAP-1988): this gates the *invasive* Sapiom→BigQuery
+// telemetry (prompt text + tool calls + session detail). Silently shipping
+// that from a tool running on someone's desktop is a reputation risk, so the
+// conservative default is off — users who never see a TTY (CI, Docker,
+// headless) are never silently opted in, and interactive users are asked with
+// a benefit-framed prompt. (Light, non-content PostHog product analytics is a
+// separate, on-by-default tier — see HarnessSettings.productAnalyticsOptIn.)
+// The first-run UI opt-in lives in web/src/components/WelcomePanel.tsx.
+const DEFAULT_TELEMETRY_OPT_IN = false;
 
 const CONSENT_COPY = `
-Sapiom Studio collects usage analytics locally and, with telemetry on,
-sends them to Sapiom to improve the product:
-  - the prompts you send and the tool calls your agent makes
-  - session start/stop lifecycle events
-This is always written locally to ~/.sapiom/harness/events.ndjson for your
-own inspection.
+Help us optimize your Studio experience.
 
-Telemetry is ON to help us improve (opt out anytime in the app's settings
-gear, or run with --no-telemetry).
+With your permission, Sapiom Studio shares your session details — the prompts
+you send, the tool calls your agent makes, and session lifecycle events — so we
+can see where the product gets in your way and improve it for you.
+
+This is always written locally to ~/.sapiom/harness/events.ndjson for your own
+inspection, whether or not you opt in. Sharing with Sapiom is OFF by default;
+turn it on anytime in the app's settings gear (or keep it off with
+--no-telemetry / SAPIOM_TELEMETRY_DISABLED=1).
 `.trim();
 
 async function promptConsent(): Promise<boolean> {
@@ -42,7 +40,7 @@ async function promptConsent(): Promise<boolean> {
 
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = (await rl.question("Keep it on? [Y/n] ")).trim().toLowerCase();
+    const answer = (await rl.question("Share session details with Sapiom? [y/N] ")).trim().toLowerCase();
     if (answer === "") return DEFAULT_TELEMETRY_OPT_IN;
     return answer === "y" || answer === "yes";
   } finally {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1081,6 +1081,7 @@ export const startServer = async (
       identity: identity
         ? {
             userId: identity.userId,
+            tenantId: identity.tenantId,
             organizationName: identity.organizationName,
           }
         : null,

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -143,8 +143,10 @@ describe("createRestRouter", () => {
         version: "9.9.9-test",
         authenticated: false,
         userId: null,
+        tenantId: null,
         organizationName: null,
         telemetryOptIn: false,
+        productAnalyticsOptIn: true,
         sessions: [],
         workflows: [],
         macros: [],
@@ -231,7 +233,7 @@ describe("createRestRouter", () => {
 
       start({
         sessionManager: fakeSessionManager([session]),
-        identity: { userId: "user-1", organizationName: "Acme" },
+        identity: { userId: "user-1", tenantId: "user-1", organizationName: "Acme" },
         listWorkflows: async () => [workflow],
         listMacros: () => [macro],
       });

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -169,7 +169,7 @@ export interface RestRouterOptions {
   adapters: Partial<Record<HarnessKind, HarnessAdapter>>;
   version: string;
   /** Sapiom identity from CLI auth; null when unauthenticated / --no-auth. */
-  identity: { userId: string; organizationName: string } | null;
+  identity: { userId: string; tenantId: string; organizationName: string } | null;
   listWorkflows: () => Promise<WorkflowInfo[]>;
   listMacros: () => MacroDef[];
   /** Look up a registered workflow by its path; null when not found. Backs
@@ -287,8 +287,11 @@ export function createRestRouter(options: RestRouterOptions): Router {
         version,
         authenticated: identity !== null,
         userId: identity?.userId ?? null,
+        tenantId: identity?.tenantId ?? null,
         organizationName: identity?.organizationName ?? null,
         telemetryOptIn: settings.telemetryOptIn,
+        // Absent === opted-in: light product analytics is on by default.
+        productAnalyticsOptIn: settings.productAnalyticsOptIn !== false,
         sessions: sessionManager.list(),
         workflows: await listWorkflows(),
         macros: listMacros(),

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -95,6 +95,7 @@ const bindWorkflowSchema = z.object({
 
 const settingsPatchSchema = z.object({
   telemetryOptIn: z.boolean().optional(),
+  productAnalyticsOptIn: z.boolean().optional(),
   recentDirs: z.array(z.string()).optional(),
   projectRoot: z.string().optional(),
   rollingSummary: z.boolean().optional(),

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -129,9 +129,11 @@ describe("createStaticRouter", () => {
       const html = await res.text();
       // The raw string must NOT appear verbatim — it must be JSON-escaped.
       expect(html).not.toContain(weirdToken);
-      // The safe (< → <) encoded form must be present in the page.
-      const safeJson = JSON.stringify({ token: weirdToken }).replace(/</g, "\\u003c");
-      expect(html).toContain(safeJson);
+      // The safe (< → <) encoded token value must be present in the page.
+      // (The injected payload also carries a `posthog` config, so assert on the
+      // escaped token value rather than the whole `{token}` object literal.)
+      const safeToken = JSON.stringify(weirdToken).replace(/</g, "\\u003c");
+      expect(html).toContain(safeToken);
       // The </script> breakout sequence from the token must not appear literally
       // — it would terminate the injected script block early and allow XSS.
       // The < is Unicode-escaped to < (inert to JSON.parse, opaque to

--- a/packages/harness/src/server/static.ts
+++ b/packages/harness/src/server/static.ts
@@ -4,10 +4,18 @@
  * `pnpm build:web`), so the server is still useful for API/WS-only testing.
  *
  * Boot-token injection: every HTML response has a `<script>` block baked in
- * before `</head>` that sets `window.__HARNESS__ = { token: ${bootToken} }`.
+ * before `</head>` that sets `window.__HARNESS__ = { token, posthog }`.
  * This lets `getBootToken()` (web/src/lib/api.ts) resolve the token without
  * relying on the `?token=` query param — which is lost on navigation/reload
  * and caused every /api POST to 401 after the first page load (SAP-1898).
+ *
+ * PostHog config injection (SAP-1988): the same `<script>` also carries the
+ * client PostHog project key + hosts, resolved server-side from env so ONE
+ * shipped bundle (CLI + Electron) works across environments without a
+ * build-time key. The token is a public client key by design; a documented
+ * default points at the Sapiom product project (291192). Set
+ * `SAPIOM_POSTHOG_KEY=""` (empty) to disable client analytics entirely — the
+ * provider skips init when no key is present.
  *
  * Implementation note: `express.static` serves index.html directly on `/`
  * requests, bypassing any downstream handlers. To guarantee injection we:
@@ -35,12 +43,44 @@ const PLACEHOLDER_HTML = `<!doctype html>
 `;
 
 /**
- * Builds the inline `<script>` that bakes the boot token into the page before
- * any SPA JS runs. JSON.stringify ensures the token is safely escaped even if
- * it contains characters that could break a bare string interpolation.
+ * The client PostHog config, or null when analytics is disabled (no key).
+ *
+ * `SAPIOM_POSTHOG_KEY` overrides the default; setting it to an empty string is
+ * an explicit opt-out that disables client capture (the provider skips init on
+ * a missing key). Hosts default to PostHog US cloud — `apiHost` is the ingest
+ * endpoint, `uiHost` keeps "view in PostHog" links pointing at the real app.
+ */
+interface PosthogClientConfig {
+  key: string;
+  apiHost: string;
+  uiHost: string;
+}
+
+/** Documented default client key — the Sapiom product project (291192). */
+const DEFAULT_POSTHOG_KEY = "phc_QmzsBloYUZJw7orDRBsEeV9Oz4lQ548cputd7RZ8pAq";
+
+function resolvePosthogConfig(): PosthogClientConfig | null {
+  // Explicit empty string disables; unset falls back to the default key.
+  const key = process.env.SAPIOM_POSTHOG_KEY ?? DEFAULT_POSTHOG_KEY;
+  if (!key.trim()) return null;
+  return {
+    key: key.trim(),
+    apiHost: process.env.SAPIOM_POSTHOG_HOST?.trim() || "https://us.i.posthog.com",
+    uiHost: process.env.SAPIOM_POSTHOG_UI_HOST?.trim() || "https://us.posthog.com",
+  };
+}
+
+/**
+ * Builds the inline `<script>` that bakes the boot token (and client PostHog
+ * config) into the page before any SPA JS runs. JSON.stringify ensures the
+ * values are safely escaped even if they contain characters that could break a
+ * bare string interpolation.
  */
 function buildTokenScript(bootToken: string): string {
-  const safeJson = JSON.stringify({ token: bootToken }).replace(/</g, "\\u003c");
+  const payload: { token: string; posthog?: PosthogClientConfig } = { token: bootToken };
+  const posthog = resolvePosthogConfig();
+  if (posthog) payload.posthog = posthog;
+  const safeJson = JSON.stringify(payload).replace(/</g, "\\u003c");
   return `<script>window.__HARNESS__ = ${safeJson};</script>`;
 }
 

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1025,8 +1025,24 @@ export interface AppState {
   version: string;
   authenticated: boolean;
   userId: string | null;
+  /**
+   * The Sapiom org/tenant id (SAP-1988). Exposed to the SPA so client PostHog
+   * can `group('organization', tenantId)` — segmenting studio usage by customer
+   * the same way the web app does. Null when unauthenticated. Today this equals
+   * `userId` (identity is org-scoped); kept as a distinct field so a real
+   * per-seat id can diverge later without touching the group binding.
+   */
+  tenantId: string | null;
   organizationName: string | null;
   telemetryOptIn: boolean;
+  /**
+   * Resolved light-product-analytics (PostHog) opt-in (SAP-1988). Defaults to
+   * true (on) when the user hasn't opted out. The SPA gates `posthog` capture
+   * on this AND on `consentSource !== "env-forced-off"` (the hard kill-switch,
+   * which always wins). Always present so the client never has to distinguish
+   * "absent" from "false".
+   */
+  productAnalyticsOptIn: boolean;
   /**
    * How telemetry consent was determined at CLI boot. The UI uses this to
    * decide whether to show the first-run notice: "default-silent" means the
@@ -1241,7 +1257,23 @@ export interface TemplateListResponse {
 }
 
 export interface HarnessSettings {
+  /**
+   * Opt-in to sending the *invasive* usage telemetry to Sapiom → BigQuery
+   * (prompts, tool calls, session detail). OFF by default (SAP-1988): a desktop
+   * tool that silently ships session content is a reputation risk, so this is
+   * opt-in via the setup screen with benefit-framed copy. Distinct from
+   * `productAnalyticsOptIn` (light PostHog clicks/journeys, on by default).
+   */
   telemetryOptIn: boolean;
+  /**
+   * Opt-OUT of light product analytics — PostHog autocapture clicks, journeys,
+   * and usage metrics with NO recording and NO prompt/user content (SAP-1988).
+   * ON by default (absent === true): this is non-invasive and mirrors the web
+   * app. Hard kill-switches (`SAPIOM_TELEMETRY_DISABLED` / `DO_NOT_TRACK` /
+   * `--no-telemetry`, surfaced as `AppState.consentSource === "env-forced-off"`)
+   * always win regardless of this flag.
+   */
+  productAnalyticsOptIn?: boolean;
   /** Most-recently-used project directories, newest first. */
   recentDirs: string[];
   /**

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -708,6 +708,10 @@ export const App = (): JSX.Element => {
           onToggleTelemetry={async (next) => {
             await harness.updateSettings({ telemetryOptIn: next });
           }}
+          productAnalyticsOptIn={state.productAnalyticsOptIn}
+          onToggleProductAnalytics={async (next) => {
+            await harness.updateSettings({ productAnalyticsOptIn: next });
+          }}
           rollingSummary={harness.settings?.rollingSummary === true}
           onToggleRollingSummary={async (next) => {
             await harness.updateSettings({ rollingSummary: next });
@@ -1085,6 +1089,10 @@ export const App = (): JSX.Element => {
           }}
           onDismiss={dismissWelcome}
           firstRun={state.firstRun === true}
+          telemetryOptIn={harness.settings?.telemetryOptIn ?? state.telemetryOptIn}
+          onToggleTelemetry={async (next) => {
+            await harness.updateSettings({ telemetryOptIn: next });
+          }}
         />
       )}
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -237,15 +237,19 @@ export const App = (): JSX.Element => {
   // pathname-derived journey — it has no router).
   useEffect(() => {
     if (!st) return;
+    const active = st.sessions.find((session) => session.id === harness.activeSessionId);
     const view: HarnessView = {
       firstRun: st.firstRun === true,
       settingsOpen,
       templatesOpen,
       hasLiveSession: st.sessions.some((session) => session.status !== "exited"),
+      // Reviewing a finished session (active session has exited) is the observe
+      // arc — without this the dead-session view falls through to `unknown`.
+      inspectingDeadSession: active?.status === "exited",
       rightTab,
     };
     registerViewContext(view);
-  }, [st, settingsOpen, templatesOpen, rightTab]);
+  }, [st, harness.activeSessionId, settingsOpen, templatesOpen, rightTab]);
 
   // Crossing the breakpoint resets both panes to that mode's default.
   const prevMobile = useRef(isMobile);

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -45,6 +45,9 @@ import { historyDirs } from "./lib/history-meta";
 import { resolveProjectRoot } from "./lib/project-dir";
 import { useTemplatePrompt, type StudioTemplate } from "./lib/templates";
 import { track } from "./lib/track";
+import { initAnalytics } from "./lib/analytics/posthog";
+import { registerViewContext, track as trackProduct } from "./lib/analytics/events";
+import type { HarnessView } from "./lib/analytics/journeys";
 import { resolveMacroUrl } from "./lib/macro-gating";
 import { directActionKind } from "./lib/macro-actions";
 import { sessionDisplayName } from "./lib/session-name";
@@ -213,6 +216,37 @@ export const App = (): JSX.Element => {
     setFocusedAgentPath(boundWorkflowPathOf(active) ?? harness.state.workflows[0]?.path ?? null);
   }, [harness.state, harness.activeSessionId]);
 
+  // Client PostHog (SAP-1988): init once state is known and re-sync identity +
+  // consent whenever they change. initAnalytics is idempotent and gates itself
+  // on the two consent tiers, so this is safe to call on every relevant change.
+  const st = harness.state;
+  useEffect(() => {
+    if (st) initAnalytics(st);
+  }, [
+    st,
+    st?.authenticated,
+    st?.userId,
+    st?.tenantId,
+    st?.consentSource,
+    st?.productAnalyticsOptIn,
+    st?.version,
+  ]);
+
+  // Stamp the current journey + view as PostHog super-properties so autocapture
+  // clicks group by arc of intent (the harness's replacement for the web app's
+  // pathname-derived journey — it has no router).
+  useEffect(() => {
+    if (!st) return;
+    const view: HarnessView = {
+      firstRun: st.firstRun === true,
+      settingsOpen,
+      templatesOpen,
+      hasLiveSession: st.sessions.some((session) => session.status !== "exited"),
+      rightTab,
+    };
+    registerViewContext(view);
+  }, [st, settingsOpen, templatesOpen, rightTab]);
+
   // Crossing the breakpoint resets both panes to that mode's default.
   const prevMobile = useRef(isMobile);
   useEffect(() => {
@@ -339,6 +373,7 @@ export const App = (): JSX.Element => {
     closeMobileDrawer();
     const session = await harness.createSession({ cwd, harness: agentHarness });
     track("session.created");
+    trackProduct("session.started", { harness_kind: agentHarness, origin: "user" });
     return session;
   };
 

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -17,11 +17,14 @@ interface SettingsPopoverProps {
   authenticated: boolean;
   organizationName: string | null;
   telemetryOptIn: boolean;
-  /** How consent was determined - "env-forced-off" locks the toggle. */
+  /** Light product-analytics (PostHog clicks/journeys) opt-in — on by default. */
+  productAnalyticsOptIn: boolean;
+  /** How consent was determined - "env-forced-off" locks BOTH toggles. */
   consentSource?: AppState["consentSource"];
   /** Which env var forced telemetry off, when consentSource is "env-forced-off". */
   consentEnvReason?: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  onToggleProductAnalytics: (next: boolean) => Promise<void>;
   /** `HarnessSettings.rollingSummary` — see the toggle's own note below. */
   rollingSummary: boolean;
   onToggleRollingSummary: (next: boolean) => Promise<void>;
@@ -35,9 +38,11 @@ export function SettingsPopover({
   authenticated,
   organizationName,
   telemetryOptIn,
+  productAnalyticsOptIn,
   consentSource,
   consentEnvReason,
   onToggleTelemetry,
+  onToggleProductAnalytics,
   rollingSummary,
   onToggleRollingSummary,
   onStartAuth,
@@ -49,6 +54,8 @@ export function SettingsPopover({
   // would silently lose to it on the next boot, so the control locks instead.
   const envForced = consentSource === "env-forced-off";
   const effectiveOptIn = envForced ? false : telemetryOptIn;
+  // The env kill-switch turns off ALL telemetry, product analytics included.
+  const effectiveProductAnalytics = envForced ? false : productAnalyticsOptIn;
 
   const handleToggle = async (): Promise<void> => {
     const next = !telemetryOptIn;
@@ -56,6 +63,17 @@ export function SettingsPopover({
     try {
       await onToggleTelemetry(next);
       track("consent.changed", { optIn: next });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggleProductAnalytics = async (): Promise<void> => {
+    const next = !productAnalyticsOptIn;
+    setBusy(true);
+    try {
+      await onToggleProductAnalytics(next);
+      track("consent.changed", { productAnalytics: next });
     } finally {
       setBusy(false);
     }
@@ -159,7 +177,7 @@ export function SettingsPopover({
       )}
 
       <label className="settings-toggle-row">
-        <span>Send usage analytics to Sapiom</span>
+        <span>Share session details with Sapiom</span>
         <button
           type="button"
           role="switch"
@@ -173,17 +191,39 @@ export function SettingsPopover({
         </button>
       </label>
 
-      {envForced && (
-        <p className="settings-note settings-env-note" data-testid="telemetry-env-note">
-          Analytics is turned off by {consentEnvReason ? `$${consentEnvReason}` : "an environment variable"}. Unset it
-          and restart the Studio server to manage consent here.
-        </p>
-      )}
+      <p className="settings-note">
+        Help us optimize your experience: with this on, your prompts, tool calls, and session
+        lifecycle events are shared with Sapiom so we can see where the Studio gets in your way.
+        Off by default. Always written locally to <code>{HARNESS_PATHS.events}</code> either way.
+      </p>
+
+      <label className="settings-toggle-row">
+        <span>Product analytics (clicks &amp; usage)</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={effectiveProductAnalytics}
+          data-testid="product-analytics-toggle"
+          className={"toggle-switch" + (effectiveProductAnalytics ? " is-on" : "")}
+          disabled={busy || envForced}
+          onClick={() => void handleToggleProductAnalytics()}
+        >
+          <span className="toggle-knob" />
+        </button>
+      </label>
 
       <p className="settings-note">
-        Prompts, tool calls, and session lifecycle events are always written locally to{" "}
-        <code>{HARNESS_PATHS.events}</code>. With your consent, they&rsquo;re also sent to Sapiom.
+        Anonymous-by-default usage: which buttons and screens you use, and how you move through the
+        Studio. No prompt text, no file contents, and never a screen recording. On by default; turn
+        it off here anytime.
       </p>
+
+      {envForced && (
+        <p className="settings-note settings-env-note" data-testid="telemetry-env-note">
+          All telemetry is turned off by {consentEnvReason ? `$${consentEnvReason}` : "an environment variable"}. Unset
+          it and restart the Studio server to manage consent here.
+        </p>
+      )}
 
       <label className="settings-toggle-row">
         <span>Summarize sessions in the background</span>

--- a/packages/harness/web/src/components/TelemetryNotice.tsx
+++ b/packages/harness/web/src/components/TelemetryNotice.tsx
@@ -24,8 +24,8 @@ export function TelemetryNotice({ onDismiss, onOpenSettings }: TelemetryNoticePr
     <div className="telemetry-notice" role="status" data-testid="telemetry-notice">
       <div className="telemetry-notice-body">
         <p className="telemetry-notice-text">
-          Analytics are <strong>on by default</strong>: usage events (including prompts and tool calls)
-          are collected locally and sent to Sapiom to help improve the product. Change this any time in{" "}
+          Sharing session details with Sapiom is <strong>off by default</strong>. Your prompts and
+          tool calls stay local unless you opt in to help us improve the Studio. Turn it on any time in{" "}
           <button
             className="telemetry-notice-settings-link"
             onClick={() => {

--- a/packages/harness/web/src/components/WelcomePanel.tsx
+++ b/packages/harness/web/src/components/WelcomePanel.tsx
@@ -13,6 +13,7 @@ import { recentWorkspaces, unlistedAgentCount } from "../lib/recent-workspaces";
 import { relativeTimeLabel } from "../lib/relative-time";
 import { loadUiPrefs } from "../lib/ui-prefs";
 import { useDismissable } from "../lib/use-dismissable";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 import { Icon } from "./Icon";
 import { AddWorkspaceDialog } from "./AddWorkspaceDialog";
 
@@ -61,6 +62,12 @@ interface WelcomePanelProps {
    * once. It used to select between two whole layouts.
    */
   firstRun: boolean;
+  /**
+   * Opt-in to sharing session detail with Sapiom (the invasive BQ tier). OFF by
+   * default — this is the first-run "setup screen" surface for it (SAP-1988).
+   */
+  telemetryOptIn: boolean;
+  onToggleTelemetry: (next: boolean) => Promise<void>;
 }
 
 /** How many workspace rows Overview shows before deferring to the rail.
@@ -105,6 +112,8 @@ export function WelcomePanel({
   onBrowseTemplates,
   onDismiss,
   firstRun,
+  telemetryOptIn,
+  onToggleTelemetry,
 }: WelcomePanelProps): JSX.Element {
   const [modalOpen, setModalOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -183,7 +192,7 @@ export function WelcomePanel({
             <Icon name="X" size={14} />
           </button>
 
-          <div className="welcome-body">
+          <div className="welcome-body" {...trackingAttrs({ surface: "welcome" })}>
             {/* One greeting, two readings: "Welcome to" is a thing you say once.
                 This card used to fork into two whole layouts — a product pitch for
                 a first run, an Overview list for a return — which meant the
@@ -232,6 +241,7 @@ export function WelcomePanel({
                 className="btn-primary welcome-open-cta"
                 data-testid="welcome-start-project"
                 onClick={() => setModalOpen(true)}
+                {...trackingAttrs({ object: "workspace", intent: "open_folder" })}
               >
                 Open folder
               </button>
@@ -256,6 +266,7 @@ export function WelcomePanel({
                 className="btn-line welcome-open-cta"
                 data-testid="welcome-browse-templates"
                 onClick={onBrowseTemplates}
+                {...trackingAttrs({ object: "template", intent: "browse_templates" })}
               >
                 Browse templates
               </button>
@@ -270,6 +281,29 @@ export function WelcomePanel({
             >
               Read documentation <Icon name="ArrowUpRight" size={12} />
             </a>
+
+            {/* Setup-screen opt-in for the invasive Sapiom→BQ tier (SAP-1988):
+                off by default, framed by the benefit. The light product
+                analytics (clicks/journeys) is a separate on-by-default tier
+                managed in Settings; this toggle is only about sharing session
+                detail with Sapiom. */}
+            <label className="welcome-consent" data-testid="welcome-consent">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={telemetryOptIn}
+                data-testid="welcome-telemetry-toggle"
+                className={"toggle-switch" + (telemetryOptIn ? " is-on" : "")}
+                onClick={() => void onToggleTelemetry(!telemetryOptIn)}
+              >
+                <span className="toggle-knob" />
+              </button>
+              <span className="welcome-consent-copy">
+                Help us optimize your experience — share your session details with
+                Sapiom so we can improve how the Studio works for you. Off by
+                default; change it anytime in Settings.
+              </span>
+            </label>
 
             {/* Where you have already been. Absent on a first run because there is
                 genuinely nothing to list — see lib/recent-workspaces.ts for why

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -81,12 +81,14 @@ interface WorkflowsRailProps {
   /** Push a message onto the app's toast rail (copy confirmations etc.). */
   onToast: (message: string) => void;
   telemetryOptIn: boolean;
+  productAnalyticsOptIn: boolean;
   rollingSummary: boolean;
   consentSource?: AppState["consentSource"];
   consentEnvReason?: string | null;
   authenticated: boolean;
   organizationName: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  onToggleProductAnalytics: (next: boolean) => Promise<void>;
   onToggleRollingSummary: (next: boolean) => Promise<void>;
   /** Kick off the browser OAuth flow for the in-app Connect button. */
   onStartAuth: () => Promise<AuthStartResponse>;
@@ -304,12 +306,14 @@ export function WorkflowsRail({
   onScanWorkflows,
   onToast,
   telemetryOptIn,
+  productAnalyticsOptIn,
   rollingSummary,
   consentSource,
   consentEnvReason,
   authenticated,
   organizationName,
   onToggleTelemetry,
+  onToggleProductAnalytics,
   onToggleRollingSummary,
   onStartAuth,
   onDisconnect,
@@ -707,10 +711,12 @@ export function WorkflowsRail({
           authenticated={authenticated}
           organizationName={organizationName}
           telemetryOptIn={telemetryOptIn}
+          productAnalyticsOptIn={productAnalyticsOptIn}
           rollingSummary={rollingSummary}
           consentSource={consentSource}
           consentEnvReason={consentEnvReason}
           onToggleTelemetry={onToggleTelemetry}
+          onToggleProductAnalytics={onToggleProductAnalytics}
           onToggleRollingSummary={onToggleRollingSummary}
           onStartAuth={onStartAuth}
           onDisconnect={onDisconnect}
@@ -781,10 +787,12 @@ function ProfileRow({
   authenticated,
   organizationName,
   telemetryOptIn,
+  productAnalyticsOptIn,
   rollingSummary,
   consentSource,
   consentEnvReason,
   onToggleTelemetry,
+  onToggleProductAnalytics,
   onToggleRollingSummary,
   onStartAuth,
   onDisconnect,
@@ -797,10 +805,12 @@ function ProfileRow({
   authenticated: boolean;
   organizationName: string | null;
   telemetryOptIn: boolean;
+  productAnalyticsOptIn: boolean;
   rollingSummary: boolean;
   consentSource?: AppState["consentSource"];
   consentEnvReason?: string | null;
   onToggleTelemetry: (next: boolean) => Promise<void>;
+  onToggleProductAnalytics: (next: boolean) => Promise<void>;
   onToggleRollingSummary: (next: boolean) => Promise<void>;
   onStartAuth: () => Promise<AuthStartResponse>;
   onDisconnect: () => Promise<void>;
@@ -910,10 +920,12 @@ function ProfileRow({
           authenticated={authenticated}
           organizationName={organizationName}
           telemetryOptIn={telemetryOptIn}
+          productAnalyticsOptIn={productAnalyticsOptIn}
           rollingSummary={rollingSummary}
           consentSource={consentSource}
           consentEnvReason={consentEnvReason}
           onToggleTelemetry={onToggleTelemetry}
+          onToggleProductAnalytics={onToggleProductAnalytics}
           onToggleRollingSummary={onToggleRollingSummary}
           onStartAuth={onStartAuth}
           onDisconnect={onDisconnect}

--- a/packages/harness/web/src/components/analytics/TrackScope.tsx
+++ b/packages/harness/web/src/components/analytics/TrackScope.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { type TrackingContext, trackingAttrs } from "../../lib/analytics/tracking-attrs";
+
+/**
+ * Attribute an entire subtree for autocapture without an `onClick` at every leaf
+ * (SAP-1988; ported from the web app's `TrackScope`).
+ *
+ * Renders a `display: contents` wrapper carrying `data-ph-capture-attribute-*`,
+ * so posthog-js inherits the context onto every click beneath it while the
+ * wrapper itself adds no box to the layout. Prefer spreading {@link trackingAttrs}
+ * directly onto an element you already have; reach for `TrackScope` only when you
+ * need to wrap a group that has no single natural host element.
+ */
+export function TrackScope({
+  children,
+  ...context
+}: TrackingContext & { children: ReactNode }): React.JSX.Element {
+  return (
+    <div style={{ display: "contents" }} {...trackingAttrs(context)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/analytics/before-send.test.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.test.ts
@@ -1,0 +1,79 @@
+import type { CaptureResult } from "posthog-js";
+import { describe, expect, it } from "vitest";
+
+import { beforeSend, sanitizeUrl } from "./before-send";
+
+function capture(event: string, properties: Record<string, unknown>, extra?: Partial<CaptureResult>): CaptureResult {
+  return { event, properties, ...extra } as CaptureResult;
+}
+
+describe("sanitizeUrl", () => {
+  it("strips the query string (which carries the boot token) and the fragment", () => {
+    expect(sanitizeUrl("http://localhost:4100/?token=super-secret")).toBe("http://localhost:4100/");
+    expect(sanitizeUrl("http://localhost:4100/workbench?token=x#frag")).toBe("http://localhost:4100/workbench");
+  });
+
+  it("passes non-URL / empty values through unchanged", () => {
+    expect(sanitizeUrl("not a url")).toBe("not a url");
+    expect(sanitizeUrl("")).toBe("");
+    expect(sanitizeUrl(undefined)).toBe(undefined);
+  });
+});
+
+describe("beforeSend", () => {
+  it("returns null/passthrough unchanged for a null result", () => {
+    expect(beforeSend(null)).toBeNull();
+  });
+
+  it("redacts the boot token from $current_url and person-property URLs", () => {
+    const result = capture(
+      "$pageview",
+      { $current_url: "http://localhost:4100/?token=secret" },
+      { $set_once: { $initial_current_url: "http://localhost:4100/?token=secret" } },
+    );
+    const out = beforeSend(result)!;
+    expect((out.properties as Record<string, unknown>).$current_url).toBe("http://localhost:4100/");
+    expect((out.$set_once as Record<string, unknown>).$initial_current_url).toBe("http://localhost:4100/");
+  });
+
+  it("truncates long click text on a normal surface but keeps it", () => {
+    const long = "x".repeat(300);
+    const out = beforeSend(capture("$autocapture", { $el_text: long, surface: "agent_rail" }))!;
+    const text = (out.properties as Record<string, unknown>).$el_text as string;
+    expect(text.length).toBeLessThan(300);
+    expect(text.endsWith("…")).toBe(true);
+  });
+
+  it("DROPS click text entirely on a secrets surface", () => {
+    const out = beforeSend(
+      capture("$autocapture", { $el_text: "sk-live-abc123", surface: "secrets_panel" }),
+    )!;
+    expect((out.properties as Record<string, unknown>).$el_text).toBeUndefined();
+  });
+
+  it("scrubs $elements attributes on a secrets surface but keeps class/id", () => {
+    const out = beforeSend(
+      capture("$autocapture", {
+        object: "secret",
+        $elements: [{ $el_text: "sk-live-abc", attr__aria_label: "copy sk-live-abc", attr__class: "btn", attr__id: "copy" }],
+      }),
+    )!;
+    const el = (out.properties as { $elements: Record<string, unknown>[] }).$elements[0];
+    expect(el.$el_text).toBeUndefined();
+    expect(el.attr__aria_label).toBeUndefined();
+    expect(el.attr__class).toBe("btn");
+    expect(el.attr__id).toBe("copy");
+  });
+
+  it("never throws — passes the event through if a property is malformed", () => {
+    // A getter that throws should not take down capture.
+    const props: Record<string, unknown> = {};
+    Object.defineProperty(props, "$current_url", {
+      get() {
+        throw new Error("boom");
+      },
+      enumerable: true,
+    });
+    expect(() => beforeSend(capture("$autocapture", props))).not.toThrow();
+  });
+});

--- a/packages/harness/web/src/lib/analytics/before-send.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.ts
@@ -1,0 +1,171 @@
+import type { CaptureResult } from "posthog-js";
+
+/**
+ * The one middleware every client event passes through (SAP-1988; ported and
+ * trimmed from the web app's `before-send.ts`).
+ *
+ * posthog-js calls `before_send` for every capture — autocaptured, manual, and
+ * internal (`$pageview`, `$feature_flag_called`) alike — which makes it the only
+ * place a rule applies to *all* telemetry without touching a call site. In the
+ * harness its job is **redaction** (the web app also enriches with a journey and
+ * drops replay snapshots here; the harness sets journey as a super-property and
+ * never records, so both are gone):
+ *
+ * 1. **Strip URL secrets.** The harness serves itself at
+ *    `http://localhost:<port>/?token=<bootToken>` — the boot token is a live
+ *    credential sitting in `$current_url` on every event. Drop ALL query params
+ *    and fragments (the harness has no attribution params worth keeping).
+ * 2. **Redact click text.** Truncate autocaptured `$el_text` everywhere, and
+ *    drop it entirely on a secrets/vault surface, where a copy-button's label or
+ *    a field value can be the secret itself.
+ *
+ * Never throws: posthog-js does not guard this callback, so an exception here
+ * would take down capture for the whole page. On failure we pass the event
+ * through unmodified rather than losing it.
+ */
+
+/** Upper bound on retained click text — longer runs are likely user content. */
+const MAX_EL_TEXT_LENGTH = 120;
+
+/**
+ * Element attributes kept when scrubbing a secrets surface. `class`/`id` survive
+ * because heatmaps and PostHog Actions match on them and neither is a plausible
+ * place for a credential; everything else (aria-label, title, value, placeholder)
+ * is dropped because any of them can carry the secret.
+ */
+const KEPT_ELEMENT_ATTRIBUTES: ReadonlySet<string> = new Set(["attr__class", "attr__id"]);
+
+/** `attr__href` values inside the serialized `$elements_chain` string. */
+const CHAIN_HREF_PATTERN = /attr__href="([^"]*)"/gi;
+
+/** Person-property keys whose values are URLs, matched by suffix. */
+const URL_VALUED_PERSON_PROPERTIES = /(?:current_url|referrer|pathname)$/;
+
+/**
+ * Whether the event's autocapture attribution marks it as coming from a
+ * secrets/vault surface — the container is tagged `surface: "secrets_panel"`
+ * (or `object: "secret"`) via `trackingAttrs`, so the marker rides on the event
+ * itself and we can redact without knowing a pathname (the harness has none).
+ */
+function isSecretSurface(properties: Record<string, unknown>): boolean {
+  const surface = typeof properties.surface === "string" ? properties.surface.toLowerCase() : "";
+  const object = typeof properties.object === "string" ? properties.object.toLowerCase() : "";
+  return /secret|vault|credential/.test(surface) || /secret|vault|credential/.test(object);
+}
+
+/**
+ * Strip the query string and fragment from an absolute URL, keeping only
+ * origin + path. Returns the input unchanged if it does not parse, since a
+ * non-URL value here means our assumption is wrong and silently blanking it
+ * would lose more than it protects.
+ */
+export function sanitizeUrl(rawUrl: unknown): unknown {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+  // The harness carries no attribution params — drop the whole query (which
+  // includes the boot token) and any fragment.
+  return `${url.origin}${url.pathname}`;
+}
+
+/** Truncate retained click text with an ellipsis marker. */
+function truncateElementText(text: string): string {
+  return text.length > MAX_EL_TEXT_LENGTH ? `${text.slice(0, MAX_EL_TEXT_LENGTH)}…` : text;
+}
+
+/** Scrub one entry of `properties.$elements`. */
+function scrubElement(element: Record<string, unknown>, isSecret: boolean): void {
+  if (isSecret) {
+    delete element.$el_text;
+    for (const key of Object.keys(element)) {
+      if (key.startsWith("attr__") && !KEPT_ELEMENT_ATTRIBUTES.has(key)) delete element[key];
+    }
+    return;
+  }
+  if (typeof element.$el_text === "string") {
+    element.$el_text = truncateElementText(element.$el_text);
+  }
+  if (typeof element.attr__href === "string") {
+    element.attr__href = sanitizeUrl(element.attr__href);
+  }
+}
+
+/**
+ * Scrub the two nested carriers of autocaptured element data. posthog-js emits
+ * **either** `$elements` (array) or `$elements_chain` (string) depending on
+ * remote config, so both are handled — a server-side flip cannot silently start
+ * leaking.
+ */
+function scrubElementCarriers(properties: Record<string, unknown>, isSecret: boolean): void {
+  const elements = properties.$elements;
+  if (Array.isArray(elements)) {
+    for (const element of elements) {
+      if (element && typeof element === "object") scrubElement(element as Record<string, unknown>, isSecret);
+    }
+  }
+
+  if (typeof properties.$elements_chain !== "string") return;
+  if (isSecret) {
+    delete properties.$elements_chain;
+    return;
+  }
+  properties.$elements_chain = properties.$elements_chain.replace(CHAIN_HREF_PATTERN, (match, href: string) => {
+    const sanitized = sanitizeUrl(href);
+    return typeof sanitized === "string" ? `attr__href="${sanitized}"` : match;
+  });
+}
+
+/**
+ * Sanitize every URL-valued field on the event, including the `$set`/`$set_once`
+ * person-property bags (siblings of `properties`, not members of it) — posthog-js
+ * writes `$initial_current_url` there, which would otherwise pin the boot-token
+ * URL onto the person profile permanently.
+ */
+function redactUrls(result: CaptureResult, properties: Record<string, unknown>): void {
+  properties.$current_url = sanitizeUrl(properties.$current_url);
+  properties.$referrer = sanitizeUrl(properties.$referrer);
+
+  for (const bag of [result.$set, result.$set_once]) {
+    if (!bag) continue;
+    const personProperties = bag as Record<string, unknown>;
+    for (const key of Object.keys(personProperties)) {
+      if (URL_VALUED_PERSON_PROPERTIES.test(key)) personProperties[key] = sanitizeUrl(personProperties[key]);
+    }
+  }
+}
+
+/** Redact autocaptured click text — the top-level `$el_text` and the nested carriers. */
+function redactClickText(properties: Record<string, unknown>, isSecret: boolean): void {
+  if (typeof properties.$el_text === "string") {
+    if (isSecret) {
+      delete properties.$el_text;
+    } else {
+      properties.$el_text = truncateElementText(properties.$el_text);
+    }
+  }
+  scrubElementCarriers(properties, isSecret);
+}
+
+/** `before_send` implementation. Returns `null` to drop an event (never used today). */
+export function beforeSend(result: CaptureResult | null): CaptureResult | null {
+  if (!result) return result;
+  try {
+    const properties = (result.properties ?? {}) as Record<string, unknown>;
+    const secret = isSecretSurface(properties);
+
+    redactUrls(result, properties);
+    redactClickText(properties, secret);
+
+    result.properties = properties;
+    return result;
+  } catch {
+    // Pass through unmodified — dropping telemetry is worse than un-redacted
+    // telemetry only in the sense that an unhandled throw here breaks capture
+    // page-wide; the URL/token risk is mitigated by posthog's own config too.
+    return result;
+  }
+}

--- a/packages/harness/web/src/lib/analytics/events.ts
+++ b/packages/harness/web/src/lib/analytics/events.ts
@@ -1,0 +1,157 @@
+import posthog from "posthog-js";
+
+import { type HarnessView, type Journey, journeyForView } from "./journeys";
+
+/**
+ * Typed event registry for the Studio (SAP-1988; ported from the web app's
+ * `events.ts`).
+ *
+ * ## What belongs here, and what does not
+ *
+ * Autocapture + `trackingAttrs` already covers **intent** — every click, with
+ * journey and surface attribution, for free. This registry is for the half
+ * autocapture is blind to: **outcomes and non-DOM state transitions.** "They
+ * clicked Deploy" is autocaptured; "the deploy succeeded 4s later" or "the run
+ * failed" is not, and that gap is where the launch-scorecard funnel lives.
+ *
+ * - A user pressed something → rely on autocapture + `trackingAttrs`.
+ * - A run/deploy changed state, a secret write failed, a turn got stuck → add it
+ *   here.
+ *
+ * ## Naming
+ *
+ * `<object>.<action>`, snake_case within segments — dotted to namespace, the same
+ * convention the web app moved to. Payloads are snake_case and ids stay strings
+ * so a breakdown never splits across a number/string of the same id.
+ *
+ * ## Privacy
+ *
+ * NEVER put prompt text, file contents, secret values, or any user content in a
+ * payload — the same rule the BQ `track()` enforces. Only ids, enums, counts,
+ * and durations.
+ */
+export interface AnalyticsEventMap {
+  /** A new Studio session was created (the studio's own "session start"). */
+  "session.started": {
+    harness_kind?: string;
+    /** Whether this was the auto-created boot session vs a user-created one. */
+    origin?: "boot" | "user";
+  };
+
+  /** A workflow/agent run was triggered from the Studio. */
+  "agent.run_started": {
+    workflow_slug?: string;
+    session_id?: string;
+  };
+  /** A run reached a terminal success. */
+  "agent.run_succeeded": {
+    workflow_slug?: string;
+    session_id?: string;
+    duration_ms?: number;
+  };
+  /** A run reached a terminal failure. `error_kind` is an enum, never a message. */
+  "agent.run_failed": {
+    workflow_slug?: string;
+    session_id?: string;
+    duration_ms?: number;
+    error_kind?: string;
+  };
+
+  /** A deploy was initiated from the Studio. */
+  "agent.deploy_started": { workflow_slug?: string };
+  /** A deploy completed successfully. */
+  "agent.deploy_succeeded": { workflow_slug?: string; duration_ms?: number };
+  /** A deploy failed. `error_kind` is an enum, never a message. */
+  "agent.deploy_failed": { workflow_slug?: string; error_kind?: string };
+
+  /** A template was cloned into a new workspace/agent. */
+  "agent.template_cloned": {
+    template_slug?: string;
+    /** Where the clone was initiated from, for the on-ramp breakdown. */
+    surface?: "welcome" | "template_gallery" | "template_detail";
+  };
+
+  /** The secrets/vault panel was opened — the friction surface that motivated this work. */
+  "secrets.panel_opened": { session_id?: string };
+  /** A secret/env var was set successfully. */
+  "secrets.set_succeeded": { session_id?: string };
+  /** Setting a secret failed. `error_kind` is an enum, never a message or value. */
+  "secrets.set_failed": { session_id?: string; error_kind?: string };
+
+  /**
+   * The agent appears stuck — repeated tool errors or a turn making no progress.
+   * The signal we'd have wanted when Yash & Oded got stuck on vault/secrets.
+   */
+  "agent.turn_stuck": {
+    session_id?: string;
+    /** What we think it's stuck on, as a coarse enum: e.g. "secrets", "tool_error". */
+    stuck_on?: string;
+    /** How many consecutive failing/repeating tool calls triggered the signal. */
+    repeats?: number;
+  };
+}
+
+/**
+ * Emit a custom event. The only way to fire a non-autocapture event — an
+ * unregistered name is a type error, which keeps the taxonomy from drifting one
+ * ad-hoc `posthog.capture` at a time. Best-effort: wrapped so a capture failure
+ * never breaks the measured flow.
+ */
+export function track<K extends keyof AnalyticsEventMap>(event: K, properties: AnalyticsEventMap[K]): void {
+  try {
+    posthog.capture(event, properties);
+  } catch {
+    // Analytics must never break the UI.
+  }
+}
+
+/**
+ * Super properties that ride on every subsequent event (including autocaptured
+ * clicks with no call site to thread context through). Set once identity/app
+ * context is known and re-set when it changes.
+ */
+export interface AppContextProperties {
+  active_organization_id?: string;
+  app_version?: string;
+  harness_kind?: string;
+  /** Which host is running the SPA — "cli" (npx) or "desktop" (Electron). */
+  harness_host?: string;
+}
+
+export function registerAppContext(context: AppContextProperties): void {
+  try {
+    // Drop undefineds so they never land as the string "undefined".
+    const clean: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(context)) {
+      if (v !== undefined && v !== null && v !== "") clean[k] = v;
+    }
+    posthog.register(clean);
+  } catch {
+    // no-op
+  }
+}
+
+/**
+ * Stamp the current journey + a coarse view label as super properties, so every
+ * event — autocapture included — is groupable by arc of intent. This is the
+ * harness's replacement for the web app's pathname-derived `before_send`
+ * enrichment; called by App whenever its view state changes.
+ */
+export function registerViewContext(view: HarnessView): void {
+  try {
+    const journey: Journey = journeyForView(view);
+    posthog.register({ journey, view: coarseViewLabel(view) });
+  } catch {
+    // no-op
+  }
+}
+
+/** A stable, low-cardinality label for the current view, for breakdowns. */
+function coarseViewLabel(view: HarnessView): string {
+  if (view.settingsOpen) return "settings";
+  if (view.firstRun && !view.hasLiveSession) return "welcome";
+  if (view.templatesOpen) return "templates";
+  if (view.hasLiveSession) return `workbench:${view.rightTab ?? "chat"}`;
+  if (view.inspectingDeadSession) return "session_history";
+  return "unknown";
+}

--- a/packages/harness/web/src/lib/analytics/journeys.test.ts
+++ b/packages/harness/web/src/lib/analytics/journeys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { type HarnessView, journeyForView } from "./journeys";
+
+describe("journeyForView", () => {
+  it("returns unknown for null/undefined/empty", () => {
+    expect(journeyForView(null)).toBe("unknown");
+    expect(journeyForView(undefined)).toBe("unknown");
+    expect(journeyForView({})).toBe("unknown");
+  });
+
+  it("classifies the settings surface as account, above everything else", () => {
+    const view: HarnessView = { settingsOpen: true, hasLiveSession: true, templatesOpen: true };
+    expect(journeyForView(view)).toBe("account");
+  });
+
+  it("classifies the first-run welcome (no session) as onboarding", () => {
+    expect(journeyForView({ firstRun: true, hasLiveSession: false })).toBe("onboarding");
+  });
+
+  it("does NOT treat first-run as onboarding once a session is live", () => {
+    expect(journeyForView({ firstRun: true, hasLiveSession: true })).toBe("agent_build");
+  });
+
+  it("classifies browsing templates as agent_build (the authoring on-ramp)", () => {
+    expect(journeyForView({ templatesOpen: true })).toBe("agent_build");
+  });
+
+  it("splits a live session by right tab: operate vs observe vs build", () => {
+    expect(journeyForView({ hasLiveSession: true, rightTab: "canvas" })).toBe("agent_operate");
+    expect(journeyForView({ hasLiveSession: true, rightTab: "preview" })).toBe("agent_operate");
+    expect(journeyForView({ hasLiveSession: true, rightTab: "logs" })).toBe("agent_observe");
+    expect(journeyForView({ hasLiveSession: true, rightTab: "diff" })).toBe("agent_observe");
+    // Chatting/iterating with no operate tab focused is authoring.
+    expect(journeyForView({ hasLiveSession: true, rightTab: "steps" })).toBe("agent_build");
+    expect(journeyForView({ hasLiveSession: true, rightTab: null })).toBe("agent_build");
+  });
+
+  it("classifies inspecting a dead session as observe", () => {
+    expect(journeyForView({ hasLiveSession: false, inspectingDeadSession: true })).toBe("agent_observe");
+  });
+});

--- a/packages/harness/web/src/lib/analytics/journeys.ts
+++ b/packages/harness/web/src/lib/analytics/journeys.ts
@@ -1,0 +1,85 @@
+/**
+ * Journey taxonomy for the Studio (SAP-1988) — the harness port of the web
+ * app's `frontend/src/lib/analytics/journeys.ts`.
+ *
+ * A "journey" is the arc of intent a user is in, stamped on every event so
+ * autocapture is groupable by intent instead of raw UI coordinates. The web app
+ * derives it from the URL pathname; the harness has **no router and no
+ * pathname** — it is a single-page shell with internal view state — so we
+ * classify from a small {@link HarnessView} descriptor the App computes from its
+ * live state instead.
+ *
+ * The `Journey` union is intentionally identical to the web app's so studio and
+ * web events share one `journey` vocabulary and can sit in the same PostHog
+ * funnels. The harness only ever emits the subset it can reach; the rest exist
+ * for cross-surface compatibility.
+ */
+
+/** The arcs of intent we analyse. Mirrors the web app's union verbatim. */
+export type Journey =
+  | "auth"
+  | "onboarding"
+  | "overview"
+  | "agent_build"
+  | "agent_operate"
+  | "agent_observe"
+  | "capabilities"
+  | "assistant"
+  | "account"
+  | "internal_demo"
+  | "unknown";
+
+/**
+ * The minimal view descriptor the App derives from its own state. Deliberately
+ * decoupled from App's concrete state variable names so this module stays pure
+ * and unit-testable — App maps its state onto this shape once (see
+ * `viewForAppState` at the call site).
+ */
+export interface HarnessView {
+  /** First-run welcome overlay is showing (no prior harness use, no live session). */
+  readonly firstRun?: boolean;
+  /** The settings popover / account surface is open. */
+  readonly settingsOpen?: boolean;
+  /** The template gallery is open. */
+  readonly templatesOpen?: boolean;
+  /** There is at least one live (running) agent session. */
+  readonly hasLiveSession?: boolean;
+  /** The currently-selected session is a dead/historical one being inspected. */
+  readonly inspectingDeadSession?: boolean;
+  /** The active right-hand tab, when a session is open: canvas | preview | logs | diff … */
+  readonly rightTab?: string | null;
+}
+
+/**
+ * Classify a view descriptor into its journey. Order matters — the most
+ * specific, highest-intent signal wins. Returns `'unknown'` for a shape no rule
+ * matched rather than guessing, so `unknown` surfacing in analysis is the
+ * signal that this table needs a new rule (same discipline as the web app).
+ */
+export function journeyForView(view: HarnessView | null | undefined): Journey {
+  if (!view) return "unknown";
+
+  // Account/settings is a modal surface that outlives whatever is behind it.
+  if (view.settingsOpen) return "account";
+
+  // First-run welcome is the onboarding arc, before any session exists.
+  if (view.firstRun && !view.hasLiveSession) return "onboarding";
+
+  // Browsing templates is where building starts (the on-ramp to authoring).
+  if (view.templatesOpen) return "agent_build";
+
+  // With a live session, the right-hand tab distinguishes operating a run
+  // (canvas/preview — watching it do the thing) from observing it (logs/diff).
+  if (view.hasLiveSession) {
+    const tab = view.rightTab ?? "";
+    if (tab === "logs" || tab === "diff") return "agent_observe";
+    if (tab === "canvas" || tab === "preview") return "agent_operate";
+    // Chatting/iterating in the workbench with no operate tab focused: authoring.
+    return "agent_build";
+  }
+
+  // Inspecting a finished/dead session is the observe arc.
+  if (view.inspectingDeadSession) return "agent_observe";
+
+  return "unknown";
+}

--- a/packages/harness/web/src/lib/analytics/posthog.test.ts
+++ b/packages/harness/web/src/lib/analytics/posthog.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppState } from "@shared/types";
+
+// Mock the posthog-js singleton so we can assert on init/opt-in/opt-out without
+// a browser. `vi.hoisted` so the mock object exists before the hoisted vi.mock
+// factory references it. Also satisfies events.ts's import (register/capture).
+const ph = vi.hoisted(() => {
+  const m: {
+    __loaded: boolean;
+    init: ReturnType<typeof vi.fn>;
+    opt_in_capturing: ReturnType<typeof vi.fn>;
+    opt_out_capturing: ReturnType<typeof vi.fn>;
+    has_opted_out_capturing: ReturnType<typeof vi.fn>;
+    identify: ReturnType<typeof vi.fn>;
+    group: ReturnType<typeof vi.fn>;
+    register: ReturnType<typeof vi.fn>;
+    reset: ReturnType<typeof vi.fn>;
+    capture: ReturnType<typeof vi.fn>;
+  } = {
+    __loaded: false,
+    init: vi.fn(() => {
+      m.__loaded = true;
+    }),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    has_opted_out_capturing: vi.fn(() => false),
+    identify: vi.fn(),
+    group: vi.fn(),
+    register: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  };
+  return m;
+});
+
+vi.mock("posthog-js", () => ({ default: ph }));
+
+import { initAnalytics, resetAnalyticsForTest } from "./posthog";
+
+function appState(over: Partial<AppState> = {}): AppState {
+  return {
+    version: "test",
+    authenticated: true,
+    userId: "u1",
+    tenantId: "t1",
+    organizationName: "Acme",
+    telemetryOptIn: false,
+    productAnalyticsOptIn: true,
+    sessions: [],
+    workflows: [],
+    macros: [],
+    launchDir: "/tmp",
+    ...over,
+  } as AppState;
+}
+
+describe("initAnalytics consent gate", () => {
+  beforeEach(() => {
+    resetAnalyticsForTest();
+    ph.__loaded = false;
+    for (const fn of [
+      ph.init,
+      ph.opt_in_capturing,
+      ph.opt_out_capturing,
+      ph.identify,
+      ph.group,
+      ph.reset,
+    ]) {
+      fn.mockClear();
+    }
+    ph.has_opted_out_capturing.mockReturnValue(false);
+    vi.stubGlobal("window", {
+      __HARNESS__: { posthog: { key: "phc_test", apiHost: "https://h", uiHost: "https://u" } },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT init when env-forced-off — the hard kill-switch always wins", () => {
+    initAnalytics(appState({ consentSource: "env-forced-off" }));
+    expect(ph.init).not.toHaveBeenCalled();
+  });
+
+  it("does NOT init when light product analytics is opted out", () => {
+    initAnalytics(appState({ productAnalyticsOptIn: false }));
+    expect(ph.init).not.toHaveBeenCalled();
+  });
+
+  it("inits, identifies, and binds the org group when consent is on", () => {
+    initAnalytics(appState());
+    expect(ph.init).toHaveBeenCalledTimes(1);
+    expect(ph.identify).toHaveBeenCalledWith("u1");
+    expect(ph.group).toHaveBeenCalledWith(
+      "organization",
+      "t1",
+      expect.objectContaining({ name: "Acme" }),
+    );
+  });
+
+  it("never captures without an injected key (analytics disabled)", () => {
+    vi.stubGlobal("window", { __HARNESS__: {} });
+    initAnalytics(appState());
+    expect(ph.init).not.toHaveBeenCalled();
+  });
+
+  it("opts out when consent flips off after init", () => {
+    initAnalytics(appState());
+    expect(ph.init).toHaveBeenCalledTimes(1);
+    initAnalytics(appState({ productAnalyticsOptIn: false }));
+    expect(ph.opt_out_capturing).toHaveBeenCalled();
+  });
+
+  it("inits lazily only once consent flips on", () => {
+    initAnalytics(appState({ productAnalyticsOptIn: false }));
+    expect(ph.init).not.toHaveBeenCalled();
+    initAnalytics(appState({ productAnalyticsOptIn: true }));
+    expect(ph.init).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/harness/web/src/lib/analytics/posthog.ts
+++ b/packages/harness/web/src/lib/analytics/posthog.ts
@@ -1,0 +1,175 @@
+import posthog from "posthog-js";
+
+import type { AppState } from "@shared/types";
+
+import { beforeSend } from "./before-send";
+import { registerAppContext } from "./events";
+
+/**
+ * Client PostHog wiring for the Studio (SAP-1988).
+ *
+ * The web app mounts a React `<PostHogProvider>`; the harness is a single-page
+ * shell that already owns its `AppState`, so we skip the provider and drive the
+ * posthog singleton directly:
+ *
+ *   - {@link initAnalytics} runs once, the first time `AppState` is known, so the
+ *     consent decision is atomic — there is no window where an opted-out or
+ *     env-forced-off user captures anything before consent loads.
+ *   - {@link syncConsent} / {@link syncIdentity} re-run whenever consent or
+ *     identity changes (a Settings toggle, a sign-in).
+ *
+ * Two consent tiers gate this (see HarnessSettings): a hard kill-switch
+ * (`consentSource === "env-forced-off"`, i.e. `SAPIOM_TELEMETRY_DISABLED` /
+ * `DO_NOT_TRACK` / `--no-telemetry`) always wins; otherwise the light
+ * product-analytics opt-in (`productAnalyticsOptIn`, on by default) decides.
+ *
+ * NO session/screen recording is ever initialized.
+ */
+
+/** The PostHog config the server bakes into `window.__HARNESS__.posthog`. */
+interface InjectedPosthog {
+  key: string;
+  apiHost: string;
+  uiHost: string;
+}
+
+function injectedConfig(): InjectedPosthog | null {
+  if (typeof window === "undefined") return null;
+  // Never send real analytics from Playwright mock mode.
+  if (import.meta.env.VITE_MOCK) return null;
+  const injected = (window as unknown as { __HARNESS__?: { posthog?: InjectedPosthog } }).__HARNESS__;
+  const cfg = injected?.posthog;
+  if (!cfg?.key) return null;
+  return cfg;
+}
+
+/** The hard kill-switch: env/flag forced telemetry off for this boot. */
+function isHardOff(state: AppState): boolean {
+  return state.consentSource === "env-forced-off";
+}
+
+/** Whether light product analytics should capture, given both consent tiers. */
+function shouldCapture(state: AppState): boolean {
+  return !isHardOff(state) && state.productAnalyticsOptIn;
+}
+
+let initialized = false;
+
+/**
+ * Initialize PostHog once, gated on consent. Idempotent — later calls only
+ * re-sync consent/identity. Safe to call with any `AppState`.
+ */
+export function initAnalytics(state: AppState): void {
+  if (initialized) {
+    syncConsent(state);
+    syncIdentity(state);
+    return;
+  }
+  const cfg = injectedConfig();
+  if (!cfg) return; // analytics disabled (no key, or mock mode)
+  if (posthog.__loaded) {
+    initialized = true;
+    syncConsent(state);
+    syncIdentity(state);
+    return;
+  }
+
+  const optOutToStart = !shouldCapture(state);
+
+  posthog.init(cfg.key, {
+    api_host: cfg.apiHost,
+    ui_host: cfg.uiHost,
+
+    // One "studio opened" signal per app load. The harness has no router, so
+    // there are no SPA route changes to capture — journey context rides as a
+    // super property (see events.registerViewContext) instead.
+    capture_pageview: true,
+    capture_pageleave: true,
+    autocapture: true,
+
+    // Clickmaps + scrollmaps (fed by autocapture + $pageleave, both on).
+    enable_heatmaps: true,
+    // Clicks that hit nothing — the highest-signal frustration metric.
+    capture_dead_clicks: true,
+
+    // Single choke point for redaction. See before-send.ts.
+    before_send: beforeSend,
+
+    // Persist distinct id + the failed-request retry queue to localStorage so
+    // events captured offline (intermittent desktop/CLI connectivity) survive a
+    // reload and flush on reconnect. posthog-js batches and retries by default;
+    // localStorage persistence is what makes that durable across restarts.
+    persistence: "localStorage",
+
+    // NO recording. This is a tool running on someone's desktop — we never
+    // capture the screen, and disabling it explicitly guards against a remote
+    // config flip turning it on.
+    disable_session_recording: true,
+
+    // Respect our own hard kill-switch from the first event: when consent is
+    // off we start opted-out so the load-time $pageview never fires either.
+    opt_out_capturing_by_default: optOutToStart,
+  });
+
+  initialized = true;
+  syncConsent(state);
+  syncIdentity(state);
+}
+
+/**
+ * Bring posthog's capturing state in line with the two consent tiers. Called on
+ * init and whenever consent changes (Settings toggle).
+ */
+export function syncConsent(state: AppState): void {
+  if (!initialized) return;
+  try {
+    if (shouldCapture(state)) {
+      if (posthog.has_opted_out_capturing()) posthog.opt_in_capturing();
+    } else if (!posthog.has_opted_out_capturing()) {
+      posthog.opt_out_capturing();
+    }
+  } catch {
+    // no-op
+  }
+}
+
+/**
+ * Identify the person and bind their org group so studio usage is segmentable by
+ * customer, exactly like the web app. Org id is `tenantId` (identity is
+ * org-scoped today; `userId === tenantId`). Resets on a real sign-out so the next
+ * user doesn't inherit the previous org binding.
+ */
+let identifiedUserId: string | null = null;
+
+export function syncIdentity(state: AppState): void {
+  if (!initialized) return;
+  try {
+    if (state.authenticated && state.userId) {
+      identifiedUserId = state.userId;
+      posthog.identify(state.userId);
+      if (state.tenantId) {
+        posthog.group("organization", state.tenantId, {
+          ...(state.organizationName ? { name: state.organizationName } : {}),
+        });
+      }
+      registerAppContext({
+        active_organization_id: state.tenantId ?? undefined,
+        app_version: state.version,
+      });
+      return;
+    }
+    // Reset only on a real identified → anonymous transition.
+    if (identifiedUserId) {
+      identifiedUserId = null;
+      posthog.reset();
+    }
+  } catch {
+    // no-op
+  }
+}
+
+/** Test-only: reset module state between cases. */
+export function resetAnalyticsForTest(): void {
+  initialized = false;
+  identifiedUserId = null;
+}

--- a/packages/harness/web/src/lib/analytics/posthog.ts
+++ b/packages/harness/web/src/lib/analytics/posthog.ts
@@ -67,14 +67,23 @@ export function initAnalytics(state: AppState): void {
   }
   const cfg = injectedConfig();
   if (!cfg) return; // analytics disabled (no key, or mock mode)
+
+  // Do NOT init while consent is off (env-forced-off, or the light-analytics
+  // opt-out). Relying on `opt_out_capturing_by_default` is not enough: with
+  // `persistence: "localStorage"` posthog restores a prior opt-IN preference,
+  // which takes precedence over that flag and would fire the load-time
+  // $pageview before syncConsent could opt out. Not calling init() at all is
+  // the only way to honor the hard kill-switch's "never fires" guarantee. When
+  // consent later flips on (a Settings toggle re-runs this effect with
+  // `initialized` still false), we init then.
+  if (!shouldCapture(state)) return;
+
   if (posthog.__loaded) {
     initialized = true;
     syncConsent(state);
     syncIdentity(state);
     return;
   }
-
-  const optOutToStart = !shouldCapture(state);
 
   posthog.init(cfg.key, {
     api_host: cfg.apiHost,
@@ -105,13 +114,11 @@ export function initAnalytics(state: AppState): void {
     // capture the screen, and disabling it explicitly guards against a remote
     // config flip turning it on.
     disable_session_recording: true,
-
-    // Respect our own hard kill-switch from the first event: when consent is
-    // off we start opted-out so the load-time $pageview never fires either.
-    opt_out_capturing_by_default: optOutToStart,
   });
 
   initialized = true;
+  // syncConsent flips a stale localStorage opt-out back on (we only reach here
+  // when consent is on); syncIdentity binds the person + org group.
   syncConsent(state);
   syncIdentity(state);
 }

--- a/packages/harness/web/src/lib/analytics/tracking-attrs.ts
+++ b/packages/harness/web/src/lib/analytics/tracking-attrs.ts
@@ -1,0 +1,69 @@
+import type { Journey } from "./journeys";
+
+/**
+ * Declarative click attribution via autocapture data attributes (SAP-1988;
+ * ported from the web app's `frontend/src/lib/analytics/tracking-attrs.ts`).
+ *
+ * posthog-js collects any attribute named `data-ph-capture-attribute-<key>`
+ * into the `$autocapture` event as the property `<key>`, and it does so **while
+ * walking the clicked element's ancestor chain**, merging what it finds at every
+ * level. That ancestor merge is the whole design: context set once on a
+ * container is inherited by every click beneath it, so a surface gets full
+ * attribution with zero per-callsite tracking code.
+ *
+ * Two consequences worth knowing:
+ *
+ * - **Values must be strings.** The SDK skips non-string attribute values, so
+ *   everything here is coerced.
+ * - **The OUTERMOST element wins a key conflict** — not the nearest. Give each
+ *   level its own key: broad context (`journey`, `surface`) on containers,
+ *   specific context (`intent`, `object`) on the control. Never set the same key
+ *   at two depths.
+ */
+
+const ATTRIBUTE_PREFIX = "data-ph-capture-attribute-";
+
+export interface TrackingContext {
+  /**
+   * The arc of intent. Usually omitted — the current journey rides as a
+   * super-property (see events.ts `registerViewContext`). Set it explicitly only
+   * for UI that outlives its view (a global modal, a command palette) where the
+   * ambient view would misattribute the click.
+   */
+  readonly journey?: Journey;
+  /**
+   * The specific UI region, in snake_case: `agent_rail`, `run_canvas`,
+   * `secrets_panel`. The main dimension for "where did they click?"
+   */
+  readonly surface?: string;
+  /** The kind of entity being acted on: `session`, `template`, `secret`, `run`. */
+  readonly object?: string;
+  /**
+   * What the control is trying to do: `deploy`, `run`, `open_detail`,
+   * `set_secret`. Belongs on the control itself rather than a container.
+   */
+  readonly intent?: string;
+}
+
+/**
+ * Build the `data-ph-capture-attribute-*` props for a tracking context.
+ *
+ * Spread onto any element to attribute it and everything inside it:
+ *
+ * ```tsx
+ * <button {...trackingAttrs({ surface: "agent_rail", intent: "deploy" })}>Deploy</button>
+ * ```
+ *
+ * Undefined and empty values are omitted so they never land as the string
+ * `"undefined"` in analysis.
+ */
+export function trackingAttrs(context: TrackingContext): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (value === undefined || value === null) continue;
+    const stringValue = String(value);
+    if (stringValue.length === 0) continue;
+    attrs[`${ATTRIBUTE_PREFIX}${key}`] = stringValue;
+  }
+  return attrs;
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -759,8 +759,16 @@ class MockApi implements HarnessApi {
       version: "0.0.1-mock",
       authenticated: true,
       userId: "user_mock",
+      tenantId: "tenant_mock",
       organizationName: "Acme (mock)",
       telemetryOptIn,
+      // Light product analytics defaults on; e2e can force off with
+      // ?mockProductAnalytics=off to assert the PostHog opt-out gate.
+      productAnalyticsOptIn:
+        typeof window !== "undefined" &&
+        new URLSearchParams(window.location.search).get("mockProductAnalytics") === "off"
+          ? false
+          : true,
       sessions: this.sessions,
       workflows: this.workflows,
       macros: MOCK_MACROS,

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -922,6 +922,14 @@ export function useHarnessState(): HarnessStateHook {
     if (patch.telemetryOptIn !== undefined) {
       setState((prev) => (prev ? { ...prev, telemetryOptIn: updated.telemetryOptIn } : prev));
     }
+    // Mirror the light-analytics opt-in into AppState so the PostHog consent
+    // gate (App's initAnalytics effect) re-syncs immediately on toggle. Absent
+    // === on, matching the server's resolution.
+    if (patch.productAnalyticsOptIn !== undefined) {
+      setState((prev) =>
+        prev ? { ...prev, productAnalyticsOptIn: updated.productAnalyticsOptIn !== false } : prev,
+      );
+    }
     return updated;
   }, []);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@19.2.7)
+      posthog-js:
+        specifier: ^1.363.5
+        version: 1.409.5
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -1875,6 +1878,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@posthog/browser-common@0.3.1':
+    resolution: {integrity: sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ==}
+
+  '@posthog/core@1.46.1':
+    resolution: {integrity: sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg==}
+
+  '@posthog/types@1.399.0':
+    resolution: {integrity: sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -2198,6 +2210,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -2793,6 +2808,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -2958,6 +2976,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -3253,6 +3274,9 @@ packages:
   fetch-mock@12.6.0:
     resolution: {integrity: sha512-oAy0OqAvjAvduqCeWveBix7LLuDbARPqZZ8ERYtBcCURA3gy7EALA3XWq0tCNxsSg+RmmJqyaeeZlOCV9abv6w==}
     engines: {node: '>=18.11.0'}
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4636,6 +4660,17 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.409.5:
+    resolution: {integrity: sha512-s1iJz+vq0YAluUD4OwLjUFIJt/9pqiiB6MITvHWIS16a7pqTJqbSLXsd5/8kJcIgfrOSZHe+mdYAXLYcJCS4LQ==}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4717,6 +4752,9 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5428,6 +5466,9 @@ packages:
 
   weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6822,6 +6863,17 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@posthog/browser-common@0.3.1':
+    dependencies:
+      '@posthog/core': 1.46.1
+      '@posthog/types': 1.399.0
+
+  '@posthog/core@1.46.1':
+    dependencies:
+      '@posthog/types': 1.399.0
+
+  '@posthog/types@1.399.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.0':
@@ -7151,6 +7203,9 @@ snapshots:
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/uuid@10.0.0': {}
 
@@ -7894,6 +7949,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.2:
     optional: true
 
@@ -8055,6 +8112,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -8529,6 +8590,8 @@ snapshots:
       dequal: 2.0.3
       glob-to-regexp: 0.4.1
       regexparam: 3.0.0
+
+  fflate@0.4.9: {}
 
   figures@6.1.0:
     dependencies:
@@ -9939,6 +10002,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.409.5:
+    dependencies:
+      '@posthog/browser-common': 0.3.1
+      '@posthog/core': 1.46.1
+      '@posthog/types': 1.399.0
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.9
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.7: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -10000,6 +10079,8 @@ snapshots:
       side-channel: 1.1.1
 
   quansync@0.2.11: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10726,6 +10807,8 @@ snapshots:
       defaults: 1.0.4
 
   weapon-regex@1.3.6: {}
+
+  web-vitals@5.3.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Instruments the Studio (`@sapiom/harness`) with client-side PostHog — journeys, click tracking (autocapture), and UI-driven outcome events — mirroring the web app's SAP-2117 analytics into the **same PostHog project (291192)** so studio and web journeys sit side by side. Ships with a privacy-forward, two-tier consent model appropriate to a tool that runs on someone's desktop. **No session/screen recording, ever.**

Motivation: Yash & Oded got stuck on vault/secrets in the Studio (a docs/usability miss, not a bug), and we couldn't see it — the Studio streams to our BigQuery transcript pipeline but emits **nothing to PostHog**, so its UI-interaction layer (clicks, buttons, journeys) is dark. This closes that gap.

## Changes

### Client PostHog module (`web/src/lib/analytics/`)
- `journeys.ts` — journey is classified from **App view state**, not a URL (the harness has no router); same `Journey` vocabulary as the web app.
- `before-send.ts` — redaction choke point: strips the boot token from URLs, truncates click text, and **drops it entirely on secrets/vault surfaces**. Replay/`$snapshot` logic removed (no recording).
- `events.ts` — typed outcome-event registry + `track()`; journey/view ride as super-properties via `registerViewContext`.
- `tracking-attrs.ts` + `TrackScope.tsx` — declarative autocapture attribution.
- `posthog.ts` — init / identify / org-group / consent-gate. Initializes lazily from the first `AppState` so the consent decision is atomic (no pre-consent capture window). `disable_session_recording`, `persistence: localStorage` for offline buffering.

### Identity + config
- `tenantId` exposed on `AppState` / `GET /api/state`; `identify(userId)` + `group('organization', tenantId)`.
- PostHog key/host injected at **runtime** via `window.__HARNESS__` (`server/static.ts`) — one bundle across CLI + desktop; `SAPIOM_POSTHOG_KEY=""` disables.

### Two-tier consent
- **PostHog (light: clicks/journeys/usage)** — **on by default**, honors `SAPIOM_TELEMETRY_DISABLED` / `DO_NOT_TRACK` / `--no-telemetry`, opt-out in Settings (`productAnalyticsOptIn`).
- **Sapiom→BQ (invasive: session detail)** — **flipped to opt-out by default** (the pre-release TODO), benefit-framed opt-in on the WelcomePanel setup surface + desktop `setup.html`.
- Surfaced in existing surfaces only (SettingsPopover + WelcomePanel + TelemetryNotice) — no new screens.

## Testing
- [x] `pnpm --filter @sapiom/harness typecheck` (server + web) green
- [x] `pnpm --filter @sapiom/harness test` — **1634 unit tests pass** (15 new: journeys mapping + redaction/secrets-drop + boot-token strip)
- [x] lint clean (0 errors)
- [ ] Manual: run the Studio, confirm events land in PostHog 291192 with journey/org group; verify consent gating + offline flush (follow-up — see ticket)

## Related
- Refs: SAP-1988
- Pattern mirrored from SAP-2117 (web journeys); harness telemetry lineage: SAP-1449 / SAP-1442 / SAP-1423.

## Notes / follow-ups (in-ticket)
- Richer named events on deploy/run/secrets controls + broader `trackingAttrs` (autocapture already captures these clicks; this labels them).
- Live PostHog verification pass.
- Org-level grouping only for now (`userId === tenantId` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)