### PR TITLE
feat(tools): searchindex namespace (ctx.sapiom.searchindex) + search.map() (SAP-2255)

### DIFF
--- a/.changeset/sap-2255-searchindex-namespace.md
+++ b/.changeset/sap-2255-searchindex-namespace.md
@@ -2,24 +2,26 @@
 "@sapiom/tools": minor
 ---
 
-Add the `searchindex` namespace (`ctx.sapiom.searchindex`) and `search.map()` (SAP-2255).
+Add the `searchindex` namespace (`ctx.sapiom.searchindex`) and `search.map()`
+(SAP-2255).
 
-`searchindex` covers the full priced Upstash Search surface behind the Sapiom
+`searchindex` covers the complete provisioned-search surface behind the Sapiom
 gateway — control plane `create`/`get`/`list`/`update`/`delete`, with
 `create`/`get`/`list` returning a bound `SearchIndex` handle carrying the
 data-plane operations (`upsert`/`query`/`range`/`fetchDocuments`/
-`deleteDocuments`) against the index's own `*.search.data.sapiom.ai` URL.
-Documents are `{ id, content, metadata? }` — `content` is auto-embedded
-server-side, `metadata` is stored verbatim (put URLs/content-hashes there).
-`range` is the enumeration/reconciliation primitive; data-plane calls are
-priced per request ($0.000050; `query` reranking +$0.001). Errors throw the new
-`SearchIndexHttpError`.
+`deleteDocuments`) against the index's own Sapiom data-plane URL. Write inputs
+require `{ id, content, metadata? }`; read results preserve omitted content and
+metadata. `range` defaults to a valid first page (`cursor: "0"`, `limit: 100`).
+Malformed successful envelopes fail closed with `SearchIndexContractError`.
 
-`search.map({ url })` exposes Firecrawl site mapping ($0.009 flat) with
-structured `{ links: [{ url, title?, description? }] }` output — gateway-direct,
-since `/v2/map` is not a routed capability.
+The public contract names provider-invisible meters: `searchindex.index`,
+`searchindex.upsert`, `searchindex.query`, `searchindex.query_rerank`,
+`searchindex.range`, `searchindex.fetch_documents`, and
+`searchindex.delete_documents`.
+
+`search.map({ url })` exposes site mapping with structured
+`{ links: [{ url, title?, description? }] }` output.
 
 Both are wired into the `Sapiom` client interface, `bind()`, the barrel, the
-`./search-index` subpath export, and the stub client (stateful in-memory
-indexes, so `run_local` exercises upsert → query/range/fetch/delete flows
-deterministically).
+`./search-index` subpath export, and a stateful, validation-faithful stub client
+so `run_local` exercises upsert → query/range/fetch/delete flows.

--- a/.changeset/sap-2255-searchindex-namespace.md
+++ b/.changeset/sap-2255-searchindex-namespace.md
@@ -19,8 +19,9 @@ The public contract names provider-invisible meters: `searchindex.index`,
 `searchindex.range`, `searchindex.fetch_documents`, and
 `searchindex.delete_documents`.
 
-`search.map({ url })` exposes site mapping with structured
-`{ links: [{ url, title?, description? }] }` output.
+`search.map({ url })` exposes gateway-direct site mapping with structured
+`{ links: [{ url, title?, description? }] }` output. Malformed successful map
+responses fail closed with `SearchContractError`.
 
 Both are wired into the `Sapiom` client interface, `bind()`, the barrel, the
 `./search-index` subpath export, and a stateful, validation-faithful stub client

--- a/.changeset/sap-2255-searchindex-namespace.md
+++ b/.changeset/sap-2255-searchindex-namespace.md
@@ -1,0 +1,25 @@
+---
+"@sapiom/tools": minor
+---
+
+Add the `searchindex` namespace (`ctx.sapiom.searchindex`) and `search.map()` (SAP-2255).
+
+`searchindex` covers the full priced Upstash Search surface behind the Sapiom
+gateway — control plane `create`/`get`/`list`/`update`/`delete`, with
+`create`/`get`/`list` returning a bound `SearchIndex` handle carrying the
+data-plane operations (`upsert`/`query`/`range`/`fetchDocuments`/
+`deleteDocuments`) against the index's own `*.search.data.sapiom.ai` URL.
+Documents are `{ id, content, metadata? }` — `content` is auto-embedded
+server-side, `metadata` is stored verbatim (put URLs/content-hashes there).
+`range` is the enumeration/reconciliation primitive; data-plane calls are
+priced per request ($0.000050; `query` reranking +$0.001). Errors throw the new
+`SearchIndexHttpError`.
+
+`search.map({ url })` exposes Firecrawl site mapping ($0.009 flat) with
+structured `{ links: [{ url, title?, description? }] }` output — gateway-direct,
+since `/v2/map` is not a routed capability.
+
+Both are wired into the `Sapiom` client interface, `bind()`, the barrel, the
+`./search-index` subpath export, and the stub client (stateful in-memory
+indexes, so `run_local` exercises upsert → query/range/fetch/delete flows
+deterministically).

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/esm/search/index.js",
       "require": "./dist/cjs/search/index.js"
     },
