### PR TITLE
[SAP-2365] Clarify cloud operation contracts

### DIFF
--- a/.changeset/clear-cloud-agent-boundaries.md
+++ b/.changeset/clear-cloud-agent-boundaries.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/cli": patch
+"@sapiom/harness": patch
+"@sapiom/mcp": patch
+---
+
+Describe deploy as a synthesized bundle of current local source, distinguish
+account-free local validation from metered cloud builds and production runs,
+and make execution inspection's cost-agnostic evidence boundary explicit.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -74,12 +74,12 @@ API-key principal; link, deploy, and cloud run require it.
 
 ### 4. Link → deploy → run → inspect
 
-| Command                     | What it does                                  |
-| --------------------------- | --------------------------------------------- |
-| `sapiom_dev_agents_link`    | Registers the agent under your tenant         |
-| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud          |
-| `sapiom_dev_agents_run`     | Starts a real (billed) execution              |
-| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+| Command                     | What it does                                        |
+| --------------------------- | --------------------------------------------------- |
+| `sapiom_dev_agents_link`    | Registers the agent under your tenant               |
+| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud                |
+| `sapiom_dev_agents_run`     | Starts a real (billed) execution                    |
+| `sapiom_dev_agents_inspect` | Watch status, pinned build, steps, logs, and output |
 
 ## The Step Model — Hard Rules
 

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -1,19 +1,19 @@
 /**
- * deploy — mint push credentials, push the current commit, trigger a build,
- * and poll until the build reaches a terminal state.
+ * deploy — bundle the current local source, push a synthesized build tree,
+ * trigger a build, and poll until the build reaches a terminal state.
  *
  * Networked operation: requires a GatewayClient. All inputs passed explicitly;
  * no process.cwd() reads — the caller supplies the project directory and client.
  */
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { getOrchestrationAnalytics, telemetryErrorCode } from './analytics.js';
-import { bundleForDeploy } from './bundle.js';
-import { GatewayClient } from './client.js';
-import { AgentOperationError } from './errors.js';
-import { assertDeployable, pushHead, pushSynthesizedTree } from './git.js';
+import { getOrchestrationAnalytics, telemetryErrorCode } from "./analytics.js";
+import { bundleForDeploy } from "./bundle.js";
+import { GatewayClient } from "./client.js";
+import { AgentOperationError } from "./errors.js";
+import { assertDeployable, pushHead, pushSynthesizedTree } from "./git.js";
 
 /**
  * Whether a git push error looks like an auth failure — a short-lived push
@@ -22,13 +22,13 @@ import { assertDeployable, pushHead, pushSynthesizedTree } from './git.js';
  * rejection, checking the already-redacted hint so the match is safe to log.
  */
 function isPushAuthError(err: unknown): boolean {
-  if (!(err instanceof AgentOperationError) || err.code !== 'GIT') return false;
-  const text = ((err.hint ?? '') + ' ' + err.message).toLowerCase();
+  if (!(err instanceof AgentOperationError) || err.code !== "GIT") return false;
+  const text = ((err.hint ?? "") + " " + err.message).toLowerCase();
   return (
-    text.includes('authentication failed') ||
-    text.includes('could not read from') ||
-    text.includes('the requested url returned error: 401') ||
-    text.includes('the requested url returned error: 403')
+    text.includes("authentication failed") ||
+    text.includes("could not read from") ||
+    text.includes("the requested url returned error: 401") ||
+    text.includes("the requested url returned error: 403")
   );
 }
 
@@ -39,11 +39,12 @@ interface BuildRun {
   error?: { name?: string; message?: string; stack?: string } | null;
 }
 
