### PR TITLE
chore(tools): changeset to release getPublicUrl + downloadUrlUnavailable

### DIFF
--- a/.changeset/durable-public-url-and-unavailable-signal.md
+++ b/.changeset/durable-public-url-and-unavailable-signal.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": minor
+---
+
+file-storage: add `fileStorage.getPublicUrl(fileId)` — a pure helper that builds the durable, unauthenticated `/public/:id` permalink (the gateway re-signs a fresh URL on each hit), so callers can email or embed a link for an external recipient instead of a ~15-min presigned URL.
+
+content-generation: add `downloadUrlUnavailable?: boolean` to `ImageResultPayload` / `VideoResultPayload` outputs, so a resumed step can tell "URL omitted, re-fetch from fileId" from "no asset".
+
+Both are additive; no breaking changes. (Releases the changes merged in #504.)


### PR DESCRIPTION
## Summary
Adds a `minor` changeset for `@sapiom/tools` to cut a release for the additive SDK changes merged in #504 — which shipped **without a changeset**, so no release was published (registry is still `0.25.0`, missing `getPublicUrl`).

## Why
Part of epic SAP-2377 (deliver generated assets via email with durable links). The template ticket **SAP-2380** is blocked until `getPublicUrl` is published, and the gateway permalink endpoint (SAP-2378, merged #4035) has no consumer without it.

## What ships on release
- `fileStorage.getPublicUrl(fileId)` — durable `/public/:id` permalink helper (pure, no network).
- `downloadUrlUnavailable?: boolean` on `ImageResultPayload` / `VideoResultPayload`.

Both additive; no breaking changes.

## Next
Merging this triggers the Version Packages release PR; merging that publishes the new `@sapiom/tools`. Then SAP-2380 bumps the template's dep and applies the permalink change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7MfX8ZsGE8ffsGgmNW5pW