+    "./search-index": {
+      "types": "./dist/cjs/search-index/index.d.ts",
+      "import": "./dist/esm/search-index/index.js",
+      "require": "./dist/cjs/search-index/index.js"
+    },
     "./database": {
       "types": "./dist/cjs/database/index.d.ts",
       "import": "./dist/esm/database/index.js",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -312,12 +312,12 @@ export interface Sapiom {
     };
   };
   /**
-   * Provisioned Upstash Search indexes with server-side auto-embedding —
-   * full-text + semantic search over JSON documents. Control plane manages
-   * indexes; `create`/`get`/`list` return a bound {@link SearchIndex} handle
-   * carrying the per-request-priced data-plane operations (upsert / query /
-   * range / fetchDocuments / deleteDocuments) against the index's own
-   * data-plane URL. Distinct from `search` (web search / scrape).
+   * Provisioned search indexes with server-side auto-embedding — full-text +
+   * semantic search over JSON documents. Control plane manages indexes;
+   * `create`/`get`/`list` return a bound {@link SearchIndex} handle carrying
+   * logically-metered data-plane operations (upsert / query / range /
+   * fetchDocuments / deleteDocuments) against the index's own data-plane URL.
+   * Distinct from `search` (web search / scrape).
    */
   readonly searchindex: {
     /** Create an index. Omit `ttl` for long-lived — expired indexes are reaped. */

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -85,6 +85,7 @@ import {
   findEmail,
   verifyEmail,
   domainSearch,
+  map as searchMap,
 } from "./search/index.js";
 import type {
   ScrapeInput,
@@ -97,7 +98,15 @@ import type {
   VerifyEmailResult,
   DomainSearchInput,
   DomainSearchResult,
+  MapInput,
+  MapResult,
 } from "./search/index.js";
+import * as searchindex from "./search-index/index.js";
+import type {
+  CreateSearchIndexInput,
+  UpdateSearchIndexInput,
+  SearchIndex,
+} from "./search-index/index.js";
 import * as database from "./database/index.js";
 import type { CreateDatabaseInput, Database } from "./database/index.js";
 import * as email from "./email/index.js";
@@ -290,6 +299,8 @@ export interface Sapiom {
     scrape(input: ScrapeInput): Promise<ScrapeResult>;
     /** Search the web — a synthesized answer plus results by default. */
     webSearch(input: WebSearchInput): Promise<WebSearchResponse>;
+    /** Map every URL discoverable on a site — structured links ($0.009 flat). */
+    map(input: MapInput): Promise<MapResult>;
     /** Find, verify, and discover professional email addresses. */
     readonly emailSearch: {
       /** Find a person's email from their name and company. */
@@ -299,6 +310,26 @@ export interface Sapiom {
       /** Discover the emails published at a company domain. */
       domainSearch(input: DomainSearchInput): Promise<DomainSearchResult>;
     };
+  };
+  /**
+   * Provisioned Upstash Search indexes with server-side auto-embedding —
+   * full-text + semantic search over JSON documents. Control plane manages
+   * indexes; `create`/`get`/`list` return a bound {@link SearchIndex} handle
+   * carrying the per-request-priced data-plane operations (upsert / query /
+   * range / fetchDocuments / deleteDocuments) against the index's own
+   * data-plane URL. Distinct from `search` (web search / scrape).
+   */
+  readonly searchindex: {
+    /** Create an index. Omit `ttl` for long-lived — expired indexes are reaped. */
+    create(input: CreateSearchIndexInput): Promise<SearchIndex>;
+    /** Retrieve an index by id as a bound handle. */
+    get(id: string): Promise<SearchIndex>;
+    /** List your indexes as bound handles (read-only). */
+    list(): Promise<SearchIndex[]>;
+    /** Update an index's name and/or expiry. */
+    update(id: string, input: UpdateSearchIndexInput): Promise<SearchIndex>;
+    /** Delete a whole index and ALL its data (document-level: `deleteDocuments`). */
+    delete(id: string): Promise<void>;
   };
   /** On-demand Postgres databases, returned with direct connection credentials. */
   readonly database: {
@@ -585,11 +616,19 @@ function bind(transport: Transport): Sapiom {
     search: {
       scrape: (input) => scrape(input, transport),
       webSearch: (input) => webSearch(input, transport),
+      map: (input) => searchMap(input, transport),
       emailSearch: {
         findEmail: (input) => findEmail(input, transport),
         verifyEmail: (input) => verifyEmail(input, transport),
         domainSearch: (input) => domainSearch(input, transport),
       },
+    },
+    searchindex: {
+      create: (input) => searchindex.create(input, transport),
+      get: (id) => searchindex.get(id, transport),
+      list: () => searchindex.list(transport),
+      update: (id, input) => searchindex.update(id, input, transport),
+      delete: (id) => searchindex.delete(id, transport),
     },
     database: {
       create: (input) => database.create(input, transport),

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -129,6 +129,7 @@ export type {
   SearchDocument,
   SearchHit,
   SearchQueryInput,
+  SearchIndexIncludeOptions,
   SearchIndexRangeInput,
   SearchIndexRangeResult,
 } from "./search-index/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -114,6 +114,24 @@ export { toImageResumePayload } from "./content-generation/index.js";
 
 export * as search from "./search/index.js";
 export { SearchHttpError } from "./search/index.js";
+export type { MapInput, MapLink, MapResult } from "./search/index.js";
+
+// searchindex — provisioned Upstash Search indexes (auto-embedding); control
+// plane + a bound per-index handle for the data-plane operations.
+export * as searchindex from "./search-index/index.js";
+export { SearchIndexHttpError } from "./search-index/index.js";
+export type {
+  SearchIndex,
+  SearchIndexInfo,
+  SearchIndexStatus,
+  CreateSearchIndexInput,
+  UpdateSearchIndexInput,
+  SearchDocument,
+  SearchHit,
+  SearchQueryInput,
+  SearchIndexRangeInput,
+  SearchIndexRangeResult,
+} from "./search-index/index.js";
 
 export * as database from "./database/index.js";
 export { DatabaseHttpError } from "./database/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -116,16 +116,22 @@ export * as search from "./search/index.js";
 export { SearchHttpError } from "./search/index.js";
 export type { MapInput, MapLink, MapResult } from "./search/index.js";
 
-// searchindex — provisioned Upstash Search indexes (auto-embedding); control
-// plane + a bound per-index handle for the data-plane operations.
+// searchindex — provisioned search indexes (auto-embedding); control plane + a
+// bound per-index handle for the data-plane operations.
 export * as searchindex from "./search-index/index.js";
-export { SearchIndexHttpError } from "./search-index/index.js";
+export {
+  DEFAULT_SEARCH_INDEX_RANGE_CURSOR,
+  DEFAULT_SEARCH_INDEX_RANGE_LIMIT,
+  SearchIndexContractError,
+  SearchIndexHttpError,
+} from "./search-index/index.js";
 export type {
   SearchIndex,
   SearchIndexInfo,
   SearchIndexStatus,
   CreateSearchIndexInput,
   UpdateSearchIndexInput,
+  SearchDocumentInput,
   SearchDocument,
   SearchHit,
   SearchQueryInput,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -113,7 +113,7 @@ export { toVideoResumePayload } from "./content-generation/index.js";
 export { toImageResumePayload } from "./content-generation/index.js";
 
 export * as search from "./search/index.js";
-export { SearchHttpError } from "./search/index.js";
+export { SearchContractError, SearchHttpError } from "./search/index.js";
 export type { MapInput, MapLink, MapResult } from "./search/index.js";
 
 // searchindex — provisioned search indexes (auto-embedding); control plane + a

--- a/packages/tools/src/search-index/README.md
+++ b/packages/tools/src/search-index/README.md
@@ -1,0 +1,70 @@
+# `searchindex` — provisioned search indexes with auto-embedding
+
+Upstash Search behind the Sapiom gateway: create an index, upsert JSON
+documents, and query them with combined full-text + semantic search. Documents
+are auto-embedded server-side — there is no embedding pipeline to run.
+
+Not to be confused with the `search` namespace (web search / page scrape /
+email lookup): `searchindex` is a data store you fill and query.
+
+## Usage
+
+```ts
+import { searchindex } from "@sapiom/tools"; // ambient auth
+// or: ctx.sapiom.searchindex inside a workflow step
+// or: createClient({ apiKey }).searchindex
+
+// Control plane — create/list/get/update/delete indexes.
+const idx = await searchindex.create({ name: "docs-corpus" }); // no ttl: long-lived
+
+// Data plane — the returned handle is bound to the index's own URL.
+await idx.upsert([
+  {
+    id: "getting-started",
+    content: { title: "Get Started", body: "…" }, // auto-embedded
+    metadata: { url: "https://docs.example.com/", contentHash: "…" }, // NOT embedded
+  },
+]);
+
+const hits = await idx.query({ query: "how do I authenticate?", limit: 3 });
+// hits: [{ id, content, metadata, score }] — best first
+
+// Reconciliation: enumerate everything, page by page.
+let cursor: string | null = null;
+do {
+  const page = await idx.range({ cursor: cursor ?? undefined, limit: 100 });
+  // page.documents[].metadata.contentHash → diff against fresh hashes
+  cursor = page.nextCursor;
+} while (cursor);
+
+await idx.deleteDocuments(["stale-doc"]);
+
+// Resolve an existing index by name:
+const again = (await searchindex.list()).find((i) => i.name === "docs-corpus");
+```
+
+## Semantics worth knowing
+
+- **`content` is embedded, `metadata` is not.** Put searchable text in
+  `content`; put bookkeeping (URLs, hashes, timestamps) in `metadata` so it
+  doesn't pollute relevance.
+- **`ttl` means reaping.** An index created with `ttl` (max 30d) is deleted
+  when it expires. Omit `ttl` for anything long-lived; `update(id,
+  { expiresAt })` adjusts expiry later.
+- **`indexName` is a namespace** inside the index (default `"default"`). Most
+  callers never set it.
+- **`delete(id)` destroys the whole index and all its data.** Use the handle's
+  `deleteDocuments(ids)` for document-level deletes.
+- Errors throw `SearchIndexHttpError` carrying `status` + parsed `body`. A 404
+  also covers ownership mismatches; 422 is the per-account index limit (50).
+
+## Pricing
+
+Data-plane operations are priced **per request, not per document** — batch your
+upserts:
+
+| Operation                                            | Price     |
+| ---------------------------------------------------- | --------- |
+| `upsert` / `query` / `range` / `fetchDocuments` / `deleteDocuments` | $0.000050 |
+| `query` with `reranking: true`                        | +$0.001   |
+| Control plane (create/get/list/update/delete)         | identity-first (nominal) |

--- a/packages/tools/src/search-index/README.md
+++ b/packages/tools/src/search-index/README.md
@@ -1,11 +1,12 @@
 # `searchindex` — provisioned search indexes with auto-embedding
 
-Upstash Search behind the Sapiom gateway: create an index, upsert JSON
-documents, and query them with combined full-text + semantic search. Documents
-are auto-embedded server-side — there is no embedding pipeline to run.
+Create an index, upsert JSON documents, and query them with combined full-text
+and semantic search. Documents are auto-embedded server-side, so there is no
+embedding pipeline to run. The backing provider is an implementation detail;
+the public contract is the `searchindex` namespace and its logical meters.
 
-Not to be confused with the `search` namespace (web search / page scrape /
-email lookup): `searchindex` is a data store you fill and query.
+This is distinct from `search` (web search, page scrape, and email lookup):
+`searchindex` is a data store you fill and query.
 
 ## Usage
 
@@ -17,60 +18,76 @@ import { searchindex } from "@sapiom/tools"; // ambient auth
 // Control plane — create/list/get/update/delete indexes.
 const idx = await searchindex.create({ name: "docs-corpus" }); // no ttl: long-lived
 
-// Data plane — the returned handle is bound to the index's own URL.
+// Data plane — the returned handle is bound to the index's own Sapiom URL.
 await idx.upsert([
   {
     id: "getting-started",
     content: { title: "Get Started", body: "…" }, // auto-embedded
-    metadata: { url: "https://docs.example.com/", contentHash: "…" }, // NOT embedded
+    metadata: { url: "https://docs.example.com/", contentHash: "…" },
   },
 ]);
 
 const hits = await idx.query({ query: "how do I authenticate?", limit: 3 });
-// hits: [{ id, content, metadata, score }] — best first
+// hits: [{ id, content?, metadata?, score? }] — best first
 
-// Reconciliation: enumerate everything, page by page. Range items carry only
-// `id` unless you ask for payloads — `includeMetadata: true` is the
-// hash-diff reconciler's flag (verified against the live data plane).
+// Reconciliation starts at cursor "0" with a bounded default page size of 100.
+// Range/fetch payload fields are omitted unless their include flag is true.
 let cursor: string | null = null;
 do {
   const page = await idx.range({
     cursor: cursor ?? undefined,
-    limit: 100,
     includeMetadata: true,
   });
-  // page.documents[].metadata.contentHash → diff against fresh hashes
+  // page.documents[].metadata?.contentHash → diff against fresh hashes
   cursor = page.nextCursor;
 } while (cursor);
 
 await idx.deleteDocuments(["stale-doc"]);
 
-// Resolve an existing index by name:
+// Resolve an existing index by name. The canonical wire envelope is
+// `{ databases: [...] }`; the SDK unwraps it and returns bound handles.
 const again = (await searchindex.list()).find((i) => i.name === "docs-corpus");
 ```
 
 ## Semantics worth knowing
 
-- **`content` is embedded, `metadata` is not.** Put searchable text in
-  `content`; put bookkeeping (URLs, hashes, timestamps) in `metadata` so it
-  doesn't pollute relevance.
-- **`ttl` means reaping.** An index created with `ttl` (max 30d) is deleted
-  when it expires. Omit `ttl` for anything long-lived; `update(id,
-  { expiresAt })` adjusts expiry later.
-- **`indexName` is a namespace** inside the index (default `"default"`). Most
-  callers never set it.
-- **`delete(id)` destroys the whole index and all its data.** Use the handle's
-  `deleteDocuments(ids)` for document-level deletes.
-- Errors throw `SearchIndexHttpError` carrying `status` + parsed `body`. A 404
-  also covers ownership mismatches; 422 is the per-account index limit (50).
+- `content` is embedded; `metadata` is not. Put searchable text in `content`
+  and bookkeeping such as URLs, hashes, and timestamps in `metadata`.
+- `ttl` means reaping. It must be greater than zero and no more than 30 days.
+  Omit it for long-lived indexes; `update(id, { expiresAt })` adjusts expiry.
+- `region` can be `null` on a read when a legacy record has no region.
+- `indexName` is a namespace within the index (default `"default"`).
+- `query()` defaults to 5 results; public `limit` is sent as the data-plane
+  `topK` field.
+- `range()` defaults to `{ cursor: "0", limit: 100 }`; pass each non-null
+  `nextCursor` to the next call.
+- Range and fetch results always contain `id`. `content` and `metadata` remain
+  absent unless requested, so omitted data cannot be mistaken for `{}`.
+- `delete(id)` destroys an entire index. Use `deleteDocuments(ids)` for
+  document-level deletion.
+- HTTP failures throw `SearchIndexHttpError`. A successful HTTP response with a
+  malformed list/query/range/fetch envelope throws `SearchIndexContractError`
+  instead of masquerading as an empty index.
+- List responses canonically use `{ databases: [...] }`. The SDK retains a bare
+  array only as an explicitly documented pre-envelope compatibility shape; any
+  other object envelope throws `SearchIndexContractError`.
+- Query/fetch responses canonically use `{ result: [...] }`; legacy bare arrays
+  remain supported. Range canonically uses
+  `{ result: { nextCursor, vectors } }`; the documented Search SDK page
+  `{ nextCursor, documents }` remains supported. Other shapes fail closed.
 
-## Pricing
+## Logical meters
 
-Data-plane operations are priced **per request, not per document** — batch your
-upserts:
+The customer contract is provider-invisible. The effective plan/catalog is the
+authority for allowance and price; each data-plane call consumes one request,
+regardless of batch size.
 
-| Operation                                            | Price     |
-| ---------------------------------------------------- | --------- |
-| `upsert` / `query` / `range` / `fetchDocuments` / `deleteDocuments` | $0.000050 |
-| `query` with `reranking: true`                        | +$0.001   |
-| Control plane (create/get/list/update/delete)         | identity-first (nominal) |
+| SDK operation                | Logical meter                  | Current catalog unit rate |
+| ---------------------------- | ------------------------------ | ------------------------: |
+| active index allocation      | `searchindex.index`            |           plan allocation |
+| `upsert`                     | `searchindex.upsert`           |                 $0.000050 |
+| `query`                      | `searchindex.query`            |                 $0.000050 |
+| `query({ reranking: true })` | `searchindex.query_rerank`     |                 $0.001050 |
+| `range`                      | `searchindex.range`            |                 $0.000050 |
+| `fetchDocuments`             | `searchindex.fetch_documents`  |                 $0.000050 |
+| `deleteDocuments`            | `searchindex.delete_documents` |                 $0.000050 |

--- a/packages/tools/src/search-index/README.md
+++ b/packages/tools/src/search-index/README.md
@@ -29,10 +29,16 @@ await idx.upsert([
 const hits = await idx.query({ query: "how do I authenticate?", limit: 3 });
 // hits: [{ id, content, metadata, score }] — best first
 
-// Reconciliation: enumerate everything, page by page.
+// Reconciliation: enumerate everything, page by page. Range items carry only
+// `id` unless you ask for payloads — `includeMetadata: true` is the
+// hash-diff reconciler's flag (verified against the live data plane).
 let cursor: string | null = null;
 do {
-  const page = await idx.range({ cursor: cursor ?? undefined, limit: 100 });
+  const page = await idx.range({
+    cursor: cursor ?? undefined,
+    limit: 100,
+    includeMetadata: true,
+  });
   // page.documents[].metadata.contentHash → diff against fresh hashes
   cursor = page.nextCursor;
 } while (cursor);

--- a/packages/tools/src/search-index/errors.ts
+++ b/packages/tools/src/search-index/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * Error thrown by the `searchindex` capability when the gateway returns a
+ * non-2xx response. Exposes `status` (HTTP status code) and `body` (parsed JSON
+ * body, or raw text when the body isn't JSON) for programmatic inspection.
+ *
+ * Useful statuses to branch on: `401` (missing/invalid credential), `404`
+ * (index not found — also returned on an ownership mismatch), `422`
+ * (per-account index limit reached).
+ */
+export class SearchIndexHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "SearchIndexHttpError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Return the response when 2xx, otherwise throw a {@link SearchIndexHttpError}.
+ * Parses the error body as JSON when possible; falls back to raw text.
+ */
+export async function ensureOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+  let body: unknown;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  throw new SearchIndexHttpError(
+    `${errorPrefix}: ${response.status} ${text}`,
+    response.status,
+    body,
+  );
+}

--- a/packages/tools/src/search-index/errors.ts
+++ b/packages/tools/src/search-index/errors.ts
@@ -20,6 +20,24 @@ export class SearchIndexHttpError extends Error {
 }
 
 /**
+ * A successful HTTP response that does not match the documented SearchIndex
+ * wire contract. This is deliberately distinct from an empty result: callers
+ * performing reconciliation must never interpret a gateway/provider regression
+ * as an empty index.
+ */
+export class SearchIndexContractError extends Error {
+  readonly operation: string;
+  readonly body: unknown;
+
+  constructor(operation: string, message: string, body: unknown) {
+    super(`Invalid SearchIndex ${operation} response: ${message}`);
+    this.name = "SearchIndexContractError";
+    this.operation = operation;
+    this.body = body;
+  }
+}
+
+/**
  * Return the response when 2xx, otherwise throw a {@link SearchIndexHttpError}.
  * Parses the error body as JSON when possible; falls back to raw text.
  */

--- a/packages/tools/src/search-index/index.spec.ts
+++ b/packages/tools/src/search-index/index.spec.ts
@@ -1,7 +1,57 @@
 import { Transport } from "../_client/index.js";
 import * as searchindex from "./index.js";
-import { SearchIndexHttpError } from "./index.js";
-import type { SearchIndex } from "./index.js";
+import { SearchIndexContractError, SearchIndexHttpError } from "./index.js";
+import type { SearchDocument, SearchIndex } from "./index.js";
+
+/**
+ * Wire-contract fixtures rather than invented empty mocks:
+ *
+ * - Gateway index/list values follow `SearchDatabaseResponse` and
+ *   `SearchService.list()` in
+ *   `sapiom/Sapiom@4ba50cd31f7ec36d141f28174a22e211ddc19bd4`.
+ * - Provider query/range/fetch values follow the raw REST envelopes consumed by
+ *   Upstash's official `search-js` client. The range value also matches the live
+ *   response captured while provisioning the Assistant corpus on 2026-08-03.
+ */
+const gatewayIndexFixture = {
+  id: "res_abc123",
+  type: "search",
+  name: "docs-corpus",
+  status: "active",
+  url: "https://res_abc123.search.data.test",
+  region: "us-central1",
+  expiresAt: null,
+  createdAt: "2026-08-01T00:00:00.000Z",
+} as const;
+
+const gatewayListFixture = {
+  databases: [{ ...gatewayIndexFixture, region: null }],
+} as const;
+
+const providerQueryFixture = {
+  result: [
+    {
+      id: "getting-started",
+      content: { title: "Get Started" },
+      metadata: { url: "https://docs.example.com/" },
+      score: 0.92,
+    },
+  ],
+} as const;
+
+const providerRangeFixture = {
+  result: {
+    nextCursor: "42",
+    vectors: [
+      { id: "a", metadata: { contentHash: "h1" } },
+      { id: "b", content: { title: "Second" } },
+    ],
+  },
+} as const;
+
+const providerFetchFixture = {
+  result: [{ id: "a", metadata: { contentHash: "h1" } }, null],
+} as const;
 
 // Capability fns are tested directly with a real Transport plus a scripted fetch
 // mock, so URL/method/header/body assertions are exact and we verify the Transport
@@ -56,14 +106,7 @@ const headerOf = (c: FetchCall, k: string) =>
 const bodyOf = (c: FetchCall) => JSON.parse(c.init.body as string);
 
 const indexDto = (overrides: Record<string, unknown> = {}) => ({
-  id: "res_abc123",
-  type: "search",
-  name: "docs-corpus",
-  status: "active",
-  url: DATA_URL,
-  region: "us-central1",
-  expiresAt: null,
-  createdAt: "2026-08-01T00:00:00.000Z",
+  ...gatewayIndexFixture,
   ...overrides,
 });
 
@@ -151,6 +194,23 @@ describe("searchindex.create()", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it("rejects a ttl over 30 days before fetching", async () => {
+    const { transport, calls } = makeTransport([]);
+    await expect(
+      searchindex.create({ name: "x", ttl: "31d" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws a contract error when a successful create body is malformed", async () => {
+    const { transport } = makeTransport([
+      () => jsonResponse({ id: "res_bad" }),
+    ]);
+    await expect(
+      searchindex.create({ name: "docs-corpus" }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchIndexContractError);
+  });
+
   it("throws SearchIndexHttpError with status + body on a non-2xx (e.g. 422 limit)", async () => {
     const { transport } = makeTransport([
       () =>
@@ -174,7 +234,9 @@ describe("searchindex.create()", () => {
 
 describe("searchindex.get() / list() / update() / delete()", () => {
   it("GETs /v1/search/indexes/:id (URL-encoded) and binds the handle", async () => {
-    const { transport, calls } = makeTransport([() => jsonResponse(indexDto())]);
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(indexDto()),
+    ]);
     const idx = await searchindex.get("res_abc123", transport, BASE);
     expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes/res_abc123`);
     expect(calls[0]!.init.method ?? "GET").toBe("GET");
@@ -183,36 +245,98 @@ describe("searchindex.get() / list() / update() / delete()", () => {
     expect(typeof idx.range).toBe("function");
   });
 
-  it("lists indexes as bound handles and tolerates a non-array response", async () => {
+  it("parses the canonical { databases } fixture into bound handles", async () => {
     const { transport } = makeTransport([
       (c) =>
         c.url === `${BASE}/v1/search/indexes`
-          ? jsonResponse([indexDto(), indexDto({ id: "res_def456", name: "other" })])
+          ? jsonResponse({
+              databases: [
+                ...gatewayListFixture.databases,
+                indexDto({ id: "res_def456", name: "other" }),
+              ],
+            })
           : undefined,
     ]);
     const all = await searchindex.list(transport, BASE);
     expect(all).toHaveLength(2);
     expect(all[0]!.name).toBe("docs-corpus");
+    expect(all[0]!.region).toBeNull();
     expect(typeof all[1]!.upsert).toBe("function");
+  });
 
-    const { transport: t2 } = makeTransport([() => jsonResponse({})]);
-    expect(await searchindex.list(t2, BASE)).toEqual([]);
+  it("retains the explicitly documented bare-array list compatibility shape", async () => {
+    const { transport } = makeTransport([() => jsonResponse([indexDto()])]);
+    await expect(searchindex.list(transport, BASE)).resolves.toHaveLength(1);
+  });
+
+  it("fails closed for unknown list envelopes and malformed entries", async () => {
+    const { transport } = makeTransport([() => jsonResponse({})]);
+    await expect(searchindex.list(transport, BASE)).rejects.toMatchObject({
+      name: "SearchIndexContractError",
+      operation: "list",
+    });
+
+    const { transport: malformedEntry } = makeTransport([
+      () => jsonResponse({ databases: [{ id: "res_only" }] }),
+    ]);
+    await expect(searchindex.list(malformedEntry, BASE)).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
   });
 
   it("PATCHes only the provided fields on update", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse(indexDto({ expiresAt: "2027-01-01T00:00:00.000Z" })),
+      () => jsonResponse(indexDto({ expiresAt: "2099-01-01T00:00:00.000Z" })),
     ]);
     const idx = await searchindex.update(
       "res_abc123",
-      { expiresAt: "2027-01-01T00:00:00.000Z" },
+      { expiresAt: "2099-01-01T00:00:00.000Z" },
       transport,
       BASE,
     );
     expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes/res_abc123`);
     expect(calls[0]!.init.method).toBe("PATCH");
-    expect(bodyOf(calls[0]!)).toEqual({ expiresAt: "2027-01-01T00:00:00.000Z" });
-    expect(idx.expiresAt).toBe("2027-01-01T00:00:00.000Z");
+    expect(bodyOf(calls[0]!)).toEqual({
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+    expect(idx.expiresAt).toBe("2099-01-01T00:00:00.000Z");
+  });
+
+  it("accepts a future ISO-8601 calendar date like the gateway DTO", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(indexDto({ expiresAt: "2099-01-01T00:00:00.000Z" })),
+    ]);
+    await searchindex.update(
+      "res_abc123",
+      { expiresAt: "2099-01-01" },
+      transport,
+      BASE,
+    );
+    expect(bodyOf(calls[0]!)).toEqual({ expiresAt: "2099-01-01" });
+  });
+
+  it("shares fail-fast id/update validation across control-plane calls", async () => {
+    const { transport, calls } = makeTransport([]);
+    await expect(searchindex.get("", transport, BASE)).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      searchindex.update("res_abc123", { name: "" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      searchindex.update(
+        "res_abc123",
+        { expiresAt: "January 1, 2099" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(searchindex.delete("", transport, BASE)).rejects.toMatchObject(
+      {
+        status: 400,
+      },
+    );
+    expect(calls).toHaveLength(0);
   });
 
   it("DELETEs the index and accepts a 204 with no body", async () => {
@@ -226,7 +350,7 @@ describe("searchindex.get() / list() / update() / delete()", () => {
     expect(calls[0]!.init.method).toBe("DELETE");
   });
 
-  it("surfaces a 404 (not-found / ownership mismatch) as SearchIndexHttpError", async () => {
+  it("surfaces control-plane not-found / ownership mismatch as 404", async () => {
     const { transport } = makeTransport([
       () =>
         new Response(JSON.stringify({ message: "Not found" }), {
@@ -234,9 +358,23 @@ describe("searchindex.get() / list() / update() / delete()", () => {
           headers: { "Content-Type": "application/json" },
         }),
     ]);
-    await expect(
-      searchindex.get("res_missing", transport, BASE),
-    ).rejects.toMatchObject({ status: 404 });
+    const calls = [
+      () => searchindex.get("res_missing", transport, BASE),
+      () =>
+        searchindex.update(
+          "res_missing",
+          { name: "still-missing" },
+          transport,
+          BASE,
+        ),
+      () => searchindex.delete("res_missing", transport, BASE),
+    ];
+    for (const call of calls) {
+      await expect(call()).rejects.toMatchObject({
+        name: "SearchIndexHttpError",
+        status: 404,
+      });
+    }
   });
 });
 
@@ -278,23 +416,23 @@ describe("SearchIndex.upsert()", () => {
     await expect(
       idx.upsert([{ id: "a", content: {} }], { indexName: "bad name!" }),
     ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      idx.upsert([{ id: "a", content: null } as never]),
+    ).rejects.toMatchObject({ status: 400 });
     expect(calls).toHaveLength(0);
   });
 });
 
 describe("SearchIndex.query()", () => {
   const hits = [
-    {
-      id: "getting-started",
-      content: { title: "Get Started" },
-      metadata: { url: "https://docs.example.com/" },
-      score: 0.92,
-    },
+    ...providerQueryFixture.result,
     { id: "verify", content: { title: "Verify Users" } },
   ];
 
   it("POSTs {url}/search/default with query/limit/reranking/filter and maps hits", async () => {
-    const { idx, calls } = await makeHandle([() => jsonResponse(hits)]);
+    const { idx, calls } = await makeHandle([
+      () => jsonResponse({ result: hits }),
+    ]);
     const results = await idx.query({
       query: "how do I authenticate?",
       limit: 3,
@@ -304,7 +442,9 @@ describe("SearchIndex.query()", () => {
     expect(calls[0]!.url).toBe(`${DATA_URL}/search/default`);
     expect(bodyOf(calls[0]!)).toEqual({
       query: "how do I authenticate?",
-      limit: 3,
+      topK: 3,
+      includeData: true,
+      includeMetadata: true,
       reranking: true,
       filter: "tags = 'auth'",
     });
@@ -318,26 +458,39 @@ describe("SearchIndex.query()", () => {
     expect(results[1]!.score).toBeUndefined();
   });
 
-  it("unwraps a { result: [...] } envelope", async () => {
-    const { idx } = await makeHandle([() => jsonResponse({ result: hits })]);
+  it("retains the documented bare-array query compatibility shape", async () => {
+    const { idx, calls } = await makeHandle([() => jsonResponse(hits)]);
     const results = await idx.query({ query: "verify" });
+    expect(bodyOf(calls[0]!)).toEqual({
+      query: "verify",
+      topK: 5,
+      includeData: true,
+      includeMetadata: true,
+    });
     expect(results.map((h) => h.id)).toEqual(["getting-started", "verify"]);
   });
 
-  it("returns [] for a non-array response and drops malformed hits", async () => {
+  it("fails closed for unknown query envelopes and malformed hits", async () => {
     const { idx } = await makeHandle([
       () => jsonResponse({ result: [{ notAnId: true }, hits[0]] }),
     ]);
-    const results = await idx.query({ query: "x" });
-    expect(results.map((h) => h.id)).toEqual(["getting-started"]);
+    await expect(idx.query({ query: "x" })).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
 
     const { idx: idx2 } = await makeHandle([() => jsonResponse("weird")]);
-    expect(await idx2.query({ query: "x" })).toEqual([]);
+    await expect(idx2.query({ query: "x" })).rejects.toMatchObject({
+      name: "SearchIndexContractError",
+      operation: "query",
+    });
   });
 
-  it("throws before fetching on an empty query", async () => {
+  it("throws before fetching on invalid query inputs", async () => {
     const { idx, calls } = await makeHandle([]);
-    await expect(idx.query({ query: "" })).rejects.toMatchObject({
+    await expect(idx.query({ query: "   " })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(idx.query({ query: "x", limit: 0 })).rejects.toMatchObject({
       status: 400,
     });
     expect(calls).toHaveLength(0);
@@ -345,28 +498,31 @@ describe("SearchIndex.query()", () => {
 });
 
 describe("SearchIndex.range()", () => {
+  it("allows an id-only read result without fabricating payload fields", () => {
+    const document: SearchDocument = { id: "id-only" };
+    expect(document).toEqual({ id: "id-only" });
+  });
+
   it("POSTs {url}/range/default with cursor/limit/include flags and maps the live `vectors` page shape", async () => {
-    // Live-verified upstream shape (2026-08-03): { result: { nextCursor, vectors } }.
+    // Captured live shape (2026-08-03): { result: { nextCursor, vectors } }.
     const { idx, calls } = await makeHandle([
-      () =>
-        jsonResponse({
-          result: {
-            nextCursor: "42",
-            vectors: [
-              { id: "a", metadata: { contentHash: "h1" } },
-              { id: "b", content: { t: 2 } },
-            ],
-          },
-        }),
+      () => jsonResponse(providerRangeFixture),
     ]);
-    const page = await idx.range({ cursor: "0", limit: 100, includeMetadata: true });
+    const page = await idx.range({
+      cursor: "0",
+      limit: 100,
+      includeMetadata: true,
+    });
     expect(calls[0]!.url).toBe(`${DATA_URL}/range/default`);
-    expect(bodyOf(calls[0]!)).toEqual({ cursor: "0", limit: 100, includeMetadata: true });
+    expect(bodyOf(calls[0]!)).toEqual({
+      cursor: "0",
+      limit: 100,
+      includeMetadata: true,
+    });
     expect(page.nextCursor).toBe("42");
     expect(page.documents.map((d) => d.id)).toEqual(["a", "b"]);
     expect(page.documents[0]!.metadata).toEqual({ contentHash: "h1" });
-    // Items without payloads (flags off upstream) still map with empty content.
-    expect(page.documents[0]!.content).toEqual({});
+    expect(page.documents[0]).not.toHaveProperty("content");
   });
 
   it("falls back to a `documents` page key and maps it identically", async () => {
@@ -382,27 +538,95 @@ describe("SearchIndex.range()", () => {
     expect(page.documents.map((d) => d.id)).toEqual(["a"]);
   });
 
-  it("sends an empty body on the first page and normalizes an empty nextCursor to null", async () => {
+  it("sends valid first-page defaults and normalizes an empty nextCursor to null", async () => {
     const { idx, calls } = await makeHandle([
       () => jsonResponse({ result: { nextCursor: "", vectors: [] } }),
     ]);
     const page = await idx.range();
-    expect(bodyOf(calls[0]!)).toEqual({});
+    expect(bodyOf(calls[0]!)).toEqual({ cursor: "0", limit: 100 });
     expect(page).toEqual({ nextCursor: null, documents: [] });
+  });
+
+  it("fails closed for malformed pages/documents", async () => {
+    const { idx } = await makeHandle([
+      () => jsonResponse({ result: { nextCursor: "", wrong: [] } }),
+    ]);
+    await expect(idx.range()).rejects.toBeInstanceOf(SearchIndexContractError);
+
+    const { idx: malformedDocument } = await makeHandle([
+      () =>
+        jsonResponse({
+          result: { nextCursor: "", vectors: [{ id: "a", content: null }] },
+        }),
+    ]);
+    await expect(malformedDocument.range()).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
+  });
+
+  it("rejects undocumented range envelope combinations", async () => {
+    const { idx: topLevelVectors } = await makeHandle([
+      () => jsonResponse({ nextCursor: "", vectors: [] }),
+    ]);
+    await expect(topLevelVectors.range()).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
+
+    const { idx: nestedDocuments } = await makeHandle([
+      () => jsonResponse({ result: { nextCursor: "", documents: [] } }),
+    ]);
+    await expect(nestedDocuments.range()).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
+  });
+
+  it("validates cursor, limit, and include flags before fetching", async () => {
+    const { idx, calls } = await makeHandle([]);
+    await expect(idx.range({ cursor: "" })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(idx.range({ limit: 1001 })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      idx.range({ includeMetadata: "yes" } as never),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
   });
 });
 
 describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
   it("POSTs {url}/fetch/default with ids + include flags and preserves nulls for misses", async () => {
     const { idx, calls } = await makeHandle([
-      () => jsonResponse({ result: [{ id: "a", metadata: { contentHash: "h1" } }, null] }),
+      () => jsonResponse(providerFetchFixture),
     ]);
-    const docs = await idx.fetchDocuments(["a", "missing"], { includeMetadata: true });
+    const docs = await idx.fetchDocuments(["a", "missing"], {
+      includeMetadata: true,
+    });
     expect(calls[0]!.url).toBe(`${DATA_URL}/fetch/default`);
-    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "missing"], includeMetadata: true });
+    expect(bodyOf(calls[0]!)).toEqual({
+      ids: ["a", "missing"],
+      includeMetadata: true,
+    });
     expect(docs[0]!.id).toBe("a");
     expect(docs[0]!.metadata).toEqual({ contentHash: "h1" });
+    expect(docs[0]).not.toHaveProperty("content");
     expect(docs[1]).toBeNull();
+  });
+
+  it("fails closed for malformed fetch envelopes and positional cardinality", async () => {
+    const { idx } = await makeHandle([() => jsonResponse({})]);
+    await expect(idx.fetchDocuments(["a"])).rejects.toBeInstanceOf(
+      SearchIndexContractError,
+    );
+
+    const { idx: short } = await makeHandle([
+      () => jsonResponse({ result: [{ id: "a" }] }),
+    ]);
+    await expect(short.fetchDocuments(["a", "b"])).rejects.toMatchObject({
+      name: "SearchIndexContractError",
+      operation: "fetchDocuments",
+    });
   });
 
   it("DELETEs {url}/delete/default with the ids body", async () => {
@@ -421,10 +645,13 @@ describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
     await expect(idx.deleteDocuments([])).rejects.toMatchObject({
       status: 400,
     });
+    await expect(idx.fetchDocuments([""])).rejects.toMatchObject({
+      status: 400,
+    });
     expect(calls).toHaveLength(0);
   });
 
-  it("surfaces a data-plane 404 (ownership mismatch) as SearchIndexHttpError", async () => {
+  it("surfaces data-plane not-found / ownership mismatch as 404", async () => {
     const { idx } = await makeHandle([
       () =>
         new Response(JSON.stringify({ message: "Not found" }), {
@@ -432,9 +659,18 @@ describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
           headers: { "Content-Type": "application/json" },
         }),
     ]);
-    await expect(idx.fetchDocuments(["a"])).rejects.toMatchObject({
-      name: "SearchIndexHttpError",
-      status: 404,
-    });
+    const calls = [
+      () => idx.upsert([{ id: "a", content: {} }]),
+      () => idx.query({ query: "anything" }),
+      () => idx.range(),
+      () => idx.fetchDocuments(["a"]),
+      () => idx.deleteDocuments(["a"]),
+    ];
+    for (const call of calls) {
+      await expect(call()).rejects.toMatchObject({
+        name: "SearchIndexHttpError",
+        status: 404,
+      });
+    }
   });
 });

--- a/packages/tools/src/search-index/index.spec.ts
+++ b/packages/tools/src/search-index/index.spec.ts
@@ -345,28 +345,46 @@ describe("SearchIndex.query()", () => {
 });
 
 describe("SearchIndex.range()", () => {
-  it("POSTs {url}/range/default with cursor/limit and maps the page", async () => {
+  it("POSTs {url}/range/default with cursor/limit/include flags and maps the live `vectors` page shape", async () => {
+    // Live-verified upstream shape (2026-08-03): { result: { nextCursor, vectors } }.
     const { idx, calls } = await makeHandle([
       () =>
         jsonResponse({
-          nextCursor: "42",
-          documents: [
-            { id: "a", content: { t: 1 }, metadata: { contentHash: "h1" } },
-            { id: "b", content: { t: 2 } },
-          ],
+          result: {
+            nextCursor: "42",
+            vectors: [
+              { id: "a", metadata: { contentHash: "h1" } },
+              { id: "b", content: { t: 2 } },
+            ],
+          },
         }),
     ]);
-    const page = await idx.range({ cursor: "0", limit: 100 });
+    const page = await idx.range({ cursor: "0", limit: 100, includeMetadata: true });
     expect(calls[0]!.url).toBe(`${DATA_URL}/range/default`);
-    expect(bodyOf(calls[0]!)).toEqual({ cursor: "0", limit: 100 });
+    expect(bodyOf(calls[0]!)).toEqual({ cursor: "0", limit: 100, includeMetadata: true });
     expect(page.nextCursor).toBe("42");
     expect(page.documents.map((d) => d.id)).toEqual(["a", "b"]);
     expect(page.documents[0]!.metadata).toEqual({ contentHash: "h1" });
+    // Items without payloads (flags off upstream) still map with empty content.
+    expect(page.documents[0]!.content).toEqual({});
+  });
+
+  it("falls back to a `documents` page key and maps it identically", async () => {
+    const { idx } = await makeHandle([
+      () =>
+        jsonResponse({
+          nextCursor: "7",
+          documents: [{ id: "a", content: { t: 1 } }],
+        }),
+    ]);
+    const page = await idx.range();
+    expect(page.nextCursor).toBe("7");
+    expect(page.documents.map((d) => d.id)).toEqual(["a"]);
   });
 
   it("sends an empty body on the first page and normalizes an empty nextCursor to null", async () => {
     const { idx, calls } = await makeHandle([
-      () => jsonResponse({ nextCursor: "", documents: [] }),
+      () => jsonResponse({ result: { nextCursor: "", vectors: [] } }),
     ]);
     const page = await idx.range();
     expect(bodyOf(calls[0]!)).toEqual({});
@@ -375,14 +393,15 @@ describe("SearchIndex.range()", () => {
 });
 
 describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
-  it("POSTs {url}/fetch/default with ids and preserves nulls for misses", async () => {
+  it("POSTs {url}/fetch/default with ids + include flags and preserves nulls for misses", async () => {
     const { idx, calls } = await makeHandle([
-      () => jsonResponse([{ id: "a", content: { t: 1 } }, null]),
+      () => jsonResponse({ result: [{ id: "a", metadata: { contentHash: "h1" } }, null] }),
     ]);
-    const docs = await idx.fetchDocuments(["a", "missing"]);
+    const docs = await idx.fetchDocuments(["a", "missing"], { includeMetadata: true });
     expect(calls[0]!.url).toBe(`${DATA_URL}/fetch/default`);
-    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "missing"] });
+    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "missing"], includeMetadata: true });
     expect(docs[0]!.id).toBe("a");
+    expect(docs[0]!.metadata).toEqual({ contentHash: "h1" });
     expect(docs[1]).toBeNull();
   });
 

--- a/packages/tools/src/search-index/index.spec.ts
+++ b/packages/tools/src/search-index/index.spec.ts
@@ -629,6 +629,31 @@ describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
     });
   });
 
+  it("fails closed when non-null fetch results do not match requested ID positions", async () => {
+    const { idx: swapped } = await makeHandle([
+      () => jsonResponse({ result: [{ id: "b" }, { id: "a" }] }),
+    ]);
+    await expect(swapped.fetchDocuments(["a", "b"])).rejects.toMatchObject({
+      name: "SearchIndexContractError",
+      operation: "fetchDocuments",
+    });
+
+    const { idx: wrong } = await makeHandle([
+      () => jsonResponse({ result: [{ id: "unexpected" }, null] }),
+    ]);
+    await expect(wrong.fetchDocuments(["a", "missing"])).rejects.toMatchObject({
+      name: "SearchIndexContractError",
+      operation: "fetchDocuments",
+    });
+
+    const { idx: positionalMiss } = await makeHandle([
+      () => jsonResponse({ result: [null, { id: "b" }] }),
+    ]);
+    await expect(
+      positionalMiss.fetchDocuments(["missing", "b"]),
+    ).resolves.toEqual([null, { id: "b" }]);
+  });
+
   it("DELETEs {url}/delete/default with the ids body", async () => {
     const { idx, calls } = await makeHandle([
       () => jsonResponse({ deleted: 2 }),

--- a/packages/tools/src/search-index/index.spec.ts
+++ b/packages/tools/src/search-index/index.spec.ts
@@ -1,0 +1,421 @@
+import { Transport } from "../_client/index.js";
+import * as searchindex from "./index.js";
+import { SearchIndexHttpError } from "./index.js";
+import type { SearchIndex } from "./index.js";
+
+// Capability fns are tested directly with a real Transport plus a scripted fetch
+// mock, so URL/method/header/body assertions are exact and we verify the Transport
+// injects the tenant credential on the gateway-direct default header
+// (x-sapiom-api-key) for BOTH planes — control (management gateway) and data
+// (the index's own URL).
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "test-key",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://upstash.test";
+const DATA_URL = "https://res_abc123.search.data.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+const bodyOf = (c: FetchCall) => JSON.parse(c.init.body as string);
+
+const indexDto = (overrides: Record<string, unknown> = {}) => ({
+  id: "res_abc123",
+  type: "search",
+  name: "docs-corpus",
+  status: "active",
+  url: DATA_URL,
+  region: "us-central1",
+  expiresAt: null,
+  createdAt: "2026-08-01T00:00:00.000Z",
+  ...overrides,
+});
+
+/** Build a bound handle by round-tripping `create` against a mocked gateway. */
+async function makeHandle(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+): Promise<{ idx: SearchIndex; calls: FetchCall[] }> {
+  const { transport, calls } = makeTransport([
+    (c) =>
+      c.url === `${BASE}/v1/search/indexes` && c.init.method === "POST"
+        ? jsonResponse(indexDto(), { status: 201 })
+        : undefined,
+    ...handlers,
+  ]);
+  const idx = await searchindex.create(
+    { name: "docs-corpus" },
+    transport,
+    BASE,
+  );
+  calls.length = 0; // drop the create call; tests assert data-plane calls only
+  return { idx, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Control plane
+// ---------------------------------------------------------------------------
+
+describe("searchindex.create()", () => {
+  it("POSTs /v1/search/indexes on x-sapiom-api-key and returns a bound handle", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(indexDto(), { status: 201 }),
+    ]);
+
+    const idx = await searchindex.create(
+      { name: "docs-corpus", region: "us-central1", ttl: "7d" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // Gateway-direct surface — credential rides the default x-sapiom-api-key.
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({
+      name: "docs-corpus",
+      region: "us-central1",
+      ttl: "7d",
+    });
+
+    expect(idx.id).toBe("res_abc123");
+    expect(idx.name).toBe("docs-corpus");
+    expect(idx.status).toBe("active");
+    expect(idx.url).toBe(DATA_URL);
+    expect(idx.expiresAt).toBeNull();
+    expect(typeof idx.upsert).toBe("function");
+    expect(typeof idx.query).toBe("function");
+    expect(typeof idx.range).toBe("function");
+    expect(typeof idx.fetchDocuments).toBe("function");
+    expect(typeof idx.deleteDocuments).toBe("function");
+  });
+
+  it("omits region/ttl from the body when not provided", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(indexDto(), { status: 201 }),
+    ]);
+    await searchindex.create({ name: "docs-corpus" }, transport, BASE);
+    expect(bodyOf(calls[0]!)).toEqual({ name: "docs-corpus" });
+  });
+
+  it("throws before fetching on a missing name", async () => {
+    const { transport, calls } = makeTransport([]);
+    await expect(
+      searchindex.create({ name: "" }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchIndexHttpError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws before fetching on a malformed ttl", async () => {
+    const { transport, calls } = makeTransport([]);
+    await expect(
+      searchindex.create({ name: "x", ttl: "1 week" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws SearchIndexHttpError with status + body on a non-2xx (e.g. 422 limit)", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "resource_limit_exceeded",
+            message: "Maximum 50 Search databases per account",
+          }),
+          { status: 422, headers: { "Content-Type": "application/json" } },
+        ),
+    ]);
+    await expect(
+      searchindex.create({ name: "docs-corpus" }, transport, BASE),
+    ).rejects.toMatchObject({
+      name: "SearchIndexHttpError",
+      status: 422,
+      body: { error: "resource_limit_exceeded" },
+    });
+  });
+});
+
+describe("searchindex.get() / list() / update() / delete()", () => {
+  it("GETs /v1/search/indexes/:id (URL-encoded) and binds the handle", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(indexDto())]);
+    const idx = await searchindex.get("res_abc123", transport, BASE);
+    expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes/res_abc123`);
+    expect(calls[0]!.init.method ?? "GET").toBe("GET");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(idx.url).toBe(DATA_URL);
+    expect(typeof idx.range).toBe("function");
+  });
+
+  it("lists indexes as bound handles and tolerates a non-array response", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.url === `${BASE}/v1/search/indexes`
+          ? jsonResponse([indexDto(), indexDto({ id: "res_def456", name: "other" })])
+          : undefined,
+    ]);
+    const all = await searchindex.list(transport, BASE);
+    expect(all).toHaveLength(2);
+    expect(all[0]!.name).toBe("docs-corpus");
+    expect(typeof all[1]!.upsert).toBe("function");
+
+    const { transport: t2 } = makeTransport([() => jsonResponse({})]);
+    expect(await searchindex.list(t2, BASE)).toEqual([]);
+  });
+
+  it("PATCHes only the provided fields on update", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse(indexDto({ expiresAt: "2027-01-01T00:00:00.000Z" })),
+    ]);
+    const idx = await searchindex.update(
+      "res_abc123",
+      { expiresAt: "2027-01-01T00:00:00.000Z" },
+      transport,
+      BASE,
+    );
+    expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes/res_abc123`);
+    expect(calls[0]!.init.method).toBe("PATCH");
+    expect(bodyOf(calls[0]!)).toEqual({ expiresAt: "2027-01-01T00:00:00.000Z" });
+    expect(idx.expiresAt).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  it("DELETEs the index and accepts a 204 with no body", async () => {
+    const { transport, calls } = makeTransport([
+      () => new Response(null, { status: 204 }),
+    ]);
+    await expect(
+      searchindex.delete("res_abc123", transport, BASE),
+    ).resolves.toBeUndefined();
+    expect(calls[0]!.url).toBe(`${BASE}/v1/search/indexes/res_abc123`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+  });
+
+  it("surfaces a 404 (not-found / ownership mismatch) as SearchIndexHttpError", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(
+      searchindex.get("res_missing", transport, BASE),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data plane (via the bound handle)
+// ---------------------------------------------------------------------------
+
+describe("SearchIndex.upsert()", () => {
+  it("POSTs the documents ARRAY verbatim to {url}/upsert/default", async () => {
+    const { idx, calls } = await makeHandle([
+      () => jsonResponse({ result: "Success" }),
+    ]);
+    const docs = [
+      {
+        id: "getting-started",
+        content: { title: "Get Started", body: "…" },
+        metadata: { url: "https://docs.example.com/", contentHash: "abc" },
+      },
+    ];
+    await idx.upsert(docs);
+    expect(calls[0]!.url).toBe(`${DATA_URL}/upsert/default`);
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    // The body is the bare array — the gateway forwards it verbatim.
+    expect(bodyOf(calls[0]!)).toEqual(docs);
+  });
+
+  it("targets a custom indexName namespace", async () => {
+    const { idx, calls } = await makeHandle([() => jsonResponse({})]);
+    await idx.upsert([{ id: "a", content: { t: 1 } }], {
+      indexName: "articles",
+    });
+    expect(calls[0]!.url).toBe(`${DATA_URL}/upsert/articles`);
+  });
+
+  it("throws before fetching on an empty documents array or bad indexName", async () => {
+    const { idx, calls } = await makeHandle([]);
+    await expect(idx.upsert([])).rejects.toMatchObject({ status: 400 });
+    await expect(
+      idx.upsert([{ id: "a", content: {} }], { indexName: "bad name!" }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("SearchIndex.query()", () => {
+  const hits = [
+    {
+      id: "getting-started",
+      content: { title: "Get Started" },
+      metadata: { url: "https://docs.example.com/" },
+      score: 0.92,
+    },
+    { id: "verify", content: { title: "Verify Users" } },
+  ];
+
+  it("POSTs {url}/search/default with query/limit/reranking/filter and maps hits", async () => {
+    const { idx, calls } = await makeHandle([() => jsonResponse(hits)]);
+    const results = await idx.query({
+      query: "how do I authenticate?",
+      limit: 3,
+      reranking: true,
+      filter: "tags = 'auth'",
+    });
+    expect(calls[0]!.url).toBe(`${DATA_URL}/search/default`);
+    expect(bodyOf(calls[0]!)).toEqual({
+      query: "how do I authenticate?",
+      limit: 3,
+      reranking: true,
+      filter: "tags = 'auth'",
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      id: "getting-started",
+      content: { title: "Get Started" },
+      metadata: { url: "https://docs.example.com/" },
+      score: 0.92,
+    });
+    expect(results[1]!.score).toBeUndefined();
+  });
+
+  it("unwraps a { result: [...] } envelope", async () => {
+    const { idx } = await makeHandle([() => jsonResponse({ result: hits })]);
+    const results = await idx.query({ query: "verify" });
+    expect(results.map((h) => h.id)).toEqual(["getting-started", "verify"]);
+  });
+
+  it("returns [] for a non-array response and drops malformed hits", async () => {
+    const { idx } = await makeHandle([
+      () => jsonResponse({ result: [{ notAnId: true }, hits[0]] }),
+    ]);
+    const results = await idx.query({ query: "x" });
+    expect(results.map((h) => h.id)).toEqual(["getting-started"]);
+
+    const { idx: idx2 } = await makeHandle([() => jsonResponse("weird")]);
+    expect(await idx2.query({ query: "x" })).toEqual([]);
+  });
+
+  it("throws before fetching on an empty query", async () => {
+    const { idx, calls } = await makeHandle([]);
+    await expect(idx.query({ query: "" })).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("SearchIndex.range()", () => {
+  it("POSTs {url}/range/default with cursor/limit and maps the page", async () => {
+    const { idx, calls } = await makeHandle([
+      () =>
+        jsonResponse({
+          nextCursor: "42",
+          documents: [
+            { id: "a", content: { t: 1 }, metadata: { contentHash: "h1" } },
+            { id: "b", content: { t: 2 } },
+          ],
+        }),
+    ]);
+    const page = await idx.range({ cursor: "0", limit: 100 });
+    expect(calls[0]!.url).toBe(`${DATA_URL}/range/default`);
+    expect(bodyOf(calls[0]!)).toEqual({ cursor: "0", limit: 100 });
+    expect(page.nextCursor).toBe("42");
+    expect(page.documents.map((d) => d.id)).toEqual(["a", "b"]);
+    expect(page.documents[0]!.metadata).toEqual({ contentHash: "h1" });
+  });
+
+  it("sends an empty body on the first page and normalizes an empty nextCursor to null", async () => {
+    const { idx, calls } = await makeHandle([
+      () => jsonResponse({ nextCursor: "", documents: [] }),
+    ]);
+    const page = await idx.range();
+    expect(bodyOf(calls[0]!)).toEqual({});
+    expect(page).toEqual({ nextCursor: null, documents: [] });
+  });
+});
+
+describe("SearchIndex.fetchDocuments() / deleteDocuments()", () => {
+  it("POSTs {url}/fetch/default with ids and preserves nulls for misses", async () => {
+    const { idx, calls } = await makeHandle([
+      () => jsonResponse([{ id: "a", content: { t: 1 } }, null]),
+    ]);
+    const docs = await idx.fetchDocuments(["a", "missing"]);
+    expect(calls[0]!.url).toBe(`${DATA_URL}/fetch/default`);
+    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "missing"] });
+    expect(docs[0]!.id).toBe("a");
+    expect(docs[1]).toBeNull();
+  });
+
+  it("DELETEs {url}/delete/default with the ids body", async () => {
+    const { idx, calls } = await makeHandle([
+      () => jsonResponse({ deleted: 2 }),
+    ]);
+    await idx.deleteDocuments(["a", "b"]);
+    expect(calls[0]!.url).toBe(`${DATA_URL}/delete/default`);
+    expect(calls[0]!.init.method).toBe("DELETE");
+    expect(bodyOf(calls[0]!)).toEqual({ ids: ["a", "b"] });
+  });
+
+  it("throws before fetching on empty ids", async () => {
+    const { idx, calls } = await makeHandle([]);
+    await expect(idx.fetchDocuments([])).rejects.toMatchObject({ status: 400 });
+    await expect(idx.deleteDocuments([])).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces a data-plane 404 (ownership mismatch) as SearchIndexHttpError", async () => {
+    const { idx } = await makeHandle([
+      () =>
+        new Response(JSON.stringify({ message: "Not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(idx.fetchDocuments(["a"])).rejects.toMatchObject({
+      name: "SearchIndexHttpError",
+      status: 404,
+    });
+  });
+});

--- a/packages/tools/src/search-index/index.ts
+++ b/packages/tools/src/search-index/index.ts
@@ -375,22 +375,31 @@ function parseRangeResponse(raw: unknown): SearchIndexRangeResult {
 
 function parseFetchResponse(
   raw: unknown,
-  expectedCount: number,
+  expectedIds: readonly string[],
 ): Array<SearchDocument | null> {
   const results = isRecord(raw) && "result" in raw ? raw.result : raw;
   if (!Array.isArray(results)) {
     contractError("fetchDocuments", "expected { result: [...] }", raw);
   }
-  if (results.length !== expectedCount) {
+  if (results.length !== expectedIds.length) {
     contractError(
       "fetchDocuments",
-      `expected ${expectedCount} positional results, received ${results.length}`,
+      `expected ${expectedIds.length} positional results, received ${results.length}`,
       raw,
     );
   }
-  return results.map((item, index) =>
-    item === null ? null : parseDocument(item, "fetchDocuments", index),
-  );
+  return results.map((item, index) => {
+    if (item === null) return null;
+    const document = parseDocument(item, "fetchDocuments", index);
+    if (document.id !== expectedIds[index]) {
+      contractError(
+        "fetchDocuments",
+        `expected document id '${expectedIds[index]}' at index ${index}, received '${document.id}'`,
+        item,
+      );
+    }
+    return document;
+  });
 }
 
 function parseListResponse(raw: unknown): SearchIndexInfo[] {
@@ -514,7 +523,7 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
       );
       return parseFetchResponse(
         await readRequiredJson(response, "fetchDocuments"),
-        ids.length,
+        ids,
       );
     },
 

--- a/packages/tools/src/search-index/index.ts
+++ b/packages/tools/src/search-index/index.ts
@@ -1,0 +1,526 @@
+/**
+ * `searchindex` capability — provisioned Upstash Search indexes with
+ * auto-embedding: full-text + semantic search over JSON documents, no embedding
+ * pipeline to run. Distinct from the `search` namespace (web search / scrape);
+ * this one is a data store you fill and query.
+ *
+ *   import { searchindex } from "@sapiom/tools";            // ambient auth
+ *   const idx = await searchindex.create({ name: "docs-corpus" });
+ *   await idx.upsert([
+ *     { id: "getting-started", content: { title: "Get Started", body: "…" },
+ *       metadata: { url: "https://docs.example.com/", contentHash: "…" } },
+ *   ]);
+ *   const hits = await idx.query({ query: "how do I authenticate?", limit: 3 });
+ *   hits[0]?.id;                                            // best-matching document
+ *
+ *   const again = await searchindex.get(idx.id);            // re-bind by id
+ *   const all = await searchindex.list();                   // every index you own
+ *   const page = await again.range({ limit: 100 });         // enumerate documents
+ *
+ * Or via an explicit client / a workflow step: `ctx.sapiom.searchindex.create(...)`.
+ *
+ * Two planes, one handle. The control plane (create/get/list/update/delete)
+ * lives on the management gateway; `create`/`get`/`list` return a
+ * {@link SearchIndex} handle whose data-plane operations
+ * (upsert/query/range/fetchDocuments/deleteDocuments) are bound to that index's
+ * own data-plane URL (`https://<id>.search.data.sapiom.ai`). Documents are
+ * auto-embedded from `content` server-side; `metadata` is stored verbatim and
+ * NOT embedded — put bookkeeping there (URLs, content hashes), never in
+ * `content`.
+ *
+ * Lifetime: indexes created with a `ttl` expire and are REAPED (max ttl 30d).
+ * Omit `ttl` for a long-lived index (e.g. a docs corpus); `update(id,
+ * { expiresAt })` can extend or set expiry later.
+ *
+ * Pricing (per request, not per document): upsert / query / range /
+ * fetchDocuments / deleteDocuments are $0.000050 each; `query` with
+ * `reranking: true` adds a $0.001 surcharge. Control-plane calls are
+ * identity-first (nominal). Batch upserts — one call with 50 documents costs
+ * the same as one call with 1.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, SearchIndexHttpError } from "./errors.js";
+
+export { SearchIndexHttpError };
+
+const DEFAULT_BASE_URL = resolveServiceUrl(
+  "upstash",
+  process.env.SAPIOM_SEARCHINDEX_URL,
+);
+
+// ----- Types -----
+
+/** Lifecycle state of a search index. */
+export type SearchIndexStatus =
+  | "provisioning"
+  | "active"
+  | "expired"
+  | "deleting"
+  | "deleted";
+
+export interface CreateSearchIndexInput {
+  /** Index name (1–128 chars). Not unique server-side — prefer distinctive names. */
+  name: string;
+  /** Optional region (default: us-central1; eu-west-1 also available). */
+  region?: string;
+  /**
+   * Optional time-to-live, e.g. `"1h"`, `"24h"`, `"7d"` (max 30 days). An
+   * expired index is deleted by a reaper — OMIT for a long-lived index.
+   */
+  ttl?: string;
+}
+
+export interface UpdateSearchIndexInput {
+  /** New display name (1–128 chars). */
+  name?: string;
+  /** New ISO-8601 expiry (must be in the future), e.g. to extend a ttl. */
+  expiresAt?: string;
+}
+
+/** Read-only metadata for a search index. */
+export interface SearchIndexInfo {
+  /** Unique index id (`res_…`) — also the subdomain of the data-plane URL. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Lifecycle state. */
+  status: SearchIndexStatus;
+  /** The index's own data-plane base URL (`https://<id>.search.data.sapiom.ai`). */
+  url: string;
+  /** Region the index is provisioned in. */
+  region: string;
+  /** ISO-8601 expiry, or `null` when the index does not expire. */
+  expiresAt: string | null;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+}
+
+/** One document to store: `content` is auto-embedded, `metadata` is not. */
+export interface SearchDocument {
+  /** Unique document id within the index. */
+  id: string;
+  /** The searchable fields (auto-embedded server-side), e.g. `{ title, body }`. */
+  content: Record<string, unknown>;
+  /** Stored verbatim, never embedded — URLs, content hashes, timestamps, … */
+  metadata?: Record<string, unknown>;
+}
+
+/** One search result. `score` is higher-is-better relevance when present. */
+export interface SearchHit {
+  id: string;
+  content?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  score?: number;
+}
+
+export interface SearchQueryInput {
+  /** The search query (semantic + full-text). */
+  query: string;
+  /** Max results to return (1–1000). */
+  limit?: number;
+  /** Re-rank results server-side for better relevance (+$0.001 per query). */
+  reranking?: boolean;
+  /** Optional metadata filter expression. */
+  filter?: string;
+}
+
+export interface SearchIndexRangeInput {
+  /** Opaque pagination cursor from a previous page (start with none or `"0"`). */
+  cursor?: string;
+  /** Page size. */
+  limit?: number;
+}
+
+/** One page of documents. Keep calling with `nextCursor` until it is null/empty. */
+export interface SearchIndexRangeResult {
+  nextCursor: string | null;
+  documents: SearchDocument[];
+}
+
+/** Options accepted by every data-plane operation. */
+export interface DataPlaneOptions {
+  /**
+   * The namespace inside the index to operate on (alphanumeric, `-`, `_`).
+   * Defaults to `"default"` — most callers never set this.
+   */
+  indexName?: string;
+}
+
+/**
+ * A bound search-index handle: the index's metadata plus its data-plane
+ * operations, each priced per request ($0.000050; query reranking +$0.001).
+ */
+export interface SearchIndex extends SearchIndexInfo {
+  /** Insert or replace documents — ONE priced request regardless of count. */
+  upsert(documents: SearchDocument[], opts?: DataPlaneOptions): Promise<void>;
+  /** Search the index. Returns ranked hits (best first). */
+  query(input: SearchQueryInput, opts?: DataPlaneOptions): Promise<SearchHit[]>;
+  /** Enumerate documents page by page — the reconciliation primitive. */
+  range(
+    input?: SearchIndexRangeInput,
+    opts?: DataPlaneOptions,
+  ): Promise<SearchIndexRangeResult>;
+  /** Fetch specific documents by id (`null` for ids that don't exist). */
+  fetchDocuments(
+    ids: string[],
+    opts?: DataPlaneOptions,
+  ): Promise<Array<SearchDocument | null>>;
+  /** Delete specific documents by id. */
+  deleteDocuments(ids: string[], opts?: DataPlaneOptions): Promise<void>;
+}
+
+// ----- Internal wire shapes -----
+
+/** The gateway's `SearchDatabaseResponse` DTO. */
+interface RawSearchIndexResponse {
+  id: string;
+  type?: string;
+  name: string;
+  status: string;
+  url: string;
+  region: string;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+function mapInfo(raw: RawSearchIndexResponse): SearchIndexInfo {
+  return {
+    id: raw.id,
+    name: raw.name,
+    status: raw.status as SearchIndexStatus,
+    url: raw.url,
+    region: raw.region,
+    expiresAt: raw.expiresAt ?? null,
+    createdAt: raw.createdAt,
+  };
+}
+
+const INDEX_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const TTL_PATTERN = /^\d+[mhd]$/;
+
+function resolveIndexName(opts?: DataPlaneOptions): string {
+  const indexName = opts?.indexName ?? "default";
+  if (!INDEX_NAME_PATTERN.test(indexName)) {
+    throw new SearchIndexHttpError(
+      `indexName must match ${INDEX_NAME_PATTERN} (got "${indexName}")`,
+      400,
+      { indexName },
+    );
+  }
+  return indexName;
+}
+
+/**
+ * Unwrap an Upstash data-plane response defensively: the API returns either the
+ * value directly or wrapped as `{ result: value }` depending on the endpoint.
+ */
+function unwrapResult(raw: unknown): unknown {
+  if (raw && typeof raw === "object" && "result" in raw) {
+    return (raw as { result: unknown }).result;
+  }
+  return raw;
+}
+
+function toDocument(raw: unknown): SearchDocument | null {
+  if (!raw || typeof raw === "string" || typeof raw !== "object") return null;
+  const doc = raw as {
+    id?: unknown;
+    content?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  };
+  if (typeof doc.id !== "string") return null;
+  return {
+    id: doc.id,
+    content: doc.content ?? {},
+    ...(doc.metadata !== undefined && { metadata: doc.metadata }),
+  };
+}
+
+function toHit(raw: unknown): SearchHit | null {
+  const doc = toDocument(raw);
+  if (!doc) return null;
+  const score = (raw as { score?: unknown }).score;
+  return {
+    ...doc,
+    ...(typeof score === "number" && { score }),
+  };
+}
+
+async function dataPlaneJson(
+  transport: Transport,
+  url: string,
+  init: RequestInit,
+  errorPrefix: string,
+): Promise<unknown> {
+  const res = await ensureOk(await transport.fetch(url, init), errorPrefix);
+  if (res.status === 204) return undefined;
+  const text = await res.text().catch(() => "");
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+// ----- The handle -----
+
+/** Bind an index's data-plane operations to its own URL. */
+function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
+  return {
+    ...info,
+
+    async upsert(documents, opts) {
+      if (!Array.isArray(documents) || documents.length === 0) {
+        throw new SearchIndexHttpError(
+          "upsert requires at least one document",
+          400,
+          undefined,
+        );
+      }
+      const indexName = resolveIndexName(opts);
+      // The gateway forwards the array body verbatim and remaps to Upstash's
+      // auto-embedding upsert. Priced per REQUEST — batch your documents.
+      await dataPlaneJson(
+        transport,
+        `${info.url}/upsert/${indexName}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(documents),
+        },
+        `Failed to upsert into search index '${info.id}'`,
+      );
+    },
+
+    async query(input, opts) {
+      if (!input?.query) {
+        throw new SearchIndexHttpError(
+          "query requires a non-empty query string",
+          400,
+          undefined,
+        );
+      }
+      const indexName = resolveIndexName(opts);
+      const body: Record<string, unknown> = { query: input.query };
+      if (input.limit != null) body.limit = input.limit;
+      if (input.reranking != null) body.reranking = input.reranking;
+      if (input.filter != null) body.filter = input.filter;
+
+      const raw = await dataPlaneJson(
+        transport,
+        `${info.url}/search/${indexName}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        `Failed to query search index '${info.id}'`,
+      );
+      const results = unwrapResult(raw);
+      if (!Array.isArray(results)) return [];
+      return results
+        .map(toHit)
+        .filter((hit): hit is SearchHit => hit !== null);
+    },
+
+    async range(input, opts) {
+      const indexName = resolveIndexName(opts);
+      const body: Record<string, unknown> = {};
+      if (input?.cursor != null) body.cursor = input.cursor;
+      if (input?.limit != null) body.limit = input.limit;
+
+      const raw = await dataPlaneJson(
+        transport,
+        `${info.url}/range/${indexName}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        `Failed to range search index '${info.id}'`,
+      );
+      const page = unwrapResult(raw) as
+        | { nextCursor?: unknown; documents?: unknown }
+        | undefined;
+      const documents = Array.isArray(page?.documents)
+        ? page.documents
+            .map(toDocument)
+            .filter((doc): doc is SearchDocument => doc !== null)
+        : [];
+      const nextCursor =
+        typeof page?.nextCursor === "string" && page.nextCursor !== ""
+          ? page.nextCursor
+          : null;
+      return { nextCursor, documents };
+    },
+
+    async fetchDocuments(ids, opts) {
+      if (!Array.isArray(ids) || ids.length === 0) {
+        throw new SearchIndexHttpError(
+          "fetchDocuments requires at least one id",
+          400,
+          undefined,
+        );
+      }
+      const indexName = resolveIndexName(opts);
+      const raw = await dataPlaneJson(
+        transport,
+        `${info.url}/fetch/${indexName}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ids }),
+        },
+        `Failed to fetch documents from search index '${info.id}'`,
+      );
+      const results = unwrapResult(raw);
+      if (!Array.isArray(results)) return ids.map(() => null);
+      return results.map(toDocument);
+    },
+
+    async deleteDocuments(ids, opts) {
+      if (!Array.isArray(ids) || ids.length === 0) {
+        throw new SearchIndexHttpError(
+          "deleteDocuments requires at least one id",
+          400,
+          undefined,
+        );
+      }
+      const indexName = resolveIndexName(opts);
+      await dataPlaneJson(
+        transport,
+        `${info.url}/delete/${indexName}`,
+        {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ids }),
+        },
+        `Failed to delete documents from search index '${info.id}'`,
+      );
+    },
+  };
+}
+
+// ----- Control-plane operations -----
+
+/**
+ * Create a search index and return its bound handle. Omit `ttl` for a
+ * long-lived index — expired indexes are reaped. Failed requests throw
+ * {@link SearchIndexHttpError} (422 when the per-account index limit is hit).
+ */
+export async function create(
+  input: CreateSearchIndexInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SearchIndex> {
+  if (!input?.name || input.name.length > 128) {
+    throw new SearchIndexHttpError(
+      "create requires a name of 1-128 characters",
+      400,
+      { name: input?.name },
+    );
+  }
+  if (input.ttl !== undefined && !TTL_PATTERN.test(input.ttl)) {
+    throw new SearchIndexHttpError(
+      `ttl must match ${TTL_PATTERN} (e.g. "1h", "24h", "7d"), got "${input.ttl}"`,
+      400,
+      { ttl: input.ttl },
+    );
+  }
+  const body: Record<string, unknown> = { name: input.name };
+  if (input.region !== undefined) body.region = input.region;
+  if (input.ttl !== undefined) body.ttl = input.ttl;
+
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/search/indexes`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    "Failed to create search index",
+  );
+  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+}
+
+/** Retrieve a search index by id and return its bound handle. */
+export async function get(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SearchIndex> {
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/search/indexes/${encodeURIComponent(id)}`,
+    ),
+    `Failed to get search index '${id}'`,
+  );
+  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+}
+
+/**
+ * List your active search indexes as bound handles. Read-only — useful for
+ * resolving an index by name before operating on it:
+ *
+ *   const idx = (await searchindex.list()).find((i) => i.name === "docs-corpus");
+ */
+export async function list(
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SearchIndex[]> {
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v1/search/indexes`),
+    "Failed to list search indexes",
+  );
+  const raw = (await res.json()) as RawSearchIndexResponse[];
+  return Array.isArray(raw)
+    ? raw.map((r) => bindIndex(mapInfo(r), transport))
+    : [];
+}
+
+/** Update an index's `name` and/or `expiresAt`; returns the updated handle. */
+export async function update(
+  id: string,
+  input: UpdateSearchIndexInput,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<SearchIndex> {
+  const body: Record<string, unknown> = {};
+  if (input?.name !== undefined) body.name = input.name;
+  if (input?.expiresAt !== undefined) body.expiresAt = input.expiresAt;
+
+  const res = await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/search/indexes/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+    `Failed to update search index '${id}'`,
+  );
+  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+}
+
+/**
+ * Delete a whole index and ALL its data (idempotent server-side). For deleting
+ * individual documents use the handle's `deleteDocuments`. Exported as `delete`:
+ * `await searchindex.delete(id)`.
+ */
+async function deleteIndex(
+  id: string,
+  transport: Transport = defaultTransport(),
+  baseUrl = DEFAULT_BASE_URL,
+): Promise<void> {
+  await ensureOk(
+    await transport.fetch(
+      `${baseUrl}/v1/search/indexes/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    ),
+    `Failed to delete search index '${id}'`,
+  );
+}
+
+export { deleteIndex as delete };

