### PR TITLE
[SAP-2334] Migrate coding-agent prompts and Studio context

### DIFF
--- a/.changeset/fresh-agent-compass.md
+++ b/.changeset/fresh-agent-compass.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Clarify Agent Studio coding-agent prompts, resume metadata, and authoring action labels.

--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -23,21 +23,21 @@
  *   5. Writing to the session's canvas dir produces a canvas.reload frame,
  *      and GET /canvas/:id/ serves what was written.
  *   6. POST /api/macros/:id/run is accepted (injects into the pty).
- *   7. The CLI's launch directory is scanned for workflows at boot, and a
+ *   7. The CLI's launch directory is scanned for agents at boot, and a
  *      new directory is scanned when a session opens in it — both fire a
  *      workflows.changed frame on /ws/events AND rewrite every open
- *      session's HARNESS_CONTEXT_FILE with the newly discovered workflow in
- *      its `workflows` array (not just GET /api/workflows), even before any
- *      bind happens.
+ *      session's HARNESS_CONTEXT_FILE with the newly discovered agent in
+ *      its `agents` array (not just GET /api/workflows), independent of
+ *      whether the workspace watcher's concurrent auto-bind has landed.
  *   8. (separate, isolated server instance) autoCreateSession creates a
  *      session in launchDir without any client ever calling POST
  *      /api/sessions, AppState.launchDir reports it, the generated
  *      mcp-config for an authenticated identity carries the x-api-key header,
  *      and — the entry point that used to skip this file entirely, since the
  *      write used to live only in the POST /api/sessions REST handler —
