### PR TITLE
Studio feedback: sapiom_send_feedback MCP tool + sendFeedback SDK method (SAP-2286)

### DIFF
--- a/.changeset/sap-2286-studio-feedback.md
+++ b/.changeset/sap-2286-studio-feedback.md
@@ -1,0 +1,20 @@
+---
+"@sapiom/agent-core": minor
+"@sapiom/mcp": minor
+---
+
+Studio feedback: `sendFeedback` SDK function + the `sapiom_send_feedback` MCP tool (SAP-2286).
+
+`@sapiom/agent-core` gains `sendFeedback({ message, context?, clientMeta? }, client)`, which POSTs
+to `/v1/studio-feedback` and returns the stored record's id. Because that route sits at the API host
+root rather than under `/v1/workflows`, `GatewayClient` gains one new public method,
+`postAtHostRoot(path, body?)` — a separate method rather than a special-cased path prefix, so a call
+site always declares which base its path is relative to. Every JSON request now funnels through a
+single private `send()` (`openStream` keeps its own handshake path); as a side effect a `NETWORK`
+error message now names the full URL instead of only the base.
+
+`@sapiom/mcp` registers `sapiom_send_feedback`, which relays a user's feedback along with
+client-side context it gathers itself (package version, platform, arch, node version, environment,
+timestamp) so the model never has to read that off the machine. Internal: `ok`/`fail`/`gatewayClient`
+moved from `tools/agents.ts` to a new `tools/shared.ts`, and `packageVersion()` from `analytics.ts`
+to a new `version.ts`.

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -10,7 +10,7 @@ to use when.
 | Server name | `sapiom` | `sapiom-dev` |
 | Package | — (hosted connector) | [`@sapiom/mcp`](../packages/mcp) (`npx -y @sapiom/mcp`) |
 | Transport | Remote / hosted | stdio (runs on your machine) |
-| Tools | ~30+ capability tools — `sapiom_sandbox_*`, scrape, web search, content generation, storage, … | `sapiom_authenticate`, `sapiom_status`, and `sapiom_dev_agents_{scaffold,check,run_local,link,deploy,run,inspect,signal}` |
+| Tools | ~30+ capability tools — `sapiom_sandbox_*`, scrape, web search, content generation, storage, … | `sapiom_{authenticate,status,logout,send_feedback}`, `sapiom_dev_agents_{scaffold,check,run_local,link,clone,deploy,run,inspect,signal,schedule,…}`, `sapiom_dev_sandbox_*` — full list in the [package README](../packages/mcp#tools) |
 | Cost | Paid — capability calls are gateway-routed and metered (x402) | Unmetered — the surface itself makes no paid capability calls. `run` / `deploy` trigger real cloud runs whose capability calls are metered |
 | Use it to… | **call** a capability directly from an agent or client | **build, test, and operate on** Sapiom (today: author & ship agents that orchestrate capabilities) |
 
@@ -37,6 +37,13 @@ run it locally against stubs (no cost), then link, deploy, run, and inspect it
 in the cloud. The `sapiom_dev_` prefix leaves room for other non-capability
 developer tooling later (e.g. governance, log inspection) without colliding with
 the capability namespace.
+
+A handful of its tools are deliberately *unprefixed* — `sapiom_authenticate`,
+`sapiom_status`, `sapiom_logout`, `sapiom_send_feedback`. Those act on the
+client's relationship with Sapiom (who am I, log me in, here's what I think of
+the product) rather than on anything being built, so the `_dev_` infix would
+misdescribe them. The prefix marks *developer operations*, not *server
+membership*.
 
 It deliberately does **not** expose capability tools. There is no
 `sapiom_dev_scrape` or `sapiom_dev_sandbox_create`. Instead you write a agent

--- a/packages/agent-core/src/__tests__/client.test.ts
+++ b/packages/agent-core/src/__tests__/client.test.ts
@@ -89,14 +89,29 @@ describe('createClient / GatewayClient', () => {
     expect(init.body).toBe(JSON.stringify({ message: 'hi' }));
   });
 
