### PR TITLE
feat(studio): publish branded Agent Studio npm launcher

### DIFF
--- a/.changeset/branded-agent-studio-launcher.md
+++ b/.changeset/branded-agent-studio-launcher.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/agent-studio": minor
+"@sapiom/harness": patch
+---
+
+Publish `@sapiom/agent-studio` as the branded Agent Studio launcher while
+keeping `@sapiom/harness` as the supported implementation and compatibility
+command.

--- a/packages/agent-studio/CHANGELOG.md
+++ b/packages/agent-studio/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @sapiom/agent-studio

--- a/packages/agent-studio/LICENSE
+++ b/packages/agent-studio/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-studio/README.md
+++ b/packages/agent-studio/README.md
@@ -1,0 +1,23 @@
+# Agent Studio
+
+Agent Studio is a local workspace for building, testing, deploying, and running
+Sapiom agents with your own coding agent.
+
+```bash
+npx @sapiom/agent-studio@latest [dir]
+```
+
+The optional directory defaults to the current working directory. Every Agent
+Studio launch flag is passed through unchanged, including `--port`, `--login`,
+`--no-open`, `--no-auth`, `--no-telemetry`, `--no-session`, and `--state-root`.
+
+This package is the branded public launcher. It delegates to an exact,
+release-tested version of the `@sapiom/harness` implementation package; it does
+not contain a second copy of the application. The supported direct command
+continues to work:
+
+```bash
+npx @sapiom/harness@latest [dir]
+```
+
+Agent Studio requires Node.js 20 or newer and Claude Code or Codex on `PATH`.

