### PR TITLE
feat(content-generation): add images.launch async dispatch to fix 30s router 503s

### DIFF
--- a/.changeset/images-launch-async-dispatch.md
+++ b/.changeset/images-launch-async-dispatch.md
@@ -1,0 +1,20 @@
+---
+"@sapiom/tools": minor
+---
+
+`contentGeneration.images.launch` — a dispatchable async surface for image generation, mirroring
+`video.launch`.
+
+The routed synchronous `images.create` holds its HTTP request open for the full generate+store,
+which meets Core's 30s router cap: a concurrent fan-out (`Promise.all` over N rows) drove every
+request in the batch past 30s, so the whole step 503'd on every retry. The backend already supported
+async image dispatch (`dispatch: 'async'`, SAP-1802) over the same fal-queue → webhook → resume rail
+as video, but the SDK never exposed it.
+
+`images.launch` submits with `dispatch: 'async'`, forwards the workflow resume token, and returns an
+`ImageLaunchHandle` (`requestId`, `dispatch`, and an inline `wait()`) — so the submit returns as soon
+as the job is enqueued and the 30s wall no longer applies. Pass the handle to
+`pauseUntilSignal(handle, { resumeStep })` to suspend a workflow step until the image is ready, or
+`await handle.wait()` to poll inline. Also exported: `IMAGE_RESULT_SIGNAL`, the `ImageResultPayload`
+shape a resumed step receives, and `toImageResumePayload`. `images.create` is unchanged. No backend
+change is required — the async completion→resume path is media-agnostic.

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -7,7 +7,12 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
-import { VIDEO_RESULT_SIGNAL, type VideoResultPayload } from "@sapiom/tools";
+import {
+  VIDEO_RESULT_SIGNAL,
+  IMAGE_RESULT_SIGNAL,
+  type VideoResultPayload,
+  type ImageResultPayload,
+} from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -20,31 +25,33 @@ import { z } from "zod/v4";
  * asset — an image (`contentGeneration.images`) or a short clip
  * (`contentGeneration.video`) — persists it, and emails the recipient a link.
  *
- * The graph forks on the chosen medium:
+ * The graph forks on the chosen medium — both are async launch/collect loops:
  *
- *   fetch ─▶ renderImages ─────────────────▶ deliver
- *   (db)  └▶ renderClip ⇄ collectClip ──────▶ deliver
- *            (video.launch)   (drain)          (email)
+ *   fetch ─▶ renderImage ⇄ collectImage ────▶ deliver
+ *   (db)  └▶ renderClip  ⇄ collectClip  ────▶ deliver
+ *            (images/video.launch) (drain)     (email)
  *
  *   1. fetch — read up to `limit` recipient rows from a Postgres table
  *      (`ctx.sapiom.database`), creating and seeding it on first run so the
  *      template works out of the box. `dryRun` stops here and returns the rows
  *      plus the prompt each would get, with nothing generated or sent.
- *   2a. renderImages (image medium) — fan out one personalized image per row,
- *       all at once (sync), each persisted for a durable `fileId`.
- *   2b. renderClip ⇄ collectClip (video medium) — one row at a time, launch an
- *       async text-to-video job and `pauseUntilSignal` on it; the FAL webhook
- *       resumes `collectClip`, which records the clip and loops back for the
- *       next row or advances once every row is done.
+ *   2a. renderImage ⇄ collectImage (image medium) — one row at a time, launch an
+ *       async image job and `pauseUntilSignal` on it; the FAL webhook resumes
+ *       `collectImage`, which records the image and loops back for the next row
+ *       or advances once every row is done.
+ *   2b. renderClip ⇄ collectClip (video medium) — same shape with `video.launch`.
  *   3. deliver — email each recipient a link to their own asset.
  *
- * Why sequential clips rather than launching every video at once: a paused step
- * waits on a single `(signal, correlationId)` pair, so launching shot i only
- * after shot i-1 has resumed keeps a paused step always waiting before its job
- * can complete (the `scene-to-video` lesson).
+ * Why sequential rather than launching every job at once: a paused step waits on a
+ * single `(signal, correlationId)` pair, so launching row i only after row i-1 has
+ * resumed keeps a paused step always waiting before its job can complete (the
+ * `scene-to-video` lesson). This is also why images moved OFF the old sync
+ * `Promise.all` fan-out: the routed sync `images.create` holds the request open for
+ * the full generate+store, and a concurrent fan-out drove every request past Core's
+ * 30s router cap → 503s. `images.launch` enqueues and returns immediately, so the
+ * 30s wall no longer applies.
  *
- * Images are the cheaper default. Video is async and pricier — keep `limit`
- * small while you try it.
+ * Images are the cheaper default. Video is pricier — keep `limit` small while you try it.
  */
 
 // ─────────────────────────────────────────────────────────────── config ──
