### PR TITLE
fix(studio): replace generated workflow terminology

### DIFF
--- a/.changeset/calm-canvas-agents.md
+++ b/.changeset/calm-canvas-agents.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Use Agent terminology across generated Canvas content, server errors, and demo fixtures.

--- a/packages/harness/e2e/canvas-template.spec.ts
+++ b/packages/harness/e2e/canvas-template.spec.ts
@@ -13,7 +13,7 @@ const ORDER_TRIAGE_BODY = `
   <header class="canvas-header">
     <div class="canvas-title-row">
       <h1 class="canvas-title">order-triage</h1>
-      <span class="canvas-badge">standalone workflow</span>
+      <span class="canvas-badge">standalone agent</span>
     </div>
     <p class="canvas-subtitle">Support-ticket triage: intake -&gt; classify -&gt; route, then auto-resolve or escalate.</p>
     <div class="canvas-stats">
@@ -89,15 +89,15 @@ const ORDER_TRIAGE_BODY = `
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--pause"></span>pause / waits for input</span>
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-success"></span>terminal &middot; success</span>
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-warn"></span>terminal &middot; escalation</span>
-    <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-workflow signal/handoff</span>
+    <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-agent signal/handoff</span>
   </div>
-  <p class="canvas-note">Static preview — regenerate after the workflow changes.</p>
+  <p class="canvas-note">Static preview — regenerate after the agent changes.</p>
 </footer>
 `.trim();
 
 const WORKSPACE_OVERVIEW_BODY = `
 <section class="canvas-panel">
-  <header class="canvas-header"><div class="canvas-title-row"><h1 class="canvas-title">workflow-a</h1></div></header>
+  <header class="canvas-header"><div class="canvas-title-row"><h1 class="canvas-title">agent-a</h1></div></header>
   <div class="canvas-diagram-panel">
     <svg class="canvas-graph-svg" viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
       <g class="canvas-node node--entry" filter="url(#canvas-glow)" transform="translate(20,20)">
@@ -108,7 +108,7 @@ const WORKSPACE_OVERVIEW_BODY = `
   </div>
 </section>
 <section class="canvas-panel">
-  <header class="canvas-header"><div class="canvas-title-row"><h1 class="canvas-title">workflow-b</h1></div></header>
+  <header class="canvas-header"><div class="canvas-title-row"><h1 class="canvas-title">agent-b</h1></div></header>
   <div class="canvas-diagram-panel">
     <svg class="canvas-graph-svg" viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
       <g class="canvas-node node--terminal-success" filter="url(#canvas-glow)" transform="translate(20,20)">

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -34,7 +34,7 @@ const NODE_KIND_LABEL: Record<CanvasNodeKind, string> = {
   pause: "pause / waits for input",
   "terminal-success": "terminal · success",
   "terminal-warn": "terminal · escalation",
-  "launched-workflow": "launches another workflow",
+  "launched-workflow": "launches another agent",
 };
 
 const NODE_KIND_ORDER: CanvasNodeKind[] = [
@@ -58,7 +58,7 @@ export function buildLegendHtml(nodeKinds: Set<CanvasNodeKind>, edgeKinds: Set<C
   );
   if (edgeKinds.has("cross")) {
     items.push(
-      `<span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-workflow signal/handoff</span>`,
+      `<span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-agent signal/handoff</span>`,
     );
   }
   if (items.length === 0) return "";
@@ -184,7 +184,7 @@ export function buildErrorPanelHtml(title: string, reason: string): string {
     </div>
   </header>
   <div class="canvas-diagram-panel">
-    <p class="canvas-empty-note">Could not extract this workflow's step graph: ${esc(reason)}. Ask your agent to fix the issue (see the terminal for details) — this pane updates automatically once it builds cleanly.</p>
+    <p class="canvas-empty-note">Could not extract this agent's step graph: ${esc(reason)}. Ask your coding agent to fix the issue (see the terminal for details) — this pane updates automatically once it builds cleanly.</p>
   </div>
 </section>`;
 }