--- a/packages/agent-studio/bin/agent-studio.mjs
+++ b/packages/agent-studio/bin/agent-studio.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { AgentStudioLaunchError, launchAgentStudio } from "../lib/launcher.mjs";
+
+try {
+  await launchAgentStudio();
+} catch (error) {
+  if (error instanceof AgentStudioLaunchError) {
+    console.error(
+      `Agent Studio failed to launch [${error.code}]: ${error.message}`,
+    );
+    if (error.hint) console.error(error.hint);
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Agent Studio failed to launch: ${message}`);
+  }
+  process.exitCode = 1;
+}

--- a/packages/agent-studio/lib/launcher.mjs
+++ b/packages/agent-studio/lib/launcher.mjs
@@ -1,0 +1,158 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const requireFromLauncher = createRequire(import.meta.url);
+
+export class AgentStudioLaunchError extends Error {
+  constructor({ code, message, hint, cause }) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "AgentStudioLaunchError";
+    this.code = code;
+    this.hint = hint;
+  }
+}
+
+function defaultResolvePackageJson() {
+  return requireFromLauncher.resolve("@sapiom/harness/package.json");
+}
+
+/** Resolve the implementation bin without importing or duplicating Harness. */
+export function resolveHarnessBin({
+  resolvePackageJson = defaultResolvePackageJson,
+  readFile = readFileSync,
+  fileExists = existsSync,
+} = {}) {
+  let packageJsonPath;
+  try {
+    packageJsonPath = resolvePackageJson();
+  } catch (cause) {
+    throw new AgentStudioLaunchError({
+      code: "HARNESS_NOT_INSTALLED",
+      message:
+        "The @sapiom/harness implementation package could not be resolved.",
+      hint: "Reinstall with: npx --yes @sapiom/agent-studio@latest",
+      cause,
+    });
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFile(packageJsonPath, "utf8"));
+  } catch (cause) {
+    throw new AgentStudioLaunchError({
+      code: "HARNESS_MANIFEST_INVALID",
+      message: "The @sapiom/harness package manifest could not be read.",
+      hint: "Reinstall with: npx --yes @sapiom/agent-studio@latest",
+      cause,
+    });
+  }
+
+  const binEntry = manifest?.bin?.["sapiom-harness"];
+  if (typeof binEntry !== "string" || binEntry.length === 0) {
+    throw new AgentStudioLaunchError({
+      code: "HARNESS_BIN_NOT_FOUND",
+      message: "The @sapiom/harness manifest has no sapiom-harness bin entry.",
+      hint: "Reinstall with: npx --yes @sapiom/agent-studio@latest",
+    });
+  }
+
+  const binPath = path.resolve(path.dirname(packageJsonPath), binEntry);
+  if (!fileExists(binPath)) {
+    throw new AgentStudioLaunchError({
+      code: "HARNESS_BIN_NOT_FOUND",
+      message: `The sapiom-harness bin was not found at ${binPath}.`,
+      hint: "Reinstall with: npx --yes @sapiom/agent-studio@latest",
+    });
+  }
+
+  return binPath;
+}
+
+/** Convert child signal termination to the shell's conventional exit status. */
+export function signalExitCode(signal) {
+  const numbers = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGQUIT: 3,
+    SIGKILL: 9,
+    SIGTERM: 15,
+  };
+  return 128 + (numbers[signal] ?? 0);
+}
+
+/**
+ * Launch Harness as an inherited child process.
+ *
+ * SIGINT is deliberately not forwarded: an interactive terminal delivers
+ * Ctrl-C to both processes in the foreground group, so forwarding it would
+ * signal Harness twice. SIGTERM and SIGHUP do need explicit forwarding.
+ */
+export async function launchAgentStudio({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  execPath = process.execPath,
+  processRef = process,
+  spawn = nodeSpawn,
+  resolver,
+} = {}) {
+  const harnessBin = resolveHarnessBin(resolver);
+
+  await new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(execPath, [harnessBin, ...argv], {
+        cwd,
+        env,
+        stdio: "inherit",
+      });
+    } catch (cause) {
+      reject(
+        new AgentStudioLaunchError({
+          code: "HARNESS_SPAWN_FAILED",
+          message: `Could not start sapiom-harness: ${cause instanceof Error ? cause.message : String(cause)}`,
+          cause,
+        }),
+      );
+      return;
+    }
+
+    let settled = false;
+    const forwardSigterm = () => child.kill("SIGTERM");
+    const forwardSighup = () => child.kill("SIGHUP");
+    const cleanup = () => {
+      processRef.off("SIGTERM", forwardSigterm);
+      processRef.off("SIGHUP", forwardSighup);
+    };
+
+    processRef.on("SIGTERM", forwardSigterm);
+    processRef.on("SIGHUP", forwardSighup);
+
+    child.once("error", (cause) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(
+        new AgentStudioLaunchError({
+          code: "HARNESS_SPAWN_FAILED",
+          message: `Could not start sapiom-harness: ${cause.message}`,
+          cause,
+        }),
+      );
+    });
+
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (signal) {
+        processRef.exitCode = signalExitCode(signal);
+      } else if (code !== null && code !== 0) {
+        processRef.exitCode = code;
+      }
+      resolve();
+    });
+  });
+}

--- a/packages/agent-studio/package.json
+++ b/packages/agent-studio/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@sapiom/agent-studio",
+  "version": "0.0.1",
+  "description": "Agent Studio — build, test, deploy, and run Sapiom agents with your coding agent in a local workspace.",
+  "keywords": [
+    "sapiom",
+    "agent-studio",
+    "claude",
+    "codex",
+    "agents"
+  ],
+  "homepage": "https://github.com/sapiom/sapiom-js/tree/main/packages/agent-studio#readme",
+  "bugs": {
+    "url": "https://github.com/sapiom/sapiom-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/agent-studio"
+  },
+  "license": "MIT",
+  "author": "Sapiom",
+  "type": "module",
+  "bin": {
+    "agent-studio": "./bin/agent-studio.mjs"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "node --check bin/agent-studio.mjs && node --check lib/launcher.mjs",
+    "test": "node --test test/*.test.mjs",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@sapiom/harness": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-studio/test/launcher.test.mjs
+++ b/packages/agent-studio/test/launcher.test.mjs
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  AgentStudioLaunchError,
+  launchAgentStudio,
+  resolveHarnessBin,
+  signalExitCode,
+} from "../lib/launcher.mjs";
+
+const packageJsonPath = path.resolve(
+  "install/node_modules/@sapiom/harness/package.json",
+);
+const harnessBinPath = path.resolve(
+  "install/node_modules/@sapiom/harness/dist/cli/bin.js",
+);
+
+function resolver(overrides = {}) {
+  return {
+    resolvePackageJson: () => packageJsonPath,
+    readFile: () =>
+      JSON.stringify({ bin: { "sapiom-harness": "./dist/cli/bin.js" } }),
+    fileExists: () => true,
+    ...overrides,
+  };
+}
+
+class FakeChild extends EventEmitter {
+  killSignals = [];
+
+  kill(signal) {
+    this.killSignals.push(signal);
+    return true;
+  }
+}
+
+class FakeProcess extends EventEmitter {
+  exitCode = undefined;
+}
+
+test("package exposes one branded bin and an exact workspace dependency", () => {
+  const manifest = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+
+  assert.equal(manifest.name, "@sapiom/agent-studio");
+  assert.deepEqual(manifest.bin, {
+    "agent-studio": "./bin/agent-studio.mjs",
+  });
+  assert.equal(manifest.dependencies["@sapiom/harness"], "workspace:*");
+  assert.equal(manifest.engines.node, ">=20.0.0");
+  assert.deepEqual(manifest.files, [
+    "bin",
+    "lib",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+  ]);
+});
+
+test("resolves the sapiom-harness bin from its manifest", () => {
+  assert.equal(resolveHarnessBin(resolver()), harnessBinPath);
+});
+
+test("reports an actionable error when Harness cannot be resolved", () => {
+  assert.throws(
+    () =>
+      resolveHarnessBin(
+        resolver({
+          resolvePackageJson: () => {
+            throw Object.assign(new Error("missing"), {
+              code: "MODULE_NOT_FOUND",
+            });
+          },
+        }),
+      ),
+    (error) => {
+      assert.ok(error instanceof AgentStudioLaunchError);
+      assert.equal(error.code, "HARNESS_NOT_INSTALLED");
+      assert.match(error.hint, /@sapiom\/agent-studio@latest/);
+      return true;
+    },
+  );
+});
+
+test("rejects an unreadable or malformed Harness manifest", () => {
+  assert.throws(
+    () => resolveHarnessBin(resolver({ readFile: () => "not json" })),
+    (error) => {
+      assert.ok(error instanceof AgentStudioLaunchError);
+      assert.equal(error.code, "HARNESS_MANIFEST_INVALID");
+      return true;
+    },
+  );
+});
+
+test("rejects a manifest without the sapiom-harness bin", () => {
+  assert.throws(
+    () =>
+      resolveHarnessBin(
+        resolver({ readFile: () => JSON.stringify({ bin: {} }) }),
+      ),
+    (error) => {
+      assert.ok(error instanceof AgentStudioLaunchError);
+      assert.equal(error.code, "HARNESS_BIN_NOT_FOUND");
+      assert.match(error.message, /no sapiom-harness bin entry/);
+      return true;
+    },
+  );
+});
+
+test("rejects a manifest whose bin target is absent", () => {
+  assert.throws(
+    () => resolveHarnessBin(resolver({ fileExists: () => false })),
+    (error) => {
+      assert.ok(error instanceof AgentStudioLaunchError);
+      assert.equal(error.code, "HARNESS_BIN_NOT_FOUND");
+      assert.match(error.message, /was not found/);
+      return true;
+    },
+  );
+});
+
+test("forwards arguments, cwd, environment, and stdio unchanged", async () => {
+  const child = new FakeChild();
+  const processRef = new FakeProcess();
+  const argv = ["/workspace/with spaces", "--port", "4200", "--no-open"];
+  const env = { PATH: "/custom/bin", SAPIOM_TEST: "1" };
+  let spawnCall;
+
+  const launched = launchAgentStudio({
+    argv,
+    cwd: "/caller/cwd",
+    env,
+    execPath: "/custom/node",
+    processRef,
+    resolver: resolver(),
+    spawn: (...args) => {
+      spawnCall = args;
+      return child;
+    },
+  });
+
+  child.emit("close", 0, null);
+  await launched;
+
+  assert.deepEqual(spawnCall, [
+    "/custom/node",
+    [harnessBinPath, ...argv],
+    { cwd: "/caller/cwd", env, stdio: "inherit" },
+  ]);
+  assert.equal(processRef.exitCode, undefined);
+});
+
+test("forwards SIGTERM and SIGHUP but does not install a SIGINT handler", async () => {
+  const child = new FakeChild();
+  const processRef = new FakeProcess();
+  const launched = launchAgentStudio({
+    processRef,
+    resolver: resolver(),
+    spawn: () => child,
+  });
+
+  assert.equal(processRef.listenerCount("SIGINT"), 0);
+  processRef.emit("SIGTERM");
+  processRef.emit("SIGHUP");
+  assert.deepEqual(child.killSignals, ["SIGTERM", "SIGHUP"]);
+
+  child.emit("close", 0, null);
+  await launched;
+  assert.equal(processRef.listenerCount("SIGTERM"), 0);
+  assert.equal(processRef.listenerCount("SIGHUP"), 0);
+});
+
+test("propagates a nonzero child exit code", async () => {
+  const child = new FakeChild();
+  const processRef = new FakeProcess();
+  const launched = launchAgentStudio({
+    processRef,
+    resolver: resolver(),
+    spawn: () => child,
+  });
+
+  child.emit("close", 23, null);
+  await launched;
+  assert.equal(processRef.exitCode, 23);
+});
+
+test("maps child signal termination to the conventional exit code", async () => {
+  const child = new FakeChild();
+  const processRef = new FakeProcess();
+  const launched = launchAgentStudio({
+    processRef,
+    resolver: resolver(),
+    spawn: () => child,
+  });
+
+  child.emit("close", null, "SIGTERM");
+  await launched;
+  assert.equal(processRef.exitCode, 143);
+  assert.equal(signalExitCode("SIGINT"), 130);
+});
+
+test("reports asynchronous child-process launch failures", async () => {
+  const child = new FakeChild();
+  const processRef = new FakeProcess();
+  const launched = launchAgentStudio({
+    processRef,
+    resolver: resolver(),
+    spawn: () => child,
+  });
+
+  child.emit("error", new Error("spawn failed"));
+  await assert.rejects(launched, (error) => {
+    assert.ok(error instanceof AgentStudioLaunchError);
+    assert.equal(error.code, "HARNESS_SPAWN_FAILED");
+    assert.match(error.message, /spawn failed/);
+    return true;
+  });
+  assert.equal(processRef.listenerCount("SIGTERM"), 0);
+  assert.equal(processRef.listenerCount("SIGHUP"), 0);
+});
+
+test("reports synchronous child-process launch failures", async () => {
+  await assert.rejects(
+    launchAgentStudio({
+      resolver: resolver(),
+      spawn: () => {
+        throw new Error("spawn threw");
+      },
+    }),
+    (error) => {
+      assert.ok(error instanceof AgentStudioLaunchError);
+      assert.equal(error.code, "HARNESS_SPAWN_FAILED");
+      assert.match(error.message, /spawn threw/);
+      return true;
+    },
+  );
+});

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -3,7 +3,9 @@
 Agent Studio is a local web app for building on Sapiom with your own coding agent.
 
 ```bash
-npx @sapiom/harness [dir]
+npx @sapiom/agent-studio@latest [dir]
+# supported direct implementation command:
+npx @sapiom/harness@latest [dir]
 # also available via the Sapiom CLI (npm i -g @sapiom/cli @sapiom/harness):
 sapiom dev [dir]
 ```

--- a/packages/harness/web/src/lib/mock-terminal.test.ts
+++ b/packages/harness/web/src/lib/mock-terminal.test.ts
@@ -39,6 +39,8 @@ describe("attachMockTerminal", () => {
     expect(rendered).toContain(
       "This is a recorded demo. Prompts aren't sent to a coding agent here.",
     );
+    expect(rendered).toContain("npx @sapiom/agent-studio@latest");
+    expect(rendered).not.toContain("npx @sapiom/harness");
     expect(rendered).not.toContain("Prompts aren't sent to an agent here.");
 
     handle.dispose();

--- a/packages/harness/web/src/lib/mock-terminal.ts
+++ b/packages/harness/web/src/lib/mock-terminal.ts
@@ -90,11 +90,13 @@ function promptBox(term: XTerm): string {
 function transcript(): ScriptLine[] {
   return [
     // Authored demo copy must never split a word at the xterm column
-    // boundary: the tip is pre-broken into two short lines that fit
+    // boundary: the tip is pre-broken into short lines that fit
     // every pane width the demo renders at, instead of relying on wrap.
     {
       text:
-        dim("  ※ Tip: run `npx @sapiom/harness`") +
+        dim("  ※ Tip: run") +
+        "\r\n" +
+        dim("    `npx @sapiom/agent-studio@latest`") +
         "\r\n" +
         dim("    for the real, PTY-backed session") +
         "\r\n\r\n",
@@ -195,7 +197,9 @@ export function attachMockTerminal(term: XTerm): MockTerminalHandle {
           green("⏺") +
             dim(" This is a recorded demo. Prompts aren't sent to a coding agent here.") +
             "\r\n" +
-            dim("  Run `npx @sapiom/harness` locally to work with a real session.") +
+            dim("  Run `npx @sapiom/agent-studio@latest`") +
+            "\r\n" +
+            dim("    locally to work with a real session.") +
             "\r\n\r\n",
         );
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,12 @@ importers:
         specifier: ^4.1.0
         version: 4.4.3
 
+  packages/agent-studio:
+    dependencies:
+      '@sapiom/harness':
+        specifier: workspace:*
+        version: link:../harness
+
   packages/analytics-core:
     devDependencies:
       '@stryker-mutator/core':

--- a/scripts/agent-studio-terminology-check.mjs
+++ b/scripts/agent-studio-terminology-check.mjs
@@ -56,6 +56,7 @@ const STATIC_TARGETS = [
   "packages/agent-core/package.json",
   "packages/agent-core/src",
   "packages/agent-core/templates",
+  "packages/agent-studio",
   "packages/cli/package.json",
   "packages/cli/src",
   "packages/cli/templates",


### PR DESCRIPTION
## Summary

- add the public `@sapiom/agent-studio` workspace package as a thin Node ESM launcher over the exact installed `@sapiom/harness` bin
- forward argv, cwd, environment, stdio, shutdown signals, and child exit status without introducing application logic
- make the branded command canonical in the Harness npm README and recorded demo while preserving `@sapiom/harness` as a supported direct command
- include the package in the Agent Studio terminology guard and add the release changeset/lockfile entry

## Release behavior

The source package starts at `0.0.1`. The included Changeset produces:

- `@sapiom/harness@0.2.7` (patch)
- `@sapiom/agent-studio@0.1.0` (minor), pinned exactly to Harness `0.2.7` by `pnpm pack`

A disposable follow-on Harness-only changeset was also verified to bump the launcher automatically from `0.1.0` to `0.1.1`.

Dashboard and docs copy remain intentionally gated until the new npm command has been published and verified.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm terminology:check`
- launcher syntax and 12 unit tests on Node 20.20.2 and Node 22.23.2
- source and simulated-version `pnpm pack` inspection, including strict tarball contents and exact dependency assertions
- clean temporary install of both simulated release tarballs
- live launch with an isolated state root, path containing spaces, representative flags, `/api/state` version/directory checks, Agent Studio HTML title check, Ctrl-C cleanup, SIGTERM exit 143, and no surviving port/child process

Refs: SAP-2376