@@ -70,7 +77,7 @@ type Medium = "image" | "video";
 interface EntryInput {
   /** Database handle holding the recipient table. */
   dbHandle?: string;
-  /** "image" (default, sync, cheaper) or "video" (async, pricier). */
+  /** "image" (default, cheaper) or "video" (pricier). Both render async per row. */
   medium?: Medium;
   /** Cron cadence this batch is meant to run on (e.g. "0 9 * * *"). */
   schedule?: string;
@@ -114,8 +121,8 @@ interface Shared extends Record<string, unknown> {
   videoModel: string;
   rows: Recipient[];
   assets: Asset[];
-  /** Index of the next row to animate; advanced by `collectClip`. */
-  clipIndex: number;
+  /** Index of the next row to render; advanced by `collectImage` / `collectClip`. */
+  mediaIndex: number;
   /** One plain sentence about whose rows these are and whether we provisioned them. */
   note?: string;
 }
@@ -312,7 +319,7 @@ const entryInput = z.object({
 const fetch = defineStep({
   name: "fetch",
   inputSchema: entryInput,
-  next: ["renderImages", "renderClip"],
+  next: ["renderImage", "renderClip"],
   terminal: true,
   async run(input: EntryInput, ctx: Ctx) {
     const dbHandle = resolveResourceHandle(input, {
@@ -332,7 +339,7 @@ const fetch = defineStep({
     ctx.shared.set("aspectRatio", aspectRatio);
     ctx.shared.set("videoModel", videoModel);
     ctx.shared.set("assets", []);
-    ctx.shared.set("clipIndex", 0);
+    ctx.shared.set("mediaIndex", 0);
 
     // Read the recipient rows (free — runs on a dry run too). Under stubbed
     // capabilities in run_local there's no connection string, so `rows` stays
@@ -408,44 +415,65 @@ const fetch = defineStep({
           .join(" "),
       });
     }
-    return goto(medium === "video" ? "renderClip" : "renderImages", {});
+    return goto(medium === "video" ? "renderClip" : "renderImage", {});
   },
 });
 
-const renderImages = defineStep({
-  name: "renderImages",
-  next: ["deliver"],
+const renderImage = defineStep({
+  name: "renderImage",
+  next: [],
+  // Async pause/resume, same as the video path: `images.launch` submits and returns a
+  // handle immediately (the submit is a quick enqueue, so it never meets Core's 30s
+  // router cap — the 503 the old sync `Promise.all` fan-out hit). The FAL webhook fires
+  // IMAGE_RESULT_SIGNAL on completion, resuming `collectImage` with the image's result.
+  pause: { signal: IMAGE_RESULT_SIGNAL, resumeStep: "collectImage" },
   async run(_input: unknown, ctx: Ctx) {
     const rows = must(ctx.shared.get("rows"), "rows");
     const style = ctx.shared.get("style") ?? "";
-    ctx.logger.info("generating images", { rows: rows.length });
+    const index = must(ctx.shared.get("mediaIndex"), "mediaIndex");
+    const row = rows[index];
 
-    // Fan-out: one personalized image per row, generated concurrently. `storage`
-    // persists each output so we get a durable `fileId` + a ready-to-use link.
-    const generated = await Promise.all(
-      rows.map((row) =>
-        ctx.sapiom.contentGeneration.images.create({
-          prompt: buildPrompt(row, "image", style),
-          numImages: 1,
-          storage: { visibility: "private" },
-        }),
-      ),
-    );
-    const assets: Asset[] = generated.map((result, i) => {
-      const row = rows[i];
-      const img = result.images?.[0];
-      return {
-        recipientId: row.id,
-        name: row.name,
-        email: row.email,
-        medium: "image",
-        fileId: img?.fileId ?? null,
-        downloadUrl: img?.downloadUrl ?? img?.url ?? null,
-      };
+    ctx.logger.info("rendering image", { index: index + 1, of: rows.length });
+    const handle = await ctx.sapiom.contentGeneration.images.launch({
+      prompt: buildPrompt(row, "image", style),
+      numImages: 1,
+      storage: { visibility: "private" },
     });
-    ctx.shared.set("assets", assets);
-    ctx.logger.info("images ready", { count: assets.length });
-    return goto("deliver", { assets });
+    return await pauseUntilSignal(handle, { resumeStep: "collectImage" });
+  },
+});
+
+const collectImage = defineStep({
+  name: "collectImage",
+  next: ["renderImage", "deliver"],
+  async run(result: ImageResultPayload, ctx: Ctx) {
+    const rows = must(ctx.shared.get("rows"), "rows");
+    const assets = must(ctx.shared.get("assets"), "assets");
+    const index = must(ctx.shared.get("mediaIndex"), "mediaIndex");
+    const row = rows[index];
+
+    const out = result.outputs?.[0];
+    const asset: Asset = {
+      recipientId: row.id,
+      name: row.name,
+      email: row.email,
+      medium: "image",
+      fileId: out?.fileId ?? null,
+      downloadUrl: out?.downloadUrl ?? null,
+    };
+    const nextAssets = [...assets, asset];
+    const nextIndex = index + 1;
+    ctx.shared.set("assets", nextAssets);
+    ctx.shared.set("mediaIndex", nextIndex);
+    ctx.logger.info("collected image", {
+      collected: nextAssets.length,
+      of: rows.length,
+    });
+
+    // More rows to render? Loop back. Otherwise every image is in — deliver them.
+    return nextIndex < rows.length
+      ? goto("renderImage", {})
+      : goto("deliver", { assets: nextAssets });
   },
 });
 
@@ -458,7 +486,7 @@ const renderClip = defineStep({
   async run(_input: unknown, ctx: Ctx) {
     const rows = must(ctx.shared.get("rows"), "rows");
     const style = ctx.shared.get("style") ?? "";
-    const index = must(ctx.shared.get("clipIndex"), "clipIndex");
+    const index = must(ctx.shared.get("mediaIndex"), "mediaIndex");
     const row = rows[index];
 
     ctx.logger.info("rendering clip", { index: index + 1, of: rows.length });
@@ -480,7 +508,7 @@ const collectClip = defineStep({
   async run(result: VideoResultPayload, ctx: Ctx) {
     const rows = must(ctx.shared.get("rows"), "rows");
     const assets = must(ctx.shared.get("assets"), "assets");
-    const index = must(ctx.shared.get("clipIndex"), "clipIndex");
+    const index = must(ctx.shared.get("mediaIndex"), "mediaIndex");
     const row = rows[index];
 
     const out = result.outputs?.[0];
@@ -495,7 +523,7 @@ const collectClip = defineStep({
     const nextAssets = [...assets, asset];
     const nextIndex = index + 1;
     ctx.shared.set("assets", nextAssets);
-    ctx.shared.set("clipIndex", nextIndex);
+    ctx.shared.set("mediaIndex", nextIndex);
     ctx.logger.info("collected clip", {
       collected: nextAssets.length,
       of: rows.length,
@@ -616,5 +644,5 @@ const deliver = defineStep({
 export const agent = defineAgent<EntryInput, Shared>({
   name: "personalized-media-at-scale",
   entry: "fetch",
-  steps: { fetch, renderImages, renderClip, collectClip, deliver },
+  steps: { fetch, renderImage, collectImage, renderClip, collectClip, deliver },
 });

--- a/packages/tools/src/_client/capability-call.ts
+++ b/packages/tools/src/_client/capability-call.ts
@@ -54,6 +54,13 @@ export interface CapabilityCallOptions {
   makeError: (message: string, status: number, body: unknown) => Error;
   /** Human-readable prefix for the thrown error's message. */
   errorPrefix: string;
+  /**
+   * Extra request headers to merge in (after `content-type`, so they can't drop it).
+   * The async-dispatch verbs use this to forward the engine's `x-sapiom-workflow-token`
+   * so the service can resume a paused workflow step on completion — a header, not a
+   * body field, so author-supplied request fields can't clobber it.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -75,7 +82,7 @@ export async function capabilityCall<Res>(
     `${baseUrl}/v1/capabilities/${id}`,
     {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...opts.headers },
       body: JSON.stringify(req),
     },
     { authHeader: "x-api-key" },

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -74,6 +74,7 @@ import * as contentGeneration from "./content-generation/index.js";
 import type {
   ImageCreateInput,
   ImageGenerationResult,
+  ImageLaunchHandle,
   VideoCreateInput,
   VideoGenerationResult,
   VideoLaunchHandle,
@@ -244,9 +245,20 @@ export interface Sapiom {
     images: {
       /**
        * Generate image(s) from a prompt. Pass `storage` to persist each output into
-       * file-storage (the returned images then carry `file_id`).
+       * file-storage (the returned images then carry `file_id`). Synchronous: the
+       * request is held open for the full generate+store, so prefer `launch` from a
+       * workflow or when fanning out many at once.
        */
       create(input: ImageCreateInput): Promise<ImageGenerationResult>;
+      /**
+       * Submit an image generation job and return a dispatchable handle immediately.
+       * Pass the handle to `pauseUntilSignal(handle, { resumeStep })` to suspend the
+       * workflow step until the image is ready, or call `handle.wait()` to block inline
+       * (equivalent result to `images.create`). Unlike `create`, the submit returns as
+       * soon as the job is enqueued, so it never meets Core's 30s router cap. Pass
+       * `storage` to persist the output.
+       */
+      launch(input: ImageCreateInput): Promise<ImageLaunchHandle>;
     };
     video: {
       /**
@@ -557,6 +569,7 @@ function bind(transport: Transport): Sapiom {
     contentGeneration: {
       images: {
         create: (input) => contentGeneration.createImage(input, transport),
+        launch: (input) => contentGeneration.launchImage(input, transport),
       },
       video: {
         create: (input) => contentGeneration.createVideo(input, transport),

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -3,10 +3,13 @@ import { Transport } from "../_client/index.js";
 import {
   images,
   createImage,
+  launchImage,
   createVideo,
   launchVideo,
   toVideoResumePayload,
+  toImageResumePayload,
   VIDEO_RESULT_SIGNAL,
+  IMAGE_RESULT_SIGNAL,
   ContentGenerationHttpError,
 } from "./index.js";
 
@@ -841,6 +844,194 @@ describe("createClient().contentGeneration.video.launch", () => {
 });
 
 // ---------------------------------------------------------------------------
+// contentGeneration.images.launch() — routed async dispatch + resume token
+// ---------------------------------------------------------------------------
+
+describe("contentGeneration.images.launch()", () => {
+  it("POSTs the routed capability with x-api-key, dispatch:'async', and returns a handle", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { requestId: "img-1", responseUrl: `${BASE}/queue/img-1` },
+      { images: [{ url: "https://media/x.png" }] },
+    );
+
+    const handle = await launchImage({ prompt: "a red bike" }, transport, BASE);
+
+    // Routed URL (Core), NOT the fal-direct /run/<model> path video uses.
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.images`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    // Routed auth header, not the gateway-direct one.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    // `dispatch: 'async'` is what selects the queue path over the sync 30s-capped one.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "a red bike",
+      dispatch: "async",
+    });
+    expect(handle.requestId).toBe("img-1");
+  });
+
+  it("dispatch.correlationId equals requestId and resultSignal equals IMAGE_RESULT_SIGNAL", async () => {
+    const { transport } = makeLaunchTransport(
+      { requestId: "img-disp", responseUrl: `${BASE}/queue/img-disp` },
+      { images: [{ url: "u" }] },
+    );
+
+    const handle = await launchImage({ prompt: "a wave" }, transport, BASE);
+
+    expect(handle.dispatch.correlationId).toBe("img-disp");
+    expect(handle.dispatch.resultSignal).toBe(IMAGE_RESULT_SIGNAL);
+  });
+
+  it("IMAGE_RESULT_SIGNAL is the capability-stable terminal signal", () => {
+    expect(IMAGE_RESULT_SIGNAL).toBe("contentGeneration.images.result");
+  });
+
+  it("accepts a statusUrl-only handle, deriving the poll URL by stripping /status", async () => {
+    let polledUrl = "";
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      const url = String(input);
+      if (init.method === "POST") {
+        return jsonResponse({
+          requestId: "img-status-only",
+          statusUrl: `${BASE}/queue/img-status-only/status`,
+        });
+      }
+      polledUrl = url;
+      return jsonResponse({ images: [{ url: "https://media/x.png" }] });
+    }) as typeof globalThis.fetch;
+    const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+
+    const handle = await launchImage({ prompt: "x" }, transport, BASE);
+    await expect(handle.wait({ pollMs: 1 })).resolves.toMatchObject({
+      images: [{ url: "https://media/x.png" }],
+    });
+    expect(polledUrl).toBe(`${BASE}/queue/img-status-only`);
+  });
+
+  it("forwards numImages, params, model, and storage alongside dispatch:'async'", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { requestId: "img-fields", responseUrl: `${BASE}/queue/img-fields` },
+      { images: [] },
+    );
+
+    await launchImage(
+      {
+        prompt: "x",
+        numImages: 2,
+        params: { image_size: "square" },
+        model: "fal-ai/flux/dev",
+        storage: { visibility: "private" },
+      },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      dispatch: "async",
+      numImages: 2,
+      params: { image_size: "square" },
+      model: "fal-ai/flux/dev",
+      storage: { visibility: "private" },
+    });
+  });
+
+  it("includes x-sapiom-workflow-token when transport.resumeToken is set", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { requestId: "img-tok", responseUrl: `${BASE}/queue/img-tok` },
+      { images: [{ url: "u" }] },
+      "tok-workflow-img",
+    );
+
+    await launchImage({ prompt: "x" }, transport, BASE);
+
+    expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
+      "tok-workflow-img",
+    );
+  });
+
+  it("omits x-sapiom-workflow-token when resumeToken is not set", async () => {
+    const { transport, calls } = makeLaunchTransport(
+      { requestId: "img-notok", responseUrl: `${BASE}/queue/img-notok` },
+      { images: [{ url: "u" }] },
+    );
+
+    await launchImage({ prompt: "x" }, transport, BASE);
+
+    expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBeUndefined();
+  });
+
+  it("wait() polls the responseUrl and returns the mapped result; maps fileId", async () => {
+    let polls = 0;
+    const calls: FetchCall[] = [];
+    const fetchMock = (async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init: RequestInit = {},
+    ): Promise<Response> => {
+      calls.push({ url: String(input), init });
+      if (init.method === "POST") {
+        return jsonResponse({
+          requestId: "img-wait",
+          responseUrl: `${BASE}/queue/img-wait`,
+        });
+      }
+      polls += 1;
+      return polls < 2
+        ? jsonResponse({ status: "IN_PROGRESS" })
+        : jsonResponse({
+            images: [{ url: "https://media/x.png", fileId: "f-img" }],
+          });
+    }) as typeof globalThis.fetch;
+    const transport = new Transport({ apiKey: "test-key", fetch: fetchMock });
+
+    const handle = await launchImage({ prompt: "x" }, transport, BASE);
+    const result = await handle.wait({ pollMs: 1 });
+
+    expect(result.images?.[0]?.fileId).toBe("f-img");
+    expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(2);
+  });
+
+  it("throws ContentGenerationHttpError when the submit fails — never polls", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ error: "bad model" }, { status: 422 }),
+    ]);
+
+    await expect(
+      launchImage({ prompt: "x" }, transport, BASE),
+    ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("wait() throws if the result isn't ready before the timeout", async () => {
+    const { transport } = makeLaunchTransport(
+      { requestId: "img-timeout", responseUrl: `${BASE}/queue/img-timeout` },
+      { status: "IN_PROGRESS" },
+    );
+
+    const handle = await launchImage({ prompt: "x" }, transport, BASE);
+    await expect(handle.wait({ timeoutMs: 20, pollMs: 1 })).rejects.toThrow(
+      /did not complete within/,
+    );
+  });
+
+  it("`images.launch` is the same operation as `launchImage`", async () => {
+    const { transport } = makeLaunchTransport(
+      { requestId: "img-ns", responseUrl: `${BASE}/queue/img-ns` },
+      { images: [{ url: "u" }] },
+    );
+
+    const handle = await images.launch({ prompt: "x" }, transport, BASE);
+    expect(handle.requestId).toBe("img-ns");
+    expect(handle.dispatch.resultSignal).toBe(IMAGE_RESULT_SIGNAL);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // toVideoResumePayload()
 // ---------------------------------------------------------------------------
 
@@ -891,9 +1082,63 @@ describe("toVideoResumePayload()", () => {
     });
     expect(payload).toEqual({
       outputs: [
-        { fileId: "f-3", downloadUrl: "https://dl/f-3", downloadUrlExpiresAt: "2026-03-03T00:00:00Z" },
+        {
+          fileId: "f-3",
+          downloadUrl: "https://dl/f-3",
+          downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
+        },
       ],
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toImageResumePayload()
+// ---------------------------------------------------------------------------
+
+describe("toImageResumePayload()", () => {
+  it("maps each image to an outputs[] entry (one per image, order preserved)", () => {
+    const payload = toImageResumePayload({
+      images: [
+        { url: "u1", fileId: "f-1" },
+        { url: "u2", fileId: "f-2", storageError: "partial" },
+      ],
+    });
+    expect(payload).toEqual({
+      outputs: [{ fileId: "f-1" }, { fileId: "f-2", storageError: "partial" }],
+    });
+  });
+
+  it("returns empty outputs when there are no images", () => {
+    expect(toImageResumePayload({})).toEqual({ outputs: [] });
+    expect(toImageResumePayload({ images: [] })).toEqual({ outputs: [] });
+  });
+
+  it("carries the convenience downloadUrl + its expiry alongside fileId", () => {
+    const payload = toImageResumePayload({
+      images: [
+        {
+          url: "u",
+          fileId: "f-3",
+          downloadUrl: "https://dl/f-3",
+          downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
+        },
+      ],
+    });
+    expect(payload).toEqual({
+      outputs: [
+        {
+          fileId: "f-3",
+          downloadUrl: "https://dl/f-3",
+          downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  it("emits an empty-field entry for an image with no storage annotations", () => {
+    const payload = toImageResumePayload({ images: [{ url: "u" }] });
+    expect(payload).toEqual({ outputs: [{}] });
   });
 });
 
@@ -901,7 +1146,7 @@ describe("toVideoResumePayload()", () => {
 // prompt-guard: null / empty / non-string prompt throws before any fetch
 // ---------------------------------------------------------------------------
 
-describe("prompt-guard — createImage, createVideo, launchVideo throw on invalid prompt", () => {
+describe("prompt-guard — createImage, launchImage, createVideo, launchVideo throw on invalid prompt", () => {
   const noFetch = (): never => {
     throw new Error("fetch should not be called with an invalid prompt");
   };
@@ -962,6 +1207,23 @@ describe("prompt-guard — createImage, createVideo, launchVideo throw on invali
       ).rejects.toBeInstanceOf(ContentGenerationHttpError);
       await expect(
         launchVideo(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it(`launchImage throws ContentGenerationHttpError(400) for prompt = ${label}`, async () => {
+      await expect(
+        launchImage(
+          { prompt: prompt as unknown as string },
+          noFetchTransport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(ContentGenerationHttpError);
+      await expect(
+        launchImage(
           { prompt: prompt as unknown as string },
           noFetchTransport,
           BASE,

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -49,6 +49,15 @@ const DEFAULT_BASE_URL = resolveServiceUrl(
  */
 export const VIDEO_RESULT_SIGNAL = "contentGeneration.video.result";
 
+/**
+ * Capability-stable signal an image launch fires when the image reaches a terminal
+ * state. The async completion→resume path is media-agnostic: the engine reads this
+ * name off the paused step row and matches the resume on `correlationId` (the launch
+ * `requestId`), so images resume through the exact same rail as video — this name is
+ * just the label carried in the handle's `dispatch.resultSignal`.
+ */
+export const IMAGE_RESULT_SIGNAL = "contentGeneration.images.result";
+
 // ----- Types -----
 
 export interface StorageOptions {
@@ -243,11 +252,196 @@ export async function createImage(
   return mapResult(raw);
 }
 
+// ----- Image async dispatch (SAP-1802) -----
+
+/** How often to poll for the async image result, and when to give up. Caller-overridable. */
+const DEFAULT_IMAGE_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_IMAGE_TIMEOUT_MS = 2 * 60_000;
+
 /**
- * The `images` sub-namespace, so `contentGeneration.images.create(...)` reads the
- * same whether imported from the barrel or used on a client.
+ * The routed async-submit handle the Core capability router returns for a
+ * `dispatch: 'async'` image request — camelCase (the router normalizes fal's
+ * snake_case away), with `servedBy` stripped at the public `/v1` boundary. Mirrors
+ * the video dispatch handle; the image is NOT here yet (completion is out-of-band).
  */
-export const images = { create: createImage };
+interface ImageDispatchResponse {
+  requestId: string;
+  statusUrl: string;
+  responseUrl?: string;
+}
+
+/**
+ * The result endpoint to poll. Prefer `responseUrl`; fall back to `statusUrl` with a
+ * trailing `/status` removed (the same convention as video's queue handle), so an
+ * async image launch stays usable when only `statusUrl` comes back.
+ */
+function imageResultUrl(handle: ImageDispatchResponse): string | undefined {
+  if (handle.responseUrl) return handle.responseUrl;
+  if (!handle.statusUrl) return undefined;
+  const url = new URL(handle.statusUrl);
+  if (!url.pathname.endsWith("/status")) return undefined;
+  url.pathname = url.pathname.slice(0, -"/status".length);
+  return url.toString();
+}
+
+/**
+ * A launched-but-not-awaited image generation job. Satisfies {@link DispatchHandle},
+ * so it can be handed straight to `pauseUntilSignal(handle, { resumeStep })` to
+ * suspend a workflow step until the image is ready — or `wait()`-ed inline for
+ * standalone use (same result as `images.create`, but with the dispatchable surface
+ * that doesn't hold the request open behind Core's 30s router cap).
+ */
+export interface ImageLaunchHandle extends DispatchHandle {
+  /** The queue request id for this job (also the correlation id a workflow resumes on). */
+  requestId: string;
+  /** Poll to completion and resolve the full result. */
+  wait(opts?: {
+    timeoutMs?: number;
+    pollMs?: number;
+  }): Promise<ImageGenerationResult>;
+}
+
+/**
+ * The image job's terminal result as it arrives at a step **resumed** from
+ * `pauseUntilSignal(launchHandle, { resumeStep })`. It crossed a wire boundary, so
+ * the shape is the engine's generic, media-agnostic dispatch payload (`outputs[]`) —
+ * the identical shape a resumed video step receives. Annotate a resumed step's input
+ * with this type instead of hand-rolling the shape.
+ */
+export interface ImageResultPayload {
+  outputs: Array<{
+    /** Present when the output was persisted to file storage — the durable reference. */
+    fileId?: string;
+    /**
+     * A ready-to-use, short-lived signed download URL for the persisted output, when
+     * available. Convenience only — it may have expired by the time a resumed step runs;
+     * re-fetch from `fileId` via `fileStorage.getDownloadUrl(fileId)` for a fresh one.
+     */
+    downloadUrl?: string;
+    /** ISO expiry of `downloadUrl`, when present — may already be past by the time a step resumes. */
+    downloadUrlExpiresAt?: string;
+    /** Present when storage was requested but persisting this output failed. */
+    storageError?: string;
+  }>;
+}
+
+/**
+ * Map a live, awaited {@link ImageGenerationResult} to the plain
+ * {@link ImageResultPayload} a resumed step receives across the wire boundary.
+ */
+export function toImageResumePayload(
+  result: ImageGenerationResult,
+): ImageResultPayload {
+  return {
+    outputs: (result.images ?? []).map((img) => ({
+      ...(img.fileId !== undefined && { fileId: img.fileId }),
+      ...(img.downloadUrl !== undefined && { downloadUrl: img.downloadUrl }),
+      ...(img.downloadUrlExpiresAt !== undefined && {
+        downloadUrlExpiresAt: img.downloadUrlExpiresAt,
+      }),
+      ...(img.storageError !== undefined && { storageError: img.storageError }),
+    })),
+  };
+}
+
+/**
+ * Submit an image generation job and return a dispatchable handle immediately, rather
+ * than holding the request open for the full generate+store the way the routed sync
+ * {@link createImage} does. The handle's `dispatch` member lets a workflow step pause
+ * until the image is ready; `handle.wait()` blocks inline instead.
+ *
+ * Routed (SAP-1116) + async (SAP-1802): POSTs `dispatch: 'async'` to
+ * `POST /v1/capabilities/content.generation.images`, forwarding the engine's workflow
+ * resume token so the service resumes the paused step on completion. The router returns
+ * a queue handle (not the image); the result arrives via signal resume or `wait()`.
+ * Because the submit returns as soon as the job is enqueued, it never meets Core's 30s
+ * router cap — the failure mode the blocking sync path hits under a fan-out.
+ *
+ * Pass `storage` to persist the output (the result then carries `fileId`). Throws
+ * {@link ContentGenerationHttpError} when the submit fails.
+ */
+export async function launchImage(
+  input: ImageCreateInput,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = resolveCoreBaseUrl(),
+): Promise<ImageLaunchHandle> {
+  assertPrompt(input.prompt);
+
+  // Mirror createImage's body byte-for-byte, plus `dispatch: 'async'` to select the
+  // queue path. `params` rides nested; `storage` uses a truthy check (so `storage: null`
+  // is "no storage"); `!= null` keeps an explicit JS null off the wire.
+  const body: Record<string, unknown> = {
+    prompt: input.prompt,
+    dispatch: "async",
+  };
+  if (input.model != null) body.model = input.model;
+  if (input.numImages !== undefined) body.numImages = input.numImages;
+  if (input.storage) body.storage = input.storage;
+  if (input.params != null) body.params = input.params;
+
+  const handle = await capabilityCall<ImageDispatchResponse>(
+    "content.generation.images",
+    body,
+    {
+      transport,
+      baseUrl,
+      // Forward the resume token so the service resumes a paused workflow step when the
+      // job completes (no header, no behavior change outside a workflow context).
+      headers: workflowResumeHeaders(transport.resumeToken),
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to launch image generation",
+    },
+  );
+
+  const responseUrl = imageResultUrl(handle);
+  if (!responseUrl) {
+    throw new Error("Image submit did not return a result URL to poll");
+  }
+  const requestId = handle.requestId ?? "unknown";
+
+  const wait = async ({
+    timeoutMs = DEFAULT_IMAGE_TIMEOUT_MS,
+    pollMs = DEFAULT_IMAGE_POLL_INTERVAL_MS,
+  }: {
+    timeoutMs?: number;
+    pollMs?: number;
+  } = {}): Promise<ImageGenerationResult> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const res = await transport.fetch(responseUrl, { method: "GET" });
+      if (res.ok) {
+        const raw = (await res.json()) as RawImageResult;
+        if (Array.isArray(raw.images)) return mapResult(raw);
+      } else {
+        // Still generating, or a transient error. Drain the unread body so the
+        // connection can be reused, then keep polling — `timeoutMs` is the backstop.
+        try {
+          await res.body?.cancel();
+        } catch {
+          // best-effort drain
+        }
+      }
+      await sleep(pollMs);
+    }
+    throw new Error(
+      `Image generation did not complete within ${timeoutMs}ms (request id: ${requestId})`,
+    );
+  };
+
+  return {
+    requestId,
+    dispatch: { correlationId: requestId, resultSignal: IMAGE_RESULT_SIGNAL },
+    wait,
+  };
+}
+
+/**
+ * The `images` sub-namespace: `contentGeneration.images.create(...)` (routed sync) and
+ * `contentGeneration.images.launch(...)` (routed async-dispatch, for workflow pause or
+ * inline `wait()`), read the same whether imported from the barrel or used on a client.
+ */
+export const images = { create: createImage, launch: launchImage };
 
 // ----- Video (async) -----
 
@@ -355,7 +549,9 @@ function mapVideo(raw: RawMedia): GeneratedVideo {
     ...(raw.content_type !== undefined && { contentType: raw.content_type }),
     ...(raw.file_id !== undefined && { fileId: raw.file_id }),
     ...(raw.download_url !== undefined && { downloadUrl: raw.download_url }),
-    ...(raw.download_url_expires_at !== undefined && { downloadUrlExpiresAt: raw.download_url_expires_at }),
+    ...(raw.download_url_expires_at !== undefined && {
+      downloadUrlExpiresAt: raw.download_url_expires_at,
+    }),
     ...(raw.storage_error !== undefined && { storageError: raw.storage_error }),
   };
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -99,11 +99,14 @@ export * as contentGeneration from "./content-generation/index.js";
 export { ContentGenerationHttpError } from "./content-generation/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
 export { VIDEO_RESULT_SIGNAL } from "./content-generation/index.js";
-// The shape a step resumed from `pauseUntilSignal(videoLaunchHandle, …)` receives
-// as input — annotate the resumed step with it instead of hand-rolling the shape.
+export { IMAGE_RESULT_SIGNAL } from "./content-generation/index.js";
+// The shape a step resumed from `pauseUntilSignal(launchHandle, …)` receives as input
+// — annotate the resumed step with it instead of hand-rolling the shape.
 export type { VideoResultPayload } from "./content-generation/index.js";
-// Map a live VideoGenerationResult to the wire shape the resumed step receives.
+export type { ImageResultPayload } from "./content-generation/index.js";
+// Map a live generation result to the wire shape the resumed step receives.
 export { toVideoResumePayload } from "./content-generation/index.js";
+export { toImageResumePayload } from "./content-generation/index.js";
 
 export * as search from "./search/index.js";
 export { SearchHttpError } from "./search/index.js";

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -58,10 +58,13 @@ import type {
 } from "../file-storage/index.js";
 import {
   VIDEO_RESULT_SIGNAL,
+  IMAGE_RESULT_SIGNAL,
   toVideoResumePayload,
+  toImageResumePayload,
 } from "../content-generation/index.js";
 import type {
   ImageGenerationResult,
+  ImageLaunchHandle,
   VideoGenerationResult,
   VideoLaunchHandle,
 } from "../content-generation/index.js";
@@ -1051,6 +1054,45 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               ],
             })) as ImageGenerationResult,
           ),
+        launch: (input) => {
+          const requestId = `stub-image-${++launchSeq}`;
+          const result = r(
+            dispatchedKeys("contentGeneration.images"),
+            [input],
+            () => ({
+              images: [
+                {
+                  url: "https://content.local/stub-image.png",
+                  contentType: "image/png",
+                  width: 512,
+                  height: 512,
+                  ...(input.storage
+                    ? {
+                        fileId: "stub-file",
+                        downloadUrl: "https://content.local/stub-download",
+                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+                      }
+                    : {}),
+                },
+              ],
+            }),
+          ) as ImageGenerationResult;
+
+          const handle: ImageLaunchHandle = {
+            requestId,
+            dispatch: {
+              correlationId: requestId,
+              resultSignal: IMAGE_RESULT_SIGNAL,
+            },
+            wait: () => Promise.resolve(result),
+          };
+
+          // Register the resume payload so a local `pauseUntilSignal` on this handle
+          // resolves with an ImageResultPayload.
+          return dispatchable(handle, opts.signals, () =>
+            toImageResumePayload(result),
+          );
+        },
       },
       video: {
         create: (input) =>


### PR DESCRIPTION
## Summary

Image generation was failing with **503 Heroku "Application Error"** pages under any fan-out. The routed synchronous `images.create` holds its HTTP request open for the full generate+store, which meets Core's **30s router cap (Heroku H12)** — a `Promise.all` over N rows drove every request in the batch past 30s, so the step 503'd on every retry.

The backend already supported async image dispatch (`dispatch: 'async'`, SAP-1802) over the **same** fal-queue → webhook → resume rail as video, but the SDK never exposed it. This was an asymmetry (video got the full launch/pause/webhook treatment; images didn't), not an outage. This PR closes the gap **SDK-only** — no backend/gateway/engine change is required, because the async completion→resume path is already media-agnostic (resumes on `correlationId == requestId`, delivers a generic `outputs[]` payload).

## Changes

### `@sapiom/tools` (new public API — minor)
- Add `contentGeneration.images.launch` mirroring `video.launch`: submits with `dispatch: 'async'`, forwards `x-sapiom-workflow-token`, returns an `ImageLaunchHandle` (`requestId`, `dispatch`, inline `wait()`). The submit returns as soon as the job is enqueued, so the 30s wall no longer applies.
- Add `IMAGE_RESULT_SIGNAL`, the `ImageResultPayload` shape a resumed step receives, and `toImageResumePayload`.
- Extend the `capabilityCall` seam to forward request headers (so the routed async verb can carry the resume token).
- Wire the client namespace, barrel exports, and the run-local stub.
- `images.create` is unchanged.

### Agent (`personalized-media-at-scale`)
- Rewrite the blocking `renderImages` fan-out into a `renderImage` ⇄ `collectImage` launch + `pauseUntilSignal` loop — a one-to-one mirror of the video path (`renderClip` ⇄ `collectClip`).
- Images now render **sequentially** (a paused step waits on a single `(signal, correlationId)` pair — the same reason video is sequential). Tradeoff vs. the old all-at-once fan-out, but the fan-out was the 503 trigger.

## Testing
- [x] `@sapiom/tools`: typecheck, lint, **517 tests pass** (+21 new for `launchImage` / `toImageResumePayload` / prompt-guard)
- [x] `@sapiom/agent` (92) and `@sapiom/agent-core` (133) suites pass — stub change is safe
- [x] Example typechecked against the locally-built SDK (caught a stale step-name reference); `defineAgent` graph validation passes with all 6 steps
- [ ] End-to-end deploy of agent 451 (see below)

## Notes
- A full `run_local` of this example's image path isn't a clean signal: the `fetch` step needs a real Postgres connection that stubs don't provide (affects the video path identically, predates this change).
- To ship agent 451: publish the SDK change, then `link` → `deploy` the example from a checkout with the updated `@sapiom/tools`.

## Related
- Builds on SAP-1802 (backend async image dispatch) / SAP-1116 (routed capability seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)