- *      HARNESS_CONTEXT_FILE already exists in its cwd with
- *      boundWorkflow: null, before any PATCH has ever run, with its
- *      `workflows` array already populated from the seeded launch dir.
+ *      HARNESS_CONTEXT_FILE already exists in its cwd with its `agents`
+ *      array populated from the seeded launch dir; its binding is either
+ *      null or the workspace watcher's schema-consistent auto-bind.
  *   9. GET /api/fs/list (the path-picker's directory autocomplete) is
  *      mounted and boot-token-gated like the rest of /api.
  *  10. (third, isolated server instance) `defaultHarnessKind: "codex"`
@@ -46,11 +46,11 @@
  *      `availableHarnesses` passed to startServer() round-trips through
  *      GET /api/state.
  *  11. PATCH /api/sessions/:id/workflow binds a session to a registered
- *      workflow, writes HARNESS_CONTEXT_FILE in the session's cwd with the
- *      bound workflow's {name, path, definitionId} plus the session's own
+ *      agent, writes HARNESS_CONTEXT_FILE in the session's cwd with the
+ *      bound agent's {name, path, definitionId} plus the session's own
  *      {id, cwd, harness}, broadcasts the change as a session.status frame
  *      on /ws/events, and unbinding (workflowPath: null) writes
- *      `boundWorkflow: null` to the same file rather than deleting it.
+ *      `boundAgent: null` to the same file rather than deleting it.
  *  12. A tool.call event that echoes the harness's own listening port and
  *      the analytics collector's port produces no port.detected frame at
  *      all — proving server/index.ts's exclusion wiring, not just
@@ -71,10 +71,8 @@
  *      default path never touches the pty. A second render of the unchanged
  *      workflow is served from the extraction cache (no child process), and
  *      unbinding flips GET /canvas/:id/ back to the agent-authored
- *      index.html untouched. Binding that cleanly-extracting workflow also
- *      auto-spawns ONE bounded AI enrichment task (--model sonnet,
- *      --max-turns 8, graph-inline JSON-only prompt), reported in
- *      AppState.tasks scoped to the session + workflow (item 14a).
+ *      index.html untouched. Binding that cleanly-extracting agent derives
+ *      annotations in-process and spawns no coding-agent enrichment task.
  *  15. State isolation + registry hygiene: `stateRoot` alone (no per-file
  *      overrides, no machineId) roots every piece of persistent state under
  *      the scratch dir — machine-id included — and a pre-seeded registry
@@ -303,10 +301,10 @@ async function testCoreFlow(): Promise<void> {
     console.log(`created session ${sessionId}`);
     assert(session.boundWorkflowPath === null, "a freshly created session reports boundWorkflowPath: null");
 
-    type HarnessContextWorkflowLike = { name: string; path: string; definitionId: number | null };
+    type HarnessContextAgentLike = { name: string; path: string; definitionId: number | null };
     type HarnessContextLike = {
-      boundWorkflow: HarnessContextWorkflowLike | null;
-      workflows: HarnessContextWorkflowLike[];
+      boundAgent: HarnessContextAgentLike | null;
+      agents: HarnessContextAgentLike[];
       session: { id: string; cwd: string; harness: string };
       updatedAt: string;
     };
@@ -315,7 +313,11 @@ async function testCoreFlow(): Promise<void> {
 
     // Written synchronously before POST /api/sessions responds — should already be there.
     const initialContext = await readContext();
-    assert(initialContext.boundWorkflow === null, "harness-context.json is written on session create with boundWorkflow: null");
+    assert(initialContext.boundAgent === null, "harness-context.json is written on session create with boundAgent: null");
+    assert(
+      !("boundWorkflow" in initialContext) && !("workflows" in initialContext),
+      "harness-context.json emits only boundAgent/agents public keys",
+    );
 
     // The canvas kit's template is also backfilled before the pty spawns —
     // the canvas pane must never open to a bare empty iframe, and a pristine
@@ -353,6 +355,13 @@ async function testCoreFlow(): Promise<void> {
     assert(settingsPath?.includes(sessionId), "--settings path is scoped to this session");
     assert(mcpConfigPath?.includes(sessionId), "--mcp-config path is scoped to this session");
     assert((systemPromptText?.length ?? 0) > 0, "--append-system-prompt carries non-empty text");
+    assert(systemPromptText?.includes("Agent Studio") === true, "the delivered prompt names Agent Studio");
+    assert(systemPromptText?.includes('"boundAgent"') === true, "the delivered prompt teaches boundAgent");
+    assert(systemPromptText?.includes('"agents"') === true, "the delivered prompt teaches agents");
+    assert(
+      !systemPromptText?.toLowerCase().includes("workflow"),
+      "the delivered prompt does not teach Workflow terminology",
+    );
 
     const settingsJson = JSON.parse(await fs.readFile(settingsPath, "utf8")) as { hooks?: Record<string, unknown> };
     assert(Object.keys(settingsJson.hooks ?? {}).length === 6, "generated settings.json registers all 6 hooks");
@@ -530,16 +539,18 @@ async function testCoreFlow(): Promise<void> {
       "boot-time scan of the CLI's launch directory discovered its sapiom.json (definitionId read from the marker)",
     );
 
-    // --- 11'. the scan also rewrites harness-context.json's own workflows array — not just
-    // GET /api/workflows — for every already-open session, before any bind happens ---
+    // --- 11'. the scan also rewrites harness-context.json's own agents array — not just
+    // GET /api/workflows — for every already-open session. The workspace watcher may
+    // auto-bind the project concurrently, so either binding state is valid here. ---
     const scannedContext = await waitFor(async () => {
       const context = await readContext();
-      return context.workflows.some((w) => w.path === projectDir) ? context : undefined;
+      return context.agents.some((w) => w.path === projectDir) ? context : undefined;
     });
+    const scannedAgent = scannedContext.agents.find((agent) => agent.path === projectDir);
     assert(
-      scannedContext.workflows.some((w) => w.path === projectDir && w.definitionId === 4821) &&
-        scannedContext.boundWorkflow === null,
-      "workflows.changed rewrites harness-context.json's workflows array with the newly scanned project, still unbound",
+      scannedAgent?.definitionId === 4821 &&
+        (scannedContext.boundAgent === null || scannedContext.boundAgent.path === scannedAgent.path),
+      "workflows.changed rewrites harness-context.json's agents array and any concurrent auto-bind stays schema-consistent",
     );
     assert(
       scannedContext.session.id === sessionId &&
@@ -548,14 +559,14 @@ async function testCoreFlow(): Promise<void> {
       "harness-context.json embeds the session's own {id, cwd, harness}",
     );
 
-    // --- 10a. visualize with nothing bound yet — the force-refresh macro is unbound-friendly
-    // (requiresWorkflow: false, a cheap no-op), unlike every other action-rail macro. ---
+    // --- 10a. visualize is binding-independent (requiresWorkflow: false, a
+    // cheap no-op), unlike every other action-rail macro. ---
     const unboundMacroRes = await fetch(`${baseUrl}/api/macros/visualize/run`, {
       method: "POST",
       headers,
       body: JSON.stringify({ harnessSessionId: sessionId }),
     });
-    assert(unboundMacroRes.status === 200, "POST /api/macros/visualize/run succeeds with no workflow bound");
+    assert(unboundMacroRes.status === 200, "POST /api/macros/visualize/run succeeds independent of binding");
 
     // --- 11a. bind the session to that discovered workflow ---
     const workflowStatusBefore = wsMessages.filter((m) => m.type === "session.status").length;
@@ -568,22 +579,26 @@ async function testCoreFlow(): Promise<void> {
     const boundSession = (await bindRes.json()) as { boundWorkflowPath: string | null };
     assert(boundSession.boundWorkflowPath === projectDir, "response reports the new boundWorkflowPath");
 
-    await waitFor(async () => {
-      const count = wsMessages.filter((m) => m.type === "session.status").length;
-      return count > workflowStatusBefore ? true : undefined;
-    });
-    const lastStatusFrame = wsMessages
-      .filter((m) => m.type === "session.status")
-      .at(-1) as { session?: { id: string; boundWorkflowPath: string | null } } | undefined;
-    assert(
-      lastStatusFrame?.session?.id === sessionId && lastStatusFrame.session.boundWorkflowPath === projectDir,
-      "binding broadcasts a session.status frame reflecting the new boundWorkflowPath",
-    );
+    if (scannedContext.boundAgent?.path !== projectDir) {
+      await waitFor(async () => {
+        const count = wsMessages.filter((m) => m.type === "session.status").length;
+        return count > workflowStatusBefore ? true : undefined;
+      });
+      const lastStatusFrame = wsMessages
+        .filter((m) => m.type === "session.status")
+        .at(-1) as { session?: { id: string; boundWorkflowPath: string | null } } | undefined;
+      assert(
+        lastStatusFrame?.session?.id === sessionId && lastStatusFrame.session.boundWorkflowPath === projectDir,
+        "binding broadcasts a session.status frame reflecting the new boundWorkflowPath",
+      );
+    } else {
+      console.log("workspace watcher had already auto-bound this path; the idempotent PATCH needs no new status frame");
+    }
 
     const boundContext = await readContext();
     assert(
-      boundContext.boundWorkflow?.path === projectDir && boundContext.boundWorkflow.definitionId === 4821,
-      "harness-context.json reflects the bound workflow's {name, path, definitionId}",
+      boundContext.boundAgent?.path === projectDir && boundContext.boundAgent.definitionId === 4821,
+      "harness-context.json reflects the bound agent's {name, path, definitionId}",
     );
 
     // --- 11a-2. also run visualize now that a workflow IS bound — here it's a
@@ -633,6 +648,9 @@ async function testCoreFlow(): Promise<void> {
     });
     assert(connectRes.status === 200, "POST /api/workflows/connect registers the real order-triage project");
 
+    const reloadFramesBefore = wsMessages.filter(
+      (message) => message.type === "canvas.reload" && message.harnessSessionId === sessionId,
+    ).length;
     const renderBindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {
       method: "PATCH",
       headers,
@@ -640,50 +658,21 @@ async function testCoreFlow(): Promise<void> {
     });
     assert(renderBindRes.status === 200, "binds the session to the real order-triage workflow");
 
-    // --- 14a. binding a cleanly-extracting workflow with no fresh enrichment
-    // cached auto-spawns ONE bounded enrichment task: a headless fake-claude
-    // run pinned to the enrichment model and turn cap, carrying the
-    // extracted graph inline and the JSON-only contract. The task's capture
-    // overwrites the interactive session's — every argv/env assertion on
-    // that one already ran above. (The fixture never completes its "turn",
-    // so no enrichment is ever persisted here; server.close() reaps it.) ---
-    const enrichmentCapture = await waitFor<FakeClaudeCapture>(async () => {
-      try {
-        const capture = JSON.parse(await fs.readFile(captureFile, "utf8")) as FakeClaudeCapture;
-        return capture.argv.includes("--max-turns") ? capture : undefined;
-      } catch {
-        return undefined;
-      }
-    });
+    // --- 14a. annotations are derived in-process from the extracted graph.
+    // Binding/rendering must not launch a second coding-agent process or add
+    // a background task for this agent. ---
+    const captureAfterBind = JSON.parse(await fs.readFile(captureFile, "utf8")) as FakeClaudeCapture;
     assert(
-      enrichmentCapture.argv[enrichmentCapture.argv.indexOf("--model") + 1] === "sonnet",
-      "the auto-spawned enrichment task pins --model sonnet",
+      !captureAfterBind.argv.includes("--max-turns"),
+      "deterministic Canvas enrichment launches no bounded coding-agent task",
     );
-    assert(
-      enrichmentCapture.argv[enrichmentCapture.argv.indexOf("--max-turns") + 1] === "8",
-      "the auto-spawned enrichment task caps --max-turns at 8",
-    );
-    const enrichmentPrompt = enrichmentCapture.argv[enrichmentCapture.argv.indexOf("-p") + 1] ?? "";
-    assert(enrichmentPrompt.includes("RETURN ONLY a JSON object"), "enrichment prompt demands JSON-only output");
-    assert(
-      enrichmentPrompt.includes('"manifestName": "order-triage"'),
-      "enrichment prompt carries the extracted graph inline",
-    );
-    // The fixture exits as soon as its (ignored) stdin drains, so the task
-    // may already be finished here — what matters is the SCOPING it was
-    // launched with: the pane filters its activity by exactly these fields.
-    const stateWithTask = (await (await fetch(`${baseUrl}/api/state`, { headers })).json()) as {
+    const stateAfterBind = (await (await fetch(`${baseUrl}/api/state`, { headers })).json()) as {
       tasks?: Array<{ macroId: string; workflowPath: string | null; harnessSessionId: string; status: string }>;
     };
-    const enrichmentTask = stateWithTask.tasks?.find((t) => t.workflowPath === workflowDir);
     assert(
-      enrichmentTask?.macroId === "visualize" && enrichmentTask.harnessSessionId === sessionId,
-      "AppState.tasks reports the enrichment task scoped to this session + workflow",
+      !stateAfterBind.tasks?.some((task) => task.workflowPath === workflowDir),
+      "AppState.tasks contains no coding-agent enrichment task for the deterministic render",
     );
-
-    const reloadFramesBefore = wsMessages.filter(
-      (m) => m.type === "canvas.reload" && m.harnessSessionId === sessionId,
-    ).length;
 
     const renderRes = await fetch(`${baseUrl}/api/canvas/${sessionId}/render`, { method: "POST", headers });
     assert(renderRes.status === 200, "POST /api/canvas/:id/render returns 200");
@@ -709,7 +698,7 @@ async function testCoreFlow(): Promise<void> {
       ).length;
       return count > reloadFramesBefore ? true : undefined;
     });
-    console.log("canvas.reload frame received for the deterministic render's write");
+    console.log("canvas.reload frame received for the deterministic bind/render write");
 
     // GET /canvas/:id/ resolves the session's binding at request time and
     // serves the bound workflow's render file.
@@ -732,7 +721,7 @@ async function testCoreFlow(): Promise<void> {
       "re-rendering the unchanged workflow is served from the extraction cache (no child process)",
     );
 
-    // --- 11b. unbind — the context file gets boundWorkflow: null, not deleted ---
+    // --- 11b. unbind — the context file gets boundAgent: null, not deleted ---
     const unbindRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workflow`, {
       method: "PATCH",
       headers,
@@ -742,9 +731,9 @@ async function testCoreFlow(): Promise<void> {
 
     const unboundContext = await waitFor(async () => {
       const context = await readContext();
-      return context.boundWorkflow === null ? context : undefined;
+      return context.boundAgent === null ? context : undefined;
     });
-    assert(unboundContext.boundWorkflow === null, "unbinding writes boundWorkflow: null to harness-context.json");
+    assert(unboundContext.boundAgent === null, "unbinding writes boundAgent: null to harness-context.json");
 
     // Unbound again, the canvas root falls back to the legacy agent-authored
     // index.html — the render files stay on disk for the next bind.
@@ -819,7 +808,7 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
   await fs.mkdir(projectDir, { recursive: true });
   // Seeded before startServer(), same as testCoreFlow's launch-dir marker —
   // proves the auto-created boot session's harness-context.json reflects the
-  // boot-time scan's `workflows` array, not just its own (unbound) session.
+  // boot-time scan's `agents` array, not just its own (unbound) session.
   await fs.writeFile(path.join(projectDir, "sapiom.json"), JSON.stringify({ definitionId: 7331 }));
 
   const bootToken = crypto.randomUUID();
@@ -863,39 +852,40 @@ async function testAutoSessionAndMcpAuth(): Promise<void> {
     // This is the exact entry point that used to skip harness-context.json
     // entirely — autoCreateSession calls sessionManager.create() directly,
     // bypassing the POST /api/sessions REST handler the write used to live
-    // in. Assert it now exists, unbound, with no PATCH ever having run.
+    // in. Assert it now exists with no PATCH ever having run.
     // Polled, not a single read: the session appears in GET /api/state as
     // soon as it's added to the in-memory registry, which happens before
     // create()'s own await on the context-file write completes.
-    type HarnessContextWorkflowLike = { name: string; path: string; definitionId: number | null };
+    type HarnessContextAgentLike = { name: string; path: string; definitionId: number | null };
     type HarnessContextLike = {
-      boundWorkflow: HarnessContextWorkflowLike | null;
-      workflows: HarnessContextWorkflowLike[];
+      boundAgent: HarnessContextAgentLike | null;
+      agents: HarnessContextAgentLike[];
       session: { id: string; cwd: string; harness: string };
       updatedAt: string;
     };
-    // Polled on workflows, not just file existence: the initial write from
+    // Polled on agents, not just file existence: the initial write from
     // SessionManager.create() can land before the boot-time scan of
     // launchDir finishes populating the registry (both run concurrently at
     // startup) — scanWorkflowsAndBroadcast's rewrite-all-open-sessions step
-    // is what backfills `workflows` once the scan completes.
+    // is what backfills `agents` once the scan completes.
     const autoSessionContext = await waitFor<HarnessContextLike>(async () => {
       try {
         const context = JSON.parse(
           await fs.readFile(path.join(projectDir, ".sapiom", "harness-context.json"), "utf8"),
         ) as HarnessContextLike;
-        return context.workflows.some((w) => w.path === projectDir) ? context : undefined;
+        return context.agents.some((w) => w.path === projectDir) ? context : undefined;
       } catch {
         return undefined;
       }
     });
+    const autoAgent = autoSessionContext.agents.find((agent) => agent.path === projectDir);
     assert(
-      autoSessionContext.boundWorkflow === null,
-      "the auto-created boot session's harness-context.json exists with boundWorkflow: null, before any bind",
+      autoSessionContext.boundAgent === null || autoSessionContext.boundAgent.path === autoAgent?.path,
+      "the auto-created boot session's context is unbound or carries the workspace watcher's schema-consistent auto-bind",
     );
     assert(
-      autoSessionContext.workflows.some((w) => w.path === projectDir && w.definitionId === 7331),
-      "the auto-created boot session's harness-context.json workflows array is populated from the seeded launch dir",
+      autoSessionContext.agents.some((w) => w.path === projectDir && w.definitionId === 7331),
+      "the auto-created boot session's harness-context.json agents array is populated from the seeded launch dir",
     );
 
     const capture = await waitFor<FakeClaudeCapture>(async () => {

--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -359,6 +359,18 @@ async function testCoreFlow(): Promise<void> {
     assert(systemPromptText?.includes('"boundAgent"') === true, "the delivered prompt teaches boundAgent");
     assert(systemPromptText?.includes('"agents"') === true, "the delivered prompt teaches agents");
     assert(
+      systemPromptText?.includes("The Canvas follows that selection") === true,
+      "the delivered Claude prompt teaches automatic Canvas selection",
+    );
+    assert(
+      systemPromptText?.includes("Local Run, Prod Run, and Deploy") === true,
+      "the delivered Claude prompt names the real action bar",
+    );
+    assert(
+      !systemPromptText?.includes("Visualize button") && !systemPromptText?.includes("⌘K"),
+      "the delivered Claude prompt omits stale Visualize and command-palette lifecycle guidance",
+    );
+    assert(
       !systemPromptText?.toLowerCase().includes("workflow"),
       "the delivered prompt does not teach Workflow terminology",
     );
@@ -989,6 +1001,25 @@ async function testAutoSessionKindSelection(): Promise<void> {
     assert(
       capture.argv.includes("check_for_update_on_startup=false"),
       "the auto-created session actually launched via the codex adapter, not claude-code",
+    );
+    const developerInstructionsPrefix = "developer_instructions=";
+    const developerInstructionsArg = capture.argv.find((arg) => arg.startsWith(developerInstructionsPrefix));
+    assert(developerInstructionsArg !== undefined, "the codex adapter receives developer instructions");
+    const codexSystemPromptText = JSON.parse(
+      developerInstructionsArg.slice(developerInstructionsPrefix.length),
+    ) as string;
+    assert(codexSystemPromptText.includes("Agent Studio"), "the delivered Codex prompt names Agent Studio");
+    assert(
+      codexSystemPromptText.includes("The Canvas follows that selection"),
+      "the delivered Codex prompt teaches automatic Canvas selection",
+    );
+    assert(
+      codexSystemPromptText.includes("Local Run, Prod Run, and Deploy"),
+      "the delivered Codex prompt names the real action bar",
+    );
+    assert(
+      !codexSystemPromptText.includes("Visualize button") && !codexSystemPromptText.includes("⌘K"),
+      "the delivered Codex prompt omits stale Visualize and command-palette lifecycle guidance",
     );
   } finally {
     await server.close();

--- a/packages/harness/src/core/adapters/claude-code.test.ts
+++ b/packages/harness/src/core/adapters/claude-code.test.ts
@@ -42,7 +42,7 @@ describe("ClaudeCodeAdapter", () => {
     it("builds a launch SpawnSpec with settings/mcp-config/system-prompt flags and unsets CLAUDECODE", async () => {
       const promptDir = await mkdtemp(join(tmpdir(), "harness-claude-test-"));
       const promptFile = join(promptDir, "prompt.txt");
-      await writeFile(promptFile, "You are a Sapiom workflow builder.", "utf8");
+      await writeFile(promptFile, "You are the coding agent in Agent Studio.", "utf8");
 
       const adapter = new ClaudeCodeAdapter({ binary: "fake-claude" });
       const spec = adapter.launch({
@@ -62,7 +62,19 @@ describe("ClaudeCodeAdapter", () => {
         "--mcp-config",
         "/tmp/proj/.sapiom/mcp.json",
         "--append-system-prompt",
-        "You are a Sapiom workflow builder.",
+        "You are the coding agent in Agent Studio.",
+      ]);
+
+      const resumed = adapter.resume("agent-uuid-123", {
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+        systemPromptFile: promptFile,
+      });
+      expect(resumed.args).toEqual([
+        "--resume",
+        "agent-uuid-123",
+        "--append-system-prompt",
+        "You are the coding agent in Agent Studio.",
       ]);
 
       await rm(promptDir, { recursive: true, force: true });

--- a/packages/harness/src/core/adapters/claude-code.test.ts
+++ b/packages/harness/src/core/adapters/claude-code.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_SYSTEM_PROMPT } from "../../profiles/default.js";
 import { ClaudeCodeAdapter, encodeProjectPath } from "./claude-code.js";
 
 describe("ClaudeCodeAdapter", () => {
@@ -42,7 +43,7 @@ describe("ClaudeCodeAdapter", () => {
     it("builds a launch SpawnSpec with settings/mcp-config/system-prompt flags and unsets CLAUDECODE", async () => {
       const promptDir = await mkdtemp(join(tmpdir(), "harness-claude-test-"));
       const promptFile = join(promptDir, "prompt.txt");
-      await writeFile(promptFile, "You are the coding agent in Agent Studio.", "utf8");
+      await writeFile(promptFile, DEFAULT_SYSTEM_PROMPT, "utf8");
 
       const adapter = new ClaudeCodeAdapter({ binary: "fake-claude" });
       const spec = adapter.launch({
@@ -62,7 +63,7 @@ describe("ClaudeCodeAdapter", () => {
         "--mcp-config",
         "/tmp/proj/.sapiom/mcp.json",
         "--append-system-prompt",
-        "You are the coding agent in Agent Studio.",
+        DEFAULT_SYSTEM_PROMPT,
       ]);
 
       const resumed = adapter.resume("agent-uuid-123", {
@@ -74,7 +75,7 @@ describe("ClaudeCodeAdapter", () => {
         "--resume",
         "agent-uuid-123",
         "--append-system-prompt",
-        "You are the coding agent in Agent Studio.",
+        DEFAULT_SYSTEM_PROMPT,
       ]);
 
       await rm(promptDir, { recursive: true, force: true });

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -45,7 +45,7 @@ describe("CodexAdapter", () => {
     it("embeds the systemPromptFile's content inline via -c developer_instructions=<value>", async () => {
       const promptDir = await mkdtemp(join(tmpdir(), "harness-codex-prompt-"));
       const promptFile = join(promptDir, "prompt.txt");
-      await writeFile(promptFile, "You are a Sapiom workflow builder.\nBe concise.", "utf8");
+      await writeFile(promptFile, "You are the coding agent in Agent Studio.\nBe concise.", "utf8");
 
       const adapter = new CodexAdapter({ binary: "fake-codex" });
       const spec = adapter.launch({ harnessSessionId: "h1", cwd: "/tmp/proj", systemPromptFile: promptFile });
@@ -65,8 +65,17 @@ describe("CodexAdapter", () => {
         "-c",
         'sandbox_mode="workspace-write"',
         "-c",
-        `developer_instructions=${JSON.stringify("You are a Sapiom workflow builder.\nBe concise.")}`,
+        `developer_instructions=${JSON.stringify("You are the coding agent in Agent Studio.\nBe concise.")}`,
       ]);
+
+      const resumed = adapter.resume("019e62d5-a020-75f1-b5e8-253383076f83", {
+        harnessSessionId: "h1",
+        cwd: "/tmp/proj",
+        systemPromptFile: promptFile,
+      });
+      expect(resumed.args.at(-1)).toBe(
+        `developer_instructions=${JSON.stringify("You are the coding agent in Agent Studio.\nBe concise.")}`,
+      );
 
       await rm(promptDir, { recursive: true, force: true });
     });

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_SYSTEM_PROMPT } from "../../profiles/default.js";
 import { CodexAdapter } from "./codex.js";
 
 /** A minimal, synthetic (not real-user-data) rollout line set matching the
@@ -45,7 +46,7 @@ describe("CodexAdapter", () => {
     it("embeds the systemPromptFile's content inline via -c developer_instructions=<value>", async () => {
       const promptDir = await mkdtemp(join(tmpdir(), "harness-codex-prompt-"));
       const promptFile = join(promptDir, "prompt.txt");
-      await writeFile(promptFile, "You are the coding agent in Agent Studio.\nBe concise.", "utf8");
+      await writeFile(promptFile, DEFAULT_SYSTEM_PROMPT, "utf8");
 
       const adapter = new CodexAdapter({ binary: "fake-codex" });
       const spec = adapter.launch({ harnessSessionId: "h1", cwd: "/tmp/proj", systemPromptFile: promptFile });
@@ -65,7 +66,7 @@ describe("CodexAdapter", () => {
         "-c",
         'sandbox_mode="workspace-write"',
         "-c",
-        `developer_instructions=${JSON.stringify("You are the coding agent in Agent Studio.\nBe concise.")}`,
+        `developer_instructions=${JSON.stringify(DEFAULT_SYSTEM_PROMPT)}`,
       ]);
 
       const resumed = adapter.resume("019e62d5-a020-75f1-b5e8-253383076f83", {
@@ -74,7 +75,7 @@ describe("CodexAdapter", () => {
         systemPromptFile: promptFile,
       });
       expect(resumed.args.at(-1)).toBe(
-        `developer_instructions=${JSON.stringify("You are the coding agent in Agent Studio.\nBe concise.")}`,
+        `developer_instructions=${JSON.stringify(DEFAULT_SYSTEM_PROMPT)}`,
       );
 
       await rm(promptDir, { recursive: true, force: true });

--- a/packages/harness/src/core/inject/system-prompt.test.ts
+++ b/packages/harness/src/core/inject/system-prompt.test.ts
@@ -24,6 +24,10 @@ describe("generateSystemPromptFile", () => {
 
     const content = await fs.readFile(filePath, "utf8");
     expect(content).toBe(DEFAULT_SYSTEM_PROMPT);
+    expect(content).toContain("coding agent running in Agent Studio");
+    expect(content).toContain('"boundAgent"');
+    expect(content).toContain('"agents"');
+    expect(content.toLowerCase()).not.toContain("workflow");
   });
 
   it("writes a custom prompt when one is provided", async () => {

--- a/packages/harness/src/core/inject/system-prompt.test.ts
+++ b/packages/harness/src/core/inject/system-prompt.test.ts
@@ -27,6 +27,10 @@ describe("generateSystemPromptFile", () => {
     expect(content).toContain("coding agent running in Agent Studio");
     expect(content).toContain('"boundAgent"');
     expect(content).toContain('"agents"');
+    expect(content).toContain("The Canvas follows that selection");
+    expect(content).toContain("Local Run, Prod Run, and Deploy");
+    expect(content).not.toContain("Visualize button");
+    expect(content).not.toContain("⌘K");
     expect(content.toLowerCase()).not.toContain("workflow");
   });
 

--- a/packages/harness/src/core/resume-brief.test.ts
+++ b/packages/harness/src/core/resume-brief.test.ts
@@ -128,11 +128,20 @@ describe("buildResumeBrief", () => {
       expect(brief).toContain("claude-code");
       expect(brief).toContain("**Coding agent:** claude-code");
       expect(brief).toContain("**Bound agent:** order-triage");
-      expect(brief).toContain("**Agent run:**");
+      expect(brief).toContain("**Session span:** 2026-07-27T10:00:00.000Z → 2026-07-27T11:00:00.000Z");
+      expect(brief).not.toContain("**Agent run:**");
       expect(brief).not.toContain("**Bound workflow:**");
       expect(brief.toLowerCase()).not.toContain("workflow");
       expect(brief).toContain("order-triage");
       expect(brief).toContain("definition 188");
+    });
+
+    it("identifies a self-started turn as coding-agent activity", () => {
+      const brief = buildResumeBrief(
+        record({ turns: [turn(1, { prompt: null, promptAt: null })] }),
+      );
+      expect(brief).toContain("the coding agent started this turn itself");
+      expect(brief).not.toContain("or the agent started this turn itself");
     });
 
     it("says a workflow is not linked rather than printing a null definition", () => {

--- a/packages/harness/src/core/resume-brief.test.ts
+++ b/packages/harness/src/core/resume-brief.test.ts
@@ -82,6 +82,8 @@ describe("buildResumeBrief", () => {
         const brief = buildResumeBrief(record(), { maxTokens });
         expect(brief).toContain("reconstruction, not restored context");
         expect(brief).toContain("You are a **fresh session**");
+        expect(brief).toContain("coding agent");
+        expect(brief).toContain("Agent Studio");
         expect(brief).toContain("check the current state of the");
       }
     });
@@ -124,6 +126,11 @@ describe("buildResumeBrief", () => {
       expect(brief).toContain("/Users/dev/project");
       expect(brief).toContain("feat/SAP-2059");
       expect(brief).toContain("claude-code");
+      expect(brief).toContain("**Coding agent:** claude-code");
+      expect(brief).toContain("**Bound agent:** order-triage");
+      expect(brief).toContain("**Agent run:**");
+      expect(brief).not.toContain("**Bound workflow:**");
+      expect(brief.toLowerCase()).not.toContain("workflow");
       expect(brief).toContain("order-triage");
       expect(brief).toContain("definition 188");
     });

--- a/packages/harness/src/core/resume-brief.ts
+++ b/packages/harness/src/core/resume-brief.ts
@@ -322,9 +322,9 @@ function blockquote(text: string): string {
  */
 const HONESTY_HEADER = `# Continuing a prior session — reconstruction, not restored context
 
-You are a **fresh session**. The agent that ran the session described below is
+You are a **fresh session**. The coding agent that ran the session described below is
 gone and none of its context is loaded. What follows was assembled by the
-Sapiom Harness from its own recorded events — it is a briefing about that
+Agent Studio from its own recorded events — it is a briefing about that
 session, not a replay of it, and it is partial by construction.
 
 Treat every claim here as something a colleague told you, not as something you
@@ -421,19 +421,19 @@ function renderIdentity(record: SessionRecord, options: BuildResumeBriefOptions)
   if (options.title) lines.push(`- **Title:** ${options.title}`);
   lines.push(`- **Directory:** ${record.cwd ?? "not recorded"}`);
   if (options.gitBranch) lines.push(`- **Git branch:** ${options.gitBranch}`);
-  lines.push(`- **Agent:** ${record.harness}`);
+  lines.push(`- **Coding agent:** ${record.harness}`);
   if (options.workflow) {
     const { name, path: workflowPath, definitionId } = options.workflow;
     lines.push(
-      `- **Bound workflow:** ${name} (\`${workflowPath}\`)${
+      `- **Bound agent:** ${name} (\`${workflowPath}\`)${
         definitionId !== null ? ` — definition ${definitionId}` : " — not yet linked to a deployed definition"
       }`,
     );
   } else {
-    lines.push("- **Bound workflow:** none");
+    lines.push("- **Bound agent:** none");
   }
   const span = [record.startedAt, record.endedAt].filter(Boolean).join(" → ");
-  if (span) lines.push(`- **Ran:** ${span}`);
+  if (span) lines.push(`- **Agent run:** ${span}`);
   lines.push(`- **Recorded turns:** ${record.turnCount}`);
 
   if (record.limitations.length > 0) {

--- a/packages/harness/src/core/resume-brief.ts
+++ b/packages/harness/src/core/resume-brief.ts
@@ -288,7 +288,7 @@ function renderTurn(turn: SessionRecordTurn, cwd: string | null): string {
   if (turn.prompt !== null) {
     lines.push("", "**Prompt:**", "", blockquote(clamp(turn.prompt, MAX_PROMPT_CHARS)));
   } else {
-    lines.push("", "**Prompt:** _not recorded — our recording started mid-turn, or the agent started this turn itself._");
+    lines.push("", "**Prompt:** _not recorded — our recording started mid-turn, or the coding agent started this turn itself._");
   }
 
   if (turn.toolCalls.length > 0) {
@@ -433,7 +433,7 @@ function renderIdentity(record: SessionRecord, options: BuildResumeBriefOptions)
     lines.push("- **Bound agent:** none");
   }
   const span = [record.startedAt, record.endedAt].filter(Boolean).join(" → ");
-  if (span) lines.push(`- **Agent run:** ${span}`);
+  if (span) lines.push(`- **Session span:** ${span}`);
   lines.push(`- **Recorded turns:** ${record.turnCount}`);
 
   if (record.limitations.length > 0) {

--- a/packages/harness/src/core/rolling-summary.test.ts
+++ b/packages/harness/src/core/rolling-summary.test.ts
@@ -281,6 +281,8 @@ describe("rolling summary", () => {
     it("carries the record and asks for a bounded, tool-free, honest summary", () => {
       const prompt = buildRollingSummaryPrompt(record(), null);
       expect(prompt).toContain("at most 500 words");
+      expect(prompt).toContain("FRESH coding-agent session");
+      expect(prompt).not.toContain("FRESH agent session");
       expect(prompt).toContain("Do not use any tools");
       expect(prompt).toContain("Do not invent anything the material does not state");
       expect(prompt).toContain("make the backoff jittered");

--- a/packages/harness/src/core/rolling-summary.ts
+++ b/packages/harness/src/core/rolling-summary.ts
@@ -112,7 +112,7 @@ export function buildRollingSummaryPrompt(record: SessionRecord, previous: strin
   return [
     `Summarize the coding session described below in at most ${ROLLING_SUMMARY_MAX_WORDS} words.`,
     "",
-    "The summary is read by a FRESH agent session that has none of this context,",
+    "The summary is read by a FRESH coding-agent session that has none of this context,",
     "so write for someone picking the work up cold. Cover, in this order and only",
     "where the material actually supports it:",
     "",

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -90,7 +90,7 @@ describe("SessionManager", () => {
       spawnPty?: PtySpawnFn;
       buildLaunchOpts?: SessionManagerOptions["buildLaunchOpts"];
       writeWorkspaceContext?: SessionManagerOptions["writeWorkspaceContext"];
-      workspaceContextExists?: SessionManagerOptions["workspaceContextExists"];
+      prepareWorkspaceContext?: SessionManagerOptions["prepareWorkspaceContext"];
       ensureCanvasTemplate?: SessionManagerOptions["ensureCanvasTemplate"];
       isPidAlive?: SessionManagerOptions["isPidAlive"];
       /** Pid given to every fake pty this manager spawns — see createFakePty(). */
@@ -116,7 +116,7 @@ describe("SessionManager", () => {
       spawnPty,
       buildLaunchOpts: opts.buildLaunchOpts,
       writeWorkspaceContext: opts.writeWorkspaceContext,
-      workspaceContextExists: opts.workspaceContextExists,
+      prepareWorkspaceContext: opts.prepareWorkspaceContext,
       ensureCanvasTemplate: opts.ensureCanvasTemplate,
       isPidAlive: opts.isPidAlive,
     });
@@ -752,10 +752,22 @@ describe("SessionManager", () => {
       expect(manager.list()[0]?.status).toBe("exited");
     });
 
-    it("resume() backfills the workspace context only when it's missing", async () => {
-      const writeWorkspaceContext = vi.fn(async () => {});
-      const workspaceContextExists = vi.fn(async () => false);
-      const { manager } = makeManager({ writeWorkspaceContext, workspaceContextExists });
+    it("resume() always awaits schema-aware context preparation before spawning", async () => {
+      const order: string[] = [];
+      const buildLaunchOpts = vi.fn(async () => {
+        order.push("prompt");
+        return {};
+      });
+      const prepareWorkspaceContext = vi.fn(async () => {
+        order.push("prepare");
+      });
+      const spawnPty: PtySpawnFn = (file, args) => {
+        order.push("spawn");
+        void file;
+        void args;
+        return createFakePty().pty as unknown as ReturnType<PtySpawnFn>;
+      };
+      const { manager } = makeManager({ buildLaunchOpts, prepareWorkspaceContext, spawnPty });
 
       const session = manager.registerHistorical({
         agentSessionId: "agent-uuid-9",
@@ -764,23 +776,18 @@ describe("SessionManager", () => {
         title: "past session",
         lastActiveAt: "2026-01-01T00:00:00.000Z",
       });
-      writeWorkspaceContext.mockClear(); // registerHistorical() doesn't call it; isolate resume()'s call
-
       await manager.resume(session.id);
 
-      expect(workspaceContextExists).toHaveBeenCalledWith("/tmp/proj");
-      expect(writeWorkspaceContext).toHaveBeenCalledTimes(1);
-      // Same object reference resume() mutated in place (status, exitCode,
-      // lastActiveAt) before writing — the callee (server/index.ts's
-      // writeSessionContext) resolves boundWorkflowPath itself, so passing
-      // the whole session is all resume() needs to do here.
-      expect(writeWorkspaceContext).toHaveBeenCalledWith(manager.get(session.id));
+      expect(prepareWorkspaceContext).toHaveBeenCalledTimes(1);
+      expect(prepareWorkspaceContext).toHaveBeenCalledWith(manager.get(session.id));
+      expect(order).toEqual(["prompt", "prepare", "spawn"]);
     });
 
-    it("resume() never overwrites an existing workspace context file", async () => {
-      const writeWorkspaceContext = vi.fn(async () => {});
-      const workspaceContextExists = vi.fn(async () => true);
-      const { manager } = makeManager({ writeWorkspaceContext, workspaceContextExists });
+    it("resume() refuses to spawn when context preparation cannot make the prompt schema safe", async () => {
+      const prepareWorkspaceContext = vi.fn(async () => {
+        throw new Error("context path unreadable");
+      });
+      const { manager, spawns } = makeManager({ prepareWorkspaceContext });
 
       const session = manager.registerHistorical({
         agentSessionId: "agent-uuid-9",
@@ -790,10 +797,13 @@ describe("SessionManager", () => {
         lastActiveAt: "2026-01-01T00:00:00.000Z",
       });
 
-      await manager.resume(session.id);
+      await expect(manager.resume(session.id)).rejects.toThrow("context path unreadable");
 
-      expect(workspaceContextExists).toHaveBeenCalledWith("/tmp/proj");
-      expect(writeWorkspaceContext).not.toHaveBeenCalled();
+      expect(spawns).toHaveLength(0);
+      expect(manager.get(session.id)).toMatchObject({
+        status: "exited",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      });
     });
 
     it("defaults to a no-op for both hooks so tests with fake cwds never touch the real filesystem", async () => {

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -216,21 +216,19 @@ export interface SessionManagerOptions {
    * state; this layer just decides *when* to call it. Called unconditionally
    * from `create()`, before the pty is spawned, so every session gets the
    * file regardless of entry point (REST, `autoCreateSession`) — no entry
-   * point can skip it by calling `create()` directly. Also used by
-   * `resume()` as a backfill when the file is entirely missing (see
-   * `workspaceContextExists`). Defaults to a no-op so tests that pass a fake
-   * `cwd` (e.g. `/tmp/proj`) never touch the real filesystem unless they opt
-   * in.
+   * point can skip it by calling `create()` directly. Defaults to a no-op so
+   * tests that pass a fake `cwd` (e.g. `/tmp/proj`) never touch the real
+   * filesystem unless they opt in.
    */
   writeWorkspaceContext?: (session: HarnessSession) => Promise<void>;
   /**
-   * Reports whether HARNESS_CONTEXT_FILE already exists for a cwd. Used only
-   * by `resume()`, to decide whether a backfill write is needed — resume
-   * must never clobber a file that could already reflect a real binding.
-   * Defaults to `true` (assume it exists, never backfill) to match the
-   * no-op default of `writeWorkspaceContext`.
+   * Validates or migrates HARNESS_CONTEXT_FILE before a resumed coding agent
+   * is spawned. The caller owns the current/legacy/invalid/missing schema
+   * policy and live registry resolution; this layer guarantees the operation
+   * is awaited in the same pre-spawn window as the regenerated system prompt.
+   * Defaults to a no-op for filesystem-free unit tests.
    */
-  workspaceContextExists?: (cwd: string) => Promise<boolean>;
+  prepareWorkspaceContext?: (session: HarnessSession) => Promise<void>;
   /**
    * Drops the canvas kit template into `<cwd>/.sapiom/canvas/index.html`
    * when nothing is there yet (backfill-only — the real implementation,
@@ -283,7 +281,7 @@ export class SessionManager {
   private readonly now: () => string;
   private readonly generateId: () => string;
   private readonly writeWorkspaceContext: (session: HarnessSession) => Promise<void>;
-  private readonly workspaceContextExists: (cwd: string) => Promise<boolean>;
+  private readonly prepareWorkspaceContext: (session: HarnessSession) => Promise<void>;
   private readonly ensureCanvasTemplate: (cwd: string) => Promise<void>;
   private readonly isPidAlive: (pid: number) => boolean;
 
@@ -308,7 +306,7 @@ export class SessionManager {
     this.now = options.now ?? (() => new Date().toISOString());
     this.generateId = options.generateId ?? randomUUID;
     this.writeWorkspaceContext = options.writeWorkspaceContext ?? (async () => {});
-    this.workspaceContextExists = options.workspaceContextExists ?? (async () => true);
+    this.prepareWorkspaceContext = options.prepareWorkspaceContext ?? (async () => {});
     this.ensureCanvasTemplate = options.ensureCanvasTemplate ?? (async () => {});
     this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
     // Many WS clients (terminal + events) can subscribe over a long-running process.
@@ -513,13 +511,12 @@ export class SessionManager {
     await this.persist();
     this.emitStatus(session);
     try {
-      // Backfill only — never overwrite a file that could already reflect a
-      // real binding. The caller resolves session.boundWorkflowPath against
-      // the live registry, so unlike the old cwd-only signature this actually
-      // reconstructs the real binding on backfill, not just `null`.
-      if (!(await this.workspaceContextExists(session.cwd))) {
-        await this.writeWorkspaceContext(session);
-      }
+      // Schema-aware and strict: the caller leaves a valid current file
+      // untouched, translates a valid legacy file, and reconstructs anything
+      // missing/invalid from this session plus the live registry. Await it in
+      // the prompt-regeneration window so no resumed process can observe the
+      // new prompt with an old context contract.
+      await this.prepareWorkspaceContext(session);
       // Also backfill-only (ensureCanvasTemplate does its own existence check)
       // — a session from before the canvas kit existed, or one whose canvas
       // file was somehow deleted, still gets a live pane on resume.

--- a/packages/harness/src/core/workspace-context.test.ts
+++ b/packages/harness/src/core/workspace-context.test.ts
@@ -5,7 +5,12 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { WorkflowInfo } from "../shared/types.js";
-import { harnessContextFileExists, writeHarnessContext, type WorkspaceContextSession } from "./workspace-context.js";
+import {
+  prepareHarnessContextForResume,
+  writeHarnessContext,
+  writeHarnessContextForLaunch,
+  type WorkspaceContextSession,
+} from "./workspace-context.js";
 
 const workflow: WorkflowInfo = {
   name: "leasing",
@@ -41,26 +46,28 @@ describe("writeHarnessContext", () => {
     return JSON.parse(raw);
   }
 
-  it("creates .sapiom/ and writes a bound workflow", async () => {
+  it("creates .sapiom/ and writes a bound agent without legacy keys", async () => {
     await writeHarnessContext(session, workflow, [workflow]);
     const context = await readContext();
     expect(context).toMatchObject({
-      boundWorkflow: { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821 },
+      boundAgent: { name: "leasing", path: "/Users/demo/acme-app/leasing", definitionId: 4821 },
     });
+    expect(context).not.toHaveProperty("boundWorkflow");
+    expect(context).not.toHaveProperty("workflows");
     expect(typeof (context as { updatedAt: string }).updatedAt).toBe("string");
   });
 
-  it("writes boundWorkflow: null for an unbound/never-bound session", async () => {
+  it("writes boundAgent: null for an unbound/never-bound session", async () => {
     await writeHarnessContext(session, null, []);
     const context = await readContext();
-    expect(context).toMatchObject({ boundWorkflow: null });
+    expect(context).toMatchObject({ boundAgent: null });
   });
 
   it("unbind writes null rather than deleting the file (no ENOENT race for a concurrent reader)", async () => {
     await writeHarnessContext(session, workflow, [workflow]);
     await writeHarnessContext(session, null, [workflow]);
     const context = await readContext();
-    expect(context).toMatchObject({ boundWorkflow: null });
+    expect(context).toMatchObject({ boundAgent: null });
     // The file must still exist (only its content changed).
     await expect(fs.access(path.join(cwd, ".sapiom", "harness-context.json"))).resolves.toBeUndefined();
   });
@@ -70,7 +77,7 @@ describe("writeHarnessContext", () => {
     const renamed = { ...workflow, name: "renamed", definitionId: 9999 };
     await writeHarnessContext(session, renamed, [renamed]);
     const context = await readContext();
-    expect(context).toMatchObject({ boundWorkflow: { name: "renamed", definitionId: 9999 } });
+    expect(context).toMatchObject({ boundAgent: { name: "renamed", definitionId: 9999 } });
 
     const entries = await fs.readdir(path.join(cwd, ".sapiom"));
     expect(entries).toEqual(["harness-context.json"]);
@@ -87,32 +94,41 @@ describe("writeHarnessContext", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("writes the full workflows registry, trimmed to {name, path, definitionId} (no source)", async () => {
+  it("strict launch writes reject instead of spawning with a stale context contract", async () => {
+    const blockedFile = path.join(cwd, "blocked-launch");
+    await fs.writeFile(blockedFile, "x");
+
+    await expect(
+      writeHarnessContextForLaunch({ ...session, cwd: blockedFile }, workflow, [workflow]),
+    ).rejects.toThrow();
+  });
+
+  it("writes the full agents registry, trimmed to {name, path, definitionId} (no source)", async () => {
     await writeHarnessContext(session, null, [workflow, otherWorkflow]);
-    const context = (await readContext()) as { workflows: unknown[] };
-    expect(context.workflows).toContainEqual({ name: "leasing", path: workflow.path, definitionId: 4821 });
-    expect(context.workflows).toContainEqual({ name: "billing", path: otherWorkflow.path, definitionId: 4822 });
-    for (const entry of context.workflows) {
+    const context = (await readContext()) as { agents: unknown[] };
+    expect(context.agents).toContainEqual({ name: "leasing", path: workflow.path, definitionId: 4821 });
+    expect(context.agents).toContainEqual({ name: "billing", path: otherWorkflow.path, definitionId: 4822 });
+    for (const entry of context.agents) {
       expect(entry).not.toHaveProperty("source");
     }
   });
 
-  it("sorts the workflows array by path, independent of input order, for cheap diffing across writes", async () => {
+  it("sorts the agents array by path, independent of input order, for cheap diffing across writes", async () => {
     await writeHarnessContext(session, null, [workflow, otherWorkflow]); // leasing, then billing
-    const first = (await readContext()) as { workflows: Array<{ path: string }> };
+    const first = (await readContext()) as { agents: Array<{ path: string }> };
 
     await writeHarnessContext(session, null, [otherWorkflow, workflow]); // billing, then leasing
-    const second = (await readContext()) as { workflows: Array<{ path: string }> };
+    const second = (await readContext()) as { agents: Array<{ path: string }> };
 
-    expect(first.workflows.map((w) => w.path)).toEqual(second.workflows.map((w) => w.path));
-    expect(first.workflows.map((w) => w.path)).toEqual([otherWorkflow.path, workflow.path].sort());
+    expect(first.agents.map((w) => w.path)).toEqual(second.agents.map((w) => w.path));
+    expect(first.agents.map((w) => w.path)).toEqual([otherWorkflow.path, workflow.path].sort());
   });
 
-  it("includes workflows even when none of them is the bound one", async () => {
+  it("includes agents even when none of them is the bound one", async () => {
     await writeHarnessContext(session, workflow, [workflow, otherWorkflow]);
-    const context = (await readContext()) as { boundWorkflow: { path: string }; workflows: Array<{ path: string }> };
-    expect(context.boundWorkflow?.path).toBe(workflow.path);
-    expect(context.workflows.map((w) => w.path)).toContain(otherWorkflow.path);
+    const context = (await readContext()) as { boundAgent: { path: string }; agents: Array<{ path: string }> };
+    expect(context.boundAgent?.path).toBe(workflow.path);
+    expect(context.agents.map((w) => w.path)).toContain(otherWorkflow.path);
   });
 
   it("embeds the session's own identity", async () => {
@@ -140,11 +156,11 @@ describe("writeHarnessContext", () => {
     const results = await Promise.allSettled(writes);
     expect(results.every((r) => r.status === "fulfilled")).toBe(true);
 
-    const context = (await readContext()) as { boundWorkflow: { definitionId: number } };
+    const context = (await readContext()) as { boundAgent: { definitionId: number } };
     // Serialized in call order, not completion order: the last call
     // enqueued must be the one that's actually on disk at the end,
     // regardless of which write's disk I/O happened to finish first.
-    expect(context.boundWorkflow.definitionId).toBe(9);
+    expect(context.boundAgent.definitionId).toBe(9);
 
     const entries = await fs.readdir(path.join(cwd, ".sapiom"));
     expect(entries).toEqual(["harness-context.json"]);
@@ -162,42 +178,144 @@ describe("writeHarnessContext", () => {
         ),
       ]);
 
-      const mine = (await readContext()) as { boundWorkflow: { definitionId: number }; session: { id: string } };
+      const mine = (await readContext()) as { boundAgent: { definitionId: number }; session: { id: string } };
       const theirs = JSON.parse(
         await fs.readFile(path.join(otherCwd, ".sapiom", "harness-context.json"), "utf8"),
-      ) as { boundWorkflow: { definitionId: number }; session: { id: string } };
+      ) as { boundAgent: { definitionId: number }; session: { id: string } };
 
       expect(mine.session.id).toBe("sess-1");
-      expect(mine.boundWorkflow.definitionId).toBe(4);
+      expect(mine.boundAgent.definitionId).toBe(4);
       expect(theirs.session.id).toBe("sess-2");
-      expect(theirs.boundWorkflow.definitionId).toBe(104);
+      expect(theirs.boundAgent.definitionId).toBe(104);
     } finally {
       await fs.rm(otherCwd, { recursive: true, force: true });
     }
   });
 });
 
-describe("harnessContextFileExists", () => {
+describe("prepareHarnessContextForResume", () => {
   let cwd: string;
+  let session: WorkspaceContextSession;
+  let contextPath: string;
 
   beforeEach(async () => {
-    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "harness-context-exists-test-"));
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "harness-context-resume-test-"));
+    session = { id: "current-session", cwd, harness: "claude-code" };
+    contextPath = path.join(cwd, ".sapiom", "harness-context.json");
   });
 
   afterEach(async () => {
     await fs.rm(cwd, { recursive: true, force: true });
   });
 
-  it("is false for a cwd that has never had a context file written", async () => {
-    await expect(harnessContextFileExists(cwd)).resolves.toBe(false);
+  async function writeRaw(raw: string): Promise<void> {
+    await fs.mkdir(path.dirname(contextPath), { recursive: true });
+    await fs.writeFile(contextPath, raw, "utf8");
+  }
+
+  async function readParsed(): Promise<Record<string, unknown>> {
+    return JSON.parse(await fs.readFile(contextPath, "utf8")) as Record<string, unknown>;
+  }
+
+  it("leaves an already-current schema byte-for-byte untouched", async () => {
+    const raw = JSON.stringify({
+      boundAgent: { name: "saved", path: "/saved", definitionId: 7 },
+      agents: [{ name: "saved", path: "/saved", definitionId: 7 }],
+      session: { id: "saved-session", cwd: "/saved", harness: "codex" },
+      updatedAt: "2025-01-02T03:04:05.000Z",
+    });
+    await writeRaw(raw);
+
+    await expect(prepareHarnessContextForResume(session, workflow, [workflow])).resolves.toBe("current");
+    await expect(fs.readFile(contextPath, "utf8")).resolves.toBe(raw);
   });
 
-  it("is true once writeHarnessContext has run, regardless of bound/unbound", async () => {
-    await writeHarnessContext({ id: "sess-1", cwd, harness: "claude-code" }, null, []);
-    await expect(harnessContextFileExists(cwd)).resolves.toBe(true);
+  it("translates a valid legacy schema while preserving all saved values", async () => {
+    const legacy = {
+      boundWorkflow: { name: "saved", path: "/saved", definitionId: 7 },
+      workflows: [{ name: "other", path: "/other", definitionId: null }],
+      session: { id: "saved-session", cwd: "/saved", harness: "codex" },
+      updatedAt: "2025-01-02T03:04:05.000Z",
+    };
+    await writeRaw(JSON.stringify(legacy));
+
+    await expect(prepareHarnessContextForResume(session, workflow, [workflow])).resolves.toBe("migrated");
+    const migrated = await readParsed();
+    expect(migrated).toEqual({
+      boundAgent: legacy.boundWorkflow,
+      agents: legacy.workflows,
+      session: legacy.session,
+      updatedAt: legacy.updatedAt,
+    });
+    expect(migrated).not.toHaveProperty("boundWorkflow");
+    expect(migrated).not.toHaveProperty("workflows");
   });
 
-  it("is false for a cwd that doesn't exist at all", async () => {
-    await expect(harnessContextFileExists(path.join(cwd, "nope"))).resolves.toBe(false);
+  it("rebuilds a missing file from the current session, binding, and registry", async () => {
+    await expect(prepareHarnessContextForResume(session, workflow, [otherWorkflow, workflow])).resolves.toBe(
+      "rewritten",
+    );
+
+    expect(await readParsed()).toMatchObject({
+      boundAgent: { name: workflow.name, path: workflow.path, definitionId: workflow.definitionId },
+      agents: [
+        { name: otherWorkflow.name, path: otherWorkflow.path, definitionId: otherWorkflow.definitionId },
+        { name: workflow.name, path: workflow.path, definitionId: workflow.definitionId },
+      ],
+      session: { id: "current-session", cwd, harness: "claude-code" },
+    });
+  });
+
+  it("rebuilds malformed JSON from the current state", async () => {
+    await writeRaw("{ nope");
+
+    await expect(prepareHarnessContextForResume(session, null, [workflow])).resolves.toBe("rewritten");
+    expect(await readParsed()).toMatchObject({
+      boundAgent: null,
+      agents: [{ name: workflow.name, path: workflow.path, definitionId: workflow.definitionId }],
+      session: { id: "current-session", cwd, harness: "claude-code" },
+    });
+  });
+
+  it.each([
+    ["incomplete", { boundAgent: null, agents: [] }],
+    [
+      "mixed legacy/current",
+      {
+        boundAgent: null,
+        agents: [],
+        boundWorkflow: null,
+        workflows: [],
+        session: { id: "old", cwd: "/old", harness: "codex" },
+        updatedAt: "old",
+      },
+    ],
+    [
+      "invalid current value",
+      {
+        boundAgent: { name: "bad", path: 42, definitionId: null },
+        agents: [],
+        session: { id: "old", cwd: "/old", harness: "codex" },
+        updatedAt: "old",
+      },
+    ],
+  ])("rebuilds a %s schema instead of exposing it", async (_label, saved) => {
+    await writeRaw(JSON.stringify(saved));
+
+    await expect(prepareHarnessContextForResume(session, workflow, [workflow])).resolves.toBe("rewritten");
+    const rewritten = await readParsed();
+    expect(rewritten).toMatchObject({
+      boundAgent: { name: workflow.name, path: workflow.path },
+      agents: [{ name: workflow.name, path: workflow.path }],
+      session: { id: "current-session", cwd, harness: "claude-code" },
+    });
+    expect(rewritten).not.toHaveProperty("boundWorkflow");
+    expect(rewritten).not.toHaveProperty("workflows");
+  });
+
+  it("rejects resume when an existing path cannot be read as a file", async () => {
+    await fs.mkdir(contextPath, { recursive: true });
+
+    await expect(prepareHarnessContextForResume(session, workflow, [workflow])).rejects.toThrow();
   });
 });

--- a/packages/harness/src/core/workspace-context.ts
+++ b/packages/harness/src/core/workspace-context.ts
@@ -1,19 +1,19 @@
 /**
  * Writes HARNESS_CONTEXT_FILE (`.sapiom/harness-context.json`) in a
- * session's cwd — the agent-legible mirror of this workspace's UI state:
- * which workflow (if any) the session is bound to, every workflow the
+ * session's cwd — the coding-agent-legible mirror of this workspace's UI
+ * state: which agent (if any) the session is bound to, every agent the
  * registry currently knows about, and the session's own identity. Called
- * unconditionally from `SessionManager.create()` so the file exists for
- * every session regardless of entry point (REST, `autoCreateSession`), as a
- * backfill from `SessionManager.resume()` when it's missing entirely, on
+ * strictly from `SessionManager.create()` so the file exists for every
+ * session regardless of entry point (REST, `autoCreateSession`), through
+ * schema-aware preparation from `SessionManager.resume()`, on
  * every `PATCH /api/sessions/:id/workflow`, and whenever the workflow
  * registry changes (scan/connect) — see server/index.ts's
  * `writeSessionContext`/`scanWorkflowsAndBroadcast` for how those call
  * sites are wired, and both of which can legitimately fire concurrent
  * writes to the *same* destination (a scan's rewrite-all-open-sessions step
  * racing a user's live bind click, for instance) — see `withPerPathQueue`.
- * Unbinding writes `boundWorkflow: null` rather than deleting the file, so a
- * concurrent read from the agent never races a momentary ENOENT.
+ * Unbinding writes `boundAgent: null` rather than deleting the file, so a
+ * concurrent read from the coding agent never races a momentary ENOENT.
  */
 
 import * as crypto from "node:crypto";
@@ -22,13 +22,14 @@ import * as path from "node:path";
 
 import {
   HARNESS_CONTEXT_FILE,
+  SPAWNABLE_HARNESS_KINDS,
   type HarnessKind,
   type HarnessWorkspaceContext,
-  type HarnessWorkspaceContextWorkflow,
+  type HarnessWorkspaceContextAgent,
   type WorkflowInfo,
 } from "../shared/types.js";
 
-function toContextWorkflowEntry(workflow: WorkflowInfo): HarnessWorkspaceContextWorkflow {
+function toContextAgentEntry(workflow: WorkflowInfo): HarnessWorkspaceContextAgent {
   return { name: workflow.name, path: workflow.path, definitionId: workflow.definitionId };
 }
 
@@ -57,9 +58,9 @@ const writeQueues = new Map<string, Promise<void>>();
 
 async function withPerPathQueue(filePath: string, task: () => Promise<void>): Promise<void> {
   const previous = writeQueues.get(filePath) ?? Promise.resolve();
-  // `task` never throws (its own try/catch logs and swallows) — chaining
-  // onto both branches of `previous` is defense in depth, so one write's
-  // failure can never wedge the queue for the next one to this same path.
+  // Chain onto both branches of `previous`: strict launch/resume operations
+  // may throw when they cannot make the prompt-visible schema safe, but that
+  // must never wedge the queue for the next operation on this same path.
   const current = previous.then(task, task);
   writeQueues.set(filePath, current);
   try {
@@ -75,53 +76,189 @@ async function withPerPathQueue(filePath: string, task: () => Promise<void>): Pr
  * (permissions, deleted out from under the session) — that must never fail
  * the caller that triggered it, so errors are logged, not thrown.
  *
- * `workflows` is sorted by path before writing (deterministic, independent
- * of registry scan/insertion order) so an agent re-reading the file across
- * turns can diff it cheaply instead of re-parsing a reordered blob every
- * time.
+ * `agents` is sorted by path before writing (deterministic, independent
+ * of registry scan/insertion order) so a coding agent re-reading the file
+ * across turns can diff it cheaply instead of re-parsing a reordered blob
+ * every time.
  */
 export async function writeHarnessContext(
   session: WorkspaceContextSession,
   boundWorkflow: WorkflowInfo | null,
   workflows: WorkflowInfo[],
 ): Promise<void> {
-  const filePath = path.join(session.cwd, HARNESS_CONTEXT_FILE);
-  const sortedWorkflows = [...workflows].sort((a, b) => a.path.localeCompare(b.path)).map(toContextWorkflowEntry);
-  const context: HarnessWorkspaceContext = {
-    boundWorkflow: boundWorkflow ? toContextWorkflowEntry(boundWorkflow) : null,
-    workflows: sortedWorkflows,
-    session: { id: session.id, cwd: session.cwd, harness: session.harness },
-    updatedAt: new Date().toISOString(),
-  };
-
-  await withPerPathQueue(filePath, async () => {
-    try {
-      const dir = path.dirname(filePath);
-      await fs.mkdir(dir, { recursive: true });
-      // A random suffix, not just pid+Date.now(): millisecond resolution is
-      // not fine enough to stay unique across a burst of concurrent writes
-      // to the same destination (confirmed via repro). Collision-proof
-      // regardless of timing, independent of the queue above.
-      const tmpPath = path.join(dir, `.harness-context.json.tmp-${process.pid}-${crypto.randomUUID()}`);
-      await fs.writeFile(tmpPath, JSON.stringify(context, null, 2) + "\n", "utf8");
-      await fs.rename(tmpPath, filePath);
-    } catch (err) {
-      console.error(`[harness] failed to write ${filePath}:`, err);
-    }
-  });
+  try {
+    await writeHarnessContextForLaunch(session, boundWorkflow, workflows);
+  } catch (err) {
+    const filePath = path.join(session.cwd, HARNESS_CONTEXT_FILE);
+    console.error(`[harness] failed to write ${filePath}:`, err);
+  }
 }
 
 /**
- * True if `<cwd>/.sapiom/harness-context.json` already exists. Used by
- * `SessionManager.resume()` to decide whether a backfill write is needed —
- * resume must never clobber a file that could already reflect a real
- * binding.
+ * The strict form used in SessionManager.create()'s pre-spawn window. A write
+ * failure rejects creation so a coding agent can never receive the new prompt
+ * while an old or missing context contract remains on disk. Registry and bind
+ * refreshes use the best-effort wrapper above because a later refresh failure
+ * must not terminate an already-running session.
  */
-export async function harnessContextFileExists(cwd: string): Promise<boolean> {
+export async function writeHarnessContextForLaunch(
+  session: WorkspaceContextSession,
+  boundWorkflow: WorkflowInfo | null,
+  workflows: WorkflowInfo[],
+): Promise<void> {
+  const filePath = path.join(session.cwd, HARNESS_CONTEXT_FILE);
+  const context = buildHarnessContext(session, boundWorkflow, workflows);
+
+  await withPerPathQueue(filePath, async () => {
+    await writeContextAtomically(filePath, context);
+  });
+}
+
+export type HarnessContextResumePreparation = "current" | "migrated" | "rewritten";
+
+interface LegacyHarnessWorkspaceContext {
+  boundWorkflow: HarnessWorkspaceContextAgent | null;
+  workflows: HarnessWorkspaceContextAgent[];
+  session: HarnessWorkspaceContext["session"];
+  updatedAt: string;
+}
+
+function buildHarnessContext(
+  session: WorkspaceContextSession,
+  boundWorkflow: WorkflowInfo | null,
+  workflows: WorkflowInfo[],
+): HarnessWorkspaceContext {
+  const agents = [...workflows].sort((a, b) => a.path.localeCompare(b.path)).map(toContextAgentEntry);
+  return {
+    boundAgent: boundWorkflow ? toContextAgentEntry(boundWorkflow) : null,
+    agents,
+    session: { id: session.id, cwd: session.cwd, harness: session.harness },
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+async function writeContextAtomically(filePath: string, context: HarnessWorkspaceContext): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  // A random suffix, not just pid+Date.now(): millisecond resolution is not
+  // fine enough to stay unique across a burst of concurrent writes.
+  const tmpPath = path.join(dir, `.harness-context.json.tmp-${process.pid}-${crypto.randomUUID()}`);
   try {
-    await fs.access(path.join(cwd, HARNESS_CONTEXT_FILE));
-    return true;
-  } catch {
+    await fs.writeFile(tmpPath, JSON.stringify(context, null, 2) + "\n", "utf8");
+    await fs.rename(tmpPath, filePath);
+  } finally {
+    await fs.rm(tmpPath, { force: true });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function isContextAgent(value: unknown): value is HarnessWorkspaceContextAgent {
+  if (!isRecord(value) || !hasExactKeys(value, ["definitionId", "name", "path"])) return false;
+  return (
+    typeof value.name === "string" &&
+    typeof value.path === "string" &&
+    (typeof value.definitionId === "number" || value.definitionId === null)
+  );
+}
+
+function isContextSession(value: unknown): value is HarnessWorkspaceContext["session"] {
+  if (!isRecord(value) || !hasExactKeys(value, ["cwd", "harness", "id"])) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.cwd === "string" &&
+    typeof value.harness === "string" &&
+    SPAWNABLE_HARNESS_KINDS.some((harness) => harness === value.harness)
+  );
+}
+
+function hasSharedValidFields(value: Record<string, unknown>): boolean {
+  return isContextSession(value.session) && typeof value.updatedAt === "string";
+}
+
+function isCurrentContext(value: unknown): value is HarnessWorkspaceContext {
+  if (!isRecord(value) || !hasExactKeys(value, ["agents", "boundAgent", "session", "updatedAt"])) return false;
+  return (
+    hasSharedValidFields(value) &&
+    (value.boundAgent === null || isContextAgent(value.boundAgent)) &&
+    Array.isArray(value.agents) &&
+    value.agents.every(isContextAgent)
+  );
+}
+
+function isLegacyContext(value: unknown): value is LegacyHarnessWorkspaceContext {
+  if (!isRecord(value) || !hasExactKeys(value, ["boundWorkflow", "session", "updatedAt", "workflows"])) {
     return false;
   }
+  return (
+    hasSharedValidFields(value) &&
+    (value.boundWorkflow === null || isContextAgent(value.boundWorkflow)) &&
+    Array.isArray(value.workflows) &&
+    value.workflows.every(isContextAgent)
+  );
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+/**
+ * Makes HARNESS_CONTEXT_FILE safe for a resumed coding agent before its new
+ * Agent Studio prompt can reach the process. A valid current-schema file is
+ * byte-for-byte untouched; a valid legacy file keeps its values and only
+ * renames the two public keys; anything missing, malformed, mixed, or
+ * incomplete is rebuilt from the live session and registry.
+ *
+ * Unlike ordinary registry/bind refreshes, this is strict: an unreadable file
+ * or failed atomic replacement rejects resume so the prompt and on-disk
+ * contract can never disagree during a launch.
+ */
+export async function prepareHarnessContextForResume(
+  session: WorkspaceContextSession,
+  boundWorkflow: WorkflowInfo | null,
+  workflows: WorkflowInfo[],
+): Promise<HarnessContextResumePreparation> {
+  const filePath = path.join(session.cwd, HARNESS_CONTEXT_FILE);
+  let result: HarnessContextResumePreparation = "rewritten";
+
+  await withPerPathQueue(filePath, async () => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    } catch (error) {
+      if (!isMissingFileError(error) && !(error instanceof SyntaxError)) throw error;
+      await writeContextAtomically(filePath, buildHarnessContext(session, boundWorkflow, workflows));
+      result = "rewritten";
+      return;
+    }
+
+    if (isCurrentContext(parsed)) {
+      result = "current";
+      return;
+    }
+
+    if (isLegacyContext(parsed)) {
+      await writeContextAtomically(filePath, {
+        boundAgent: parsed.boundWorkflow,
+        agents: parsed.workflows,
+        session: parsed.session,
+        updatedAt: parsed.updatedAt,
+      });
+      result = "migrated";
+      return;
+    }
+
+    await writeContextAtomically(filePath, buildHarnessContext(session, boundWorkflow, workflows));
+    result = "rewritten";
+  });
+
+  return result;
 }

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -7,7 +7,7 @@
  * closing line asks for one visible signal that it actually loaded.
  */
 export const DEFAULT_SYSTEM_PROMPT = `
-You are running in the Sapiom Harness. This is not a stock coding session —
+You are the coding agent running in Agent Studio. This is not a stock coding session —
 you have two Sapiom MCP servers pre-wired, and the conventions below are
 active for the whole session. Follow them.
 
@@ -26,39 +26,39 @@ step code against stub capabilities, no cost) → link (associate the project
 with a hosted agent) → deploy (push, build, go live). Read a project's
 AGENTS.md before touching its steps — it documents that project's specifics.
 
-**Canvas convention:** the canvas pane renders the selected workflow's step
+**Canvas convention:** the canvas pane renders the selected agent's step
 graph automatically and deterministically — the harness extracts it from the
-workflow's manifest and draws the diagram (nodes, edges, a summary and
+agent's manifest and draws the diagram (nodes, edges, a summary and
 annotations) server-side: no LLM, no tokens, identical every time. You do NOT
 author or edit any canvas HTML, and there is nothing to write under
-\`.sapiom/canvas/\`. When someone asks to "visualize this workflow" or "how
-does everything connect", just make sure the workflow is selected in the rail
+\`.sapiom/canvas/\`. When someone asks to "visualize this agent" or "how
+does everything connect", just make sure the agent is selected in the rail
 (the Visualize button and the ⌘K action only force a re-render) — it draws
 itself.
 
-**Your current workspace state:** the harness mirrors what it knows about
+**Your current workspace state:** Agent Studio mirrors what it knows about
 this workspace at \`.sapiom/harness-context.json\`, relative to your working
-directory (\`{"boundWorkflow": {name, path, definitionId} | null,
-"workflows": [{name, path, definitionId}, ...], "session": {id, cwd,
-harness}, "updatedAt": ...}\`). \`boundWorkflow\` is whichever workflow the
+directory (\`{"boundAgent": {name, path, definitionId} | null,
+"agents": [{name, path, definitionId}, ...], "session": {id, cwd,
+harness}, "updatedAt": ...}\`). \`boundAgent\` is whichever deployable agent the
 person currently has selected in the app, or \`null\` if none;
-\`workflows\` is every workflow the app has discovered here, selected or
-not. Read it when they say "this workflow," ask what they're working on, or
-ask what workflows exist — both fields can change mid-session (a new
+\`agents\` is every agent the app has discovered here, selected or
+not. Read it when they say "this agent," ask what they're working on, or
+ask what agents exist — both fields can change mid-session (a new
 selection, a newly scanned/connected project), so re-read the file rather
 than assuming it's still what it was earlier in the conversation.
 
 **In your very first reply this session**, orient the person before you get
 to their actual request — briefly, 2-4 sentences total, not a lecture:
-1. Acknowledge that you're running in the Sapiom Harness with these MCPs
+1. Acknowledge that you're the coding agent in Agent Studio with these MCPs
    available (one line), so they can see this loaded.
-2. Say what you can do for them here: visualize a workflow on the canvas
-   pane, run it locally against stub capabilities at no cost, and deploy it
+2. Say what you can do for them here: visualize an agent on the canvas
+   pane, start an agent run locally against stub capabilities at no cost, and deploy it
    live — all also one click away via the action buttons next to each
-   workflow, or ⌘K.
+   agent, or ⌘K.
 3. Suggest ONE concrete first step, picked from the workspace state file
-   above: if a workflow is bound or listed (e.g. the bundled order-triage
-   sample project), offer to visualize or run that one by name; if none
+   above: if an agent is bound or listed (e.g. the bundled order-triage
+   sample project), offer by name to visualize it or start an agent run; if none
    exists yet, offer to scaffold a new agent project. Phrase it as an
    invitation ("want me to…?"), then stop — don't act on it unprompted.
 `.trim();

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -32,9 +32,10 @@ agent's manifest and draws the diagram (nodes, edges, a summary and
 annotations) server-side: no LLM, no tokens, identical every time. You do NOT
 author or edit any canvas HTML, and there is nothing to write under
 \`.sapiom/canvas/\`. When someone asks to "visualize this agent" or "how
-does everything connect", just make sure the agent is selected in the rail
-(the Visualize button and the ⌘K action only force a re-render) — it draws
-itself.
+does everything connect", make sure the agent is selected in the workspace
+rail. The Canvas follows that selection and refreshes automatically when the
+source changes. Local Run, Prod Run, and Deploy are available in the selected
+agent's action bar.
 
 **Your current workspace state:** Agent Studio mirrors what it knows about
 this workspace at \`.sapiom/harness-context.json\`, relative to your working
@@ -52,13 +53,14 @@ than assuming it's still what it was earlier in the conversation.
 to their actual request — briefly, 2-4 sentences total, not a lecture:
 1. Acknowledge that you're the coding agent in Agent Studio with these MCPs
    available (one line), so they can see this loaded.
-2. Say what you can do for them here: visualize an agent on the canvas
-   pane, start an agent run locally against stub capabilities at no cost, and deploy it
-   live — all also one click away via the action buttons next to each
-   agent, or ⌘K.
+2. Say what you can do for them here: inspect the selected agent on its
+   automatically generated Canvas, start a local agent run against stub
+   capabilities at no cost, start a production agent run after deployment,
+   and deploy it live. The exact action-bar controls are Local Run, Prod Run,
+   and Deploy.
 3. Suggest ONE concrete first step, picked from the workspace state file
    above: if an agent is bound or listed (e.g. the bundled order-triage
-   sample project), offer by name to visualize it or start an agent run; if none
+   sample project), offer by name to inspect its Canvas or start a Local Run; if none
    exists yet, offer to scaffold a new agent project. Phrase it as an
    invitation ("want me to…?"), then stop — don't act on it unprompted.
 `.trim();

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -87,8 +87,9 @@ import { ExecutionDetector } from "../core/execution-detector.js";
 import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
 import {
+  prepareHarnessContextForResume,
   writeHarnessContext,
-  harnessContextFileExists,
+  writeHarnessContextForLaunch,
 } from "../core/workspace-context.js";
 import { ensureCanvasTemplate } from "../core/canvas-template.js";
 import { renderCanvasForSession } from "../core/canvas-render.js";
@@ -484,13 +485,13 @@ export const startServer = async (
       }),
   });
 
-  // Declared before sessionManager: writeSessionContext (sessionManager's
-  // writeWorkspaceContext option) needs workflowsCache in scope to resolve a
-  // session's boundWorkflowPath into a full WorkflowInfo. scanWorkflowsAndBroadcast
-  // stays defined below sessionManager instead, since it needs sessionManager
+  // Declared before sessionManager: its context writers need workflowsCache
+  // in scope to resolve a session's boundWorkflowPath into a full WorkflowInfo.
+  // scanWorkflowsAndBroadcast stays defined below sessionManager instead,
+  // since it needs sessionManager
   // itself (to rewrite every open session's context file on a registry change) —
-  // no circularity, since only writeSessionContext is threaded into SessionManager's
-  // constructor, and it doesn't need sessionManager.
+  // no circularity, since the context callbacks threaded into SessionManager's
+  // constructor don't need sessionManager themselves.
   const workflowRegistry = new WorkflowRegistry(
     options.workflowsRegistryPath ?? statePaths.workflows,
   );
@@ -527,23 +528,35 @@ export const startServer = async (
   }, WORKFLOWS_CACHE_REFRESH_MS);
   workflowsCacheTimer.unref?.();
 
+  const boundWorkflowForSession = (session: HarnessSession): WorkflowInfo | null =>
+    session.boundWorkflowPath
+      ? (workflowsCache.find((workflow) => workflow.path === session.boundWorkflowPath) ?? null)
+      : null;
+
   /**
    * Writes HARNESS_CONTEXT_FILE for a single session, resolving its
    * `boundWorkflowPath` against the live registry so the file always
    * reflects the session's actual current binding (not just what a caller
-   * happened to have on hand) — and the full `workflows` list, so an agent
-   * can answer "what workflows exist" without a UI round-trip. Shared by
-   * SessionManager's create()/resume(), the PATCH bind/unbind route, and
-   * scanWorkflowsAndBroadcast's rewrite-all-open-sessions step below.
+   * happened to have on hand) — and the full agent list. Bind/unbind and
+   * registry refreshes use this best-effort writer; create and resume use
+   * their strict pre-spawn counterparts below.
    */
   const writeSessionContext = async (
     session: HarnessSession,
   ): Promise<void> => {
-    const boundWorkflow = session.boundWorkflowPath
-      ? (workflowsCache.find((w) => w.path === session.boundWorkflowPath) ??
-        null)
-      : null;
-    await writeHarnessContext(session, boundWorkflow, workflowsCache);
+    await writeHarnessContext(session, boundWorkflowForSession(session), workflowsCache);
+  };
+
+  const initializeSessionContext = async (
+    session: HarnessSession,
+  ): Promise<void> => {
+    await writeHarnessContextForLaunch(session, boundWorkflowForSession(session), workflowsCache);
+  };
+
+  const prepareSessionContext = async (
+    session: HarnessSession,
+  ): Promise<void> => {
+    await prepareHarnessContextForResume(session, boundWorkflowForSession(session), workflowsCache);
   };
 
   // Declared before the launch-opts builder (rather than beside the ingest
@@ -678,8 +691,8 @@ export const startServer = async (
     buildLaunchOpts,
     // Every session gets its initial harness-context.json regardless of
     // entry point (REST, autoCreateSession) — see SessionManager.create().
-    writeWorkspaceContext: writeSessionContext,
-    workspaceContextExists: (cwd) => harnessContextFileExists(cwd),
+    writeWorkspaceContext: initializeSessionContext,
+    prepareWorkspaceContext: prepareSessionContext,
     ensureCanvasTemplate,
   });
   await sessionManager.init();

--- a/packages/harness/src/server/rehydrate-session.test.ts
+++ b/packages/harness/src/server/rehydrate-session.test.ts
@@ -164,6 +164,10 @@ describe("portable continue — rehydrating a fresh session", () => {
         // The harness's own profile is still there — the brief is appended to
         // it, never a replacement for it.
         expect(prompt).toContain(DEFAULT_SYSTEM_PROMPT.slice(0, 60));
+        expect(prompt).toContain('"boundAgent"');
+        expect(prompt).toContain('"agents"');
+        expect(prompt).not.toContain('"boundWorkflow"');
+        expect(prompt).not.toContain('"workflows"');
         // …and it is labelled as a reconstruction before anything else.
         expect(prompt).toContain("reconstruction, not restored context");
         // What the session was doing.

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -106,10 +106,10 @@ export const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024;
 export const JSON_BODY_LIMIT_BYTES = Math.ceil((MAX_IMAGE_UPLOAD_BYTES * 4) / 3) + 1024 * 1024;
 
 /**
- * Workspace-state convention: the harness mirrors this session's binding,
- * the full workflow registry, and its own identity here, relative to the
- * session cwd, so the agent has an always-current, agent-legible answer to
- * "what am I working on" and "what workflows exist" without asking. Written
+ * Workspace-state convention: Agent Studio mirrors this session's binding,
+ * the full agent registry, and its own identity here, relative to the
+ * session cwd, so the coding agent has an always-current answer to
+ * "what am I working on" and "what agents exist" without asking. Written
  * on session create, on every `PATCH /api/sessions/:id/workflow`, and
  * whenever the workflow registry changes (scan/connect) — see
  * HarnessWorkspaceContext. Kept present (never deleted) even on unbind.
@@ -163,9 +163,9 @@ export interface HarnessSession {
   lastActiveAt: string;
   /** Exit code when status === "exited". */
   exitCode?: number | null;
-  /** The workflow (by path) this session is currently bound to, if any. Set
+  /** The deployable agent (by path) this session is currently bound to, if any. Set
    *  via `PATCH /api/sessions/:id/workflow`; mirrored into
-   *  HARNESS_CONTEXT_FILE in the session's cwd so the agent can read it. */
+   *  HARNESS_CONTEXT_FILE in the session's cwd so the coding agent can read it. */
   boundWorkflowPath: string | null;
   /**
    * The prior session this one was seeded from (portable continue — see
@@ -994,29 +994,32 @@ export interface BindWorkflowRequest {
   workflowPath: string | null;
 }
 
-/** The trimmed workflow shape embedded in HarnessWorkspaceContext — just
- *  enough for an agent to identify a workflow, not the full WorkflowInfo
- *  (e.g. `source` is registry bookkeeping the agent has no use for). */
-export interface HarnessWorkspaceContextWorkflow {
+/** The trimmed agent shape embedded in HarnessWorkspaceContext — just
+ *  enough for a coding agent to identify a deployable agent, not the full
+ *  internal WorkflowInfo (e.g. `source` is registry bookkeeping it has no
+ *  use for). */
+export interface HarnessWorkspaceContextAgent {
   name: string;
   path: string;
   definitionId: number | null;
 }
+
+/** @deprecated Use {@link HarnessWorkspaceContextAgent}. */
+export type HarnessWorkspaceContextWorkflow = HarnessWorkspaceContextAgent;
 
 /**
  * The shape written to HARNESS_CONTEXT_FILE in a session's cwd. Schemaless
  * by convention elsewhere in the harness, but this one file IS a contract —
  * the default system prompt tells the agent to read it, so its shape is
  * fixed here like any other REST payload. Deliberately small and
- * stable-ordered (`workflows` sorted by path) so an agent can diff it
+ * stable-ordered (`agents` sorted by path) so a coding agent can diff it
  * cheaply across reads rather than re-parsing a growing blob.
  */
 export interface HarnessWorkspaceContext {
-  boundWorkflow: HarnessWorkspaceContextWorkflow | null;
-  /** Every workflow currently known to this harness instance's registry,
-   *  selected or not — lets an agent answer "what workflows exist" without
-   *  a UI action, not just "which one is selected." */
-  workflows: HarnessWorkspaceContextWorkflow[];
+  boundAgent: HarnessWorkspaceContextAgent | null;
+  /** Every deployable agent currently known to this Studio instance's
+   *  registry, selected or not. */
+  agents: HarnessWorkspaceContextAgent[];
   session: { id: string; cwd: string; harness: HarnessKind };
   updatedAt: string;
 }

--- a/packages/harness/web/e2e/canvas-describe-ai.spec.ts
+++ b/packages/harness/web/e2e/canvas-describe-ai.spec.ts
@@ -85,6 +85,8 @@ test.describe("Describe with AI", () => {
     expect(run.req.subject ?? "").toContain("/Users/demo/acme-app/leasing");
     expect((run.req.subject ?? "").toLowerCase()).toContain("description");
     expect(run.req.subject ?? "").toContain("defineStep");
+    expect(run.req.subject ?? "").toContain("whole agent");
+    expect((run.req.subject ?? "").toLowerCase()).not.toContain("workflow");
 
     // Instant feedback: the button flips to a disabled loading state.
     await expect(btn).toBeDisabled();

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1728,10 +1728,14 @@ test("steps tab drills into a step's real transitions and slides back", async ({
   const header = page.getByTestId("workflow-actions-header");
   await expect(header.getByTestId("canvas-detail-back")).toBeVisible();
   await expect(header.getByTestId("canvas-detail-title")).toHaveText("approve?");
-  await expect(header.getByTestId("canvas-detail-ask")).toBeVisible();
+  const askCodingAgent = header.getByTestId("canvas-detail-ask");
+  await expect(askCodingAgent).toBeVisible();
+  await expect(askCodingAgent).toHaveAccessibleName("Ask coding agent");
+  await expect(askCodingAgent).toHaveAttribute("data-tooltip", "Ask the coding agent in the terminal");
+  await expect(askCodingAgent).toContainText("Ask coding agent");
   await expect(header.getByTestId("canvas-detail-menu")).toBeVisible();
 
-  await header.getByTestId("canvas-detail-ask").click();
+  await askCodingAgent.click();
   await expect
     .poll(async () =>
       page.evaluate(() =>
@@ -1751,7 +1755,7 @@ test("steps tab drills into a step's real transitions and slides back", async ({
     if (hook) delete hook.lastInjectInput;
   });
   await header.getByTestId("canvas-detail-menu").click();
-  await page.getByRole("menuitem", { name: "Ask agent to modify" }).click();
+  await page.getByRole("menuitem", { name: "Ask coding agent to modify" }).click();
   await expect
     .poll(async () =>
       page.evaluate(() =>

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1731,6 +1731,36 @@ test("steps tab drills into a step's real transitions and slides back", async ({
   await expect(header.getByTestId("canvas-detail-ask")).toBeVisible();
   await expect(header.getByTestId("canvas-detail-menu")).toBeVisible();
 
+  await header.getByTestId("canvas-detail-ask").click();
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+          .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+      ),
+    )
+    .toContain('step of this agent');
+  const askPrompt = await page.evaluate(() =>
+    (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+      .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+  );
+  expect(askPrompt.toLowerCase()).not.toContain("workflow");
+
+  await page.evaluate(() => {
+    const hook = (window as unknown as { __HARNESS_TEST__?: Record<string, unknown> }).__HARNESS_TEST__;
+    if (hook) delete hook.lastInjectInput;
+  });
+  await header.getByTestId("canvas-detail-menu").click();
+  await page.getByRole("menuitem", { name: "Ask agent to modify" }).click();
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+          .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+      ),
+    )
+    .toContain('step of this agent');
+
   // Real outgoing transitions with their branch conditions, both terminals.
   const detail = page.getByTestId("canvas-step-detail");
   await expect(detail).toContainText("draft-lease");
@@ -1752,6 +1782,33 @@ test("steps tab drills into a step's real transitions and slides back", async ({
   await expect(frame).toHaveAttribute("data-view", "steps");
   await page.getByTestId("right-tab-canvas").click();
   await expect(frame).toHaveAttribute("data-view", "board");
+});
+
+test("canvas repair sends the coding agent an Agent-terminology prompt", async ({ page }) => {
+  const canvasBody = page.frameLocator(".canvas-iframe").locator("body");
+  await expect(canvasBody).toBeVisible();
+  await canvasBody.evaluate(() => {
+    window.parent.postMessage(
+      { type: "sapiom-canvas:error", title: "leasing", reason: "TypeScript extraction failed" },
+      "*",
+    );
+  });
+  await expect(page.getByTestId("canvas-render-error")).toBeVisible();
+  await page.getByTestId("canvas-error-fix").click();
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+          .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+      ),
+    )
+    .toContain("agent graph extracts cleanly");
+  const prompt = await page.evaluate(() =>
+    (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+      .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+  );
+  expect(prompt.toLowerCase()).not.toContain("workflow");
 });
 
 test("a detected dev server surfaces a Preview chip on the action bar", async ({ page }) => {

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -219,7 +219,10 @@ test.describe("templates journey (from the welcome panel)", () => {
       .poll(async () => (await lastInject(page))?.req.text ?? "")
       .toContain("sapiom agents init . -t coding-pause");
     // The starter path carries the same run continuation as the clone path.
-    expect((await lastInject(page))?.req.text).toContain("sapiom_dev_agents_run_local");
+    const prompt = (await lastInject(page))?.req.text ?? "";
+    expect(prompt).toContain("sapiom_dev_agents_run_local");
+    expect(prompt).toContain("adapt the agent");
+    expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 
   test("use: straight from a card's spec sheet, skipping the read", async ({ page }) => {

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -90,6 +90,12 @@ test.describe("add workspace (three doors)", () => {
         .__HARNESS_TEST__;
       return test?.lastInjectInput?.req.text.includes("sapiom agents init") ?? false;
     });
+    const scaffoldPrompt = await page.evaluate(() =>
+      (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
+        .__HARNESS_TEST__?.lastInjectInput?.req.text,
+    );
+    expect(scaffoldPrompt).toContain("define the first agent");
+    expect(scaffoldPrompt?.toLowerCase()).not.toContain("workflow");
   });
 
   test("a root holding several projects offers to add them all, and toasts the count", async ({ page }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -448,7 +448,7 @@ export const App = (): JSX.Element => {
       session.id,
       trimmedIdea
         ? `${base} build this:\n\n${trimmedIdea}`
-        : `${base} define the first workflow.`,
+        : `${base} define the first agent.`,
       "Couldn't send the scaffold prompt. Ask the agent to run sapiom agents init.",
     );
   };
@@ -476,7 +476,7 @@ export const App = (): JSX.Element => {
   const handleScaffoldInSession = (sessionId: string): void => {
     injectPromptWithRetry(
       sessionId,
-      "Scaffold a new Sapiom agent project in this directory: run `sapiom agents init .`, then use the sapiom-agent-authoring skill to define the first workflow.",
+      "Scaffold a new Sapiom agent project in this directory: run `sapiom agents init .`, then use the sapiom-agent-authoring skill to define the first agent.",
       "Couldn't send the scaffold prompt. Ask the agent to run sapiom agents init.",
     );
   };

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -946,7 +946,7 @@ export function CanvasPane({
                   data-testid="canvas-error-fix"
                   onClick={() =>
                     onInjectPrompt(
-                      `The canvas render for ${postedError.title || "this workflow"} failed: ${postedError.reason} Fix the project so the workflow graph extracts cleanly.`,
+                      `The canvas render for ${postedError.title || "this agent"} failed: ${postedError.reason} Fix the project so the agent graph extracts cleanly.`,
                     )
                   }
                 >

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -91,7 +91,7 @@ export function WorkflowActionsHeader({
           data-testid="canvas-detail-ask"
           aria-label="Ask agent"
           data-tooltip="Sends the request to the agent in the terminal"
-          onClick={() => onAskAgent(`Walk me through the "${detailStep.label}" step of this workflow: what it does, its inputs and outputs, and its transitions.`)}
+          onClick={() => onAskAgent(`Walk me through the "${detailStep.label}" step of this agent: what it does, its inputs and outputs, and its transitions.`)}
         >
           <Icon name="MessageSquare" size={13} />
           {/* Hidden by the subheader's container query when the pane is too
@@ -124,7 +124,7 @@ export function WorkflowActionsHeader({
                 role="menuitem"
                 className="profile-menu-item"
                 onClick={() => {
-                  onAskAgent(`Modify the "${detailStep.label}" step of this workflow. Show me the step's code first, then propose the change.`);
+                  onAskAgent(`Modify the "${detailStep.label}" step of this agent. Show me the step's code first, then propose the change.`);
                   closeMenu();
                 }}
               >

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -45,7 +45,7 @@ function runChipLabel(run: RunView, target: RunTarget | null): string {
  * - Steps list: the workflow name and the real step count, info left, no
  *   competing actions (rows are the interface).
  * - Step detail: 1×1 back left-anchored, the step's name and kind, then the
- *   right-anchored main action (Ask agent) and a ⋯ menu with the rest —
+ *   right-anchored main action (Ask coding agent) and a ⋯ menu with the rest —
  *   the drill-down's chrome lives HERE, not inside the scroll area.
  */
 export function WorkflowActionsHeader({
@@ -89,14 +89,14 @@ export function WorkflowActionsHeader({
         <button
           className="btn-ghost canvas-detail-ask"
           data-testid="canvas-detail-ask"
-          aria-label="Ask agent"
-          data-tooltip="Sends the request to the agent in the terminal"
+          aria-label="Ask coding agent"
+          data-tooltip="Ask the coding agent in the terminal"
           onClick={() => onAskAgent(`Walk me through the "${detailStep.label}" step of this agent: what it does, its inputs and outputs, and its transitions.`)}
         >
           <Icon name="MessageSquare" size={13} />
           {/* Hidden by the subheader's container query when the pane is too
               narrow — icon + tooltip + aria-label keep naming the action. */}
-          <span className="canvas-detail-ask-label">Ask agent</span>
+          <span className="canvas-detail-ask-label">Ask coding agent</span>
         </button>
         <div className="canvas-detail-menu-wrap">
           <button
@@ -129,7 +129,7 @@ export function WorkflowActionsHeader({
                 }}
               >
                 <Icon name="Wand2" size={13} />
-                Ask agent to modify
+                Ask coding agent to modify
               </button>
               <button
                 role="menuitem"

--- a/packages/harness/web/src/lib/describe-prompt.test.ts
+++ b/packages/harness/web/src/lib/describe-prompt.test.ts
@@ -26,6 +26,8 @@ describe("describeWorkflowPrompt", () => {
     const leasing = describeWorkflowPrompt(workflow());
     expect(leasing).toContain('"leasing"');
     expect(leasing).toContain("/Users/demo/acme-app/leasing");
+    expect(leasing).toContain("whole agent");
+    expect(leasing.toLowerCase()).not.toContain("workflow");
 
     const rfq = describeWorkflowPrompt(workflow({ name: "rfq", path: "/Users/demo/rfq-workflows" }));
     expect(rfq).toContain('"rfq"');

--- a/packages/harness/web/src/lib/describe-prompt.ts
+++ b/packages/harness/web/src/lib/describe-prompt.ts
@@ -4,7 +4,7 @@ import type { WorkflowInfo } from "@shared/types";
  * The prompt behind the canvas "Describe with AI" action.
  *
  * The canvas descriptions are deterministic Option-A fields: the renderer reads
- * `description` off `defineAgent` / `defineStep` in the workflow source (no LLM
+ * `description` off `defineAgent` / `defineStep` in the agent source (no LLM
  * in the render path). This action hands the bound agent the one job that DOES
  * need a reading of the code — writing those `description` fields — and leaves
  * everything downstream deterministic. The output is durable, editable, and
@@ -18,10 +18,10 @@ import type { WorkflowInfo } from "@shared/types";
  */
 export function describeWorkflowPrompt(workflow: WorkflowInfo): string {
   return [
-    `Add human-readable descriptions to the "${workflow.name}" workflow so its Sapiom canvas explains what each part does.`,
+    `Add human-readable descriptions to the "${workflow.name}" agent so its Sapiom canvas explains what each part does.`,
     ``,
-    `Edit the workflow definition file(s) under ${workflow.path} (the entry is usually index.ts):`,
-    `1. Give the defineAgent({ ... }) call a one-line \`description\` summarizing what the whole workflow does.`,
+    `Edit the agent definition file(s) under ${workflow.path} (the entry is usually index.ts):`,
+    `1. Give the defineAgent({ ... }) call a one-line \`description\` summarizing what the whole agent does.`,
     `2. Give every defineStep({ ... }) a one-line \`description\` of what that step does — infer it from the step's own code: its input, the Sapiom services it calls, and where it transitions.`,
     ``,
     `Rules:`,

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -229,6 +229,8 @@ describe("useTemplatePrompt", () => {
   it("starter: names the real init command with the bundled template flag", () => {
     const prompt = useTemplatePrompt(STARTER_TEMPLATES[1], "/tmp/coding-pause");
     expect(prompt).toContain("sapiom agents init . -t coding-pause");
+    expect(prompt).toContain("adapt the agent");
+    expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 
   it("both paths end with the free local test continuation (use to run is one path)", () => {

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -226,7 +226,7 @@ export function useTemplatePrompt(template: StudioTemplate, dir: string): string
   return (
     `Scaffold the "${template.id}" starter in this directory: ` +
     `run \`sapiom agents init . -t ${template.id}\`, then run npm install and read AGENTS.md. ` +
-    "Use the sapiom-agent-authoring skill to adapt the workflow. " +
+    "Use the sapiom-agent-authoring skill to adapt the agent. " +
     runContinuation
   );
 }


### PR DESCRIPTION
## Summary

- Migrates every coding-agent prompt and resume brief in scope to Agent Studio terminology.
- Changes the public harness context schema to `boundAgent` and `agents` while preserving the deprecated TypeScript alias and compatibility-sensitive internal contracts.
- Adds strict atomic launch/resume preparation covering current, legacy, missing, malformed, mixed, and unreadable context files.
- Corrects coding-session language to “Session span,” identifies self-started turns and rolling-summary consumers as coding-agent activity, and labels step actions “Ask coding agent.”
- Replaces stale Visualize-button and ⌘K lifecycle guidance with the real automatic Canvas selection behavior and Local Run / Prod Run / Deploy action bar.
- Verifies the same corrected shared prompt reaches Claude Code and Codex, including live-host delivery.
- Adds a patch changeset for `@sapiom/harness`.

## Verification

- `pnpm --filter @sapiom/harness exec vitest run src/core/inject/system-prompt.test.ts src/core/resume-brief.test.ts src/core/rolling-summary.test.ts src/core/adapters/claude-code.test.ts src/core/adapters/codex.test.ts` — 95 passed
- `pnpm --filter @sapiom/harness test` — 1,649 unit + 4 performance tests passed
- `pnpm --filter @sapiom/harness e2e:live` — all three phases passed, including Claude Code and Codex prompt delivery
- `pnpm --filter @sapiom/harness typecheck` — passed
- `pnpm --filter @sapiom/harness... build` — passed
- `pnpm --filter @sapiom/harness lint` — zero errors; one pre-existing warning in `rest.test.ts`
- relevant Harness Playwright (`smoke`, `wave5`, `templates`, `canvas-describe-ai`) — 114 passed
- `pnpm changeset status --since=origin/main` — only `@sapiom/harness` patch
- `git diff --check` — passed

Closes SAP-2334