### PR TITLE
fix(studio): preserve local work through auth failure

### DIFF
--- a/.changeset/calm-studios-auth.md
+++ b/.changeset/calm-studios-auth.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/mcp": patch
+---
+
+Make browser-auth completion pages host-neutral and report failed callbacks honestly. Agent Studio desktop now preserves signed-out local work when account authentication is unavailable or cancelled.

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -34,6 +34,7 @@ import { esbuildBinaryPath } from "./esbuild-binary.js";
 import { resolveWebDir } from "./paths.js";
 import { createMainWindow } from "./windows.js";
 import { ensureSapiomCli, installClaudeCode } from "./agent-install.js";
+import { resolveDesktopIdentity } from "./desktop-auth.js";
 import { installRuntimeShims } from "./runtime-shims.js";
 import { BOOT_PROGRESS, BOOT_ERROR, CONSENT_SUBMIT, RETRY, type BootProgress, type BootErrorPayload } from "./ipc.js";
 
@@ -314,20 +315,28 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
 
   // 5. Auth. Probe for a cached credential first (non-interactive) so we can
   //    show the right message: a cached credential signs in instantly; without
-  //    one we must open the browser and tell the user to complete sign-in there
-  //    (otherwise the window just sits on a vague "Signing you in…").
+  //    one we open the browser and explain that it connects cloud actions. A
+  //    cancelled or failed flow continues signed out for local work.
   progress(setupWin, { phase: "auth", message: "Signing you in…", status: "active" });
   //    Smoke mode stops at the cached probe: an interactive sign-in would open
   //    a browser and block forever on a CI runner. Booting unauthenticated is a
   //    supported state (identity is optional to startServer).
