### PR TITLE
feat(file-storage): add getPublicUrl + downloadUrlUnavailable resume signal

### DIFF
--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -322,6 +322,13 @@ export interface ImageResultPayload {
     downloadUrl?: string;
     /** ISO expiry of `downloadUrl`, when present — may already be past by the time a step resumes. */
     downloadUrlExpiresAt?: string;
+    /**
+     * `true` when the output persisted (so `fileId` is set) but the gateway could not mint a
+     * `downloadUrl` for this resume payload. An explicit signal to re-fetch from `fileId` — a
+     * fresh presigned URL via `fileStorage.getDownloadUrl(fileId)`, or a durable link via
+     * `fileStorage.getPublicUrl(fileId)` — rather than treating a missing `downloadUrl` as "no asset".
+     */
+    downloadUrlUnavailable?: boolean;
     /** Present when storage was requested but persisting this output failed. */
     storageError?: string;
   }>;
@@ -715,6 +722,13 @@ export interface VideoResultPayload {
     downloadUrl?: string;
     /** ISO expiry of `downloadUrl`, when present — may already be past by the time a step resumes. */
     downloadUrlExpiresAt?: string;
+    /**
+     * `true` when the output persisted (so `fileId` is set) but the gateway could not mint a
+     * `downloadUrl` for this resume payload. An explicit signal to re-fetch from `fileId` — a
+     * fresh presigned URL via `fileStorage.getDownloadUrl(fileId)`, or a durable link via
+     * `fileStorage.getPublicUrl(fileId)` — rather than treating a missing `downloadUrl` as "no asset".
+     */
+    downloadUrlUnavailable?: boolean;
     /** Present when storage was requested but persisting this output failed. */
     storageError?: string;
   }>;

--- a/packages/tools/src/file-storage/index.spec.ts
+++ b/packages/tools/src/file-storage/index.spec.ts
@@ -195,6 +195,22 @@ describe("fileStorage.getDownloadUrl()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// getPublicUrl()
+// ---------------------------------------------------------------------------
+
+describe("fileStorage.getPublicUrl()", () => {
+  it("builds the /public/:fileId permalink with no network call", () => {
+    expect(fileStorage.getPublicUrl("f-123", BASE)).toBe(`${BASE}/public/f-123`);
+  });
+
+  it("encodes special characters in fileId", () => {
+    expect(fileStorage.getPublicUrl("file id/with slash", BASE)).toBe(
+      `${BASE}/public/file%20id%2Fwith%20slash`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // list()
 // ---------------------------------------------------------------------------
 

--- a/packages/tools/src/file-storage/index.ts
+++ b/packages/tools/src/file-storage/index.ts
@@ -210,6 +210,22 @@ export async function getDownloadUrl(
   return { downloadUrl: raw.download_url, expiresAt: raw.expires_at };
 }
 
+/**
+ * Build the durable PUBLIC permalink for a file — a stable URL that never expires and
+ * re-signs a fresh presigned URL on each request (the service 302-redirects to it).
+ *
+ * Use this for a link you email or embed for an external recipient. Unlike
+ * {@link getDownloadUrl} — a ~15-minute presigned URL that must be minted with auth and
+ * dies quickly in an inbox — this permalink stays valid. It only resolves for files stored
+ * with `visibility: "public"`; a private file's permalink returns 404. Pure and synchronous:
+ * it constructs the URL string and makes no network call.
+ *
+ *   const link = fileStorage.getPublicUrl(fileId); // https://file-storage.…/public/<id>
+ */
+export function getPublicUrl(fileId: string, baseUrl = DEFAULT_BASE_URL): string {
+  return `${baseUrl}/public/${encodeURIComponent(fileId)}`;
+}
+
 /** List files owned by the authenticated tenant. */
 export async function list(
   opts?: ListOptions,


### PR DESCRIPTION
## Summary
Two additive SDK changes so a workflow can deliver a generated asset by a link that survives in an inbox, and reliably know when to re-fetch one. No behavior change to existing calls.

Part of the "deliver generated assets via email (durable links)" epic. Pairs with the gateway public-permalink endpoint and the FAL resume-reliability change.

## Changes
- **`fileStorage.getPublicUrl(fileId)`** — pure, no-network helper that builds the durable `/public/:id` permalink (a stable URL the gateway re-signs on each hit). Lets callers email/embed a link for an external recipient instead of a ~15-min presigned URL that dies quickly in an inbox. Resolves only for `public`-visibility files.
- **`downloadUrlUnavailable?: boolean`** on `ImageResultPayload` / `VideoResultPayload` outputs — the gateway sets it when an output persisted (`fileId` present) but its `downloadUrl` couldn't be minted, so a resumed step can deterministically re-fetch from `fileId` instead of treating a missing `downloadUrl` as "no asset".

## Testing
- [x] `pnpm --filter @sapiom/tools build` — clean (cjs + esm)
- [x] `jest src/file-storage/index.spec.ts src/content-generation/index.spec.ts` — 97/97 pass (incl. new `getPublicUrl` cases)
- [x] ESLint clean on changed files

## Dependencies
- The `getPublicUrl` link only resolves once the gateway `GET /public/:id` endpoint ships (separate PR to the Sapiom monorepo). Publishing this SDK before that endpoint is deployed is safe (the helper just builds a string).

## Checklist
- [x] Additive; no breaking changes
- [x] No hardcoded secrets
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7MfX8ZsGE8ffsGgmNW5pW