-  it('strips a trailing slash from the host for both bases', async () => {
+  it('strips trailing slashes from the host for both bases', async () => {
     const spy = mockFetch([{ status: 200, body: {} }]);
-    const client = createClient({ host: 'https://example.com/', apiKey: 'sk' });
+    const client = createClient({ host: 'https://example.com//', apiKey: 'sk' });
     await client.postAtHostRoot('/v1/studio-feedback');
     await client.get('/foo');
 
     expect(spy.mock.calls[0][0]).toBe('https://example.com/v1/studio-feedback');
     expect(spy.mock.calls[1][0]).toBe('https://example.com/v1/workflows/foo');
+  });
+
+  it('normalizes the host in linear time, not by backtracking', () => {
+    // The natural `/\/+$/` is quadratic on a host with many interior slashes,
+    // and the host is caller-supplied (a project config or credentials file).
+    // 100k slashes finishes instantly if the scan is linear; the regex form
+    // takes seconds. Guards the fix for the js/polynomial-redos alert.
+    const nasty = `https://example.com/${'/'.repeat(100_000)}x`;
+    const started = Date.now();
+    const client = createClient({ host: nasty, apiKey: 'sk' });
+    expect(Date.now() - started).toBeLessThan(250);
+    // Nothing to strip — the string does not end in a slash.
+    const spy = mockFetch([{ status: 200, body: {} }]);
+    void client.get('/foo');
+    expect(spy.mock.calls[0][0]).toBe(`${nasty}/v1/workflows/foo`);
   });
 
   it('maps postAtHostRoot failures through the same error shaping', async () => {

--- a/packages/agent-core/src/__tests__/client.test.ts
+++ b/packages/agent-core/src/__tests__/client.test.ts
@@ -75,6 +75,38 @@ describe('createClient / GatewayClient', () => {
     const client = createClient({ host: 'https://example.com', apiKey: 'sk' });
     await expect(client.get('/foo')).rejects.toMatchObject({ code: 'NETWORK' });
   });
+
+  it('postAtHostRoot targets the host root, bypassing the /v1/workflows base', async () => {
+    const spy = mockFetch([{ status: 200, body: { id: 'fb_1' } }]);
+    const client = createClient({ host: 'https://example.com', apiKey: 'sk_test' });
+    await client.postAtHostRoot('/v1/studio-feedback', { message: 'hi' });
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.com/v1/studio-feedback');
+    expect(url).not.toContain('/v1/workflows');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['x-api-key']).toBe('sk_test');
+    expect(init.body).toBe(JSON.stringify({ message: 'hi' }));
+  });
+
+  it('strips a trailing slash from the host for both bases', async () => {
+    const spy = mockFetch([{ status: 200, body: {} }]);
+    const client = createClient({ host: 'https://example.com/', apiKey: 'sk' });
+    await client.postAtHostRoot('/v1/studio-feedback');
+    await client.get('/foo');
+
+    expect(spy.mock.calls[0][0]).toBe('https://example.com/v1/studio-feedback');
+    expect(spy.mock.calls[1][0]).toBe('https://example.com/v1/workflows/foo');
+  });
+
+  it('maps postAtHostRoot failures through the same error shaping', async () => {
+    mockFetch([{ status: 401, body: { message: 'Unauthorized' } }]);
+    const client = createClient({ host: 'https://example.com', apiKey: 'bad' });
+    await expect(client.postAtHostRoot('/v1/studio-feedback', {})).rejects.toMatchObject({
+      code: 'HTTP_401',
+      message: 'Unauthorized',
+    });
+  });
 });
 
 // ── run ───────────────────────────────────────────────────────────────────────

--- a/packages/agent-core/src/client.ts
+++ b/packages/agent-core/src/client.ts
@@ -45,10 +45,7 @@ export class GatewayClient {
   private readonly apiKey: string;
 
   constructor(opts: ClientOptions) {
-    // All trailing slashes, not just one: a hand-edited credentials file or a
-    // proxy config ending in `//` would otherwise produce `host//v1/...`, which
-    // many routers treat as a distinct (404ing) path.
-    this.host = (opts.host ?? DEFAULT_WORKFLOWS_HOST).replace(/\/+$/, '');
+    this.host = stripTrailingSlashes(opts.host ?? DEFAULT_WORKFLOWS_HOST);
     this.base = `${this.host}/v1/workflows`;
     this.apiKey = opts.apiKey;
   }
@@ -177,6 +174,21 @@ export class GatewayClient {
  */
 export function createClient(opts: ClientOptions): GatewayClient {
   return new GatewayClient(opts);
+}
+
+/**
+ * Normalize a host by dropping every trailing slash — a hand-edited credentials
+ * file or a proxy config ending in `//` would otherwise produce `host//v1/...`,
+ * which many routers treat as a distinct (404ing) path.
+ *
+ * Deliberately not a regex. The obvious `/\/+$/` backtracks quadratically on a
+ * host with many interior slashes (`a` + `/`.repeat(n) + `b`), and the host is
+ * caller-supplied; this scan is linear and allocates once.
+ */
+function stripTrailingSlashes(host: string): string {
+  let end = host.length;
+  while (end > 0 && host.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
+  return end === host.length ? host : host.slice(0, end);
 }
 
 /** Unreachable-host failure, shaped identically wherever a fetch rejects. */

--- a/packages/agent-core/src/client.ts
+++ b/packages/agent-core/src/client.ts
@@ -7,7 +7,8 @@ import { AgentOperationError } from './errors.js';
 
 /**
  * Production host for the Sapiom backend tenant API.
- * The `/v1/workflows` path is appended internally.
+ * The `/v1/workflows` path is appended internally for every method except
+ * `postAtHostRoot`, which addresses the host root directly.
  */
 export const DEFAULT_WORKFLOWS_HOST = 'https://api.sapiom.ai';
 
@@ -27,31 +28,77 @@ export interface GatewayErrorBody {
  * A minimal, stateless HTTP client for the Sapiom workflows gateway. Construct
  * one per call-site with explicit credentials; pass it into networked core
  * functions rather than relying on environment look-ups.
+ *
+ * Its identity is host + credential. `/v1/workflows` is the base almost every
+ * route shares, not the whole of what this client can address — see
+ * {@link postAtHostRoot}.
  */
 export class GatewayClient {
+  /**
+   * API host root, no trailing slash. The primary field — {@link base} is
+   * derived from it. Kept because a few tenant-API routes are not workflow
+   * resources and sit at the root (see {@link postAtHostRoot}).
+   */
+  private readonly host: string;
+  /** `${host}/v1/workflows` — what get/post/request/openStream paths are relative to. */
   private readonly base: string;
   private readonly apiKey: string;
 
   constructor(opts: ClientOptions) {
-    const host = (opts.host ?? DEFAULT_WORKFLOWS_HOST).replace(/\/$/, '');
-    this.base = `${host}/v1/workflows`;
+    // All trailing slashes, not just one: a hand-edited credentials file or a
+    // proxy config ending in `//` would otherwise produce `host//v1/...`, which
+    // many routers treat as a distinct (404ing) path.
+    this.host = (opts.host ?? DEFAULT_WORKFLOWS_HOST).replace(/\/+$/, '');
+    this.base = `${this.host}/v1/workflows`;
     this.apiKey = opts.apiKey;
   }
 
-  async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+  /** `path` is relative to `/v1/workflows`. */
+  request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+    return this.send<T>(method, `${this.base}${path}`, body);
+  }
+
+  get<T = unknown>(path: string): Promise<T> {
+    return this.request<T>('GET', path);
+  }
+
+  post<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('POST', path, body);
+  }
+
+  /**
+   * POST to a path rooted at the API HOST instead of the `/v1/workflows` base.
+   * `path` must be the full route including its version segment
+   * (e.g. `/v1/studio-feedback`).
+   *
+   * Most of the tenant API lives under `/v1/workflows`, so that prefix is baked
+   * into {@link base}. A few routes are not workflow resources but reach the
+   * same host with the same `x-api-key` — keeping them on this client keeps
+   * them on the one AgentOperationError mapping, rather than a bare `fetch`
+   * that re-implements it. A separate method rather than a special path prefix
+   * on {@link request}: which base a path is relative to must be declared by
+   * the call site, never inferred from how the path is spelled.
+   *
+   * POST-only on purpose — add sibling verbs when a route actually needs one.
+   */
+  postAtHostRoot<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.send<T>('POST', `${this.host}${path}`, body);
+  }
+
+  /**
+   * The single JSON request path — every method above funnels here so the
+   * NETWORK / HTTP_* / 401-hint mapping is defined exactly once.
+   */
+  private async send<T>(method: string, url: string, body?: unknown): Promise<T> {
     let res: Response;
     try {
-      res = await fetch(`${this.base}${path}`, {
+      res = await fetch(url, {
         method,
         headers: { 'x-api-key': this.apiKey, 'content-type': 'application/json' },
         body: body === undefined ? undefined : JSON.stringify(body),
       });
     } catch (err) {
-      throw new AgentOperationError({
-        code: 'NETWORK',
-        message: `Could not reach ${this.base}.`,
-        hint: err instanceof Error ? err.message : String(err),
-      });
+      throw networkError(url, err);
     }
 
     const text = await res.text();
@@ -67,14 +114,6 @@ export class GatewayClient {
       });
     }
     return data as T;
-  }
-
-  get<T = unknown>(path: string): Promise<T> {
-    return this.request<T>('GET', path);
-  }
-
-  post<T = unknown>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', path, body);
   }
 
   /**
@@ -101,15 +140,12 @@ export class GatewayClient {
       headers['last-event-id'] = opts.lastEventId;
     }
 
+    const url = `${this.base}${path}`;
     let res: Response;
     try {
-      res = await fetch(`${this.base}${path}`, { method: 'GET', headers, signal: opts.signal });
+      res = await fetch(url, { method: 'GET', headers, signal: opts.signal });
     } catch (err) {
-      throw new AgentOperationError({
-        code: 'NETWORK',
-        message: `Could not reach ${this.base}.`,
-        hint: err instanceof Error ? err.message : String(err),
-      });
+      throw networkError(url, err);
     }
 
     if (!res.ok) {
@@ -127,7 +163,7 @@ export class GatewayClient {
     if (!res.body) {
       throw new AgentOperationError({
         code: 'NETWORK',
-        message: `Stream at ${this.base}${path} returned no body.`,
+        message: `Stream at ${url} returned no body.`,
       });
     }
     return res;
@@ -141,6 +177,15 @@ export class GatewayClient {
  */
 export function createClient(opts: ClientOptions): GatewayClient {
   return new GatewayClient(opts);
+}
+
+/** Unreachable-host failure, shaped identically wherever a fetch rejects. */
+function networkError(url: string, err: unknown): AgentOperationError {
+  return new AgentOperationError({
+    code: 'NETWORK',
+    message: `Could not reach ${url}.`,
+    hint: err instanceof Error ? err.message : String(err),
+  });
 }
 
 function safeParse(text: string): unknown {

--- a/packages/agent-core/src/feedback.spec.ts
+++ b/packages/agent-core/src/feedback.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * sendFeedback — assert it POSTs to the host-rooted `/v1/studio-feedback`
+ * (never the `/v1/workflows` base), omits absent optionals rather than sending
+ * empties, and tolerates a response body that doesn't carry an id. The
+ * GatewayClient is faked to record calls.
+ */
+import type { GatewayClient } from './client.js';
+import { sendFeedback } from './feedback.js';
+
+interface Call {
+  path: string;
+  body?: unknown;
+}
+
+function fakeClient(response: unknown = { id: 'fb_1' }): {
+  client: GatewayClient;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const client = {
+    postAtHostRoot: async (path: string, body?: unknown) => {
+      calls.push({ path, body });
+      return response;
+    },
+    // Present so a regression that reaches for the workflows-relative helpers
+    // fails loudly rather than silently hitting the wrong base.
+    post: async () => {
+      throw new Error('sendFeedback must not use the /v1/workflows base');
+    },
+  } as unknown as GatewayClient;
+  return { client, calls };
+}
+
+describe('sendFeedback', () => {
+  it('POSTs the host-rooted studio-feedback route', async () => {
+    const { client, calls } = fakeClient();
+    await sendFeedback({ message: 'the deploy button does nothing' }, client);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe('/v1/studio-feedback');
+  });
+
+  it('forwards message, context and clientMeta', async () => {
+    const { client, calls } = fakeClient();
+    await sendFeedback(
+      {
+        message: 'the deploy button does nothing',
+        context: 'after run_local passed',
+        clientMeta: { client: 'sapiom-mcp', platform: 'darwin' },
+      },
+      client,
+    );
+    expect(calls[0].body).toEqual({
+      message: 'the deploy button does nothing',
+      context: 'after run_local passed',
+      clientMeta: { client: 'sapiom-mcp', platform: 'darwin' },
+    });
+  });
+
+  it('omits context and clientMeta when absent', async () => {
+    const { client, calls } = fakeClient();
+    await sendFeedback({ message: 'hi' }, client);
+    expect(calls[0].body).toEqual({ message: 'hi' });
+  });
+
+  it('omits an empty context string and an empty clientMeta object', async () => {
+    const { client, calls } = fakeClient();
+    await sendFeedback({ message: 'hi', context: '', clientMeta: {} }, client);
+    expect(calls[0].body).toEqual({ message: 'hi' });
+  });
+
+  it('treats an explicit null context/clientMeta as absent rather than throwing', async () => {
+    // A JS caller, or anything built from JSON.parse, can hand us null where
+    // the type says undefined. Object.keys(null) throws.
+    const { client, calls } = fakeClient();
+    await sendFeedback(
+      { message: 'hi', context: null, clientMeta: null } as never,
+      client,
+    );
+    expect(calls[0].body).toEqual({ message: 'hi' });
+  });
+
+  it('returns the server-assigned id', async () => {
+    const { client } = fakeClient({ id: 'fb_42' });
+    await expect(sendFeedback({ message: 'hi' }, client)).resolves.toEqual({ id: 'fb_42' });
+  });
+
+  it('tolerates a response with no id rather than throwing', async () => {
+    const { client } = fakeClient({});
+    await expect(sendFeedback({ message: 'hi' }, client)).resolves.toEqual({ id: undefined });
+  });
+
+  it('ignores a non-string id', async () => {
+    const { client } = fakeClient({ id: 42 });
+    await expect(sendFeedback({ message: 'hi' }, client)).resolves.toEqual({ id: undefined });
+  });
+
+  it('tolerates an empty (undefined) response body', async () => {
+    // Built inline rather than via fakeClient(undefined) — that would land on
+    // the default parameter and quietly test the happy path instead.
+    const client = {
+      postAtHostRoot: async () => undefined,
+    } as unknown as GatewayClient;
+    await expect(sendFeedback({ message: 'hi' }, client)).resolves.toEqual({ id: undefined });
+  });
+
+  it('propagates gateway errors untouched', async () => {
+    const client = {
+      postAtHostRoot: async () => {
+        throw Object.assign(new Error('Unauthorized'), { code: 'HTTP_401' });
+      },
+    } as unknown as GatewayClient;
+    await expect(sendFeedback({ message: 'hi' }, client)).rejects.toMatchObject({
+      code: 'HTTP_401',
+    });
+  });
+});

--- a/packages/agent-core/src/feedback.ts
+++ b/packages/agent-core/src/feedback.ts
@@ -1,0 +1,78 @@
+/**
+ * sendFeedback — relay a user's product feedback to the Sapiom team.
+ *
+ * Networked operation: requires a GatewayClient. All inputs passed explicitly.
+ *
+ * The route lives at the API host root rather than under `/v1/workflows` (it is
+ * not a workflow resource), hence `postAtHostRoot` rather than `post`.
+ *
+ * Two deliberate departures from the neighbouring operations:
+ *
+ * - **No analytics wrapper.** `link`/`deploy`/`run` wrap themselves in a
+ *   `workflow.*` track() because they are the activation funnel; `signal`,
+ *   `inspect`, `clone` and the `schedule*` family do not. Feedback is neither,
+ *   and its only caller (the `sapiom_send_feedback` MCP tool) already emits one
+ *   `tool.call` event per invocation carrying the structured error code — so a
+ *   wrapper here would double-count a single user action.
+ * - **A missing `id` is tolerated, not an error.** `run` throws `RUN_NO_ID`
+ *   because an execution you cannot address is useless. Here the id is only a
+ *   reference number and the row already exists by the time we read the body;
+ *   telling a user their feedback failed when it in fact landed is the worse
+ *   outcome.
+ */
+import { GatewayClient } from './client.js';
+
+/** Host-rooted, NOT under the client's `/v1/workflows` base. */
+const FEEDBACK_PATH = '/v1/studio-feedback';
+
+export interface SendFeedbackOptions {
+  /** The user's feedback, verbatim. */
+  message: string;
+  /**
+   * Optional plain-language summary of what the user was doing when the
+   * feedback came up. Prose, not JSON — the backend stores and renders it as
+   * text.
+   */
+  context?: string;
+  /**
+   * Client-collected environment facts (package versions, platform, environment
+   * name, timestamp). Metadata only: never credentials, never a `process.env`
+   * dump, and never tenant identity — the backend resolves the tenant from the
+   * API key.
+   *
+   * Deliberately untyped, mirroring the backend's `clientMeta?: object`. The
+   * shape is owned by the calling client (see `@sapiom/mcp`), so a caller adds
+   * a field without an agent-core release, and the SDK does not invent a
+   * second, stricter contract that the server does not enforce.
+   */
+  clientMeta?: Record<string, unknown>;
+}
+
+export interface SendFeedbackResult {
+  /**
+   * Server-assigned id of the stored feedback record. Optional: the 201 is
+   * authoritative, its body is not guaranteed.
+   */
+  id?: string;
+}
+
+/**
+ * Submit feedback. Throws `AgentOperationError` on gateway errors.
+ */
+export async function sendFeedback(
+  opts: SendFeedbackOptions,
+  client: GatewayClient,
+): Promise<SendFeedbackResult> {
+  // Omit rather than send empty values, so the backend's optionals stay
+  // meaningfully optional. Both guards lead with truthiness rather than
+  // `!== undefined`: a JS caller (or anything built from `JSON.parse`) can hand
+  // us an explicit `null`, and `Object.keys(null)` throws.
+  const res = await client.postAtHostRoot<{ id?: unknown }>(FEEDBACK_PATH, {
+    message: opts.message,
+    ...(opts.context ? { context: opts.context } : {}),
+    ...(opts.clientMeta && Object.keys(opts.clientMeta).length > 0
+      ? { clientMeta: opts.clientMeta }
+      : {}),
+  });
+  return { id: typeof res?.id === 'string' ? res.id : undefined };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -125,6 +125,10 @@ export type { WatchExecutionOptions } from "./watch.js";
 export { signal, parseSignalPayload } from "./signal.js";
 export type { SignalOptions, SignalResult } from "./signal.js";
 
+// feedback (networked) — relay a user's product feedback to the Sapiom team
+export { sendFeedback } from "./feedback.js";
+export type { SendFeedbackOptions, SendFeedbackResult } from "./feedback.js";
+
 // schedules / triggers (networked)
 export { createSchedule, listSchedules, getSchedule, cancelSchedule, previewCron } from "./schedule.js";
 export type {

--- a/packages/harness/src/core/inject/mcp-config.test.ts
+++ b/packages/harness/src/core/inject/mcp-config.test.ts
@@ -54,6 +54,28 @@ describe("generateMcpConfig", () => {
     expect(config.mcpServers["sapiom-dev"].env).toEqual({ SAPIOM_ENVIRONMENT: "staging" });
   });
 
+  it("advertises the harness version so feedback records can name the build", async () => {
+    const filePath = await generateMcpConfig("session-457", { harnessVersion: "0.2.5" });
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers["sapiom-dev"].env).toEqual({
+      SAPIOM_HARNESS_VERSION: "0.2.5",
+    });
+  });
+
+  it("carries environment and harness version together", async () => {
+    const filePath = await generateMcpConfig("session-458", {
+      environment: "staging",
+      harnessVersion: "0.2.5",
+    });
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers["sapiom-dev"].env).toEqual({
+      SAPIOM_ENVIRONMENT: "staging",
+      SAPIOM_HARNESS_VERSION: "0.2.5",
+    });
+  });
+
   it("isolates sessions into separate directories", async () => {
     const a = await generateMcpConfig("session-a");
     const b = await generateMcpConfig("session-b");

--- a/packages/harness/src/core/inject/mcp-config.ts
+++ b/packages/harness/src/core/inject/mcp-config.ts
@@ -19,6 +19,15 @@ export interface McpConfigOptions {
   /** Root directory generated configs live under. Defaults to
    *  HARNESS_PATHS.generated. Override in tests to avoid the real home dir. */
   generatedRoot?: string;
+  /**
+   * This harness's own version, advertised to the sapiom-dev child as
+   * `SAPIOM_HARNESS_VERSION`. The MCP is `npx`'d from the registry and so has
+   * no way to know which Studio launched it; `sapiom_send_feedback` stamps this
+   * into every feedback record, which is what makes "which build is this user
+   * on" answerable during triage. Omitted when absent — the tool leaves the
+   * field out rather than inventing an "unknown".
+   */
+  harnessVersion?: string;
 }
 
 /**
@@ -36,9 +45,14 @@ export async function generateMcpConfig(
   await fs.mkdir(dir, { recursive: true });
 
   const sapiomEnvironment = options.environment ?? process.env.SAPIOM_ENVIRONMENT;
-  const devEnv: Record<string, string> | undefined = sapiomEnvironment
-    ? { SAPIOM_ENVIRONMENT: sapiomEnvironment }
-    : undefined;
+  const devEnvEntries: Record<string, string> = {
+    ...(sapiomEnvironment ? { SAPIOM_ENVIRONMENT: sapiomEnvironment } : {}),
+    ...(options.harnessVersion
+      ? { SAPIOM_HARNESS_VERSION: options.harnessVersion }
+      : {}),
+  };
+  const devEnv: Record<string, string> | undefined =
+    Object.keys(devEnvEntries).length > 0 ? devEnvEntries : undefined;
 
   const config = {
     mcpServers: {

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -20,6 +20,12 @@ active for the whole session. Follow them.
   session. Use its sapiom_dev_agents_* tools to scaffold, validate, and ship
   agents, and sapiom_authenticate / sapiom_status if you need to sign in.
 
+**When something about Sapiom is wrong, send it upstream.** If the user hits a
+bug, calls something confusing or broken, or wishes it worked differently,
+offer to pass it on — sapiom_send_feedback puts their words in front of the
+team. Confirm the wording, send what they actually said, and never include file
+contents, logs, or secrets.
+
 **The authoring loop, in order:** scaffold a new agent project → check
 (bundle + manifest + step-graph validation, offline) → run_local (your real
 step code against stub capabilities, no cost) → link (associate the project

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -340,6 +340,7 @@ function createDefaultBuildLaunchOpts(
           environment: process.env.SAPIOM_ENVIRONMENT,
           apiKey,
           generatedRoot,
+          harnessVersion: readVersion(),
         }),
         generateSystemPromptFile(harnessSessionId, {
           generatedRoot,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -76,6 +76,7 @@ authentication — they run entirely offline.
 | `sapiom_authenticate` | browser | Log in and cache an API key for the current environment |
 | `sapiom_status` | — | Report authentication status |
 | `sapiom_logout` | — | Clear cached credentials |
+| `sapiom_send_feedback` | ✓ | Relay the user's product feedback to the Sapiom team |
 | `sapiom_dev_agents_scaffold` | — | Create a new orchestration project |
 | `sapiom_dev_agents_check` | — | Bundle + validate the step graph offline |
 | `sapiom_dev_agents_run_local` | — | Run the workflow locally, resolving capability calls from stubs (no cost) |
@@ -102,6 +103,19 @@ from stubs; a real `run`/`deploy` executes them in the cloud (metered). This MCP
 never grows a per-capability tool of its own — capabilities live in
 `@sapiom/tools` and the remote `sapiom` MCP. See
 [the positioning doc](../../docs/mcp-servers.md) for the full policy.
+
+## Sending feedback
+
+`sapiom_send_feedback` relays a user's product feedback (a bug, a rough edge, a
+feature request) to the Sapiom team. The agent sends only what the user said;
+the server attaches package version, platform, arch, node version, environment
+and a timestamp itself, so the model never has to read those off the machine.
+
+A host embedding this server can advertise its own version with
+**`SAPIOM_HARNESS_VERSION`** — it rides along as `clientMeta.harnessVersion`,
+which is what makes "which build is this user on" answerable during triage. The
+field is omitted entirely when the variable is unset, never filled with a
+placeholder. `@sapiom/harness` sets it automatically.
 
 ## Usage analytics
 

--- a/packages/mcp/src/analytics.e2e.test.ts
+++ b/packages/mcp/src/analytics.e2e.test.ts
@@ -47,6 +47,7 @@ const ALL_TOOL_NAMES = [
   "sapiom_dev_sandbox_configure",
   "sapiom_dev_sandbox_preview",
   "sapiom_logout",
+  "sapiom_send_feedback",
   "sapiom_status",
 ];
 

--- a/packages/mcp/src/analytics.ts
+++ b/packages/mcp/src/analytics.ts
@@ -13,23 +13,9 @@
  * complete no-op (zero network calls, zero disk writes). `track()` is a
  * synchronous enqueue that never throws and never blocks a tool call.
  */
-import { createRequire } from "node:module";
-
 import { createAnalytics, type SapiomAnalytics } from "@sapiom/analytics-core";
 
-const nodeRequire = createRequire(import.meta.url);
-
-/** This package's own version, for the envelope's `sdk_version` field. */
-function packageVersion(): string {
-  try {
-    const pkg = nodeRequire("../package.json") as { version?: unknown };
-    return typeof pkg.version === "string" && pkg.version.length > 0
-      ? pkg.version
-      : "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
-}
+import { packageVersion } from "./version.js";
 
 let instance: SapiomAnalytics | null = null;
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,7 @@ import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerAgents } from "./tools/agents.js";
 import { register as registerSandbox } from "./tools/sandbox.js";
+import { register as registerFeedback } from "./tools/feedback.js";
 import { fetchInstructions } from "./instructions-fetch.js";
 
 async function main(): Promise<void> {
@@ -57,6 +58,7 @@ async function main(): Promise<void> {
   registerStatus(server, env);
   registerAgents(server, env);
   registerSandbox(server, env);
+  registerFeedback(server, env);
 
   // Connect via stdio transport
   const transport = new StdioServerTransport();

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -17,10 +17,8 @@ import {
   cancelSchedule,
   check,
   clone,
-  createClient,
   createSchedule,
   deploy,
-  GatewayClient,
   getSchedule,
   inspect,
   inspectBuild,
@@ -42,76 +40,9 @@ import {
   type SchedulePolicy,
   type StubFile,
 } from "@sapiom/agent-core";
-import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
+import { type ResolvedEnvironment } from "../credentials.js";
 import { registerTool } from "../register-tool.js";
-
-type ToolResult = {
-  content: Array<{ type: "text"; text: string }>;
-  isError?: boolean;
-};
-
-function ok(data: unknown): ToolResult {
-  let text: string;
-  try {
-    text = JSON.stringify(data, null, 2);
-  } catch (err) {
-    // A value in the result resisted serialization. Don't drop the whole
-    // payload (e.g. a run_local trace) on the floor — emit a sanitized version
-    // that keeps everything serializable and marks the node that failed, so the
-    // result stays actionable instead of surfacing as an opaque crash.
-    text = JSON.stringify(
-      {
-        _serializationError: err instanceof Error ? err.message : String(err),
-        data: sanitize(data),
-      },
-      null,
-      2,
-    );
-  }
-  return { content: [{ type: "text" as const, text }] };
-}
-
-/** Best-effort deep copy that replaces any node which throws on access or
- *  serialization with a marker, so a single bad value can't sink the response. */
-function sanitize(value: unknown, seen = new WeakSet<object>()): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (seen.has(value)) return "[Circular]";
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) return value.map((v) => sanitize(v, seen));
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>)) {
-      try {
-        out[key] = sanitize((value as Record<string, unknown>)[key], seen);
-      } catch (err) {
-        out[key] =
-          `[unserializable: ${err instanceof Error ? err.message : String(err)}]`;
-      }
-    }
-    return out;
-  } catch (err) {
-    return `[unserializable: ${err instanceof Error ? err.message : String(err)}]`;
-  }
-}
-
-function fail(err: unknown): ToolResult {
-  const structured =
-    err instanceof AgentOperationError
-      ? err.toStructured()
-      : {
-          code: "UNEXPECTED",
-          message: err instanceof Error ? err.message : String(err),
-        };
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({ error: structured }, null, 2),
-      },
-    ],
-    isError: true,
-  };
-}
+import { fail, gatewayClient, NOT_AUTHED, ok } from "./shared.js";
 
 /**
  * Coerce a tool argument that may arrive as a JSON string (some MCP clients
@@ -138,22 +69,6 @@ function coreTemplatesDir(): string {
   const entry = nodeRequire.resolve("@sapiom/agent-core");
   return path.resolve(path.dirname(entry), "..", "..", "templates");
 }
-
-async function gatewayClient(
-  env: ResolvedEnvironment,
-): Promise<GatewayClient | null> {
-  const creds = await readCredentials(env.name);
-  if (!creds) return null;
-  return createClient({ apiKey: creds.apiKey, host: env.apiURL });
-}
-
-const NOT_AUTHED = fail(
-  new AgentOperationError({
-    code: "NOT_AUTHENTICATED",
-    message: "Not authenticated.",
-    hint: "Use the sapiom_authenticate tool first.",
-  }),
-);
 
 /**
  * Agent-facing one-liner about a schedule's health: surfaces recent fire failures (with the

--- a/packages/mcp/src/tools/feedback.test.ts
+++ b/packages/mcp/src/tools/feedback.test.ts
@@ -1,0 +1,270 @@
+/**
+ * sapiom_send_feedback — the tool's contract with the agent calling it.
+ *
+ * Two of these assertions are acceptance criteria rather than regressions, and
+ * are asserted rather than eyeballed: the description and field descriptions
+ * must forbid code and secrets, and `clientMeta` must carry only the allowlist
+ * (no paths, no repo identity, no user content).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ResolvedEnvironment } from "../credentials.js";
+
+vi.mock("../credentials.js", () => ({
+  readCredentials: vi.fn(),
+}));
+
+// Keep the real module — `AgentOperationError` must stay a real class so
+// `fail()` produces the structured envelope — but stub the networked call.
+vi.mock("@sapiom/agent-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sapiom/agent-core")>();
+  return { ...actual, sendFeedback: vi.fn(), createClient: vi.fn(() => ({})) };
+});
+
+vi.mock("../version.js", () => ({ packageVersion: () => "9.9.9" }));
+
+import { register } from "./feedback.js";
+import { readCredentials } from "../credentials.js";
+import { AgentOperationError, createClient, sendFeedback } from "@sapiom/agent-core";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+interface Registration {
+  name: string;
+  description: string;
+  schema: Record<string, z.ZodTypeAny>;
+  handler: ToolHandler;
+}
+
+function createMockServer(): {
+  server: McpServer;
+  registrations: Map<string, Registration>;
+} {
+  const registrations = new Map<string, Registration>();
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        description: string,
+        schema: Record<string, z.ZodTypeAny>,
+        handler: ToolHandler,
+      ) => {
+        registrations.set(name, { name, description, schema, handler });
+      },
+    ),
+  } as unknown as McpServer;
+  return { server, registrations };
+}
+
+const TOOL = "sapiom_send_feedback";
+
+const env: ResolvedEnvironment = {
+  name: "production",
+  appURL: "https://app.sapiom.ai",
+  apiURL: "https://api.sapiom.ai",
+  services: {},
+  credentials: null,
+};
+
+const parse = (res: { content: Array<{ text: string }> }) =>
+  JSON.parse(res.content[0].text);
+
+function setup(overrides: Partial<ResolvedEnvironment> = {}): Registration {
+  const { server, registrations } = createMockServer();
+  register(server, { ...env, ...overrides });
+  return registrations.get(TOOL)!;
+}
+
+/** The clientMeta the handler built on the last sendFeedback call. */
+function lastMeta(): Record<string, unknown> {
+  const [opts] = vi.mocked(sendFeedback).mock.calls[0];
+  return opts.clientMeta as Record<string, unknown>;
+}
+
+describe("sapiom_send_feedback tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-03T10:00:00.000Z"));
+    vi.mocked(readCredentials).mockResolvedValue({
+      apiKey: "sk_test",
+      tenantId: "t-1",
+      organizationName: "Org",
+      apiKeyId: "k-1",
+    } as never);
+    vi.mocked(sendFeedback).mockResolvedValue({ id: "fb_1" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("registers under the documented name", () => {
+    expect(setup().name).toBe(TOOL);
+  });
+
+  it("tells the agent when to reach for it and forbids code and secrets", () => {
+    const { description } = setup();
+    expect(description).toMatch(/feedback/i);
+    expect(description).toMatch(/never/i);
+    expect(description).toMatch(/secret/i);
+    expect(description).toMatch(/code/i);
+    // The clause that stops the model going to read version/OS off the machine.
+    expect(description).toMatch(/attached automatically/i);
+  });
+
+  it("repeats the prohibition on the context field itself", () => {
+    const { schema } = setup();
+    expect(schema.context.description).toMatch(/never include/i);
+    expect(schema.message.description).toMatch(/no code, logs, stack traces, or secrets/i);
+  });
+
+  it("requires a non-empty message and an optional string context", () => {
+    const shape = z.object(setup().schema);
+    expect(shape.safeParse({ message: "it broke" }).success).toBe(true);
+    expect(shape.safeParse({ message: "it broke", context: "deploying" }).success).toBe(true);
+    expect(shape.safeParse({ message: "" }).success).toBe(false);
+    expect(shape.safeParse({}).success).toBe(false);
+    expect(shape.safeParse({ message: "it broke", context: 1 }).success).toBe(false);
+  });
+
+  it("rejects a whitespace-only message and trims the rest", () => {
+    const shape = z.object(setup().schema);
+    expect(shape.safeParse({ message: "   " }).success).toBe(false);
+    expect(shape.safeParse({ message: "\n\t " }).success).toBe(false);
+    const parsed = shape.safeParse({ message: "  it broke  " });
+    expect(parsed.success && parsed.data.message).toBe("it broke");
+  });
+
+  it("builds a client from the cached credential and the environment host", async () => {
+    await setup().handler({ message: "it broke" });
+    expect(createClient).toHaveBeenCalledWith({
+      apiKey: "sk_test",
+      host: "https://api.sapiom.ai",
+    });
+  });
+
+  it("forwards the message and context the agent supplied", async () => {
+    await setup().handler({ message: "it broke", context: "deploying an agent" });
+    expect(vi.mocked(sendFeedback).mock.calls[0][0]).toMatchObject({
+      message: "it broke",
+      context: "deploying an agent",
+    });
+  });
+
+  it("sends exactly message, context and clientMeta — nothing else", async () => {
+    await setup().handler({ message: "it broke", context: "deploying" });
+    expect(Object.keys(vi.mocked(sendFeedback).mock.calls[0][0]).sort()).toEqual([
+      "clientMeta",
+      "context",
+      "message",
+    ]);
+  });
+
+  it("leaves context undefined rather than sending an empty string", async () => {
+    await setup().handler({ message: "it broke" });
+    expect(vi.mocked(sendFeedback).mock.calls[0][0].context).toBeUndefined();
+  });
+
+  it("attaches exactly the client-meta allowlist", async () => {
+    await setup().handler({ message: "it broke" });
+    expect(lastMeta()).toEqual({
+      client: "sapiom-mcp",
+      clientVersion: "9.9.9",
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      environment: "production",
+      sentAt: "2026-08-03T10:00:00.000Z",
+    });
+  });
+
+  it("omits harnessVersion entirely when no harness advertises one", async () => {
+    await setup().handler({ message: "it broke" });
+    expect("harnessVersion" in lastMeta()).toBe(false);
+  });
+
+  it("includes harnessVersion when a harness advertises one", async () => {
+    vi.stubEnv("SAPIOM_HARNESS_VERSION", "0.2.5");
+    await setup().handler({ message: "it broke" });
+    expect(lastMeta().harnessVersion).toBe("0.2.5");
+  });
+
+  it("reports the resolved environment name verbatim", async () => {
+    const reg = setup({ name: "local", apiURL: "http://localhost:3000" });
+    await reg.handler({ message: "it broke" });
+    expect(lastMeta().environment).toBe("local");
+    expect(createClient).toHaveBeenCalledWith({
+      apiKey: "sk_test",
+      host: "http://localhost:3000",
+    });
+  });
+
+  it("confirms in prose, quoting the reference id", async () => {
+    const res = await setup().handler({ message: "it broke" });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("Sapiom team");
+    expect(res.content[0].text).toContain("fb_1");
+  });
+
+  it("still confirms when the response carries no id", async () => {
+    vi.mocked(sendFeedback).mockResolvedValue({});
+    const res = await setup().handler({ message: "it broke" });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("Sapiom team");
+    expect(res.content[0].text).not.toContain("undefined");
+  });
+
+  it("routes an unauthenticated caller to sapiom_authenticate without calling out", async () => {
+    vi.mocked(readCredentials).mockResolvedValue(null);
+    const res = await setup().handler({ message: "it broke" });
+    expect(res.isError).toBe(true);
+    const { error } = parse(res);
+    expect(error.code).toBe("NOT_AUTHENTICATED");
+    expect(error.hint).toContain("sapiom_authenticate");
+    expect(sendFeedback).not.toHaveBeenCalled();
+  });
+
+  it("relays a gateway error with its structured code and hint", async () => {
+    vi.mocked(sendFeedback).mockRejectedValue(
+      new AgentOperationError({
+        code: "HTTP_401",
+        message: "Unauthorized",
+        hint: "Check your API key.",
+      }),
+    );
+    const res = await setup().handler({ message: "it broke" });
+    expect(res.isError).toBe(true);
+    const { error } = parse(res);
+    expect(error.code).toBe("HTTP_401");
+    expect(error.hint).toBe("Check your API key.");
+  });
+
+  it("classifies an unexpected throw rather than crashing the server", async () => {
+    vi.mocked(sendFeedback).mockRejectedValue(new Error("boom"));
+    const res = await setup().handler({ message: "it broke" });
+    expect(res.isError).toBe(true);
+    const { error } = parse(res);
+    expect(error.code).toBe("UNEXPECTED");
+    expect(error.message).toBe("boom");
+  });
+
+  it("never echoes the API key, on either path", async () => {
+    const okRes = await setup().handler({ message: "it broke" });
+    expect(okRes.content[0].text).not.toContain("sk_test");
+
+    // The thrown message deliberately does NOT contain the key: `fail()` relays
+    // an error message verbatim, so seeding one with the key would make this
+    // assertion pass for the wrong reason. What is under test is that the tool
+    // does not add the credential it holds.
+    vi.mocked(sendFeedback).mockRejectedValue(new Error("upstream refused"));
+    const errRes = await setup().handler({ message: "it broke" });
+    expect(errRes.isError).toBe(true);
+    expect(errRes.content[0].text).not.toContain("sk_test");
+  });
+});