--- a/packages/tools/src/search-index/index.ts
+++ b/packages/tools/src/search-index/index.ts
@@ -1,8 +1,8 @@
 /**
- * `searchindex` capability — provisioned Upstash Search indexes with
- * auto-embedding: full-text + semantic search over JSON documents, no embedding
- * pipeline to run. Distinct from the `search` namespace (web search / scrape);
- * this one is a data store you fill and query.
+ * `searchindex` capability — provisioned search indexes with auto-embedding:
+ * full-text + semantic search over JSON documents, with no embedding pipeline to
+ * run. Distinct from the `search` namespace (web search / scrape); this one is a
+ * data store you fill and query.
  *
  *   import { searchindex } from "@sapiom/tools";            // ambient auth
  *   const idx = await searchindex.create({ name: "docs-corpus" });
@@ -32,17 +32,41 @@
  * Omit `ttl` for a long-lived index (e.g. a docs corpus); `update(id,
  * { expiresAt })` can extend or set expiry later.
  *
- * Pricing (per request, not per document): upsert / query / range /
- * fetchDocuments / deleteDocuments are $0.000050 each; `query` with
- * `reranking: true` adds a $0.001 surcharge. Control-plane calls are
- * identity-first (nominal). Batch upserts — one call with 50 documents costs
- * the same as one call with 1.
+ * Customer usage is expressed through provider-invisible logical meters:
+ * `searchindex.index` for active allocations and one of `searchindex.upsert`,
+ * `searchindex.query`, `searchindex.query_rerank`, `searchindex.range`,
+ * `searchindex.fetch_documents`, or `searchindex.delete_documents` per
+ * data-plane request. Batch upserts — one call with 50 documents uses the same
+ * request count as one call with 1.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
 import { resolveServiceUrl } from "../_client/service-url.js";
-import { ensureOk, SearchIndexHttpError } from "./errors.js";
+import {
+  ensureOk,
+  SearchIndexContractError,
+  SearchIndexHttpError,
+} from "./errors.js";
+import {
+  DEFAULT_SEARCH_INDEX_QUERY_LIMIT,
+  DEFAULT_SEARCH_INDEX_RANGE_CURSOR,
+  DEFAULT_SEARCH_INDEX_RANGE_LIMIT,
+  normalizeSearchIndexRangeInput,
+  resolveSearchIndexName,
+  validateCreateSearchIndexInput,
+  validateSearchDocumentIds,
+  validateSearchDocumentInputs,
+  validateSearchIndexId,
+  validateSearchIndexIncludeOptions,
+  validateSearchQueryInput,
+  validateUpdateSearchIndexInput,
+} from "./validation.js";
 
-export { SearchIndexHttpError };
+export {
+  DEFAULT_SEARCH_INDEX_RANGE_CURSOR,
+  DEFAULT_SEARCH_INDEX_RANGE_LIMIT,
+  SearchIndexContractError,
+  SearchIndexHttpError,
+};
 
 const DEFAULT_BASE_URL = resolveServiceUrl(
   "upstash",
@@ -88,8 +112,8 @@ export interface SearchIndexInfo {
   status: SearchIndexStatus;
   /** The index's own data-plane base URL (`https://<id>.search.data.sapiom.ai`). */
   url: string;
