### PR TITLE
[SAP-2362] Fix Studio starter scaffolding

### DIFF
--- a/.changeset/brave-starters-scaffold.md
+++ b/.changeset/brave-starters-scaffold.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/harness": patch
+"@sapiom/mcp": patch
+---
+
+Make bundled starters work from a fresh Agent Studio session by preserving Studio-owned state, writing the project discovery marker, and handing Claude the local scaffold MCP tool directly.

--- a/packages/agent-core/src/__tests__/scaffold.test.ts
+++ b/packages/agent-core/src/__tests__/scaffold.test.ts
@@ -7,6 +7,7 @@
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -66,6 +67,7 @@ describe("scaffold", () => {
       expect(result.projectName).toBe("my-orch");
       expect(result.template).toBe("default");
       expect(existsSync(path.join(targetDir, "index.ts"))).toBe(true);
+      expect(readFileSync(path.join(targetDir, "sapiom.json"), "utf8")).toBe("{}\n");
 
       // Replacements applied: __PROJECT_NAME__ → my-orch in package.json
       const pkg = JSON.parse(
@@ -124,6 +126,52 @@ describe("scaffold", () => {
           versions: { agent: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
         }),
       ).rejects.toMatchObject({ code: "DIR_NOT_EMPTY" });
+    } finally {
+      rmSync(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it("scaffolds around Studio-owned .sapiom state without committing it", async () => {
+    const targetDir = makeTmp();
+    const studioDir = path.join(targetDir, ".sapiom");
+    mkdirSync(studioDir);
+    writeFileSync(path.join(studioDir, "harness-context.json"), '{"sentinel":"__PROJECT_NAME__"}\n');
+    try {
+      const result = await scaffold({
+        targetDir,
+        projectName: "studio-agent",
+        versions: { agent: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+      });
+
+      expect(result.gitInitialized).toBe(true);
+      expect(readFileSync(path.join(studioDir, "harness-context.json"), "utf8")).toBe(
+        '{"sentinel":"__PROJECT_NAME__"}\n',
+      );
+
+      const tracked = execFileSync("git", ["ls-files"], {
+        cwd: targetDir,
+        encoding: "utf8",
+      }).trim().split("\n");
+      expect(tracked).toContain("sapiom.json");
+      expect(tracked).toContain(".sapiom-dev/stubs.json");
+      expect(tracked.some((file) => file.startsWith(".sapiom/"))).toBe(false);
+    } finally {
+      rmSync(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still rejects user content beside Studio-owned .sapiom state", async () => {
+    const targetDir = makeTmp();
+    mkdirSync(path.join(targetDir, ".sapiom"));
+    writeFileSync(path.join(targetDir, "existing.txt"), "keep me");
+    try {
+      await expect(
+        scaffold({
+          targetDir,
+          versions: { agent: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+        }),
+      ).rejects.toMatchObject({ code: "DIR_NOT_EMPTY" });
+      expect(readFileSync(path.join(targetDir, "existing.txt"), "utf8")).toBe("keep me");
     } finally {
       rmSync(targetDir, { recursive: true, force: true });
     }

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -1,8 +1,9 @@
 /**
  * scaffold — initialize a new agent project from a bundled template.
  *
- * Pure local operation: no network, no process.env. All inputs are passed
- * explicitly; the caller is responsible for output rendering.
+ * Local authoring operation: no Sapiom account or capability calls. Dependency
+ * versions are resolved from npm when reachable (with a bundled fallback), and
+ * the caller is responsible for output rendering.
  *
  * Template resolution: the `templates/` directory ships alongside `dist/` in
  * the published package. The resolution seam is deliberately isolated here so
@@ -13,6 +14,7 @@ import { execFileSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -23,6 +25,7 @@ import {
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { writeConfig } from "./config.js";
 import { AgentOperationError } from "./errors.js";
 import { VERSION_FALLBACK } from "./version-fallback.generated.js";
 
@@ -192,9 +195,28 @@ function applyReplacements(
 function walk(dir: string, onFile: (file: string) => void): void {
   for (const entry of readdirSync(dir)) {
     const full = path.join(dir, entry);
+    // Agent Studio creates its private session/Canvas state before asking the
+    // coding agent to scaffold in this directory. It is not template content
+    // and must remain byte-for-byte untouched.
+    if (entry === ".sapiom" && lstatSync(full).isDirectory()) continue;
     if (statSync(full).isDirectory()) walk(full, onFile);
     else onFile(full);
   }
+}
+
+/**
+ * A Studio session owns `.sapiom/` and creates it before the coding agent can
+ * receive a scaffold prompt. Treat that one real directory as an empty target;
+ * every other pre-existing entry remains a hard stop so scaffolding cannot
+ * overwrite user work. Symlinks are deliberately rejected.
+ */
+function isScaffoldableTarget(targetDir: string): boolean {
+  if (!existsSync(targetDir)) return true;
+  const entries = readdirSync(targetDir);
+  if (entries.length === 0) return true;
+  if (entries.length !== 1 || entries[0] !== ".sapiom") return false;
+  const studioState = lstatSync(path.join(targetDir, ".sapiom"));
+  return studioState.isDirectory() && !studioState.isSymbolicLink();
 }
 
 function copyTemplate(
@@ -286,14 +308,15 @@ export interface ScaffoldResult {
  * Initialize a new agent project from a bundled template.
  *
  * Throws `AgentOperationError` (code `DIR_NOT_EMPTY` | `UNKNOWN_TEMPLATE`) on
- * precondition failures; all other errors propagate as-is.
+ * precondition failures; all other errors propagate as-is. A target containing
+ * only Agent Studio's private `.sapiom/` directory is treated as empty.
  */
 export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   const { targetDir } = opts;
   const template = opts.template ?? DEFAULT_TEMPLATE;
   const projectName = opts.projectName ?? path.basename(targetDir);
 
-  if (existsSync(targetDir) && readdirSync(targetDir).length > 0) {
+  if (!isScaffoldableTarget(targetDir)) {
     throw new AgentOperationError({
       code: "DIR_NOT_EMPTY",
       message: `Target directory '${targetDir}' already exists and is not empty.`,
@@ -336,6 +359,10 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
     path.join(devDir, "stubs.json"),
     JSON.stringify({ version: 1, steps: {} }, null, 2) + "\n",
   );
+
+  // The marker is intentionally valid but unlinked. Agent Studio discovers
+  // agent projects by this file; deploy/link fill in server identity later.
+  writeConfig(targetDir, {});
 
   const gitInitialized = initGitRepo(targetDir);
 

--- a/packages/agent-core/templates/coding-pause/_gitignore
+++ b/packages/agent-core/templates/coding-pause/_gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.tsbuildinfo
+.sapiom/

--- a/packages/agent-core/templates/default/_gitignore
+++ b/packages/agent-core/templates/default/_gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.tsbuildinfo
+.sapiom/

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -6,7 +6,7 @@
  * bundled starters are local, the detail view renders only real manifest fields,
  * and "Use template" performs the REAL handoff shape — a session at the
  * destination folder plus the agent prompt naming sapiom_dev_agents_clone
- * (gallery) or `sapiom agents init -t` (bundled starter). MockApi records the
+ * (gallery) or `sapiom_dev_agents_scaffold` (bundled starter). MockApi records the
  * injection on window.__HARNESS_TEST__.lastInjectInput.
  *
  * Browsing is a DESTINATION now, not a dialog, and that changes the shape of
@@ -210,7 +210,7 @@ test.describe("templates journey (from the welcome panel)", () => {
     expect(record?.req.text).toContain("free local test run (sapiom_dev_agents_run_local)");
   });
 
-  test("use (starter): the real bundled-template init command", async ({ page }) => {
+  test("use (starter): the real bundled-template scaffold tool", async ({ page }) => {
     await open(page, "coding-pause");
     await page.getByTestId("template-use-btn").click();
     await expect(page.getByTestId("dir-picker-input")).toHaveValue(
@@ -221,9 +221,12 @@ test.describe("templates journey (from the welcome panel)", () => {
     await expect(page.getByTestId("session-context-title")).toContainText("coding-pause");
     await expect
       .poll(async () => (await lastInject(page))?.req.text ?? "")
-      .toContain("sapiom agents init . -t coding-pause");
+      .toContain("sapiom_dev_agents_scaffold");
     // The starter path carries the same run continuation as the clone path.
     const prompt = (await lastInject(page))?.req.text ?? "";
+    expect(prompt).toContain(
+      '{"dir":"/Users/demo/acme-app/projects/coding-pause","template":"coding-pause"}',
+    );
     expect(prompt).toContain("sapiom_dev_agents_run_local");
     expect(prompt).toContain("adapt the agent");
     expect(prompt.toLowerCase()).not.toContain("workflow");

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -228,7 +228,7 @@ test.describe("templates journey (from the welcome panel)", () => {
       '{"dir":"/Users/demo/acme-app/projects/coding-pause","template":"coding-pause"}',
     );
     expect(prompt).toContain("sapiom_dev_agents_run_local");
-    expect(prompt).toContain("adapt the agent");
+    expect(prompt).toContain("Keep the shipped starter unchanged");
     expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -92,11 +92,14 @@ test.describe("add workspace (three doors)", () => {
     await page.waitForFunction(() => {
       const test = (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
         .__HARNESS_TEST__;
-      return test?.lastInjectInput?.req.text.includes("sapiom agents init") ?? false;
+      return test?.lastInjectInput?.req.text.includes("sapiom_dev_agents_scaffold") ?? false;
     });
     const scaffoldPrompt = await page.evaluate(() =>
       (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
         .__HARNESS_TEST__?.lastInjectInput?.req.text,
+    );
+    expect(scaffoldPrompt).toContain(
+      '{"dir":"/Users/demo/brand-new-agent","template":"default"}',
     );
     expect(scaffoldPrompt).toContain("define the first agent");
     expect(scaffoldPrompt?.toLowerCase()).not.toContain("workflow");

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -43,7 +43,7 @@ import { ApiError, boundWorkflowPathOf } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { historyDirs } from "./lib/history-meta";
 import { resolveProjectRoot } from "./lib/project-dir";
-import { useTemplatePrompt, type StudioTemplate } from "./lib/templates";
+import { starterScaffoldInstruction, useTemplatePrompt, type StudioTemplate } from "./lib/templates";
 import { track } from "./lib/track";
 import { initAnalytics } from "./lib/analytics/posthog";
 import { registerViewContext, track as trackProduct } from "./lib/analytics/events";
@@ -442,14 +442,15 @@ export const App = (): JSX.Element => {
   ): Promise<void> => {
     const session = await createSessionAt(cwd, agentHarness);
     const base =
-      "Scaffold a new Sapiom agent project in this directory: run `sapiom agents init .`, then use the sapiom-agent-authoring skill to";
+      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, ` +
+      "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
     const trimmedIdea = idea?.trim();
     injectPromptWithRetry(
       session.id,
       trimmedIdea
         ? `${base} build this:\n\n${trimmedIdea}`
         : `${base} define the first agent.`,
-      "Couldn't send the scaffold prompt. Ask the coding agent to run sapiom agents init.",
+      "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
     );
   };
 
@@ -474,10 +475,11 @@ export const App = (): JSX.Element => {
   // Bare-scaffold folder affordance: a live session sits in a folder
   // with no agent yet. Ask that session to scaffold its first agent in place.
   const handleScaffoldInSession = (sessionId: string): void => {
+    const cwd = state.sessions.find((session) => session.id === sessionId)?.cwd ?? ".";
     injectPromptWithRetry(
       sessionId,
-      "Scaffold a new Sapiom agent project in this directory: run `sapiom agents init .`, then use the sapiom-agent-authoring skill to define the first agent.",
-      "Couldn't send the scaffold prompt. Ask the coding agent to run sapiom agents init.",
+      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to define the first agent.`,
+      "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
     );
   };
 
@@ -490,7 +492,7 @@ export const App = (): JSX.Element => {
       useTemplatePrompt(template, cwd),
       template.kind === "gallery"
         ? "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone."
-        : "Couldn't send the starter prompt. Ask the coding agent to run sapiom agents init.",
+        : "Couldn't send the starter prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
     );
   };
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -431,9 +431,8 @@ export const App = (): JSX.Element => {
    *
    * `idea` is what the "start from an idea" door collects. It rides along
    * verbatim — the agent needs the intent, not our paraphrase of it. Omitted
-   * (door 1's plain/new outcomes, the bare-folder affordance), the prompt is
-   * byte-identical to what it has always been, so the blank-starter path is
-   * unchanged.
+   * (door 1's plain/new outcomes, the bare-folder affordance), the prompt keeps
+   * the same default-starter path without inventing an idea for the user.
    */
   const handleScaffoldSession = async (
     cwd: string,

--- a/packages/harness/web/src/components/AddWorkspaceDialog.tsx
+++ b/packages/harness/web/src/components/AddWorkspaceDialog.tsx
@@ -638,9 +638,10 @@ function ResultBlock({
 
 /**
  * A folder is unavoidable here, which is the whole reason this door has two
- * fields instead of one: a session is a PTY with a `cwd`, `sapiom agents init .`
- * writes into it, and `scaffold()` refuses a non-empty target — so the folder
- * must exist, be empty, and be NAMED before the agent can read the idea. The
+ * fields instead of one: a session is a PTY with a `cwd`, the local scaffold
+ * tool writes into it, and `scaffold()` refuses pre-existing user content — so
+ * the folder must exist, contain no user files, and be NAMED before the agent
+ * can read the idea. The
  * name is therefore derived client-side (nothing smarter can run yet) and the
  * resolved path is a statement rather than a field.
  */

--- a/packages/harness/web/src/lib/project-dir.ts
+++ b/packages/harness/web/src/lib/project-dir.ts
@@ -8,8 +8,9 @@
  *
  * Why a folder is unavoidable, and why the name has to be decided up front:
  *   - a session is a PTY with a `cwd`, and scaffolding is "start a session in a
- *     folder, then ask the agent to run `sapiom agents init .`";
- *   - `scaffold()` REFUSES a non-empty target (agent-core `DIR_NOT_EMPTY`);
+ *     folder, then ask the agent to call `sapiom_dev_agents_scaffold`";
+ *   - `scaffold()` refuses user content in the target (agent-core
+ *     `DIR_NOT_EMPTY`) while allowing Studio's own `.sapiom/` state;
  *   - `projectName` defaults to `basename(targetDir)` and is stamped into
  *     `package.json` "name" and `defineAgent({ name })`.
  *

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -230,7 +230,7 @@ describe("useTemplatePrompt", () => {
     const prompt = useTemplatePrompt(STARTER_TEMPLATES[1], "/tmp/coding-pause");
     expect(prompt).toContain("sapiom_dev_agents_scaffold");
     expect(prompt).toContain('{"dir":"/tmp/coding-pause","template":"coding-pause"}');
-    expect(prompt).toContain("adapt the agent");
+    expect(prompt).toContain("Keep the shipped starter unchanged");
     expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -226,9 +226,10 @@ describe("useTemplatePrompt", () => {
     expect(prompt).toContain('templateId "cold-outreach-engine"');
   });
 
-  it("starter: names the real init command with the bundled template flag", () => {
+  it("starter: names the local scaffold tool with exact arguments", () => {
     const prompt = useTemplatePrompt(STARTER_TEMPLATES[1], "/tmp/coding-pause");
-    expect(prompt).toContain("sapiom agents init . -t coding-pause");
+    expect(prompt).toContain("sapiom_dev_agents_scaffold");
+    expect(prompt).toContain('{"dir":"/tmp/coding-pause","template":"coding-pause"}');
     expect(prompt).toContain("adapt the agent");
     expect(prompt.toLowerCase()).not.toContain("workflow");
   });

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -9,17 +9,18 @@
  * There is no local copy of the gallery any more — a stale copy IS the bug.
  *
  * **Starters** stay local, and should: they are the templates bundled with
- * `@sapiom/agent-core` (`templates/{default,coding-pause}`), scaffolded by
- * `sapiom agents init -t <name>` with no account and no network. They are the
- * offline floor — what the dialog can still offer when the catalog is
- * unreachable — so describing them from the package is correct, not a shortcut.
+ * `@sapiom/agent-core` (`templates/{default,coding-pause}`), scaffolded by the
+ * local `sapiom_dev_agents_scaffold` tool with no Sapiom account or capability
+ * calls. They are the offline-capable floor — what the dialog can still offer
+ * when the catalog is unreachable — so describing them from the package is
+ * correct, not a shortcut.
  *
  * Both "use" paths are real operations driven through the session's agent:
  * - Gallery: `sapiom_dev_agents_clone` (`{dir, templateId}`) forks the template
  *   into a repo the user owns, clones it, and writes `sapiom.json` provenance.
  *   Its `templateId` is a free-form string relayed to core's fork endpoint — no
  *   allowlist — so every catalog id works, not just the two once pinned here.
- * - Starters: `sapiom agents init <dir> -t <name>`, offline.
+ * - Starters: `sapiom_dev_agents_scaffold` (`{dir, template}`), local.
  */
 import type { TemplateComplexity, TemplateDetailView, TemplateSummary } from "@shared/types";
 
@@ -32,7 +33,7 @@ export type GalleryTemplate = TemplateSummary & { kind: "gallery" };
 /** A template bundled with @sapiom/agent-core — scaffolds offline. */
 export interface StarterTemplate {
   kind: "starter";
-  /** The bundled template directory name — what `init -t` takes. */
+  /** The bundled template directory name passed as the scaffold tool's `template`. */
   id: string;
   name: string;
   description: string;
@@ -225,10 +226,15 @@ export function useTemplatePrompt(template: StudioTemplate, dir: string): string
   }
   return (
     `Scaffold the "${template.id}" starter in this directory: ` +
-    `run \`sapiom agents init . -t ${template.id}\`, then run npm install and read AGENTS.md. ` +
+    `${starterScaffoldInstruction(dir, template.id)}, then run npm install and read AGENTS.md. ` +
     "Use the sapiom-agent-authoring skill to adapt the agent. " +
     runContinuation
   );
+}
+
+/** Exact local MCP handoff shared by every bundled-starter entry point. */
+export function starterScaffoldInstruction(dir: string, template: string): string {
+  return "call the sapiom_dev_agents_scaffold tool with " + JSON.stringify({ dir, template });
 }
 
 /**

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -207,8 +207,8 @@ export function matchesQuery(template: StudioTemplate, query: string): boolean {
 /**
  * The prompt handed to the session's agent after "Use template" starts a session
  * in the destination folder. Both branches name the REAL operation: the clone
- * MCP tool for gallery templates (with its auth failure path), the bundled
- * template init command for starters. Both end with the same next move (a free
+ * MCP tool for gallery templates (with its auth failure path), the local
+ * scaffold MCP tool for starters. Both end with the same next move (a free
  * local test run), so use → edit → run is one continuous path rather than a
  * journey that stops at the clone.
  */

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -227,7 +227,7 @@ export function useTemplatePrompt(template: StudioTemplate, dir: string): string
   return (
     `Scaffold the "${template.id}" starter in this directory: ` +
     `${starterScaffoldInstruction(dir, template.id)}, then run npm install and read AGENTS.md. ` +
-    "Use the sapiom-agent-authoring skill to adapt the agent. " +
+    "Keep the shipped starter unchanged until the user describes what to build. " +
     runContinuation
   );
 }

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -1,8 +1,9 @@
 /**
  * Agent authoring tools. Thin wrappers over @sapiom/agent-core.
- * Local tools (scaffold / check / run_local) need no network; networked tools
- * (link / deploy / run / inspect / signal) build a client from the cached
- * credential and the environment's API host.
+ * Local tools (scaffold / check / run_local) need no Sapiom account or real
+ * capability calls; scaffold may query npm for current dependency versions.
+ * Networked tools (link / deploy / run / inspect / signal) build a client from
+ * the cached credential and the environment's API host.
  *
  * Results are returned as JSON text so the calling agent can parse them. In
  * particular, `run_local` returns a per-step trace plus `unusedStubs` /
@@ -91,7 +92,7 @@ function scheduleHint(schedule: ScheduleDetail): string | undefined {
 }
 
 export function register(server: McpServer, env: ResolvedEnvironment): void {
-  // ── Local tools (no network) ──────────────────────────────────────────────
+  // ── Local authoring tools (no account or capability spend) ───────────────────
 
   registerTool(
     server,
@@ -102,7 +103,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         .string()
         .min(1)
         .describe(
-          "Target directory for the new project (created if absent; must be empty).",
+          "Target directory for the new project (created if absent; must otherwise be empty, except for Agent Studio's private .sapiom directory).",
         ),
       template: z
         .string()


### PR DESCRIPTION
## Summary

- let Agent Core scaffold safely into a folder containing only Agent Studio private state
- preserve and ignore .sapiom, write the sapiom.json discovery marker, and retain the non-empty-directory safety boundary
- route Studio starter prompts through sapiom_dev_agents_scaffold with exact arguments instead of relying on the desktop-only CLI
- add package and browser regression coverage plus patch changesets

## Verification

- 18 Agent Core scaffold tests
- 27 Harness template prompt tests
- 28 Chromium template and Add Workspace journey tests
- Agent Core, MCP, and Harness typechecks
- Harness dependency graph production build
- Agent Studio terminology gate
- clean-room source dogfood: Studio-shaped scaffold, npm install, full check, registry discovery, and local start-to-finish run with no warnings

Linear: SAP-2362