### PR TITLE
fix(harness): stop button labels wrapping mid-word in the no-agent modal

### DIFF
--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -6378,6 +6378,16 @@ input {
   line-height: 1.5;
 }
 
+/* The copy/setup-prompt buttons hold their size and keep their label on one
+   line; the descriptive text (flex 1, min-width 0) absorbs the row and wraps
+   instead, so "Copy setup prompt" never breaks onto three lines in the narrow
+   "no agent project" modal. Applies to the expandable per-agent list rows too. */
+.aw-mcp-row > .btn-ghost,
+.aw-mcp-list-row > .btn-ghost {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .aw-mcp-dim {
   color: var(--text-faint);
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -5651,6 +5651,19 @@ input {
   padding: var(--sp3) var(--modal-pad-x);
 }
 
+/* Keep each action button's label on one line and let the row wrap to stack
+   whole buttons when the dialog is narrow — otherwise flexbox shrinks them
+   below their content width and labels like "Start from a template" and
+   "Scaffold an agent here" break mid-word (the "no agent project" state). */
+.modal-add-workspace .modal-actions {
+  flex-wrap: wrap;
+}
+
+.modal-add-workspace .modal-actions > button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 /* Harness dropdown: compact trigger in the footer — [brand icon][label]
    [caret], same anatomy as the composer's provider control. The menu itself
    is the shared popover recipe (see .harness-select-menu). */


### PR DESCRIPTION
## What & why

In the harness "Open a folder → **No agent project in this folder**" dialog, the button labels were breaking mid-word onto multiple lines, making the modal look broken. Two flex rows, same root cause: buttons with no shrink guard get squeezed below their content width on the narrow modal, so their labels wrap.

**1. The MCP-setup row (`.aw-mcp-row`)** — "Copy setup prompt" wrapped to three lines (`Copy` / `setup` / `prompt`).

**2. The action row (`.modal-add-workspace .modal-actions`)** — "Start from a template", "Add folder anyway", and "Scaffold an agent here" each wrapped their labels to two lines.

## Fix

Scoped CSS: keep each button's label on one line (`flex-shrink: 0; white-space: nowrap`) so it holds its size; the descriptive text absorbs/wraps in the MCP row, and the action row is allowed to `flex-wrap` so whole buttons stack when the dialog is too narrow (instead of labels breaking mid-word).

```css
.aw-mcp-row > .btn-ghost,
.aw-mcp-list-row > .btn-ghost { flex-shrink: 0; white-space: nowrap; }

.modal-add-workspace .modal-actions { flex-wrap: wrap; }
.modal-add-workspace .modal-actions > button { flex-shrink: 0; white-space: nowrap; }
```

CSS-only, no behavior change. `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
