### PR TITLE
fix(authoring): align published assets with Agent terminology

### DIFF
--- a/.changeset/gentle-agents-speak.md
+++ b/.changeset/gentle-agents-speak.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/cli": patch
+---
+
+Use Agent and Agent run terminology in scaffolded and published authoring assets.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -12,7 +12,7 @@
   "keywords": [
     "sapiom",
     "agent",
-    "workflows",
+    "automation",
     "sdk"
   ],
   "main": "./dist/cjs/index.js",

--- a/packages/agent-core/src/__tests__/scaffold.test.ts
+++ b/packages/agent-core/src/__tests__/scaffold.test.ts
@@ -9,7 +9,9 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -32,6 +34,20 @@ afterEach(() => {
 
 function makeTmp(): string {
   return mkdtempSync(path.join(tmpdir(), "sapiom-scaffold-test-"));
+}
+
+function readScaffoldedText(dir: string): string {
+  const files: string[] = [];
+  const visit = (current: string): void => {
+    for (const entry of readdirSync(current)) {
+      if (entry === ".git") continue;
+      const full = path.join(current, entry);
+      if (statSync(full).isDirectory()) visit(full);
+      else files.push(full);
+    }
+  };
+  visit(dir);
+  return files.map((file) => readFileSync(file, "utf8")).join("\n");
 }
 
 describe("scaffold", () => {
@@ -142,6 +158,42 @@ describe("scaffold", () => {
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
+  });
+
+  it.each(["default", "coding-pause"])(
+    "copies the %s template with exact Agent terminology",
+    async (template) => {
+      const base = makeTmp();
+      const targetDir = path.join(base, `fresh-${template}`);
+      try {
+        await scaffold({
+          targetDir,
+          template,
+          versions: { agent: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+        });
+
+        const text = readScaffoldedText(targetDir);
+        expect(text).toContain(`# fresh-${template}`);
+        expect(text).not.toContain("__PROJECT_NAME__");
+        expect(text).toContain("This project defines exactly one Sapiom agent");
+        expect(text).toContain("agent run");
+        expect(text).not.toMatch(
+          /\b(?:workflow|workflows|orchestration|orchestrations)\b/i,
+        );
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+describe("published package metadata", () => {
+  it("uses Agent terminology in discoverability keywords", () => {
+    const pkg = JSON.parse(
+      readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8"),
+    ) as { keywords: string[] };
+
+    expect(pkg.keywords).toEqual(["sapiom", "agent", "automation", "sdk"]);
   });
 });
 

--- a/packages/agent-core/src/clone.spec.ts
+++ b/packages/agent-core/src/clone.spec.ts
@@ -189,6 +189,8 @@ describe('clone', () => {
     const spy = mockFetch([{ status: 200, body: {} }]);
     await expect(clone({ targetDir: '/tmp/whatever', cloneRepo: () => {} }, client)).rejects.toMatchObject({
       code: 'BAD_INPUT',
+      message:
+        'Provide a templateId (to fork then clone), a forkId (to clone an existing fork), or a definitionId (to clone a deployed agent).',
     });
     expect(spy).not.toHaveBeenCalled();
   });
@@ -196,7 +198,11 @@ describe('clone', () => {
   it('rejects when more than one of templateId, forkId, or definitionId is given', async () => {
     await expect(
       clone({ templateId: 't', forkId: 'f', targetDir: '/tmp/whatever', cloneRepo: () => {} }, client),
-    ).rejects.toMatchObject({ code: 'BAD_INPUT' });
+    ).rejects.toMatchObject({
+      code: 'BAD_INPUT',
+      hint:
+        'Use templateId to start from a gallery template, forkId to re-clone an existing fork, or definitionId to pull a deployed agent locally.',
+    });
     await expect(
       clone(
         { templateId: 't', definitionId: '1', targetDir: '/tmp/whatever', cloneRepo: () => {} },

--- a/packages/agent-core/src/clone.ts
+++ b/packages/agent-core/src/clone.ts
@@ -1,9 +1,9 @@
 /**
- * clone — materialize a Sapiom workflow locally, either as a fresh template/fork
- * checkout (SAP-1357) or by pulling an already-deployed workflow's live source by
+ * clone — materialize a Sapiom agent locally, either as a fresh template/fork
+ * checkout (SAP-1357) or by pulling an already-deployed agent's live source by
  * `definitionId` (SAP-1839). The client half of two handoffs that share one flow:
  *   - templateId/forkId: browse → fork → clone → deploy → run.
- *   - definitionId: an existing deployed workflow → clone its current build-repo
+ *   - definitionId: an existing deployed agent → clone its current build-repo
  *     source → edit → redeploy, round-trip-consistently.
  *
  * Given exactly one of a registry template id, an existing fork id, or a deployed
@@ -68,13 +68,13 @@ export interface CloneOptions {
    * Registry template id to fork, then clone. Mutually exclusive with `forkId`
    * and `definitionId`: pass a template id to start from the gallery, a fork id
    * to re-clone an existing fork, or a definitionId to pull a deployed
-   * workflow's live source.
+   * agent's live source.
    */
   templateId?: string;
   /** Existing fork id (`github_user_repos.id`) to clone — skips the fork step. */
   forkId?: string;
   /**
-   * Deployed workflow's definition id (engine bigint, as a string — see the
+   * Deployed agent's definition id (engine bigint, as a string — see the
    * module docstring) to clone. Skips the fork step entirely and clones the
    * engine's live `ag-*` build-repo source directly, so the checkout always
    * matches what is actually deployed. Writes `definitionId` into `sapiom.json`,
@@ -129,7 +129,7 @@ export async function clone(opts: CloneOptions, client: GatewayClient): Promise<
     throw new AgentOperationError({
       code: 'BAD_INPUT',
       message:
-        'Provide a templateId (to fork then clone), a forkId (to clone an existing fork), or a definitionId (to clone a deployed workflow).',
+        'Provide a templateId (to fork then clone), a forkId (to clone an existing fork), or a definitionId (to clone a deployed agent).',
     });
   }
   if (provided > 1) {
@@ -137,7 +137,7 @@ export async function clone(opts: CloneOptions, client: GatewayClient): Promise<
       code: 'BAD_INPUT',
       message: 'Provide only one of templateId, forkId, or definitionId.',
       hint:
-        'Use templateId to start from a gallery template, forkId to re-clone an existing fork, or definitionId to pull a deployed workflow local.',
+        'Use templateId to start from a gallery template, forkId to re-clone an existing fork, or definitionId to pull a deployed agent locally.',
     });
   }
 

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An orchestration is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract
@@ -39,7 +39,7 @@ When you've made a coherent change and want to validate it — the same point yo
 
 - **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
 - **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
-- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so a workflow runs end-to-end with zero setup. Returns a per-step trace.
+- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so an agent run completes end-to-end with zero setup. Returns a per-step trace.
 - **deploy** — ship it.
 
 > Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
@@ -58,7 +58,7 @@ When you've made a coherent change and want to validate it — the same point yo
 
 ## Dispatched runs: pause & resume
 
-A long-running capability (today the coding agent) is launched fire-and-forget and the workflow suspends until it finishes:
+A long-running capability (today the coding agent) is launched fire-and-forget and the agent run suspends until it finishes:
 
 ```ts
 const run = await ctx.sapiom.models.coding.launch({ task, gitRepository: repo }); // returns a handle, not a result

--- a/packages/agent-core/templates/coding-pause/CLAUDE.md
+++ b/packages/agent-core/templates/coding-pause/CLAUDE.md
@@ -1,4 +1,4 @@
-# Working in this orchestration
+# Working in this agent project
 
 Follow [AGENTS.md](./AGENTS.md) for authoring and validation.
 

--- a/packages/agent-core/templates/coding-pause/README.md
+++ b/packages/agent-core/templates/coding-pause/README.md
@@ -1,8 +1,8 @@
 # __PROJECT_NAME__
 
-A Sapiom orchestration that runs a **coding agent without blocking the workflow**:
-it launches the agent fire-and-forget, suspends on the run's result signal, and
-resumes once the run finishes — authored as code against
+A Sapiom agent that runs a **coding agent without blocking the agent run**:
+it launches the coding agent fire-and-forget, suspends on the result signal, and
+resumes once the coding agent finishes — authored as code against
 [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent).
 
 ```
@@ -11,7 +11,7 @@ prepare → kickoff ──pause(models.coding.result)──▶ finalize
 
 - **kickoff** calls `models.coding.launch(...)` (which returns a handle, *not* a
   result) and returns `pauseUntilSignal(handle, { resumeStep: "finalize" })`. The
-  workflow suspends — a long run holds no worker.
+  agent run suspends — a long run holds no worker.
 - **finalize** is resumed by the engine when the run reaches a terminal state.
   Its `input` **is** the run's result signal payload (typed `CodingResultPayload`).
   Because that payload crossed the pause/resume boundary, `sandbox` is plain data
@@ -31,18 +31,18 @@ branch locally, stub a failed result under the *launching* step in
 npm install
 ```
 
-Then open `index.ts`. The orchestration is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
+Then open `index.ts`. The agent is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
 
 ```ts
 const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
 const repo = await ctx.sapiom.repositories.create('my-repo');
 ```
 
-No credentials to wire — a per-execution tenant credential is injected when your orchestration runs.
+No credentials to wire — a per-execution tenant credential is injected for each agent run.
 
 ## The loop
 
-Author and run this orchestration with the Sapiom dev tools:
+Author and run this agent with the Sapiom dev tools:
 
 - **check** — validate locally (bundle, manifest, step graph). Offline.
 - **run_local** — execute the steps locally against stubs (no real capability calls), iterating until it completes.

--- a/packages/agent-core/templates/coding-pause/index.ts
+++ b/packages/agent-core/templates/coding-pause/index.ts
@@ -27,14 +27,14 @@ const entryInput = z.object({
 type EntryInput = z.infer<typeof entryInput>;
 
 /**
- * __PROJECT_NAME__ — a non-blocking coding-agent workflow.
+ * __PROJECT_NAME__ — a non-blocking coding-agent integration.
  *
  *   prepare → kickoff ──pause(models.coding.result)──▶ finalize
  *
  * `kickoff` *launches* the coding agent (fire-and-forget) and returns
- * `pauseUntilSignal(handle, …)`, suspending the workflow on the run's result
- * signal — so a long run holds no worker. When the run reaches a terminal state
- * the engine resumes `finalize` with the run result as its input.
+ * `pauseUntilSignal(handle, …)`, suspending the agent run until the coding agent's
+ * result signal arrives — so a long run holds no worker. When the run reaches a
+ * terminal state, the engine resumes `finalize` with the run result as its input.
  *
  * Key idea: the resumed step's `input` IS the signal payload (typed here as
  * `CodingResultPayload`). It crossed a wire boundary, so there are no live

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An orchestration is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract
@@ -39,7 +39,7 @@ When you've made a coherent change and want to validate it — the same point yo
 
 - **`npm run typecheck`** — types, and confirms every `ctx.sapiom.*` capability/method you used exists.
 - **check** — typecheck + bundle + manifest + step-graph validation. The full local pre-flight before deploy.
-- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so a workflow runs end-to-end with zero setup. Returns a per-step trace.
+- **run_local** — runs your **real** step code locally against **stub capabilities**: every `ctx.sapiom.*` call (namespace calls *and* handle methods like `repo.pushFromSandbox`) returns a built-in default, so an agent run completes end-to-end with zero setup. Returns a per-step trace.
 - **deploy** — ship it.
 
 > Write each step the way it should run in production. `run_local` adapts to your code (stub capabilities), not the other way around — never weaken or drop real logic to shape a local run.
@@ -58,7 +58,7 @@ When you've made a coherent change and want to validate it — the same point yo
 
 ## Dispatched runs: pause & resume
 
-A long-running capability (today the coding agent) is launched fire-and-forget and the workflow suspends until it finishes:
+A long-running capability (today the coding agent) is launched fire-and-forget and the agent run suspends until it finishes:
 
 ```ts
 const run = await ctx.sapiom.models.coding.launch({ task, gitRepository: repo }); // returns a handle, not a result

--- a/packages/agent-core/templates/default/CLAUDE.md
+++ b/packages/agent-core/templates/default/CLAUDE.md
@@ -1,4 +1,4 @@
-# Working in this orchestration
+# Working in this agent project
 
 Follow [AGENTS.md](./AGENTS.md) for authoring and validation.
 

--- a/packages/agent-core/templates/default/README.md
+++ b/packages/agent-core/templates/default/README.md
@@ -1,6 +1,6 @@
 # __PROJECT_NAME__
 
-A Sapiom orchestration, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent).
+A Sapiom agent, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent).
 
 ## Getting started
 
@@ -8,18 +8,18 @@ A Sapiom orchestration, authored as code against [`@sapiom/agent`](https://www.n
 npm install
 ```
 
-Then open `index.ts`. The orchestration is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
+Then open `index.ts`. The agent is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
 
 ```ts
 const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
 const repo = await ctx.sapiom.repositories.create('my-repo');
 ```
 
-No credentials to wire — a per-execution tenant credential is injected when your orchestration runs.
+No credentials to wire — a per-execution tenant credential is injected for each agent run.
 
 ## The loop
 
-Author and run this orchestration with the Sapiom dev tools:
+Author and run this agent with the Sapiom dev tools:
 
 - **check** — validate locally (bundle, manifest, step graph). Offline.
 - **run_local** — execute the steps locally against stubs (no real capability calls), iterating until it completes.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sapiom/cli",
   "version": "1.0.2",
-  "description": "The Sapiom command-line interface — scaffold, validate, and ship Sapiom orchestrations.",
+  "description": "The Sapiom command-line interface — scaffold, validate, and ship Sapiom agents.",
   "license": "MIT",
   "author": "Sapiom",
   "type": "module",
@@ -13,8 +13,8 @@
   "keywords": [
     "sapiom",
     "cli",
-    "orchestration",
-    "workflows"
+    "agents",
+    "automation"
   ],
   "bin": {
     "sapiom": "./dist/bin.js"

--- a/packages/cli/src/__tests__/published-authoring-assets.test.ts
+++ b/packages/cli/src/__tests__/published-authoring-assets.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const PACKAGE_ROOT = path.resolve(__dirname, "..", "..");
+const TEMPLATE_ROOT = path.join(PACKAGE_ROOT, "templates", "default");
+
+const packageJson = JSON.parse(
+  readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf8"),
+) as {
+  description: string;
+  files: string[];
+  keywords: string[];
+};
+
+describe("published authoring assets", () => {
+  it("keeps the legacy template in the published CLI boundary", () => {
+    expect(packageJson.files).toContain("templates");
+  });
+
+  it("uses Agent and Agent run terminology in legacy template prose", () => {
+    const prose = ["AGENTS.md", "CLAUDE.md", "README.md", "index.ts"]
+      .map((file) => readFileSync(path.join(TEMPLATE_ROOT, file), "utf8"))
+      .join("\n");
+
+    expect(prose).toContain("Sapiom agent");
+    expect(prose).toContain("agent run");
+    expect(prose).not.toMatch(
+      /\b(?:workflow|workflows|orchestration|orchestrations)\b/i,
+    );
+  });
+
+  it("uses Agent terminology in npm metadata", () => {
+    expect(packageJson.description).toBe(
+      "The Sapiom command-line interface — scaffold, validate, and ship Sapiom agents.",
+    );
+    expect(packageJson.keywords).toEqual([
+      "sapiom",
+      "cli",
+      "agents",
+      "automation",
+    ]);
+  });
+
+  it("uses the canonical public Agent command identifiers", () => {
+    const templatePackage = JSON.parse(
+      readFileSync(path.join(TEMPLATE_ROOT, "package.json"), "utf8"),
+    ) as { scripts: Record<string, string> };
+
+    expect(templatePackage.scripts.check).toBe("sapiom agents check");
+    expect(templatePackage.scripts.deploy).toBe("sapiom agents deploy");
+  });
+});

--- a/packages/cli/templates/default/AGENTS.md
+++ b/packages/cli/templates/default/AGENTS.md
@@ -1,15 +1,15 @@
-# Working in this orchestration
+# Working in this agent project
 
-This project defines exactly one Sapiom orchestration in `index.ts`, authored against `@sapiom/agent`.
+This project defines exactly one Sapiom agent in `index.ts`, authored against `@sapiom/agent`.
 
 ## The loop
 
-1. Edit `index.ts`. An orchestration is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Inside `run`, Sapiom capabilities are available pre-auth'd on `ctx.sapiom`.
+1. Edit `index.ts`. An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Inside `run`, Sapiom capabilities are available pre-auth'd on `ctx.sapiom`.
 2. `npm run check` — validate locally (bundles, builds the manifest, checks the step graph). Fast and offline; run it after every edit.
 3. `npm run deploy` — ship it.
 
 ## Notes for coding agents
 
 - Use `npm run check` as the tight feedback loop — prefer it over reasoning about whether the graph is valid.
-- For exact command options, run `sapiom orchestrations --help`, and pass `--json` to any command for machine-readable output. Don't hardcode capability lists or schemas — query them at runtime.
+- For exact command options, run `sapiom agents --help`, and pass `--json` to any command for machine-readable output. Don't hardcode capability lists or schemas — query them at runtime.
 - Keep exactly one `defineAgent(...)` export in `index.ts`.

--- a/packages/cli/templates/default/CLAUDE.md
+++ b/packages/cli/templates/default/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](./AGENTS.md) for how to work in this orchestration project.
+See [AGENTS.md](./AGENTS.md) for how to work in this agent project.

--- a/packages/cli/templates/default/README.md
+++ b/packages/cli/templates/default/README.md
@@ -1,6 +1,6 @@
 # __PROJECT_NAME__
 
-A Sapiom orchestration, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent).
+A Sapiom agent, authored as code against [`@sapiom/agent`](https://www.npmjs.com/package/@sapiom/agent).
 
 ## Getting started
 
@@ -8,14 +8,14 @@ A Sapiom orchestration, authored as code against [`@sapiom/agent`](https://www.n
 npm install
 ```
 
-Then open `index.ts`. The orchestration is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
+Then open `index.ts`. The agent is defined with `defineAgent({ steps })`; each step is a `defineStep({ name, next, run })`. The `run` body is ordinary code — and inside it, the full Sapiom tool catalog is available, pre-auth'd and tenant-scoped, on `ctx.sapiom`:
 
 ```ts
 const box = await ctx.sapiom.sandboxes.create({ name: 'demo' });
 const repo = await ctx.sapiom.repositories.create('my-repo');
 ```
 
-No credentials to wire — a per-execution tenant credential is injected when your orchestration runs.
+No credentials to wire — a per-execution tenant credential is injected for each agent run.
 
 ## The loop
 

--- a/packages/cli/templates/default/package.json
+++ b/packages/cli/templates/default/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "sapiom orchestrations check",
-    "deploy": "sapiom orchestrations deploy",
+    "check": "sapiom agents check",
+    "deploy": "sapiom agents deploy",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""


### PR DESCRIPTION
## Summary
Align scaffolded and published authoring assets with the Agent / Agent run terminology contract. Compatibility-sensitive backend routes, analytics event IDs, runtime types, and package identities remain unchanged.

## Changes
- Update active agent-core scaffold templates and the still-published legacy CLI template prose.
- Point the legacy template scripts at the existing sapiom agents command group.
- Update public clone errors and npm discoverability metadata.
- Add fresh-scaffold, clone-error, legacy-template, metadata, and package-boundary regression coverage.
- Add patch changesets for @sapiom/agent-core and @sapiom/cli.

## Testing
- [x] Agent-core Jest: 15 suites, 136 tests
- [x] CLI Jest: 6 suites, 73 tests
- [x] Agent-core and CLI build
- [x] Agent-core and CLI typecheck
- [x] Agent-core and CLI lint
- [x] Skill-sync coverage included in the agent-core suite
- [x] Packed both npm artifacts and verified template terminology, placeholders, metadata, canonical commands, and compatibility literals

## Related
- Closes: SAP-2336
- Linear: https://linear.app/sapiom/issue/SAP-2336/agent-authoring-update-scaffolded-and-published-authoring-assets-to

## Checklist
- [x] Diff self-reviewed
- [x] No hardcoded secrets
- [x] Canonical authoring skill copies remain unchanged
- [x] No PR merge performed