-  /** Region the index is provisioned in. */
-  region: string;
+  /** Region the index is provisioned in, or `null` for legacy/unknown records. */
+  region: string | null;
   /** ISO-8601 expiry, or `null` when the index does not expire. */
   expiresAt: string | null;
   /** ISO-8601 creation timestamp. */
@@ -97,12 +121,23 @@ export interface SearchIndexInfo {
 }
 
 /** One document to store: `content` is auto-embedded, `metadata` is not. */
-export interface SearchDocument {
+export interface SearchDocumentInput {
   /** Unique document id within the index. */
   id: string;
   /** The searchable fields (auto-embedded server-side), e.g. `{ title, body }`. */
   content: Record<string, unknown>;
   /** Stored verbatim, never embedded — URLs, content hashes, timestamps, … */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * One document returned by range/fetch. Payload fields are absent unless the
+ * corresponding include flag was requested; absence is never fabricated as an
+ * empty object.
+ */
+export interface SearchDocument {
+  id: string;
+  content?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
 }
 
@@ -117,9 +152,9 @@ export interface SearchHit {
 export interface SearchQueryInput {
   /** The search query (semantic + full-text). */
   query: string;
-  /** Max results to return (1–1000). */
+  /** Max results to return (defaults to 5; valid range 1–1000). */
   limit?: number;
-  /** Re-rank results server-side for better relevance (+$0.001 per query). */
+  /** Re-rank results server-side; selects the `searchindex.query_rerank` meter. */
   reranking?: boolean;
   /** Optional metadata filter expression. */
   filter?: string;
@@ -134,9 +169,9 @@ export interface SearchIndexIncludeOptions {
 }
 
 export interface SearchIndexRangeInput extends SearchIndexIncludeOptions {
-  /** Opaque pagination cursor from a previous page (start with none or `"0"`). */
+  /** Numeric pagination cursor from a previous page (defaults to `"0"`). */
   cursor?: string;
-  /** Page size. */
+  /** Page size (defaults to 100; valid range 1–1000). */
   limit?: number;
 }
 
@@ -156,12 +191,15 @@ export interface DataPlaneOptions {
 }
 
 /**
- * A bound search-index handle: the index's metadata plus its data-plane
- * operations, each priced per request ($0.000050; query reranking +$0.001).
+ * A bound search-index handle: the index's metadata plus its logically-metered
+ * data-plane operations.
  */
 export interface SearchIndex extends SearchIndexInfo {
   /** Insert or replace documents — ONE priced request regardless of count. */
-  upsert(documents: SearchDocument[], opts?: DataPlaneOptions): Promise<void>;
+  upsert(
+    documents: SearchDocumentInput[],
+    opts?: DataPlaneOptions,
+  ): Promise<void>;
   /** Search the index. Returns ranked hits (best first). */
   query(input: SearchQueryInput, opts?: DataPlaneOptions): Promise<SearchHit[]>;
   /**
@@ -188,95 +226,204 @@ export interface SearchIndex extends SearchIndexInfo {
 // ----- Internal wire shapes -----
 
 /** The gateway's `SearchDatabaseResponse` DTO. */
-interface RawSearchIndexResponse {
-  id: string;
-  type?: string;
-  name: string;
-  status: string;
-  url: string;
-  region: string;
-  expiresAt: string | null;
-  createdAt: string;
+const SEARCH_INDEX_STATUSES = new Set<SearchIndexStatus>([
+  "provisioning",
+  "active",
+  "expired",
+  "deleting",
+  "deleted",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function mapInfo(raw: RawSearchIndexResponse): SearchIndexInfo {
-  return {
-    id: raw.id,
-    name: raw.name,
-    status: raw.status as SearchIndexStatus,
-    url: raw.url,
-    region: raw.region,
-    expiresAt: raw.expiresAt ?? null,
-    createdAt: raw.createdAt,
-  };
+function contractError(
+  operation: string,
+  message: string,
+  body: unknown,
+): never {
+  throw new SearchIndexContractError(operation, message, body);
 }
 
-const INDEX_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
-const TTL_PATTERN = /^\d+[mhd]$/;
-
-function resolveIndexName(opts?: DataPlaneOptions): string {
-  const indexName = opts?.indexName ?? "default";
-  if (!INDEX_NAME_PATTERN.test(indexName)) {
-    throw new SearchIndexHttpError(
-      `indexName must match ${INDEX_NAME_PATTERN} (got "${indexName}")`,
-      400,
-      { indexName },
+function parseInfo(raw: unknown, operation: string): SearchIndexInfo {
+  if (!isRecord(raw)) contractError(operation, "expected an index object", raw);
+  if (raw.type !== "search") {
+    contractError(operation, "expected resource type 'search'", raw);
+  }
+  const requiredStrings = ["id", "name", "status", "url", "createdAt"] as const;
+  for (const field of requiredStrings) {
+    if (typeof raw[field] !== "string" || raw[field].length === 0) {
+      contractError(
+        operation,
+        `expected non-empty string field '${field}'`,
+        raw,
+      );
+    }
+  }
+  if (!SEARCH_INDEX_STATUSES.has(raw.status as SearchIndexStatus)) {
+    contractError(
+      operation,
+      `unknown lifecycle status '${String(raw.status)}'`,
+      raw,
     );
   }
-  return indexName;
-}
-
-/**
- * Unwrap an Upstash data-plane response defensively: the API returns either the
- * value directly or wrapped as `{ result: value }` depending on the endpoint.
- */
-function unwrapResult(raw: unknown): unknown {
-  if (raw && typeof raw === "object" && "result" in raw) {
-    return (raw as { result: unknown }).result;
+  if (raw.region !== null && typeof raw.region !== "string") {
+    contractError(operation, "expected 'region' to be a string or null", raw);
   }
-  return raw;
-}
-
-function toDocument(raw: unknown): SearchDocument | null {
-  if (!raw || typeof raw === "string" || typeof raw !== "object") return null;
-  const doc = raw as {
-    id?: unknown;
-    content?: Record<string, unknown>;
-    metadata?: Record<string, unknown>;
-  };
-  if (typeof doc.id !== "string") return null;
+  if (raw.expiresAt !== null && typeof raw.expiresAt !== "string") {
+    contractError(
+      operation,
+      "expected 'expiresAt' to be a string or null",
+      raw,
+    );
+  }
   return {
-    id: doc.id,
-    content: doc.content ?? {},
-    ...(doc.metadata !== undefined && { metadata: doc.metadata }),
+    id: raw.id as string,
+    name: raw.name as string,
+    status: raw.status as SearchIndexStatus,
+    url: raw.url as string,
+    region: raw.region as string | null,
+    expiresAt: raw.expiresAt as string | null,
+    createdAt: raw.createdAt as string,
   };
 }
 
-function toHit(raw: unknown): SearchHit | null {
-  const doc = toDocument(raw);
-  if (!doc) return null;
-  const score = (raw as { score?: unknown }).score;
+function parseDocument(
+  raw: unknown,
+  operation: string,
+  position: number,
+): SearchDocument {
+  if (!isRecord(raw) || typeof raw.id !== "string" || raw.id.length === 0) {
+    contractError(
+      operation,
+      `document at index ${position} requires a non-empty id`,
+      raw,
+    );
+  }
+  if (raw.content !== undefined && !isRecord(raw.content)) {
+    contractError(operation, `document '${raw.id}' has malformed content`, raw);
+  }
+  if (raw.metadata !== undefined && !isRecord(raw.metadata)) {
+    contractError(
+      operation,
+      `document '${raw.id}' has malformed metadata`,
+      raw,
+    );
+  }
   return {
-    ...doc,
-    ...(typeof score === "number" && { score }),
+    id: raw.id,
+    ...(raw.content !== undefined && { content: raw.content }),
+    ...(raw.metadata !== undefined && { metadata: raw.metadata }),
   };
 }
 
-async function dataPlaneJson(
+function parseQueryResponse(raw: unknown): SearchHit[] {
+  // Canonical provider envelope is `{ result: [...] }`. A bare array is the
+  // explicitly retained pre-envelope compatibility shape.
+  const results = isRecord(raw) && "result" in raw ? raw.result : raw;
+  if (!Array.isArray(results)) {
+    contractError("query", "expected { result: [...] }", raw);
+  }
+  return results.map((item, index) => {
+    const document = parseDocument(item, "query", index);
+    const score = (item as Record<string, unknown>).score;
+    if (score !== undefined && typeof score !== "number") {
+      contractError(
+        "query",
+        `document '${document.id}' has malformed score`,
+        item,
+      );
+    }
+    return {
+      ...document,
+      ...(score !== undefined && { score }),
+    };
+  });
+}
+
+function parseRangeResponse(raw: unknown): SearchIndexRangeResult {
+  let page: Record<string, unknown>;
+  let items: unknown[];
+  if (isRecord(raw) && "result" in raw) {
+    // Canonical raw data-plane envelope.
+    if (!isRecord(raw.result) || !Array.isArray(raw.result.vectors)) {
+      contractError(
+        "range",
+        "expected { result: { nextCursor, vectors: [...] } }",
+        raw,
+      );
+    }
+    page = raw.result;
+    items = raw.result.vectors;
+  } else {
+    // Explicit compatibility with the documented Search SDK page.
+    if (!isRecord(raw) || !Array.isArray(raw.documents)) {
+      contractError("range", "expected { nextCursor, documents: [...] }", raw);
+    }
+    page = raw;
+    items = raw.documents;
+  }
+  if (typeof page.nextCursor !== "string") {
+    contractError("range", "expected a string nextCursor", raw);
+  }
+  return {
+    nextCursor: page.nextCursor === "" ? null : page.nextCursor,
+    documents: items.map((item, index) => parseDocument(item, "range", index)),
+  };
+}
+
+function parseFetchResponse(
+  raw: unknown,
+  expectedCount: number,
+): Array<SearchDocument | null> {
+  const results = isRecord(raw) && "result" in raw ? raw.result : raw;
+  if (!Array.isArray(results)) {
+    contractError("fetchDocuments", "expected { result: [...] }", raw);
+  }
+  if (results.length !== expectedCount) {
+    contractError(
+      "fetchDocuments",
+      `expected ${expectedCount} positional results, received ${results.length}`,
+      raw,
+    );
+  }
+  return results.map((item, index) =>
+    item === null ? null : parseDocument(item, "fetchDocuments", index),
+  );
+}
+
+function parseListResponse(raw: unknown): SearchIndexInfo[] {
+  // Canonical Unified contract: `{ databases: SearchDatabaseResponse[] }`.
+  // Retain the original bare-array response only as an explicit compatibility
+  // shape; every other envelope fails closed.
+  const databases = isRecord(raw) && "databases" in raw ? raw.databases : raw;
+  if (!Array.isArray(databases)) {
+    contractError("list", "expected { databases: [...] }", raw);
+  }
+  return databases.map((item, index) => parseInfo(item, `list[${index}]`));
+}
+
+async function readRequiredJson(
+  response: Response,
+  operation: string,
+): Promise<unknown> {
+  const text = await response.text().catch(() => "");
+  if (!text) contractError(operation, "expected a JSON body", undefined);
+  try {
+    return JSON.parse(text);
+  } catch {
+    contractError(operation, "response body is not valid JSON", text);
+  }
+}
+
+async function dataPlaneRequest(
   transport: Transport,
   url: string,
   init: RequestInit,
   errorPrefix: string,
-): Promise<unknown> {
-  const res = await ensureOk(await transport.fetch(url, init), errorPrefix);
-  if (res.status === 204) return undefined;
-  const text = await res.text().catch(() => "");
-  if (!text) return undefined;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
+): Promise<Response> {
+  return ensureOk(await transport.fetch(url, init), errorPrefix);
 }
 
 // ----- The handle -----
@@ -287,17 +434,11 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
     ...info,
 
     async upsert(documents, opts) {
-      if (!Array.isArray(documents) || documents.length === 0) {
-        throw new SearchIndexHttpError(
-          "upsert requires at least one document",
-          400,
-          undefined,
-        );
-      }
-      const indexName = resolveIndexName(opts);
-      // The gateway forwards the array body verbatim and remaps to Upstash's
-      // auto-embedding upsert. Priced per REQUEST — batch your documents.
-      await dataPlaneJson(
+      validateSearchDocumentInputs(documents);
+      const indexName = resolveSearchIndexName(opts);
+      // The gateway forwards the array body verbatim to the current provider.
+      // Logical usage is per request, so callers should batch documents.
+      await dataPlaneRequest(
         transport,
         `${info.url}/upsert/${indexName}`,
         {
@@ -310,20 +451,20 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
     },
 
     async query(input, opts) {
-      if (!input?.query) {
-        throw new SearchIndexHttpError(
-          "query requires a non-empty query string",
-          400,
-          undefined,
-        );
-      }
-      const indexName = resolveIndexName(opts);
-      const body: Record<string, unknown> = { query: input.query };
-      if (input.limit != null) body.limit = input.limit;
+      validateSearchQueryInput(input);
+      const indexName = resolveSearchIndexName(opts);
+      // Public `limit` maps to the provider's raw `topK`; query reads request
+      // their payloads explicitly instead of relying on provider defaults.
+      const body: Record<string, unknown> = {
+        query: input.query,
+        topK: input.limit ?? DEFAULT_SEARCH_INDEX_QUERY_LIMIT,
+        includeData: true,
+        includeMetadata: true,
+      };
       if (input.reranking != null) body.reranking = input.reranking;
       if (input.filter != null) body.filter = input.filter;
 
-      const raw = await dataPlaneJson(
+      const response = await dataPlaneRequest(
         transport,
         `${info.url}/search/${indexName}`,
         {
@@ -333,23 +474,14 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
         },
         `Failed to query search index '${info.id}'`,
       );
-      const results = unwrapResult(raw);
-      if (!Array.isArray(results)) return [];
-      return results
-        .map(toHit)
-        .filter((hit): hit is SearchHit => hit !== null);
+      return parseQueryResponse(await readRequiredJson(response, "query"));
     },
 
     async range(input, opts) {
-      const indexName = resolveIndexName(opts);
-      const body: Record<string, unknown> = {};
-      if (input?.cursor != null) body.cursor = input.cursor;
-      if (input?.limit != null) body.limit = input.limit;
-      if (input?.includeMetadata != null)
-        body.includeMetadata = input.includeMetadata;
-      if (input?.includeData != null) body.includeData = input.includeData;
+      const indexName = resolveSearchIndexName(opts);
+      const body = normalizeSearchIndexRangeInput(input);
 
-      const raw = await dataPlaneJson(
+      const response = await dataPlaneRequest(
         transport,
         `${info.url}/range/${indexName}`,
         {
@@ -359,41 +491,18 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
         },
         `Failed to range search index '${info.id}'`,
       );
-      // Verified live 2026-08-03: the upstream page shape is
-      // `{ nextCursor, vectors: [...] }` (Search rides the vector API's range;
-      // `documents` kept as a defensive fallback should upstream rename).
-      const page = unwrapResult(raw) as
-        | { nextCursor?: unknown; vectors?: unknown; documents?: unknown }
-        | undefined;
-      const items = Array.isArray(page?.vectors)
-        ? page.vectors
-        : Array.isArray(page?.documents)
-          ? page.documents
-          : [];
-      const documents = items
-        .map(toDocument)
-        .filter((doc): doc is SearchDocument => doc !== null);
-      const nextCursor =
-        typeof page?.nextCursor === "string" && page.nextCursor !== ""
-          ? page.nextCursor
-          : null;
-      return { nextCursor, documents };
+      return parseRangeResponse(await readRequiredJson(response, "range"));
     },
 
     async fetchDocuments(ids, opts) {
-      if (!Array.isArray(ids) || ids.length === 0) {
-        throw new SearchIndexHttpError(
-          "fetchDocuments requires at least one id",
-          400,
-          undefined,
-        );
-      }
-      const indexName = resolveIndexName(opts);
+      validateSearchDocumentIds(ids, "fetchDocuments");
+      validateSearchIndexIncludeOptions(opts);
+      const indexName = resolveSearchIndexName(opts);
       const body: Record<string, unknown> = { ids };
       if (opts?.includeMetadata != null)
         body.includeMetadata = opts.includeMetadata;
       if (opts?.includeData != null) body.includeData = opts.includeData;
-      const raw = await dataPlaneJson(
+      const response = await dataPlaneRequest(
         transport,
         `${info.url}/fetch/${indexName}`,
         {
@@ -403,21 +512,16 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
         },
         `Failed to fetch documents from search index '${info.id}'`,
       );
-      const results = unwrapResult(raw);
-      if (!Array.isArray(results)) return ids.map(() => null);
-      return results.map(toDocument);
+      return parseFetchResponse(
+        await readRequiredJson(response, "fetchDocuments"),
+        ids.length,
+      );
     },
 
     async deleteDocuments(ids, opts) {
-      if (!Array.isArray(ids) || ids.length === 0) {
-        throw new SearchIndexHttpError(
-          "deleteDocuments requires at least one id",
-          400,
-          undefined,
-        );
-      }
-      const indexName = resolveIndexName(opts);
-      await dataPlaneJson(
+      validateSearchDocumentIds(ids, "deleteDocuments");
+      const indexName = resolveSearchIndexName(opts);
+      await dataPlaneRequest(
         transport,
         `${info.url}/delete/${indexName}`,
         {
@@ -443,20 +547,7 @@ export async function create(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<SearchIndex> {
-  if (!input?.name || input.name.length > 128) {
-    throw new SearchIndexHttpError(
-      "create requires a name of 1-128 characters",
-      400,
-      { name: input?.name },
-    );
-  }
-  if (input.ttl !== undefined && !TTL_PATTERN.test(input.ttl)) {
-    throw new SearchIndexHttpError(
-      `ttl must match ${TTL_PATTERN} (e.g. "1h", "24h", "7d"), got "${input.ttl}"`,
-      400,
-      { ttl: input.ttl },
-    );
-  }
+  validateCreateSearchIndexInput(input);
   const body: Record<string, unknown> = { name: input.name };
   if (input.region !== undefined) body.region = input.region;
   if (input.ttl !== undefined) body.ttl = input.ttl;
@@ -469,7 +560,10 @@ export async function create(
     }),
     "Failed to create search index",
   );
-  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+  return bindIndex(
+    parseInfo(await readRequiredJson(res, "create"), "create"),
+    transport,
+  );
 }
 
 /** Retrieve a search index by id and return its bound handle. */
@@ -478,13 +572,17 @@ export async function get(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<SearchIndex> {
+  validateSearchIndexId(id);
   const res = await ensureOk(
     await transport.fetch(
       `${baseUrl}/v1/search/indexes/${encodeURIComponent(id)}`,
     ),
     `Failed to get search index '${id}'`,
   );
-  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+  return bindIndex(
+    parseInfo(await readRequiredJson(res, "get"), "get"),
+    transport,
+  );
 }
 
 /**
@@ -501,10 +599,9 @@ export async function list(
     await transport.fetch(`${baseUrl}/v1/search/indexes`),
     "Failed to list search indexes",
   );
-  const raw = (await res.json()) as RawSearchIndexResponse[];
-  return Array.isArray(raw)
-    ? raw.map((r) => bindIndex(mapInfo(r), transport))
-    : [];
+  return parseListResponse(await readRequiredJson(res, "list")).map((info) =>
+    bindIndex(info, transport),
+  );
 }
 
 /** Update an index's `name` and/or `expiresAt`; returns the updated handle. */
@@ -514,6 +611,8 @@ export async function update(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<SearchIndex> {
+  validateSearchIndexId(id);
+  validateUpdateSearchIndexInput(input);
   const body: Record<string, unknown> = {};
   if (input?.name !== undefined) body.name = input.name;
   if (input?.expiresAt !== undefined) body.expiresAt = input.expiresAt;
@@ -529,12 +628,15 @@ export async function update(
     ),
     `Failed to update search index '${id}'`,
   );
-  return bindIndex(mapInfo((await res.json()) as RawSearchIndexResponse), transport);
+  return bindIndex(
+    parseInfo(await readRequiredJson(res, "update"), "update"),
+    transport,
+  );
 }
 
 /**
- * Delete a whole index and ALL its data (idempotent server-side). For deleting
- * individual documents use the handle's `deleteDocuments`. Exported as `delete`:
+ * Delete a whole index and ALL its data. For deleting individual documents use
+ * the handle's `deleteDocuments`. Exported as `delete`:
  * `await searchindex.delete(id)`.
  */
 async function deleteIndex(
@@ -542,6 +644,7 @@ async function deleteIndex(
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<void> {
+  validateSearchIndexId(id);
   await ensureOk(
     await transport.fetch(
       `${baseUrl}/v1/search/indexes/${encodeURIComponent(id)}`,

--- a/packages/tools/src/search-index/index.ts
+++ b/packages/tools/src/search-index/index.ts
@@ -125,7 +125,15 @@ export interface SearchQueryInput {
   filter?: string;
 }
 
-export interface SearchIndexRangeInput {
+/** Payload-inclusion flags for enumeration reads (both default false upstream). */
+export interface SearchIndexIncludeOptions {
+  /** Include each document's `metadata` (e.g. contentHash) — the reconciliation flag. */
+  includeMetadata?: boolean;
+  /** Include each document's `content` payload. */
+  includeData?: boolean;
+}
+
+export interface SearchIndexRangeInput extends SearchIndexIncludeOptions {
   /** Opaque pagination cursor from a previous page (start with none or `"0"`). */
   cursor?: string;
   /** Page size. */
@@ -156,15 +164,22 @@ export interface SearchIndex extends SearchIndexInfo {
   upsert(documents: SearchDocument[], opts?: DataPlaneOptions): Promise<void>;
   /** Search the index. Returns ranked hits (best first). */
   query(input: SearchQueryInput, opts?: DataPlaneOptions): Promise<SearchHit[]>;
-  /** Enumerate documents page by page — the reconciliation primitive. */
+  /**
+   * Enumerate documents page by page — the reconciliation primitive. Items
+   * carry only `id` unless you set the include flags (verified live:
+   * `{ includeMetadata: true }` is what a hash-diff reconciler wants).
+   */
   range(
     input?: SearchIndexRangeInput,
     opts?: DataPlaneOptions,
   ): Promise<SearchIndexRangeResult>;
-  /** Fetch specific documents by id (`null` for ids that don't exist). */
+  /**
+   * Fetch specific documents by id (`null` for ids that don't exist). Items
+   * carry only `id` unless you set the include flags.
+   */
   fetchDocuments(
     ids: string[],
-    opts?: DataPlaneOptions,
+    opts?: DataPlaneOptions & SearchIndexIncludeOptions,
   ): Promise<Array<SearchDocument | null>>;
   /** Delete specific documents by id. */
   deleteDocuments(ids: string[], opts?: DataPlaneOptions): Promise<void>;
@@ -330,6 +345,9 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
       const body: Record<string, unknown> = {};
       if (input?.cursor != null) body.cursor = input.cursor;
       if (input?.limit != null) body.limit = input.limit;
+      if (input?.includeMetadata != null)
+        body.includeMetadata = input.includeMetadata;
+      if (input?.includeData != null) body.includeData = input.includeData;
 
       const raw = await dataPlaneJson(
         transport,
@@ -341,14 +359,20 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
         },
         `Failed to range search index '${info.id}'`,
       );
+      // Verified live 2026-08-03: the upstream page shape is
+      // `{ nextCursor, vectors: [...] }` (Search rides the vector API's range;
+      // `documents` kept as a defensive fallback should upstream rename).
       const page = unwrapResult(raw) as
-        | { nextCursor?: unknown; documents?: unknown }
+        | { nextCursor?: unknown; vectors?: unknown; documents?: unknown }
         | undefined;
-      const documents = Array.isArray(page?.documents)
-        ? page.documents
-            .map(toDocument)
-            .filter((doc): doc is SearchDocument => doc !== null)
-        : [];
+      const items = Array.isArray(page?.vectors)
+        ? page.vectors
+        : Array.isArray(page?.documents)
+          ? page.documents
+          : [];
+      const documents = items
+        .map(toDocument)
+        .filter((doc): doc is SearchDocument => doc !== null);
       const nextCursor =
         typeof page?.nextCursor === "string" && page.nextCursor !== ""
           ? page.nextCursor
@@ -365,13 +389,17 @@ function bindIndex(info: SearchIndexInfo, transport: Transport): SearchIndex {
         );
       }
       const indexName = resolveIndexName(opts);
+      const body: Record<string, unknown> = { ids };
+      if (opts?.includeMetadata != null)
+        body.includeMetadata = opts.includeMetadata;
+      if (opts?.includeData != null) body.includeData = opts.includeData;
       const raw = await dataPlaneJson(
         transport,
         `${info.url}/fetch/${indexName}`,
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ ids }),
+          body: JSON.stringify(body),
         },
         `Failed to fetch documents from search index '${info.id}'`,
       );

--- a/packages/tools/src/search-index/stub.spec.ts
+++ b/packages/tools/src/search-index/stub.spec.ts
@@ -1,7 +1,84 @@
 import { createStubClient } from "../stub/index.js";
 import { SearchIndexHttpError } from "./index.js";
 
+const searchIndexInfo = (id: string, name: string) => ({
+  id,
+  name,
+  status: "active" as const,
+  url: `https://${id}.search.data.stub.invalid`,
+  region: null,
+  expiresAt: null,
+  createdAt: "2026-08-04T00:00:00.000Z",
+});
+
 describe("searchindex stateful stub", () => {
+  it("generates deterministic resource IDs compatible with every SearchIndex surface", async () => {
+    const firstClient = createStubClient();
+    const first = await firstClient.searchindex.create({ name: "first" });
+    const second = await firstClient.searchindex.create({ name: "second" });
+    const repeatedClient = createStubClient();
+    const repeated = await repeatedClient.searchindex.create({ name: "first" });
+
+    expect(first.id).toBe("res_00000000000000000001");
+    expect(second.id).toBe("res_00000000000000000002");
+    expect(repeated.id).toBe(first.id);
+    expect(first.id).toMatch(/^res_[a-z0-9]{20}$/);
+    expect(first.url).toBe(`https://${first.id}.search.data.stub.invalid`);
+    await expect(firstClient.searchindex.get(first.id)).resolves.toMatchObject({
+      id: first.id,
+    });
+  });
+
+  it("coerces plain JSON control-plane overrides into registry-backed handles", async () => {
+    const createdId = "res_0000000000000000000a";
+    const fetchedId = "res_0000000000000000000b";
+    const listedId = "res_0000000000000000000c";
+    const sapiom = createStubClient({
+      overrides: {
+        "searchindex.create": searchIndexInfo(createdId, "created override"),
+        "searchindex.get": (id: unknown) =>
+          searchIndexInfo(String(id), "get override"),
+        "searchindex.list": [searchIndexInfo(listedId, "listed override")],
+        "searchindex.update": searchIndexInfo(createdId, "updated override"),
+      },
+    });
+
+    const created = await sapiom.searchindex.create({ name: "ignored" });
+    expect(created).toMatchObject({ id: createdId, name: "created override" });
+    expect(typeof created.upsert).toBe("function");
+    await created.upsert([{ id: "created-doc", content: { body: "kept" } }]);
+
+    const fetched = await sapiom.searchindex.get(fetchedId);
+    expect(fetched).toMatchObject({ id: fetchedId, name: "get override" });
+    expect(typeof fetched.query).toBe("function");
+    await fetched.upsert([{ id: "fetched-doc", content: { body: "found" } }]);
+    await expect(fetched.query({ query: "found" })).resolves.toMatchObject([
+      { id: "fetched-doc" },
+    ]);
+
+    const listed = await sapiom.searchindex.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({ id: listedId, name: "listed override" });
+    expect(typeof listed[0]!.range).toBe("function");
+    await listed[0]!.upsert([
+      { id: "listed-doc", content: { body: "listed" } },
+    ]);
+    await expect(
+      listed[0]!.range({ includeData: true }),
+    ).resolves.toMatchObject({
+      documents: [{ id: "listed-doc", content: { body: "listed" } }],
+    });
+
+    const updated = await sapiom.searchindex.update(createdId, {
+      name: "requested update",
+    });
+    expect(updated).toMatchObject({ id: createdId, name: "updated override" });
+    expect(typeof updated.fetchDocuments).toBe("function");
+    await expect(
+      updated.fetchDocuments(["created-doc"], { includeData: true }),
+    ).resolves.toEqual([{ id: "created-doc", content: { body: "kept" } }]);
+  });
+
   it("matches pagination and payload-inclusion semantics", async () => {
     const sapiom = createStubClient();
     const index = await sapiom.searchindex.create({

--- a/packages/tools/src/search-index/stub.spec.ts
+++ b/packages/tools/src/search-index/stub.spec.ts
@@ -1,0 +1,153 @@
+import { createStubClient } from "../stub/index.js";
+import { SearchIndexHttpError } from "./index.js";
+
+describe("searchindex stateful stub", () => {
+  it("matches pagination and payload-inclusion semantics", async () => {
+    const sapiom = createStubClient();
+    const index = await sapiom.searchindex.create({
+      name: "docs-corpus",
+      region: "eu-west-1",
+      ttl: "7d",
+    });
+
+    expect(index.region).toBe("eu-west-1");
+    expect(index.expiresAt).not.toBeNull();
+    await index.upsert([
+      {
+        id: "a",
+        content: { title: "Alpha" },
+        metadata: { contentHash: "h1" },
+      },
+      {
+        id: "b",
+        content: { title: "Beta" },
+        metadata: { contentHash: "h2" },
+      },
+      {
+        id: "c",
+        content: { title: "Gamma" },
+        metadata: { contentHash: "h3" },
+      },
+    ]);
+
+    const first = await index.range({ limit: 2 });
+    expect(first).toEqual({
+      nextCursor: "2",
+      documents: [{ id: "a" }, { id: "b" }],
+    });
+
+    const second = await index.range({
+      cursor: first.nextCursor!,
+      limit: 2,
+      includeMetadata: true,
+      includeData: true,
+    });
+    expect(second).toEqual({
+      nextCursor: null,
+      documents: [
+        {
+          id: "c",
+          content: { title: "Gamma" },
+          metadata: { contentHash: "h3" },
+        },
+      ],
+    });
+
+    await expect(
+      index.fetchDocuments(["a", "missing"], { includeMetadata: true }),
+    ).resolves.toEqual([{ id: "a", metadata: { contentHash: "h1" } }, null]);
+    await expect(index.query({ query: "beta" })).resolves.toMatchObject([
+      { id: "b", content: { title: "Beta" }, score: 1 },
+    ]);
+  });
+
+  it("uses the same fail-fast validation matrix as the live client", async () => {
+    const sapiom = createStubClient();
+    await expect(sapiom.searchindex.create({ name: "" })).rejects.toMatchObject(
+      {
+        status: 400,
+      },
+    );
+    await expect(
+      sapiom.searchindex.create({ name: "docs", ttl: "31d" }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(sapiom.searchindex.get("")).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      sapiom.searchindex.update("", { name: "docs" }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(sapiom.searchindex.delete("")).rejects.toMatchObject({
+      status: 400,
+    });
+
+    const index = await sapiom.searchindex.create({ name: "docs" });
+    await expect(index.upsert([])).rejects.toMatchObject({ status: 400 });
+    await expect(
+      index.upsert([{ id: "bad", content: null } as never]),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      index.upsert([{ id: "bad", content: {} }], { indexName: "bad name!" }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(index.query({ query: " ", limit: 0 })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(index.range({ cursor: "" })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(index.range({ limit: 1001 })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      index.range({ includeMetadata: "yes" } as never),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(index.fetchDocuments([])).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(index.fetchDocuments([""])).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(index.deleteDocuments([""])).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(
+      sapiom.searchindex.update(index.id, { name: "" }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      sapiom.searchindex.update(index.id, {
+        expiresAt: "January 1, 2099",
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 404 for unknown resources and invalidates handles after deletion", async () => {
+    const sapiom = createStubClient();
+    await expect(sapiom.searchindex.get("res_missing")).rejects.toEqual(
+      expect.objectContaining({ name: "SearchIndexHttpError", status: 404 }),
+    );
+    await expect(
+      sapiom.searchindex.update("res_missing", { name: "renamed" }),
+    ).rejects.toBeInstanceOf(SearchIndexHttpError);
+    await expect(
+      sapiom.searchindex.delete("res_missing"),
+    ).rejects.toMatchObject({
+      status: 404,
+    });
+
+    const index = await sapiom.searchindex.create({ name: "docs" });
+    await sapiom.searchindex.delete(index.id);
+    const staleHandleCalls = [
+      () => index.upsert([{ id: "a", content: {} }]),
+      () => index.query({ query: "anything" }),
+      () => index.range(),
+      () => index.fetchDocuments(["a"]),
+      () => index.deleteDocuments(["a"]),
+    ];
+    for (const call of staleHandleCalls) {
+      await expect(call()).rejects.toMatchObject({ status: 404 });
+    }
+    // The live control plane treats a repeated delete of the same retained row
+    // as an idempotent terminal retry.
+    await expect(sapiom.searchindex.delete(index.id)).resolves.toBeUndefined();
+  });
+});

--- a/packages/tools/src/search-index/validation.ts
+++ b/packages/tools/src/search-index/validation.ts
@@ -1,0 +1,251 @@
+import { SearchIndexHttpError } from "./errors.js";
+import type {
+  CreateSearchIndexInput,
+  DataPlaneOptions,
+  SearchDocumentInput,
+  SearchIndexIncludeOptions,
+  SearchIndexRangeInput,
+  SearchQueryInput,
+  UpdateSearchIndexInput,
+} from "./index.js";
+
+export const DEFAULT_SEARCH_INDEX_RANGE_CURSOR = "0";
+export const DEFAULT_SEARCH_INDEX_RANGE_LIMIT = 100;
+export const DEFAULT_SEARCH_INDEX_QUERY_LIMIT = 5;
+
+const INDEX_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CURSOR_PATTERN = /^\d+$/;
+const TTL_PATTERN = /^(\d+)([mhd])$/;
+const ISO_DATE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
+const MAX_TTL_MS = 30 * 86_400_000;
+const MAX_RESULT_LIMIT = 1_000;
+
+function invalid(message: string, body?: unknown): never {
+  throw new SearchIndexHttpError(message, 400, body);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateBoundedLimit(
+  value: unknown,
+  field: string,
+): asserts value is number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MAX_RESULT_LIMIT
+  ) {
+    invalid(`${field} must be an integer from 1 to ${MAX_RESULT_LIMIT}`, {
+      [field]: value,
+    });
+  }
+}
+
+export function validateCreateSearchIndexInput(
+  input: CreateSearchIndexInput,
+): void {
+  if (!isRecord(input)) invalid("create requires an input object", { input });
+  if (
+    typeof input.name !== "string" ||
+    input.name.length < 1 ||
+    input.name.length > 128
+  ) {
+    invalid("create requires a name of 1-128 characters", { name: input.name });
+  }
+  if (
+    input.region !== undefined &&
+    (typeof input.region !== "string" ||
+      input.region.length < 1 ||
+      input.region.length > 64)
+  ) {
+    invalid("region must be a non-empty string of at most 64 characters", {
+      region: input.region,
+    });
+  }
+  if (input.ttl !== undefined) {
+    if (typeof input.ttl !== "string") {
+      invalid('ttl must use the form "30m", "24h", or "7d"', {
+        ttl: input.ttl,
+      });
+    }
+    const match = TTL_PATTERN.exec(input.ttl);
+    if (!match) {
+      invalid('ttl must use the form "30m", "24h", or "7d"', {
+        ttl: input.ttl,
+      });
+    }
+    const amount = Number(match[1]);
+    const multiplier = { m: 60_000, h: 3_600_000, d: 86_400_000 }[
+      match[2] as "m" | "h" | "d"
+    ];
+    if (amount < 1 || amount * multiplier > MAX_TTL_MS) {
+      invalid("ttl must be greater than zero and no more than 30 days", {
+        ttl: input.ttl,
+      });
+    }
+  }
+}
+
+export function validateUpdateSearchIndexInput(
+  input: UpdateSearchIndexInput,
+): void {
+  if (!isRecord(input)) invalid("update requires an input object", { input });
+  if (
+    input.name !== undefined &&
+    (typeof input.name !== "string" ||
+      input.name.length < 1 ||
+      input.name.length > 128)
+  ) {
+    invalid("name must contain 1-128 characters", { name: input.name });
+  }
+  if (input.expiresAt !== undefined) {
+    if (
+      typeof input.expiresAt !== "string" ||
+      !ISO_DATE_PATTERN.test(input.expiresAt) ||
+      !Number.isFinite(Date.parse(input.expiresAt))
+    ) {
+      invalid("expiresAt must be a valid ISO-8601 date string", {
+        expiresAt: input.expiresAt,
+      });
+    }
+    if (Date.parse(input.expiresAt) <= Date.now()) {
+      invalid("expiresAt must be in the future", {
+        expiresAt: input.expiresAt,
+      });
+    }
+  }
+}
+
+export function validateSearchIndexId(id: string): void {
+  if (typeof id !== "string" || id.length === 0) {
+    invalid("search index id must be a non-empty string", { id });
+  }
+}
+
+export function resolveSearchIndexName(opts?: DataPlaneOptions): string {
+  if (opts !== undefined && !isRecord(opts)) {
+    invalid("data-plane options must be an object", { opts });
+  }
+  const indexName = opts?.indexName ?? "default";
+  if (typeof indexName !== "string" || !INDEX_NAME_PATTERN.test(indexName)) {
+    invalid(
+      `indexName must match ${INDEX_NAME_PATTERN} (got "${String(indexName)}")`,
+      {
+        indexName,
+      },
+    );
+  }
+  return indexName;
+}
+
+export function validateSearchDocumentInputs(
+  documents: SearchDocumentInput[],
+): void {
+  if (!Array.isArray(documents) || documents.length === 0) {
+    invalid("upsert requires at least one document", { documents });
+  }
+  documents.forEach((document, index) => {
+    if (!isRecord(document)) {
+      invalid(`document at index ${index} must be an object`, { document });
+    }
+    if (typeof document.id !== "string" || document.id.length === 0) {
+      invalid(`document at index ${index} requires a non-empty id`, {
+        id: document.id,
+      });
+    }
+    if (!isRecord(document.content)) {
+      invalid(`document '${document.id}' content must be an object`, {
+        content: document.content,
+      });
+    }
+    if (document.metadata !== undefined && !isRecord(document.metadata)) {
+      invalid(
+        `document '${document.id}' metadata must be an object when provided`,
+        {
+          metadata: document.metadata,
+        },
+      );
+    }
+  });
+}
+
+export function validateSearchQueryInput(input: SearchQueryInput): void {
+  if (!isRecord(input)) invalid("query requires an input object", { input });
+  if (typeof input.query !== "string" || input.query.trim().length === 0) {
+    invalid("query requires a non-empty query string", { query: input.query });
+  }
+  if (input.limit !== undefined) validateBoundedLimit(input.limit, "limit");
+  if (input.reranking !== undefined && typeof input.reranking !== "boolean") {
+    invalid("reranking must be a boolean", { reranking: input.reranking });
+  }
+  if (input.filter !== undefined && typeof input.filter !== "string") {
+    invalid("filter must be a string", { filter: input.filter });
+  }
+}
+
+export function validateSearchIndexIncludeOptions(
+  opts: SearchIndexIncludeOptions | undefined,
+): void {
+  if (
+    opts?.includeMetadata !== undefined &&
+    typeof opts.includeMetadata !== "boolean"
+  ) {
+    invalid("includeMetadata must be a boolean", {
+      includeMetadata: opts.includeMetadata,
+    });
+  }
+  if (
+    opts?.includeData !== undefined &&
+    typeof opts.includeData !== "boolean"
+  ) {
+    invalid("includeData must be a boolean", { includeData: opts.includeData });
+  }
+}
+
+export function normalizeSearchIndexRangeInput(
+  input?: SearchIndexRangeInput,
+): Required<Pick<SearchIndexRangeInput, "cursor" | "limit">> &
+  SearchIndexIncludeOptions {
+  if (input !== undefined && !isRecord(input)) {
+    invalid("range input must be an object", { input });
+  }
+  const cursor = input?.cursor ?? DEFAULT_SEARCH_INDEX_RANGE_CURSOR;
+  const limit = input?.limit ?? DEFAULT_SEARCH_INDEX_RANGE_LIMIT;
+  if (typeof cursor !== "string" || !CURSOR_PATTERN.test(cursor)) {
+    invalid('cursor must be a numeric string (use "0" for the first page)', {
+      cursor,
+    });
+  }
+  validateBoundedLimit(limit, "limit");
+  validateSearchIndexIncludeOptions(input);
+  return {
+    cursor,
+    limit,
+    ...(typeof input?.includeMetadata === "boolean" && {
+      includeMetadata: input.includeMetadata,
+    }),
+    ...(typeof input?.includeData === "boolean" && {
+      includeData: input.includeData,
+    }),
+  };
+}
+
+export function validateSearchDocumentIds(
+  ids: string[],
+  operation: string,
+): void {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    invalid(`${operation} requires at least one id`, { ids });
+  }
+  ids.forEach((id, index) => {
+    if (typeof id !== "string" || id.length === 0) {
+      invalid(`${operation} id at index ${index} must be a non-empty string`, {
+        id,
+      });
+    }
+  });
+}

--- a/packages/tools/src/search/README.md
+++ b/packages/tools/src/search/README.md
@@ -147,6 +147,11 @@ site.links; // [{ url, title?, description? }, …]
 }
 ```
 
+Unlike the routed web-search, scrape, and email operations, `map` calls the
+Firecrawl gateway directly at `/v2/map`; authentication is still handled by the
+same Sapiom client. A successful response that does not contain a valid `links`
+array throws `SearchContractError` instead of being mistaken for an empty site.
+
 Each map call is priced at $0.009, independent of the number of discovered
 links.
 

--- a/packages/tools/src/search/README.md
+++ b/packages/tools/src/search/README.md
@@ -2,7 +2,7 @@
 
 Find information across the web and beyond — searching the web, reading pages,
 and looking up professional emails. More operations land in this namespace as
-they ship; today it offers `webSearch`, `scrape`, and `emailSearch`.
+they ship; today it offers `webSearch`, `scrape`, `map`, and `emailSearch`.
 
 ## `webSearch` — search the web
 
@@ -119,6 +119,36 @@ that format was requested.
 
 `scrape` works on HTML pages and common documents (PDF, DOCX, TXT). It is not
 meant for images, video, or archives.
+
+## `map` — discover a site's URLs
+
+Map a website without scraping every page's content. The SDK returns structured
+links, unlike the equivalent MCP tool's rendered text:
+
+```typescript
+const site = await sapiom.search.map({ url: "https://docs.example.com" });
+site.links; // [{ url, title?, description? }, …]
+```
+
+### Input
+
+- `url` (required) — the site or page from which discovery starts.
+
+### Result
+
+```typescript
+{
+  links: Array<{
+    url: string;
+    title?: string | null;
+    description?: string | null;
+  }>;
+  success?: boolean;
+}
+```
+
+Each map call is priced at $0.009, independent of the number of discovered
+links.
 
 ## `emailSearch` — work with professional emails
 

--- a/packages/tools/src/search/errors.ts
+++ b/packages/tools/src/search/errors.ts
@@ -16,6 +16,23 @@ export class SearchHttpError extends Error {
 }
 
 /**
+ * A successful HTTP response that does not match a documented `search`
+ * operation's wire contract. This is deliberately distinct from an empty
+ * result and from a non-2xx {@link SearchHttpError}.
+ */
+export class SearchContractError extends Error {
+  readonly operation: string;
+  readonly body: unknown;
+
+  constructor(operation: string, message: string, body: unknown) {
+    super(`Invalid Search ${operation} response: ${message}`);
+    this.name = "SearchContractError";
+    this.operation = operation;
+    this.body = body;
+  }
+}
+
+/**
  * Return the response when 2xx, otherwise throw a {@link SearchHttpError}.
  * Parses the error body as JSON when possible; falls back to raw text.
  */

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -1,5 +1,6 @@
 import { createClient } from "../index.js";
 import { Transport } from "../_client/index.js";
+import { createStubClient, type StubCallRecord } from "../stub/index.js";
 import {
   scrape,
   webSearch,
@@ -7,6 +8,7 @@ import {
   verifyEmail,
   domainSearch,
   map,
+  SearchContractError,
   SearchHttpError,
 } from "./index.js";
 
@@ -15,9 +17,10 @@ import {
 // a scripted fetch mock, so URL/method/header/body assertions are exact and we
 // verify the Transport injects the tenant credential.
 //
-// Every verb here is routed (SAP-1116): `POST /v1/capabilities/<id>` on the Core
-// base URL, authenticated via `x-api-key` (NOT the gateway-direct x-sapiom-api-key
-// — wrong header = silent 401), with the router's normalized DTO as the response.
+// Unless a section explicitly says otherwise, verbs here are routed (SAP-1116):
+// `POST /v1/capabilities/<id>` on the Core base URL, authenticated via `x-api-key`
+// (NOT the gateway-direct x-sapiom-api-key — wrong header = silent 401), with the
+// router's normalized DTO as the response. `search.map` is the direct exception.
 // ---------------------------------------------------------------------------
 
 interface FetchCall {
@@ -1016,14 +1019,21 @@ describe("search.map()", () => {
         jsonResponse({
           success: true,
           links: [
-            { url: "https://docs.example.com/", title: "Home", description: null },
+            {
+              url: "https://docs.example.com/",
+              title: "Home",
+              description: null,
+            },
             { url: "https://docs.example.com/verify/" },
-            { notAUrl: true },
           ],
         }),
     ]);
 
-    const result = await map({ url: "https://docs.example.com" }, transport, BASE);
+    const result = await map(
+      { url: "https://docs.example.com" },
+      transport,
+      BASE,
+    );
 
     expect(calls[0]!.url).toBe(`${BASE}/v2/map`);
     expect(calls[0]!.init.method).toBe("POST");
@@ -1039,18 +1049,91 @@ describe("search.map()", () => {
     ]);
   });
 
-  it("returns empty links when the upstream omits them", async () => {
-    const { transport } = makeTransport([() => jsonResponse({ success: true })]);
-    const result = await map({ url: "https://x.test" }, transport, BASE);
-    expect(result.links).toEqual([]);
+  it("accepts a valid empty links array when the optional success flag is absent", async () => {
+    const { transport } = makeTransport([() => jsonResponse({ links: [] })]);
+
+    await expect(
+      map({ url: "https://x.test" }, transport, BASE),
+    ).resolves.toEqual({ links: [] });
   });
 
-  it("throws before fetching on a missing url", async () => {
+  it.each([
+    ["empty body", () => new Response(null, { status: 200 })],
+    [
+      "invalid JSON",
+      () =>
+        new Response("{not-json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ],
+    ["null", () => jsonResponse(null)],
+    ["an array root", () => jsonResponse([])],
+    ["an object without links", () => jsonResponse({ success: true })],
+    ["non-array links", () => jsonResponse({ links: {} })],
+    ["a null link", () => jsonResponse({ links: [null] })],
+    ["a link without a url", () => jsonResponse({ links: [{}] })],
+    ["an empty link url", () => jsonResponse({ links: [{ url: "  " }] })],
+    ["a non-string link url", () => jsonResponse({ links: [{ url: 42 }] })],
+    [
+      "a malformed link title",
+      () => jsonResponse({ links: [{ url: "https://x.test", title: 42 }] }),
+    ],
+    [
+      "a malformed link description",
+      () =>
+        jsonResponse({
+          links: [{ url: "https://x.test", description: {} }],
+        }),
+    ],
+    [
+      "a malformed success flag",
+      () => jsonResponse({ success: "yes", links: [] }),
+    ],
+  ])(
+    "fails closed with a deterministic contract error for %s",
+    async (_label, response) => {
+      const { transport } = makeTransport([response]);
+
+      const error = await map({ url: "https://x.test" }, transport, BASE).catch(
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(SearchContractError);
+      expect(error).toMatchObject({
+        name: "SearchContractError",
+        operation: "map",
+      });
+      expect(error).toHaveProperty("body");
+      expect((error as Error).message).toMatch(
+        /^Invalid Search map response: /,
+      );
+    },
+  );
+
+  it.each([
+    ["undefined input", undefined],
+    ["null input", null],
+    ["array input", []],
+    ["missing url", {}],
+    ["empty url", { url: "" }],
+    ["whitespace url", { url: "   " }],
+    ["non-string url", { url: 42 }],
+  ])("shares fail-fast live/stub validation for %s", async (_label, input) => {
     const { transport, calls } = makeTransport([]);
-    await expect(map({ url: "" }, transport, BASE)).rejects.toBeInstanceOf(
-      SearchHttpError,
-    );
+    const stubCalls: StubCallRecord[] = [];
+    const stub = createStubClient({ calls: stubCalls });
+
+    await expect(map(input as never, transport, BASE)).rejects.toMatchObject({
+      name: "SearchHttpError",
+      status: 400,
+    });
+    await expect(stub.search.map(input as never)).rejects.toMatchObject({
+      name: "SearchHttpError",
+      status: 400,
+    });
     expect(calls).toHaveLength(0);
+    expect(stubCalls).toHaveLength(0);
   });
 
   it("throws SearchHttpError with status + body on a non-2xx", async () => {

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -6,6 +6,7 @@ import {
   findEmail,
   verifyEmail,
   domainSearch,
+  map,
   SearchHttpError,
 } from "./index.js";
 
@@ -1000,5 +1001,68 @@ describe("createClient().search.emailSearch", () => {
     );
     expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
     expect(headerOf(calls[1]!, "x-api-key")).toBe("client-key");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search.map() — gateway-direct (NOT routed): straight to the Firecrawl host
+// on the default x-sapiom-api-key header, $0.009 flat.
+// ---------------------------------------------------------------------------
+
+describe("search.map()", () => {
+  it("POSTs {base}/v2/map on the default gateway header and maps links", async () => {
+    const { transport, calls } = makeTransport([
+      () =>
+        jsonResponse({
+          success: true,
+          links: [
+            { url: "https://docs.example.com/", title: "Home", description: null },
+            { url: "https://docs.example.com/verify/" },
+            { notAUrl: true },
+          ],
+        }),
+    ]);
+
+    const result = await map({ url: "https://docs.example.com" }, transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/v2/map`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // Gateway-direct — the credential rides the DEFAULT x-sapiom-api-key header
+    // (the routed verbs above use x-api-key via capabilityCall instead).
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("test-key");
+    expect(bodyOf(calls[0]!)).toEqual({ url: "https://docs.example.com" });
+
+    expect(result.success).toBe(true);
+    expect(result.links).toEqual([
+      { url: "https://docs.example.com/", title: "Home", description: null },
+      { url: "https://docs.example.com/verify/" },
+    ]);
+  });
+
+  it("returns empty links when the upstream omits them", async () => {
+    const { transport } = makeTransport([() => jsonResponse({ success: true })]);
+    const result = await map({ url: "https://x.test" }, transport, BASE);
+    expect(result.links).toEqual([]);
+  });
+
+  it("throws before fetching on a missing url", async () => {
+    const { transport, calls } = makeTransport([]);
+    await expect(map({ url: "" }, transport, BASE)).rejects.toBeInstanceOf(
+      SearchHttpError,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws SearchHttpError with status + body on a non-2xx", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "invalid url" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(
+      map({ url: "https://x.test" }, transport, BASE),
+    ).rejects.toMatchObject({ status: 400, body: { error: "invalid url" } });
   });
 });

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -31,7 +31,8 @@ import {
   defaultTransport,
   resolveCoreBaseUrl,
 } from "../_client/index.js";
-import { SearchHttpError } from "./errors.js";
+import { resolveServiceUrl } from "../_client/service-url.js";
+import { ensureOk, SearchHttpError } from "./errors.js";
 
 export { SearchHttpError };
 
@@ -622,4 +623,80 @@ export async function domainSearch(
     },
   );
   return mapDomainSearch(input.domain, raw);
+}
+
+// ----- map -----
+
+/**
+ * `map` is gateway-direct, unlike the routed verbs above: site mapping is not a
+ * routed capability (`/v2/map` carries no capability id at the gateway), so the
+ * call goes straight to the Firecrawl provider host with the credential on the
+ * default gateway header. Flat-priced at $0.009 per call.
+ */
+const MAP_BASE_URL = resolveServiceUrl(
+  "firecrawl",
+  process.env.SAPIOM_FIRECRAWL_URL,
+);
+
+export interface MapInput {
+  /** URL of the site to map (an HTML page — not an image/binary URL). */
+  url: string;
+}
+
+/** One discovered URL. `title`/`description` are best-effort and often null. */
+export interface MapLink {
+  url: string;
+  title?: string | null;
+  description?: string | null;
+}
+
+export interface MapResult {
+  /** Every URL discovered from the starting page (sitemap + crawled links). */
+  links: MapLink[];
+  /** Upstream success flag (absent on some responses; links presence is the signal). */
+  success?: boolean;
+}
+
+interface RawMapResponse {
+  success?: boolean;
+  links?: Array<{ url?: string; title?: string | null; description?: string | null }>;
+}
+
+/**
+ * Discover every URL on a website without extracting content — fast sitemap
+ * discovery from a starting page ($0.009 flat). Returns structured links
+ * (unlike the MCP tool of the same capability, which renders markdown text).
+ *
+ * Failed requests throw {@link SearchHttpError}.
+ */
+export async function map(
+  input: MapInput,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = MAP_BASE_URL,
+): Promise<MapResult> {
+  if (!input?.url) {
+    throw new SearchHttpError("map requires a url", 400, undefined);
+  }
+  const res = await ensureOk(
+    await transport.fetch(`${baseUrl}/v2/map`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: input.url }),
+    }),
+    `Failed to map ${input.url}`,
+  );
+  const raw = (await res.json()) as RawMapResponse;
+  const links = Array.isArray(raw.links)
+    ? raw.links
+        .filter((l): l is { url: string } & typeof l => typeof l?.url === "string")
+        .map((l) => ({
+          url: l.url,
+          ...(l.title !== undefined && { title: l.title }),
+          ...(l.description !== undefined && { description: l.description }),
+        }))
+    : [];
+  return {
+    links,
+    ...(raw.success !== undefined && { success: raw.success }),
+  };
 }

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -18,11 +18,13 @@
  *
  * Or via an explicit client: `createClient({ apiKey }).search.webSearch(...)`.
  *
- * Every operation here is **routed**: it goes through the shared
+ * Web search, scrape, and email operations are **routed** through the shared
  * {@link capabilityCall} seam to `POST /v1/capabilities/<id>` on the single Core
  * base URL (SAP-1116). The dotted capability id (`web.scrape`, `web.search`,
- * `email.find` / `email.verify` / `email.domain.search`) appears only on the wire —
- * the public verb names and shapes below are unchanged. Failed requests throw
+ * `email.find` / `email.verify` / `email.domain.search`) appears only on the wire.
+ * `map` is the exception: it calls the Firecrawl gateway directly at `/v2/map`
+ * because that endpoint has no routed capability id. The public verb names and
+ * shapes remain provider-neutral in both cases. Failed requests throw
  * {@link SearchHttpError} (carries `status` + parsed `body`).
  */
 import {
@@ -32,9 +34,10 @@ import {
   resolveCoreBaseUrl,
 } from "../_client/index.js";
 import { resolveServiceUrl } from "../_client/service-url.js";
-import { ensureOk, SearchHttpError } from "./errors.js";
+import { ensureOk, SearchContractError, SearchHttpError } from "./errors.js";
+import { validateMapInput } from "./validation.js";
 
-export { SearchHttpError };
+export { SearchContractError, SearchHttpError };
 
 /** Build the capability-specific error the routed call throws on a non-2xx. */
 const searchError = (message: string, status: number, body: unknown): Error =>
@@ -657,9 +660,72 @@ export interface MapResult {
   success?: boolean;
 }
 
-interface RawMapResponse {
-  success?: boolean;
-  links?: Array<{ url?: string; title?: string | null; description?: string | null }>;
+function mapContractError(message: string, body: unknown): never {
+  throw new SearchContractError("map", message, body);
+}
+
+async function readMapResponse(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => "");
+  if (!text) mapContractError("expected a JSON body", undefined);
+  try {
+    return JSON.parse(text);
+  } catch {
+    mapContractError("response body is not valid JSON", text);
+  }
+}
+
+function parseMapResponse(raw: unknown): MapResult {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    mapContractError("expected an object with a links array", raw);
+  }
+  const response = raw as Record<string, unknown>;
+  if (!Array.isArray(response.links)) {
+    mapContractError("expected a links array", raw);
+  }
+  if (response.success !== undefined && typeof response.success !== "boolean") {
+    mapContractError("expected success to be a boolean when present", raw);
+  }
+
+  const links = response.links.map((item, index): MapLink => {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      mapContractError(`link at index ${index} must be an object`, item);
+    }
+    const link = item as Record<string, unknown>;
+    if (typeof link.url !== "string" || link.url.trim().length === 0) {
+      mapContractError(
+        `link at index ${index} requires a non-empty string url`,
+        item,
+      );
+    }
+    for (const field of ["title", "description"] as const) {
+      if (
+        link[field] !== undefined &&
+        link[field] !== null &&
+        typeof link[field] !== "string"
+      ) {
+        mapContractError(
+          `link at index ${index} field '${field}' must be a string or null when present`,
+          item,
+        );
+      }
+    }
+    return {
+      url: link.url,
+      ...(link.title !== undefined && {
+        title: link.title as string | null,
+      }),
+      ...(link.description !== undefined && {
+        description: link.description as string | null,
+      }),
+    };
+  });
+
+  return {
+    links,
+    ...(response.success !== undefined && {
+      success: response.success as boolean,
+    }),
+  };
 }
 
 /**
@@ -667,16 +733,16 @@ interface RawMapResponse {
  * discovery from a starting page ($0.009 flat). Returns structured links
  * (unlike the MCP tool of the same capability, which renders markdown text).
  *
- * Failed requests throw {@link SearchHttpError}.
+ * Non-2xx responses throw {@link SearchHttpError}; malformed successful
+ * responses throw {@link SearchContractError} rather than fabricating an empty
+ * result.
  */
 export async function map(
   input: MapInput,
   transport: Transport = defaultTransport(),
   baseUrl: string = MAP_BASE_URL,
 ): Promise<MapResult> {
-  if (!input?.url) {
-    throw new SearchHttpError("map requires a url", 400, undefined);
-  }
+  validateMapInput(input);
   const res = await ensureOk(
     await transport.fetch(`${baseUrl}/v2/map`, {
       method: "POST",
@@ -685,18 +751,5 @@ export async function map(
     }),
     `Failed to map ${input.url}`,
   );
-  const raw = (await res.json()) as RawMapResponse;
-  const links = Array.isArray(raw.links)
-    ? raw.links
-        .filter((l): l is { url: string } & typeof l => typeof l?.url === "string")
-        .map((l) => ({
-          url: l.url,
-          ...(l.title !== undefined && { title: l.title }),
-          ...(l.description !== undefined && { description: l.description }),
-        }))
-    : [];
-  return {
-    links,
-    ...(raw.success !== undefined && { success: raw.success }),
-  };
+  return parseMapResponse(await readMapResponse(res));
 }

--- a/packages/tools/src/search/validation.ts
+++ b/packages/tools/src/search/validation.ts
@@ -1,0 +1,13 @@
+import { SearchHttpError } from "./errors.js";
+
+/** Validate `search.map` input identically on the live and local-stub surfaces. */
+export function validateMapInput(
+  input: unknown,
+): asserts input is { url: string } {
+  const isObject =
+    input !== null && typeof input === "object" && !Array.isArray(input);
+  const url = isObject ? (input as Record<string, unknown>).url : undefined;
+  if (typeof url !== "string" || url.trim().length === 0) {
+    throw new SearchHttpError("map requires a non-empty url", 400, { url });
+  }
+}

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -26,7 +26,10 @@ import {
   SpeechHttpError,
   BrowserAutomationHttpError,
   KeysHttpError,
+  SearchIndexContractError,
   SearchIndexHttpError,
+  DEFAULT_SEARCH_INDEX_RANGE_CURSOR,
+  DEFAULT_SEARCH_INDEX_RANGE_LIMIT,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -114,7 +117,10 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof SpeechHttpError).toBe("function");
     expect(typeof BrowserAutomationHttpError).toBe("function");
     expect(typeof KeysHttpError).toBe("function");
+    expect(typeof SearchIndexContractError).toBe("function");
     expect(typeof SearchIndexHttpError).toBe("function");
+    expect(DEFAULT_SEARCH_INDEX_RANGE_CURSOR).toBe("0");
+    expect(DEFAULT_SEARCH_INDEX_RANGE_LIMIT).toBe(100);
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -21,6 +21,7 @@ import {
   searchindex,
   Sandbox,
   Repository,
+  SearchContractError,
   SearchHttpError,
   MemoryHttpError,
   SpeechHttpError,
@@ -112,6 +113,7 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof browserAutomation).toBe("object");
     expect(typeof keys).toBe("object");
     expect(typeof searchindex).toBe("object");
+    expect(typeof SearchContractError).toBe("function");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -18,6 +18,7 @@ import {
   speech,
   browserAutomation,
   keys,
+  searchindex,
   Sandbox,
   Repository,
   SearchHttpError,
@@ -25,6 +26,7 @@ import {
   SpeechHttpError,
   BrowserAutomationHttpError,
   KeysHttpError,
+  SearchIndexHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -79,6 +81,14 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.keys).toBe("object");
     expect(typeof sapiom.keys.mintScoped).toBe("function");
 
+    expect(typeof sapiom.search.map).toBe("function");
+    expect(typeof sapiom.searchindex).toBe("object");
+    expect(typeof sapiom.searchindex.create).toBe("function");
+    expect(typeof sapiom.searchindex.get).toBe("function");
+    expect(typeof sapiom.searchindex.list).toBe("function");
+    expect(typeof sapiom.searchindex.update).toBe("function");
+    expect(typeof sapiom.searchindex.delete).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -98,11 +108,13 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof speech).toBe("object");
     expect(typeof browserAutomation).toBe("object");
     expect(typeof keys).toBe("object");
+    expect(typeof searchindex).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");
     expect(typeof BrowserAutomationHttpError).toBe("function");
     expect(typeof KeysHttpError).toBe("function");
+    expect(typeof SearchIndexHttpError).toBe("function");
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -113,13 +113,28 @@ import type {
   ActiveSession,
 } from "../browser-automation/index.js";
 import type { ScopedKey } from "../keys/index.js";
+import { SearchIndexHttpError } from "../search-index/errors.js";
 import type {
+  CreateSearchIndexInput,
   SearchDocument,
+  SearchDocumentInput,
   SearchHit,
   SearchIndex,
   SearchIndexInfo,
   SearchIndexRangeResult,
 } from "../search-index/index.js";
+import {
+  DEFAULT_SEARCH_INDEX_QUERY_LIMIT,
+  normalizeSearchIndexRangeInput,
+  resolveSearchIndexName,
+  validateCreateSearchIndexInput,
+  validateSearchDocumentIds,
+  validateSearchDocumentInputs,
+  validateSearchIndexId,
+  validateSearchIndexIncludeOptions,
+  validateSearchQueryInput,
+  validateUpdateSearchIndexInput,
+} from "../search-index/validation.js";
 import type { MapResult } from "../search/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
@@ -525,6 +540,25 @@ function stubCodingResult(
   };
 }
 
+function stubTtlMilliseconds(ttl: string): number {
+  const match = /^(\d+)([mhd])$/.exec(ttl)!;
+  const multiplier = { m: 60_000, h: 3_600_000, d: 86_400_000 }[
+    match[2] as "m" | "h" | "d"
+  ];
+  return Number(match[1]) * multiplier;
+}
+
+function stubSearchIndexNotFound(
+  id: string,
+  operation = "get",
+): SearchIndexHttpError {
+  return new SearchIndexHttpError(
+    `Failed to ${operation} search index '${id}': 404 Not Found`,
+    404,
+    { message: "Not found" },
+  );
+}
+
 function stubRunHandle(
   overrides: StubOverrides,
   correlationId: string,
@@ -703,22 +737,34 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
   // `${indexId}/${indexName}`. Stateful so run_local exercises the real flow —
   // upsert → query/range/fetchDocuments/deleteDocuments reflect prior writes.
   const searchIndexRegistry = new Map<string, SearchIndexInfo>();
-  const searchIndexDocs = new Map<string, Map<string, SearchDocument>>();
+  const searchIndexDocs = new Map<string, Map<string, SearchDocumentInput>>();
+  const deletedSearchIndexIds = new Set<string>();
   let searchIndexSeq = 0;
 
-  const stubSearchIndexInfo = (id: string, name: string): SearchIndexInfo => ({
+  const stubSearchIndexInfo = (
+    id: string,
+    input: CreateSearchIndexInput,
+  ): SearchIndexInfo => ({
     id,
-    name,
+    name: input.name,
     status: "active",
     url: `https://${id}.search.data.stub.invalid`,
-    region: "us-central1",
-    expiresAt: null,
-    createdAt: "2099-01-01T00:00:00Z",
+    region: input.region ?? "us-central1",
+    expiresAt:
+      input.ttl === undefined
+        ? null
+        : new Date(Date.now() + stubTtlMilliseconds(input.ttl)).toISOString(),
+    createdAt: new Date().toISOString(),
   });
 
   const bindStubSearchIndex = (info: SearchIndexInfo): SearchIndex => {
-    const docsFor = (indexName?: string): Map<string, SearchDocument> => {
-      const key = `${info.id}/${indexName ?? "default"}`;
+    const ensureActive = (): void => {
+      if (!searchIndexRegistry.has(info.id)) {
+        throw stubSearchIndexNotFound(info.id, "access");
+      }
+    };
+    const docsFor = (indexName: string): Map<string, SearchDocumentInput> => {
+      const key = `${info.id}/${indexName}`;
       let docs = searchIndexDocs.get(key);
       if (!docs) {
         docs = new Map();
@@ -730,72 +776,83 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
     // unless the include flags are set (a reconciler that forgets
     // `includeMetadata: true` should fail the same way under run_local).
     const stripUnrequested = (
-      doc: SearchDocument,
+      doc: SearchDocumentInput,
       flags?: { includeMetadata?: boolean; includeData?: boolean },
     ): SearchDocument => ({
       id: doc.id,
-      content: flags?.includeData ? doc.content : {},
+      ...(flags?.includeData ? { content: doc.content } : {}),
       ...(flags?.includeMetadata && doc.metadata !== undefined
         ? { metadata: doc.metadata }
         : {}),
     });
     return {
       ...info,
-      upsert: (documents, opts) =>
-        Promise.resolve(
-          r("searchindex.upsert", [documents, opts], () => {
-            const docs = docsFor(opts?.indexName);
-            for (const doc of documents) docs.set(doc.id, doc);
-            return undefined;
-          }) as void,
-        ),
-      query: (input, opts) =>
-        Promise.resolve(
-          r("searchindex.query", [input, opts], () => {
-            // Deterministic relevance: a hit is any document whose content
-            // JSON contains the query (case-insensitive), score 1.
-            const needle = input.query.toLowerCase();
-            const hits: SearchHit[] = [...docsFor(opts?.indexName).values()]
-              .filter((doc) =>
-                JSON.stringify(doc.content).toLowerCase().includes(needle),
-              )
-              .map((doc) => ({ ...doc, score: 1 }));
-            return hits.slice(0, input.limit ?? 10);
-          }) as SearchHit[],
-        ),
-      range: (input, opts) =>
-        Promise.resolve(
-          r("searchindex.range", [input, opts], () => {
-            const all = [...docsFor(opts?.indexName).values()];
-            const offset = input?.cursor ? Number(input.cursor) || 0 : 0;
-            const limit = input?.limit ?? 100;
-            const next = offset + limit;
-            return {
-              nextCursor: next < all.length ? String(next) : null,
-              documents: all
-                .slice(offset, next)
-                .map((doc) => stripUnrequested(doc, input)),
-            };
-          }) as SearchIndexRangeResult,
-        ),
-      fetchDocuments: (ids, opts) =>
-        Promise.resolve(
-          r("searchindex.fetchDocuments", [ids, opts], () => {
-            const docs = docsFor(opts?.indexName);
-            return ids.map((id) => {
-              const doc = docs.get(id);
-              return doc ? stripUnrequested(doc, opts) : null;
-            });
-          }) as Array<SearchDocument | null>,
-        ),
-      deleteDocuments: (ids, opts) =>
-        Promise.resolve(
-          r("searchindex.deleteDocuments", [ids, opts], () => {
-            const docs = docsFor(opts?.indexName);
-            for (const id of ids) docs.delete(id);
-            return undefined;
-          }) as void,
-        ),
+      upsert: async (documents, opts) => {
+        validateSearchDocumentInputs(documents);
+        const indexName = resolveSearchIndexName(opts);
+        return r("searchindex.upsert", [documents, opts], () => {
+          ensureActive();
+          const docs = docsFor(indexName);
+          for (const doc of documents) docs.set(doc.id, doc);
+          return undefined;
+        }) as void;
+      },
+      query: async (input, opts) => {
+        validateSearchQueryInput(input);
+        const indexName = resolveSearchIndexName(opts);
+        return r("searchindex.query", [input, opts], () => {
+          ensureActive();
+          // Deterministic relevance: a hit is any document whose content
+          // JSON contains the query (case-insensitive), score 1.
+          const needle = input.query.toLowerCase();
+          const hits: SearchHit[] = [...docsFor(indexName).values()]
+            .filter((doc) =>
+              JSON.stringify(doc.content).toLowerCase().includes(needle),
+            )
+            .map((doc) => ({ ...doc, score: 1 }));
+          return hits.slice(0, input.limit ?? DEFAULT_SEARCH_INDEX_QUERY_LIMIT);
+        }) as SearchHit[];
+      },
+      range: async (input, opts) => {
+        const normalized = normalizeSearchIndexRangeInput(input);
+        const indexName = resolveSearchIndexName(opts);
+        return r("searchindex.range", [input, opts], () => {
+          ensureActive();
+          const all = [...docsFor(indexName).values()];
+          const offset = Number(normalized.cursor);
+          const limit = normalized.limit;
+          const next = offset + limit;
+          return {
+            nextCursor: next < all.length ? String(next) : null,
+            documents: all
+              .slice(offset, next)
+              .map((doc) => stripUnrequested(doc, normalized)),
+          };
+        }) as SearchIndexRangeResult;
+      },
+      fetchDocuments: async (ids, opts) => {
+        validateSearchDocumentIds(ids, "fetchDocuments");
+        validateSearchIndexIncludeOptions(opts);
+        const indexName = resolveSearchIndexName(opts);
+        return r("searchindex.fetchDocuments", [ids, opts], () => {
+          ensureActive();
+          const docs = docsFor(indexName);
+          return ids.map((id) => {
+            const doc = docs.get(id);
+            return doc ? stripUnrequested(doc, opts) : null;
+          });
+        }) as Array<SearchDocument | null>;
+      },
+      deleteDocuments: async (ids, opts) => {
+        validateSearchDocumentIds(ids, "deleteDocuments");
+        const indexName = resolveSearchIndexName(opts);
+        return r("searchindex.deleteDocuments", [ids, opts], () => {
+          ensureActive();
+          const docs = docsFor(indexName);
+          for (const id of ids) docs.delete(id);
+          return undefined;
+        }) as void;
+      },
     };
   };
 
@@ -1353,57 +1410,61 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       },
     },
     searchindex: {
-      create: (input) =>
-        Promise.resolve(
-          r("searchindex.create", [input], () => {
-            const id = `stub-searchindex-${++searchIndexSeq}`;
-            const info = stubSearchIndexInfo(id, input.name);
-            searchIndexRegistry.set(id, info);
-            return bindStubSearchIndex(info);
-          }) as SearchIndex,
-        ),
-      get: (id) =>
-        Promise.resolve(
-          r("searchindex.get", [id], () =>
-            bindStubSearchIndex(
-              searchIndexRegistry.get(id) ??
-                stubSearchIndexInfo(id, `stub-${id}`),
-            ),
-          ) as SearchIndex,
-        ),
+      create: async (input) => {
+        validateCreateSearchIndexInput(input);
+        return r("searchindex.create", [input], () => {
+          const id = `stub-searchindex-${++searchIndexSeq}`;
+          const info = stubSearchIndexInfo(id, input);
+          searchIndexRegistry.set(id, info);
+          return bindStubSearchIndex(info);
+        }) as SearchIndex;
+      },
+      get: async (id) => {
+        validateSearchIndexId(id);
+        return r("searchindex.get", [id], () => {
+          const info = searchIndexRegistry.get(id);
+          if (!info) throw stubSearchIndexNotFound(id);
+          return bindStubSearchIndex(info);
+        }) as SearchIndex;
+      },
       list: () =>
         Promise.resolve(
           r("searchindex.list", [], () =>
             [...searchIndexRegistry.values()].map(bindStubSearchIndex),
           ) as SearchIndex[],
         ),
-      update: (id, input) =>
-        Promise.resolve(
-          r("searchindex.update", [id, input], () => {
-            const existing =
-              searchIndexRegistry.get(id) ??
-              stubSearchIndexInfo(id, `stub-${id}`);
-            const updated: SearchIndexInfo = {
-              ...existing,
-              ...(input.name !== undefined && { name: input.name }),
-              ...(input.expiresAt !== undefined && {
-                expiresAt: input.expiresAt,
-              }),
-            };
-            searchIndexRegistry.set(id, updated);
-            return bindStubSearchIndex(updated);
-          }) as SearchIndex,
-        ),
-      delete: (id) =>
-        Promise.resolve(
-          r("searchindex.delete", [id], () => {
-            searchIndexRegistry.delete(id);
-            for (const key of [...searchIndexDocs.keys()]) {
-              if (key.startsWith(`${id}/`)) searchIndexDocs.delete(key);
-            }
-            return undefined;
-          }) as void,
-        ),
+      update: async (id, input) => {
+        validateSearchIndexId(id);
+        validateUpdateSearchIndexInput(input);
+        return r("searchindex.update", [id, input], () => {
+          const existing = searchIndexRegistry.get(id);
+          if (!existing) throw stubSearchIndexNotFound(id, "update");
+          const updated: SearchIndexInfo = {
+            ...existing,
+            ...(input.name !== undefined && { name: input.name }),
+            ...(input.expiresAt !== undefined && {
+              expiresAt: input.expiresAt,
+            }),
+          };
+          searchIndexRegistry.set(id, updated);
+          return bindStubSearchIndex(updated);
+        }) as SearchIndex;
+      },
+      delete: async (id) => {
+        validateSearchIndexId(id);
+        return r("searchindex.delete", [id], () => {
+          if (deletedSearchIndexIds.has(id)) return undefined;
+          if (!searchIndexRegistry.has(id)) {
+            throw stubSearchIndexNotFound(id, "delete");
+          }
+          searchIndexRegistry.delete(id);
+          deletedSearchIndexIds.add(id);
+          for (const key of [...searchIndexDocs.keys()]) {
+            if (key.startsWith(`${id}/`)) searchIndexDocs.delete(key);
+          }
+          return undefined;
+        }) as void;
+      },
     },
     database: {
       create: (input) =>

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -136,6 +136,7 @@ import {
   validateUpdateSearchIndexInput,
 } from "../search-index/validation.js";
 import type { MapResult } from "../search/index.js";
+import { validateMapInput } from "../search/validation.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -741,6 +742,14 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
   const deletedSearchIndexIds = new Set<string>();
   let searchIndexSeq = 0;
 
+  const nextStubSearchIndexId = (): string => {
+    let id: string;
+    do {
+      id = `res_${(++searchIndexSeq).toString(36).padStart(20, "0")}`;
+    } while (searchIndexRegistry.has(id));
+    return id;
+  };
+
   const stubSearchIndexInfo = (
     id: string,
     input: CreateSearchIndexInput,
@@ -854,6 +863,57 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         }) as void;
       },
     };
+  };
+
+  const coerceStubSearchIndexInfo = (
+    value: unknown,
+    fallback: SearchIndexInfo,
+  ): SearchIndexInfo => {
+    const raw =
+      value !== null && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+    const statuses = new Set([
+      "provisioning",
+      "active",
+      "expired",
+      "deleting",
+      "deleted",
+    ]);
+    return {
+      id:
+        typeof raw.id === "string" && raw.id.length > 0 ? raw.id : fallback.id,
+      name: typeof raw.name === "string" ? raw.name : fallback.name,
+      status: statuses.has(String(raw.status))
+        ? (raw.status as SearchIndexInfo["status"])
+        : fallback.status,
+      url: typeof raw.url === "string" ? raw.url : fallback.url,
+      region:
+        raw.region === null || typeof raw.region === "string"
+          ? raw.region
+          : fallback.region,
+      expiresAt:
+        raw.expiresAt === null || typeof raw.expiresAt === "string"
+          ? raw.expiresAt
+          : fallback.expiresAt,
+      createdAt:
+        typeof raw.createdAt === "string" ? raw.createdAt : fallback.createdAt,
+    };
+  };
+
+  /**
+   * Turn a wire-shaped control-plane stub value into the same state-bound handle
+   * the built-in implementation returns. Registering before binding makes all
+   * data-plane methods usable and keeps subsequent control-plane calls coherent.
+   */
+  const registerStubSearchIndex = (
+    value: unknown,
+    fallback: SearchIndexInfo,
+  ): SearchIndex => {
+    const info = coerceStubSearchIndexInfo(value, fallback);
+    searchIndexRegistry.set(info.id, info);
+    deletedSearchIndexIds.delete(info.id);
+    return bindStubSearchIndex(info);
   };
 
   // Resolve a coding run result, then re-wrap its `sandbox` as a handle so the
@@ -1351,13 +1411,13 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             ],
           })) as WebSearchResponse,
         ),
-      map: (input) =>
-        Promise.resolve(
-          r("search.map", [input], () => ({
-            success: true,
-            links: [{ url: input.url, title: "Stub Page", description: null }],
-          })) as MapResult,
-        ),
+      map: async (input) => {
+        validateMapInput(input);
+        return r("search.map", [input], () => ({
+          success: true,
+          links: [{ url: input.url, title: "Stub Page", description: null }],
+        })) as MapResult;
+      },
       emailSearch: {
         findEmail: (input) =>
           Promise.resolve(
@@ -1412,43 +1472,87 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
     searchindex: {
       create: async (input) => {
         validateCreateSearchIndexInput(input);
-        return r("searchindex.create", [input], () => {
-          const id = `stub-searchindex-${++searchIndexSeq}`;
-          const info = stubSearchIndexInfo(id, input);
-          searchIndexRegistry.set(id, info);
-          return bindStubSearchIndex(info);
-        }) as SearchIndex;
+        const resolved = await r("searchindex.create", [input], () =>
+          stubSearchIndexInfo(nextStubSearchIndexId(), input),
+        );
+        const resolvedId =
+          resolved !== null &&
+          typeof resolved === "object" &&
+          !Array.isArray(resolved) &&
+          typeof (resolved as { id?: unknown }).id === "string"
+            ? (resolved as { id: string }).id
+            : nextStubSearchIndexId();
+        return registerStubSearchIndex(
+          resolved,
+          stubSearchIndexInfo(resolvedId, input),
+        );
       },
       get: async (id) => {
         validateSearchIndexId(id);
-        return r("searchindex.get", [id], () => {
+        const existing = searchIndexRegistry.get(id);
+        const resolved = await r("searchindex.get", [id], () => {
           const info = searchIndexRegistry.get(id);
           if (!info) throw stubSearchIndexNotFound(id);
-          return bindStubSearchIndex(info);
-        }) as SearchIndex;
+          return info;
+        });
+        return registerStubSearchIndex(
+          resolved,
+          existing ?? stubSearchIndexInfo(id, { name: "stub-search-index" }),
+        );
       },
-      list: () =>
-        Promise.resolve(
-          r("searchindex.list", [], () =>
-            [...searchIndexRegistry.values()].map(bindStubSearchIndex),
-          ) as SearchIndex[],
-        ),
+      list: async () => {
+        const resolved = await r("searchindex.list", [], () => [
+          ...searchIndexRegistry.values(),
+        ]);
+        if (!Array.isArray(resolved)) {
+          opts.warnings?.add(
+            `'searchindex.list' stub must be an array of search indexes; got ${describeShape(resolved)}. Returning an empty list.`,
+          );
+          return [];
+        }
+        return resolved.map((value, index) => {
+          const raw =
+            value !== null && typeof value === "object" && !Array.isArray(value)
+              ? (value as Record<string, unknown>)
+              : {};
+          const id =
+            typeof raw.id === "string" && raw.id.length > 0
+              ? raw.id
+              : nextStubSearchIndexId();
+          const name =
+            typeof raw.name === "string"
+              ? raw.name
+              : `stub-search-index-${index + 1}`;
+          return registerStubSearchIndex(
+            value,
+            stubSearchIndexInfo(id, { name }),
+          );
+        });
+      },
       update: async (id, input) => {
         validateSearchIndexId(id);
         validateUpdateSearchIndexInput(input);
-        return r("searchindex.update", [id, input], () => {
+        const existing = searchIndexRegistry.get(id);
+        const resolved = await r("searchindex.update", [id, input], () => {
           const existing = searchIndexRegistry.get(id);
           if (!existing) throw stubSearchIndexNotFound(id, "update");
-          const updated: SearchIndexInfo = {
+          return {
             ...existing,
             ...(input.name !== undefined && { name: input.name }),
             ...(input.expiresAt !== undefined && {
               expiresAt: input.expiresAt,
             }),
           };
-          searchIndexRegistry.set(id, updated);
-          return bindStubSearchIndex(updated);
-        }) as SearchIndex;
+        });
+        const fallback = {
+          ...(existing ??
+            stubSearchIndexInfo(id, { name: "stub-search-index" })),
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.expiresAt !== undefined && {
+            expiresAt: input.expiresAt,
+          }),
+        };
+        return registerStubSearchIndex(resolved, fallback);
       },
       delete: async (id) => {
         validateSearchIndexId(id);

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -726,6 +726,19 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       }
       return docs;
     };
+    // Mirror the live data plane: enumeration reads return id-only items
+    // unless the include flags are set (a reconciler that forgets
+    // `includeMetadata: true` should fail the same way under run_local).
+    const stripUnrequested = (
+      doc: SearchDocument,
+      flags?: { includeMetadata?: boolean; includeData?: boolean },
+    ): SearchDocument => ({
+      id: doc.id,
+      content: flags?.includeData ? doc.content : {},
+      ...(flags?.includeMetadata && doc.metadata !== undefined
+        ? { metadata: doc.metadata }
+        : {}),
+    });
     return {
       ...info,
       upsert: (documents, opts) =>
@@ -759,7 +772,9 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             const next = offset + limit;
             return {
               nextCursor: next < all.length ? String(next) : null,
-              documents: all.slice(offset, next),
+              documents: all
+                .slice(offset, next)
+                .map((doc) => stripUnrequested(doc, input)),
             };
           }) as SearchIndexRangeResult,
         ),
@@ -767,7 +782,10 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         Promise.resolve(
           r("searchindex.fetchDocuments", [ids, opts], () => {
             const docs = docsFor(opts?.indexName);
-            return ids.map((id) => docs.get(id) ?? null);
+            return ids.map((id) => {
+              const doc = docs.get(id);
+              return doc ? stripUnrequested(doc, opts) : null;
+            });
           }) as Array<SearchDocument | null>,
         ),
       deleteDocuments: (ids, opts) =>

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -113,6 +113,14 @@ import type {
   ActiveSession,
 } from "../browser-automation/index.js";
 import type { ScopedKey } from "../keys/index.js";
+import type {
+  SearchDocument,
+  SearchHit,
+  SearchIndex,
+  SearchIndexInfo,
+  SearchIndexRangeResult,
+} from "../search-index/index.js";
+import type { MapResult } from "../search/index.js";
 
 /** Per-capability overrides, keyed by capability path (see module docs). */
 export type StubOverrides = Record<
@@ -691,6 +699,88 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
   const memoryNamespaces = new Map<string, Map<string, StubMemoryRecord>>();
   let memorySeq = 0;
 
+  // Per-client search-index state: created indexes plus their documents, keyed
+  // `${indexId}/${indexName}`. Stateful so run_local exercises the real flow —
+  // upsert → query/range/fetchDocuments/deleteDocuments reflect prior writes.
+  const searchIndexRegistry = new Map<string, SearchIndexInfo>();
+  const searchIndexDocs = new Map<string, Map<string, SearchDocument>>();
+  let searchIndexSeq = 0;
+
+  const stubSearchIndexInfo = (id: string, name: string): SearchIndexInfo => ({
+    id,
+    name,
+    status: "active",
+    url: `https://${id}.search.data.stub.invalid`,
+    region: "us-central1",
+    expiresAt: null,
+    createdAt: "2099-01-01T00:00:00Z",
+  });
+
+  const bindStubSearchIndex = (info: SearchIndexInfo): SearchIndex => {
+    const docsFor = (indexName?: string): Map<string, SearchDocument> => {
+      const key = `${info.id}/${indexName ?? "default"}`;
+      let docs = searchIndexDocs.get(key);
+      if (!docs) {
+        docs = new Map();
+        searchIndexDocs.set(key, docs);
+      }
+      return docs;
+    };
+    return {
+      ...info,
+      upsert: (documents, opts) =>
+        Promise.resolve(
+          r("searchindex.upsert", [documents, opts], () => {
+            const docs = docsFor(opts?.indexName);
+            for (const doc of documents) docs.set(doc.id, doc);
+            return undefined;
+          }) as void,
+        ),
+      query: (input, opts) =>
+        Promise.resolve(
+          r("searchindex.query", [input, opts], () => {
+            // Deterministic relevance: a hit is any document whose content
+            // JSON contains the query (case-insensitive), score 1.
+            const needle = input.query.toLowerCase();
+            const hits: SearchHit[] = [...docsFor(opts?.indexName).values()]
+              .filter((doc) =>
+                JSON.stringify(doc.content).toLowerCase().includes(needle),
+              )
+              .map((doc) => ({ ...doc, score: 1 }));
+            return hits.slice(0, input.limit ?? 10);
+          }) as SearchHit[],
+        ),
+      range: (input, opts) =>
+        Promise.resolve(
+          r("searchindex.range", [input, opts], () => {
+            const all = [...docsFor(opts?.indexName).values()];
+            const offset = input?.cursor ? Number(input.cursor) || 0 : 0;
+            const limit = input?.limit ?? 100;
+            const next = offset + limit;
+            return {
+              nextCursor: next < all.length ? String(next) : null,
+              documents: all.slice(offset, next),
+            };
+          }) as SearchIndexRangeResult,
+        ),
+      fetchDocuments: (ids, opts) =>
+        Promise.resolve(
+          r("searchindex.fetchDocuments", [ids, opts], () => {
+            const docs = docsFor(opts?.indexName);
+            return ids.map((id) => docs.get(id) ?? null);
+          }) as Array<SearchDocument | null>,
+        ),
+      deleteDocuments: (ids, opts) =>
+        Promise.resolve(
+          r("searchindex.deleteDocuments", [ids, opts], () => {
+            const docs = docsFor(opts?.indexName);
+            for (const id of ids) docs.delete(id);
+            return undefined;
+          }) as void,
+        ),
+    };
+  };
+
   // Resolve a coding run result, then re-wrap its `sandbox` as a handle so the
   // blocking `run()` path keeps a method-capable Sandbox even when the result was
   // overridden with plain JSON. `keys` lets `launch()` accept `models.coding.launch`
@@ -1186,6 +1276,13 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             ],
           })) as WebSearchResponse,
         ),
+      map: (input) =>
+        Promise.resolve(
+          r("search.map", [input], () => ({
+            success: true,
+            links: [{ url: input.url, title: "Stub Page", description: null }],
+          })) as MapResult,
+        ),
       emailSearch: {
         findEmail: (input) =>
           Promise.resolve(
@@ -1236,6 +1333,59 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             })) as DomainSearchResult,
           ),
       },
+    },
+    searchindex: {
+      create: (input) =>
+        Promise.resolve(
+          r("searchindex.create", [input], () => {
+            const id = `stub-searchindex-${++searchIndexSeq}`;
+            const info = stubSearchIndexInfo(id, input.name);
+            searchIndexRegistry.set(id, info);
+            return bindStubSearchIndex(info);
+          }) as SearchIndex,
+        ),
+      get: (id) =>
+        Promise.resolve(
+          r("searchindex.get", [id], () =>
+            bindStubSearchIndex(
+              searchIndexRegistry.get(id) ??
+                stubSearchIndexInfo(id, `stub-${id}`),
+            ),
+          ) as SearchIndex,
+        ),
+      list: () =>
+        Promise.resolve(
+          r("searchindex.list", [], () =>
+            [...searchIndexRegistry.values()].map(bindStubSearchIndex),
+          ) as SearchIndex[],
+        ),
+      update: (id, input) =>
+        Promise.resolve(
+          r("searchindex.update", [id, input], () => {
+            const existing =
+              searchIndexRegistry.get(id) ??
+              stubSearchIndexInfo(id, `stub-${id}`);
+            const updated: SearchIndexInfo = {
+              ...existing,
+              ...(input.name !== undefined && { name: input.name }),
+              ...(input.expiresAt !== undefined && {
+                expiresAt: input.expiresAt,
+              }),
+            };
+            searchIndexRegistry.set(id, updated);
+            return bindStubSearchIndex(updated);
+          }) as SearchIndex,
+        ),
+      delete: (id) =>
+        Promise.resolve(
+          r("searchindex.delete", [id], () => {
+            searchIndexRegistry.delete(id);
+            for (const key of [...searchIndexDocs.keys()]) {
+              if (key.startsWith(`${id}/`)) searchIndexDocs.delete(key);
+            }
+            return undefined;
+          }) as void,
+        ),
     },
     database: {
       create: (input) =>


### PR DESCRIPTION
## Summary

Adds the provider-neutral `searchindex` namespace to `@sapiom/tools` and `ctx.sapiom.searchindex`, covering the full provisioned-index control and data planes. It also adds structured, gateway-direct `search.map({ url })` support for the corpus-refresh workflow.

This revision includes the release-blocking contract corrections and independent-review fixes from SAP-2255: canonical management envelopes, valid range/query defaults, fail-closed response parsing, positional fetch integrity, read/write type separation, nullable regions, logical meter documentation, and a production-faithful stateful stub.

## Changes

- Adds control-plane `create/get/list/update/delete`; returned indexes bind `upsert/query/range/fetchDocuments/deleteDocuments` to their own Sapiom data-plane URL.
- Parses canonical `{ databases: [...] }` list responses and only the explicitly documented compatibility shapes. Malformed successful list/query/range/fetch responses throw `SearchIndexContractError` instead of becoming empty data.
- Verifies non-null `fetchDocuments` results preserve the requested ID at each position; wrong or swapped IDs fail closed while positional `null` misses remain valid.
- Splits required write payloads (`SearchDocumentInput`) from read documents whose `content`/`metadata` fields remain absent unless included. `region` is `string | null`.
- Defaults queries to 5 results and maps public `limit` to raw `topK`; query payloads explicitly request content and metadata. Defaults range to `{ cursor: "0", limit: 100 }`.
- Shares SearchIndex and map input validation between the live client and stub. Invalid map inputs reject before transport or stub resolution.
- Makes successful `search.map` responses fail closed with exported `SearchContractError` unless they contain a valid links array; every link requires a non-empty URL and typed optional title/description fields.
- Coerces plain-JSON SearchIndex `create/get/list/update` stub overrides into registry-backed bound handles, preserving stateful data-plane behavior.
- Generates deterministic stub resource IDs matching `^res_[a-z0-9]{20}$`, so local workflows can pass IDs unchanged to the management and MCP surfaces.
- Documents the routing boundary: web search, scrape, and email use Core's routed capability seam; map calls the Firecrawl gateway directly at `/v2/map`.
- Documents provider-invisible SearchIndex meters and current catalog rates. The backing provider remains an implementation detail of the customer contract.
- Adds the `./search-index` package subpath, barrel/client wiring, smoke coverage, and a minor changeset.

## Contract evidence

- Unified gateway DTO/list contract: [`SearchDatabaseResponse` and `{ databases }`](https://github.com/sapiom/Sapiom/blob/4ba50cd31f7ec36d141f28174a22e211ddc19bd4/x402/apps/unified/src/providers/upstash/management/search.service.ts#L67-L104), [`SearchService.list()`](https://github.com/sapiom/Sapiom/blob/4ba50cd31f7ec36d141f28174a22e211ddc19bd4/x402/apps/unified/src/providers/upstash/management/search.service.ts#L257-L264).
- Official Search client wire mapping, pinned to `upstash/search-js@27f0c045`: public `limit` defaults to 5 and is sent as raw `topK` with `includeData: true` and `includeMetadata: true` ([source lines 76-116](https://github.com/upstash/search-js/blob/27f0c045cb7c776091c1c27571d937710ee0a6d6/src/search-index.ts#L76-L116)).
- Range fixtures use the canonical live `{ result: { nextCursor, vectors } }` shape captured on 2026-08-03; the only retained compatibility page is the documented Search SDK `{ nextCursor, documents }` shape.

## Verification

- Rebased on `sapiom-js/main@bbc3bcfa9ffcd4e97e1e310e8f9523fe3c3718e6`; `git range-diff` confirms the four SAP-2255 commits are patch-equivalent.
- `pnpm --filter @sapiom/tools exec jest --runInBand` — 29/29 suites, 583/583 tests.
- `pnpm --filter @sapiom/tools typecheck`.
- `pnpm --filter @sapiom/tools lint`.
- `pnpm --filter @sapiom/tools build` — CJS + ESM builds.
- CJS and ESM root/`./search`/`./search-index` runtime import smokes.
- Emitted declaration and package export-map inspection, including root and `./search` `SearchContractError` exports.
- `pnpm examples:check` — 11 templates and 50 registered assets valid.
- `pnpm terminology:check` — 373 files valid with no stale allowlist entries.
- `pnpm changeset status --since=origin/main` — `@sapiom/tools` minor.
- `npm pack --dry-run --json` — expected runtime, types, and docs present.

## Release boundary

The changeset schedules the next minor release. This PR does **not** publish the package, update the workflow engine, deploy, merge, or mutate production. Publication remains gated on SAP-2386 proving the authoritative SearchIndex metering rollout; engine pickup is separate follow-up work.

Closes: SAP-2255
