### PR TITLE
Templates: golden gallery curation — remove 3, promote 3 Fixables (SAP-2301)

### DIFF
--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -102,6 +102,8 @@ interface Shared extends Record<string, unknown> {
   deliverTo: string | null;
   aspectRatio: string;
   model?: string;
+  /** Whether to render the (pricey) teaser clip. Off for the built-in sample run. */
+  renderClip: boolean;
   pack: Pack;
   graphics: Graphic[];
   clip: Clip | null;
@@ -493,6 +495,12 @@ const repurpose = defineStep({
     ctx.shared.set("deliverTo", input.deliverTo?.trim() || null);
     ctx.shared.set("aspectRatio", ASPECT_RATIO);
     if (input.model) ctx.shared.set("model", input.model);
+    // The teaser clip (image-to-video) is the priciest, slowest leg. A run nobody
+    // configured — the built-in sample — renders the quote graphics but stops short of
+    // the clip, so a zero-setup run still fires a real visual artifact without becoming
+    // the most expensive one in the gallery. Supply your own `source` and the full pack
+    // (clip included) renders.
+    ctx.shared.set("renderClip", !usedSampleSource);
     ctx.shared.set("pack", pack);
     ctx.shared.set("graphics", []);
     ctx.shared.set("clip", null);
@@ -503,11 +511,10 @@ const repurpose = defineStep({
       quotes: pack.quoteGraphics.length,
     });
 
-    // dryRun: trace the graph and read the copy without paying for graphics/clip.
-    // It defaults on ONLY when the source was defaulted too — image and video are
-    // the priciest capabilities here, and a run nobody configured should not be the
-    // most expensive one in the gallery. Supply a source and the full pack renders.
-    if (input.dryRun ?? usedSampleSource) {
+    // dryRun is an explicit author opt-in — never inferred from a defaulted source —
+    // to trace the graph and read the copy without paying for any generated media. A
+    // zero-setup run (no dryRun) falls through to `graphics` and renders real artwork.
+    if (input.dryRun) {
       ctx.logger.info("dryRun — returning copy only");
       return terminate({
         dryRun: true,
@@ -515,7 +522,7 @@ const repurpose = defineStep({
         pack,
         note: [
           ctx.shared.get("note"),
-          "No quote graphics or teaser clip were rendered, and nothing was emailed — this is the copy only. Pass `dryRun: false` for the full pack.",
+          "No quote graphics or teaser clip were rendered, and nothing was emailed — this is the copy only. Omit `dryRun` for the full pack.",
         ]
           .filter(Boolean)
           .join(" "),
@@ -527,7 +534,7 @@ const repurpose = defineStep({
 
 const graphics = defineStep({
   name: "graphics",
-  next: ["clip"],
+  next: ["clip", "package"],
   async run(_input: unknown, ctx: Ctx) {
     const pack = must(ctx.shared.get("pack"), "pack");
     ctx.logger.info("generating quote graphics", {
@@ -579,7 +586,10 @@ const graphics = defineStep({
     });
     ctx.shared.set("graphics", results);
     ctx.logger.info("graphics ready", { count: results.length });
-    return goto("clip", {});
+    // The built-in sample run stops at the graphics (a real visual artifact) and skips
+    // the pricey teaser clip; a caller-supplied source renders the full pack.
+    const renderClip = ctx.shared.get("renderClip") ?? true;
+    return renderClip ? goto("clip", {}) : goto("package", {});
   },
 });
 
@@ -723,6 +733,12 @@ const deliver = defineStep({
         graphics: graphicsList.length,
         clip: Boolean(value?.fileId),
       },
+      // The rendered quote graphics, surfaced so the run's terminal carries a real,
+      // inspectable visual artifact (real links) even when nothing is emailed.
+      graphics: graphicsList.map((g) => ({
+        quote: g.quote,
+        downloadUrl: g.downloadUrl ?? g.url,
+      })),
       packFileId,
       packDownloadUrl,
       clipFileId: value?.fileId ?? null,
@@ -743,7 +759,7 @@ const deliver = defineStep({
         reason: "no-recipient",
         unmet: ["deliverTo"],
         note: [
-          "Nothing was emailed: no `deliverTo` address is set, so the pack is returned inline below.",
+          "Nothing was emailed: no `deliverTo` address is set — the rendered quote graphics and the full pack are returned inline below.",
           note,
         ]
           .filter(Boolean)

--- a/examples/content-repurposing-pipeline/template.json
+++ b/examples/content-repurposing-pipeline/template.json
@@ -84,11 +84,12 @@
     }
   ],
   "zeroSetup": {
-    "terminalState": "completed",
+    "terminalState": "completed_partial",
     "expect": [
-      { "path": "pack.newsletter", "assert": "nonEmptyString" },
-      { "path": "pack.tweetThread", "assert": "nonEmptyArray" }
+      { "path": "graphics", "assert": "nonEmptyArray" },
+      { "path": "delivered", "assert": "equals", "value": false },
+      { "path": "unmet", "assert": "nonEmptyArray" }
     ],
-    "narrative": "Repurposes a built-in sample post into a newsletter, tweet thread, video script, and LinkedIn post."
+    "narrative": "Repurposes the built-in sample post into copy plus real rendered quote graphics; skips the pricey teaser clip and emails nothing because no recipient is set."
   }
 }

--- a/examples/news-roundup/index.ts
+++ b/examples/news-roundup/index.ts
@@ -26,17 +26,17 @@ import type {
 } from "./lib/types.js";
 import { slugify, todayIso } from "./lib/util.js";
 
-// The default makes a zero-input run real rather than a schema rejection: the
-// search is a live one, just about us until you point it at your own company.
+// The default makes a zero-input run real rather than a schema rejection: it
+// searches a reliably-covered brand, so a zero-input run finds selectable news and
+// publishes a real page — until you point it at your own company.
 const entryInput = z.object({
-  companyName: z.string().min(1).default("Sapiom"),
+  companyName: z.string().min(1).default("Nvidia"),
 });
 const SITE_PORT = 3000;
 
 const search = defineStep({
   name: "search",
-  next: ["select"],
-  terminal: true,
+  next: ["select", "noNews"],
   canFail: true,
   inputSchema: entryInput,
   async run(input: { companyName: string }, ctx: AgentExecutionContext<RoundupShared>) {
@@ -58,7 +58,7 @@ const search = defineStep({
       }));
       if (articles.length === 0) {
         ctx.logger.info("no news found", { companyName });
-        return terminate({ status: "no-news", companyName });
+        return goto("noNews", { reason: "no-news" });
       }
       ctx.logger.info("search done", { count: articles.length });
       return goto("select", { articles });
@@ -71,7 +71,7 @@ const search = defineStep({
 
 const select = defineStep({
   name: "select",
-  next: ["illustrate"],
+  next: ["illustrate", "noNews"],
   canFail: true,
   async run(input: { articles: RawArticle[] }, ctx: AgentExecutionContext<RoundupShared>) {
     const companyName = ctx.shared.get("companyName") ?? "";
@@ -85,6 +85,12 @@ const select = defineStep({
         throw new Error(res.error?.message ?? `model run ended as ${res.status}`);
       }
       const selected = parseSelection(res.output);
+      // An empty selection means the hits were all off-topic — degrade honestly to
+      // the no-news terminal rather than publishing an empty roundup page.
+      if (selected.length === 0) {
+        ctx.logger.info("no articles qualified", { companyName });
+        return goto("noNews", { reason: "no-selection" });
+      }
       ctx.logger.info("selection done", { count: selected.length });
       return goto("illustrate", { selected });
     } catch (err) {
@@ -204,8 +210,33 @@ const publish = defineStep({
   },
 });
 
+// A distinct degrade terminal for the two "nothing to publish" paths — no search
+// hits, or hits that all turn out to be off-topic. It reads as a degrade
+// (`published: false` + a surfaced note), never a green publish that shipped an
+// empty page.
+const noNews = defineStep({
+  name: "noNews",
+  next: [],
+  terminal: true,
+  async run(input: { reason: "no-news" | "no-selection" }, ctx: AgentExecutionContext<RoundupShared>) {
+    const companyName = ctx.shared.get("companyName") ?? "";
+    const reason = input.reason === "no-selection" ? "no-selection" : "no-news";
+    ctx.logger.info("nothing to publish — degrade terminal", { companyName, reason });
+    return terminate({
+      status: reason,
+      published: false,
+      companyName,
+      articles: [],
+      note:
+        reason === "no-news"
+          ? `No recent news turned up for "${companyName}", so nothing was published. Point it at a company with coverage in the last week.`
+          : `Search results for "${companyName}" turned up, but none qualified as recent company news — so nothing was published rather than shipping an empty page.`,
+    });
+  },
+});
+
 export const agent = defineAgent<{ companyName: string }, RoundupShared>({
   name: "news-roundup",
   entry: "search",
-  steps: { search, select, illustrate, publish },
+  steps: { search, select, illustrate, publish, noNews },
 });

--- a/examples/news-roundup/lib/select.ts
+++ b/examples/news-roundup/lib/select.ts
@@ -10,7 +10,6 @@ const selectionSchema = z
       imagePrompt: z.string().min(1),
     }),
   )
-  .min(1)
   .max(5);
 
 export function buildSelectionPrompt(
@@ -23,7 +22,7 @@ export function buildSelectionPrompt(
     .join("\n");
   return `Today is ${runDate}. Below are web search results for news about the company "${companyName}".
 
-Select the 3 to 5 results that are genuinely recent news (roughly the last 7 days) about this specific company. Drop results about unrelated companies or people with similar names, duplicates, and pages that are not news articles. If fewer than 3 qualify, select only those that do (minimum 1).
+Select the 3 to 5 results that are genuinely recent news (roughly the last 7 days) about this specific company. Drop results about unrelated companies or people with similar names, duplicates, and pages that are not news articles. If fewer than 3 qualify, select only those that do. If none qualify, respond with an empty array [].
 
 For each selected article provide:
 - "title": the article title

--- a/examples/news-roundup/template.json
+++ b/examples/news-roundup/template.json
@@ -20,7 +20,7 @@
     }
   ],
   "defaultInput": {
-    "companyName": "Sapiom"
+    "companyName": "Nvidia"
   },
   "examples": [
     {
@@ -55,15 +55,20 @@
       },
       "output": {
         "status": "no-news",
-        "companyName": "Polsia"
+        "published": false,
+        "companyName": "Polsia",
+        "articles": [],
+        "note": "No recent news turned up for \"Polsia\", so nothing was published. Point it at a company with coverage in the last week."
       }
     }
   ],
   "zeroSetup": {
     "terminalState": "completed",
     "expect": [
-      { "path": "status", "assert": "nonEmptyString" }
+      { "path": "status", "assert": "equals", "value": "published" },
+      { "path": "siteUrl", "assert": "nonEmptyString" },
+      { "path": "articles", "assert": "nonEmptyArray" }
     ],
-    "narrative": "Searches the web for the company's recent news and publishes an illustrated roundup page; with no recent news it honestly reports no-news."
+    "narrative": "Searches the web for a well-covered default company and publishes a dated, illustrated roundup page at a live sandbox URL; a company with no recent coverage ends in a distinct no-news terminal instead."
   }
 }

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -221,7 +221,7 @@
         "runsWithNoSetup": true,
         "connectionCount": 0,
         "settingCount": 1,
-        "degradedWithoutSetup": "Repurposes a built-in sample post into a newsletter, tweet thread, video script, and LinkedIn post."
+        "degradedWithoutSetup": "Repurposes the built-in sample post into copy plus real rendered quote graphics; skips the pricey teaser clip and emails nothing because no recipient is set."
       }
     },
     {
@@ -296,54 +296,6 @@
         "connectionCount": 0,
         "settingCount": 1,
         "degradedWithoutSetup": "Runs a coding agent to triage upgrades and writes a report; pushes nothing (no repo)."
-      }
-    },
-    {
-      "id": "durable-backfill",
-      "name": "Large Dataset Backfill",
-      "description": "Process a huge dataset in resumable chunks, checkpointing progress so the job survives restarts and picks up where it left off.",
-      "tags": ["durable", "backfill", "batch", "cron"],
-      "category": "data-knowledge",
-      "discipline": "Data",
-      "cadence": "scheduled",
-      "complexity": "simple",
-      "sourcePath": "examples/durable-backfill",
-      "capabilities": [
-        "database.get",
-        "sandboxes.create",
-        "sandboxes.exec",
-        "fileStorage.upload",
-        "fileStorage.getDownloadUrl",
-        "fileStorage.list",
-        "fileStorage.delete"
-      ],
-      "steps": [
-        {
-          "name": "plan",
-          "description": "Works out the job — dataset size, chunk size, and a stable job id — then resumes from a saved checkpoint if one exists for that id.",
-          "kind": "compute",
-          "next": ["process"]
-        },
-        {
-          "name": "process",
-          "description": "Process the current chunk, save its result and rewrite the checkpoint, then wait for the next heartbeat — or, running offline with nothing to fire one, loop straight to the next chunk. Finishes once the last chunk is done.",
-          "kind": "pause",
-          "capability": "sandboxes.exec",
-          "next": ["finalize", "process"]
-        },
-        {
-          "name": "finalize",
-          "description": "Writes a manifest of the run and returns a summary.",
-          "kind": "compute",
-          "terminal": true
-        }
-      ],
-      "setup": {
-        "runsWithNoSetup": true,
-        "connectionCount": 0,
-        "settingCount": 1,
-        "provisions": ["sandbox"],
-        "degradedWithoutSetup": "Runs the backfill offline over 3 chunks (25 records); persists nothing (no dbHandle)."
       }
     },
     {
@@ -777,7 +729,7 @@
         "connectionCount": 0,
         "settingCount": 0,
         "provisions": ["sandbox"],
-        "degradedWithoutSetup": "Searches the web for the company's recent news and publishes an illustrated roundup page; with no recent news it honestly reports no-news."
+        "degradedWithoutSetup": "Searches the web for a well-covered default company and publishes a dated, illustrated roundup page at a live sandbox URL; a company with no recent coverage ends in a distinct no-news terminal instead."
       }
     },
     {
@@ -1435,7 +1387,7 @@
         "runsWithNoSetup": true,
         "connectionCount": 0,
         "settingCount": 1,
-        "degradedWithoutSetup": "Researches the topic and writes a brief with sources; emails nothing (no recipient)."
+        "degradedWithoutSetup": "Researches the topic, writes a sourced brief, and emails it to the agent's own Sapiom-hosted demo inbox; set deliverTo to send it to your address."
       }
     },
     {
@@ -1486,97 +1438,6 @@
         "connectionCount": 2,
         "settingCount": 1,
         "degradedWithoutSetup": "Composes the message and prints it; posts nothing to Slack (no bot token)."
-      }
-    },
-    {
-      "id": "the-brain",
-      "name": "Workflow Fleet Monitor",
-      "description": "Watches a fleet of workflows, spots which member is off cadence, and launches it — with a model that may only pick from a fixed list of safe moves.",
-      "tags": ["orchestration", "agents-managing-agents", "meta-workflow"],
-      "category": "reliability-governance",
-      "discipline": "Reliability",
-      "cadence": "scheduled",
-      "complexity": "involved",
-      "sourcePath": "examples/the-brain",
-      "capabilities": ["models.run", "database.get", "database.create"],
-      "steps": [
-        {
-          "name": "scan",
-          "description": "Reads the event log and works out which members are off cadence — missed today, overdue, or launched with no result.",
-          "kind": "capability",
-          "capability": "database.get",
-          "next": ["assess"]
-        },
-        {
-          "name": "assess",
-          "description": "Hands those situations to a model that may only pick a move from a fixed list, then re-checks its answer in code.",
-          "kind": "llm",
-          "capability": "models.run",
-          "next": ["actuate"]
-        },
-        {
-          "name": "actuate",
-          "description": "Runs the plan behind guardrails, launching each due member as a child workflow and recording each launch.",
-          "kind": "compute",
-          "next": ["report"]
-        },
-        {
-          "name": "report",
-          "description": "Posts a short briefing to a Slack channel, records the run, and advances its place in the log.",
-          "kind": "compute",
-          "terminal": true
-        }
-      ],
-      "setup": {
-        "runsWithNoSetup": false,
-        "connectionCount": 1,
-        "settingCount": 1,
-        "provisions": ["postgres"]
-      }
-    },
-    {
-      "id": "wait-for-webhook",
-      "name": "Slow Job Callback",
-      "description": "Start a slow external job, pause until a webhook calls back, then summarize the result and decide whether to accept it.",
-      "tags": ["durable", "pause-resume", "webhook", "async"],
-      "category": "product-engineering",
-      "discipline": "Engineering",
-      "cadence": "on-demand",
-      "complexity": "simple",
-      "sourcePath": "examples/wait-for-webhook",
-      "capabilities": ["models.run"],
-      "steps": [
-        {
-          "name": "kickoff",
-          "description": "Register the resume contract with the external job and pause until it calls back — costing nothing while idle. With no register URL, no job was started, so it decides on an empty payload rather than waiting forever.",
-          "kind": "pause",
-          "next": ["decide"]
-        },
-        {
-          "name": "decide",
-          "description": "Wakes when the callback arrives; its input is the callback payload. A model summarizes the result and picks accept or reject.",
-          "kind": "llm",
-          "capability": "models.run",
-          "next": ["accept", "reject"]
-        },
-        {
-          "name": "accept",
-          "description": "Ends the run — the callback result looked complete and usable.",
-          "kind": "compute",
-          "terminal": true
-        },
-        {
-          "name": "reject",
-          "description": "Ends the run — the callback result failed or looked wrong.",
-          "kind": "compute",
-          "terminal": true
-        }
-      ],
-      "setup": {
-        "runsWithNoSetup": true,
-        "connectionCount": 0,
-        "settingCount": 0,
-        "degradedWithoutSetup": "Evaluates the sample job and returns a decision; registers no external callback."
       }
     },
     {

--- a/examples/scheduled-research-brief/index.ts
+++ b/examples/scheduled-research-brief/index.ts
@@ -288,44 +288,44 @@ const deliver = defineStep({
     // as a `deliverTo` setting in template.json) rather than from a write-only
     // secret store nothing in the product can populate.
     const deliverTo = ctx.shared.get("deliverTo");
+    const note = ctx.shared.get("note");
 
-    // The safe path: a dry run — or a live run with no recipient configured yet —
-    // returns the computed brief without sending anything.
-    if (dryRun || !deliverTo) {
-      ctx.logger.info("skipping delivery", {
-        dryRun,
-        hasRecipient: Boolean(deliverTo),
-      });
+    // dryRun is an explicit author opt-in: compute the brief and return it as a
+    // preview without emailing anyone.
+    if (dryRun) {
+      ctx.logger.info("dry run — skipping delivery", {});
       return terminate({
         topic,
         schedule,
         delivered: false,
-        dryRun,
-        reason: dryRun ? "dry-run" : "no-recipient",
-        ...(dryRun ? {} : { unmet: ["deliverTo"] }),
-        note: [
-          dryRun
-            ? "`dryRun` was set, so nothing was emailed."
-            : "Nothing was emailed: no `deliverTo` address is set, so the brief is returned inline below.",
-          ctx.shared.get("note"),
-        ]
+        dryRun: true,
+        reason: "dry-run",
+        note: ["`dryRun` was set, so nothing was emailed.", note]
           .filter(Boolean)
           .join(" "),
-        to: deliverTo ?? null,
+        to: null,
         subject,
         brief,
         sources,
       });
     }
 
+    // The "email" headline must fire on a zero-setup run, so with no `deliverTo`
+    // we deliver to this agent's own Sapiom-hosted inbox — a real, inspectable
+    // mailbox the platform provisions for us via `resolveSenderInbox` (an
+    // `inboxId` IS its email address). A caller-supplied `deliverTo` is the
+    // upgrade that sends to a real external address instead.
     const inboxId = await resolveSenderInbox(ctx);
+    const toDemoInbox = !deliverTo;
+    const recipient = deliverTo ?? inboxId;
     const sent = await ctx.sapiom.email.messages.send(inboxId, {
-      to: deliverTo,
+      to: recipient,
       subject,
       text: brief,
     });
     ctx.logger.info("brief delivered", {
-      to: deliverTo,
+      to: recipient,
+      demo: toDemoInbox,
       messageId: sent.messageId,
     });
     return terminate({
@@ -333,11 +333,21 @@ const deliver = defineStep({
       schedule,
       delivered: true,
       dryRun: false,
-      to: deliverTo,
+      demo: toDemoInbox,
+      to: recipient,
       subject,
       messageId: sent.messageId,
+      brief,
       sources,
-      ...(ctx.shared.get("note") ? { note: ctx.shared.get("note") } : {}),
+      note:
+        [
+          toDemoInbox
+            ? `Emailed the brief to this agent's Sapiom-hosted demo inbox (${recipient}) — the message above is real and inspectable. Set \`deliverTo\` to send it to your own address instead.`
+            : null,
+          note,
+        ]
+          .filter(Boolean)
+          .join(" ") || undefined,
     });
   },
 });

--- a/examples/scheduled-research-brief/template.json
+++ b/examples/scheduled-research-brief/template.json
@@ -6,13 +6,13 @@
     "url": "https://sapiom.ai/"
   },
   "whatItDoes": "Research a topic on a schedule and email a short, sourced brief. Searches the web, reads the top results in full, and links every claim back to where it came from. Scrapes fail routinely; when one does it keeps the snippet and still sends a brief from the survivors.",
-  "longDescription": "You give it a topic and a schedule. On each tick it searches the web, reads the top results, and emails you a short brief that summarizes what it found and links every claim back to its source.\n\nThe graph is four steps: `search` (web.search) finds candidates, `scrape` reads them for full text, `curate` (`models.run`, the live x402-served model) ranks and synthesizes them into a sourced brief, and `deliver` emails it. Scrapes fail routinely on paywalls and timeouts — when one does, it keeps the search snippet and moves on, so a brief from the survivors still goes out. A `dryRun` flag computes the brief and returns it as a preview without sending; so does a run with no recipient set.\n\nIts simpler sibling is `web-research-digest`: fork that for a one-shot digest that formats in-process with no LLM and no delivery. Fork this one when you want a standing, LLM-curated brief that lands in an inbox on a cadence.\n\nYou pay for the web search, the scrapes, and the model reasoning on each run — the emails are cheap, and a dry run costs nothing beyond the search and scrape it still performs.",
+  "longDescription": "You give it a topic and a schedule. On each tick it searches the web, reads the top results, and emails you a short brief that summarizes what it found and links every claim back to its source.\n\nThe graph is four steps: `search` (web.search) finds candidates, `scrape` reads them for full text, `curate` (`models.run`, the live x402-served model) ranks and synthesizes them into a sourced brief, and `deliver` emails it. Scrapes fail routinely on paywalls and timeouts — when one does, it keeps the search snippet and moves on, so a brief from the survivors still goes out. With no `deliverTo` set it emails the brief to the agent's own Sapiom-hosted inbox, so the delivery is real and inspectable on a zero-setup run; set `deliverTo` to send it to your address instead. A `dryRun` flag computes the brief and returns it as a preview without sending anything.\n\nIts simpler sibling is `web-research-digest`: fork that for a one-shot digest that formats in-process with no LLM and no delivery. Fork this one when you want a standing, LLM-curated brief that lands in an inbox on a cadence.\n\nYou pay for the web search, the scrapes, and the model reasoning on each run — the emails are cheap, and a dry run costs nothing beyond the search and scrape it still performs.",
   "useCases": [
     "Sourced brief on a cadence",
     "Every claim links out",
     "Dry-run preview"
   ],
-  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `topic` (what to research) and a `schedule` (the cron cadence). It runs with no setup: given no topic it researches AI agent reliability incidents and says so in its output. Set `deliverTo` to have the brief emailed; without it the brief is returned in the run's output. Pass `dryRun: true` to compute the brief and get it back without sending anything. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed workflow.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole search → scrape → curate → deliver flow for free (capabilities stubbed, delivery skipped), or edit and deploy it with the Sapiom MCP.",
+  "notes": "Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page. Your $5 signup credit covers first runs.\n\nGive it a `topic` (what to research) and a `schedule` (the cron cadence). It runs with no setup: given no topic it researches AI agent reliability incidents and says so in its output. With no `deliverTo` it emails the brief to a Sapiom-hosted demo inbox so you see a real, inspectable delivery; set `deliverTo` to send it to your own address instead. Pass `dryRun: true` to compute the brief and get it back without sending anything. To run it on a cadence, attach the `schedule` as a cron trigger on the deployed workflow.\n\nPrefer to work from the code? Run it locally with `run_local` to trace the whole search → scrape → curate → deliver flow for free (capabilities stubbed, delivery skipped), or edit and deploy it with the Sapiom MCP.",
   "settings": [
     {
       "path": "deliverTo",
@@ -57,12 +57,13 @@
     }
   ],
   "zeroSetup": {
-    "terminalState": "completed_partial",
+    "terminalState": "completed",
     "expect": [
       { "path": "brief", "assert": "nonEmptyString" },
       { "path": "sources", "assert": "nonEmptyArray" },
-      { "path": "delivered", "assert": "equals", "value": false }
+      { "path": "delivered", "assert": "equals", "value": true },
+      { "path": "messageId", "assert": "nonEmptyString" }
     ],
-    "narrative": "Researches the topic and writes a brief with sources; emails nothing (no recipient)."
+    "narrative": "Researches the topic, writes a sourced brief, and emails it to the agent's own Sapiom-hosted demo inbox; set deliverTo to send it to your address."
   }
 }

--- a/scripts/examples-manifest-check.test.mjs
+++ b/scripts/examples-manifest-check.test.mjs
@@ -55,7 +55,7 @@ test("every existing manifest in the repo validates unchanged", () => {
     );
   }
   assert.deepEqual(problems, []);
-  assert.ok(registry.templates.length >= 25);
+  assert.ok(registry.templates.length >= 24);
 });
 
 test("the copy length caps are enforced by the schema, with a pointer", () => {


### PR DESCRIPTION
Curates the onboarding template gallery to the golden bar from the 2026-08-01 golden-path audit (`plans/onboarding-templates/TEMPLATE-QUALITY-BAR-2026-08-01.md`): **every card must produce a real, inspectable artifact on a zero-setup run.**

Closes SAP-2301.

## Removals (registry/gallery config)
Dropped from `examples/registry.json` (27 → 24 templates). Example dirs stay as pattern references; the harness reads the live catalog, so no fallback list needs touching.

- **durable-backfill** — durability/restart mechanics demo; a `{}` run counts a synthetic integer, writes nothing, reports green `complete:true`. No "what is Sapiom" artifact.
- **the-brain** — a *pattern* (agents-managing-agents), not a template.
- **wait-for-webhook** — a *pattern* (durable pause/resume), not a template.
- **hello-agent** kept as the starter/smoke-test.

## Promotions (Fixable → Golden)
Each satisfies the audit's **default-not-dryRun** and **honest-terminal-classification** bars.

- **content-repurposing-pipeline** — `dryRun` is now an explicit author opt-in (no longer inferred from a defaulted source). A zero-setup run renders the real quote graphics via `images.create` (surfaced as inspectable links in the terminal), then stops short of the pricey teaser clip — matching the golden precedent (`personalized-media-at-scale` keeps video off the zero-setup path). No-recipient terminal is declared `completed_partial` with `unmet:[deliverTo]`. A caller-supplied `source` renders the full pack incl. the clip.
- **scheduled-research-brief** — with no `deliverTo`, delivers to the agent's own Sapiom-hosted inbox (via the existing `resolveSenderInbox` machinery) and terminates `delivered:true` with an inspectable message, so the "email" headline fires zero-setup. Real `deliverTo` stays the upgrade; `dryRun` stays the explicit no-send opt-in.
- **news-roundup** — default `companyName` swapped to a reliably-covered brand (`Nvidia`) so a zero-input run finds selectable news and publishes; the no-news / empty-selection cases now route to a **distinct degrade terminal** (`published:false` + note) instead of a green `completed` that shipped nothing; `parseSelection`'s `.min(1)` softened. `zeroSetup.expect` tightened to assert a real published artifact.

## Verification
- `pnpm examples:check` ✅ (registry schema/sort/sourcePaths + 24 manifests)
- `pnpm examples:check:test` ✅ (87 tests; manifest-check floor updated 25 → 24)
- Per-example `tsc --noEmit` ✅ for all three edited templates
- Registry `setup` blocks regenerated via `examples:sync-setup` (narratives mirror the new zeroSetup)

The workspace `build`/`typecheck`/`lint` gates target `packages/*` only; this diff is entirely under `examples/` (outside the pnpm workspace) plus one `scripts/*.test.mjs` threshold, so those gates are unaffected. CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSDSxQn7dFZhpZdwMLNHS8