-  let identity: HarnessIdentity | null = await ensureAuthenticated({ interactive: false });
-  if (!identity && !smoke) {
-    progress(setupWin, {
-      phase: "auth",
-      message: "Opening your browser — sign in to Sapiom to continue, then come back here.",
-      status: "active",
-    });
-    identity = await ensureAuthenticated({ interactive: true });
+  const auth = await resolveDesktopIdentity({
+    authenticate: ensureAuthenticated,
+    smoke,
+    beforeInteractive: () =>
+      progress(setupWin, {
+        phase: "auth",
+        message:
+          "Opening your browser — sign in to connect cloud actions, then come back here.",
+        status: "active",
+      }),
+  });
+  const identity: HarnessIdentity | null = auth.identity;
+  if (auth.error) {
+    debug(
+      `authentication unavailable; continuing signed out: ${auth.error instanceof Error ? auth.error.message : String(auth.error)}`,
+    );
   }
   progress(setupWin, {
     phase: "auth",

--- a/packages/harness-desktop/src/main/desktop-auth.test.ts
+++ b/packages/harness-desktop/src/main/desktop-auth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DesktopAuthenticate } from "./desktop-auth.js";
+import { resolveDesktopIdentity } from "./desktop-auth.js";
+
+const IDENTITY = {
+  userId: "tenant-1",
+  tenantId: "tenant-1",
+  organizationName: "Example",
+  apiKey: "sk-test",
+  source: "cached" as const,
+};
+
+describe("resolveDesktopIdentity", () => {
+  it("reuses a cached credential without opening browser auth", async () => {
+    const authenticate = vi
+      .fn<DesktopAuthenticate>()
+      .mockResolvedValue(IDENTITY);
+    const beforeInteractive = vi.fn();
+
+    await expect(
+      resolveDesktopIdentity({ authenticate, smoke: false, beforeInteractive }),
+    ).resolves.toEqual({ identity: IDENTITY, error: null });
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(authenticate).toHaveBeenCalledWith({ interactive: false });
+    expect(beforeInteractive).not.toHaveBeenCalled();
+  });
+
+  it("opens browser auth after an empty cache probe", async () => {
+    const authenticate = vi
+      .fn<DesktopAuthenticate>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...IDENTITY, source: "fresh" });
+    const beforeInteractive = vi.fn();
+
+    await expect(
+      resolveDesktopIdentity({ authenticate, smoke: false, beforeInteractive }),
+    ).resolves.toEqual({
+      identity: { ...IDENTITY, source: "fresh" },
+      error: null,
+    });
+    expect(authenticate).toHaveBeenNthCalledWith(1, { interactive: false });
+    expect(authenticate).toHaveBeenNthCalledWith(2, { interactive: true });
+    expect(beforeInteractive).toHaveBeenCalledOnce();
+  });
+
+  it("does not open a browser in smoke mode", async () => {
+    const authenticate = vi.fn<DesktopAuthenticate>().mockResolvedValue(null);
+
+    await expect(
+      resolveDesktopIdentity({ authenticate, smoke: true }),
+    ).resolves.toEqual({ identity: null, error: null });
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues signed out when interactive authentication is cancelled", async () => {
+    const cancelled = new Error("Authentication cancelled");
+    const authenticate = vi
+      .fn<DesktopAuthenticate>()
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(cancelled);
+
+    await expect(
+      resolveDesktopIdentity({ authenticate, smoke: false }),
+    ).resolves.toEqual({ identity: null, error: cancelled });
+  });
+
+  it("continues signed out when the cache probe fails", async () => {
+    const failure = new Error("Credential store unavailable");
+    const authenticate = vi
+      .fn<DesktopAuthenticate>()
+      .mockRejectedValue(failure);
+
+    await expect(
+      resolveDesktopIdentity({ authenticate, smoke: false }),
+    ).resolves.toEqual({ identity: null, error: failure });
+    expect(authenticate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/harness-desktop/src/main/desktop-auth.ts
+++ b/packages/harness-desktop/src/main/desktop-auth.ts
@@ -1,0 +1,43 @@
+import type { HarnessIdentity } from "@sapiom/harness";
+
+export type DesktopAuthenticate = (options: {
+  interactive: boolean;
+}) => Promise<HarnessIdentity | null>;
+
+export interface DesktopAuthResult {
+  identity: HarnessIdentity | null;
+  /** Kept for boot diagnostics; local-only startup remains available. */
+  error: unknown | null;
+}
+
+/**
+ * Resolve the desktop account without making cloud authentication a boot gate.
+ *
+ * A cached credential is silent. A normal clean launch tries browser auth once;
+ * cancelling, timing out, or failing that flow leaves the local Studio usable so
+ * the account menu can retry later. Smoke mode never opens a browser.
+ */
+export async function resolveDesktopIdentity(options: {
+  authenticate: DesktopAuthenticate;
+  smoke: boolean;
+  beforeInteractive?: () => void;
+}): Promise<DesktopAuthResult> {
+  let cached: HarnessIdentity | null;
+  try {
+    cached = await options.authenticate({ interactive: false });
+  } catch (error) {
+    return { identity: null, error };
+  }
+
+  if (cached || options.smoke) return { identity: cached, error: null };
+
+  options.beforeInteractive?.();
+  try {
+    return {
+      identity: await options.authenticate({ interactive: true }),
+      error: null,
+    };
+  } catch (error) {
+    return { identity: null, error };
+  }
+}

--- a/packages/mcp/src/auth.test.ts
+++ b/packages/mcp/src/auth.test.ts
@@ -14,7 +14,7 @@ const mockedExecSync = vi.mocked(execSync);
 function callbackToServer(
   port: number,
   params: Record<string, string>,
-): Promise<string> {
+): Promise<{ body: string; status: number }> {
   return new Promise((resolve, reject) => {
     const query = new URLSearchParams(params).toString();
     const req = http.request(
@@ -22,7 +22,7 @@ function callbackToServer(
       (res) => {
         let data = "";
         res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => resolve(data));
+        res.on("end", () => resolve({ body: data, status: res.statusCode! }));
       },
     );
     req.on("error", reject);
@@ -75,10 +75,16 @@ describe("performBrowserAuth", () => {
 
     const { state, port } = extractAuthInfo();
 
-    await callbackToServer(Number(port), { code: "auth-code-123", state });
+    const callback = await callbackToServer(Number(port), {
+      code: "auth-code-123",
+      state,
+    });
 
     const result = await authPromise;
     expect(result).toEqual(mockResult);
+    expect(callback.status).toBe(200);
+    expect(callback.body).toContain("return to Sapiom");
+    expect(callback.body).not.toContain("return to your terminal");
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "https://api.test.com/v1/auth/cli/token",
@@ -100,7 +106,7 @@ describe("performBrowserAuth", () => {
 
     const { port } = extractAuthInfo();
 
-    await callbackToServer(Number(port), {
+    const callback = await callbackToServer(Number(port), {
       code: "auth-code",
       state: "wrong-state",
     });
@@ -108,6 +114,8 @@ describe("performBrowserAuth", () => {
     const error = await authPromise;
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("State mismatch");
+    expect(callback.status).toBe(400);
+    expect(callback.body).toContain("could not be completed");
   });
 
   it("should reject when no code is received", async () => {
@@ -120,13 +128,14 @@ describe("performBrowserAuth", () => {
 
     const { state, port } = extractAuthInfo();
 
-    await callbackToServer(Number(port), { state });
+    const callback = await callbackToServer(Number(port), { state });
 
     const error = await authPromise;
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain(
       "No authorization code received",
     );
+    expect(callback.status).toBe(400);
   });
 
   it("should reject when token exchange fails", async () => {
@@ -145,11 +154,15 @@ describe("performBrowserAuth", () => {
 
     const { state, port } = extractAuthInfo();
 
-    await callbackToServer(Number(port), { code: "bad-code", state });
+    const callback = await callbackToServer(Number(port), {
+      code: "bad-code",
+      state,
+    });
 
     const error = await authPromise;
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("Invalid code");
+    expect(callback.status).toBe(400);
   });
 
   it("should return 404 for non-callback paths", async () => {

--- a/packages/mcp/src/auth.ts
+++ b/packages/mcp/src/auth.ts
@@ -67,20 +67,8 @@ export async function performBrowserAuth(
       const code = reqURL.searchParams.get("code");
       const returnedState = reqURL.searchParams.get("state");
 
-      // Serve the "you can close this tab" page immediately
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(`<!DOCTYPE html>
-<html>
-<head><title>Sapiom CLI Auth</title></head>
-<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
-  <div style="text-align: center;">
-    <h1>Authentication complete</h1>
-    <p>You can close this tab and return to your terminal.</p>
-  </div>
-</body>
-</html>`);
-
       if (!returnedState || returnedState !== state) {
+        authResponse(res, false);
         settled = true;
         clearTimeout(timeout);
         server.close();
@@ -91,6 +79,7 @@ export async function performBrowserAuth(
       }
 
       if (!code) {
+        authResponse(res, false);
         settled = true;
         clearTimeout(timeout);
         server.close();
@@ -103,11 +92,13 @@ export async function performBrowserAuth(
         const address = server.address() as { port: number };
         const redirectUri = `http://localhost:${address.port}/callback`;
         const result = await exchangeCodeForApiKey(apiURL, code, redirectUri);
+        authResponse(res, true);
         settled = true;
         clearTimeout(timeout);
         server.close();
         resolve(result);
       } catch (err) {
+        authResponse(res, false);
         settled = true;
         clearTimeout(timeout);
         server.close();
@@ -140,6 +131,23 @@ export async function performBrowserAuth(
       }
     });
   });
+}
+
+function authResponse(res: http.ServerResponse, success: boolean): void {
+  res.writeHead(success ? 200 : 400, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(`<!DOCTYPE html>
+<html>
+<head><title>Sapiom authentication</title></head>
+<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+  <div style="text-align: center;">
+    <h1>${success ? "Authentication complete" : "Authentication could not be completed"}</h1>
+    <p>${success ? "You can close this tab and return to Sapiom." : "Close this tab and try connecting again from Sapiom."}</p>
+  </div>
+</body>
+</html>`);
 }
 
 async function exchangeCodeForApiKey(


### PR DESCRIPTION
## Summary

- preserve signed-out local Agent Studio startup when the desktop browser-auth flow is cancelled, times out, or fails
- keep cached desktop authentication silent and retain smoke mode's no-browser contract
- make the shared MCP/Studio callback page host-neutral
- return an honest failure page for invalid state, missing code, and failed token exchange instead of reporting authentication complete early
- add a patch changeset and focused regressions

## Dogfood

- verified the real environment-aware Studio/MCP credential cache without printing or changing its credential
- deployed a one-step configuration canary, then proved write-only secret listing, production secret injection, saved-default updates without redeploy, caller override, reset, and cleanup
- confirmed Local Run does not fetch cloud secrets but does inherit ordinary host environment

## Verification

- dependency builds through `@sapiom/mcp` and `@sapiom/harness-desktop`
- MCP suite: 92 tests passed
- desktop suite: 58 tests passed
- MCP ESLint and typecheck
- desktop typecheck and production build
- changed-file Prettier check and `git diff --check`

Stacked on [sapiom-js #505](https://github.com/sapiom/sapiom-js/pull/505).

Linear: [SAP-2361](https://linear.app/sapiom/issue/SAP-2361/docs-document-authentication-secrets-and-runtime-defaults)