--- a/packages/harness/src/core/canvas-graph.test.ts
+++ b/packages/harness/src/core/canvas-graph.test.ts
@@ -137,7 +137,7 @@ describe("extractWorkflowGraph", () => {
       id: "launch:spoke-workflow",
       kind: "launched-workflow",
       label: "spoke-workflow",
-      sublabel: "launched workflow",
+      sublabel: "launched agent",
     });
     expect(result.graph.edges).toContainEqual({
       from: "kickoff",

--- a/packages/harness/src/core/canvas-graph.ts
+++ b/packages/harness/src/core/canvas-graph.ts
@@ -197,7 +197,7 @@ export function mergeLaunchesIntoGraph(graph: CanvasGraph, launches: readonly De
     // happens to share its name.
     const nodeId = `launch:${launch.slug}`;
     if (!nodes.some((n) => n.id === nodeId)) {
-      nodes.push({ id: nodeId, kind: "launched-workflow", label: launch.slug, sublabel: "launched workflow" });
+      nodes.push({ id: nodeId, kind: "launched-workflow", label: launch.slug, sublabel: "launched agent" });
     }
     const from = launch.fromStepId && stepIds.has(launch.fromStepId) ? launch.fromStepId : graph.entry;
     const edgeKey = `${from}->${nodeId}`;

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -106,6 +106,7 @@ describe("renderCanvasForSession", () => {
     const html = await readRender(cwd, HUB);
     expect(html).toContain("node--launched-workflow");
     expect(html).toContain(">spoke-workflow<");
+    expect(html).toContain("launches another agent");
     expect(html).toContain("canvas-edge--launch");
     expect(html).toContain(">launch()<");
   });
@@ -120,7 +121,8 @@ describe("renderCanvasForSession", () => {
     const html = await readRender(cwd, NO_DEFINITION);
     expect(html).toContain("broken-flow");
     expect(html).toContain("render failed");
-    expect(html).toContain("Could not extract this workflow's step graph");
+    expect(html).toContain("Could not extract this agent's step graph");
+    expect(html).toContain("Ask your coding agent to fix the issue");
     expect(html).not.toContain('class="canvas-node '); // no diagram — just the note
   });
 

--- a/packages/harness/src/core/canvas-template.test.ts
+++ b/packages/harness/src/core/canvas-template.test.ts
@@ -169,6 +169,17 @@ describe("TEMPLATE_HTML", () => {
 
   it("carries a friendly empty-state note, not a blank panel", () => {
     expect(TEMPLATE_HTML).toMatch(/nothing visualized yet/i);
+    expect(TEMPLATE_HTML).toContain("run Visualize on an agent");
+  });
+
+  it("uses Agent Studio terminology in generated authoring copy", () => {
+    expect(TEMPLATE_HTML).toContain("<title>Agent Studio canvas</title>");
+    expect(TEMPLATE_HTML).toContain("AGENT STUDIO CANVAS TEMPLATE");
+    expect(TEMPLATE_HTML).toContain("standalone agent");
+    expect(TEMPLATE_HTML).toContain("Untitled agent");
+    expect(TEMPLATE_HTML).toContain("cross-agent signal/handoff");
+    expect(TEMPLATE_HTML).not.toContain("standalone workflow");
+    expect(TEMPLATE_HTML).not.toContain("Untitled workflow");
   });
 
   it("documents one example of every node kind and edge kind inside an inert <template>", () => {

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -144,7 +144,7 @@ body {
 .canvas-group-band { fill: var(--canvas-accent); fill-opacity: 0.06; stroke: var(--canvas-border); stroke-dasharray: 3 5; }
 .canvas-group-label { fill: var(--canvas-text-dim); font-size: 9px; text-transform: uppercase; letter-spacing: 0.06em; }
 
-/* --- edge kinds: sequential (base) | branching (--success/--warn) | cross-workflow signal/handoff (--cross) --- */
+/* --- edge kinds: sequential (base) | branching (--success/--warn) | cross-agent signal/handoff (--cross) --- */
 .canvas-edge { fill: none; stroke-width: 1.8; stroke: var(--canvas-border-strong); }
 .canvas-edge--success { stroke: var(--canvas-success); }
 .canvas-edge--warn { stroke: var(--canvas-escalation); }
@@ -261,7 +261,7 @@ const THEME_SCRIPT = `
 const PATTERNS_TEMPLATE = `
 <template id="canvas-patterns">
   <!-- copy the pattern you need; this whole block is never rendered -->
-  <span class="canvas-badge">standalone workflow</span>
+  <span class="canvas-badge">standalone agent</span>
   <div class="canvas-stat"><span class="canvas-stat-value">5</span><span class="canvas-stat-label">steps</span></div>
   <svg>
     <g class="canvas-node node--entry" filter="url(#canvas-glow)" transform="translate(392,40)">
@@ -293,7 +293,7 @@ const PATTERNS_TEMPLATE = `
     <!-- branching: a step with multiple successors -> curved, colored by the destination's outcome -->
     <path class="canvas-edge canvas-edge--success" d="M480,320 C480,365 288,365 288,410" marker-end="url(#canvas-arrow-success)" />
     <path class="canvas-edge canvas-edge--warn" d="M480,320 C480,365 688,365 688,410" marker-end="url(#canvas-arrow-warn)" />
-    <!-- cross-workflow signal/handoff: dashed, always neutral -->
+    <!-- cross-agent signal/handoff: dashed, always neutral -->
     <path class="canvas-edge canvas-edge--cross" d="M480,320 L480,410" marker-end="url(#canvas-arrow)" />
     <!-- edge label, positioned near the branch point, anchored toward its own destination -->
     <text class="canvas-edge-label" x="440" y="345" text-anchor="end">category == x</text>
@@ -309,7 +309,7 @@ const PATTERNS_TEMPLATE = `
   <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--pause"></span>pause / waits for input</span>
   <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-success"></span>terminal &middot; success</span>
   <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-warn"></span>terminal &middot; escalation</span>
-  <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-workflow signal/handoff</span>
+  <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-agent signal/handoff</span>
 </template>
 `.trim();
 
@@ -376,7 +376,7 @@ export function renderCanvasDocument(bodyHtml: string): string {
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Sapiom workflow canvas</title>
+<title>Agent Studio canvas</title>
 <script>
 ${THEME_SCRIPT}
 </script>
@@ -400,27 +400,27 @@ ${bodyHtml}
 const TEMPLATE_BODY = `
 <!--
   ═══════════════════════════════════════════════════════════════════════
-  SAPIOM CANVAS TEMPLATE — fill in the sections below to visualize a
-  workflow. Keep the <style> block in <head> and the structural classes
+  AGENT STUDIO CANVAS TEMPLATE — fill in the sections below to visualize an
+  agent. Keep the <style> block in <head> and the structural classes
   you see here untouched; only add markup using the patterns in the
   <template id="canvas-patterns"> block near the end of <body> (it is
   never rendered — read it, copy from it, don't edit it). Delete the
   empty-state note below and the patterns template once you're done
-  authoring. For a single bound workflow, one canvas-panel is enough; for
-  a workspace overview, add one canvas-panel per workflow plus an
+  authoring. For a single bound agent, one canvas-panel is enough; for
+  a workspace overview, add one canvas-panel per agent plus an
   Interconnections panel (see the pattern for its row shape).
   ═══════════════════════════════════════════════════════════════════════
 -->
 <section class="canvas-panel">
   <header class="canvas-header">
     <div class="canvas-title-row">
-      <h1 class="canvas-title">Untitled workflow</h1>
+      <h1 class="canvas-title">Untitled agent</h1>
     </div>
-    <p class="canvas-subtitle">One-line description of what this workflow does.</p>
+    <p class="canvas-subtitle">One-line description of what this agent does.</p>
     <div class="canvas-stats"></div>
   </header>
   <div class="canvas-diagram-panel">
-    <p class="canvas-empty-note">Nothing visualized yet — run Visualize on a workflow.</p>
+    <p class="canvas-empty-note">Nothing visualized yet — run Visualize on an agent.</p>
   </div>
 </section>
 

--- a/packages/harness/src/core/example-seed.test.ts
+++ b/packages/harness/src/core/example-seed.test.ts
@@ -45,6 +45,10 @@ describe("seedExampleProject", () => {
     const canvasDir = path.join(targetRoot, ".sapiom", "canvas");
     const canvasHtml = await fs.readFile(path.join(canvasDir, "index.html"), "utf8");
     expect(canvasHtml).toContain("order-triage");
+    expect(canvasHtml).toContain("standalone agent");
+    expect(canvasHtml).toContain("cross-agent signal/handoff");
+    expect(canvasHtml).toContain("after you change the agent");
+    expect(canvasHtml).not.toContain("standalone workflow");
     expect(existsSync(path.join(canvasDir, "_template.html"))).toBe(true);
   });
 

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -188,7 +188,7 @@ const ORDER_TRIAGE_CANVAS_BODY = `
   <header class="canvas-header">
     <div class="canvas-title-row">
       <h1 class="canvas-title">order-triage</h1>
-      <span class="canvas-badge">standalone workflow</span>
+      <span class="canvas-badge">standalone agent</span>
       <span class="canvas-badge">not deployed yet</span>
     </div>
     <p class="canvas-subtitle">Support-ticket triage: intake -&gt; classify -&gt; route, then auto-resolve or escalate to a human.</p>
@@ -248,7 +248,7 @@ const ORDER_TRIAGE_CANVAS_BODY = `
     <span class="canvas-legend-marker canvas-legend-marker--terminal-warn"></span>
     <span class="canvas-interconnection-title">escalate -&gt; external</span>
     <span class="canvas-interconnection-tag">handoff</span>
-    <p class="canvas-interconnection-desc">routes to a human out-of-band, not to another workflow</p>
+    <p class="canvas-interconnection-desc">routes to a human out-of-band, not to another agent</p>
   </div>
 </section>
 
@@ -258,9 +258,9 @@ const ORDER_TRIAGE_CANVAS_BODY = `
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--step"></span>step</span>
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-success"></span>terminal &middot; success</span>
     <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--terminal-warn"></span>terminal &middot; escalation</span>
-    <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-workflow signal/handoff</span>
+    <span class="canvas-legend-item"><span class="canvas-legend-marker canvas-legend-marker--cross"></span>cross-agent signal/handoff</span>
   </div>
-  <p class="canvas-note">Static preview — ask your agent to regenerate this after you change the workflow.</p>
+  <p class="canvas-note">Static preview — ask your coding agent to regenerate this after you change the agent.</p>
 </footer>
 `.trim();
 

--- a/packages/harness/src/core/macro-runner.test.ts
+++ b/packages/harness/src/core/macro-runner.test.ts
@@ -84,7 +84,7 @@ describe("resolveMacro", () => {
     };
     expect(() => resolveMacro(macro, { ...baseCtx, workflow: null })).toThrow(MacroValidationError);
     expect(() => resolveMacro(macro, { ...baseCtx, workflow: null })).toThrow(
-      "requires a selected workflow",
+      "requires a selected agent",
     );
   });
 

--- a/packages/harness/src/core/macro-runner.ts
+++ b/packages/harness/src/core/macro-runner.ts
@@ -105,7 +105,7 @@ function substitute(template: string, ctx: MacroContext): string {
  */
 export function resolveMacro(macro: MacroDef, ctx: MacroContext): ResolvedMacroAction {
   if (macro.requiresWorkflow && !ctx.workflow) {
-    throw new MacroValidationError(`Macro '${macro.id}' requires a selected workflow.`);
+    throw new MacroValidationError(`Macro '${macro.id}' requires a selected agent.`);
   }
 
   if (macro.action.kind === "open-url") {

--- a/packages/harness/src/server/actions.test.ts
+++ b/packages/harness/src/server/actions.test.ts
@@ -261,6 +261,7 @@ describe("createActionsRouter", () => {
         method: "POST",
       });
       expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "agent id is required" });
       expect(coreDeps.deploy).not.toHaveBeenCalled();
     });
 
@@ -277,7 +278,7 @@ describe("createActionsRouter", () => {
       });
       expect(res.status).toBe(404);
       const body = (await res.json()) as Record<string, unknown>;
-      expect(body.error).toBe("workflow not found");
+      expect(body.error).toBe("agent not found");
       expect(coreDeps.deploy).not.toHaveBeenCalled();
     });
 

--- a/packages/harness/src/server/actions.ts
+++ b/packages/harness/src/server/actions.ts
@@ -450,7 +450,7 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
   router.post("/api/workflows/:id/deploy", async (req, res) => {
     const id = req.params.id;
     if (!id || typeof id !== "string" || id.trim() === "") {
-      res.status(400).json({ error: "workflow id is required" });
+      res.status(400).json({ error: "agent id is required" });
       return;
     }
     if (!provider.getKey()) {
@@ -460,7 +460,7 @@ export function createActionsRouter(opts: ActionsRouterOpts): Router {
 
     const workflow = opts.resolveWorkflow(id);
     if (!workflow) {
-      res.status(404).json({ error: "workflow not found" });
+      res.status(404).json({ error: "agent not found" });
       return;
     }
 

--- a/packages/harness/src/server/canvas.test.ts
+++ b/packages/harness/src/server/canvas.test.ts
@@ -80,6 +80,10 @@ describe("canvas router", () => {
   it("404s when no canvas has been written yet", async () => {
     const res = await fetch(`${baseUrl}/canvas/sess-1/`, { method: "HEAD" });
     expect(res.status).toBe(404);
+
+    const get = await fetch(`${baseUrl}/canvas/sess-1/`);
+    expect(get.status).toBe(404);
+    expect(await get.text()).toContain("Select an agent in the rail");
   });
 
   it("serves the bound workflow's render file at the canvas root — resolved at request time, no index.html rewrite", async () => {
@@ -118,7 +122,7 @@ describe("canvas router", () => {
     sessions.set("sess-1", { cwd: projectDir, boundWorkflowPath: "/registered/workflows/not-rendered-yet" });
     const res = await fetch(`${baseUrl}/canvas/sess-1/`);
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain("Rendering workflow diagram");
+    expect(await res.text()).toContain("Rendering agent diagram");
   });
 
   it("an unbound session serves a genuine agent-authored custom canvas at the root", async () => {

--- a/packages/harness/src/server/canvas.ts
+++ b/packages/harness/src/server/canvas.ts
@@ -66,7 +66,7 @@ const EMPTY_STATE_HTML = `<!doctype html>
 <body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
   <div>
     <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Nothing rendered yet</h1>
-    <p style="margin: 0;">Select a workflow in the rail and its step graph renders here automatically.</p>
+    <p style="margin: 0;">Select an agent in the rail and its step graph renders here automatically.</p>
   </div>
 </body>
 </html>`;
@@ -80,7 +80,7 @@ const PENDING_RENDER_HTML = `<!doctype html>
 <head><meta charset="utf-8"><title>Canvas — rendering</title></head>
 <body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
   <div>
-    <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Rendering workflow diagram…</h1>
+    <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Rendering agent diagram…</h1>
     <p style="margin: 0;">This pane reloads automatically when the diagram is ready.</p>
   </div>
 </body>

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -503,11 +503,11 @@ export const startServer = async (
     const prunedWorkflows = await workflowRegistry.prune();
     for (const workflow of prunedWorkflows) {
       console.error(
-        `[harness] pruned workflow registry entry with missing path: ${workflow.path}`,
+        `[harness] pruned agent registry entry with missing path: ${workflow.path}`,
       );
     }
   } catch (err) {
-    console.error("[harness] workflow registry prune failed:", err);
+    console.error("[harness] agent registry prune failed:", err);
   }
   // Same hygiene for settings.json's recentDirs — dead entries are already
   // filtered from every read, but pruning here persists their removal.
@@ -964,7 +964,7 @@ export const startServer = async (
 
   const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch(
     (err: unknown) => {
-      console.error("[harness] initial workflow scan failed:", err);
+      console.error("[harness] initial agent scan failed:", err);
       return [] as WorkflowInfo[];
     },
   );
@@ -1105,7 +1105,7 @@ export const startServer = async (
           })
           .catch((err: unknown) => {
             console.error(
-              "[harness] workflow scan on session create failed:",
+              "[harness] agent scan on session create failed:",
               err,
             );
           });

--- a/packages/harness/src/server/macros.test.ts
+++ b/packages/harness/src/server/macros.test.ts
@@ -105,7 +105,7 @@ describe("macros router", () => {
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("requires a selected workflow");
+    expect(body.error).toContain("requires a selected agent");
   });
 
   it("404s an unknown macro id", async () => {

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -743,6 +743,9 @@ describe("createRestRouter", () => {
       );
 
       expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: "Unknown agent path '/not/registered' — scan or connect it before binding a session to it",
+      });
       expect(sessionManager.setBoundWorkflowPath).not.toHaveBeenCalled();
       expect(writeWorkspaceContext).not.toHaveBeenCalled();
     });
@@ -1467,4 +1470,3 @@ describe("createRestRouter", () => {
     });
   });
 });
-

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -423,7 +423,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
     const { workflowPath } = parsed.data;
     if (workflowPath !== null && !options.findWorkflow(workflowPath)) {
       res.status(400).json({
-        error: `Unknown workflow path '${workflowPath}' — scan or connect it before binding a session to it`,
+        error: `Unknown agent path '${workflowPath}' — scan or connect it before binding a session to it`,
       });
       return;
     }

--- a/packages/harness/web/e2e/add-workspace.spec.ts
+++ b/packages/harness/web/e2e/add-workspace.spec.ts
@@ -8,7 +8,7 @@
  * action, and door 3 cannot submit a name that would break the scaffold.
  *
  * Runs in the same mock mode as smoke.spec.ts. The mock filesystem gives a
- * deliberate spread under /Users/demo: `rfq-workflows` and `onboarding-flow`
+ * deliberate spread under /Users/demo: `rfq-agent` and `onboarding-flow`
  * hold agent projects, `acme-app` is a container whose child `leasing` is one,
  * and `scratch` is a plain folder.
  */
@@ -128,7 +128,7 @@ test.describe("door 1 — Open a folder", () => {
     await page.getByTestId("aw-door-have").click();
 
     const input = page.locator(".dir-picker-input");
-    await input.fill("/Users/demo/rfq-workflows");
+    await input.fill("/Users/demo/rfq-agent");
     await page.getByTestId("aw-have-continue").click();
 
     const result = page.getByTestId("aw-result");
@@ -168,12 +168,12 @@ test.describe("door 1 — Open a folder", () => {
 
   test("Change returns to the picker without losing the path", async ({ page }) => {
     await page.getByTestId("aw-door-have").click();
-    await page.locator(".dir-picker-input").fill("/Users/demo/rfq-workflows");
+    await page.locator(".dir-picker-input").fill("/Users/demo/rfq-agent");
     await page.getByTestId("aw-have-continue").click();
     await expect(page.getByTestId("aw-result")).toBeVisible();
 
     await page.getByRole("button", { name: "Change" }).click();
-    await expect(page.locator(".dir-picker-input")).toHaveValue("/Users/demo/rfq-workflows");
+    await expect(page.locator(".dir-picker-input")).toHaveValue("/Users/demo/rfq-agent");
   });
 });
 

--- a/packages/harness/web/e2e/direct-actions.spec.ts
+++ b/packages/harness/web/e2e/direct-actions.spec.ts
@@ -28,7 +28,7 @@
  *
  * Fixture quick-reference (MOCK_WORKFLOWS / MOCK_SESSIONS in mock-data.ts):
  *   leasing   path=/Users/demo/acme-app/leasing  definitionId=4821 (deployed)
- *   rfq       path=/Users/demo/rfq-workflows      definitionId=null (draft)
+ *   rfq       path=/Users/demo/rfq-agent          definitionId=null (draft)
  *   Boot session (sess-boot) is bound to leasing and running on load.
  *
  * F1 overlap avoided: smoke.spec.ts already has ONE assertion for the Run
@@ -166,7 +166,7 @@ test.describe("Deploy button — direct route, NDJSON build stream, no pty write
     const direct = await waitForDirectAction(page);
     expect(direct.action).toBe("deploy");
     // rfq's path, not leasing's.
-    expect(direct.req.workflowPath).toBe("/Users/demo/rfq-workflows");
+    expect(direct.req.workflowPath).toBe("/Users/demo/rfq-agent");
 
     // No pty involved.
     await assertNoPtyWrite(page, injectBefore);

--- a/packages/harness/web/e2e/past-session-record.spec.ts
+++ b/packages/harness/web/e2e/past-session-record.spec.ts
@@ -69,7 +69,7 @@ test("a CODEX session renders the same way — this reads our events, not a vend
   const transcript = page.getByTestId("session-transcript");
   await expect(transcript).toBeVisible();
   await expect(page.getByTestId("transcript-turn")).toHaveCount(1);
-  await expect(page.getByTestId("transcript-prompt")).toContainText("Summarize what the rfq workflow does");
+  await expect(page.getByTestId("transcript-prompt")).toContainText("Summarize what the rfq agent does");
   await expect(page.getByTestId("transcript-tool-call")).toHaveCount(1);
 
   // Codex reports no assistant text to the harness. The view says that

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -287,7 +287,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     // Zone 1 is a pure explorer: workspace folder headers and agent rows, no
     // sessions anywhere in the tree.
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
-    await expect(page.getByTestId("workspace-group-rfq-workflows")).toBeVisible();
+    await expect(page.getByTestId("workspace-group-rfq-agent")).toBeVisible();
     await expect(page.getByText("No workspace")).toBeVisible();
 
     // Agents carry a deployed/draft cloud state; no session dot, no expander.
@@ -378,7 +378,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
   });
 
   test("focusing an agent with no session shows the start empty state", async ({ page }) => {
-    // rfq-workflows has no live session in the fixtures, so focusing rfq cannot
+    // rfq-agent has no live session in the fixtures, so focusing rfq cannot
     // render a board (the canvas is served per session). The workbench names
     // the absence and offers the one move; no tab strip renders.
     await page.getByTestId("workflow-rfq").locator(".workflow-item-trigger").click();
@@ -404,7 +404,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     // Start runs the create+bind path in rfq's OWN folder (never borrowing the
     // acme-app session), and the workbench goes live with the terminal.
     await page.getByTestId("open-agent-start-session").click();
-    await expect(page.getByTestId("session-context-title")).toHaveText("rfq-workflows");
+    await expect(page.getByTestId("session-context-title")).toHaveText("rfq-agent");
     await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");
     await expect(page.locator(".harness-terminal")).toBeVisible();
     await expect(page.locator(".session-tab")).toHaveCount(1);
@@ -505,12 +505,12 @@ test("new-session modal: directory picker navigates and validates", async ({ pag
 
   // Type-ahead: an unrecognized tail filters the nearest real ancestor's children.
   await input.fill("/Users/demo/rf");
-  await expect(page.getByTestId("dir-picker-item-rfq-workflows")).toBeVisible();
+  await expect(page.getByTestId("dir-picker-item-rfq-agent")).toBeVisible();
   await expect(page.getByTestId("dir-picker-item-onboarding-flow")).toHaveCount(0);
 
   // Clicking a listed directory drills into it.
-  await page.getByTestId("dir-picker-item-rfq-workflows").click();
-  await expect(input).toHaveValue("/Users/demo/rfq-workflows");
+  await page.getByTestId("dir-picker-item-rfq-agent").click();
+  await expect(input).toHaveValue("/Users/demo/rfq-agent");
   await expect(page.getByTestId("dir-picker-item-src")).toBeVisible();
 
   // "Up" walks to the parent.
@@ -603,7 +603,7 @@ test("the sessions menu is ONE merged past-sessions list with status tags and ri
   await expect(exited).not.toContainText("from summary");
   await expect(exited).not.toContainText("nothing recorded");
 
-  // The list is global — rfq-workflows' past session shows without
+  // The list is global — rfq-agent's past session shows without
   // switching directories.
   await expect(page.getByTestId("exited-session-sess-rfq")).toBeVisible();
 
@@ -731,7 +731,7 @@ test("one view only: there is no folders/groups toggle in the agent-primary rail
 test.describe("held arrangement", () => {
   test("workspace collapse, right tab, and right-pane collapse survive a reload", async ({ page }) => {
     // Collapse the rfq workspace group (plain header toggles on click).
-    await page.getByTestId("workspace-group-rfq-workflows").locator(".workspace-row-main").click();
+    await page.getByTestId("workspace-group-rfq-agent").locator(".workspace-row-main").click();
     await expect(page.getByTestId("workflow-rfq")).toHaveCount(0);
 
     // Pick the Steps tab, then fold the right pane away.
@@ -1084,7 +1084,7 @@ test("a mock session without a bundled canvas doc shows the empty state and neve
   await expect(page.locator(".canvas-iframe")).toBeVisible();
 
   // Open rfq and start a session: same-workspace, so it starts in
-  // rfq-workflows — a session with NO bundled demo document.
+  // rfq-agent — a session with NO bundled demo document.
   await page.getByTestId("workflow-rfq").locator(".workflow-item-trigger").click();
   await page.getByTestId("open-agent-start-session").click();
   await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");

--- a/packages/harness/web/e2e/welcome.spec.ts
+++ b/packages/harness/web/e2e/welcome.spec.ts
@@ -81,14 +81,14 @@ test.describe("first run", () => {
     await expect(page.getByTestId("aw-doors")).toHaveCount(0);
 
     // Already at door 1: pick a fixture folder that holds an agent project.
-    await page.getByTestId("dir-picker-input").fill("/Users/demo/rfq-workflows");
+    await page.getByTestId("dir-picker-input").fill("/Users/demo/rfq-agent");
     await page.getByTestId("aw-have-continue").click();
     await expect(page.getByTestId("aw-result")).toContainText("This is an agent project");
     await page.getByTestId("aw-add").click();
 
     // The workspace joins the rail; the first-run pitch is done.
     await expect(page.locator(".modal-add-workspace")).toHaveCount(0);
-    await expect(page.getByTestId("workflow-rfq-workflows")).toBeVisible();
+    await expect(page.getByTestId("workflow-rfq-agent")).toBeVisible();
   });
 
   test("documentation is a way out to the docs, never a dismiss", async ({ page }) => {
@@ -176,7 +176,7 @@ test.describe("returning user", () => {
     await openOverview(page);
 
     await expect(page.getByTestId("welcome-recent-scratch")).toBeVisible();
-    // Newest activity first: acme-app (a live session) above rfq-workflows (a day old).
+    // Newest activity first: acme-app (a live session) above rfq-agent (a day old).
     const rows = page.getByTestId("welcome-recents").locator("li");
     await expect(rows.first()).toContainText("acme-app");
     await expect(rows).toHaveCount(4);
@@ -230,7 +230,7 @@ test.describe("returning user", () => {
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
     await openOverview(page);
-    await page.getByTestId("welcome-recent-rfq-workflows").click();
+    await page.getByTestId("welcome-recent-rfq-agent").click();
     await expect(page.getByTestId("welcome-panel")).toHaveCount(0);
 
     // The directory picker's chips are the surface that still reads recentDirs
@@ -243,7 +243,7 @@ test.describe("returning user", () => {
     // Asserted on the label, not `title`: TooltipLayer moves a title into
     // data-tip-stash to render its own tooltip, so a title assertion races that
     // rewrite and reads null once it has run.
-    await expect(chips.first()).toContainText("rfq-workflows");
+    await expect(chips.first()).toContainText("rfq-agent");
   });
 
   test("rows disable while one is opening, so a second click cannot double-fire", async ({ page }) => {
@@ -252,7 +252,7 @@ test.describe("returning user", () => {
     await openOverview(page);
 
     const row = page.getByTestId("welcome-recent-acme-app");
-    const sibling = page.getByTestId("welcome-recent-rfq-workflows");
+    const sibling = page.getByTestId("welcome-recent-rfq-agent");
     // Don't wait for the navigation the click triggers — the guard's whole point
     // is what the DOM looks like DURING the two awaits (harness registry, then
     // session create), before the panel unmounts.

--- a/packages/harness/web/public/canvas/sess-boot/index.html
+++ b/packages/harness/web/public/canvas/sess-boot/index.html
@@ -12,7 +12,7 @@
   CASCADING layout (vertical flow, group bands, labeled branch fork) for the
   demo workspace only — it is not agent output.
 
-  The document is VISUAL ONLY: workflow name/description/steps belong to the
+  The document is VISUAL ONLY: agent name/description/steps belong to the
   app chrome around the iframe. Connector system: 1px hairline verticals
   with one small arrowhead; branch labels are mono chips on the fork.
 -->
@@ -147,7 +147,7 @@
 </script>
 <div class="canvas-panel">
   <h1 class="canvas-title">leasing</h1>
-  <p class="canvas-subtitle">Deterministic workflow diagram — generated from the project's sapiom.json.</p>
+  <p class="canvas-subtitle">Deterministic agent diagram — generated from the project's sapiom.json.</p>
   <span class="canvas-badge">demo render</span>
   <div class="cascade">
     <div class="group">

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1195,7 +1195,7 @@ class MockApi implements HarnessApi {
         phase: "error",
         code: "BUILD_FAILED",
         message: "mock build error",
-        hint: "check your workflow definition",
+        hint: "check your agent definition",
       };
       onEvent?.(failed);
       return failed;

--- a/packages/harness/web/src/lib/direct-action-gating.test.ts
+++ b/packages/harness/web/src/lib/direct-action-gating.test.ts
@@ -150,7 +150,7 @@ describe("Fix 3 — Prod Run disabled-reason distinguishes deploy-failed from ne
   it("reads 'Last deploy failed — retry Deploy' after a deploy failure", () => {
     const reason = computeDisabledReason({
       ...base,
-      lastDeployError: "Deploy failed: mock build error (check your workflow definition)",
+      lastDeployError: "Deploy failed: mock build error (check your agent definition)",
     });
     expect(reason).toBe("Last deploy failed — retry Deploy");
   });

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -340,8 +340,8 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
     boundWorkflowPath: null,
     harness: "codex",
-    cwd: "/Users/demo/rfq-workflows",
-    title: "rfq-workflows",
+    cwd: "/Users/demo/rfq-agent",
+    title: "rfq-agent",
     status: "exited",
     createdAt: daysAgo(2),
     lastActiveAt: daysAgo(1),
@@ -431,14 +431,14 @@ export const MOCK_ACTIVITY_SESSION_ID = "sess-leasing-2";
 export const MOCK_FS_TREE: Record<string, string[]> = {
   "/": ["Users"],
   "/Users": ["demo"],
-  "/Users/demo": ["acme-app", "rfq-workflows", "onboarding-flow", "scratch"],
+  "/Users/demo": ["acme-app", "rfq-agent", "onboarding-flow", "scratch"],
   "/Users/demo/acme-app": ["leasing", "src", "docs"],
   "/Users/demo/acme-app/leasing": [],
   "/Users/demo/acme-app/src": [],
   "/Users/demo/acme-app/docs": [],
-  "/Users/demo/rfq-workflows": ["src", "tests"],
-  "/Users/demo/rfq-workflows/src": [],
-  "/Users/demo/rfq-workflows/tests": [],
+  "/Users/demo/rfq-agent": ["src", "tests"],
+  "/Users/demo/rfq-agent/src": [],
+  "/Users/demo/rfq-agent/tests": [],
   "/Users/demo/onboarding-flow": [],
   "/Users/demo/scratch": [],
 };
@@ -544,13 +544,13 @@ export const MOCK_HISTORY: Record<string, SessionSummary[]> = {
       turnCount: 9,
     },
   ],
-  "/Users/demo/rfq-workflows": [
+  "/Users/demo/rfq-agent": [
     {
       harnessSessionId: "sess-rfq",
       agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
       harness: "codex",
-      cwd: "/Users/demo/rfq-workflows",
-      title: "rfq-workflows",
+      cwd: "/Users/demo/rfq-agent",
+      title: "rfq-agent",
       lastActiveAt: daysAgo(1),
       source: "registry",
       resumeMode: "agent-resume",
@@ -587,13 +587,13 @@ export const MOCK_SESSION_RECORDS: Record<string, SessionRecord> = {
     turns: [
       {
         index: 1,
-        prompt: "Add the screening step to the leasing workflow and wire it to the credit check.",
+        prompt: "Add the screening step to the leasing agent and wire it to the credit check.",
         promptAt: minutesAgo(48),
         toolCalls: [
           {
             name: "Read",
             input: '{"file_path":"/Users/demo/acme-app/leasing/index.ts"}',
-            responseSummary: "export const leasing = defineWorkflow({ … })",
+            responseSummary: "export const leasing = defineAgent({ … })",
             responseTruncated: false,
             at: minutesAgo(47),
           },
@@ -752,7 +752,7 @@ export const MOCK_SESSION_RECORDS: Record<string, SessionRecord> = {
     mergedSessionIds: ["sess-rfq"],
     agentSessionId: "9c1a2b3d-4e5f-4061-8a7b-6c5d4e3f2a10",
     harness: "codex",
-    cwd: "/Users/demo/rfq-workflows",
+    cwd: "/Users/demo/rfq-agent",
     startedAt: daysAgo(1),
     endedAt: null,
     turnCount: 1,
@@ -765,13 +765,13 @@ export const MOCK_SESSION_RECORDS: Record<string, SessionRecord> = {
     turns: [
       {
         index: 1,
-        prompt: "Summarize what the rfq workflow does.",
+        prompt: "Summarize what the rfq agent does.",
         promptAt: daysAgo(1),
         toolCalls: [
           {
             name: "shell",
             input: '{"command":["cat","README.md"]}',
-            responseSummary: "# rfq-workflows\nRequest-for-quote intake and routing.",
+            responseSummary: "# rfq-agent\nRequest-for-quote intake and routing.",
             responseTruncated: false,
             at: daysAgo(1),
           },
@@ -842,7 +842,7 @@ export const MOCK_SESSION_RECORDS: Record<string, SessionRecord> = {
 
 export const MOCK_WORKFLOWS: WorkflowInfo[] = [
   { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821, definitionSlug: "leasing", source: "scan" },
-  { name: "rfq", path: "/Users/demo/rfq-workflows", definitionId: null, definitionSlug: null, source: "scan" },
+  { name: "rfq", path: "/Users/demo/rfq-agent", definitionId: null, definitionSlug: null, source: "scan" },
   // Deployed like "leasing" but with a much longer name — exercises the
   // canvas header's deployed-dot staying pinned regardless of name length.
   { name: "onboarding-flow", path: "/Users/demo/onboarding-flow", definitionId: 9001, definitionSlug: "onboarding-flow", source: "connect" },
@@ -955,10 +955,9 @@ export const MOCK_HARNESSES: HarnessEntry[] = [
 
 export const MOCK_SETTINGS: HarnessSettings = {
   telemetryOptIn: false,
-  recentDirs: ["/Users/demo/acme-app", "/Users/demo/rfq-workflows", "/Users/demo/onboarding-flow"],
+  recentDirs: ["/Users/demo/acme-app", "/Users/demo/rfq-agent", "/Users/demo/onboarding-flow"],
   // Matches the real default: opt-in, because it spends tokens on a background
   // LLM call the user never asked for.
   rollingSummary: false,
 };
-
 

--- a/packages/harness/web/src/lib/mock-terminal.test.ts
+++ b/packages/harness/web/src/lib/mock-terminal.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { attachMockTerminal } from "./mock-terminal";
+
+const stripAnsi = (value: string): string =>
+  // eslint-disable-next-line no-control-regex
+  value.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "");
+
+describe("attachMockTerminal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("labels the recorded interaction as separate from a live coding agent", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    let onData: ((data: string) => void) | undefined;
+    const terminal = {
+      cols: 80,
+      write: (value: string): void => {
+        writes.push(value);
+      },
+      onData: (listener: (data: string) => void) => {
+        onData = listener;
+        return { dispose: vi.fn() };
+      },
+    };
+
+    const handle = attachMockTerminal(
+      terminal as unknown as Parameters<typeof attachMockTerminal>[0],
+    );
+    onData?.("Map this agent");
+    onData?.("\r");
+
+    const rendered = stripAnsi(writes.join(""));
+    expect(rendered).toContain(
+      "? for shortcuts · demo, not a live coding agent",
+    );
+    expect(rendered).toContain(
+      "This is a recorded demo. Prompts aren't sent to a coding agent here.",
+    );
+    expect(rendered).not.toContain("Prompts aren't sent to an agent here.");
+
+    handle.dispose();
+  });
+});

--- a/packages/harness/web/src/lib/mock-terminal.ts
+++ b/packages/harness/web/src/lib/mock-terminal.ts
@@ -70,7 +70,7 @@ function welcomeBox(term: XTerm): string {
 function promptBox(term: XTerm): string {
   const w = boxWidth(term);
   const inner = w - 2;
-  const hint = "  ? for shortcuts · demo, not a live agent".slice(0, w);
+  const hint = "  ? for shortcuts · demo, not a live coding agent".slice(0, w);
   return (
     dim("╭" + "─".repeat(inner) + "╮") +
     "\r\n" +
@@ -193,7 +193,7 @@ export function attachMockTerminal(term: XTerm): MockTerminalHandle {
       if (typed.trim().length > 0) {
         term.write(
           green("⏺") +
-            dim(" This is a recorded demo. Prompts aren't sent to an agent here.") +
+            dim(" This is a recorded demo. Prompts aren't sent to a coding agent here.") +
             "\r\n" +
             dim("  Run `npx @sapiom/harness` locally to work with a real session.") +
             "\r\n\r\n",

--- a/packages/harness/web/src/lib/mock-terminal.ts
+++ b/packages/harness/web/src/lib/mock-terminal.ts
@@ -100,8 +100,8 @@ function transcript(): ScriptLine[] {
         "\r\n\r\n",
       delayMs: 300,
     },
-    { text: bold("> ") + "Map the leasing workflow and visualize it\r\n\r\n", delayMs: 700 },
-    { text: green("⏺") + " I'll read the workflow definition first.\r\n\r\n", delayMs: 800 },
+    { text: bold("> ") + "Map the leasing agent and visualize it\r\n\r\n", delayMs: 700 },
+    { text: green("⏺") + " I'll read the agent definition first.\r\n\r\n", delayMs: 800 },
     { text: green("⏺") + " " + bold("Read") + "(sapiom.json)\r\n", delayMs: 600 },
     { text: dim("  ⎿  Read 42 lines") + "\r\n\r\n", delayMs: 500 },
     {
@@ -110,7 +110,7 @@ function transcript(): ScriptLine[] {
       // pane width splits a step name mid-word.
       text:
         green("⏺") +
-        " Found workflow " +
+        " Found agent " +
         bold("leasing") +
         ": 4 typed steps, 2 exits\r\n  " +
         cyan("intake → screen → credit-check → approve?") +


### PR DESCRIPTION
## Summary

Replace Workflow terminology emitted outside React with the Agent Studio terminology contract. This covers generated Canvas HTML and templates, server errors and diagnostics, seeded/static demos, and mock terminal/session fixtures while preserving compatibility-sensitive internals.

## Changes

- Use Agent and coding-agent wording in Canvas empty/pending states, legends, launched-node labels, extraction failures, and generated authoring templates.
- Update REST/action/macro errors, CLI-facing server diagnostics, the seeded/static demo Canvas, and mock deploy/transcript/terminal copy.
- Rename the system-authored `rfq-workflows` mock workspace to `rfq-agent` and update dependent e2e assertions.
- Preserve `/api/workflows`, `workflowPath`, `{{workflow.*}}`, the `launched-workflow` node kind/classes, registry/state contracts, and legacy-overview compatibility fixtures.
- Add exact terminology assertions across Canvas render/template/seed and API/macro tests.

## Testing

- [x] `pnpm --filter @sapiom/harness... build`
- [x] Focused Vitest suites: 249 tests passed
- [x] `pnpm --filter @sapiom/harness test`: 1,647 tests passed, including perf
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness test:canvas`: 10 Playwright tests passed
- [ ] Web Playwright suite not run locally because its config starts a Vite server; CI remains the server-owning verification path

## Related

- Closes: SAP-2335

## Checklist

- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed
