### PR TITLE
[SAP-2333] Use Agent terminology in Canvas and Steps

### DIFF
--- a/.changeset/quiet-agents-map.md
+++ b/.changeset/quiet-agents-map.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Use Agent and Agent run terminology throughout the Canvas and Steps interfaces.

--- a/packages/harness/web/e2e/canvas-describe-ai.spec.ts
+++ b/packages/harness/web/e2e/canvas-describe-ai.spec.ts
@@ -95,7 +95,12 @@ test.describe("Describe with AI", () => {
     // leasing has an existing description, so the button is the destructive
     // Rewrite. Dismissing the confirm must launch no run and leave the button idle.
     await clearLastMacroRun(page);
-    page.on("dialog", (d) => void d.dismiss());
+    page.on("dialog", (d) => {
+      expect(d.message()).toBe(
+        "Rewrite this agent's descriptions? The agent will edit the source and may replace text you wrote by hand.",
+      );
+      void d.dismiss();
+    });
     await page.getByTestId("canvas-describe-ai").click();
     // Past the mock's macro delay — if it were going to run, it has.
     await page.waitForTimeout(500);

--- a/packages/harness/web/e2e/canvas-describe-ai.spec.ts
+++ b/packages/harness/web/e2e/canvas-describe-ai.spec.ts
@@ -68,6 +68,10 @@ test.describe("Describe with AI", () => {
     const btn = page.getByTestId("canvas-describe-ai");
     await expect(btn).toBeVisible();
     await expect(btn).toContainText(/with AI/i);
+    await expect(btn).toHaveAttribute(
+      "data-tooltip",
+      "Runs a hidden coding-agent session that writes descriptions into the agent source — the canvas updates when it saves",
+    );
   });
 
   test("clicking runs the hidden describe macro (workflow + prompt) and shows a loading state", async ({ page }) => {
@@ -97,7 +101,7 @@ test.describe("Describe with AI", () => {
     await clearLastMacroRun(page);
     page.on("dialog", (d) => {
       expect(d.message()).toBe(
-        "Rewrite this agent's descriptions? The agent will edit the source and may replace text you wrote by hand.",
+        "Rewrite this agent's descriptions? The coding agent will edit the source and may replace text you wrote by hand.",
       );
       void d.dismiss();
     });

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -100,6 +100,7 @@ test("a generic render failure names the agent graph", async ({ page }) => {
   const error = page.getByTestId("canvas-render-error");
   await expect(error).toContainText("The agent graph could not be extracted. Open the terminal for details.");
   await expect(error).not.toContainText("workflow graph");
+  await expect(page.getByRole("button", { name: "Ask coding agent to fix" })).toBeVisible();
 });
 
 test("a launched-agent node keeps its private identifiers and navigates to the agent", async ({ page }) => {

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -38,6 +38,13 @@ const pickNode = async (page: Page, nodeId: string): Promise<void> => {
   await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 };
 
+/** Post a Canvas document message from the iframe so the source-window guard
+ *  exercises the same path as a generated board. */
+const postFromCanvas = (page: Page, message: unknown): Promise<void> =>
+  page.frameLocator(".canvas-iframe").locator("body").evaluate((_, payload) => {
+    window.parent.postMessage(payload, "*");
+  }, message);
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/?seed=0");
   await expect(page.locator(".rail-workflows")).toBeVisible();
@@ -49,6 +56,14 @@ test("a board pick populates the inspector in place, with no tab switch", async 
   const panel = page.getByTestId("canvas-overview");
   await expect(panel).toContainText("Overview");
   await expect(panel).toContainText("Handles lease applications end to end");
+  await expect(page.getByTestId("canvas-overview-toggle")).toHaveAttribute(
+    "aria-label",
+    "Collapse agent overview",
+  );
+  await expect(page.getByTestId("canvas-chat-toggle")).toHaveAttribute(
+    "data-tooltip",
+    "Chat — ask about this agent or the selected step",
+  );
 
   await pickNode(page, "intake");
 
@@ -59,6 +74,10 @@ test("a board pick populates the inspector in place, with no tab switch", async 
   await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "board");
   const inspector = page.getByTestId("canvas-step-inspector");
   await expect(inspector).toContainText("Logs the incoming order");
+  await expect(page.getByTestId("canvas-inspector-close")).toHaveAttribute(
+    "aria-label",
+    "Back to the agent overview",
+  );
   // Contract chips render from the posted graph.
   await expect(inspector).toContainText("records.read");
 
@@ -69,6 +88,67 @@ test("a board pick populates the inspector in place, with no tab switch", async 
   await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
   await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "detail");
   await expect(page.getByTestId("canvas-detail-title")).toHaveText("intake");
+});
+
+test("a generic render failure names the agent graph", async ({ page }) => {
+  await postFromCanvas(page, {
+    type: "sapiom-canvas:error",
+    title: "Could not extract graph",
+    reason: "x",
+  });
+
+  const error = page.getByTestId("canvas-render-error");
+  await expect(error).toContainText("The agent graph could not be extracted. Open the terminal for details.");
+  await expect(error).not.toContainText("workflow graph");
+});
+
+test("a launched-agent node keeps its private identifiers and navigates to the agent", async ({ page }) => {
+  await postFromCanvas(page, {
+    type: "sapiom-canvas:graph",
+    graph: {
+      name: "leasing",
+      entry: "intake",
+      nodes: [
+        {
+          id: "intake",
+          kind: "entry",
+          label: "intake",
+          role: "entry",
+          description: "Logs the incoming order.",
+          timeoutMs: null,
+          inputSchema: null,
+          capabilities: [],
+        },
+        {
+          id: "launch:rfq",
+          kind: "launched-workflow",
+          label: "rfq",
+          role: "launches another agent",
+          description: "Hands off quote generation.",
+          timeoutMs: null,
+          inputSchema: null,
+          capabilities: [],
+        },
+      ],
+      edges: [{ from: "intake", to: "launch:rfq", kind: "launch", label: "launch()" }],
+      groups: [],
+      warnings: [],
+    },
+  });
+
+  await page.getByTestId("right-tab-steps").click();
+  await expect(page.getByTestId("canvas-step-row-launch:rfq")).toBeVisible();
+  await page.getByTestId("right-tab-canvas").click();
+  await postFromCanvas(page, { type: "sapiom:node-click", stepName: "rfq" });
+
+  await expect(page.getByTestId("canvas-inspector-title")).toHaveText("rfq");
+  await expect(page.locator(".canvas-detail-kind")).toHaveText("Launched agent");
+  const openAgent = page.getByTestId("canvas-open-workflow-launch:rfq");
+  await expect(openAgent).toHaveText(/Open agent/);
+  await openAgent.click();
+
+  await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-focused/);
+  await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");
 });
 
 test("deselect restores the overview: Esc, the panel's close, and empty board space", async ({ page }) => {
@@ -133,7 +213,10 @@ test("the panel hugs its content up to half the pane; taller content scrolls ins
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("canvas-step-inspector")).toHaveCount(0);
   await expect(page.getByTestId("canvas-overview")).toHaveCount(0);
-  await expect(page.getByTestId("canvas-overview-toggle")).toBeVisible();
+  await expect(page.getByTestId("canvas-overview-toggle")).toHaveAttribute(
+    "aria-label",
+    "Show agent overview",
+  );
 });
 
 // The panel is capped at half the canvas pane, so the drag-grow assertion

--- a/packages/harness/web/e2e/rich-step-detail.spec.ts
+++ b/packages/harness/web/e2e/rich-step-detail.spec.ts
@@ -134,6 +134,8 @@ test.describe("board-click inspector shows Input, Output, and Logs", () => {
     await expect(page.getByTestId("canvas-inspector-run")).toBeVisible({ timeout: 5000 });
 
     const inspector = page.getByTestId("canvas-step-inspector");
+    await expect(page.getByTestId("canvas-inspector-run")).toContainText("Agent run");
+    await expect(page.getByTestId("canvas-inspector-run")).not.toContainText("Last run");
 
     // Input disclosure must be present.
     const inputDetail = inspector.getByTestId("canvas-inspector-run-input-intake");
@@ -318,11 +320,24 @@ test.describe("Capability calls block", () => {
 
     const detail = page.getByTestId("canvas-step-detail");
     await expect(detail).toBeVisible({ timeout: 5000 });
+    await expect(detail.getByRole("heading", { name: "Agent run" })).toBeVisible();
+    await expect(detail).not.toContainText("Last run");
 
     const callsSection = detail.getByTestId("canvas-detail-capability-calls");
     await expect(callsSection).toBeVisible();
     await expect(callsSection).toContainText("records.write");
   });
+});
+
+test("the entry-step detail says the agent starts here", async ({ page }) => {
+  await loadBoard(page);
+  await page.getByTestId("right-tab-steps").click();
+  await page.getByTestId("canvas-step-row-intake").click();
+  await page.getByTestId("canvas-step-open-intake").click();
+
+  const detail = page.getByTestId("canvas-step-detail");
+  await expect(detail).toContainText("Entry point: the agent starts here.");
+  await expect(detail).not.toContainText("the workflow starts here");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -834,7 +834,7 @@ test("canvas pane shows its empty state for a session with nothing generated yet
   // the scratch session — no bundled doc — to see the honest empty state.
   await page.getByTestId("workspace-focus-scratch").click();
   await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
-  await expect(page.locator(".canvas-empty")).toContainText("Generated automatically from the bound workflow");
+  await expect(page.locator(".canvas-empty")).toContainText("Generated automatically from the bound agent");
 });
 
 test("settings popover: identity, telemetry toggle, and it persists across close/reopen", async ({ page }) => {
@@ -931,9 +931,9 @@ test("canvas empty state explains itself — no manual render action", async ({ 
   await page.getByTestId("workspace-focus-scratch").click();
   await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
   // Short supporting line, no file-editing instructions (there is no editor in
-  // this harness). The diagram generates automatically from the bound workflow
+  // this harness). The diagram generates automatically from the bound agent
   // — there is no manual render button anymore.
-  await expect(page.locator(".canvas-empty")).toContainText("Generated automatically from the bound workflow");
+  await expect(page.locator(".canvas-empty")).toContainText("Generated automatically from the bound agent");
   await expect(page.locator(".canvas-empty")).not.toContainText(".sapiom/canvas/index.html");
   await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
 
@@ -948,7 +948,7 @@ test("steps tab shows its own empty state (not canvas copy) before anything is r
   await page.getByTestId("right-tab-steps").click();
   const empty = page.locator(".canvas-empty");
   await expect(empty).toContainText("No steps yet");
-  await expect(empty).toContainText("Steps are read from the bound workflow");
+  await expect(empty).toContainText("Steps are read from the bound agent");
   await expect(empty).not.toContainText("Nothing generated yet");
   await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
 
@@ -1834,7 +1834,9 @@ test("an observed run renders its real steps even before anything is visualized"
   await expect(page.getByTestId("canvas-steps-run-note")).toHaveText("local run");
   await expect(fallback).not.toContainText("$");
   // Structure (transitions, contracts) lives on the Canvas tab; the hint says so.
-  await expect(fallback).toContainText("Open the Canvas tab");
+  await expect(fallback).toContainText(
+    "Agent run data only. Open the Canvas tab for the diagram — transitions and contracts come from the agent.",
+  );
 });
 
 test("a second run never erases the first: the run picker recalls past runs", async ({

--- a/packages/harness/web/e2e/step-macros.spec.ts
+++ b/packages/harness/web/e2e/step-macros.spec.ts
@@ -117,7 +117,10 @@ test.describe("chat panel visibility", () => {
     await openChat(page);
     // With no step selected the chat is a general ask — freeform only, no
     // step-specific macros.
-    await expect(page.getByTestId("canvas-freeform-input")).toBeVisible();
+    await expect(page.getByTestId("canvas-freeform-input")).toHaveAttribute(
+      "placeholder",
+      "Ask about this agent…",
+    );
     await expect(page.getByTestId("canvas-macro-debug")).toHaveCount(0);
   });
 

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -200,7 +200,15 @@ test("the dead-session pane shows the record's real metadata and the canvas invi
 
   // The right pane stops inviting a Visualize that cannot run.
   await expect(page.getByTestId("canvas-empty-exited")).toContainText("Session ended");
+  await expect(page.getByTestId("canvas-empty-exited")).toContainText(
+    "Resume the session to see the agent's diagram here.",
+  );
   await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
+
+  await page.getByTestId("right-tab-steps").click();
+  await expect(page.getByTestId("canvas-empty-exited")).toContainText(
+    "Resume the session to see the agent's steps here.",
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/web/src/components/CanvasOverviewPanel.tsx
+++ b/packages/harness/web/src/components/CanvasOverviewPanel.tsx
@@ -238,8 +238,8 @@ export function CanvasOverviewPanel({
             <button
               className="theme-toggle canvas-overview-close"
               data-testid="canvas-inspector-close"
-              aria-label="Back to the workflow overview"
-              data-tooltip="Back to the workflow overview (Esc)"
+              aria-label="Back to the agent overview"
+              data-tooltip="Back to the agent overview (Esc)"
               onClick={onDeselect}
             >
               <Icon name="X" size={13} />
@@ -266,8 +266,8 @@ export function CanvasOverviewPanel({
             <button
               className="theme-toggle canvas-overview-close"
               data-testid="canvas-overview-toggle"
-              aria-label="Collapse workflow overview"
-              data-tooltip="Collapse workflow overview"
+              aria-label="Collapse agent overview"
+              data-tooltip="Collapse agent overview"
               onClick={onCollapse}
             >
               <Icon name="X" size={13} />
@@ -309,7 +309,7 @@ export function CanvasOverviewPanel({
                       if (
                         overview.description &&
                         !window.confirm(
-                          "Rewrite this workflow's descriptions? The agent will edit the source and may replace text you wrote by hand.",
+                          "Rewrite this agent's descriptions? The agent will edit the source and may replace text you wrote by hand.",
                         )
                       ) {
                         return;
@@ -319,7 +319,7 @@ export function CanvasOverviewPanel({
                       setPending(true);
                       onDescribeWithAI();
                     }}
-                    data-tooltip="Runs a hidden agent that writes descriptions into the workflow source — the canvas updates when it saves"
+                    data-tooltip="Runs a hidden agent that writes descriptions into the agent source — the canvas updates when it saves"
                   >
                     {describeLoading ? (
                       <>

--- a/packages/harness/web/src/components/CanvasOverviewPanel.tsx
+++ b/packages/harness/web/src/components/CanvasOverviewPanel.tsx
@@ -309,7 +309,7 @@ export function CanvasOverviewPanel({
                       if (
                         overview.description &&
                         !window.confirm(
-                          "Rewrite this agent's descriptions? The agent will edit the source and may replace text you wrote by hand.",
+                          "Rewrite this agent's descriptions? The coding agent will edit the source and may replace text you wrote by hand.",
                         )
                       ) {
                         return;
@@ -319,7 +319,7 @@ export function CanvasOverviewPanel({
                       setPending(true);
                       onDescribeWithAI();
                     }}
-                    data-tooltip="Runs a hidden agent that writes descriptions into the agent source — the canvas updates when it saves"
+                    data-tooltip="Runs a hidden coding-agent session that writes descriptions into the agent source — the canvas updates when it saves"
                   >
                     {describeLoading ? (
                       <>

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -735,7 +735,7 @@ export function CanvasPane({
             className="canvas-empty"
             icon="Radio"
             title="No session"
-            body="Start a session to see its workflow steps here."
+            body="Start a session to see the agent's steps here."
           />
         ) : (
           <EmptyState
@@ -814,7 +814,7 @@ export function CanvasPane({
           testId="canvas-empty-exited"
           icon="History"
           title="Session ended"
-          body={`Resume the session to see its ${surface === "steps" ? "workflow steps" : "workflow diagram"} here.`}
+          body={`Resume the session to see ${surface === "steps" ? "the agent's steps" : "the agent's diagram"} here.`}
         />
       ) : !showsContent ? (
         /* Header claim + one supporting line — no action. The diagram is
@@ -828,8 +828,8 @@ export function CanvasPane({
           title={surface === "steps" ? "No steps yet" : "Nothing generated yet"}
           body={
             surface === "steps"
-              ? "Steps are read from the bound workflow's diagram — generated automatically from its code."
-              : "Generated automatically from the bound workflow; it refreshes when the code changes."
+              ? "Steps are read from the bound agent's diagram — generated automatically from its code."
+              : "Generated automatically from the bound agent; it refreshes when the code changes."
           }
         />
       ) : (
@@ -936,7 +936,7 @@ export function CanvasPane({
               <p className="canvas-error-summary">
                 {(() => {
                   const reason = postedError.reason.trim();
-                  if (reason.length < 4) return "The workflow graph could not be extracted. Open the terminal for details.";
+                  if (reason.length < 4) return "The agent graph could not be extracted. Open the terminal for details.";
                   return reason.includes(": ") ? reason.slice(reason.indexOf(": ") + 2).split(". ")[0] : reason;
                 })()}
               </p>
@@ -1005,8 +1005,8 @@ export function CanvasPane({
             <button
               className="theme-toggle canvas-overview-open"
               data-testid="canvas-overview-toggle"
-              aria-label="Show workflow overview"
-              data-tooltip="Show workflow overview"
+              aria-label="Show agent overview"
+              data-tooltip="Show agent overview"
               onClick={() => setOverviewOpen(true)}
             >
               i
@@ -1019,7 +1019,7 @@ export function CanvasPane({
               className={"theme-toggle canvas-chat-toggle" + (chatOpen ? " is-active" : "")}
               data-testid="canvas-chat-toggle"
               aria-label={chatOpen ? "Close chat" : "Open chat"}
-              data-tooltip="Chat — ask about this workflow or the selected step"
+              data-tooltip="Chat — ask about this agent or the selected step"
               onClick={() => setChatOpen((c) => !c)}
             >
               <Icon name="MessageSquare" size={14} />
@@ -1092,7 +1092,7 @@ export function CanvasPane({
                   className="canvas-empty"
                   icon="Workflow"
                   title="No steps yet"
-                  body="This diagram has no step graph. It regenerates automatically from the bound workflow — check the terminal if it never appears."
+                  body="This diagram has no step graph. It regenerates automatically from the bound agent — check the terminal if it never appears."
                 />
               )}
             </div>

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -950,7 +950,7 @@ export function CanvasPane({
                     )
                   }
                 >
-                  Ask agent to fix
+                  Ask coding agent to fix
                 </button>
                 <button
                   className="btn-ghost"

--- a/packages/harness/web/src/components/CanvasStepDetail.tsx
+++ b/packages/harness/web/src/components/CanvasStepDetail.tsx
@@ -327,7 +327,7 @@ function OpenLaunchedWorkflow({
       data-tooltip={`Switch to ${launched.name}`}
       onClick={() => onOpenWorkflow(launched.path)}
     >
-      Open workflow <Icon name="ArrowRight" size={12} />
+      Open agent <Icon name="ArrowRight" size={12} />
     </button>
   );
 }
@@ -381,7 +381,7 @@ export function RunStepsList({ run, target }: { run: RunView; target: RunTarget 
       })}
       <StubNoticeSection run={run} />
       <p className="canvas-empty-hint">
-        Run data only. Open the Canvas tab for the diagram — transitions and contracts come from the workflow.
+        Agent run data only. Open the Canvas tab for the diagram — transitions and contracts come from the agent.
       </p>
     </div>
   );
@@ -565,7 +565,7 @@ export function CanvasStepDetail({
 
         {runStep && (
           <section className="canvas-detail-section" data-testid="canvas-detail-run">
-            <h4>Last run</h4>
+            <h4>Agent run</h4>
             <div className="canvas-detail-contract">
               <span className="canvas-input-label">Status</span>
               <span className={"canvas-run-text is-" + runStep.status}>
@@ -697,7 +697,7 @@ export function CanvasStepDetail({
           </h4>
           {incoming.length === 0 ? (
             <p className="canvas-detail-empty">
-              {node.kind === "entry" ? "Entry point: the workflow starts here." : "No step routes here."}
+              {node.kind === "entry" ? "Entry point: the agent starts here." : "No step routes here."}
             </p>
           ) : (
             <ul className="canvas-detail-edges">
@@ -771,7 +771,7 @@ export function CanvasStepInspector({
       <OpenLaunchedWorkflow node={node} workflows={workflows} onOpenWorkflow={onOpenWorkflow} />
       {runStep && (
         <div className="canvas-inspector-run" data-testid="canvas-inspector-run">
-          <span className="canvas-input-label">Last run</span>
+          <span className="canvas-input-label">Agent run</span>
           <span className={"canvas-run-text is-" + runStep.status}>
             <StepStatusIcon status={runStep.status} />
             {runStep.status}
@@ -907,7 +907,7 @@ export function CanvasChatPanel({
           <textarea
             className="canvas-inspector-freeform-input"
             data-testid="canvas-freeform-input"
-            placeholder={node ? "Ask about this step…" : "Ask about this workflow…"}
+            placeholder={node ? "Ask about this step…" : "Ask about this agent…"}
             rows={2}
             value={freeformText}
             onChange={(e) => setFreeformText(e.target.value)}

--- a/packages/harness/web/src/lib/canvas-graph.test.ts
+++ b/packages/harness/web/src/lib/canvas-graph.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { nodeKindLabel } from "./canvas-graph";
+
+describe("nodeKindLabel", () => {
+  it("renders the private launched-workflow kind as a launched agent", () => {
+    expect(nodeKindLabel("launched-workflow")).toBe("Launched agent");
+  });
+});

--- a/packages/harness/web/src/lib/canvas-graph.ts
+++ b/packages/harness/web/src/lib/canvas-graph.ts
@@ -133,7 +133,7 @@ export function nodeKindLabel(kind: CanvasNodeKind): string {
     case "terminal-warn":
       return "Terminal · needs attention";
     case "launched-workflow":
-      return "Launched workflow";
+      return "Launched agent";
     default:
       return "Step";
   }


### PR DESCRIPTION
## Summary

- replace rendered Workflow copy across Canvas and Steps empty states, errors, accessibility text, overview controls, launched-node actions, and chat
- label execution detail as Agent run and launched-workflow nodes as Launched agent while preserving private component names, CSS/test IDs, the Workflow icon, and the launched-workflow kind
- clarify coding-agent actions in the authoring confirmation, hidden Describe-with-AI tooltip, and Canvas render-error recovery action, with exact Playwright assertions
- add exact unit and Playwright coverage for terminology, accessibility, launched-agent navigation, entry copy, run labels, empty/error states, and the authoring confirmation
- add a patch changeset for @sapiom/harness

## Verification

- `pnpm --filter @sapiom/harness... build`
- `pnpm --filter @sapiom/harness typecheck`
- full Harness Playwright suite: 295/295 passed after the review refinement
- 45 focused Canvas, Steps, chat, Describe-with-AI, and exited-session Playwright tests passed
- 4 changed smoke-state Playwright tests passed
- 1,636 non-PTY Harness unit tests passed; 4 performance tests passed
- targeted canvas-graph unit test passed
- `git diff --check`

## Environment note

The complete Harness unit command reached 1,637 passing tests, but six unrelated direct node-pty transcript replay cases fail at posix_spawnp under this worktree's Node 25 runtime. The separate SessionManager PTY replay passed, and the remaining 1,636 tests pass when that environment-only file is excluded.

Closes SAP-2333