### PR TITLE
feat(studio): normalize Agent Studio shell terminology

### DIFF
--- a/.changeset/calm-studios-navigate.md
+++ b/.changeset/calm-studios-navigate.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Normalize Agent Studio shell terminology and route dashboard links to the canonical Agents page.

--- a/packages/harness-desktop/electron-builder.yml
+++ b/packages/harness-desktop/electron-builder.yml
@@ -64,7 +64,7 @@ linux:
   artifactName: sapiom-${version}-${arch}.${ext}
   executableName: sapiom
   maintainer: Sapiom <team@sapiom.ai>
-  synopsis: One-click Sapiom harness — run your coding agent on Sapiom.
+  synopsis: Agent Studio — run your coding agent on Sapiom.
 
 mac:
   # dmg AND zip. The zip is not a duplicate download for testers — it is the

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@sapiom/harness-desktop",
   "version": "0.1.4",
   "private": true,
-  "description": "Electron desktop app that wraps the Sapiom harness — a one-click install that auto-sets-up and runs the harness in a native window. The npx CLI (@sapiom/harness) remains the backup; this is a second host over the same startServer().",
+  "description": "Agent Studio desktop app — a one-click native host for running Claude Code or Codex in a Sapiom-configured environment. The npx CLI (@sapiom/harness) remains the backup host over the same startServer().",
   "homepage": "https://sapiom.ai",
   "author": {
     "name": "Sapiom",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -1,6 +1,6 @@
-# @sapiom/harness
+# Agent Studio
 
-A local web app for building on Sapiom with your own coding agent.
+Agent Studio is a local web app for building on Sapiom with your own coding agent.
 
 ```bash
 npx @sapiom/harness [dir]
@@ -8,20 +8,20 @@ npx @sapiom/harness [dir]
 sapiom dev [dir]
 ```
 
-One command: checks your environment, signs you in, and opens a browser app
-with your coding agent (Claude Code today, Codex next) running in an embedded
-terminal — pre-wired with the Sapiom MCP servers and a workflow-authoring
+One command checks your environment, signs you in, and opens Agent Studio
+with your coding agent (Claude Code or Codex) running in an embedded
+terminal — pre-wired with the Sapiom MCP servers and an agent-authoring
 system prompt, in whatever project directory you choose.
 
 ## What you get
 
 - **Terminal sessions** — your agent, your subscription, your machine; the
-  harness only configures it. Multiple sessions, resumable chat history.
-- **Workflows rail** — orchestration projects (`sapiom.json`) discovered and
+  Agent Studio only configures it. Multiple sessions, resumable chat history.
+- **Agents rail** — agent projects (`sapiom.json`) discovered and
   tracked, with one-click local test run, deploy, production run, and
   open-in-Sapiom actions.
 - **Canvas** — a live pane that renders static HTML your agent writes to
-  `.sapiom/canvas/` (visualize your workflow, your docs, anything), plus a
+  `.sapiom/canvas/` (visualize your agent, your docs, anything), plus a
   preview mode for dev servers the agent starts.
 - **Zero config mutation** — everything is injected per-session via flags;
   your global agent settings are never touched.
@@ -30,7 +30,7 @@ Uninstall: `rm -rf ~/.sapiom/harness` (all harness-owned state lives there).
 
 ## Telemetry
 
-With explicit opt-in, the harness collects usage events (prompts, tool calls,
+With explicit opt-in, Agent Studio collects usage events (prompts, tool calls,
 session lifecycle) to improve Sapiom. Opt out any time; `--no-telemetry`
 disables collection entirely. Events are also written locally to
 `~/.sapiom/harness/events.ndjson` for your own inspection.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@sapiom/harness",
   "version": "0.2.5",
-  "description": "Sapiom Harness — a CLI-launched local web app that runs your coding agent (Claude Code, Codex) in a Sapiom-configured environment: MCP pre-wired, workflows tracked, one-click deploy/run, and a live canvas for previews.",
+  "description": "Agent Studio — a CLI-launched local web app that runs your coding agent (Claude Code or Codex) in a Sapiom-configured environment: MCP pre-wired, agents tracked, one-click deploy/run, and a live canvas for previews.",
   "keywords": [
     "sapiom",
     "harness",
     "claude",
     "codex",
     "terminal",
-    "workflows"
+    "agents"
   ],
   "homepage": "https://github.com/sapiom/sapiom-js/tree/main/packages/harness#readme",
   "bugs": {

--- a/packages/harness/src/cli/bin-boot.test.ts
+++ b/packages/harness/src/cli/bin-boot.test.ts
@@ -31,8 +31,8 @@ function printBanner(opts: PrintBannerOpts): void {
     : "not authenticated";
 
   console.log("");
-  console.log("  Sapiom Studio");
-  console.log("  -------------");
+  console.log("  Agent Studio");
+  console.log("  ------------");
   console.log(`  directory   ${opts.dir}`);
   console.log(`  auth        ${authLine}`);
   console.log(`  telemetry   ${opts.telemetryOptIn ? "on" : "off"}`);
@@ -96,14 +96,14 @@ describe("parseArgs — --login flag", () => {
   });
 });
 
-describe("printBanner — 'Sapiom Studio' name", () => {
+describe("printBanner — 'Agent Studio' name", () => {
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
   afterEach(() => {
     logSpy.mockClear();
   });
 
-  it("banner line says 'Sapiom Studio' (not 'Sapiom Harness')", () => {
+  it("banner line says 'Agent Studio' (not the legacy Studio or Harness names)", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
@@ -114,7 +114,8 @@ describe("printBanner — 'Sapiom Studio' name", () => {
     });
 
     const lines = logSpy.mock.calls.map((c) => String(c[0]));
-    expect(lines).toContain("  Sapiom Studio");
+    expect(lines).toContain("  Agent Studio");
+    expect(lines.some((l) => l.includes("Sapiom Studio"))).toBe(false);
     expect(lines.some((l) => l.includes("Sapiom Harness"))).toBe(false);
   });
 

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -45,8 +45,8 @@ function printBanner(opts: {
     : "not authenticated";
 
   console.log("");
-  console.log("  Sapiom Studio");
-  console.log("  -------------");
+  console.log("  Agent Studio");
+  console.log("  ------------");
   console.log(`  directory   ${opts.dir}`);
   console.log(`  auth        ${authLine}`);
   console.log(`  telemetry   ${opts.telemetryOptIn ? "on" : "off"}`);
@@ -68,7 +68,7 @@ const main = async (): Promise<void> => {
   printDoctorReport(doctorReport);
   if (!doctorReport.ok) {
     console.error(
-      "\nsapiom-harness requires Node >= 20 and at least one coding agent on PATH:\n" +
+      "\nAgent Studio (`sapiom-harness`) requires Node >= 20 and at least one coding agent on PATH:\n" +
         `  Claude Code:  ${CLAUDE_INSTALL_COMMAND}\n` +
         `  Codex:        ${CODEX_INSTALL_COMMAND}\n` +
         "Fix the checks above and try again.",
@@ -79,7 +79,7 @@ const main = async (): Promise<void> => {
   if (!doctorReport.availableHarnesses.includes("claude-code")) {
     console.log(
       `\n⚠ Claude Code not found — install with: ${CLAUDE_INSTALL_COMMAND}\n` +
-        "  Continuing with the Codex harness.",
+        "  Continuing with the Codex coding agent.",
     );
   }
 
@@ -137,7 +137,7 @@ const main = async (): Promise<void> => {
   } catch (err) {
     if (!options.dev) throw err;
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`\n⚠ Harness server is not wired up yet: ${message}`);
+    console.error(`\n⚠ Agent Studio server is not wired up yet: ${message}`);
     console.error(
       "--dev flow verified (doctor → auth → consent) without a live server.\n",
     );

--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -57,6 +57,22 @@ describe("ensureConsent", () => {
     expect(settings.telemetryOptIn).toBe(false);
   });
 
+  it("describes detailed telemetry as coding-agent activity", async () => {
+    const wasTTY = process.stdin.isTTY;
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+    try {
+      await ensureConsent({ noTelemetry: false });
+      const printed = log.mock.calls.flat().join("\n");
+      expect(printed).toContain("the tool calls your coding agent makes");
+      expect(printed).not.toContain("the tool calls your agent makes");
+    } finally {
+      log.mockRestore();
+      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+    }
+  });
+
   it("defaults to OFF (opt-out) and persists on first run when stdin is not a TTY", async () => {
     // SAP-1988: the invasive Sapiom→BQ tier is opt-out by default — a non-TTY
     // first run (CI/Docker/headless) must never silently opt the user in.

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -15,7 +15,7 @@ const CONSENT_COPY = `
 Help us optimize your Agent Studio experience.
 
 With your permission, Agent Studio shares your session details — the prompts
-you send, the tool calls your agent makes, and session lifecycle events — so we
+you send, the tool calls your coding agent makes, and session lifecycle events — so we
 can see where the product gets in your way and improve it for you.
 
 This is always written locally to ~/.sapiom/harness/events.ndjson for your own

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -12,9 +12,9 @@ import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 const DEFAULT_TELEMETRY_OPT_IN = false;
 
 const CONSENT_COPY = `
-Help us optimize your Studio experience.
+Help us optimize your Agent Studio experience.
 
-With your permission, Sapiom Studio shares your session details — the prompts
+With your permission, Agent Studio shares your session details — the prompts
 you send, the tool calls your agent makes, and session lifecycle events — so we
 can see where the product gets in your way and improve it for you.
 

--- a/packages/harness/src/core/branding.test.ts
+++ b/packages/harness/src/core/branding.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+interface PackageMetadata {
+  name: string;
+  description: string;
+  keywords?: string[];
+  bin?: Record<string, string>;
+}
+
+const harnessPackage = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageMetadata;
+const desktopPackage = JSON.parse(
+  readFileSync(
+    new URL("../../../harness-desktop/package.json", import.meta.url),
+    "utf8",
+  ),
+) as PackageMetadata;
+const desktopBuilder = readFileSync(
+  new URL("../../../harness-desktop/electron-builder.yml", import.meta.url),
+  "utf8",
+);
+
+describe("Agent Studio public metadata", () => {
+  it("uses Agent Studio and Agent terminology in package metadata", () => {
+    expect(harnessPackage.description).toMatch(/^Agent Studio —/);
+    expect(harnessPackage.description).toContain("agents tracked");
+    expect(harnessPackage.keywords).toContain("agents");
+    expect(harnessPackage.keywords).not.toContain("workflows");
+    expect(desktopPackage.description).toMatch(/^Agent Studio desktop app/);
+    expect(desktopBuilder).toContain("synopsis: Agent Studio —");
+  });
+
+  it("preserves package, binary, desktop, artifact, and updater identities", () => {
+    expect(harnessPackage.name).toBe("@sapiom/harness");
+    expect(harnessPackage.bin).toEqual({
+      "sapiom-harness": "./dist/cli/bin.js",
+    });
+    expect(desktopPackage.name).toBe("@sapiom/harness-desktop");
+    expect(desktopBuilder).toContain("appId: ai.sapiom.harness");
+    expect(desktopBuilder).toContain("productName: Sapiom");
+    expect(desktopBuilder).toContain(
+      "artifactName: sapiom-${version}-${arch}.${ext}",
+    );
+    expect(desktopBuilder).toContain("executableName: sapiom");
+  });
+});

--- a/packages/harness/src/core/macro-runner.test.ts
+++ b/packages/harness/src/core/macro-runner.test.ts
@@ -54,11 +54,11 @@ describe("resolveMacro", () => {
       id: "open",
       label: "Open",
       icon: "ExternalLink",
-      action: { kind: "open-url", url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}" },
+      action: { kind: "open-url", url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}" },
     };
     expect(resolveMacro(macro, baseCtx)).toEqual({
       kind: "open-url",
-      url: "https://app.sapiom.ai/workflows/4821",
+      url: "https://app.sapiom.ai/agents/4821",
     });
   });
 

--- a/packages/harness/src/core/macros.test.ts
+++ b/packages/harness/src/core/macros.test.ts
@@ -29,7 +29,7 @@ describe("DEFAULT_MACROS", () => {
     expect(macro.requiresWorkflow).toBe(true);
     expect(macro.action).toEqual({
       kind: "open-url",
-      url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}",
+      url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}",
     });
   });
 

--- a/packages/harness/src/core/macros.ts
+++ b/packages/harness/src/core/macros.ts
@@ -51,7 +51,7 @@ export const DEFAULT_MACROS: MacroDef[] = [
     requiresWorkflow: true,
     action: {
       kind: "open-url",
-      url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}",
+      url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}",
     },
   },
   {

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -640,7 +640,9 @@ describe("SessionManager", () => {
         code: "SESSION_NOT_RESUMEABLE",
         message: expect.stringContaining("Claude Code"),
       });
-      await expect(manager.resume(session.id)).rejects.toThrow(/before their first prompt/);
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        /before their first prompt are never written to the coding agent's history/,
+      );
     });
 
     it("probes the agent's store with the session's own agentSessionId and cwd", async () => {

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -490,7 +490,7 @@ export class SessionManager {
       throw new SessionNotResumeableError(
         id,
         `${label} no longer has the conversation for this session (${session.agentSessionId}) in ${session.cwd}. ` +
-          `Sessions that ended before their first prompt are never written to the agent's history, so there is nothing to resume — start a new session in this directory instead.`,
+          `Sessions that ended before their first prompt are never written to the coding agent's history, so there is nothing to resume — start a new session in this directory instead.`,
       );
     }
     const opts: LaunchOpts = {

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -92,7 +92,7 @@ describe("macros router", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(deps.openUrl).toHaveBeenCalledWith("https://app.sapiom.ai/workflows/4821");
+    expect(deps.openUrl).toHaveBeenCalledWith("https://app.sapiom.ai/agents/4821");
     expect(deps.injectInput).not.toHaveBeenCalled();
   });
 

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -43,7 +43,7 @@ describe("createStaticRouter", () => {
     mkdirSync(join(dir, "assets"), { recursive: true });
     writeFileSync(
       join(dir, "index.html"),
-      '<!doctype html><html><head><title>Sapiom Studio</title>' +
+      '<!doctype html><html><head><title>Agent Studio</title>' +
         '<script type="module" src="/assets/index-abc123.js"></script>' +
         '</head><body><div id="root"></div></body></html>',
     );
@@ -68,7 +68,7 @@ describe("createStaticRouter", () => {
       const res = await fetch(`${baseUrl}/`);
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("<title>Sapiom Studio</title>");
+      expect(html).toContain("<title>Agent Studio</title>");
       expect(html).toContain('<div id="root">');
       expect(html).not.toContain("hasn't been built yet");
     });
@@ -88,7 +88,7 @@ describe("createStaticRouter", () => {
       const res = await fetch(`${baseUrl}/some/client/route`);
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("<title>Sapiom Studio</title>");
+      expect(html).toContain("<title>Agent Studio</title>");
     });
 
     // SAP-1898: boot-token injection
@@ -150,7 +150,8 @@ describe("createStaticRouter", () => {
       const res = await fetch(`${baseUrl}/`);
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("Sapiom Harness");
+      expect(html).toContain("Agent Studio");
+      expect(html).not.toContain("Sapiom Harness");
       expect(html).toContain("hasn't been built yet");
     });
   });

--- a/packages/harness/src/server/static.ts
+++ b/packages/harness/src/server/static.ts
@@ -32,9 +32,9 @@ import express, { Router, type Request, type Response } from "express";
 
 const PLACEHOLDER_HTML = `<!doctype html>
 <html>
-  <head><meta charset="utf-8"><title>Sapiom Harness</title></head>
+  <head><meta charset="utf-8"><title>Agent Studio</title></head>
   <body style="font: 14px system-ui; padding: 2rem; color: #333;">
-    <h1>Sapiom Harness</h1>
+    <h1>Agent Studio</h1>
     <p>The web app hasn't been built yet. Run <code>pnpm --filter @sapiom/harness build:web</code>,
     or use <code>pnpm --filter @sapiom/harness dev:web</code> for a hot-reloading dev server.</p>
     <p>The API and WebSocket endpoints on this port are live.</p>

--- a/packages/harness/web/e2e/add-workspace.spec.ts
+++ b/packages/harness/web/e2e/add-workspace.spec.ts
@@ -61,6 +61,8 @@ test.describe("the resting state", () => {
     for (const door of ["have", "template", "idea"]) {
       await expect(doors.getByTestId(`aw-door-${door}`)).toBeVisible();
     }
+    await expect(doors.getByTestId("aw-door-have")).toContainText("agent project");
+    await expect(doors.getByTestId("aw-door-template")).toContainText("Ready-made agents");
     // It is not left behind in the Sessions menu as well — one action, one home.
     await page.keyboard.press("Escape");
     await page.getByTestId("history-trigger").click();

--- a/packages/harness/web/e2e/past-session-record.spec.ts
+++ b/packages/harness/web/e2e/past-session-record.spec.ts
@@ -112,6 +112,9 @@ test("a session whose events are gone still renders — from its archived copy, 
   // This is the SAP-2060 case in the UI: events.ndjson swept this session out
   // weeks ago, and the record still opens.
   await expect(page.getByTestId("session-transcript")).toBeVisible();
+  const reason = page.getByTestId("past-session-reason");
+  await expect(reason).toContainText("the coding agent's history");
+  await expect(reason).toContainText("The new coding agent gets a briefing");
   const turns = page.getByTestId("transcript-turn");
   await expect(turns).toHaveCount(2);
   await expect(turns.nth(1).getByTestId("transcript-prompt")).toContainText("Ship the migration");

--- a/packages/harness/web/e2e/portable-continue.spec.ts
+++ b/packages/harness/web/e2e/portable-continue.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Portable continue (SAP-2059): a session the agent can no longer reattach to
+ * Portable continue (SAP-2059): a session the coding agent can no longer reattach to
  * is still continuable, because the Studio seeds a FRESH session with its own
  * reconstruction of the old one.
  *
@@ -52,8 +52,10 @@ test("a recorded, un-resumable session offers Continue and says what carries ove
   const reason = page.getByTestId("dead-session-resume-reason");
   await expect(reason).toContainText("no saved conversation for this session");
   await expect(reason).toContainText("seeded with the reconstruction below");
-  // Honest about what the new agent is actually getting.
+  // Honest about what the new coding agent is actually getting.
   await expect(reason).toContainText("a briefing about this session, not its context");
+  await expect(reason).toContainText("The new coding agent will need to check the repository");
+  await expect(reason).toContainText("the coding agent never writes a transcript");
 
   await page.screenshot({ path: "web/e2e/screenshots/portable-continue-pane.png", fullPage: true });
 });
@@ -99,6 +101,11 @@ test("the rolling summary is off by default and reachable from settings", async 
   await expect(page.getByTestId("profile-menu")).toBeVisible();
   await page.getByTestId("settings-trigger").click();
   await expect(page.getByTestId("settings-popover")).toBeVisible();
+
+  const note = page.locator(".settings-note").filter({ hasText: "uses tokens" });
+  await expect(note).toContainText("a cheap one-shot coding-agent pass");
+  await expect(note).toContainText("the coding agent can no longer reattach");
+  await expect(note).not.toContainText("one-shot agent run");
 
   const toggle = page.getByTestId("rolling-summary-toggle");
   // Opt-in: it spends tokens on a background LLM call nobody asked for, and

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -79,8 +79,13 @@ test.describe("theme — system preference", () => {
 });
 
 test("brand header shows the Sapiom wordmark and the demo-workspace identity", async ({ page }) => {
+  await expect(page).toHaveTitle("Agent Studio");
   await expect(page.locator(".brand-name")).toHaveText("Sapiom");
-  await expect(page.locator(".brand-product")).toHaveText("Studio");
+  await expect(page.locator(".brand-product")).toHaveText("Agent Studio");
+  await expect(page.getByTestId("palette-trigger")).toHaveAttribute(
+    "aria-label",
+    "Jump to session, agent, or path",
+  );
   // Mock mode is the static demo build: it must never claim a connected
   // Sapiom account — the identity chip reads "Demo workspace" instead.
   const identity = page.getByTestId("brand-identity");
@@ -896,7 +901,7 @@ test.describe("workflow actions", () => {
     // tab bar for deployed workflows. leasing is deployed (definitionId set) on load.
     const dashLink = page.getByTestId("workflow-dashboard-link");
     await expect(dashLink).toBeVisible();
-    await expect(dashLink).toHaveAttribute("href", /app\.sapiom\.ai\/workflows\//);
+    await expect(dashLink).toHaveAttribute("href", /app\.sapiom\.ai\/agents\//);
     await expect(dashLink).toHaveAttribute("target", "_blank");
   });
 
@@ -1394,6 +1399,24 @@ test.describe("account profile row", () => {
     const menu = page.getByTestId("profile-menu");
     await expect(menu).toBeVisible();
     await expect(page.getByTestId("profile-open-dashboard")).toBeVisible();
+    await page.evaluate(() => {
+      const harnessWindow = window as unknown as {
+        __SAP_2332_OPENED_URL__?: string;
+        open: typeof window.open;
+      };
+      harnessWindow.open = ((url?: string | URL) => {
+        harnessWindow.__SAP_2332_OPENED_URL__ = String(url ?? "");
+        return null;
+      }) as typeof window.open;
+    });
+    await page.getByTestId("profile-open-dashboard").click();
+    await expect.poll(() => page.evaluate(() => (
+      window as unknown as { __SAP_2332_OPENED_URL__?: string }
+    ).__SAP_2332_OPENED_URL__)).toBe("https://app.sapiom.ai/agents");
+
+    // Reopen after the dashboard action closes the menu.
+    await profile.click();
+    await expect(menu).toBeVisible();
     // Demo build: the switch item reads as connect and stays actionable.
     await expect(page.getByTestId("profile-switch-account")).toHaveText(/Connect Sapiom account/);
     await expect(page.getByTestId("profile-switch-account")).toBeEnabled();

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -100,6 +100,18 @@ test("auto-selects the running boot session on initial load", async ({ page }) =
   const header = page.getByTestId("session-context");
   await expect(header).toHaveAttribute("data-session-id", "sess-boot");
   await expect(header.locator(".session-dot")).toHaveAttribute("data-status", "running");
+
+  await page.evaluate(() => {
+    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+      type: "session.activity",
+      harnessSessionId: "sess-boot",
+      at: new Date().toISOString(),
+    });
+  });
+  await expect(header.getByTestId("session-status-tag")).toHaveAttribute(
+    "data-tooltip",
+    "The coding agent produced output in the last few seconds",
+  );
 });
 
 test("session header: compact identity (name only; path in the tooltip); New session opens from the rail's history menu", async ({
@@ -499,7 +511,15 @@ test("add project: the rail's + registers a bare folder through the 'Open a fold
 test("new-session modal: directory picker navigates and validates", async ({ page }) => {
   await page.getByTestId("add-workspace").click();
   await page.getByTestId("new-session-btn").click();
-  await expect(page.locator(".modal-new-session")).toBeVisible();
+  const modal = page.locator(".modal-new-session");
+  await expect(modal).toBeVisible();
+  await expect(modal.locator(".modal-field-hint")).toHaveText(
+    "Pick the workspace folder the coding agent runs in; the session is named after the folder.",
+  );
+  await expect(modal.getByTestId("harness-select")).toHaveAttribute(
+    "aria-label",
+    "Coding agent for this session",
+  );
 
   const startButton = page.getByRole("button", { name: "Start session" });
   const input = page.getByTestId("dir-picker-input");
@@ -1791,6 +1811,10 @@ test("a detected dev server surfaces a Preview chip on the action bar", async ({
   await expect(chip).toBeVisible();
   await expect(chip).toContainText("Preview :5173");
   await expect(chip).toHaveAttribute("href", "http://localhost:5173/");
+  await expect(chip).toHaveAttribute(
+    "data-tooltip",
+    "The coding agent is serving an app on port 5173. Opens http://localhost:5173/",
+  );
 });
 
 test("an observed run renders per-step status and latency in the steps tab", async ({ page }) => {

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -176,7 +176,9 @@ test.describe("templates journey (from the welcome panel)", () => {
     page,
   }) => {
     await open(page, "web-research-digest");
-    await expect(page.getByTestId("template-handoff")).toContainText("Sapiom account");
+    await expect(page.getByTestId("template-handoff")).toHaveText(
+      "Using it forks the template into a repo you own, then clones it here. Needs a signed-in Sapiom account; the coding agent asks you to sign in if it is missing.",
+    );
     await open(page, "coding-pause");
     await expect(page.getByTestId("template-handoff")).toContainText("No account, no network");
   });

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -59,6 +59,8 @@ test.describe("templates journey (from the welcome panel)", () => {
   });
 
   test("browse: catalog cards plus the two bundled starters", async ({ page }) => {
+    await expect(page.locator(".templates-hero-copy")).toContainText("runnable agents");
+    await expect(page.locator(".templates-hero-copy")).not.toContainText("workflows");
     // Real clonable slugs from the catalog, not a hardcoded pair.
     await expect(page.getByTestId("template-card-web-research-digest")).toBeVisible();
     await expect(page.getByTestId("template-card-hello-agent")).toBeVisible();

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -198,7 +198,7 @@ test("the dead-session pane shows the record's real metadata and the canvas invi
 
   const detail = page.getByTestId("dead-session-detail");
   await expect(detail).toBeVisible();
-  await expect(detail).toContainText("Agent");
+  await expect(detail).toContainText("Coding agent");
   await expect(detail).toContainText("Claude Code");
   await expect(detail).toContainText("Ended");
 

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -28,11 +28,15 @@ test.describe("command palette sections and highlighting", () => {
     const list = page.getByTestId("command-palette-list");
     await expect(list).toBeVisible();
 
-    // Fixed section order: Sessions, then Past sessions, Workflows, Folders.
+    // Fixed section order: Sessions, then Past sessions, Agents, Folders.
     const sections = page.getByTestId("command-palette-section");
     await expect(sections.first()).toHaveText("Sessions");
     await expect(sections.filter({ hasText: "Past sessions" })).toHaveCount(1);
-    await expect(sections.filter({ hasText: "Workflows" })).toHaveCount(1);
+    await expect(sections.filter({ hasText: "Agents" })).toHaveCount(1);
+    await expect(page.getByTestId("command-palette-input")).toHaveAttribute(
+      "placeholder",
+      "Jump to a session, agent, or path…",
+    );
 
     // The exited fixture session is reachable from the palette now.
     await expect(list).toContainText("Build the leasing pipeline");

--- a/packages/harness/web/e2e/welcome.spec.ts
+++ b/packages/harness/web/e2e/welcome.spec.ts
@@ -49,12 +49,13 @@ test.describe("first run", () => {
     await expect(page.locator(".terminal-empty")).toBeVisible();
 
     // "Welcome to" is the one thing that marks a first run.
-    await expect(panel).toContainText("Welcome to Sapiom Agent Studio");
-    await expect(panel).toContainText("Local runs are free and offline");
+    await expect(panel).toContainText("Welcome to Agent Studio");
+    await expect(panel).toContainText("Local agent runs are free and offline");
 
     // Each way in is a row that says what picking it does, not a bare button.
     const folder = page.getByTestId("welcome-open-card");
     await expect(folder).toContainText("Open a folder");
+    await expect(folder).toContainText("Agents in the folder appear in the rail");
     await expect(folder).toContainText("Nothing is uploaded");
     await expect(page.getByTestId("welcome-start-project")).toBeVisible();
 
@@ -115,7 +116,8 @@ test.describe("returning user", () => {
 
     const panel = page.getByTestId("welcome-panel");
     // Greeted once, on the first run — not every time you open Overview.
-    await expect(panel).toContainText("Sapiom Agent Studio");
+    await expect(panel).toContainText("Agent Studio");
+    await expect(panel).not.toContainText("Sapiom Agent Studio");
     await expect(panel).not.toContainText("Welcome to");
     // Everything else is the same surface, plus the thing a returning user came
     // for: where they have already been.

--- a/packages/harness/web/index.html
+++ b/packages/harness/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sapiom Studio</title>
+    <title>Agent Studio</title>
     <script>
       // Set the theme before first paint to avoid a flash of the wrong one.
       // Storage key must match web/src/lib/theme.ts (this can't import it).

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -449,7 +449,7 @@ export const App = (): JSX.Element => {
       trimmedIdea
         ? `${base} build this:\n\n${trimmedIdea}`
         : `${base} define the first workflow.`,
-      "Couldn't send the scaffold prompt. Ask the agent to run sapiom agents init.",
+      "Couldn't send the scaffold prompt. Ask the coding agent to run sapiom agents init.",
     );
   };
 
@@ -477,7 +477,7 @@ export const App = (): JSX.Element => {
     injectPromptWithRetry(
       sessionId,
       "Scaffold a new Sapiom agent project in this directory: run `sapiom agents init .`, then use the sapiom-agent-authoring skill to define the first workflow.",
-      "Couldn't send the scaffold prompt. Ask the agent to run sapiom agents init.",
+      "Couldn't send the scaffold prompt. Ask the coding agent to run sapiom agents init.",
     );
   };
 
@@ -489,8 +489,8 @@ export const App = (): JSX.Element => {
       session.id,
       useTemplatePrompt(template, cwd),
       template.kind === "gallery"
-        ? "Couldn't send the clone prompt. Ask the agent to run sapiom_dev_agents_clone."
-        : "Couldn't send the starter prompt. Ask the agent to run sapiom agents init.",
+        ? "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone."
+        : "Couldn't send the starter prompt. Ask the coding agent to run sapiom agents init.",
     );
   };
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -315,7 +315,7 @@ export const App = (): JSX.Element => {
   }, [harness.tasks, harness.showToast]);
 
   if (harness.loading) {
-    return <div className="app-status">Loading Sapiom Studio…</div>;
+    return <div className="app-status">Loading Agent Studio…</div>;
   }
   // Boot failed (no state to render): degrade gracefully to a recoverable
   // state instead of a dead "Failed to load" white screen. The classifier
@@ -639,7 +639,7 @@ export const App = (): JSX.Element => {
       if (direct !== null) {
         if (direct === "deploy") {
           if (!workflow) {
-            harness.showToast("Select a workflow first.");
+            harness.showToast("Select an agent first.");
           } else {
             void harness.deploy(workflow.path);
           }
@@ -662,7 +662,7 @@ export const App = (): JSX.Element => {
           }
         } else if (direct === "run-local") {
           if (!workflow) {
-            harness.showToast("Select a workflow first.");
+            harness.showToast("Select an agent first.");
           } else {
             void harness.runLocal(sessionId, workflow.path);
           }
@@ -1013,11 +1013,11 @@ export const App = (): JSX.Element => {
                   <a
                     className="status-tag status-tag-action workflow-deployed-tag right-pane-deployed"
                     data-testid="workflow-dashboard-link"
-                    href={`https://app.sapiom.ai/workflows/${rightPaneWorkflow.definitionId}`}
+                    href={`https://app.sapiom.ai/agents/${rightPaneWorkflow.definitionId}`}
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Deployed — open in the Sapiom dashboard"
-                    data-tooltip="Open this workflow in the Sapiom dashboard"
+                    data-tooltip="Open this agent in the Sapiom dashboard"
                   >
                     <Icon name="Cloud" size={12} />
                     deployed

--- a/packages/harness/web/src/components/AddWorkspaceDialog.tsx
+++ b/packages/harness/web/src/components/AddWorkspaceDialog.tsx
@@ -91,8 +91,8 @@ interface AddWorkspaceDialogProps {
  *  of three labels is exactly how "Open a folder" and "I have a project" came
  *  to name the same action on two surfaces. */
 export const DOORS: { id: Door; title: string; sub: string; icon: "Folder" | "LayoutTemplate" | "Sparkles" }[] = [
-  { id: "have", title: "Open a folder", sub: "Add a folder that already holds an agent", icon: "Folder" },
-  { id: "template", title: "Start from a template", sub: "Ready-made workflows you can edit", icon: "LayoutTemplate" },
+  { id: "have", title: "Open a folder", sub: "Add a folder that already holds an agent project", icon: "Folder" },
+  { id: "template", title: "Start from a template", sub: "Ready-made agents you can edit", icon: "LayoutTemplate" },
   { id: "idea", title: "Start from an idea", sub: "Describe it; the agent scaffolds it", icon: "Sparkles" },
 ];
 
@@ -145,7 +145,7 @@ export function AddWorkspaceDialog({
       <div
         className="modal modal-add-workspace"
         role="dialog"
-        aria-label={activeDoor ? activeDoor.title : "Add to Sapiom"}
+        aria-label={activeDoor ? activeDoor.title : "Add a workspace"}
         ref={panelRef}
       >
         <div className="modal-header">
@@ -164,7 +164,7 @@ export function AddWorkspaceDialog({
               <Icon name="ArrowLeft" size={14} />
             </button>
           )}
-          <span className="aw-title">{activeDoor ? activeDoor.title : "Add to Sapiom"}</span>
+          <span className="aw-title">{activeDoor ? activeDoor.title : "Add a workspace"}</span>
           <button className="theme-toggle modal-close" aria-label="Close" title="Close" onClick={onClose}>
             <Icon name="X" size={14} />
           </button>

--- a/packages/harness/web/src/components/BrandHeader.tsx
+++ b/packages/harness/web/src/components/BrandHeader.tsx
@@ -22,7 +22,7 @@ export function BrandHeader({ onCollapse }: { onCollapse: () => void }): JSX.Ele
         <img src={sapiomMark} alt="" className="brand-mark" />
         <span className="brand-name">Sapiom</span>
         <span className="brand-divider" />
-        <span className="brand-product">Studio</span>
+        <span className="brand-product">Agent Studio</span>
       </div>
 
       <div className="brand-header-tools">

--- a/packages/harness/web/src/components/CommandPalette.tsx
+++ b/packages/harness/web/src/components/CommandPalette.tsx
@@ -53,7 +53,7 @@ const SECTION_LABELS: Record<PaletteItem["kind"], string> = {
   command: "Actions",
   session: "Sessions",
   past: "Past sessions",
-  workflow: "Workflows",
+  workflow: "Agents",
   recent: "Folders",
   path: "Folders",
 };
@@ -306,7 +306,7 @@ export function CommandPalette({
           ref={inputRef}
           className="command-palette-input"
           data-testid="command-palette-input"
-          placeholder="Jump to a session, workflow, or path…"
+          placeholder="Jump to a session, agent, or path…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/packages/harness/web/src/components/ConnectivityState.tsx
+++ b/packages/harness/web/src/components/ConnectivityState.tsx
@@ -53,7 +53,7 @@ const SCREEN_COPY: Record<
   offline: {
     icon: "CloudOff",
     title: "You're offline",
-    body: "Sapiom Studio can't reach the network. Check your connection — the moment you're back, retry to pick up right where you left off.",
+    body: "Agent Studio can't reach the network. Check your connection — the moment you're back, retry to pick up right where you left off.",
   },
   auth: {
     icon: "Plug",
@@ -62,7 +62,7 @@ const SCREEN_COPY: Record<
   },
   error: {
     icon: "TriangleAlert",
-    title: "Couldn't reach Sapiom Studio",
+    title: "Couldn't reach Agent Studio",
     body: "The server didn't respond as expected. This is usually temporary — retry in a moment.",
   },
 };
@@ -190,7 +190,7 @@ export function ConnectivityBanner({
         <Icon name="CloudOff" size={14} />
       </span>
       <span className="connectivity-banner-text">
-        You're offline. The Studio stays usable, but live actions (runs,
+        You're offline. Agent Studio stays usable, but live actions (runs,
         deploys, the terminal) pause until your connection returns.
       </span>
       {onDismiss && (

--- a/packages/harness/web/src/components/DeadSessionPane.tsx
+++ b/packages/harness/web/src/components/DeadSessionPane.tsx
@@ -270,7 +270,7 @@ function SessionRecordBody({ state }: { state: SessionRecordState }): JSX.Elemen
         <span className="empty-state-icon" aria-hidden="true">
           <Icon name="SquareTerminal" size={18} />
         </span>
-        No transcript for this session: the harness has no recorded events for it. Sessions the
+        No transcript for this session: Agent Studio has no recorded events for it. Sessions Agent
         Studio didn't run — or ones whose events have aged out of the local log — show up here as
         history rows only.
       </div>

--- a/packages/harness/web/src/components/DeadSessionPane.tsx
+++ b/packages/harness/web/src/components/DeadSessionPane.tsx
@@ -37,7 +37,7 @@ interface DeadSessionPaneProps {
 function resumeBlockedReason(session: HarnessSession): string {
   return session.agentSessionId == null
     ? "This session can't be resumed: it exited before establishing a session id."
-    : `${HARNESS_LABELS[session.harness]} has no saved conversation for this session, so there's nothing to hand back. That happens when a session ends before its first prompt — the agent never writes a transcript for those.`;
+    : `${HARNESS_LABELS[session.harness]} has no saved conversation for this session, so there's nothing to hand back. That happens when a session ends before its first prompt — the coding agent never writes a transcript for those.`;
 }
 
 /**
@@ -106,7 +106,7 @@ export function DeadSessionPane({
             </div>
           )}
           <div className="dead-session-detail-row">
-            <dt>Agent</dt>
+            <dt>Coding agent</dt>
             <dd>{HARNESS_LABELS[session.harness]}</dd>
           </div>
           {duration && (
@@ -144,7 +144,7 @@ export function DeadSessionPane({
           <div className="dead-session-resume-reason" data-testid="dead-session-resume-reason">
             {resumeBlockedReason(session)}{" "}
             {canContinue
-              ? "Continuing opens a fresh session in this directory, seeded with the reconstruction below — a briefing about this session, not its context. The new agent will need to check the repository before relying on any of it."
+              ? "Continuing opens a fresh session in this directory, seeded with the reconstruction below — a briefing about this session, not its context. The new coding agent will need to check the repository before relying on any of it."
               : "Start a new session in this directory instead; there is no recording of this one to carry over either."}
           </div>
         )}
@@ -230,9 +230,9 @@ export function PastSessionPane({
         <div className="dead-session-resume-reason" data-testid="past-session-reason">
           {HARNESS_LABELS[summary.harness]} has no saved conversation for this session, so it can't
           be reattached — sessions that end before their first prompt are never written to the
-          agent's history.{" "}
+          coding agent's history.{" "}
           {canRehydrate
-            ? "Continuing opens a fresh session here, seeded with the reconstruction below. The new agent gets a briefing about this session, not its context — it will need to check the repository before relying on any of it."
+            ? "Continuing opens a fresh session here, seeded with the reconstruction below. The new coding agent gets a briefing about this session, not its context — it will need to check the repository before relying on any of it."
             : "Starting opens a fresh session in the same directory, with no context from this one."}
         </div>
       )}

--- a/packages/harness/web/src/components/NewSessionModal.tsx
+++ b/packages/harness/web/src/components/NewSessionModal.tsx
@@ -134,7 +134,7 @@ export function NewSessionModal({
           {/* The one field is a DIRECTORY, not a name — say so, and say what
               the name will be, so nobody types a session title into a path. */}
           <p className="modal-field-hint">
-            Pick the workspace folder the agent runs in; the session is named after the folder.
+            Pick the workspace folder the coding agent runs in; the session is named after the folder.
           </p>
           {error && <div className="modal-error">{error}</div>}
         </div>
@@ -151,7 +151,7 @@ export function NewSessionModal({
                 data-testid="harness-select"
                 aria-haspopup="menu"
                 aria-expanded={pickerOpen}
-                aria-label="Agent for this session"
+                aria-label="Coding agent for this session"
                 data-tooltip="Which coding agent runs this session"
                 disabled={busy}
                 onClick={() => setPickerOpen((v) => !v)}

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -199,7 +199,7 @@ export function SessionBar({
               data-status={activeSession.status}
               data-tooltip={
                 busy
-                  ? "The agent produced output in the last few seconds"
+                  ? "The coding agent produced output in the last few seconds"
                   : activeSession.status === "running"
                     ? "Session is live; the terminal is connected"
                     : activeSession.status === "exited"

--- a/packages/harness/web/src/components/SessionStepsBar.tsx
+++ b/packages/harness/web/src/components/SessionStepsBar.tsx
@@ -157,7 +157,7 @@ export function SessionStepsBar({
           target="_blank"
           rel="noreferrer"
           aria-label={`Preview :${preview.port}`}
-          data-tooltip={`The agent is serving an app on port ${preview.port}. Opens ${preview.url}`}
+          data-tooltip={`The coding agent is serving an app on port ${preview.port}. Opens ${preview.url}`}
         >
           <Icon name="ExternalLink" size={12} />
           {/* Below 380px only the word hides; the port stays as the chip's

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -193,7 +193,7 @@ export function SettingsPopover({
 
       <p className="settings-note">
         Help us optimize your experience: with this on, your prompts, tool calls, and session
-        lifecycle events are shared with Sapiom so we can see where the Studio gets in your way.
+        lifecycle events are shared with Sapiom so we can see where Agent Studio gets in your way.
         Off by default. Always written locally to <code>{HARNESS_PATHS.events}</code> either way.
       </p>
 
@@ -214,14 +214,14 @@ export function SettingsPopover({
 
       <p className="settings-note">
         Anonymous-by-default usage: which buttons and screens you use, and how you move through the
-        Studio. No prompt text, no file contents, and never a screen recording. On by default; turn
+        Agent Studio. No prompt text, no file contents, and never a screen recording. On by default; turn
         it off here anytime.
       </p>
 
       {envForced && (
         <p className="settings-note settings-env-note" data-testid="telemetry-env-note">
           All telemetry is turned off by {consentEnvReason ? `$${consentEnvReason}` : "an environment variable"}. Unset
-          it and restart the Studio server to manage consent here.
+          it and restart the Agent Studio server to manage consent here.
         </p>
       )}
 

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -242,8 +242,9 @@ export function SettingsPopover({
 
       <p className="settings-note">
         Off by default, because it uses tokens you didn&rsquo;t ask to use: every 10 turns, and
-        once at the end, a cheap one-shot agent run folds the session into a short summary.
-        Continuing a session the agent can no longer reattach to then explains what the work was{" "}
+        once at the end, a cheap one-shot coding-agent pass folds the session into a short summary.
+        Continuing a session the coding agent can no longer reattach to then explains what the work
+        was{" "}
         <em>for</em>, not just what it last did. With this off, continuing still works — it
         carries the last few turns instead.
       </p>

--- a/packages/harness/web/src/components/TelemetryNotice.tsx
+++ b/packages/harness/web/src/components/TelemetryNotice.tsx
@@ -25,7 +25,7 @@ export function TelemetryNotice({ onDismiss, onOpenSettings }: TelemetryNoticePr
       <div className="telemetry-notice-body">
         <p className="telemetry-notice-text">
           Sharing session details with Sapiom is <strong>off by default</strong>. Your prompts and
-          tool calls stay local unless you opt in to help us improve the Studio. Turn it on any time in{" "}
+          tool calls stay local unless you opt in to help us improve Agent Studio. Turn it on any time in{" "}
           <button
             className="telemetry-notice-settings-link"
             onClick={() => {

--- a/packages/harness/web/src/components/TemplateDetail.tsx
+++ b/packages/harness/web/src/components/TemplateDetail.tsx
@@ -295,7 +295,7 @@ export function TemplateDetail({
       {/* What "Use template" really does — the two paths differ, say so. */}
       <p className="template-handoff" data-testid="template-handoff">
         {template.kind === "gallery"
-          ? "Using it forks the template into a repo you own, then clones it here. Needs a signed-in Sapiom account; the agent asks you to sign in if it is missing."
+          ? "Using it forks the template into a repo you own, then clones it here. Needs a signed-in Sapiom account; the coding agent asks you to sign in if it is missing."
           : "Scaffolds offline from the template bundled with the CLI. No account, no network."}
       </p>
     </div>

--- a/packages/harness/web/src/components/TemplatesPanel.tsx
+++ b/packages/harness/web/src/components/TemplatesPanel.tsx
@@ -163,7 +163,7 @@ export function TemplatesPanel({
                       advertise templates that are not on screen. */}
                   {loading
                     ? "Loading the catalog…"
-                    : `${gallery.length} runnable agent workflows. Open one to read what it does, then use it. A session starts in a new folder and sets it up for you.`}
+                    : `${gallery.length} runnable agents. Open one to read what it does, then use it. A session starts in a new folder and sets it up for you.`}
                 </p>
               </header>
 

--- a/packages/harness/web/src/components/WelcomePanel.tsx
+++ b/packages/harness/web/src/components/WelcomePanel.tsx
@@ -177,7 +177,7 @@ export function WelcomePanel({
         role="dialog"
         aria-modal="true"
         aria-label={
-          firstRun ? "Welcome to Sapiom Agent Studio" : "Sapiom Agent Studio"
+          firstRun ? "Welcome to Agent Studio" : "Agent Studio"
         }
       >
         <div className="welcome-card" ref={cardRef}>
@@ -202,8 +202,8 @@ export function WelcomePanel({
                 brand-new install, so it renders nothing. */}
             <h1 className="welcome-title">
               {firstRun
-                ? "Welcome to Sapiom Agent Studio"
-                : "Sapiom Agent Studio"}
+                ? "Welcome to Agent Studio"
+                : "Agent Studio"}
             </h1>
             {/* Three beats, in the order the product earns trust: what it makes of
                 your code, what a run costs and shows, who decides to ship. The
@@ -211,8 +211,8 @@ export function WelcomePanel({
                 spend the one paragraph anybody reads on instructions they are
                 about to be given. */}
             <p className="welcome-intro">
-              Studio turns the agent workflows in your codebase into a diagram
-              you can run. Local runs are free and offline, with every
+              Agent Studio turns the agents in your codebase into diagrams you
+              can inspect and run. Local agent runs are free and offline, with every
               step&rsquo;s input, output and capability call on screen. Nothing
               ships until you say so.
             </p>
@@ -231,7 +231,7 @@ export function WelcomePanel({
               <span className="welcome-open-copy">
                 <span className="welcome-open-title">Open a folder</span>
                 <span className="welcome-open-desc">
-                  Workflows in the folder appear in the rail. Nothing is
+                  Agents in the folder appear in the rail. Nothing is
                   uploaded.
                 </span>
               </span>
@@ -300,7 +300,7 @@ export function WelcomePanel({
               </button>
               <span className="welcome-consent-copy">
                 Help us optimize your experience — share your session details with
-                Sapiom so we can improve how the Studio works for you. Off by
+                Sapiom so we can improve how Agent Studio works for you. Off by
                 default; change it anytime in Settings.
               </span>
             </label>

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -27,7 +27,7 @@ import { HARNESS_LABELS, historyDirs, historyRowMeta, sessionRowState } from "..
 import { loadUiPrefs, saveUiPrefs } from "../lib/ui-prefs";
 import { buildWorkspaceTree } from "../lib/workspace-tree";
 
-const SAPIOM_DASHBOARD_URL = "https://app.sapiom.ai/workflows";
+const SAPIOM_DASHBOARD_URL = "https://app.sapiom.ai/agents";
 
 interface WorkflowsRailProps {
   /** Resizable width (px) — the rail can shrink to minWidth under pressure. */
@@ -416,7 +416,7 @@ export function WorkflowsRail({
         <button
           className="palette-trigger"
           data-testid="palette-trigger"
-          aria-label="Jump to session, workflow, or path"
+          aria-label="Jump to session, agent, or path"
           onClick={onOpenPalette}
         >
           <Icon name="Search" size={13} />

--- a/packages/harness/web/src/lib/direct-action-gating.test.ts
+++ b/packages/harness/web/src/lib/direct-action-gating.test.ts
@@ -194,7 +194,7 @@ describe("Fix 1 — blocked direct actions produce a specific toast reason", () 
     lastDeployError: string | null,
   ): string | null {
     if (kind === "deploy") {
-      return workflow ? null : "Select a workflow first.";
+      return workflow ? null : "Select an agent first.";
     }
     if (kind === "prod-run") {
       if (workflow?.definitionId != null) return null; // proceed
@@ -203,13 +203,13 @@ describe("Fix 1 — blocked direct actions produce a specific toast reason", () 
         : "This agent isn't deployed yet — deploy it first.";
     }
     if (kind === "run-local") {
-      return workflow ? null : "Select a workflow first.";
+      return workflow ? null : "Select an agent first.";
     }
     return null;
   }
 
-  it("deploy with no workflow toasts 'Select a workflow first.'", () => {
-    expect(directActionToastReason("deploy", null, null)).toBe("Select a workflow first.");
+  it("deploy with no agent toasts 'Select an agent first.'", () => {
+    expect(directActionToastReason("deploy", null, null)).toBe("Select an agent first.");
   });
 
   it("deploy with a workflow proceeds (no toast)", () => {
@@ -217,8 +217,8 @@ describe("Fix 1 — blocked direct actions produce a specific toast reason", () 
     expect(directActionToastReason("deploy", wf, null)).toBeNull();
   });
 
-  it("run-local with no workflow toasts 'Select a workflow first.'", () => {
-    expect(directActionToastReason("run-local", null, null)).toBe("Select a workflow first.");
+  it("run-local with no agent toasts 'Select an agent first.'", () => {
+    expect(directActionToastReason("run-local", null, null)).toBe("Select an agent first.");
   });
 
   it("run-local with a workflow proceeds (no toast)", () => {
@@ -287,9 +287,9 @@ describe("macroDisabledReason — existing gating not regressed", () => {
     expect(macroDisabledReason(macro, wf, "sess-1")).toBeNull();
   });
 
-  it("requiresWorkflow: returns 'Select a workflow first' when no workflow", () => {
+  it("requiresWorkflow: returns 'Select an agent first' when no agent is selected", () => {
     const macro = makeMacro({ requiresWorkflow: true });
-    expect(macroDisabledReason(macro, null, "sess-1")).toBe("Select a workflow first");
+    expect(macroDisabledReason(macro, null, "sess-1")).toBe("Select an agent first");
   });
 
   it("non-open-url + no session: returns 'Start a session first'", () => {

--- a/packages/harness/web/src/lib/harness-registry.ts
+++ b/packages/harness/web/src/lib/harness-registry.ts
@@ -50,14 +50,14 @@ export function isHarnessSelectable(entry: HarnessEntry): boolean {
  *  the absence when it doesn't. */
 export function harnessUnavailableReason(entry: HarnessEntry): string | null {
   if (isHarnessSelectable(entry)) return null;
-  if (entry.mode === "external") return `${entry.label} runs in its own app. Studio can't launch it yet.`;
+  if (entry.mode === "external") return `${entry.label} runs in its own app. Agent Studio can't launch it yet.`;
   if (!entry.installed) {
     const prompt = entry.installMcpPrompt.trim();
     return prompt.length > 0
       ? prompt
-      : `${entry.label} isn't on this machine's PATH. Install its CLI, then restart the Studio server.`;
+      : `${entry.label} isn't on this machine's PATH. Install its CLI, then restart the Agent Studio server.`;
   }
-  return `This Studio build can't launch ${entry.label} yet.`;
+  return `This Agent Studio build can't launch ${entry.label} yet.`;
 }
 
 /** The label the registry ships for an id, falling back to the id itself. */

--- a/packages/harness/web/src/lib/macro-gating.ts
+++ b/packages/harness/web/src/lib/macro-gating.ts
@@ -12,7 +12,7 @@ export function macroDisabledReason(
   activeSessionId: string | null,
 ): string | null {
   if (macro.requiresWorkflow) {
-    if (!workflow) return "Select a workflow first";
+    if (!workflow) return "Select an agent first";
     if (
       macro.action.kind === "open-url" &&
       macro.action.url.includes("{{workflow.definitionId}}") &&

--- a/packages/harness/web/src/lib/workspace-logic.test.ts
+++ b/packages/harness/web/src/lib/workspace-logic.test.ts
@@ -131,7 +131,7 @@ describe("macro gating", () => {
       id: "open_prod",
       label: "Open",
       icon: "ExternalLink",
-      action: { kind: "open-url", url: "https://app.sapiom.ai/workflows/{{workflow.definitionId}}" },
+      action: { kind: "open-url", url: "https://app.sapiom.ai/agents/{{workflow.definitionId}}" },
       requiresWorkflow: true,
     },
   ];
@@ -145,7 +145,7 @@ describe("macro gating", () => {
   });
 
   it("requires a selected workflow for requiresWorkflow macros", () => {
-    expect(macroDisabledReason(macros[1], null, "sess-1")).toBe("Select a workflow first");
+    expect(macroDisabledReason(macros[1], null, "sess-1")).toBe("Select an agent first");
   });
 
   it("blocks definitionId-dependent macros until deployed", () => {


### PR DESCRIPTION
## Summary

- Normalize browser, CLI, desktop, package, and public help branding to Agent Studio.
- Replace shell-facing Workflow nouns with Agent, Agent project, Workspace, and Agent run terminology.
- Send every Studio-owned dashboard link to the canonical `/agents` route while preserving compatibility-sensitive package, binary, installer, and updater identities.
- Add focused unit and Playwright assertions for the new copy, links, and preserved metadata.

## Testing

- `pnpm --filter @sapiom/harness test` — 1,644 unit + 4 performance tests passed.
- Focused Harness Vitest — 114/114 passed.
- `pnpm --filter @sapiom/harness typecheck` — passed.
- `pnpm --filter @sapiom/harness-desktop typecheck` — passed.
- `pnpm --filter @sapiom/harness-desktop test` — 53/53 passed.
- `pnpm --filter @sapiom/harness build` — passed.
- Focused Harness Playwright (`welcome`, `wave5`, `smoke`, `add-workspace`, `templates`) — 139/139 passed.
- `pnpm --filter @sapiom/harness-desktop dist` — packaged successfully on macOS arm64.
- Packaged desktop `--smoke` could not acquire the single-instance lock because the user-owned Sapiom desktop app was already running; no user process was stopped. Cloud desktop smoke remains the authoritative packaged run.

## Related

- SAP-2332
- SAP-2071
