### PR TITLE
feat(scheduled-db-insight-report): author zeroSetup and clarify queries input (SAP-2342)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1337,10 +1337,11 @@
         }
       ],
       "setup": {
-        "runsWithNoSetup": false,
+        "runsWithNoSetup": true,
         "connectionCount": 1,
         "settingCount": 1,
-        "provisions": ["postgres"]
+        "provisions": ["postgres"],
+        "degradedWithoutSetup": "Snapshots the seeded demo database's own catalog, writes a real narrative report with a rendered chart, and returns it inline — nothing is emailed, because no `deliverTo` recipient is set."
       }
     },
     {

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -320,7 +320,7 @@ const entryInput = z.object({
     .array(z.object({ name: z.string(), sql: z.string() }))
     .optional()
     .describe(
-      "Queries to snapshot; defaults to catalog introspection when omitted.",
+      "Advanced: read-only queries to snapshot, each `{ name, sql }` where `sql` returns `label`/`value` columns. Optional — defaults to catalog introspection when omitted.",
     ),
   schedule: z
     .string()

--- a/examples/scheduled-db-insight-report/template.json
+++ b/examples/scheduled-db-insight-report/template.json
@@ -83,5 +83,15 @@
         "deliverTo": "founders@example.com"
       }
     }
-  ]
+  ],
+  "zeroSetup": {
+    "terminalState": "completed",
+    "expect": [
+      { "path": "report", "assert": "nonEmptyString" },
+      { "path": "chartUrl", "assert": "nonEmptyString" },
+      { "path": "delivered", "assert": "equals", "value": false },
+      { "path": "unmet", "assert": "nonEmptyArray" }
+    ],
+    "narrative": "Snapshots the seeded demo database's own catalog, writes a real narrative report with a rendered chart, and returns it inline — nothing is emailed, because no `deliverTo` recipient is set."
+  }
 }


### PR DESCRIPTION
## What & why

The **Scheduled Metrics Report** (`scheduled-db-insight-report`) template had **no authored `zeroSetup` block**, so its `{}` zero-interaction run had no machine-checkable pass/fail assertion — part of the [SAP-2080](https://linear.app/sapiom/issue/SAP-2080) gap across the gallery. It also presented `queries` as a bare optional input whose description didn't convey shape or optionality.

Run **149021** (zero-setup defaults `{dbHandle: db-insight-demo}`) is the ground truth: it **completed** with a real narrative `report`, a rendered GCS-hosted `chartUrl`, and honest `delivered:false, reason:"no-recipient"` — so the unconfigured run is gradeable.

## Change

- **`zeroSetup`** on the template manifest — `terminalState: completed`, asserting:
  - `report` — `nonEmptyString`
  - `chartUrl` — `nonEmptyString`
  - `delivered` — `equals false`
  - `unmet` — `nonEmptyArray` (the run reports `unmet: ["deliverTo"]`)
  - plus an honest `narrative` (rendered verbatim as `setup.degradedWithoutSetup`) that never implies a send.
- **`registry.json` setup re-synced** via `pnpm examples:sync-setup` — the template now derives `runsWithNoSetup: true` with a `degradedWithoutSetup` line.
- **`queries` description clarified** in the entry zod schema: names the `{ name, sql }` shape and that it defaults to catalog introspection when omitted, so it reads as advanced/optional rather than a required blob.

## Verification

- `pnpm examples:check` — **passes**: registry schema-valid, sorted, all sourcePaths present, 24 manifests schema-valid (`template.schema.json` is `additionalProperties:false`, so the `zeroSetup` shape is validated).
- `prettier --check` — clean on all three files.

## Companion PR

This is the template-side half of **SAP-2342**. The generalizable **frontend** half — folding optional nested inputs (like `queries`) behind an **"Advanced" disclosure** in the Run dialog — ships in **sapiom/Sapiom#4005**.

Refs SAP-2342, SAP-2080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)