### PR TITLE
feat(logged-in-screenshots): swap default URLs to content-rich pages

### DIFF
--- a/examples/logged-in-screenshots/index.ts
+++ b/examples/logged-in-screenshots/index.ts
@@ -43,11 +43,14 @@ import { z } from "zod/v4";
 /** Cap how many pages one session captures, to bound session time and cost. */
 const MAX_URLS = 8;
 /**
- * The pages a zero-input run captures. Both are IANA reserved example domains —
- * about the most stable public pages there are — so the default run always has
- * something real to shoot.
+ * The pages a zero-input run captures. Both are content-rich, ultra-stable,
+ * universally recognized public pages — so the default run always has something
+ * real to shoot and the screenshot obviously reads as a captured webpage.
  */
-const DEFAULT_URLS = ["https://example.com", "https://example.org"];
+const DEFAULT_URLS = [
+  "https://en.wikipedia.org/wiki/Main_Page",
+  "https://news.ycombinator.com",
+];
 
 /** The env var the login password is read from (never an input field). */
 const PASSWORD_ENV = "BROWSER_LOGIN_PASSWORD";

--- a/examples/logged-in-screenshots/template.json
+++ b/examples/logged-in-screenshots/template.json
@@ -24,13 +24,16 @@
     }
   ],
   "defaultInput": {
-    "urls": ["https://example.com", "https://example.org"]
+    "urls": [
+      "https://en.wikipedia.org/wiki/Main_Page",
+      "https://news.ycombinator.com"
+    ]
   },
   "examples": [
     {
       "title": "Capture public pages",
       "input": {
-        "urls": ["https://example.com"]
+        "urls": ["https://en.wikipedia.org/wiki/Main_Page"]
       },
       "output": {
         "authenticated": false,
@@ -38,7 +41,7 @@
         "captured": 1,
         "screenshots": [
           {
-            "url": "https://example.com",
+            "url": "https://en.wikipedia.org/wiki/Main_Page",
             "imageUrl": "https://cdn.sapiom.ai/screenshots/abc123.png",
             "expiresAt": "2026-08-01T00:00:00Z",
             "ok": true,


### PR DESCRIPTION
## What

Swaps the `logged-in-screenshots` zero-setup default capture targets from the IANA reserved placeholders (`example.com` / `example.org`) to two content-rich, ultra-stable, universally recognized public pages:

- `https://en.wikipedia.org/wiki/Main_Page`
- `https://news.ycombinator.com`

Changed in both `index.ts` (`DEFAULT_URLS` + its doc comment) and `template.json` (`defaultInput.urls`), plus the "Capture public pages" manifest example for consistency.

## Why

The template passes its zeroSetup rubric, but the placeholders render a blank "Example Domain" text block — so the zero-setup artifact was technically valid but not compelling. A new user saw a screenshot of nothing recognizable (passes golden-bar dim A "real artifact", whiffs dim E "oh, *that's* what Sapiom does"). The placeholders were chosen for stability; Wikipedia and Hacker News keep that stability while reading obviously as a real captured webpage.

Kept to **two** defaults for speed/cost, public-only / no login, so the `authenticated: false` zero-setup path stays intact.

## Acceptance

- [x] Zero-setup `{}` run captures two content-rich recognizable pages (not `example.com`).
- [x] Still `completed` · `screenshots` nonEmptyArray · `authenticated: false` (zeroSetup rubric and defaults unchanged in shape).
- [x] `pnpm examples:check` passes (registry + 24 manifests schema-valid).

Closes SAP-2345 · Refs SAP-2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)