-const TERMINAL = new Set(['ready', 'failed', 'cancelled', 'superseded']);
+const TERMINAL = new Set(["ready", "failed", "cancelled", "superseded"]);
 const POLL_DELAYS_MS = [1000, 2000, 3000, 5000, 5000, 8000, 10000];
 const POLL_BUDGET_MS = 300_000;
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 export interface DeployOptions {
   /** Absolute path to the agent project directory. */
@@ -61,10 +62,11 @@ export interface DeployResult {
 }
 
 /**
- * Deploy the current commit of an agent project.
+ * Deploy the current local source of an agent project.
  *
- * Validates the git state, mints push credentials, pushes HEAD, triggers a
- * build, and polls until the build reaches a terminal status.
+ * Requires a git repository with at least one commit, then bundles the working
+ * tree (including uncommitted source), mints push credentials, pushes a
+ * synthesized build tree, triggers a build, and polls until terminal status.
  *
  * Throws `AgentOperationError` on git, network, or build failures.
  *
@@ -72,24 +74,27 @@ export interface DeployResult {
  * status, duration). Live by default — see ./analytics.ts; telemetry never
  * changes the operation's behavior.
  */
-export async function deploy(opts: DeployOptions, client: GatewayClient): Promise<DeployResult> {
+export async function deploy(
+  opts: DeployOptions,
+  client: GatewayClient,
+): Promise<DeployResult> {
   const startedAt = Date.now();
   try {
     const result = await deployOperation(opts, client);
-    getOrchestrationAnalytics().track('workflow.deploy', {
+    getOrchestrationAnalytics().track("workflow.deploy", {
       workflow_id: opts.definitionId,
-      branch: opts.branch ?? 'main',
+      branch: opts.branch ?? "main",
       build_run_id: result.buildRunId,
       build_status: result.status,
-      status: 'success',
+      status: "success",
       duration_ms: Date.now() - startedAt,
     });
     return result;
   } catch (err) {
-    getOrchestrationAnalytics().track('workflow.deploy', {
+    getOrchestrationAnalytics().track("workflow.deploy", {
       workflow_id: opts.definitionId,
-      branch: opts.branch ?? 'main',
-      status: 'error',
+      branch: opts.branch ?? "main",
+      status: "error",
       error_code: telemetryErrorCode(err),
       duration_ms: Date.now() - startedAt,
     });
@@ -98,8 +103,11 @@ export async function deploy(opts: DeployOptions, client: GatewayClient): Promis
 }
 
 /** The operation body — unchanged from before the analytics wrapper. */
-async function deployOperation(opts: DeployOptions, client: GatewayClient): Promise<DeployResult> {
-  const { projectDir, definitionId, branch = 'main' } = opts;
+async function deployOperation(
+  opts: DeployOptions,
+  client: GatewayClient,
+): Promise<DeployResult> {
+  const { projectDir, definitionId, branch = "main" } = opts;
 
   assertDeployable(projectDir);
 
@@ -116,12 +124,21 @@ async function deployOperation(opts: DeployOptions, client: GatewayClient): Prom
     {},
   );
 
-  const treeDir = mkdtempSync(path.join(tmpdir(), 'sapiom-deploy-'));
+  const treeDir = mkdtempSync(path.join(tmpdir(), "sapiom-deploy-"));
   try {
-    writeFileSync(path.join(treeDir, 'index.ts'), code);
+    writeFileSync(path.join(treeDir, "index.ts"), code);
     writeFileSync(
-      path.join(treeDir, 'package.json'),
-      JSON.stringify({ name: 'agent-definition', private: true, type: 'module', dependencies }, null, 2) + '\n',
+      path.join(treeDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "agent-definition",
+          private: true,
+          type: "module",
+          dependencies,
+        },
+        null,
+        2,
+      ) + "\n",
     );
     try {
       pushSynthesizedTree(treeDir, pushUrl, branch);
@@ -145,31 +162,34 @@ async function deployOperation(opts: DeployOptions, client: GatewayClient): Prom
     rmSync(treeDir, { recursive: true, force: true });
   }
 
-  const triggered = await client.post<BuildRun>(`/definitions/${definitionId}/builds`, {});
+  const triggered = await client.post<BuildRun>(
+    `/definitions/${definitionId}/builds`,
+    {},
+  );
   const buildRunId = triggered.buildRunId ?? triggered.id;
   if (!buildRunId) {
     throw new AgentOperationError({
-      code: 'BUILD_NO_ID',
-      message: 'The build was triggered but no build id was returned.',
+      code: "BUILD_NO_ID",
+      message: "The build was triggered but no build id was returned.",
     });
   }
 
   const final = await pollBuild(client, definitionId, buildRunId);
-  if (final.status !== 'ready') {
-    if (final.status === 'superseded') {
+  if (final.status !== "ready") {
+    if (final.status === "superseded") {
       // A newer deploy replaced this one while the build was in flight —
       // expected when the user re-deploys quickly. Surface a distinct code so
       // the UI can treat this as informational rather than a hard failure.
       throw new AgentOperationError({
-        code: 'BUILD_SUPERSEDED',
-        message: 'A newer deploy superseded this build.',
-        step: 'build',
+        code: "BUILD_SUPERSEDED",
+        message: "A newer deploy superseded this build.",
+        step: "build",
       });
     }
     throw new AgentOperationError({
-      code: 'BUILD_FAILED',
+      code: "BUILD_FAILED",
       message: `Build ${final.status}.`,
-      step: 'build',
+      step: "build",
       hint: final.error?.stack || final.error?.message,
     });
   }
@@ -177,20 +197,26 @@ async function deployOperation(opts: DeployOptions, client: GatewayClient): Prom
   return { definitionId, buildRunId, status: final.status };
 }
 
-async function pollBuild(client: GatewayClient, definitionId: string, buildRunId: string): Promise<BuildRun> {
+async function pollBuild(
+  client: GatewayClient,
+  definitionId: string,
+  buildRunId: string,
+): Promise<BuildRun> {
   let elapsed = 0;
   let i = 0;
   while (elapsed < POLL_BUDGET_MS) {
-    const build = await client.get<BuildRun>(`/definitions/${definitionId}/builds/${buildRunId}`);
+    const build = await client.get<BuildRun>(
+      `/definitions/${definitionId}/builds/${buildRunId}`,
+    );
     if (TERMINAL.has(build.status)) return build;
     const delay = POLL_DELAYS_MS[Math.min(i++, POLL_DELAYS_MS.length - 1)];
     await sleep(delay);
     elapsed += delay;
   }
   throw new AgentOperationError({
-    code: 'BUILD_TIMEOUT',
-    message: 'Build did not finish in time.',
-    step: 'build',
+    code: "BUILD_TIMEOUT",
+    message: "Build did not finish in time.",
+    step: "build",
     hint: `Check it later via the logs API for build ${buildRunId}`,
   });
 }

--- a/packages/agent-core/src/git.ts
+++ b/packages/agent-core/src/git.ts
@@ -3,21 +3,27 @@
  * directly (passed as the remote argument) rather than persisting it via
  * `remote set-url`, so the short-lived token never lands in `.git/config`.
  */
-import { execFileSync } from 'node:child_process';
+import { execFileSync } from "node:child_process";
 
-import { AgentOperationError } from './errors.js';
+import { AgentOperationError } from "./errors.js";
 
 function git(args: string[], cwd: string): string {
   try {
-    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
   } catch (err) {
     const raw = (err as { stderr?: Buffer | string }).stderr?.toString().trim();
     // Redact any embedded credential (e.g. a token-bearing push URL echoed by
     // git into stderr) before it reaches the caller, the CLI, or the browser
     // stream. Applies to every git command so no path can leak a token.
-    const hint = redactCredentials(raw || (err instanceof Error ? err.message : String(err)));
+    const hint = redactCredentials(
+      raw || (err instanceof Error ? err.message : String(err)),
+    );
     throw new AgentOperationError({
-      code: 'GIT',
+      code: "GIT",
       message: `git ${args[0]} failed.`,
       hint,
     });
@@ -27,20 +33,23 @@ function git(args: string[], cwd: string): string {
 /** Fail clearly unless `dir` is a git repo with at least one commit. */
 export function assertDeployable(dir: string): void {
   try {
-    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], { cwd: dir, stdio: 'ignore' });
+    execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd: dir,
+      stdio: "ignore",
+    });
   } catch {
     throw new AgentOperationError({
-      code: 'NOT_GIT',
-      message: 'Not a git repository.',
+      code: "NOT_GIT",
+      message: "Not a git repository.",
       hint: 'Initialize one: git init && git add -A && git commit -m "init"',
     });
   }
   try {
-    execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, stdio: 'ignore' });
+    execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, stdio: "ignore" });
   } catch {
     throw new AgentOperationError({
-      code: 'NO_COMMITS',
-      message: 'This repository has no commits yet.',
+      code: "NO_COMMITS",
+      message: "This repository has no commits yet.",
       hint: 'Commit your work: git add -A && git commit -m "…"',
     });
   }
@@ -54,7 +63,7 @@ export function assertDeployable(dir: string): void {
  * short-lived GitHub App token.
  */
 export function redactCredentials(text: string): string {
-  return text.replace(/(https?:\/\/)[^@\s/]+@/gi, '$1***@');
+  return text.replace(/(https?:\/\/)[^@\s/]+@/gi, "$1***@");
 }
 
 export interface CloneRepoOptions {
@@ -92,19 +101,30 @@ export function cloneRepo(opts: CloneRepoOptions): void {
   const { cloneUrl, targetDir, branch, repoFullName, cwd } = opts;
   try {
     execFileSync(
-      'git',
+      "git",
       // `--` terminates option parsing so a cloneUrl/targetDir that begins with
       // `-` can never be read as a git flag (e.g. `--upload-pack=<cmd>`, which
       // would run an arbitrary command) — second-order argv injection hardening.
-      ['clone', '--depth', '1', '--single-branch', '--branch', branch, '--', cloneUrl, targetDir],
-      { cwd, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+      [
+        "clone",
+        "--depth",
+        "1",
+        "--single-branch",
+        "--branch",
+        branch,
+        "--",
+        cloneUrl,
+        targetDir,
+      ],
+      { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" },
     );
   } catch (err) {
     const stderr = (err as { stderr?: Buffer | string }).stderr?.toString();
-    const raw = stderr?.trim() || (err instanceof Error ? err.message : String(err));
+    const raw =
+      stderr?.trim() || (err instanceof Error ? err.message : String(err));
     throw new AgentOperationError({
-      code: 'GIT_CLONE',
-      message: 'git clone failed.',
+      code: "GIT_CLONE",
+      message: "git clone failed.",
       hint: redactCredentials(raw),
     });
   }
@@ -115,18 +135,21 @@ export function cloneRepo(opts: CloneRepoOptions): void {
   // best-effort attempt is the right trade-off: worst case the ~1h token lingers
   // in .git/config, which the caller was told to treat as ephemeral anyway.
   try {
-    git(['remote', 'set-url', 'origin', `https://github.com/${repoFullName}.git`], targetDir);
+    git(
+      ["remote", "set-url", "origin", `https://github.com/${repoFullName}.git`],
+      targetDir,
+    );
   } catch {
     // Non-fatal — see comment above.
   }
 }
 
 export function pushHead(dir: string, pushUrl: string, branch: string): void {
-  // Force-push: `deploy` ships the author's current commit, and the freshly
-  // provisioned repo is auto-initialized (a starting commit on the branch), so
-  // a plain push is non-fast-forward. The author's working tree is the source
-  // of truth for their definition; the remote is only a build source.
-  git(['push', '--force', pushUrl, `HEAD:${branch}`], dir);
+  // Force-push the already-committed synthesized deploy tree. This helper is
+  // used only when retrying a credential-rejected push; the freshly
+  // provisioned repo may already contain a starting commit, so a plain push is
+  // non-fast-forward. The remote is only a build source.
+  git(["push", "--force", pushUrl, `HEAD:${branch}`], dir);
 }
 
 /**
@@ -136,9 +159,25 @@ export function pushHead(dir: string, pushUrl: string, branch: string): void {
  * author's raw commit — so relative imports that escape the author's repo root
  * (shared local utils) are already inlined and the remote build can resolve them.
  */
-export function pushSynthesizedTree(treeDir: string, pushUrl: string, branch: string): void {
-  git(['init', '-q', '-b', branch], treeDir);
-  git(['add', '-A'], treeDir);
-  git(['-c', 'user.email=deploy@sapiom.ai', '-c', 'user.name=Sapiom Deploy', 'commit', '-q', '-m', 'deploy'], treeDir);
-  git(['push', '--force', pushUrl, `HEAD:${branch}`], treeDir);
+export function pushSynthesizedTree(
+  treeDir: string,
+  pushUrl: string,
+  branch: string,
+): void {
+  git(["init", "-q", "-b", branch], treeDir);
+  git(["add", "-A"], treeDir);
+  git(
+    [
+      "-c",
+      "user.email=deploy@sapiom.ai",
+      "-c",
+      "user.name=Sapiom Deploy",
+      "commit",
+      "-q",
+      "-m",
+      "deploy",
+    ],
+    treeDir,
+  );
+  git(["push", "--force", pushUrl, `HEAD:${branch}`], treeDir);
 }

--- a/packages/agent-core/src/inspect.ts
+++ b/packages/agent-core/src/inspect.ts
@@ -23,11 +23,12 @@ export interface InspectOptions {
 }
 
 /**
- * Fetch the full {@link ExecutionProjection} for a single execution — the same
- * tree + per-node cost + trace refs the REST DTO returns (Module P / SAP-1138).
- * The SDK is a thin passthrough of the REST shape; the body is only NORMALIZED
- * (see {@link decodeExecutionProjection}) so pre-seam runs decode without error
- * (degraded tree from lineage, flat cost fallback) — never reshaped or recosted.
+ * Fetch the full execution audit for a single run: status, pinned build, step
+ * attempts, logs/events, output/error, trace refs, and dispatch lineage. The
+ * SDK is a thin passthrough of the REST shape; the body is only NORMALIZED (see
+ * {@link decodeExecutionProjection}) so pre-seam runs decode without error.
+ * This endpoint is cost-agnostic today, so missing run/step cost stays `null`
+ * rather than being fabricated or fetched from another endpoint.
  *
  * Throws `AgentOperationError` (code `HTTP_*` | `NETWORK`) on gateway errors.
  */
@@ -163,9 +164,10 @@ export async function waitForExecution(
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), Math.max(0, deadline - now()));
   timer.unref?.();
-  const events = watch({ executionId: opts.executionId, signal: abort.signal }, client)[
-    Symbol.asyncIterator
-  ]();
+  const events = watch(
+    { executionId: opts.executionId, signal: abort.signal },
+    client,
+  )[Symbol.asyncIterator]();
   try {
     for (;;) {
       const next = await events.next(); // resolves on each SSE event (heartbeats filtered)
@@ -173,7 +175,8 @@ export async function waitForExecution(
       execution = await read();
       settled = settledResult(execution, autoResume);
       if (settled) return { execution, ...settled };
-      if (now() >= deadline) return { execution, reason: "timeout", done: false };
+      if (now() >= deadline)
+        return { execution, reason: "timeout", done: false };
     }
     if (now() >= deadline) return { execution, reason: "timeout", done: false };
   } catch {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -221,11 +221,10 @@ export interface StepProjection {
 }
 
 /**
- * The canonical inspection projection for a single execution — the same tree +
- * per-node cost + trace identity the REST `ExecutionProjection` returns (Module
- * P / SAP-1138). One read returns everything a view needs. Extension of the
- * engine execution detail: the base audit fields plus the tree/cost/trace
- * projection additions.
+ * The canonical inspection projection for a single execution: the engine audit
+ * fields plus dispatch lineage, trace identity, step logs/events, and nullable
+ * cost slots. The execution-detail read is cost-agnostic today; one inspection
+ * therefore returns the execution evidence, while missing cost remains `null`.
  */
 export interface ExecutionProjection {
   // ── identity / status ──────────────────────────────────────────────────────

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -74,12 +74,12 @@ API-key principal; link, deploy, and cloud run require it.
 
 ### 4. Link → deploy → run → inspect
 
-| Command                     | What it does                                  |
-| --------------------------- | --------------------------------------------- |
-| `sapiom_dev_agents_link`    | Registers the agent under your tenant         |
-| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud          |
-| `sapiom_dev_agents_run`     | Starts a real (billed) execution              |
-| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+| Command                     | What it does                                        |
+| --------------------------- | --------------------------------------------------- |
+| `sapiom_dev_agents_link`    | Registers the agent under your tenant               |
+| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud                |
+| `sapiom_dev_agents_run`     | Starts a real (billed) execution                    |
+| `sapiom_dev_agents_inspect` | Watch status, pinned build, steps, logs, and output |
 
 ## The Step Model — Hard Rules
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -74,12 +74,12 @@ API-key principal; link, deploy, and cloud run require it.
 
 ### 4. Link → deploy → run → inspect
 
-| Command                     | What it does                                  |
-| --------------------------- | --------------------------------------------- |
-| `sapiom_dev_agents_link`    | Registers the agent under your tenant         |
-| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud          |
-| `sapiom_dev_agents_run`     | Starts a real (billed) execution              |
-| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+| Command                     | What it does                                        |
+| --------------------------- | --------------------------------------------------- |
+| `sapiom_dev_agents_link`    | Registers the agent under your tenant               |
+| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud                |
+| `sapiom_dev_agents_run`     | Starts a real (billed) execution                    |
+| `sapiom_dev_agents_inspect` | Watch status, pinned build, steps, logs, and output |
 
 ## The Step Model — Hard Rules
 

--- a/packages/cli/src/commands/agents/index.ts
+++ b/packages/cli/src/commands/agents/index.ts
@@ -1,20 +1,20 @@
-import { Command } from 'commander';
+import { Command } from "commander";
 
-import { action, json } from '../shared.js';
-import { runCheck } from './check.js';
-import { runDeploy } from './deploy.js';
-import { runInit } from './init.js';
-import { runLink } from './link.js';
-import { runLogs } from './logs.js';
-import { runRun } from './run.js';
+import { action, json } from "../shared.js";
+import { runCheck } from "./check.js";
+import { runDeploy } from "./deploy.js";
+import { runInit } from "./init.js";
+import { runLink } from "./link.js";
+import { runLogs } from "./logs.js";
+import { runRun } from "./run.js";
 import {
   runScheduleCancel,
   runScheduleCreate,
   runScheduleInspect,
   runScheduleList,
   runSchedulePreview,
-} from './schedule.js';
-import { runSignal } from './signal.js';
+} from "./schedule.js";
+import { runSignal } from "./signal.js";
 
 /**
  * Attach the shared --host / --target flags to a command. These override the
@@ -22,80 +22,139 @@ import { runSignal } from './signal.js';
  */
 function withHostFlags(cmd: Command): Command {
   return cmd
-    .option('--host <url>', 'API host URL (overrides config and SAPIOM_HOST)')
-    .option('--target <target>', 'target environment: prod (default) or local');
+    .option("--host <url>", "API host URL (overrides config and SAPIOM_HOST)")
+    .option("--target <target>", "target environment: prod (default) or local");
 }
 
 /** Mount the `sapiom agents …` command group. */
 export function registerAgentsCommands(program: Command): void {
   const group = program
-    .command('agents')
-    .alias('ag')
-    .description('Author, validate, and ship Sapiom agents.');
+    .command("agents")
+    .alias("ag")
+    .description("Author, validate, and ship Sapiom agents.");
 
-  json(group.command('init [dir]').description('Scaffold a new agent project.'))
-    .option('-t, --template <name>', 'template to scaffold from', 'default')
+  json(group.command("init [dir]").description("Scaffold a new agent project."))
+    .option("-t, --template <name>", "template to scaffold from", "default")
     .action(action(runInit));
 
-  json(group.command('check [dir]').description('Validate an agent locally (bundle, manifest, graph).')).action(
-    action(runCheck),
-  );
+  json(
+    group
+      .command("check [dir]")
+      .description("Validate an agent locally (bundle, manifest, graph)."),
+  ).action(action(runCheck));
 
-  withHostFlags(json(group.command('link [name]').description('Link this project to its server-side agent.')))
-    .option('--create', 'create the agent if it does not exist')
+  withHostFlags(
+    json(
+      group
+        .command("link [name]")
+        .description("Link this project to its server-side agent."),
+    ),
+  )
+    .option("--create", "create the agent if it does not exist")
     .action(action(runLink));
 
   withHostFlags(
-    json(group.command('deploy').description('Push the current commit, build, and wait for it to finish.')),
-  ).option('-b, --branch <branch>', 'branch to push to', 'main').action(action(runDeploy));
+    json(
+      group
+        .command("deploy")
+        .description(
+          "Bundle the current local source, build, and wait for it to finish.",
+        ),
+    ),
+  )
+    .option("-b, --branch <branch>", "branch to push to", "main")
+    .action(action(runDeploy));
 
-  withHostFlags(json(group.command('run').description('Start an execution of the linked agent.')))
-    .option('--input <json>', 'execution input as a JSON string')
-    .option('--input-file <path>', 'read execution input from a JSON file')
+  withHostFlags(
+    json(
+      group
+        .command("run")
+        .description("Start an execution of the linked agent."),
+    ),
+  )
+    .option("--input <json>", "execution input as a JSON string")
+    .option("--input-file <path>", "read execution input from a JSON file")
     .action(action(runRun));
 
   withHostFlags(
-    json(group.command('logs [executionId]').description('Inspect an execution, a build (--build), or recent runs.')),
+    json(
+      group
+        .command("logs [executionId]")
+        .description(
+          "Inspect an execution, a build (--build), or recent runs.",
+        ),
+    ),
   )
-    .option('--build <buildRunId>', 'inspect a build instead of an execution')
+    .option("--build <buildRunId>", "inspect a build instead of an execution")
     .action(action(runLogs));
 
-  withHostFlags(json(group.command('signal <executionId>').description('Resume a paused execution.')))
-    .requiredOption('--name <name>', 'the signal name to deliver')
-    .requiredOption('--correlation-id <id>', 'the signal correlation id')
-    .option('--payload <json>', 'signal payload as a JSON string')
+  withHostFlags(
+    json(
+      group
+        .command("signal <executionId>")
+        .description("Resume a paused execution."),
+    ),
+  )
+    .requiredOption("--name <name>", "the signal name to deliver")
+    .requiredOption("--correlation-id <id>", "the signal correlation id")
+    .option("--payload <json>", "signal payload as a JSON string")
     .action(action(runSignal));
 
   // `sapiom agents schedule …` — cron + one-off schedules for an agent (by slug).
   const schedule = group
-    .command('schedule')
-    .description('Manage schedules (cron + one-off triggers) for an agent.');
+    .command("schedule")
+    .description("Manage schedules (cron + one-off triggers) for an agent.");
 
   withHostFlags(
-    json(schedule.command('create <definition>').description('Create a cron (--cron) or one-off (--at) schedule.')),
+    json(
+      schedule
+        .command("create <definition>")
+        .description("Create a cron (--cron) or one-off (--at) schedule."),
+    ),
   )
-    .option('--cron <expr>', 'cron expression (recurring schedule)')
-    .option('--timezone <tz>', 'IANA timezone for the cron (default UTC)')
-    .option('--at <iso>', 'one-off fire time (ISO 8601)')
-    .option('--input <json>', 'execution input as a JSON string')
-    .option('--start-at <iso>', 'cron: earliest occurrence (ISO)')
-    .option('--end-at <iso>', 'cron: latest occurrence (ISO)')
+    .option("--cron <expr>", "cron expression (recurring schedule)")
+    .option("--timezone <tz>", "IANA timezone for the cron (default UTC)")
+    .option("--at <iso>", "one-off fire time (ISO 8601)")
+    .option("--input <json>", "execution input as a JSON string")
+    .option("--start-at <iso>", "cron: earliest occurrence (ISO)")
+    .option("--end-at <iso>", "cron: latest occurrence (ISO)")
     .action(action(runScheduleCreate));
 
-  withHostFlags(json(schedule.command('list <definition>').description("List an agent's schedules.")))
-    .option('--status <status>', 'filter by status (active|paused|completed|disabled)')
+  withHostFlags(
+    json(
+      schedule
+        .command("list <definition>")
+        .description("List an agent's schedules."),
+    ),
+  )
+    .option(
+      "--status <status>",
+      "filter by status (active|paused|completed|disabled)",
+    )
     .action(action(runScheduleList));
 
   withHostFlags(
-    json(schedule.command('inspect <scheduleId>').description('Show a schedule, its next fire, and recent fires.')),
+    json(
+      schedule
+        .command("inspect <scheduleId>")
+        .description("Show a schedule, its next fire, and recent fires."),
+    ),
   ).action(action(runScheduleInspect));
 
-  withHostFlags(json(schedule.command('cancel <scheduleId>').description('Cancel a schedule.'))).action(
-    action(runScheduleCancel),
-  );
+  withHostFlags(
+    json(
+      schedule.command("cancel <scheduleId>").description("Cancel a schedule."),
+    ),
+  ).action(action(runScheduleCancel));
 
-  withHostFlags(json(schedule.command('preview <cron>').description('Preview a cron expression (next occurrences).')))
-    .option('--timezone <tz>', 'IANA timezone (default UTC)')
-    .option('--count <n>', 'number of occurrences to show (default 5)')
+  withHostFlags(
+    json(
+      schedule
+        .command("preview <cron>")
+        .description("Preview a cron expression (next occurrences)."),
+    ),
+  )
+    .option("--timezone <tz>", "IANA timezone (default UTC)")
+    .option("--count <n>", "number of occurrences to show (default 5)")
     .action(action(runSchedulePreview));
 }

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -16,9 +16,11 @@ active for the whole session. Follow them.
   *runtime* from inside a deployed agent's step code (ctx.sapiom.*):
   repositories, sandboxes, models, and so on. You don't call this directly
   while authoring.
-- **sapiom-dev** (local, stdio) — the unmetered authoring surface for this
-  session. Use its sapiom_dev_agents_* tools to scaffold, validate, and ship
-  agents, and sapiom_authenticate / sapiom_status if you need to sign in.
+- **sapiom-dev** (local, stdio) — the developer surface for this session. Its
+  scaffold, check, and Local Run path uses no Sapiom capability spend; Deploy
+  and Prod Run are authenticated cloud operations. Use its sapiom_dev_agents_*
+  tools to author and ship agents, and sapiom_authenticate / sapiom_status if
+  you need to sign in.
 
 **When something about Sapiom is wrong, send it upstream.** If the user hits a
 bug, calls something confusing or broken, or wishes it worked differently,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,15 +1,16 @@
 # @sapiom/mcp
 
 The **local developer** MCP server for Sapiom. It runs on your machine over
-stdio under the server name `sapiom-dev` — the unmetered `sapiom_dev_*` surface
-for building and operating on Sapiom. Today it gives a coding agent the tools to
-scaffold, test, deploy, and inspect Sapiom orchestrations; the namespace leaves
-room for other non-capability developer tooling later.
+stdio under the server name `sapiom-dev`. Today it gives a coding agent the
+tools to scaffold, test, deploy, and inspect Sapiom agents; the namespace leaves
+room for other developer tooling later.
 
 > **Not the capability surface.** This is _not_ the remote "Sapiom" MCP (the
 > hosted connector with `sapiom_sandbox_*`, scrape, search, … capability tools).
-> `sapiom-dev` is the local developer surface; it makes no paid capability calls
-> and exposes no capability tools. See
+> `sapiom-dev` exposes no direct capability tools. Its local check and Local
+> Run path uses stubbed capabilities without Sapiom capability spend; deploys,
+> cloud builds, production runs, signals, and schedules operate Sapiom cloud
+> state and may be metered. See
 > [the two Sapiom MCP servers](../../docs/mcp-servers.md) for which to use when.
 
 ## Install
@@ -85,7 +86,7 @@ filesystem, environment, and process effects in author code remain real.
 | `sapiom_dev_agents_run_local`        | author code only | Run locally with `ctx.sapiom.*` calls stubbed (no Sapiom capability spend) |
 | `sapiom_dev_agents_link`             | ✓                | Resolve/create the hosted orchestration and cache its id                   |
 | `sapiom_dev_agents_clone`            | ✓                | Fork a gallery template (or re-clone a fork) into a local project          |
-| `sapiom_dev_agents_deploy`           | ✓                | Push the current commit, build, and wait for it                            |
+| `sapiom_dev_agents_deploy`           | ✓                | Bundle current local source, build in the cloud, and wait                  |
 | `sapiom_dev_agents_run`              | ✓                | Start a real cloud execution                                               |
 | `sapiom_dev_agents_inspect`          | ✓                | Inspect an execution or build (optionally waiting for it)                  |
 | `sapiom_dev_agents_signal`           | ✓                | Resume a paused execution by delivering a signal                           |
@@ -102,8 +103,9 @@ A typical loop: `scaffold` → write step code → `run_local` until green → `
 Workflows authored here call Sapiom capabilities — sandboxes, repositories,
 coding agents, search, storage, content generation — through
 [`@sapiom/tools`](../tools) (`ctx.sapiom.*`). `run_local` resolves those calls
-from stubs; a real `run`/`deploy` executes them in the cloud (metered). This MCP
-never grows a per-capability tool of its own — capabilities live in
+from stubs; deploy and production run cross into authenticated cloud operations
+and can be metered. This MCP never grows a per-capability tool of its own —
+capabilities live in
 `@sapiom/tools` and the remote `sapiom` MCP. See
 [the positioning doc](../../docs/mcp-servers.md) for the full policy.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -33,8 +33,8 @@ async function main(): Promise<void> {
   const server = new McpServer(
     {
       // The local developer surface — distinct from the remote Sapiom
-      // capabilities MCP. This is the unmetered `sapiom_dev_*` namespace for
-      // building and operating on Sapiom (today: agent authoring &
+      // capabilities MCP. This is the `sapiom_dev_*` namespace for building
+      // and operating on Sapiom (today: agent authoring &
       // lifecycle; room for more dev tooling later). The `name` is the stable
       // wire identifier; `title` and `description` are what MCP clients show, so
       // they spell out which Sapiom this is to keep it from reading as a
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
       name: "sapiom-dev",
       title: "Sapiom Dev — local developer tools",
       description:
-        "The local, unmetered Sapiom developer MCP (sapiom_dev_*). Today it scaffolds, tests, deploys, and inspects agents. Not the remote Sapiom capability MCP — it makes no paid capability calls.",
+        "The local Sapiom developer MCP (sapiom_dev_*). Scaffold, check, and run with stubbed capabilities locally; authenticated deploys and production runs use Sapiom cloud. It is not the hosted direct-capability MCP.",
       version: "0.1.0",
     },
     {

--- a/packages/mcp/src/tools/agents.local-contract.test.ts
+++ b/packages/mcp/src/tools/agents.local-contract.test.ts
@@ -45,5 +45,11 @@ describe("local agent tool contracts", () => {
       schemas.get("sapiom_dev_agents_run_local")?.stubs?.description ?? "";
     expect(stubs).toContain("not a sequence of responses");
     expect(stubs).not.toContain("<response> | [<response>]");
+
+    const deploy = descriptions.get("sapiom_dev_agents_deploy") ?? "";
+    expect(deploy).toContain("current local source");
+    expect(deploy).toContain("including uncommitted source");
+    expect(deploy).toContain("metered cloud build");
+    expect(deploy).not.toContain("current git commit");
   });
 });

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -325,7 +325,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_deploy",
-    "Deploy the linked agent: push the current git commit, trigger a build, and wait for it to finish. The project must be linked (sapiom.json) and a git repo with at least one commit.",
+    "Deploy the linked agent: bundle the current local source (including uncommitted source), push a synthesized build tree, trigger a metered cloud build, and wait for it to finish. The project must be linked (sapiom.json) and a git repo with at least one commit.",
     {
       dir: z
         .string()

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -74,12 +74,12 @@ API-key principal; link, deploy, and cloud run require it.
 
 ### 4. Link → deploy → run → inspect
 
-| Command                     | What it does                                  |
-| --------------------------- | --------------------------------------------- |
-| `sapiom_dev_agents_link`    | Registers the agent under your tenant         |
-| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud          |
-| `sapiom_dev_agents_run`     | Starts a real (billed) execution              |
-| `sapiom_dev_agents_inspect` | Watch an execution's status, steps, and spend |
+| Command                     | What it does                                        |
+| --------------------------- | --------------------------------------------------- |
+| `sapiom_dev_agents_link`    | Registers the agent under your tenant               |
+| `sapiom_dev_agents_deploy`  | Builds and deploys to Sapiom's cloud                |
+| `sapiom_dev_agents_run`     | Starts a real (billed) execution                    |
+| `sapiom_dev_agents_inspect` | Watch status, pinned build, steps, logs, and output |
 
 ## The Step Model — Hard Rules
 


### PR DESCRIPTION
## Summary

- define deploy as a bundle of current reachable working-tree source, including uncommitted changes, pushed through a synthesized build tree
- expose exact `buildRunId` language throughout Agent Core and CLI guidance instead of treating Git HEAD as the release identity
- distinguish metered cloud builds and production runs from the account-free local scaffold/check/Local Run boundary
- make execution inspection explicitly cost-agnostic and name the returned attempts, evidence, and lineage
- synchronize the canonical authoring skill across Agent Core, bundled starters, and the Sapiom plugin
- add a patch changeset and an MCP identity regression

## Why

SAP-2365 dogfooding proved that deploy includes uncommitted reachable source, that a production run pins the resulting build, and that execution audit does not include the dashboard's separate run-grain charge. Existing product guidance contradicted each of those implemented boundaries and described the whole developer MCP as unmetered.

## Dogfood evidence

- deployed a dirty default-starter checkout through the locally built MCP
- observed the uncommitted marker in the completed production output
- correlated the returned ready build ID with the execution audit and dashboard version list
- verified separate run usage and overage reads without exposing account credentials or organization identity

## Verification

- Agent Core: 158 tests passed across 16 suites
- CLI: 73 tests passed across 6 suites
- MCP local-contract regression: 1 test passed
- Agent Core, MCP, CLI, and Harness typechecks passed
- affected-package lint: 0 errors; one pre-existing Harness warning
- terminology check passed across 373 files with no stale allowlist entries
- `git diff --check` passed

Linear: [SAP-2365](https://linear.app/sapiom/issue/SAP-2365/docs-publish-deploy-production-run-and-inspection-guides)
