### PR TITLE
feat(tools): add ctx.sapiom.keys.mintScoped for deployed artifacts (SAP-2300)

### DIFF
--- a/examples/nl-db-query-endpoint/README.md
+++ b/examples/nl-db-query-endpoint/README.md
@@ -24,8 +24,10 @@ validate ─▶ resolve ─▶ plan ─▶ guard ─┬─▶ deploy ─┬─�
    deployed once the safe path is proven.
 5. **deploy** — writes a small server into a sandbox and exposes it at a stable URL
    (`sandboxes.deployPreview`). `DATABASE_URL` and the server's own
-   `SAPIOM_API_KEY` (from the injected `ENDPOINT_SAPIOM_API_KEY`) are passed
-   as env — never baked into source.
+   `SAPIOM_API_KEY` are passed as env — never baked into source. The key is minted
+   for the endpoint (`ctx.sapiom.keys.mintScoped`): a durable, narrowly-scoped
+   credential, since the engine's per-run token expires with the step. (Set
+   `ENDPOINT_SAPIOM_API_KEY` to override with a key you control.)
 6. **deployed** / **deploy_failed** / **rejected** — terminal; report the endpoint
    URL, surface the deploy logs, or explain the rejection.
 

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -126,9 +126,9 @@ const ENDPOINT_API_KEY = "ENDPOINT_SAPIOM_API_KEY";
 /**
  * Lifetime of the scoped key minted for the deployed endpoint. The key is durable
  * relative to the run (the per-run `sat_` the engine injects expires with the step)
- * but still bounded and revocable — long enough for the preview to serve requests,
- * short enough that a leaked key is not forever. Revoke the definition's key to
- * cascade-revoke it sooner.
+ * but still bounded — long enough for the preview to serve requests, short enough
+ * that a leaked key is not forever. It carries transaction (payment) authority only,
+ * and can be revoked by its id before the TTL.
  */
 const ENDPOINT_KEY_TTL = "30d";
 

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -29,11 +29,13 @@ import { z } from "zod/v4";
  *      only deployed once the safe path is proven.
  *   5. deploy   — write a small server (which re-runs translate → guard → execute
  *      per request) into a sandbox and expose it at a stable URL