--- a/packages/mcp/src/tools/feedback.ts
+++ b/packages/mcp/src/tools/feedback.ts
@@ -1,0 +1,132 @@
+/**
+ * sapiom_send_feedback — relay a user's product feedback to the Sapiom team.
+ *
+ * The agent supplies only what a human said: the feedback itself, plus an
+ * optional plain-language note about what they were doing. Everything else —
+ * package version, platform, environment, clock — is gathered here, so the
+ * model never has to guess it and, more importantly, has no reason to go read
+ * it off the machine.
+ *
+ * Success returns prose: a receipt is a message for a human, not a payload to
+ * parse, and `registerTool` does not inspect a non-error result. Failure
+ * returns the shared structured envelope, which is the only shape
+ * `classifyErrorResult` can turn into a real `error_class`.
+ *
+ * Note on reach: `registerTool` records tool arguments in full on the
+ * `tool.call` analytics event, so `message` and `context` land in the analytics
+ * pipeline as well as the feedback table. Both are Sapiom-owned, and the field
+ * descriptions below are what keep code and secrets out of either one.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { sendFeedback } from "@sapiom/agent-core";
+
+import { type ResolvedEnvironment } from "../credentials.js";
+import { registerTool } from "../register-tool.js";
+import { packageVersion } from "../version.js";
+import { fail, gatewayClient, NOT_AUTHED } from "./shared.js";
+
+const DESCRIPTION =
+  "Send the user's feedback about Sapiom — a bug, a rough edge, a feature request, or praise — " +
+  "to the Sapiom team. Reach for this when the user says something like \"this is broken\", " +
+  "\"tell Sapiom\", \"file feedback\", or \"this should work differently\": confirm the wording " +
+  "with them, then send their words as `message`. NEVER put file contents, code snippets, logs, " +
+  "stack traces, environment variables, API keys, or any other secret in `message` or `context` — " +
+  "both fields are plain prose only. Package version, platform, environment, and timestamp are " +
+  "attached automatically; do not restate them.";
+
+/**
+ * Client-side auto-context. An allowlist of build/runtime facts, deliberately
+ * narrow: no filesystem paths, no repo identity, no user content, and no tenant
+ * identity (the backend resolves that from the API key).
+ *
+ * A `type` alias rather than an `interface` on purpose — an interface has no
+ * implicit index signature and so is not assignable to the SDK's
+ * `Record<string, unknown>`.
+ */
+type FeedbackClientMeta = {
+  client: string;
+  clientVersion: string;
+  harnessVersion?: string;
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  environment: string;
+  sentAt: string;
+};
+
+function clientMeta(env: ResolvedEnvironment): FeedbackClientMeta {
+  // Nothing sets this today — the harness passes only SAPIOM_ENVIRONMENT to the
+  // sapiom-dev child. Read it anyway so a future harness can advertise itself
+  // without an MCP release, and omit the key when absent: a fabricated
+  // "unknown" would poison every aggregation over this field.
+  const harnessVersion = process.env.SAPIOM_HARNESS_VERSION;
+  return {
+    client: "sapiom-mcp",
+    clientVersion: packageVersion(),
+    ...(harnessVersion ? { harnessVersion } : {}),
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+    // Verbatim, not remapped to prod/local: resolveEnvironment has already
+    // collapsed the aliases, and the value may be an arbitrary custom name from
+    // ~/.sapiom/credentials.json.
+    environment: env.name,
+    // The client's clock, hence the name — the backend keeps its own createdAt.
+    sentAt: new Date().toISOString(),
+  };
+}
+
+export function register(server: McpServer, env: ResolvedEnvironment): void {
+  registerTool(
+    server,
+    "sapiom_send_feedback",
+    DESCRIPTION,
+    {
+      message: z
+        .string()
+        // Trim before the length check: `min(1)` alone accepts "   ", and a
+        // whitespace-only row would land in the team's Slack inbox as a blank
+        // message. This is the only layer that knows the field is prose.
+        .trim()
+        .min(1)
+        .describe(
+          "The user's feedback in their own words: what's wrong, what they expected, or what " +
+            "they want. Plain language only — no code, logs, stack traces, or secrets.",
+        ),
+      context: z
+        .string()
+        .optional()
+        .describe(
+          "Optional one- or two-sentence plain-language summary of what the user was doing when " +
+            'the feedback came up (e.g. "deploying an agent after run_local passed"). Never ' +
+            "include file contents, code snippets, logs, stack traces, environment variables, " +
+            "API keys, or tokens.",
+        ),
+    },
+    async ({ message, context }) => {
+      const client = await gatewayClient(env);
+      if (!client) return NOT_AUTHED;
+      try {
+        const { id } = await sendFeedback(
+          { message, context, clientMeta: clientMeta(env) },
+          client,
+        );
+        return {
+          content: [
+            {
+              type: "text" as const,
+              // `id` is optional — a 201 with an empty body must not render
+              // "reference undefined" at a user.
+              text: id
+                ? `Thanks — your feedback was sent to the Sapiom team (reference ${id}).`
+                : "Thanks — your feedback was sent to the Sapiom team.",
+            },
+          ],
+        };
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -1,0 +1,122 @@
+/**
+ * The preamble every networked tool module shares: build a client from the
+ * cached credential, bail with a consistent not-authenticated result, and shape
+ * success/failure into a CallToolResult.
+ *
+ * Extracted from `agents.ts` when a second module (`feedback.ts`) needed the
+ * same three lines. It lives in its own module rather than being exported from
+ * `agents.ts` so that a tool module never has to import another tool module —
+ * that edge would be a cycle waiting to happen, and `agents.ts` is not a
+ * utility.
+ *
+ * `sandbox.ts` still has its own near-twins, and they are NOT equivalent: its
+ * `fail` keys off `PreviewOperationError` rather than `AgentOperationError`,
+ * and its `ok` predates the serialization fallback below, so a value that
+ * `JSON.stringify` chokes on throws there and degrades gracefully here.
+ * Converging them means widening `fail`'s guard (both error classes expose an
+ * identical `toStructured()`), which is a behavioral change to the sandbox
+ * tools and belongs in its own change rather than riding along with this one.
+ */
+import {
+  AgentOperationError,
+  createClient,
+  GatewayClient,
+} from "@sapiom/agent-core";
+
+import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
+
+export type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+export function ok(data: unknown): ToolResult {
+  let text: string;
+  try {
+    text = JSON.stringify(data, null, 2);
+  } catch (err) {
+    // A value in the result resisted serialization. Don't drop the whole
+    // payload (e.g. a run_local trace) on the floor — emit a sanitized version
+    // that keeps everything serializable and marks the node that failed, so the
+    // result stays actionable instead of surfacing as an opaque crash.
+    text = JSON.stringify(
+      {
+        _serializationError: err instanceof Error ? err.message : String(err),
+        data: sanitize(data),
+      },
+      null,
+      2,
+    );
+  }
+  return { content: [{ type: "text" as const, text }] };
+}
+
+/** Best-effort deep copy that replaces any node which throws on access or
+ *  serialization with a marker, so a single bad value can't sink the response. */
+function sanitize(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) return value.map((v) => sanitize(v, seen));
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      try {
+        out[key] = sanitize((value as Record<string, unknown>)[key], seen);
+      } catch (err) {
+        out[key] =
+          `[unserializable: ${err instanceof Error ? err.message : String(err)}]`;
+      }
+    }
+    return out;
+  } catch (err) {
+    return `[unserializable: ${err instanceof Error ? err.message : String(err)}]`;
+  }
+}
+
+/**
+ * Shape a thrown value as the structured `{"error": {code, message, hint?}}`
+ * envelope. The JSON matters beyond readability: `registerTool` parses
+ * `error.code` out of it to classify the `tool.call` analytics event, so a
+ * plain-prose error degrades every failure to the `"tool_error"` bucket.
+ */
+export function fail(err: unknown): ToolResult {
+  const structured =
+    err instanceof AgentOperationError
+      ? err.toStructured()
+      : {
+          code: "UNEXPECTED",
+          message: err instanceof Error ? err.message : String(err),
+        };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ error: structured }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * A client for the resolved environment, or `null` when no credential is
+ * cached. Re-reads the credentials file on every call rather than using the
+ * startup snapshot in `env.credentials`, so a mid-session `sapiom_authenticate`
+ * takes effect immediately.
+ */
+export async function gatewayClient(
+  env: ResolvedEnvironment,
+): Promise<GatewayClient | null> {
+  const creds = await readCredentials(env.name);
+  if (!creds) return null;
+  return createClient({ apiKey: creds.apiKey, host: env.apiURL });
+}
+
+export const NOT_AUTHED = fail(
+  new AgentOperationError({
+    code: "NOT_AUTHENTICATED",
+    message: "Not authenticated.",
+    hint: "Use the sapiom_authenticate tool first.",
+  }),
+);

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,0 +1,29 @@
+/**
+ * This package's own version, read from its `package.json` at runtime.
+ *
+ * Read with `createRequire` rather than a static JSON import because
+ * `tsconfig.json` sets `rootDir: "./src"` — importing a file outside that root
+ * breaks the build even though `resolveJsonModule` is on. The relative path is
+ * resolved from the compiled `dist/version.js`, so `../package.json` is the
+ * package root either way.
+ *
+ * Its own module rather than a private helper of `analytics.ts`: the version is
+ * not a telemetry concern (the feedback tool stamps it into `clientMeta`), and
+ * a non-telemetry consumer importing the analytics module to get it would be a
+ * puzzle for the next reader.
+ */
+import { createRequire } from "node:module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/** The `version` field of `@sapiom/mcp`'s package.json, or `"0.0.0"`. */
+export function packageVersion(): string {
+  try {
+    const pkg = nodeRequire("../package.json") as { version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0
+      ? pkg.version
+      : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}


### PR DESCRIPTION
The sapiom-js half of SAP-2286 (T2). The backend route (SAP-2287) and the Slack channel + secrets (SAP-2288) ship separately.

Interface contract this consumes, fixed by SAP-2287:

```
POST /v1/studio-feedback     header: x-api-key
body:     { message: string; context?: string; clientMeta?: object }
response: 201 { id: string }
```

## What's here

**`@sapiom/agent-core`** — `sendFeedback({ message, context?, clientMeta? }, client)`.

That route sits at the API **host root**, not under `/v1/workflows`, which `GatewayClient` bakes into its base at construction — so it was unreachable with today's client. Rather than a bare `fetch` that would fork the `NETWORK` / `HTTP_*` / 401-hint mapping `client.ts` owns, the class gains one new public method: `postAtHostRoot(path, body?)`. A separate method rather than a special-cased path prefix on `request()`, so which base a path is relative to is always declared by the call site, never inferred from how the path is spelled. Every JSON request now funnels through a single private `send()`; `openStream` keeps its own handshake path.

**`@sapiom/mcp`** — `sapiom_send_feedback`, registered through the `registerTool` analytics seam.

The agent sends only what the user said. Package version, platform, arch, node version, environment and timestamp are gathered by the tool, so the model never has to read them off the machine — and has no reason to go looking. Success returns prose (a receipt is a message for a human, and `resultOutcome` doesn't inspect non-error results); failure returns the structured `{"error":{code}}` envelope, which is the only shape `classifyErrorResult` can turn into a real `error_class` rather than the `tool_error` bucket.

**`@sapiom/harness`** — two changes needed for the feature to work in the product it was built for:
- Advertises its version as `SAPIOM_HARNESS_VERSION`, so a feedback record can name the build it came from. Without it every Studio row is indistinguishable from a bare CLI user's.
- `DEFAULT_SYSTEM_PROMPT` now mentions the tool. It **enumerates** the sapiom-dev surface, so a tool missing from that list is effectively invisible to the session — which is the one thing this ticket is for.

**Internal** — `ok`/`fail`/`gatewayClient` move from `tools/agents.ts` to `tools/shared.ts` rather than being copied a third time; `packageVersion()` moves from `analytics.ts` to `version.ts` so a non-telemetry consumer needn't import the telemetry module.

## ⚠️ Merge this, but hold the release

`mcp-config.ts` pins `npx -y @sapiom/mcp@latest`, so whatever we publish is what every Studio session resolves. Releasing before SAP-2287 is on prod gives users a registered tool that returns `HTTP_404`.

Changesets already separates these: the changeset rides in this PR; the release happens when the `chore: version packages` PR merges. **Hold that one until SAP-2287 is deployed.**

## Verification

Beyond the suites, I drove the tool over a real stdio server against a stub of the T1 contract — 28/28 checks: host-rooted URL, `x-api-key`, body shape, `clientMeta` allowlist, prose confirmation, `HTTP_403` relay, unauthenticated gate. Plus 5/5 more covering `harnessVersion` and whitespace handling.

| | |
| --- | --- |
| `@sapiom/agent-core` | 146/146 |
| `@sapiom/mcp` | 91/91 (incl. the over-the-wire `ALL_TOOL_NAMES` guard) |
| `@sapiom/harness` | 1644/1644 |
| build / typecheck / lint | clean |

## Decisions worth a reviewer's attention

- **Tool name is `sapiom_send_feedback`, not `sapiom_dev_send_feedback`.** It sits with `sapiom_authenticate` / `_status` / `_logout` — tools about the client's relationship with Sapiom — rather than the `sapiom_dev_*` authoring namespace. `docs/mcp-servers.md` now documents that the prefix marks *developer operations*, not *server membership*.
- **A missing `id` in the 201 body is tolerated, not an error**, diverging from `run.ts`'s `RUN_NO_ID`. For `run`, an unaddressable execution is useless; here the id is a reference number and the row already exists. Telling a user their feedback failed when it landed is the worse outcome.
- **No analytics wrapper on `sendFeedback`.** `registerTool` already emits one `tool.call` per invocation with the structured error code; wrapping would double-count one user action, and the `workflow.*` taxonomy is the activation funnel, which this isn't.
- **`message` and `context` reach the analytics collector too**, since `registerTool` captures args in full. Both are Sapiom-owned; noted at the call site.
- **`message` has `min(1)` but no `.max()`** — the ticket specified `min(1)`, so I didn't deviate. Size-capping belongs in the T1 DTO; worth raising there.

## Known limitation

**A user who can't authenticate can't report that authentication is broken.** The tool gates on a cached credential because the endpoint requires `x-api-key`. Not fixable on this side — flagging it for T1/T3 in case an unauthenticated intake path is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
