### PR TITLE
feat(templates): declare & honor per-resource DB reuse for every Postgres template (SAP-2319)

### DIFF
--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -3,6 +3,7 @@ import {
   defineStep,
   goto,
   pauseUntilSignal,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -409,9 +410,17 @@ const start = defineStep({
       "escalateTo",
       input.escalateTo?.trim() || config.ESCALATION_EMAIL || null,
     );
+    // The durable ledger is opt-in: absent a handle the chain runs off `ctx.shared`
+    // alone and provisions no Postgres. Read the chosen handle through the canonical
+    // injection seam (declared as `resources[].reuse.key: "ledgerHandle"`) so a
+    // deploy-time reuse picker can point it at a ledger DB the tenant already owns.
+    // Fallback is `""`, not a default handle: an empty result must degrade to null,
+    // never force a managed database onto a run that asked for none.
     ctx.shared.set(
       "ledgerHandle",
-      input.ledgerHandle?.trim() || config.LEDGER_HANDLE || null,
+      resolveResourceHandle(input, { key: "ledgerHandle", fallback: "" }) ||
+        config.LEDGER_HANDLE ||
+        null,
     );
     ctx.shared.set("maxReminders", input.maxReminders ?? DEFAULT_MAX_REMINDERS);
     ctx.shared.set("dryRun", input.dryRun === true);

--- a/examples/approval-chain/template.json
+++ b/examples/approval-chain/template.json
@@ -18,7 +18,8 @@
       "kind": "postgres",
       "handle": "approval-chain-ledger",
       "duration": "7d",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "ledgerHandle" }
     }
   ],
   "settings": [

--- a/examples/cold-outreach-engine/template.json
+++ b/examples/cold-outreach-engine/template.json
@@ -18,7 +18,8 @@
       "kind": "postgres",
       "handle": "cold-outreach-engine",
       "duration": "7d",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "settings": [

--- a/examples/error-triage-digest/template.json
+++ b/examples/error-triage-digest/template.json
@@ -18,7 +18,8 @@
       "kind": "postgres",
       "handle": "error-triage-digest",
       "duration": "7d",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "settings": [

--- a/examples/meeting-notes-crm/template.json
+++ b/examples/meeting-notes-crm/template.json
@@ -18,7 +18,8 @@
       "kind": "postgres",
       "handle": "meeting-notes-crm",
       "duration": "7d",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "settings": [

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -2,6 +2,7 @@ import {
   defineAgent,
   defineStep,
   goto,
+  resolveResourceHandle,
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
@@ -133,7 +134,13 @@ const ENDPOINT_API_KEY = "ENDPOINT_SAPIOM_API_KEY";
 const ENDPOINT_KEY_TTL = "30d";
 
 function resolveConfig(input: EntryInput | undefined): Config {
-  const dbHandle = input?.dbHandle?.trim() ?? "";
+  // Read the target handle through the canonical injection seam so a deploy-time
+  // reuse picker (declared as `resources[].reuse.key: "dbHandle"`) can repoint the
+  // endpoint at a database the caller already owns. The fallback is `""`, not
+  // DEFAULT_DB_HANDLE: "no handle named" is a real state here — it selects the
+  // seeded demo DB below only when no `connectionString` was given either, and a
+  // user-named handle that 404s is rejected rather than silently reprovisioned.
+  const dbHandle = resolveResourceHandle(input ?? {}, { fallback: "" });
   const connectionString = input?.connectionString?.trim() ?? "";
   const usingDemoDatabase = !dbHandle && !connectionString;
   return {

--- a/examples/nl-db-query-endpoint/template.json
+++ b/examples/nl-db-query-endpoint/template.json
@@ -19,7 +19,8 @@
       "handle": "nl-db-query-demo",
       "duration": "7d",
       "seed": "seed.sql",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "requiredSecrets": [

--- a/examples/personalized-media-at-scale/template.json
+++ b/examples/personalized-media-at-scale/template.json
@@ -19,7 +19,8 @@
       "handle": "personalized-media",
       "duration": "7d",
       "seed": "seed.sql",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "defaultInput": {

--- a/examples/scheduled-db-insight-report/template.json
+++ b/examples/scheduled-db-insight-report/template.json
@@ -19,7 +19,8 @@
       "handle": "db-insight-demo",
       "duration": "7d",
       "seed": "seed.sql",
-      "ephemeral": false
+      "ephemeral": false,
+      "reuse": { "key": "dbHandle" }
     }
   ],
   "requiredSecrets": [

--- a/examples/template.schema.json
+++ b/examples/template.schema.json
@@ -136,6 +136,19 @@
             "type": "boolean",
             "default": true,
             "description": "True when the resource is disposable per run. False signals the 7-day TTL problem applies and the template needs a durability story in `notes`."
+          },
+          "reuse": {
+            "type": "object",
+            "required": ["key"],
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "type": "string",
+                "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+                "description": "The top-level entry-input key the run reads the chosen handle from — `resolveResourceHandle(input, { key })`, default `dbHandle`. This is the settings path the picker writes; a `settings[]` entry with the same `path` may render it as a plain field too. One key per resource is sufficient for the current gallery (one Postgres per template); the field is what makes a second Postgres forward-compatible without inventing a second naming convention. Not a dotted path — `resolveResourceHandle` reads a top-level key only."
+              }
+            },
+            "description": "Present ⇒ the resource is user-repointable: the deploy-time reuse picker may offer \"use a database you already have\", and the run opens the chosen handle instead of the declared default. Absent ⇒ the resource is internal state (not user data) and no picker is offered — the honest marker for a database whose contents a user should never be handed. Only ever offer the picker for a resource whose STEP CODE reads the injected handle via `resolveResourceHandle`; a `reuse` descriptor on a resource the code hardcodes advertises a control the next run silently ignores, which the `manifest-resource-reuse` check rejects."
           }
         }
       }

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -21,6 +21,9 @@
 //      names paths the code's entry `inputSchema` declares — a projection onto
 //      a field the schema never declares is the drift SAP-2226 exists to catch.
 //      See scripts/examples-entry-schema-check.mjs.
+//   5c. a resource marked reusable (`resources[].reuse.key`) has that key read
+//      via `resolveResourceHandle` in index.ts — so the reuse picker (SAP-2320)
+//      can never offer a handle the run ignores. See examples-manifest-check.mjs.
 //   6. house-style copy rules the schemas cannot express — see
 //      scripts/examples-copy-check.mjs. (The length caps ARE in the schemas,
 //      as `maxLength`, so they surface through checks 1 and 5.)
@@ -40,6 +43,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
 import {
+  checkResourceReuse,
   checkResourceSeeds,
   checkSetupSync,
   createManifestChecker,
@@ -137,6 +141,12 @@ for (const t of templates) {
     ? readFileSync(indexPath, "utf8")
     : null;
   errors.push(...checkEntrySchemaCoverage(t.id, manifest, indexSource));
+
+  // 5c. A resource marked reusable (`reuse.key`) must have its handle read from
+  // the entry input via `resolveResourceHandle` in the same index.ts — otherwise
+  // the picker offers a control the next run silently ignores (design-v2
+  // § Landmines). Reuses the index source read just above.
+  errors.push(...checkResourceReuse(t.id, manifest, indexSource));
 
   manifests.set(t.id, manifest);
   manifestsChecked++;

--- a/scripts/examples-manifest-check.mjs
+++ b/scripts/examples-manifest-check.mjs
@@ -160,6 +160,66 @@ export function checkResourceSeeds(templateId, manifest, fileExists) {
 }
 
 /**
+ * True when `source` reads the injected handle under `key` via
+ * `resolveResourceHandle`. The default key (`dbHandle`) is read by any call with
+ * no `key` option, so a bare call satisfies it; a non-default key must be named
+ * explicitly in the options bag, which is exactly what keeps the declaration and
+ * the runtime read from drifting.
+ */
+function readsInjectedHandle(source, key) {
+  if (!/resolveResourceHandle\s*\(/.test(source)) return false;
+  if (key === "dbHandle") return true;
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`key\\s*:\\s*["']${escaped}["']`).test(source);
+}
+
+/**
+ * A `reuse` descriptor is the deploy-time picker's permission to offer "use a
+ * database you already have" for a resource. It is honest ONLY when the step
+ * actually opens the injected handle — otherwise the user picks a database the
+ * next run ignores, the dishonest affordance design-v2 § Landmines forbids
+ * ("a picker turns a latent hazard into a likely one"). Two rules the schema
+ * cannot express:
+ *   - reuse is a postgres concept — the picker lists databases, so a marker on a
+ *     sandbox / repository / inbox would offer a control with nothing to show.
+ *   - the declared `key` must be read by a `resolveResourceHandle(...)` call in
+ *     the step code, so a `reuse` marker can never sit on a hardcoded handle.
+ *
+ * @param indexSource  contents of the template's index.ts, or null when absent.
+ */
+export function checkResourceReuse(templateId, manifest, indexSource) {
+  const resources = Array.isArray(manifest?.resources)
+    ? manifest.resources
+    : [];
+  const errors = [];
+  const where = `"${templateId}" template.json`;
+  resources.forEach((resource, i) => {
+    const reuse = resource?.reuse;
+    if (reuse === undefined || reuse === null) return;
+    if (resource?.kind !== "postgres") {
+      errors.push(
+        `manifest-resource-reuse: ${where} /resources/${i} declares \`reuse\` on a "${resource?.kind}" resource — reuse is the postgres "use a database you already have" picker; only postgres resources may carry it.`,
+      );
+      return;
+    }
+    const key = reuse?.key;
+    if (typeof key !== "string") return; // the descriptor's shape is the schema's job.
+    if (indexSource === null) {
+      errors.push(
+        `manifest-resource-reuse: ${where} /resources/${i} is marked reusable but the template has no index.ts to read the injected "${key}" — a picker would repoint a handle no step opens.`,
+      );
+      return;
+    }
+    if (!readsInjectedHandle(indexSource, key)) {
+      errors.push(
+        `manifest-resource-reuse: ${where} /resources/${i}/reuse/key "${key}" is never read via resolveResourceHandle in index.ts — a reuse descriptor promises the run opens the picked handle, so the step must read it (the SAP-2191 migration pattern). Either wire the read or drop \`reuse\`.`,
+      );
+    }
+  });
+  return errors;
+}
+
+/**
  * Compile the manifest schema once and return a checker.
  *
  * @param ajv       the Ajv instance already built for the registry check

--- a/scripts/examples-manifest-check.mjs
+++ b/scripts/examples-manifest-check.mjs
@@ -160,17 +160,64 @@ export function checkResourceSeeds(templateId, manifest, fileExists) {
 }
 
 /**
- * True when `source` reads the injected handle under `key` via
- * `resolveResourceHandle`. The default key (`dbHandle`) is read by any call with
- * no `key` option, so a bare call satisfies it; a non-default key must be named
- * explicitly in the options bag, which is exactly what keeps the declaration and
- * the runtime read from drifting.
+ * The set of injected-input keys the step code reads via `resolveResourceHandle`.
+ * A call's `key: "…"` option is the key it reads; a call that names no key reads
+ * the default `dbHandle`.
+ *
+ * Only each call's own ARGUMENT LIST is inspected — located by matching
+ * `resolveResourceHandle(` and scanning balanced parens — so a `key:` sitting in
+ * a comment, a JSDoc `@link`, or an unrelated object literal cannot forge a read.
+ * That closes the two loopholes a whole-source regex leaves open: (1) a declared
+ * `dbHandle` "satisfied" by any resolver call even when that call reads a
+ * different key, and (2) a non-default key "read" only because the string appears
+ * in a comment (e.g. the `reuse.key: "ledgerHandle"` note this file's own
+ * templates carry). The reuse check leans on this, and SAP-2320 leans on the
+ * reuse check, so a false positive here is a dishonest picker downstream.
+ *
+ * Value-side heuristics kept deliberately narrow: a `key` whose value is not a
+ * string literal (a variable) reads an unknown key and is intentionally NOT
+ * credited — the picker needs a statically declared key, so "compute the key at
+ * runtime" should fail the declaration, not pass it.
+ */
+function keysReadViaResolver(source) {
+  const keys = new Set();
+  const marker = "resolveResourceHandle";
+  for (
+    let at = source.indexOf(marker);
+    at !== -1;
+    at = source.indexOf(marker, at + marker.length)
+  ) {
+    // Skip a longer identifier that merely ends in the marker.
+    const before = source[at - 1];
+    if (before && /[A-Za-z0-9_$]/.test(before)) continue;
+    let i = at + marker.length;
+    while (i < source.length && /\s/.test(source[i])) i++;
+    if (source[i] !== "(") continue; // an import specifier or an @link, not a call.
+    let depth = 0;
+    let end = -1;
+    for (let j = i; j < source.length; j++) {
+      if (source[j] === "(") depth++;
+      else if (source[j] === ")" && --depth === 0) {
+        end = j;
+        break;
+      }
+    }
+    if (end === -1) continue;
+    const args = source.slice(i + 1, end);
+    const keyMatch = /\bkey\s*:\s*["']([^"']+)["']/.exec(args);
+    if (keyMatch) keys.add(keyMatch[1]);
+    else if (!/\bkey\s*:/.test(args)) keys.add("dbHandle"); // a bare call ⇒ the default key.
+  }
+  return keys;
+}
+
+/**
+ * True when `source` reads the injected handle under `key` via a real
+ * `resolveResourceHandle` call — see {@link keysReadViaResolver} for why this
+ * inspects call arguments rather than the whole source.
  */
 function readsInjectedHandle(source, key) {
-  if (!/resolveResourceHandle\s*\(/.test(source)) return false;
-  if (key === "dbHandle") return true;
-  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`key\\s*:\\s*["']${escaped}["']`).test(source);
+  return keysReadViaResolver(source).has(key);
 }
 
 /**

--- a/scripts/examples-manifest-check.test.mjs
+++ b/scripts/examples-manifest-check.test.mjs
@@ -383,6 +383,44 @@ test("checkResourceReuse: a reusable resource with no index.ts fails", () => {
   assert.match(errors[0], /no index\.ts/);
 });
 
+// Loophole 1: a declared default key must be read by a call that actually reads
+// the default — not credited just because *some* resolveResourceHandle call
+// exists. Here the only call reads a different key.
+test("checkResourceReuse: a declared dbHandle is not satisfied by a call reading another key", () => {
+  const errors = checkResourceReuse(
+    "fixture",
+    {
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "dbHandle" } },
+      ],
+    },
+    `const h = resolveResourceHandle(input, { key: "somethingElse", fallback: "" });`,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /never read via resolveResourceHandle/);
+});
+
+// Loophole 2: the declared key appearing only in a comment (or any text outside
+// a real call's arguments) must NOT satisfy the check — the exact shape this
+// PR's own templates carry, e.g. `reuse.key: "ledgerHandle"` in a doc comment.
+test("checkResourceReuse: a key named only in a comment does not count as read", () => {
+  const commentOnly = [
+    `// declared as \`resources[].reuse.key: "ledgerHandle"\``,
+    `const h = resolveResourceHandle(input, { fallback: "" }); // reads dbHandle`,
+  ].join("\n");
+  const errors = checkResourceReuse(
+    "fixture",
+    {
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "ledgerHandle" } },
+      ],
+    },
+    commentOnly,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /never read via resolveResourceHandle/);
+});
+
 test("checkResourceReuse: an internal-state resource with no reuse marker is fine", () => {
   // the-brain: hardcoded handle, no reuse descriptor ⇒ no picker, no error.
   assert.deepEqual(

--- a/scripts/examples-manifest-check.test.mjs
+++ b/scripts/examples-manifest-check.test.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import Ajv from "ajv";
 import {
+  checkResourceReuse,
   checkResourceSeeds,
   checkSetupSync,
   createManifestChecker,
@@ -244,6 +245,183 @@ test("a resource naming a storage location fails", () => {
   });
   assert.equal(errors.length, 1);
   assert.match(errors[0], /\/resources\/0 must NOT have additional properties/);
+});
+
+// --- reuse descriptor (the deploy-time "use my own database" picker) --------
+
+test("a resource with a fully declared reuse descriptor is valid", () => {
+  assert.deepEqual(
+    check({
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "dbHandle" } },
+      ],
+    }),
+    [],
+  );
+});
+
+test("a reuse descriptor missing key fails", () => {
+  assert.deepEqual(
+    check({ resources: [{ kind: "postgres", handle: "db", reuse: {} }] }),
+    [
+      `manifest-schema: "fixture" template.json /resources/0/reuse must have required property 'key'.`,
+    ],
+  );
+});
+
+test("a reuse descriptor with an extra property fails", () => {
+  const errors = check({
+    resources: [
+      {
+        kind: "postgres",
+        handle: "db",
+        reuse: { key: "dbHandle", copy: true },
+      },
+    ],
+  });
+  assert.equal(errors.length, 1);
+  assert.match(
+    errors[0],
+    /\/resources\/0\/reuse must NOT have additional properties/,
+  );
+});
+
+test("a reuse key that is a dotted path fails — the seam reads a top-level key", () => {
+  const errors = check({
+    resources: [
+      { kind: "postgres", handle: "db", reuse: { key: "config.dbHandle" } },
+    ],
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /\/resources\/0\/reuse\/key must match pattern/);
+});
+
+// checkResourceReuse is the semantic half — reuse is postgres-only, and its key
+// must actually be read via resolveResourceHandle in the step code.
+const READS_DEFAULT = `const h = resolveResourceHandle(input, { fallback: DEFAULT_DB_HANDLE });`;
+const READS_LEDGER = `resolveResourceHandle(input, { key: "ledgerHandle", fallback: "" });`;
+const HARDCODED = `const DB_HANDLE = "the-brain"; const h = DB_HANDLE;`;
+
+test("checkResourceReuse: a reuse marker on a non-postgres resource fails", () => {
+  const errors = checkResourceReuse(
+    "fixture",
+    {
+      resources: [{ kind: "sandbox", handle: "s", reuse: { key: "dbHandle" } }],
+    },
+    READS_DEFAULT,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /only postgres resources may carry it/);
+});
+
+test("checkResourceReuse: a reusable resource whose handle the code hardcodes fails", () => {
+  const errors = checkResourceReuse(
+    "fixture",
+    {
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "dbHandle" } },
+      ],
+    },
+    HARDCODED,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /never read via resolveResourceHandle/);
+});
+
+test("checkResourceReuse: the default key is satisfied by a bare resolveResourceHandle call", () => {
+  assert.deepEqual(
+    checkResourceReuse(
+      "fixture",
+      {
+        resources: [
+          { kind: "postgres", handle: "db", reuse: { key: "dbHandle" } },
+        ],
+      },
+      READS_DEFAULT,
+    ),
+    [],
+  );
+});
+
+test("checkResourceReuse: a non-default key must be named explicitly in the options bag", () => {
+  const drift = checkResourceReuse(
+    "fixture",
+    {
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "ledgerHandle" } },
+      ],
+    },
+    READS_DEFAULT, // reads dbHandle, not ledgerHandle
+  );
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /never read via resolveResourceHandle/);
+  assert.deepEqual(
+    checkResourceReuse(
+      "fixture",
+      {
+        resources: [
+          { kind: "postgres", handle: "db", reuse: { key: "ledgerHandle" } },
+        ],
+      },
+      READS_LEDGER,
+    ),
+    [],
+  );
+});
+
+test("checkResourceReuse: a reusable resource with no index.ts fails", () => {
+  const errors = checkResourceReuse(
+    "fixture",
+    {
+      resources: [
+        { kind: "postgres", handle: "db", reuse: { key: "dbHandle" } },
+      ],
+    },
+    null,
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no index\.ts/);
+});
+
+test("checkResourceReuse: an internal-state resource with no reuse marker is fine", () => {
+  // the-brain: hardcoded handle, no reuse descriptor ⇒ no picker, no error.
+  assert.deepEqual(
+    checkResourceReuse(
+      "fixture",
+      { resources: [{ kind: "postgres", handle: "the-brain" }] },
+      HARDCODED,
+    ),
+    [],
+  );
+});
+
+test("checkResourceReuse passes for every real reusable manifest against its index.ts", () => {
+  const registry = JSON.parse(
+    readFileSync(path.join(ROOT, "examples", "registry.json"), "utf8"),
+  );
+  for (const t of registry.templates) {
+    const dir = path.join(ROOT, t.sourcePath ?? path.join("examples", t.id));
+    let manifest;
+    try {
+      manifest = JSON.parse(
+        readFileSync(path.join(dir, "template.json"), "utf8"),
+      );
+    } catch {
+      continue;
+    }
+    const indexPath = path.join(dir, "index.ts");
+    let indexSource = null;
+    try {
+      indexSource = readFileSync(indexPath, "utf8");
+    } catch {
+      indexSource = null;
+    }
+    assert.deepEqual(
+      checkResourceReuse(t.id, manifest, indexSource),
+      [],
+      `${t.id} declares a reuse descriptor its step code does not honor`,
+    );
+  }
 });
 
 test("a settings entry missing default fails", () => {


### PR DESCRIPTION
## What & why

Runtime **foundation** for the DB-reuse epic ([SAP-2303](https://linear.app/sapiom/issue/SAP-2303)). Makes every gallery Postgres resource honestly **runtime-repointable** and self-describing, so the reuse picker ([SAP-2320](https://linear.app/sapiom/issue/SAP-2320)) can offer *"use a database you already have"* for any declared Postgres — with zero author pre-wiring — and **never show a picker the next run silently ignores** (`design-v2.md` § Landmines).

The [SAP-2191](https://linear.app/sapiom/issue/SAP-2191) handle-read is opt-in per template. Audit of the 8 Postgres templates: 3 read the injected handle **and** declared a key (picker works today), 2 read it but declared nothing, and 3 hardcoded. A picker built on a hardcoded template would be a dishonest affordance — so the runtime must honor the handle **before** the UI may offer it.

Carries no delete risk (delete is already reference-counted, SAP-2190) and no UI, so it ships ahead of the picker.

## Interface contract (owned here, consumed by SAP-2320)

`resources[]` entry gains **`reuse?: { key: string }`**:
- **present** ⇒ user-repointable; `key` is the top-level entry-input path the run reads via `resolveResourceHandle` (default `dbHandle`).
- **absent** ⇒ internal state, not user data — no picker.

## Changes

- **Schema** (`examples/template.schema.json`): add the `reuse` descriptor.
- **Runtime migration** — route the handle read through the canonical `resolveResourceHandle` seam:
  - `approval-chain` → key `ledgerHandle`
  - `nl-db-query-endpoint` → key `dbHandle`
  - Both preserve opt-in / conditional-default semantics via `fallback: ""` — a zero-setup run is **never** forced to provision Postgres, and a user-named handle that 404s is still rejected rather than silently reprovisioned.
- **Declarations** — add `reuse` to the 7 reusable manifests (`meeting-notes-crm`, `cold-outreach-engine`, `error-triage-digest`, `personalized-media-at-scale`, `scheduled-db-insight-report`, `approval-chain`, `nl-db-query-endpoint`).
- **`the-brain`: non-reusable.** Its DB is the brain's own `fleet_events` state, not user data, and it is excluded from the gallery by design (T0.2). The **absence** of a `reuse` descriptor is the marker — index.ts is left hardcoded, deliberately.
- **Lint** (`examples-check` §5c, `manifest-resource-reuse`): `reuse` is postgres-only, and its declared `key` must actually be read via `resolveResourceHandle` in the same `index.ts` — so declaration and code can never drift and the picker can never advertise a control the run ignores. Rejects a malformed descriptor (schema) and a hardcoded-handle drift (semantic).
- **Tests**: fixture cases for the schema field and the semantic check, plus a pass over **every real reusable manifest against its index.ts**.

## Verification

- `pnpm examples:check` ✅ — 24 templates, schema-valid.
- `pnpm examples:check:test` (`node --test`) ✅ — 98/98 pass (incl. new reuse cases).
- Confirmed the lint **rejects** a malformed `reuse` (missing/extra/dotted key) and a drift (reuse key not read via `resolveResourceHandle`).
- Prettier-clean on all changed `.mjs`/`.ts`. No behavior change for the 3 already-reusable templates.

> **Follow-up (not blocking):** the acceptance criterion "verified against a run/trace" is best exercised in the funded-tenant baseline pass — deploy each reusable template, set the injection key to a second handle, and confirm the trace opens it. The static `manifest-resource-reuse` check mechanically enforces the honesty invariant (every declared key is read via the seam) in the meantime.

Closes SAP-2319.