- *      (`sandboxes.deployPreview`). DATABASE_URL and the server's own API key
- *      (injected into this step's environment as `ENDPOINT_SAPIOM_API_KEY`) are
- *      passed as env — never baked into source. With no key, nothing is deployed
- *      and the run stops at `endpoint_skipped`: a URL whose only route cannot
- *      answer is worse than no URL.
+ *      (`sandboxes.deployPreview`). DATABASE_URL and the server's own API key are
+ *      passed as env — never baked into source. The endpoint's key is MINTED for it
+ *      (`ctx.sapiom.keys.mintScoped`): a durable, narrowly-scoped credential the
+ *      long-lived server uses to call `models.run`, since the engine's per-run token
+ *      expires with this step. Only if minting is unavailable and no key was supplied
+ *      does the run stop at `endpoint_skipped`: a URL whose only route cannot answer
+ *      is worse than no URL.
  *   6. deployed / endpoint_skipped / deploy_failed / rejected — terminal.
  *
  * The read-only guardrail is defense-in-depth: the LLM is *told* to emit a SELECT,
@@ -110,19 +112,25 @@ const DEFAULT_PORT = 3000;
  */
 const DEFAULT_DB_HANDLE = "nl-db-query-demo";
 /**
- * Env key holding the API key the DEPLOYED endpoint uses to call `models.run` on
- * each request. Declared as a required secret in `template.json`; the platform
- * injects it here and the step forwards it to the server as `SAPIOM_API_KEY`.
- * The declared key cannot itself be named `SAPIOM_*` — that namespace belongs to
- * the engine and a template may never override it.
- *
- * This is the template's one genuinely unsolved requirement: the endpoint needs a
- * Sapiom credential of its own, and there is no primitive today that mints one
- * scoped to a deployed preview. Until there is, a run with no key translates and
- * guards for real and then stops, rather than publishing a URL whose only
- * interesting route cannot answer.
+ * Optional OVERRIDE env key for the API key the DEPLOYED endpoint uses to call
+ * `models.run` on each request. The default path needs none: the deploy step mints
+ * the endpoint its own durable, narrowly-scoped key via `ctx.sapiom.keys.mintScoped`
+ * (SAP-2300) and forwards it to the server as `SAPIOM_API_KEY`. This secret only
+ * exists as an escape hatch — bring-your-own key when you want to control which
+ * credential the endpoint runs as. The declared key cannot itself be named
+ * `SAPIOM_*` — that namespace belongs to the engine and a template may never
+ * override it.
  */
 const ENDPOINT_API_KEY = "ENDPOINT_SAPIOM_API_KEY";
+
+/**
+ * Lifetime of the scoped key minted for the deployed endpoint. The key is durable
+ * relative to the run (the per-run `sat_` the engine injects expires with the step)
+ * but still bounded and revocable — long enough for the preview to serve requests,
+ * short enough that a leaked key is not forever. Revoke the definition's key to
+ * cascade-revoke it sooner.
+ */
+const ENDPOINT_KEY_TTL = "30d";
 
 function resolveConfig(input: EntryInput | undefined): Config {
   const dbHandle = input?.dbHandle?.trim() ?? "";
@@ -521,10 +529,31 @@ const deploy = defineStep({
     const connectionString = ctx.shared.get("connectionString") ?? "";
     const sampleSql = ctx.shared.get("sampleSql") ?? "";
 
-    // The server's own API key (used to call models.run per request) comes from
-    // the environment the platform injected it into, or the dev-only input.
-    const apiKey =
+    // The server's own API key (used to call models.run per request). A caller can
+    // bring one — the dev-only input, or the optional ENDPOINT_SAPIOM_API_KEY
+    // override — but the zero-setup default is to MINT the endpoint its own durable,
+    // narrowly-scoped key. The engine's per-run `sat_` expires with this step, so it
+    // can't be handed to a long-lived artifact; `keys.mintScoped` returns one that can.
+    let apiKey =
       config.sapiomApiKey || process.env[ENDPOINT_API_KEY]?.trim() || "";
+    if (!apiKey && !config.dryRun) {
+      try {
+        const minted = await ctx.sapiom.keys.mintScoped({
+          ttl: ENDPOINT_KEY_TTL,
+        });
+        apiKey = minted.key;
+        ctx.logger.info("minted scoped endpoint credential", {
+          keyId: minted.id,
+          expiresAt: minted.expiresAt,
+        });
+      } catch (err) {
+        // Fail honest, not silent: if minting is unavailable we still translate and
+        // guard, then stop at endpoint_skipped rather than publishing a dead URL.
+        ctx.logger.warn("could not mint an endpoint credential", {
+          err: String(err),
+        });
+      }
+    }
 
     const env: Record<string, string> = {
       PORT: String(config.port),
@@ -537,7 +566,8 @@ const deploy = defineStep({
     // No key means the deployed server cannot call `models.run`, so `/query` — the
     // only interesting route — would return an error for every request. Publishing
     // that URL is the worst failure mode this template has. Stop with the
-    // translated, guarded SQL instead and name what is missing.
+    // translated, guarded SQL instead and name what is missing. Reached now only if
+    // minting failed AND no key was supplied — the default zero-setup run deploys.
     if (!apiKey && !config.dryRun) {
       ctx.logger.warn("no endpoint credential — not deploying", {
         key: ENDPOINT_API_KEY,

--- a/examples/nl-db-query-endpoint/template.json
+++ b/examples/nl-db-query-endpoint/template.json
@@ -6,13 +6,13 @@
     "url": "https://sapiom.ai/"
   },
   "whatItDoes": "Stand up a live endpoint that answers plain-English questions about a read-only database. One run deploys it; after that anyone can POST a question and get the answer back, with the generated SQL held to read-only.",
-  "longDescription": "Deploy a live endpoint that answers questions about your database in plain English. One run stands up the endpoint; then anyone can `POST /query` a question and get the data back — no SQL required.\n\nEach request introspects your schema, asks an LLM (`models.run`) for a single `SELECT`, and returns the rows. The read-only guardrail is the point: the model is told to write only a `SELECT`, the query is checked (single statement, starts with `SELECT`/`WITH`, no write or DDL keywords), and it runs inside a `READ ONLY` transaction that Postgres enforces at the engine level — with a statement timeout and a row cap. A write can't slip through even if the model misbehaves.\n\nThe workflow itself is the deployer: it reads the connection string from a Sapiom database handle (`database.get`), previews the translation on a sample question so a bad path fails before anything ships, then writes a small server into a sandbox and exposes it at a stable URL (`sandboxes.deployPreview`). The server's own API key is handed to the step as an environment variable, never baked into source; with no key nothing is deployed and the run returns the translated, guarded SQL instead.\n\nYou pay for the deploy (one sandbox) plus the model reasoning on each question the endpoint answers — the endpoint sitting idle is free.",
+  "longDescription": "Deploy a live endpoint that answers questions about your database in plain English. One run stands up the endpoint; then anyone can `POST /query` a question and get the data back — no SQL required.\n\nEach request introspects your schema, asks an LLM (`models.run`) for a single `SELECT`, and returns the rows. The read-only guardrail is the point: the model is told to write only a `SELECT`, the query is checked (single statement, starts with `SELECT`/`WITH`, no write or DDL keywords), and it runs inside a `READ ONLY` transaction that Postgres enforces at the engine level — with a statement timeout and a row cap. A write can't slip through even if the model misbehaves.\n\nThe workflow itself is the deployer: it reads the connection string from a Sapiom database handle (`database.get`), previews the translation on a sample question so a bad path fails before anything ships, then writes a small server into a sandbox and exposes it at a stable URL (`sandboxes.deployPreview`). The endpoint gets its OWN Sapiom credential — the deploy step mints a durable, narrowly-scoped key (`keys.mintScoped`) and hands it to the server as an environment variable, never baked into source. No manual key needed: the engine's per-run token expires with the step, so the long-lived endpoint is minted one that lasts.\n\nYou pay for the deploy (one sandbox) plus the model reasoning on each question the endpoint answers — the endpoint sitting idle is free.",
   "useCases": [
     "Plain-English question box",
     "Read-only SQL",
     "Live POST endpoint"
   ],
-  "notes": "**Use this template.** Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page to stand up the endpoint. Your $5 signup credit covers first runs.\n\nYou need a target database: pass a Sapiom Postgres handle as `dbHandle` (or a full `connectionString`). The deployed server calls the LLM on every request, so it needs an API key of its own: supply `ENDPOINT_SAPIOM_API_KEY`. Without one the run still translates your question to SQL and checks it against the read-only guardrail, then stops and says why no endpoint was deployed — a URL whose only route cannot answer is worse than no URL. Once deployed, `POST /query { \"question\": \"…\" }` to the returned URL.\n\n**Advanced (prefer to work from the code?):** Run it locally with `run_local` to trace the whole flow for free. The `models.run` stub returns non-SQL, so on defaults `guard` routes to `rejected` — a legible demo of the guardrail. To trace the deploy branch, pass `{ \"dryRun\": true }` and a stub override returning a real SELECT (see `AGENTS.md`). Then edit and deploy with the Sapiom MCP.",
+  "notes": "**Use this template.** Click **Use this template** — Sapiom builds and deploys it for you, then run it from the workflow page to stand up the endpoint. Your $5 signup credit covers first runs.\n\nYou need a target database: pass a Sapiom Postgres handle as `dbHandle` (or a full `connectionString`). Nothing else — the deployed server calls the LLM on every request, and the run mints it its own scoped Sapiom key automatically, so a zero-setup run deploys a working endpoint. Once deployed, `POST /query { \"question\": \"…\" }` to the returned URL. (Advanced: set `ENDPOINT_SAPIOM_API_KEY` to make the endpoint run as a key you control instead.)\n\n**Advanced (prefer to work from the code?):** Run it locally with `run_local` to trace the whole flow for free. The `models.run` stub returns non-SQL, so on defaults `guard` routes to `rejected` — a legible demo of the guardrail. To trace the deploy branch, pass `{ \"dryRun\": true }` and a stub override returning a real SELECT (see `AGENTS.md`). Then edit and deploy with the Sapiom MCP.",
   "resources": [
     {
       "kind": "postgres",
@@ -25,10 +25,10 @@
   "requiredSecrets": [
     {
       "key": "ENDPOINT_SAPIOM_API_KEY",
-      "label": "API key for the deployed endpoint",
+      "label": "API key for the deployed endpoint (optional override)",
       "provider": "sapiom",
       "credentialKind": "api_key",
-      "description": "The key the endpoint server uses to call the model on each request. Without it nothing is deployed and the run returns the translated, guarded SQL instead.",
+      "description": "Optional. The endpoint mints its own scoped Sapiom key by default; set this only to make it run as a specific key you control instead.",
       "optional": true
     }
   ],
@@ -38,16 +38,14 @@
   },
   "examples": [
     {
-      "title": "No endpoint credential — translated and guarded, not deployed",
+      "title": "Zero setup — mints a scoped key and deploys a working endpoint",
       "input": {},
       "output": {
-        "deployed": false,
-        "url": null,
-        "queryEndpoint": null,
+        "deployed": true,
+        "url": "https://nl-db-query-endpoint.preview.sapiom.ai",
+        "queryEndpoint": "https://nl-db-query-endpoint.preview.sapiom.ai/query",
         "sampleQuestion": "How many rows are in each table?",
-        "sampleSql": "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC",
-        "unmet": ["ENDPOINT_SAPIOM_API_KEY"],
-        "note": "The question was translated to SQL and passed the read-only guardrail — that part really ran. No endpoint was deployed: the server needs its own `ENDPOINT_SAPIOM_API_KEY` to translate each request, and none is set. Supply one to stand the endpoint up."
+        "sampleSql": "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC"
       }
     },
     {
@@ -64,12 +62,12 @@
     }
   ],
   "zeroSetup": {
-    "terminalState": "completed_partial",
+    "terminalState": "completed",
     "expect": [
       { "path": "sampleSql", "assert": "nonEmptyString" },
-      { "path": "deployed", "assert": "equals", "value": false },
-      { "path": "unmet", "assert": "nonEmptyArray" }
+      { "path": "deployed", "assert": "equals", "value": true },
+      { "path": "queryEndpoint", "assert": "nonEmptyString" }
     ],
-    "narrative": "Translates a sample question to SQL and validates it; deploys no endpoint (needs a scoped key)."
+    "narrative": "Translates a sample question to SQL, mints the endpoint its own scoped key, and deploys a working /query endpoint."
   }
 }

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -910,7 +910,7 @@
         "connectionCount": 1,
         "settingCount": 0,
         "provisions": ["postgres"],
-        "degradedWithoutSetup": "Translates a sample question to SQL and validates it; deploys no endpoint (needs a scoped key)."
+        "degradedWithoutSetup": "Translates a sample question to SQL, mints the endpoint its own scoped key, and deploys a working /query endpoint."
       }
     },
     {

--- a/packages/harness/web/e2e/dismiss.spec.ts
+++ b/packages/harness/web/e2e/dismiss.spec.ts
@@ -25,7 +25,9 @@ test.describe("session history dropdown", () => {
     await expect(menu).toBeHidden();
   });
 
-  test("closes on Escape and returns focus to the trigger", async ({ page }) => {
+  test("closes on Escape and returns focus to the trigger", async ({
+    page,
+  }) => {
     await page.getByTestId("history-trigger").click();
     await expect(page.getByTestId("history-menu")).toBeVisible();
 
@@ -54,11 +56,20 @@ test.describe("settings popover", () => {
     await page.getByTestId("telemetry-toggle").click();
     await expect(popover).toBeVisible();
 
-    await page.locator(".brand-name").click();
+    // Click well outside the popover to light-dismiss it. The popover anchors at
+    // the top-left brand/settings area and its identity row now overlaps
+    // `.brand-name`, so that (top-left) target is no longer "outside" — it's
+    // occluded by the popover and the click lands on the popover itself. Click the
+    // lower-right of the viewport, which is unambiguously outside a top-anchored popover.
+    const viewport = page.viewportSize();
+    if (!viewport) throw new Error("viewport size unavailable");
+    await page.mouse.click(viewport.width - 40, viewport.height - 40);
     await expect(popover).toBeHidden();
   });
 
-  test("closes on Escape and returns focus to the trigger", async ({ page }) => {
+  test("closes on Escape and returns focus to the trigger", async ({
+    page,
+  }) => {
     await page.getByTestId("brand-identity").click();
     await page.getByTestId("settings-trigger").click();
     await expect(page.getByTestId("settings-popover")).toBeVisible();
@@ -70,7 +81,9 @@ test.describe("settings popover", () => {
 });
 
 test.describe("new-session modal", () => {
-  test("closes on Escape and returns focus to the history trigger that spawned it", async ({ page }) => {
+  test("closes on Escape and returns focus to the history trigger that spawned it", async ({
+    page,
+  }) => {
     await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     await expect(page.locator(".modal-new-session")).toBeVisible();
@@ -80,7 +93,9 @@ test.describe("new-session modal", () => {
     await expect(page.getByTestId("history-trigger")).toBeFocused();
   });
 
-  test("still closes on a backdrop click, but not on clicks inside the panel", async ({ page }) => {
+  test("still closes on a backdrop click, but not on clicks inside the panel", async ({
+    page,
+  }) => {
     await page.getByTestId("add-workspace").click();
     await page.getByTestId("new-session-btn").click();
     await expect(page.locator(".modal-new-session")).toBeVisible();
@@ -95,16 +110,22 @@ test.describe("new-session modal", () => {
 });
 
 test.describe("end-session confirm dialog", () => {
-  const openConfirm = async (page: import("@playwright/test").Page): Promise<void> => {
+  const openConfirm = async (
+    page: import("@playwright/test").Page,
+  ): Promise<void> => {
     await page.getByTestId("session-menu").click();
     await page.getByTestId("session-end-btn").click();
     await expect(page.getByTestId("end-session-confirm")).toBeVisible();
   };
 
-  test("opens with focus on the SAFE action (Keep session)", async ({ page }) => {
+  test("opens with focus on the SAFE action (Keep session)", async ({
+    page,
+  }) => {
     await openConfirm(page);
     // Enter must keep the session; ending it takes a deliberate move.
-    await expect(page.getByRole("button", { name: "Keep session" })).toBeFocused();
+    await expect(
+      page.getByRole("button", { name: "Keep session" }),
+    ).toBeFocused();
   });
 
   test("Escape keeps the session and closes the dialog", async ({ page }) => {
@@ -112,13 +133,19 @@ test.describe("end-session confirm dialog", () => {
     await page.keyboard.press("Escape");
     await expect(page.getByTestId("end-session-confirm")).toHaveCount(0);
     // Nothing died: the active session is still shown.
-    await expect(page.getByTestId("session-context")).not.toContainText("No active session");
+    await expect(page.getByTestId("session-context")).not.toContainText(
+      "No active session",
+    );
   });
 
-  test("a backdrop click keeps the session and closes the dialog", async ({ page }) => {
+  test("a backdrop click keeps the session and closes the dialog", async ({
+    page,
+  }) => {
     await openConfirm(page);
     await page.locator(".modal-backdrop").click({ position: { x: 5, y: 5 } });
     await expect(page.getByTestId("end-session-confirm")).toHaveCount(0);
-    await expect(page.getByTestId("session-context")).not.toContainText("No active session");
+    await expect(page.getByTestId("session-context")).not.toContainText(
+      "No active session",
+    );
   });
 });

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -160,6 +160,8 @@ import type {
   ActiveSession,
 } from "./browser-automation/index.js";
 import * as vault from "./vault/index.js";
+import * as keys from "./keys/index.js";
+import type { MintScopedInput, ScopedKey } from "./keys/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -423,6 +425,17 @@ export interface Sapiom {
     getMany(ref: string, keys: string[]): Promise<Record<string, string>>;
     getAll(ref: string): Promise<Record<string, string>>;
   };
+  /**
+   * Mint a durable, narrowly-scoped Sapiom API key for an artifact this step deploys
+   * (SAP-2300). The per-run credential expires with the step, so a long-lived child
+   * (e.g. a deployed HTTP endpoint) needs its own key: `mintScoped` returns one that
+   * is attenuated to a subset of this run's authority (never wildcard), attributed to
+   * the workflow definition, and always expiring/revocable. Inject the returned `key`
+   * into the artifact's environment (e.g. `SAPIOM_API_KEY`) — never persist or echo it.
+   */
+  readonly keys: {
+    mintScoped(input: MintScopedInput): Promise<ScopedKey>;
+  };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
     /** Generate speech audio from text. */
@@ -449,7 +462,9 @@ export interface Sapiom {
       /** Open a new browser session. */
       create(): Promise<BrowserSession>;
       /** Open a new browser session pre-authenticated with an identity. */
-      createWithIdentity(input: { identityId: string }): Promise<BrowserSession>;
+      createWithIdentity(input: {
+        identityId: string;
+      }): Promise<BrowserSession>;
       /** Close a session and settle its billing. */
       close(sessionId: string): Promise<SessionSettlement>;
     };
@@ -626,6 +641,9 @@ function bind(transport: Transport): Sapiom {
       getMany: (ref, keys) => vault.getMany(ref, keys, transport),
       getAll: (ref) => vault.getAll(ref, transport),
     },
+    keys: {
+      mintScoped: (input) => keys.mintScoped(input, transport),
+    },
     speech: {
       textToSpeech: {
         create: (input) => speech.createSpeech(input, transport),
@@ -642,7 +660,8 @@ function bind(transport: Transport): Sapiom {
         create: () => browserAutomation.createSession(transport),
         createWithIdentity: (input) =>
           browserAutomation.createSessionWithIdentity(input, transport),
-        close: (sessionId) => browserAutomation.closeSession(sessionId, transport),
+        close: (sessionId) =>
+          browserAutomation.closeSession(sessionId, transport),
       },
       screenshot: (input) => browserAutomation.screenshot(input, transport),
       withSession: (fn, opts) =>

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -79,7 +79,10 @@ export { agentResultSchema, AgentResultSchemaError } from "./agents/index.js";
 // `releaseSession` — deferred capacity, repeatable calls).
 export * as llm from "./llm/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on an llm step.
-export { LLM_ROUTE_RESULT_SIGNAL, LLM_SESSION_READY_SIGNAL } from "./llm/index.js";
+export {
+  LLM_ROUTE_RESULT_SIGNAL,
+  LLM_SESSION_READY_SIGNAL,
+} from "./llm/index.js";
 // The shape a step resumed from `pauseUntilSignal(llmHandle, …)` receives as
 // input — annotate the resumed step with it instead of hand-rolling the shape.
 export type { LlmRouteResultPayload } from "./llm/index.js";
@@ -125,3 +128,7 @@ export { BrowserAutomationHttpError } from "./browser-automation/index.js";
 
 export * as vault from "./vault/index.js";
 export { VaultHttpError } from "./vault/index.js";
+
+export * as keys from "./keys/index.js";
+export { KeysHttpError } from "./keys/index.js";
+export type { MintScopedInput, ScopedKey } from "./keys/index.js";

--- a/packages/tools/src/keys/errors.ts
+++ b/packages/tools/src/keys/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * Error thrown by the `keys` capability when the Core API returns a non-2xx
+ * response to a mint request. Exposes `status` (HTTP status code) and `body`
+ * (parsed JSON body, or raw text when the body isn't JSON) for programmatic
+ * inspection.
+ *
+ * Useful statuses to branch on: `401` (missing/invalid credential), `403` (the
+ * caller is not a workflow-run token, or the requested scope exceeds it).
+ */
+export class KeysHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "KeysHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link KeysHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new KeysHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/keys/index.spec.ts
+++ b/packages/tools/src/keys/index.spec.ts
@@ -1,0 +1,185 @@
+import { Transport } from "../_client/index.js";
+import * as keys from "./index.js";
+import { KeysHttpError, toTtlSeconds } from "./index.js";
+
+// Capability fns are tested directly with a real Transport plus a scripted fetch
+// mock, so URL/method/header/body assertions are exact and we verify the Transport
+// injects the tenant credential on the header the /v1 controller guard reads.
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://api.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+const mintResponse = (overrides: Record<string, unknown> = {}) => ({
+  apiKey: {
+    id: "child-key-1",
+    expiresAt: "2026-09-01T00:00:00Z",
+    permissions: ["org.transactions.write"],
+    ...overrides,
+  },
+  plainKey: "sk_live_child-secret",
+});
+
+describe("keys.mintScoped()", () => {
+  it("POSTs /v1/api-keys/scoped/workflow on x-api-key and maps the response", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(mintResponse()),
+    ]);
+
+    const result = await keys.mintScoped({ ttl: 2592000 }, transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/api-keys/scoped/workflow`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // The /v1 controller guard reads x-api-key — NOT the gateway-direct x-sapiom-api-key.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ ttl: 2592000 });
+
+    expect(result).toEqual({
+      key: "sk_live_child-secret",
+      id: "child-key-1",
+      expiresAt: "2026-09-01T00:00:00Z",
+      permissions: ["org.transactions.write"],
+    });
+  });
+
+  it("accepts a compact duration string for ttl", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(mintResponse()),
+    ]);
+    await keys.mintScoped({ ttl: "30d" }, transport, BASE);
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ ttl: 2592000 });
+  });
+
+  it("omits scope when not provided (server defaults it)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(mintResponse()),
+    ]);
+    await keys.mintScoped({ ttl: 3600 }, transport, BASE);
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ ttl: 3600 });
+  });
+
+  it("normalizes a single scope string to an array", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(mintResponse()),
+    ]);
+    await keys.mintScoped(
+      { ttl: 3600, scope: "org.transactions.write" },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      ttl: 3600,
+      scope: ["org.transactions.write"],
+    });
+  });
+
+  it("passes an array scope through unchanged", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(mintResponse()),
+    ]);
+    await keys.mintScoped(
+      { ttl: 3600, scope: ["org.transactions.write"] },
+      transport,
+      BASE,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string).scope).toEqual([
+      "org.transactions.write",
+    ]);
+  });
+
+  it("defaults expiresAt/permissions when the response omits them", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ apiKey: { id: "child-2" }, plainKey: "sk_live_x" }),
+    ]);
+    const result = await keys.mintScoped({ ttl: 3600 }, transport, BASE);
+    expect(result).toEqual({
+      key: "sk_live_x",
+      id: "child-2",
+      expiresAt: null,
+      permissions: [],
+    });
+  });
+
+  it("throws KeysHttpError on a non-2xx response, carrying status + body", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "not a workflow run token" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(
+      keys.mintScoped({ ttl: 3600 }, transport, BASE),
+    ).rejects.toMatchObject({
+      name: "KeysHttpError",
+      status: 403,
+      body: { message: "not a workflow run token" },
+    });
+    await expect(
+      keys.mintScoped({ ttl: 3600 }, transport, BASE),
+    ).rejects.toBeInstanceOf(KeysHttpError);
+  });
+});
+
+describe("toTtlSeconds()", () => {
+  it("passes a positive number of seconds through (floored)", () => {
+    expect(toTtlSeconds(3600)).toBe(3600);
+    expect(toTtlSeconds(90.9)).toBe(90);
+  });
+
+  it("parses compact duration strings", () => {
+    expect(toTtlSeconds("45s")).toBe(45);
+    expect(toTtlSeconds("45m")).toBe(45 * 60);
+    expect(toTtlSeconds("12h")).toBe(12 * 60 * 60);
+    expect(toTtlSeconds("30d")).toBe(30 * 60 * 60 * 24);
+    expect(toTtlSeconds("3600")).toBe(3600); // bare number → seconds
+  });
+
+  it("throws on non-positive or unparseable values", () => {
+    expect(() => toTtlSeconds(0)).toThrow(TypeError);
+    expect(() => toTtlSeconds(-5)).toThrow(TypeError);
+    expect(() => toTtlSeconds("soon")).toThrow(TypeError);
+    expect(() => toTtlSeconds("10w")).toThrow(TypeError);
+  });
+});

--- a/packages/tools/src/keys/index.ts
+++ b/packages/tools/src/keys/index.ts
@@ -1,0 +1,156 @@
+/**
+ * `keys` capability — mint a durable, narrowly-scoped Sapiom API key from inside a
+ * workflow step, so a long-lived artifact the step DEPLOYS can call Sapiom on every
+ * future request with its own credential (SAP-2300).
+ *
+ *   import { keys } from "@sapiom/tools";                       // ambient auth
+ *   const minted = await keys.mintScoped({ ttl: "30d" });      // scope defaults to
+ *                                                              // metered-capability authority
+ *   // inject minted.key into the deployed artifact's env as SAPIOM_API_KEY
+ *
+ * Or on the step context: `ctx.sapiom.keys.mintScoped({ ttl, scope })`.
+ *
+ * WHY this exists: the per-run capability token the engine injects as `SAPIOM_API_KEY`
+ * EXPIRES with the step, so it cannot be handed to a child that outlives the run. And
+ * the read-only `vault` deliberately cannot mint. `mintScoped` fills that gap through
+ * the brokered scoped-key path: the Core endpoint mints a key attenuated to a SUBSET of
+ * the run token's own permissions (never wildcard), attributed to the workflow
+ * definition for lineage + billing, and ALWAYS expiring/revocable. It is minting-only —
+ * there is no plaintext tenant key involved, and no way to widen authority beyond the
+ * run's.
+ *
+ * The minted `key` is the plaintext secret, shown ONCE: inject it into the artifact's
+ * environment and never persist or echo it.
+ *
+ * Wire: Core `POST /v1/api-keys/scoped/workflow`, the tenant credential on `x-api-key`
+ * (the header the `/v1` controller guard reads — NOT the gateway-direct
+ * `x-sapiom-api-key`). Only a workflow-run token may call it; any other principal 403s.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveCoreBaseUrl } from "../_client/capability-call.js";
+import { ensureOk, KeysHttpError } from "./errors.js";
+
+export { KeysHttpError };
+
+/** How long a minted key lives before it expires. */
+export interface MintScopedInput {
+  /**
+   * Lifetime of the minted key. A number is SECONDS; a string is a compact duration
+   * (`"30d"`, `"12h"`, `"45m"`, `"3600s"`, or a bare number of seconds like `"3600"`).
+   * Required — a workflow-minted key always expires. Clamped server-side to 60s..1 year.
+   */
+  ttl: number | string;
+  /**
+   * Permission scope(s) for the minted key — must be a subset of the calling token, and
+   * never `"*"`. Omit to default to `"org.transactions.write"`, the authority every
+   * metered Sapiom capability (models, database, sandboxes, search, …) needs. Pass a
+   * narrower/different subset only when the artifact needs something specific.
+   */
+  scope?: string | string[];
+}
+
+/** A freshly minted scoped key. */
+export interface ScopedKey {
+  /**
+   * The plaintext secret, shown ONCE. Inject it into your deployed artifact's
+   * environment (e.g. `SAPIOM_API_KEY`); never persist, log, or echo it.
+   */
+  key: string;
+  /** The minted key's id — use it to revoke the key later from the dashboard/API. */
+  id: string;
+  /** ISO-8601 expiry timestamp. The key always expires. */
+  expiresAt: string | null;
+  /** The permission keys the minted key carries. */
+  permissions: string[];
+}
+
+/** The Core `CreateApiKeyResponseDto` shape (`{ apiKey, plainKey }`). */
+interface MintResponse {
+  apiKey: {
+    id: string;
+    expiresAt?: string | null;
+    permissions?: string[] | null;
+  };
+  plainKey: string;
+}
+
+const DURATION_UNIT_SECONDS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 60 * 60,
+  d: 60 * 60 * 24,
+};
+
+/**
+ * Normalize `ttl` to whole seconds. Accepts a number (seconds) or a compact duration
+ * string (`"30d"`, `"12h"`, `"45m"`, `"3600s"`, or a bare `"3600"`). Throws on an
+ * unparseable or non-positive value — a bad TTL should fail loudly at the call site,
+ * not silently mint a key with a surprising lifetime.
+ */
+export function toTtlSeconds(ttl: number | string): number {
+  if (typeof ttl === "number") {
+    if (!Number.isFinite(ttl) || ttl <= 0) {
+      throw new TypeError(
+        `ttl must be a positive number of seconds, got ${ttl}`,
+      );
+    }
+    return Math.floor(ttl);
+  }
+  const trimmed = ttl.trim();
+  const match = /^(\d+)\s*([smhd]?)$/i.exec(trimmed);
+  if (!match) {
+    throw new TypeError(
+      `ttl must be a number of seconds or a duration like "30d"/"12h"/"45m", got "${ttl}"`,
+    );
+  }
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase() || "s";
+  const seconds = amount * DURATION_UNIT_SECONDS[unit];
+  if (seconds <= 0) {
+    throw new TypeError(
+      `ttl must resolve to a positive number of seconds, got "${ttl}"`,
+    );
+  }
+  return seconds;
+}
+
+/**
+ * Mint a durable, narrowly-scoped Sapiom API key for an artifact the current workflow
+ * step deploys. Returns the plaintext `key` (shown once) plus its id, expiry, and
+ * permissions. Throws {@link KeysHttpError} on a non-2xx response (e.g. 403 when called
+ * outside a workflow run or when the requested scope exceeds the run token).
+ */
+export async function mintScoped(
+  input: MintScopedInput,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = resolveCoreBaseUrl(),
+): Promise<ScopedKey> {
+  const ttl = toTtlSeconds(input.ttl);
+  const scope =
+    input.scope === undefined
+      ? undefined
+      : Array.isArray(input.scope)
+        ? input.scope
+        : [input.scope];
+
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/api-keys/scoped/workflow`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ttl, ...(scope ? { scope } : {}) }),
+      },
+      { authHeader: "x-api-key" },
+    ),
+    "Failed to mint scoped key",
+  );
+
+  const body = (await res.json()) as MintResponse;
+  return {
+    key: body.plainKey,
+    id: body.apiKey.id,
+    expiresAt: body.apiKey.expiresAt ?? null,
+    permissions: body.apiKey.permissions ?? [],
+  };
+}

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -17,12 +17,14 @@ import {
   memory,
   speech,
   browserAutomation,
+  keys,
   Sandbox,
   Repository,
   SearchHttpError,
   MemoryHttpError,
   SpeechHttpError,
   BrowserAutomationHttpError,
+  KeysHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -66,11 +68,16 @@ describe("@sapiom/tools public surface", () => {
 
     expect(typeof sapiom.browserAutomation).toBe("object");
     expect(typeof sapiom.browserAutomation.sessions.create).toBe("function");
-    expect(typeof sapiom.browserAutomation.sessions.createWithIdentity).toBe("function");
+    expect(typeof sapiom.browserAutomation.sessions.createWithIdentity).toBe(
+      "function",
+    );
     expect(typeof sapiom.browserAutomation.sessions.close).toBe("function");
     expect(typeof sapiom.browserAutomation.screenshot).toBe("function");
     expect(typeof sapiom.browserAutomation.withSession).toBe("function");
     expect(typeof sapiom.browserAutomation.identities.create).toBe("function");
+
+    expect(typeof sapiom.keys).toBe("object");
+    expect(typeof sapiom.keys.mintScoped).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });
@@ -90,10 +97,12 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof memory).toBe("object");
     expect(typeof speech).toBe("object");
     expect(typeof browserAutomation).toBe("object");
+    expect(typeof keys).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");
     expect(typeof BrowserAutomationHttpError).toBe("function");
+    expect(typeof KeysHttpError).toBe("function");
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -109,6 +109,7 @@ import type {
   Identity,
   ActiveSession,
 } from "../browser-automation/index.js";
+import type { ScopedKey } from "../keys/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -679,7 +680,8 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
     args: unknown[],
     fallback: () => unknown,
     capabilityOverride?: string,
-  ) => resolve(overrides, paths, args, fallback, opts.calls, capabilityOverride);
+  ) =>
+    resolve(overrides, paths, args, fallback, opts.calls, capabilityOverride);
 
   // Per-client memory state: namespace → (id → record). See the `memory`
   // capability below for what is and isn't simulated.
@@ -978,7 +980,8 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       releaseSession: (session) =>
         Promise.resolve(
           r("llm.releaseSession", [session], () => ({
-            sessionId: typeof session === "string" ? session : session.sessionId,
+            sessionId:
+              typeof session === "string" ? session : session.sessionId,
             state: "expired" as const,
           })) as LlmSession,
         ),
@@ -1633,7 +1636,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       list: (ref: string) =>
         Promise.resolve(r("vault.list", [ref], () => []) as string[]),
       get: (ref: string, key: string) =>
-        Promise.resolve(r("vault.get", [ref, key], () => null) as string | null),
+        Promise.resolve(
+          r("vault.get", [ref, key], () => null) as string | null,
+        ),
       getMany: (ref: string, keys: string[]) =>
         Promise.resolve(
           r("vault.getMany", [ref, keys], () => ({})) as Record<string, string>,
@@ -1641,6 +1646,24 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       getAll: (ref: string) =>
         Promise.resolve(
           r("vault.getAll", [ref], () => ({})) as Record<string, string>,
+        ),
+    },
+    // Scoped-key mint (SAP-2300). A local run mints no real credential — it returns a
+    // clearly-fake, shape-faithful key so a deploy step can trace the full graph
+    // offline. The `key` is an obvious placeholder, never a usable secret.
+    keys: {
+      mintScoped: (input) =>
+        Promise.resolve(
+          r("keys.mintScoped", [input], () => ({
+            key: "sk_live_stub-scoped-key",
+            id: "stub-scoped-key",
+            expiresAt: null,
+            permissions: Array.isArray(input.scope)
+              ? input.scope
+              : input.scope
+                ? [input.scope]
+                : ["org.transactions.write"],
+          })) as ScopedKey,
         ),
     },
     speech: {


### PR DESCRIPTION
## Problem

A workflow that **deploys a durable artifact** needs its own Sapiom key: the per-run capability token the engine injects as `SAPIOM_API_KEY` **expires with the step**, so it can't be handed to a long-lived child, and the read-only `vault` deliberately can't mint. There was no author-facing primitive to mint a durable scoped key — so `nl-db-query-endpoint` required a manual `ENDPOINT_SAPIOM_API_KEY` secret and a zero-setup run degraded to `endpoint_skipped`.

Part of SAP-2300 (backend endpoint is the companion `sapiom/Sapiom` PR).

## Change

**New `keys` namespace** (`packages/tools/src/keys/`), mirroring the read-only `vault` namespace:

```ts
const minted = await ctx.sapiom.keys.mintScoped({ ttl: "30d" });
// inject minted.key into the deployed artifact's env as SAPIOM_API_KEY
```

- POSTs the run token to Core's brokered mint (`POST /v1/api-keys/scoped/workflow`) with the credential on `x-api-key` (the header the `/v1` controller guard reads), reusing `resolveCoreBaseUrl()`.
- `scope` defaults to `org.transactions.write` (the authority every metered capability needs) and is never wildcard; accepts a single string or array.
- `ttl` accepts seconds (number) or a compact duration string (`"30d"`, `"12h"`, `"45m"`) — `toTtlSeconds` normalizes it.
- Returns `{ key, id, expiresAt, permissions }` — `key` is the plaintext secret, shown once.
- Wired into the `Sapiom` interface, `bind()`, the barrel (`export * as keys` + `KeysHttpError` + types), and the **stub client** (a shape-faithful, obviously-fake key so local `run_local` traces the deploy branch).

## `nl-db-query-endpoint`

The deploy step now **mints the endpoint its own scoped key** instead of relying on a manual secret, so a zero-setup `{}` run deploys a **working** endpoint:

- `ENDPOINT_SAPIOM_API_KEY` demoted to an optional bring-your-own override.
- `template.json` (`longDescription`, `notes`, `requiredSecrets`, `examples`, `zeroSetup` → `completed`/`deployed: true`), `registry.json` (synced), and `README.md` updated.

## Tests

- `keys/index.spec.ts` — URL/method/`x-api-key` header/body, duration-string ttl, scope normalization, response mapping + defaults, `KeysHttpError` on non-2xx, and `toTtlSeconds` unit cases.
- `smoke.spec.ts` — extended to assert the `keys` namespace + barrel export.
- `examples-check` passes (schema + copy + registry sync).

15/15 tests green; `@sapiom/tools` builds, lints, prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)