### PR TITLE
fix(examples): bump @sapiom/agent to ^0.8.0 in nl-db-query-endpoint + approval-chain (SAP-2354)

### DIFF
--- a/examples/approval-chain/package.json
+++ b/examples/approval-chain/package.json
@@ -10,7 +10,7 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.0",
+    "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.20.0",
     "postgres": "^3.4.5",
     "zod": "^3.25.76 || ^4.0.0"

--- a/examples/nl-db-query-endpoint/package.json
+++ b/examples/nl-db-query-endpoint/package.json
@@ -10,7 +10,7 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.0",
+    "@sapiom/agent": "^0.8.0",
     "@sapiom/tools": "^0.20.0",
     "zod": "^3.25.76 || ^4.0.0"
   },


### PR DESCRIPTION
## Summary
Two gallery templates fail to build on the prod/dashboard path with:
> `No matching export in "@sapiom/agent/dist/esm/index.js" for import "resolveResourceHandle"`

They import `resolveResourceHandle` (added to `@sapiom/agent` ~0.8.0, SAP-2191) but pinned `^0.6.0`, which resolves to `0.6.x` — a version without the export. Studio/local builds passed because they resolve `@sapiom/agent` from the workspace (newest); only a real pinned-deps install (prod) fails.

## Change
Bump `@sapiom/agent` `^0.6.0 → ^0.8.0` in:
- `examples/nl-db-query-endpoint/package.json` (rank-1 wow template)
- `examples/approval-chain/package.json`

This matches the pin of the other five `resolveResourceHandle` importers (all `^0.8.0`), which build cleanly on prod today.

## Scope
Gallery scan confirmed these are the **only** two templates with this skew — every other stale-pinned template imports only long-standing exports. The broader pin-inconsistency + a CI guard are tracked in SAP-2368.

## Testing
- [x] Gallery scan: only these 2 import `resolveResourceHandle` while pinning `<0.8.0`.
- [ ] Post-merge: dashboard "Use template" build of nl-db-query-endpoint + approval-chain succeeds.

## Related
- Closes: SAP-2354
- Prevention: SAP-2368 (CI build-against-pinned-deps gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzCzBm5rNjt6kWjaFi9ADy