### PR TITLE
[SAP-2363] Fix Agent Studio recovery and state isolation

### DIFF
--- a/.changeset/safe-studios-recover.md
+++ b/.changeset/safe-studios-recover.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/analytics-core": patch
+"@sapiom/harness": patch
+---
+
+Keep isolated Agent Studio launches out of normal consent and analytics state,
+make browser launch and session-history sources failure-tolerant, preserve agent
+binding across portable continuation, retry transient run inspection, and drop
+analytics events whose privacy redaction cannot complete.

--- a/packages/analytics-core/src/__tests__/identity.test.ts
+++ b/packages/analytics-core/src/__tests__/identity.test.ts
@@ -215,8 +215,26 @@ describe("seedAnalyticsIdentity", () => {
     const result = seedAnalyticsIdentity(secondId);
 
     expect(result).toBe(false);
-    const record = JSON.parse(fs.readFileSync(home.identityPath, "utf8")) as { anonymous_id: string };
+    const record = JSON.parse(fs.readFileSync(home.identityPath, "utf8")) as {
+      anonymous_id: string;
+    };
     expect(record.anonymous_id).toBe(firstId); // unchanged
+  });
+
+  it("seeds an explicitly supplied identity path instead of HOME", () => {
+    const id = "99999999-aaaa-4bbb-8ccc-dddddddddddd";
+    const explicitPath = path.join(home.dir, "isolated", "analytics.json");
+
+    expect(seedAnalyticsIdentity(id, explicitPath)).toBe(true);
+    expect(fs.existsSync(home.identityPath)).toBe(false);
+    expect(fs.statSync(explicitPath).mode & 0o777).toBe(0o600);
+    expect(
+      (
+        JSON.parse(fs.readFileSync(explicitPath, "utf8")) as {
+          anonymous_id: string;
+        }
+      ).anonymous_id,
+    ).toBe(id);
   });
 
   it("returns false without throwing when HOME is unwritable", () => {

--- a/packages/analytics-core/src/identity.ts
+++ b/packages/analytics-core/src/identity.ts
@@ -118,23 +118,35 @@ function resolveHomeDir(): string {
 }
 
 /**
- * Seed `~/.sapiom/analytics.json` with a known `anonymous_id` if it does not
- * yet exist. Idempotent: when the file already exists the call is a no-op and
- * returns `false`. When the seed succeeds it returns `true`. On any error
- * (unwritable HOME, permission denied, …) it silently returns `false` so
- * callers can treat the result as best-effort.
+ * Seed `~/.sapiom/analytics.json` (or an explicit identity path) with a known
+ * `anonymous_id` if it does not yet exist. Idempotent: when the file already
+ * exists the call is a no-op and returns `false`. When the seed succeeds it
+ * returns `true`. On any error (unwritable HOME, permission denied, …) it
+ * silently returns `false` so callers can treat the result as best-effort.
  *
  * Intended for one-way migration of a legacy per-install id (e.g.
  * `~/.sapiom/harness/machine-id`) into the canonical analytics identity so
  * the longitudinal join key survives across versions.
+ *
+ * @param identityPath Override the canonical file location. Used by isolated
+ * callers and tests; no fallback write occurs if this path is unavailable.
  */
-export function seedAnalyticsIdentity(anonymousId: string): boolean {
+export function seedAnalyticsIdentity(
+  anonymousId: string,
+  identityPath?: string,
+): boolean {
   try {
-    const filePath = path.join(resolveHomeDir(), ".sapiom", "analytics.json");
+    const filePath =
+      identityPath ?? path.join(resolveHomeDir(), ".sapiom", "analytics.json");
     if (fs.existsSync(filePath)) return false;
-    const record: IdentityRecord = { anonymous_id: anonymousId, first_run_notice_at: null };
+    const record: IdentityRecord = {
+      anonymous_id: anonymousId,
+      first_run_notice_at: null,
+    };
     fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-    fs.writeFileSync(filePath, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+    fs.writeFileSync(filePath, JSON.stringify(record, null, 2) + "\n", {
+      mode: 0o600,
+    });
     try {
       fs.chmodSync(filePath, 0o600);
     } catch {

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -14,7 +14,6 @@
  * --no-open, --no-session, --dev, --state-root <dir>.
  */
 import * as crypto from "node:crypto";
-import open from "open";
 import {
   runDoctor,
   printDoctorReport,
@@ -29,6 +28,7 @@ import { loadSettings, recordRecentDir } from "./settings.js";
 import { getOrCreateMachineId } from "./machine-id.js";
 import { resolveStatePaths } from "../core/paths.js";
 import { parseArgs } from "./args.js";
+import { openStudioInBrowser } from "./open-browser.js";
 import { startServer, type HarnessServer } from "../server/index.js";
 
 const main = async (): Promise<void> => {
@@ -72,9 +72,15 @@ const main = async (): Promise<void> => {
   // out explicitly so "auth silently worked" doesn't read as "nothing
   // happened" (a fresh login is its own visible browser flow already).
   if (identity?.source === "cached") {
-    console.log(`\nSigned in as ${identity.organizationName} (cached credential).`);
+    console.log(
+      `\nSigned in as ${identity.organizationName} (cached credential).`,
+    );
   }
-  const consentResult = await ensureConsent({ noTelemetry: options.noTelemetry });
+  const consentResult = await ensureConsent({
+    noTelemetry: options.noTelemetry,
+    settingsPath: statePaths.settings,
+    eventsPath: statePaths.events,
+  });
   const { telemetryOptIn } = consentResult;
   // First run = no recent directories recorded before this boot. Must be read
   // BEFORE recordRecentDir below stamps the launch dir in — after that the
@@ -82,7 +88,8 @@ const main = async (): Promise<void> => {
   // and suppresses the auto-created boot session, so a brand-new user lands on
   // the welcome panel rather than a bare terminal in whatever directory they
   // happened to launch from.
-  const firstRun = (await loadSettings(statePaths.settings)).recentDirs.length === 0;
+  const firstRun =
+    (await loadSettings(statePaths.settings)).recentDirs.length === 0;
   await recordRecentDir(options.dir, statePaths.settings);
 
   const bootToken = crypto.randomBytes(32).toString("hex");
@@ -123,7 +130,9 @@ const main = async (): Promise<void> => {
   });
 
   if (server && !options.noOpen) {
-    await open(`http://localhost:${server.port}/?token=${bootToken}`);
+    await openStudioInBrowser(
+      `http://localhost:${server.port}/?token=${bootToken}`,
+    );
   }
 
   if (server) {

--- a/packages/harness/src/cli/consent.test.ts
+++ b/packages/harness/src/cli/consent.test.ts
@@ -60,7 +60,10 @@ describe("ensureConsent", () => {
   it("describes detailed telemetry as coding-agent activity", async () => {
     const wasTTY = process.stdin.isTTY;
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
 
     try {
       await ensureConsent({ noTelemetry: false });
@@ -69,7 +72,44 @@ describe("ensureConsent", () => {
       expect(printed).not.toContain("the tool calls your agent makes");
     } finally {
       log.mockRestore();
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
+    }
+  });
+
+  it("uses an isolated settings file and names its actual event log", async () => {
+    const wasTTY = process.stdin.isTTY;
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    const stateRoot = path.join(tmpDir, "throwaway-state");
+    const settingsPath = path.join(stateRoot, "settings.json");
+    const eventsPath = path.join(stateRoot, "events.ndjson");
+
+    try {
+      const result = await ensureConsent({
+        noTelemetry: false,
+        settingsPath,
+        eventsPath,
+      });
+
+      expect(result.source).toBe("default-silent");
+      expect(await hasStoredSettings(settingsPath)).toBe(true);
+      expect(await hasStoredSettings()).toBe(false);
+      expect((await loadSettings(settingsPath)).telemetryOptIn).toBe(false);
+      const printed = log.mock.calls.flat().join("\n");
+      expect(printed).toContain(eventsPath);
+      expect(printed).not.toContain("~/.sapiom/harness/events.ndjson");
+    } finally {
+      log.mockRestore();
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
@@ -77,7 +117,10 @@ describe("ensureConsent", () => {
     // SAP-1988: the invasive Sapiom→BQ tier is opt-out by default — a non-TTY
     // first run (CI/Docker/headless) must never silently opt the user in.
     const wasTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
 
     try {
       const result = await ensureConsent({ noTelemetry: false });
@@ -87,13 +130,19 @@ describe("ensureConsent", () => {
       const settings = await loadSettings();
       expect(settings.telemetryOptIn).toBe(false);
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
   it("reuses the persisted answer on subsequent runs without re-prompting", async () => {
     const wasTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
 
     try {
       await ensureConsent({ noTelemetry: false }); // first run persists the default (false)
@@ -109,13 +158,19 @@ describe("ensureConsent", () => {
       expect(result.telemetryOptIn).toBe(true);
       expect(result.source).toBe("stored-explicit");
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
   it("interactive prompt: a blank answer accepts the default (off)", async () => {
     const wasTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
     nextAnswer = "";
 
     try {
@@ -123,13 +178,19 @@ describe("ensureConsent", () => {
       expect(result.telemetryOptIn).toBe(false);
       expect(result.source).toBe("prompted");
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
   it("interactive prompt: an explicit 'n' opts out", async () => {
     const wasTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
     nextAnswer = "n";
 
     try {
@@ -137,13 +198,19 @@ describe("ensureConsent", () => {
       expect(result.telemetryOptIn).toBe(false);
       expect(result.source).toBe("prompted");
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
   it("interactive prompt: an explicit 'y' opts in", async () => {
     const wasTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
     nextAnswer = "y";
 
     try {
@@ -151,7 +218,10 @@ describe("ensureConsent", () => {
       expect(result.telemetryOptIn).toBe(true);
       expect(result.source).toBe("prompted");
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: wasTTY,
+        configurable: true,
+      });
     }
   });
 
@@ -179,32 +249,41 @@ describe("ensureConsent", () => {
       ["SAPIOM_TELEMETRY_DISABLED", "TRUE"],
       ["DO_NOT_TRACK", "1"],
       ["DO_NOT_TRACK", "true"],
-    ])("%s=%s forces telemetry off without prompting, on a first run", async (envVar, value) => {
-      process.env[envVar] = value;
+    ])(
+      "%s=%s forces telemetry off without prompting, on a first run",
+      async (envVar, value) => {
+        process.env[envVar] = value;
 
-      const result = await ensureConsent({ noTelemetry: false });
+        const result = await ensureConsent({ noTelemetry: false });
 
-      expect(result.telemetryOptIn).toBe(false);
-      expect(result.source).toBe("env-forced-off");
-      expect(result.envReason).toBe(envVar);
-      expect(questionCallCount).toBe(0);
-      // Nothing persisted: hasStoredSettings() must still say "no" so a
-      // later run without the env var gets a genuine first-run prompt,
-      // rather than silently inheriting a fabricated opt-out answer.
-      expect(await hasStoredSettings()).toBe(false);
-    });
+        expect(result.telemetryOptIn).toBe(false);
+        expect(result.source).toBe("env-forced-off");
+        expect(result.envReason).toBe(envVar);
+        expect(questionCallCount).toBe(0);
+        // Nothing persisted: hasStoredSettings() must still say "no" so a
+        // later run without the env var gets a genuine first-run prompt,
+        // rather than silently inheriting a fabricated opt-out answer.
+        expect(await hasStoredSettings()).toBe(false);
+      },
+    );
 
     it("overrides a previously persisted opt-in for this run, without rewriting it", async () => {
       // Establish a stored opt-in from an earlier, env-free run — an explicit
       // 'y' at the prompt (the default is now off, so blank would not opt in).
       const wasTTY = process.stdin.isTTY;
-      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: true,
+        configurable: true,
+      });
       nextAnswer = "y";
       try {
         const firstResult = await ensureConsent({ noTelemetry: false });
         expect(firstResult.telemetryOptIn).toBe(true);
       } finally {
-        Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+        Object.defineProperty(process.stdin, "isTTY", {
+          value: wasTTY,
+          configurable: true,
+        });
       }
       expect((await loadSettings()).telemetryOptIn).toBe(true);
 
@@ -230,7 +309,10 @@ describe("ensureConsent", () => {
     ])("%s=%s is not treated as an opt-out", async (envVar, value) => {
       process.env[envVar] = value;
       const wasTTY = process.stdin.isTTY;
-      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: false,
+        configurable: true,
+      });
 
       try {
         const result = await ensureConsent({ noTelemetry: false });
@@ -242,7 +324,10 @@ describe("ensureConsent", () => {
         expect(result.source).toBe("default-silent");
         expect(result.envReason).toBeNull();
       } finally {
-        Object.defineProperty(process.stdin, "isTTY", { value: wasTTY, configurable: true });
+        Object.defineProperty(process.stdin, "isTTY", {
+          value: wasTTY,
+          configurable: true,
+        });
       }
     });
 

--- a/packages/harness/src/cli/consent.ts
+++ b/packages/harness/src/cli/consent.ts
@@ -1,4 +1,5 @@
 import * as readline from "node:readline/promises";
+import { HARNESS_PATHS } from "../shared/types.js";
 import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 
 // Opt-OUT by default (SAP-1988): this gates the *invasive* Sapiom→BigQuery
@@ -11,21 +12,23 @@ import { hasStoredSettings, loadSettings, saveSettings } from "./settings.js";
 // The first-run UI opt-in lives in web/src/components/WelcomePanel.tsx.
 const DEFAULT_TELEMETRY_OPT_IN = false;
 
-const CONSENT_COPY = `
+function consentCopy(eventsPath: string): string {
+  return `
 Help us optimize your Agent Studio experience.
 
 With your permission, Agent Studio shares your session details — the prompts
 you send, the tool calls your coding agent makes, and session lifecycle events — so we
 can see where the product gets in your way and improve it for you.
 
-This is always written locally to ~/.sapiom/harness/events.ndjson for your own
+This is always written locally to ${eventsPath} for your own
 inspection, whether or not you opt in. Sharing with Sapiom is OFF by default;
 turn it on anytime in the app's settings gear (or keep it off with
 --no-telemetry / SAPIOM_TELEMETRY_DISABLED=1).
 `.trim();
+}
 
-async function promptConsent(): Promise<boolean> {
-  console.log(`\n${CONSENT_COPY}\n`);
+async function promptConsent(eventsPath: string): Promise<boolean> {
+  console.log(`\n${consentCopy(eventsPath)}\n`);
 
   if (!process.stdin.isTTY) {
     // The full consent copy (what's collected, local store, and opt-out path)
@@ -33,14 +36,21 @@ async function promptConsent(): Promise<boolean> {
     // reviewing logs see it clearly.
     console.log(
       `Non-interactive session — telemetry is defaulting to ${DEFAULT_TELEMETRY_OPT_IN ? "on" : "off"}` +
-      ` per the notice above. Run with --no-telemetry or set SAPIOM_TELEMETRY_DISABLED=1 to opt out.\n`,
+        ` per the notice above. Run with --no-telemetry or set SAPIOM_TELEMETRY_DISABLED=1 to opt out.\n`,
     );
     return DEFAULT_TELEMETRY_OPT_IN;
   }
 
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
   try {
-    const answer = (await rl.question("Share session details with Sapiom? [y/N] ")).trim().toLowerCase();
+    const answer = (
+      await rl.question("Share session details with Sapiom? [y/N] ")
+    )
+      .trim()
+      .toLowerCase();
     if (answer === "") return DEFAULT_TELEMETRY_OPT_IN;
     return answer === "y" || answer === "yes";
   } finally {
@@ -51,6 +61,10 @@ async function promptConsent(): Promise<boolean> {
 export interface EnsureConsentOptions {
   /** The `--no-telemetry` flag — forces telemetry off without prompting. */
   noTelemetry: boolean;
+  /** Settings file for this boot. Defaults to the normal Harness path. */
+  settingsPath?: string;
+  /** Local event-log path named in the first-run notice. */
+  eventsPath?: string;
 }
 
 /**
@@ -95,7 +109,8 @@ function isEnvFlagSet(value: string | undefined): boolean {
 
 /** Which env var (if any) forces telemetry off this run, for the printed reason. */
 function envDisableReason(): string | null {
-  if (isEnvFlagSet(process.env.SAPIOM_TELEMETRY_DISABLED)) return "SAPIOM_TELEMETRY_DISABLED";
+  if (isEnvFlagSet(process.env.SAPIOM_TELEMETRY_DISABLED))
+    return "SAPIOM_TELEMETRY_DISABLED";
   if (isEnvFlagSet(process.env.DO_NOT_TRACK)) return "DO_NOT_TRACK";
   return null;
 }
@@ -113,28 +128,38 @@ function envDisableReason(): string | null {
  * uses this to show a first-run notice when the user never explicitly answered
  * (source === "default-silent"), skipping it when they did.
  */
-export async function ensureConsent(options: EnsureConsentOptions): Promise<ConsentResult> {
+export async function ensureConsent(
+  options: EnsureConsentOptions,
+): Promise<ConsentResult> {
   if (options.noTelemetry) {
     return { telemetryOptIn: false, envReason: null, source: "env-forced-off" };
   }
 
   const envReason = envDisableReason();
   if (envReason) {
-    console.log(`Telemetry disabled via ${envReason} — skipping the consent prompt.\n`);
+    console.log(
+      `Telemetry disabled via ${envReason} — skipping the consent prompt.\n`,
+    );
     return { telemetryOptIn: false, envReason, source: "env-forced-off" };
   }
 
-  const isFirstRun = !(await hasStoredSettings());
-  const settings = await loadSettings();
+  const isFirstRun = !(await hasStoredSettings(options.settingsPath));
+  const settings = await loadSettings(options.settingsPath);
 
   if (!isFirstRun) {
-    return { telemetryOptIn: settings.telemetryOptIn, envReason: null, source: "stored-explicit" };
+    return {
+      telemetryOptIn: settings.telemetryOptIn,
+      envReason: null,
+      source: "stored-explicit",
+    };
   }
 
   // First run: prompt the user (TTY) or apply the silent default (non-TTY).
   const isTTY = process.stdin.isTTY;
-  const telemetryOptIn = await promptConsent();
-  await saveSettings({ ...settings, telemetryOptIn });
+  const telemetryOptIn = await promptConsent(
+    options.eventsPath ?? HARNESS_PATHS.events,
+  );
+  await saveSettings({ ...settings, telemetryOptIn }, options.settingsPath);
   const source: ConsentSource = isTTY ? "prompted" : "default-silent";
   return { telemetryOptIn, envReason: null, source };
 }

--- a/packages/harness/src/cli/open-browser.test.ts
+++ b/packages/harness/src/cli/open-browser.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openStudioInBrowser } from "./open-browser.js";
+
+describe("openStudioInBrowser", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true after the platform opener succeeds", async () => {
+    const openUrl = vi.fn(async () => undefined);
+
+    await expect(
+      openStudioInBrowser("http://localhost:4100/?token=secret", openUrl),
+    ).resolves.toBe(true);
+    expect(openUrl).toHaveBeenCalledWith("http://localhost:4100/?token=secret");
+  });
+
+  it("keeps opener failure nonfatal and does not repeat the boot token", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const openUrl = vi.fn(async () => {
+      throw new Error("could not open http://localhost:4100/?token=secret");
+    });
+
+    await expect(
+      openStudioInBrowser("http://localhost:4100/?token=secret", openUrl),
+    ).resolves.toBe(false);
+    const printed = error.mock.calls.flat().join("\n");
+    expect(printed).toContain("Open the full URL printed above");
+    expect(printed).not.toContain("secret");
+  });
+});

--- a/packages/harness/src/cli/open-browser.ts
+++ b/packages/harness/src/cli/open-browser.ts
@@ -1,0 +1,29 @@
+import open from "open";
+
+type OpenUrl = (url: string) => Promise<unknown>;
+
+/**
+ * Opens the already-started Studio in the user's browser.
+ *
+ * Browser launch is convenience, not server liveness. The startup banner is
+ * printed before this runs and contains the exact tokenized URL, so a platform
+ * opener failure must leave the healthy server running and point the user back
+ * to that fallback instead of reaching the CLI's fatal top-level handler.
+ */
+export async function openStudioInBrowser(
+  url: string,
+  openUrl: OpenUrl = open,
+): Promise<boolean> {
+  try {
+    await openUrl(url);
+    return true;
+  } catch {
+    // Do not echo the error: platform opener errors can include `url`, whose
+    // query contains the live per-boot access token. The banner immediately
+    // above already printed the one intentional copy.
+    console.error(
+      "\n⚠ Agent Studio could not open a browser automatically. Open the full URL printed above on this machine.\n",
+    );
+    return false;
+  }
+}

--- a/packages/harness/src/core/collector/identity-migration.test.ts
+++ b/packages/harness/src/core/collector/identity-migration.test.ts
@@ -30,9 +30,16 @@ interface TempDir {
 }
 
 function makeTempDir(): TempDir {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-identity-migration-"));
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "harness-identity-migration-"),
+  );
   const analyticsJsonPath = path.join(dir, ".sapiom", "analytics.json");
-  const legacyMachineIdPath = path.join(dir, ".sapiom", "harness", "machine-id");
+  const legacyMachineIdPath = path.join(
+    dir,
+    ".sapiom",
+    "harness",
+    "machine-id",
+  );
   return {
     dir,
     analyticsJsonPath,
@@ -50,7 +57,9 @@ function writeLegacyMachineId(machineIdPath: string, id: string): void {
 
 function readAnalyticsId(analyticsPath: string): string | null {
   try {
-    const parsed = JSON.parse(fs.readFileSync(analyticsPath, "utf8")) as { anonymous_id: string };
+    const parsed = JSON.parse(fs.readFileSync(analyticsPath, "utf8")) as {
+      anonymous_id: string;
+    };
     return parsed.anonymous_id;
   } catch {
     return null;
@@ -82,7 +91,10 @@ describe("migrateHarnessIdentity", () => {
   it("(a) fresh HOME: analytics.json does not exist → analytics.json NOT created by migration alone (analytics-core does that on first track)", async () => {
     // No legacy machine-id either → nothing to migrate
     expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(false);
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
     // Migration only seeds when legacy file exists; with neither file it's a no-op
     expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(false);
   });
@@ -92,7 +104,10 @@ describe("migrateHarnessIdentity", () => {
     writeLegacyMachineId(tmp.legacyMachineIdPath, legacyId);
 
     expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(false);
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
 
     expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(true);
     // Permissions must be 0600
@@ -108,11 +123,15 @@ describe("migrateHarnessIdentity", () => {
     fs.mkdirSync(path.dirname(tmp.analyticsJsonPath), { recursive: true });
     fs.writeFileSync(
       tmp.analyticsJsonPath,
-      JSON.stringify({ anonymous_id: analyticsId, first_run_notice_at: null }) + "\n",
+      JSON.stringify({ anonymous_id: analyticsId, first_run_notice_at: null }) +
+        "\n",
       { mode: 0o600 },
     );
 
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
 
     // analytics.json unchanged
     expect(readAnalyticsId(tmp.analyticsJsonPath)).toBe(analyticsId);
@@ -133,12 +152,18 @@ describe("migrateHarnessIdentity", () => {
     await expect(
       migrateHarnessIdentity(tmp.legacyMachineIdPath, unwritablePath),
     ).resolves.toBeUndefined();
+    // The explicit target is the contract. A failed write there must not fall
+    // back to HOME and silently mutate a different identity file.
+    expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(false);
   });
 
   it("ignores a non-UUID machine-id (malformed content)", async () => {
     writeLegacyMachineId(tmp.legacyMachineIdPath, "not-a-uuid");
 
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
 
     // analytics.json should NOT have been created
     expect(fs.existsSync(tmp.analyticsJsonPath)).toBe(false);
@@ -148,11 +173,17 @@ describe("migrateHarnessIdentity", () => {
     const legacyId = crypto.randomUUID();
     writeLegacyMachineId(tmp.legacyMachineIdPath, legacyId);
 
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
     const firstRead = readAnalyticsId(tmp.analyticsJsonPath);
 
     // Second call: analytics.json now exists, should be a no-op
-    await migrateHarnessIdentity(tmp.legacyMachineIdPath, tmp.analyticsJsonPath);
+    await migrateHarnessIdentity(
+      tmp.legacyMachineIdPath,
+      tmp.analyticsJsonPath,
+    );
     expect(readAnalyticsId(tmp.analyticsJsonPath)).toBe(firstRead);
   });
 });

--- a/packages/harness/src/core/collector/identity-migration.ts
+++ b/packages/harness/src/core/collector/identity-migration.ts
@@ -69,7 +69,7 @@ export async function migrateHarnessIdentity(
 
     // Seed analytics.json. seedAnalyticsIdentity handles atomic write +
     // 0600 permissions + degrade-on-error.
-    seedAnalyticsIdentity(machineId);
+    seedAnalyticsIdentity(machineId, targetPath);
   } catch {
     // Migration failures must never crash the server.
   }

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -3,8 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { HarnessAdapter, HarnessKind, HarnessSession, SpawnSpec } from "../shared/types.js";
-import { SessionManager, type PtySpawnFn, type SessionManagerOptions } from "./session-manager.js";
+import type {
+  HarnessAdapter,
+  HarnessKind,
+  HarnessSession,
+  SpawnSpec,
+} from "../shared/types.js";
+import {
+  SessionManager,
+  type PtySpawnFn,
+  type SessionManagerOptions,
+} from "./session-manager.js";
 import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
 
 /** Minimal fake IPty: lets tests drive onData/onExit and observe write/resize/kill.
@@ -14,7 +23,9 @@ import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
  *  leaves it undefined, which the sweep must treat as "can't tell, hands off". */
 function createFakePty(pid?: number) {
   const dataListeners: Array<(chunk: string) => void> = [];
-  const exitListeners: Array<(e: { exitCode: number; signal?: number }) => void> = [];
+  const exitListeners: Array<
+    (e: { exitCode: number; signal?: number }) => void
+  > = [];
   const pty = {
     pid,
     onData: (cb: (chunk: string) => void) => {
@@ -36,7 +47,9 @@ function createFakePty(pid?: number) {
   };
 }
 
-function createFakeAdapter(overrides: Partial<HarnessAdapter> = {}): HarnessAdapter {
+function createFakeAdapter(
+  overrides: Partial<HarnessAdapter> = {},
+): HarnessAdapter {
   return {
     id: "claude-code",
     eventSource: "hooks",
@@ -126,10 +139,16 @@ describe("SessionManager", () => {
 
   it("creates a session, spawns via the adapter's SpawnSpec, and marks it running", async () => {
     const { manager, adapter } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     expect(adapter.launch).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: "/tmp/proj", harnessSessionId: session.id }),
+      expect.objectContaining({
+        cwd: "/tmp/proj",
+        harnessSessionId: session.id,
+      }),
     );
     expect(session.status).toBe("running");
     expect(session.cwd).toBe("/tmp/proj");
@@ -140,10 +159,15 @@ describe("SessionManager", () => {
 
   it("persists sessions to disk and reconciles non-exited sessions to exited on reload", async () => {
     const { manager } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
     expect(session.status).toBe("running");
 
-    const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
+    const raw = JSON.parse(
+      await readFile(sessionsPath, "utf8"),
+    ) as HarnessSession[];
     expect(raw).toHaveLength(1);
     expect(raw[0]?.id).toBe(session.id);
     expect(raw[0]?.status).toBe("running");
@@ -157,7 +181,10 @@ describe("SessionManager", () => {
 
   it("routes write() and resize() to the underlying pty", async () => {
     const { manager, spawns } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     expect(manager.write(session.id, "echo hi\r")).toBe(true);
     expect(spawns[0]?.pty.write).toHaveBeenCalledWith("echo hi\r");
@@ -180,10 +207,17 @@ describe("SessionManager", () => {
 
     it("splits non-empty submitted text into a text write, then a separate \\r after a delay", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setReady(session.id);
 
-      const submitPromise = manager.submitInput(session.id, "hello world", true);
+      const submitPromise = manager.submitInput(
+        session.id,
+        "hello world",
+        true,
+      );
 
       // Text lands immediately; the trailing Enter must NOT be part of the
       // same write (that's exactly the bracketed-paste bug this fixes).
@@ -202,7 +236,10 @@ describe("SessionManager", () => {
 
     it("writes a bare \\r in a single call for submit:true with empty text (no splitting needed)", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setReady(session.id);
 
       const ok = await manager.submitInput(session.id, "", true);
@@ -214,7 +251,10 @@ describe("SessionManager", () => {
 
     it("writes only the text, with no \\r at all, when submit is false", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setReady(session.id);
 
       const ok = await manager.submitInput(session.id, "draft text", false);
@@ -226,12 +266,17 @@ describe("SessionManager", () => {
 
     it("returns false for an unknown session without ever touching a pty", async () => {
       const { manager } = makeManager();
-      expect(await manager.submitInput("unknown-id", "hello", true)).toBe(false);
+      expect(await manager.submitInput("unknown-id", "hello", true)).toBe(
+        false,
+      );
     });
 
     it("does not write the trailing \\r if the session's pty is gone by the time the delay elapses", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setReady(session.id);
 
       const submitPromise = manager.submitInput(session.id, "hello", true);
@@ -256,16 +301,22 @@ describe("SessionManager", () => {
       vi.useRealTimers();
     });
 
-    it("a fresh session starts not-ready even though its pty is already \"running\"", async () => {
+    it('a fresh session starts not-ready even though its pty is already "running"', async () => {
       const { manager } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       expect(session.status).toBe("running");
       expect(session.ready).toBe(false);
     });
 
     it("write() (raw keystrokes) is never gated on readiness — a human must be able to answer a blocking prompt themselves", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       expect(session.ready).toBe(false);
 
       expect(manager.write(session.id, "1\r")).toBe(true);
@@ -277,7 +328,10 @@ describe("SessionManager", () => {
         "setReady() fires before the grace period elapses (macro fired a beat before onboarding finished)",
       async () => {
         const { manager, spawns } = makeManager();
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         // Not ready yet — must NOT have written anything, this is exactly the
@@ -304,7 +358,10 @@ describe("SessionManager", () => {
 
     it("throws SessionNotReadyError (never silently proceeds) when a session never becomes ready within the grace period", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const submitPromise = manager.submitInput(session.id, "hello", true);
       const assertion = expect(submitPromise).rejects.toThrow(/not ready yet/i);
@@ -317,7 +374,10 @@ describe("SessionManager", () => {
 
     it("resuming resets ready back to false, even for a session that was ready before its pty exited", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setAgentSessionId(session.id, "agent-1");
       manager.setReady(session.id);
       expect(manager.get(session.id)?.ready).toBe(true);
@@ -340,8 +400,13 @@ describe("SessionManager", () => {
     describe("harnesses with detectBlockingPrompt (Codex's lazy-rollout-file bridge)", () => {
       it("is not ready before the settle window elapses, even with a clean scrollback", async () => {
         const detectBlockingPrompt = vi.fn(() => false);
-        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager, spawns } = makeManager({
+          adapter: createFakeAdapter({ detectBlockingPrompt }),
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
@@ -357,8 +422,13 @@ describe("SessionManager", () => {
 
       it("becomes ready enough after the settle window when the scrollback shows no blocking prompt (the common already-trusted case)", async () => {
         const detectBlockingPrompt = vi.fn(() => false);
-        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager, spawns } = makeManager({
+          adapter: createFakeAdapter({ detectBlockingPrompt }),
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         await vi.advanceTimersByTimeAsync(700);
         const submitPromise = manager.submitInput(session.id, "hello", true);
@@ -374,8 +444,13 @@ describe("SessionManager", () => {
       it("stays not-ready while the scrollback shows a blocking prompt, then proceeds once it clears", async () => {
         let showingPrompt = true;
         const detectBlockingPrompt = vi.fn(() => showingPrompt);
-        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager, spawns } = makeManager({
+          adapter: createFakeAdapter({ detectBlockingPrompt }),
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         await vi.advanceTimersByTimeAsync(700);
@@ -390,11 +465,17 @@ describe("SessionManager", () => {
 
       it("throws SessionNotReadyError if the blocking prompt never clears within the grace period", async () => {
         const detectBlockingPrompt = vi.fn(() => true);
-        const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt }) });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager, spawns } = makeManager({
+          adapter: createFakeAdapter({ detectBlockingPrompt }),
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
-        const assertion = expect(submitPromise).rejects.toThrow(/not ready yet/i);
+        const assertion =
+          expect(submitPromise).rejects.toThrow(/not ready yet/i);
         await vi.advanceTimersByTimeAsync(8_000);
         await assertion;
 
@@ -405,7 +486,10 @@ describe("SessionManager", () => {
 
   it("replays the scrollback buffer to new attach()ers and streams live data", async () => {
     const { manager, spawns } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     spawns[0]?.emitData("hello ");
     spawns[0]?.emitData("world");
@@ -426,7 +510,10 @@ describe("SessionManager", () => {
     it("broadcasts once immediately, then throttles further data within the window", async () => {
       vi.useFakeTimers();
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const activity: string[] = [];
       manager.onActivity((id) => activity.push(id));
@@ -477,7 +564,10 @@ describe("SessionManager", () => {
 
   it("marks a session exited when its pty exits, and notifies status listeners", async () => {
     const { manager, spawns } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     const statuses: HarnessSession["status"][] = [];
     manager.onStatusChange((s) => {
@@ -493,7 +583,10 @@ describe("SessionManager", () => {
 
   it("kill() signals the pty for a running session and returns a Promise resolving true; returns Promise<false> otherwise", async () => {
     const { manager, spawns } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     // kill() now returns Promise<boolean> — fire-and-forget still works via void,
     // but here we confirm the resolved value and that the signal was sent.
@@ -533,9 +626,14 @@ describe("SessionManager", () => {
 
   it("resume() requires a known agentSessionId and respawns via adapter.resume", async () => {
     const { manager, adapter, spawns } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
-    await expect(manager.resume(session.id)).rejects.toThrow(/no agentSessionId/);
+    await expect(manager.resume(session.id)).rejects.toThrow(
+      /no agentSessionId/,
+    );
 
     manager.setAgentSessionId(session.id, "agent-uuid-1");
     spawns[0]?.emitExit(0);
@@ -544,12 +642,17 @@ describe("SessionManager", () => {
     const resumed = await manager.resume(session.id);
     expect(adapter.resume).toHaveBeenCalledWith(
       "agent-uuid-1",
-      expect.objectContaining({ harnessSessionId: session.id, cwd: "/tmp/proj" }),
+      expect.objectContaining({
+        harnessSessionId: session.id,
+        cwd: "/tmp/proj",
+      }),
     );
     expect(resumed.status).toBe("running");
     expect(resumed.id).toBe(session.id);
 
-    await expect(manager.resume("does-not-exist")).rejects.toThrow(/Unknown session/);
+    await expect(manager.resume("does-not-exist")).rejects.toThrow(
+      /Unknown session/,
+    );
   });
 
   it("awaits an async buildLaunchOpts and merges its result into launch opts", async () => {
@@ -558,14 +661,19 @@ describe("SessionManager", () => {
       return { settingsFile: `/generated/${harnessSessionId}/settings.json` };
     });
     const { manager, adapter } = makeManager({ buildLaunchOpts });
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     expect(buildLaunchOpts).toHaveBeenCalledWith(
       session.id,
       expect.objectContaining({ cwd: "/tmp/proj", harness: "claude-code" }),
     );
     expect(adapter.launch).toHaveBeenCalledWith(
-      expect.objectContaining({ settingsFile: `/generated/${session.id}/settings.json` }),
+      expect.objectContaining({
+        settingsFile: `/generated/${session.id}/settings.json`,
+      }),
     );
   });
 
@@ -574,7 +682,10 @@ describe("SessionManager", () => {
       mcpConfigFile: `/generated/${harnessSessionId}/mcp-config.json`,
     }));
     const { manager, adapter, spawns } = makeManager({ buildLaunchOpts });
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
     manager.setAgentSessionId(session.id, "agent-uuid-1");
     spawns[0]?.emitExit(0);
 
@@ -582,7 +693,9 @@ describe("SessionManager", () => {
 
     expect(adapter.resume).toHaveBeenLastCalledWith(
       "agent-uuid-1",
-      expect.objectContaining({ mcpConfigFile: `/generated/${session.id}/mcp-config.json` }),
+      expect.objectContaining({
+        mcpConfigFile: `/generated/${session.id}/mcp-config.json`,
+      }),
     );
   });
 
@@ -620,11 +733,15 @@ describe("SessionManager", () => {
     }
 
     it("throws SessionNotResumeableError instead of spawning when the agent no longer holds the conversation", async () => {
-      const adapter = createFakeAdapter({ canResume: vi.fn(async () => false) });
+      const adapter = createFakeAdapter({
+        canResume: vi.fn(async () => false),
+      });
       const { manager, spawns } = makeManager({ adapter });
       const session = registerPhantom(manager);
 
-      await expect(manager.resume(session.id)).rejects.toThrow(SessionNotResumeableError);
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        SessionNotResumeableError,
+      );
       // The point of the pre-flight: no doomed pty. Previously this spawned
       // `claude --resume <id>`, which exited 1 with "No conversation found".
       expect(spawns).toHaveLength(0);
@@ -632,7 +749,9 @@ describe("SessionManager", () => {
     });
 
     it("names the agent and the reason so the 409 tells the user WHY", async () => {
-      const adapter = createFakeAdapter({ canResume: vi.fn(async () => false) });
+      const adapter = createFakeAdapter({
+        canResume: vi.fn(async () => false),
+      });
       const { manager } = makeManager({ adapter });
       const session = registerPhantom(manager);
 
@@ -647,7 +766,9 @@ describe("SessionManager", () => {
 
     it("probes the agent's store with the session's own agentSessionId and cwd", async () => {
       const canResume = vi.fn(async () => true);
-      const { manager } = makeManager({ adapter: createFakeAdapter({ canResume }) });
+      const { manager } = makeManager({
+        adapter: createFakeAdapter({ canResume }),
+      });
       const session = registerPhantom(manager);
 
       await manager.resume(session.id);
@@ -656,10 +777,14 @@ describe("SessionManager", () => {
     });
 
     it("leaves a rejected session's record untouched — still exited, same lastActiveAt", async () => {
-      const { manager } = makeManager({ adapter: createFakeAdapter({ canResume: vi.fn(async () => false) }) });
+      const { manager } = makeManager({
+        adapter: createFakeAdapter({ canResume: vi.fn(async () => false) }),
+      });
       const session = registerPhantom(manager);
 
-      await expect(manager.resume(session.id)).rejects.toThrow(SessionNotResumeableError);
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        SessionNotResumeableError,
+      );
 
       const after = manager.get(session.id);
       expect(after?.status).toBe("exited");
@@ -677,7 +802,9 @@ describe("SessionManager", () => {
       });
       const session = registerPhantom(manager);
 
-      await expect(manager.resume(session.id)).rejects.toThrow("node-pty exploded");
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        "node-pty exploded",
+      );
 
       const after = manager.get(session.id);
       expect(after?.status).toBe("exited");
@@ -688,20 +815,69 @@ describe("SessionManager", () => {
 
     it("still short-circuits on a missing agentSessionId without probing the adapter", async () => {
       const canResume = vi.fn(async () => true);
-      const { manager } = makeManager({ adapter: createFakeAdapter({ canResume }) });
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const { manager } = makeManager({
+        adapter: createFakeAdapter({ canResume }),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       await manager.kill(session.id);
 
-      await expect(manager.resume(session.id)).rejects.toThrow(SessionNotResumeableError);
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        SessionNotResumeableError,
+      );
       expect(canResume).not.toHaveBeenCalled();
     });
   });
 
   it("new sessions start with boundWorkflowPath: null", async () => {
     const { manager } = makeManager();
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
     expect(session.boundWorkflowPath).toBeNull();
     expect(manager.get(session.id)?.boundWorkflowPath).toBeNull();
+  });
+
+  it("preserves a tracked project binding when portable continuation assembled a brief", async () => {
+    const { manager } = makeManager({
+      buildLaunchOpts: async (_id, req) =>
+        req.rehydrateFrom ? { rehydratedFrom: req.rehydrateFrom } : {},
+    });
+    const prior = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
+    manager.setBoundWorkflowPath(prior.id, "/tmp/proj/agent");
+
+    const continued = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+      rehydrateFrom: prior.id,
+    });
+
+    expect(continued.rehydratedFrom).toBe(prior.id);
+    expect(continued.boundWorkflowPath).toBe("/tmp/proj/agent");
+  });
+
+  it("does not copy a binding when portable continuation found no record", async () => {
+    const { manager } = makeManager({ buildLaunchOpts: async () => ({}) });
+    const prior = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
+    manager.setBoundWorkflowPath(prior.id, "/tmp/proj/agent");
+
+    const fresh = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+      rehydrateFrom: prior.id,
+    });
+
+    expect(fresh.rehydratedFrom).toBeNull();
+    expect(fresh.boundWorkflowPath).toBeNull();
   });
 
   describe("harness-context.json wiring", () => {
@@ -713,7 +889,10 @@ describe("SessionManager", () => {
       // autoCreateSession call shape (server/index.ts calling
       // sessionManager.create() directly), the entry point that used to skip
       // the write entirely because it lived in the REST handler instead.
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       expect(writeWorkspaceContext).toHaveBeenCalledTimes(1);
       expect(writeWorkspaceContext).toHaveBeenCalledWith(session);
@@ -746,7 +925,9 @@ describe("SessionManager", () => {
       });
       const { manager } = makeManager({ writeWorkspaceContext });
 
-      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow("disk full");
+      await expect(
+        manager.create({ cwd: "/tmp/proj", harness: "claude-code" }),
+      ).rejects.toThrow("disk full");
       // The record was persisted as "starting" before the failing write — it
       // must not stay that way (a non-exited record with no pty behind it
       // renders as a ghost tab forever).
@@ -769,7 +950,11 @@ describe("SessionManager", () => {
         void args;
         return createFakePty().pty as unknown as ReturnType<PtySpawnFn>;
       };
-      const { manager } = makeManager({ buildLaunchOpts, prepareWorkspaceContext, spawnPty });
+      const { manager } = makeManager({
+        buildLaunchOpts,
+        prepareWorkspaceContext,
+        spawnPty,
+      });
 
       const session = manager.registerHistorical({
         agentSessionId: "agent-uuid-9",
@@ -781,7 +966,9 @@ describe("SessionManager", () => {
       await manager.resume(session.id);
 
       expect(prepareWorkspaceContext).toHaveBeenCalledTimes(1);
-      expect(prepareWorkspaceContext).toHaveBeenCalledWith(manager.get(session.id));
+      expect(prepareWorkspaceContext).toHaveBeenCalledWith(
+        manager.get(session.id),
+      );
       expect(order).toEqual(["prompt", "prepare", "spawn"]);
     });
 
@@ -799,7 +986,9 @@ describe("SessionManager", () => {
         lastActiveAt: "2026-01-01T00:00:00.000Z",
       });
 
-      await expect(manager.resume(session.id)).rejects.toThrow("context path unreadable");
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        "context path unreadable",
+      );
 
       expect(spawns).toHaveLength(0);
       expect(manager.get(session.id)).toMatchObject({
@@ -816,7 +1005,9 @@ describe("SessionManager", () => {
       // that doesn't exist) or leave a real .sapiom dir behind on the test
       // runner's machine — neither happens, proving both defaults are inert.
       const { manager } = makeManager();
-      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).resolves.toBeDefined();
+      await expect(
+        manager.create({ cwd: "/tmp/proj", harness: "claude-code" }),
+      ).resolves.toBeDefined();
 
       const historical = manager.registerHistorical({
         agentSessionId: "agent-uuid-9",
@@ -881,7 +1072,9 @@ describe("SessionManager", () => {
 
     it("defaults to a no-op so tests with fake cwds never touch the real filesystem", async () => {
       const { manager } = makeManager();
-      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).resolves.toBeDefined();
+      await expect(
+        manager.create({ cwd: "/tmp/proj", harness: "claude-code" }),
+      ).resolves.toBeDefined();
     });
   });
 
@@ -892,7 +1085,9 @@ describe("SessionManager", () => {
       });
       const { manager } = makeManager({ ensureCanvasTemplate });
 
-      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow("read-only fs");
+      await expect(
+        manager.create({ cwd: "/tmp/proj", harness: "claude-code" }),
+      ).rejects.toThrow("read-only fs");
       expect(manager.list()[0]?.status).toBe("exited");
     });
 
@@ -904,16 +1099,18 @@ describe("SessionManager", () => {
       const statuses: string[] = [];
       manager.onStatusChange((s) => statuses.push(s.status));
 
-      await expect(manager.create({ cwd: "/tmp/proj", harness: "claude-code" })).rejects.toThrow(
-        "posix_spawnp failed",
-      );
+      await expect(
+        manager.create({ cwd: "/tmp/proj", harness: "claude-code" }),
+      ).rejects.toThrow("posix_spawnp failed");
       expect(manager.list()[0]?.status).toBe("exited");
       expect(statuses).toContain("exited");
 
       // The reconciliation must be durable, not just in-memory — a persisted
       // "starting" record would still ghost after the SPA refetches state.
       await manager.flush();
-      const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
+      const raw = JSON.parse(
+        await readFile(sessionsPath, "utf8"),
+      ) as HarnessSession[];
       expect(raw[0]?.status).toBe("exited");
     });
 
@@ -938,7 +1135,10 @@ describe("SessionManager", () => {
 
     it("kill() transitions a stale non-exited record with no pty to exited instead of failing", async () => {
       const { manager, spawns } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       spawns[0]?.emitExit(0);
       // Simulate the ghost state directly (the transitions that used to
       // produce it are all reconciled now): a record stuck non-exited whose
@@ -963,8 +1163,14 @@ describe("SessionManager", () => {
         // The node-pty missed-exit bug (see kill()'s fallback), but for a
         // process that died on its own — no kill() call means no fallback
         // was ever armed, which is exactly what the sweep exists to catch.
-        const { manager } = makeManager({ fakePid: 4242, isPidAlive: () => false });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager } = makeManager({
+          fakePid: 4242,
+          isPidAlive: () => false,
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
         expect(session.status).toBe("running");
 
         const statuses: string[] = [];
@@ -978,13 +1184,21 @@ describe("SessionManager", () => {
         expect(manager.attach(session.id, () => {})).toBeUndefined();
 
         await manager.flush();
-        const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
+        const raw = JSON.parse(
+          await readFile(sessionsPath, "utf8"),
+        ) as HarnessSession[];
         expect(raw[0]?.status).toBe("exited");
       });
 
       it("leaves sessions whose process is alive untouched", async () => {
-        const { manager } = makeManager({ fakePid: 4242, isPidAlive: () => true });
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const { manager } = makeManager({
+          fakePid: 4242,
+          isPidAlive: () => true,
+        });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         manager.sweepDeadSessions();
 
@@ -994,7 +1208,10 @@ describe("SessionManager", () => {
       it("never probes a pty without a numeric pid, and never declares it dead", async () => {
         const isPidAlive = vi.fn(() => false);
         const { manager } = makeManager({ isPidAlive }); // fake pty with pid: undefined
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
 
         manager.sweepDeadSessions();
 
@@ -1004,7 +1221,10 @@ describe("SessionManager", () => {
 
       it("reconciles a non-exited record with no pty only after it outlives the grace window", async () => {
         const { manager, spawns } = makeManager();
-        const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        const session = await manager.create({
+          cwd: "/tmp/proj",
+          harness: "claude-code",
+        });
         spawns[0]?.emitExit(0);
         const record = manager.get(session.id)!;
         record.status = "starting"; // simulate the stale mid-transition ghost
@@ -1026,7 +1246,10 @@ describe("SessionManager", () => {
   describe("setBoundWorkflowPath", () => {
     it("updates the in-memory session, persists it, and notifies status listeners", async () => {
       const { manager } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const statuses: (string | null)[] = [];
       manager.onStatusChange((s) => {
@@ -1039,13 +1262,20 @@ describe("SessionManager", () => {
       expect(manager.get(session.id)?.boundWorkflowPath).toBe("/tmp/leasing");
       expect(statuses).toEqual(["/tmp/leasing"]);
 
-      const raw = JSON.parse(await readFile(sessionsPath, "utf8")) as HarnessSession[];
-      expect(raw.find((s) => s.id === session.id)?.boundWorkflowPath).toBe("/tmp/leasing");
+      const raw = JSON.parse(
+        await readFile(sessionsPath, "utf8"),
+      ) as HarnessSession[];
+      expect(raw.find((s) => s.id === session.id)?.boundWorkflowPath).toBe(
+        "/tmp/leasing",
+      );
     });
 
     it("unbinds with null, persisting and notifying again", async () => {
       const { manager } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setBoundWorkflowPath(session.id, "/tmp/leasing");
 
       const statuses: (string | null)[] = [];
@@ -1065,14 +1295,19 @@ describe("SessionManager", () => {
       const statuses: string[] = [];
       manager.onStatusChange(() => statuses.push("fired"));
 
-      expect(() => manager.setBoundWorkflowPath("does-not-exist", "/tmp/leasing")).not.toThrow();
+      expect(() =>
+        manager.setBoundWorkflowPath("does-not-exist", "/tmp/leasing"),
+      ).not.toThrow();
       await manager.flush();
       expect(statuses).toEqual([]);
     });
 
     it("is a no-op when rebinding to the already-current value (no redundant persist/notify)", async () => {
       const { manager } = makeManager();
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       manager.setBoundWorkflowPath(session.id, "/tmp/leasing");
       await manager.flush();
 
@@ -1095,10 +1330,15 @@ describe("SessionManager", () => {
       return fake.pty as unknown as ReturnType<PtySpawnFn>;
     };
     const { manager } = makeManager({ spawnPty });
-    const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
 
     const env = capturedEnvs[0];
-    expect(env?.["SAPIOM_HARNESS_INGEST_URL"]).toBe("http://127.0.0.1:4100/ingest");
+    expect(env?.["SAPIOM_HARNESS_INGEST_URL"]).toBe(
+      "http://127.0.0.1:4100/ingest",
+    );
     expect(env?.["SAPIOM_HARNESS_INGEST_TOKEN"]).toBe("boot-token");
     expect(env?.["SAPIOM_HARNESS_SESSION_ID"]).toBe(session.id);
   });
@@ -1139,7 +1379,8 @@ describe("SessionManager", () => {
    * "0.28.1"` on a project that builds fine outside the app.
    */
   it("never leaks the host's ESBUILD_BINARY_PATH pin into the agent's environment", async () => {
-    process.env["ESBUILD_BINARY_PATH"] = "/app/resources/app.asar.unpacked/node_modules/@esbuild/linux-x64/bin/esbuild";
+    process.env["ESBUILD_BINARY_PATH"] =
+      "/app/resources/app.asar.unpacked/node_modules/@esbuild/linux-x64/bin/esbuild";
     const capturedEnvs: Record<string, string | undefined>[] = [];
     const spawnPty: PtySpawnFn = (_file, _args, options) => {
       capturedEnvs.push(options.env ?? {});
@@ -1175,7 +1416,10 @@ describe("SessionManager", () => {
         fakePid: 9999,
         isPidAlive: () => pidAlive,
       });
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
       expect(session.status).toBe("running");
 
       // Confirm the pty exists and won't emit onExit on its own — the exit
@@ -1204,8 +1448,14 @@ describe("SessionManager", () => {
     });
 
     it("kill() resolves immediately via real onExit when node-pty fires before the escalation window", async () => {
-      const { manager, spawns } = makeManager({ fakePid: 8888, isPidAlive: () => false });
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const { manager, spawns } = makeManager({
+        fakePid: 8888,
+        isPidAlive: () => false,
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const killPromise = manager.kill(session.id);
       // Drive the real onExit — this fires before the escalation timer.
@@ -1224,7 +1474,10 @@ describe("SessionManager", () => {
         fakePid: 7777,
         isPidAlive: () => pidAlive,
       });
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const killPromise = manager.kill(session.id);
       expect(spawns[0]?.pty.kill).toHaveBeenCalledTimes(1); // initial SIGTERM (no arg)
@@ -1243,7 +1496,10 @@ describe("SessionManager", () => {
     });
 
     it("killAll() resolves once all sessions are confirmed dead, even when exits come at different times", async () => {
-      const { manager, spawns } = makeManager({ fakePid: 6666, isPidAlive: () => false });
+      const { manager, spawns } = makeManager({
+        fakePid: 6666,
+        isPidAlive: () => false,
+      });
       const a = await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
       const b = await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
 
@@ -1275,7 +1531,10 @@ describe("SessionManager", () => {
       // Both ptys swallow their onExit events — killAll() must still resolve
       // via the missed-exit synthesis path within the escalation window.
       let pidAlive = true;
-      const { manager } = makeManager({ fakePid: 5555, isPidAlive: () => pidAlive });
+      const { manager } = makeManager({
+        fakePid: 5555,
+        isPidAlive: () => pidAlive,
+      });
       await manager.create({ cwd: "/tmp/a", harness: "claude-code" });
       await manager.create({ cwd: "/tmp/b", harness: "claude-code" });
 
@@ -1306,7 +1565,10 @@ describe("SessionManager", () => {
         // Always "alive" — simulates an EPERM zombie that survives all probes.
         isPidAlive: () => true,
       });
-      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
 
       const killPromise = manager.kill(session.id);
       // Initial signal sent.
@@ -1350,7 +1612,9 @@ describe("SessionManager", () => {
         lastActiveAt: new Date().toISOString(),
       });
 
-      await expect(manager.resume(session.id)).rejects.toThrow(ExternalHarnessError);
+      await expect(manager.resume(session.id)).rejects.toThrow(
+        ExternalHarnessError,
+      );
     });
 
     it("resume() ExternalHarnessError has code HARNESS_EXTERNAL and names the harness label", async () => {
@@ -1389,7 +1653,9 @@ describe("SessionManager", () => {
         lastActiveAt: new Date().toISOString(),
       });
 
-      await expect(manager.submitInput(session.id, "hello")).rejects.toThrow(ExternalHarnessError);
+      await expect(manager.submitInput(session.id, "hello")).rejects.toThrow(
+        ExternalHarnessError,
+      );
     });
 
     it("submitInput() ExternalHarnessError has code HARNESS_EXTERNAL", async () => {

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -48,7 +48,11 @@ export {
 // the whole server at import time.
 type IPty = import("node-pty").IPty;
 type PtyForkOptions = import("node-pty").IPtyForkOptions;
-export type PtySpawnFn = (file: string, args: string[], options: PtyForkOptions) => IPty;
+export type PtySpawnFn = (
+  file: string,
+  args: string[],
+  options: PtyForkOptions,
+) => IPty;
 
 let defaultSpawn: PtySpawnFn | undefined;
 let defaultSpawnError: Error | undefined;
@@ -67,7 +71,9 @@ let defaultSpawnError: Error | undefined;
 export async function ensureSpawnHelperExecutable(): Promise<void> {
   if (process.platform === "win32") return;
   try {
-    const nodePtyPkgJson = createRequire(import.meta.url).resolve("node-pty/package.json");
+    const nodePtyPkgJson = createRequire(import.meta.url).resolve(
+      "node-pty/package.json",
+    );
     const helperPath = join(
       dirname(nodePtyPkgJson),
       "prebuilds",
@@ -189,8 +195,13 @@ export type SessionActivityListener = (harnessSessionId: string) => void;
  */
 export type LaunchOptsBuilder = (
   harnessSessionId: string,
-  req: Pick<CreateSessionRequest, "cwd" | "harness" | "profile" | "rehydrateFrom">,
-) => Omit<LaunchOpts, "harnessSessionId" | "cwd"> | Promise<Omit<LaunchOpts, "harnessSessionId" | "cwd">>;
+  req: Pick<
+    CreateSessionRequest,
+    "cwd" | "harness" | "profile" | "rehydrateFrom"
+  >,
+) =>
+  | Omit<LaunchOpts, "harnessSessionId" | "cwd">
+  | Promise<Omit<LaunchOpts, "harnessSessionId" | "cwd">>;
 
 const defaultBuildLaunchOpts: LaunchOptsBuilder = () => ({});
 
@@ -280,8 +291,12 @@ export class SessionManager {
   private readonly buildLaunchOpts: LaunchOptsBuilder;
   private readonly now: () => string;
   private readonly generateId: () => string;
-  private readonly writeWorkspaceContext: (session: HarnessSession) => Promise<void>;
-  private readonly prepareWorkspaceContext: (session: HarnessSession) => Promise<void>;
+  private readonly writeWorkspaceContext: (
+    session: HarnessSession,
+  ) => Promise<void>;
+  private readonly prepareWorkspaceContext: (
+    session: HarnessSession,
+  ) => Promise<void>;
   private readonly ensureCanvasTemplate: (cwd: string) => Promise<void>;
   private readonly isPidAlive: (pid: number) => boolean;
 
@@ -300,14 +315,19 @@ export class SessionManager {
     this.ingestUrl = options.ingestUrl;
     this.ingestToken = options.ingestToken;
     this.collectorUrl = options.collectorUrl;
-    this.sessionsPath = expandHome(options.sessionsPath ?? HARNESS_PATHS.sessions);
+    this.sessionsPath = expandHome(
+      options.sessionsPath ?? HARNESS_PATHS.sessions,
+    );
     this.spawnPty = options.spawnPty;
     this.buildLaunchOpts = options.buildLaunchOpts ?? defaultBuildLaunchOpts;
     this.now = options.now ?? (() => new Date().toISOString());
     this.generateId = options.generateId ?? randomUUID;
-    this.writeWorkspaceContext = options.writeWorkspaceContext ?? (async () => {});
-    this.prepareWorkspaceContext = options.prepareWorkspaceContext ?? (async () => {});
-    this.ensureCanvasTemplate = options.ensureCanvasTemplate ?? (async () => {});
+    this.writeWorkspaceContext =
+      options.writeWorkspaceContext ?? (async () => {});
+    this.prepareWorkspaceContext =
+      options.prepareWorkspaceContext ?? (async () => {});
+    this.ensureCanvasTemplate =
+      options.ensureCanvasTemplate ?? (async () => {});
     this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
     // Many WS clients (terminal + events) can subscribe over a long-running process.
     this.statusEmitter.setMaxListeners(0);
@@ -372,7 +392,8 @@ export class SessionManager {
       // with harness="conductor" (written by an earlier build, hand-edited, or
       // a future registration) hits this path on resume/submitInput.
       const info = listHarnessAdapters().find((a) => a.id === harness);
-      if (info?.mode === "external") throw new ExternalHarnessError(harness, info.label);
+      if (info?.mode === "external")
+        throw new ExternalHarnessError(harness, info.label);
       throw new AdapterNotFoundError(harness);
     }
     return adapter;
@@ -387,6 +408,23 @@ export class SessionManager {
       ...(await this.buildLaunchOpts(id, req)),
     };
     const spec = adapter.launch(opts);
+    // Portable continuation starts a new coding-agent conversation, but when
+    // the source is one of OUR tracked sessions its project binding is durable
+    // Studio state and can be carried forward independently of vendor context.
+    // Require both an assembled brief and the same cwd: an arbitrary
+    // rehydrateFrom id must never bind an unrelated directory.
+    const rehydratedSession = opts.rehydratedFrom
+      ? (this.sessions.get(req.rehydrateFrom ?? "") ??
+        Array.from(this.sessions.values()).find(
+          (candidate) =>
+            candidate.agentSessionId === req.rehydrateFrom &&
+            candidate.cwd === req.cwd,
+        ))
+      : undefined;
+    const preservedBinding =
+      rehydratedSession?.cwd === req.cwd
+        ? rehydratedSession.boundWorkflowPath
+        : null;
     const session: HarnessSession = {
       id,
       agentSessionId: null,
@@ -397,7 +435,7 @@ export class SessionManager {
       createdAt: this.now(),
       lastActiveAt: this.now(),
       exitCode: null,
-      boundWorkflowPath: null,
+      boundWorkflowPath: preservedBinding,
       // What the builder actually managed to assemble, not what the caller
       // asked for: `req.rehydrateFrom` naming a session our event log holds
       // nothing for yields no brief, and this stays null so nothing downstream
@@ -484,7 +522,9 @@ export class SessionManager {
     // Failing here instead keeps the record exactly as it was — unspawned,
     // and (see below) with its real lastActiveAt intact.
     if (!(await adapter.canResume(session.agentSessionId, session.cwd))) {
-      const label = listHarnessAdapters().find((a) => a.id === session.harness)?.label ?? session.harness;
+      const label =
+        listHarnessAdapters().find((a) => a.id === session.harness)?.label ??
+        session.harness;
       throw new SessionNotResumeableError(
         id,
         `${label} no longer has the conversation for this session (${session.agentSessionId}) in ${session.cwd}. ` +
@@ -641,7 +681,10 @@ export class SessionManager {
       if (handle) {
         // Guard against non-numeric pids (test fakes) — never probe the OS
         // with a garbage value, and never declare a session dead on one.
-        if (typeof handle.pty.pid === "number" && !this.isPidAlive(handle.pty.pid)) {
+        if (
+          typeof handle.pty.pid === "number" &&
+          !this.isPidAlive(handle.pty.pid)
+        ) {
           this.markExited(session.id, handle, null);
         }
         continue;
@@ -651,7 +694,8 @@ export class SessionManager {
       // so only sweep records older than the grace period (an unparseable
       // lastActiveAt is garbage and sweeps immediately).
       const ageMs = Date.now() - Date.parse(session.lastActiveAt);
-      if (!(ageMs < NO_PTY_SWEEP_GRACE_MS)) void this.transitionExited(session, null);
+      if (!(ageMs < NO_PTY_SWEEP_GRACE_MS))
+        void this.transitionExited(session, null);
     }
   }
 
@@ -692,7 +736,8 @@ export class SessionManager {
     const handle = this.ptys.get(id);
     if (!handle) {
       const info = listHarnessAdapters().find((a) => a.id === session.harness);
-      if (info?.mode === "external") throw new ExternalHarnessError(session.harness, info.label);
+      if (info?.mode === "external")
+        throw new ExternalHarnessError(session.harness, info.label);
       return false;
     }
     if (!this.isReadyEnough(session, handle)) {
@@ -825,7 +870,9 @@ export class SessionManager {
     // what's actually on screen right now; checking the whole history would
     // make a session that dismissed its trust prompt minutes ago look
     // permanently stuck.
-    return !adapter.detectBlockingPrompt(handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES));
+    return !adapter.detectBlockingPrompt(
+      handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES),
+    );
   }
 
   /**
@@ -835,7 +882,10 @@ export class SessionManager {
    * keystrokes) must never wait on this, since a human answering the very
    * prompt this is waiting out is exactly how a session becomes ready.
    */
-  private async waitUntilReady(id: string, timeoutMs: number): Promise<boolean> {
+  private async waitUntilReady(
+    id: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
       const handle = this.ptys.get(id);
@@ -916,7 +966,14 @@ export class SessionManager {
     const exited = new Promise<void>((resolve) => {
       resolveExited = resolve;
     });
-    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now(), exited, resolveExited };
+    const handle: PtyHandle = {
+      pty,
+      buffer: "",
+      emitter,
+      spawnedAt: Date.now(),
+      exited,
+      resolveExited,
+    };
     this.ptys.set(session.id, handle);
 
     session.status = "running";
@@ -946,7 +1003,11 @@ export class SessionManager {
    * silent no-op rather than double-transitioning or clobbering a newer
    * session/handle that's since taken its place (e.g. a resume).
    */
-  private markExited(id: string, handle: PtyHandle, exitCode: number | null): void {
+  private markExited(
+    id: string,
+    handle: PtyHandle,
+    exitCode: number | null,
+  ): void {
     if (this.ptys.get(id) !== handle) return;
     this.ptys.delete(id);
     this.lastActivityBroadcast.delete(id);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -121,10 +121,7 @@ import { createFsRouter } from "./fs.js";
 import { createRunsRouter } from "./runs.js";
 import { createTemplatesRouter } from "./templates.js";
 import { createActionsRouter } from "./actions.js";
-import {
-  createAuthRouter,
-  createMutableAuthState,
-} from "./auth-routes.js";
+import { createAuthRouter, createMutableAuthState } from "./auth-routes.js";
 // resolveAgentsBaseUrl is imported above from definition-slug-resolver.js
 // (an identical helper); the runs router reuses it for its agents base URL.
 
@@ -356,7 +353,9 @@ function createDefaultBuildLaunchOpts(
       ...(pluginDir ? { pluginDir } : {}),
       // Set on BOTH channels: the post-ready path hasn't delivered yet, but a
       // brief exists and will, and this is the flag that tells it to.
-      ...(brief !== null && rehydrateFrom ? { rehydratedFrom: rehydrateFrom } : {}),
+      ...(brief !== null && rehydrateFrom
+        ? { rehydratedFrom: rehydrateFrom }
+        : {}),
     };
   };
 }
@@ -387,11 +386,15 @@ export const startServer = async (
   const machineId =
     options.machineId ?? (await getOrCreateMachineId(statePaths.machineId));
 
-  // One-way identity migration: seed ~/.sapiom/analytics.json from the
+  // One-way identity migration: seed ~/.sapiom/analytics.json from the real
   // legacy harness machine-id so existing installs keep the same anonymous_id
-  // after the upgrade (longitudinal join key survives). No-op when analytics.json
-  // already exists or when HOME is unwritable.
-  await migrateHarnessIdentity(statePaths.machineId);
+  // after the upgrade (longitudinal join key survives). An explicit stateRoot is
+  // a throwaway Harness installation: never let its fresh machine id mutate the
+  // shared analytics identity outside that root. With telemetry hard-off, that
+  // makes a clean-room boot leave normal user state untouched.
+  if (options.stateRoot === undefined) {
+    await migrateHarnessIdentity(statePaths.machineId);
+  }
   const launchDir = options.launchDir ?? process.cwd();
 
   // Serve-time slug enrichment: resolves each workflow's definitionSlug from
@@ -532,9 +535,13 @@ export const startServer = async (
   }, WORKFLOWS_CACHE_REFRESH_MS);
   workflowsCacheTimer.unref?.();
 
-  const boundWorkflowForSession = (session: HarnessSession): WorkflowInfo | null =>
+  const boundWorkflowForSession = (
+    session: HarnessSession,
+  ): WorkflowInfo | null =>
     session.boundWorkflowPath
-      ? (workflowsCache.find((workflow) => workflow.path === session.boundWorkflowPath) ?? null)
+      ? (workflowsCache.find(
+          (workflow) => workflow.path === session.boundWorkflowPath,
+        ) ?? null)
       : null;
 
   /**
@@ -548,19 +555,31 @@ export const startServer = async (
   const writeSessionContext = async (
     session: HarnessSession,
   ): Promise<void> => {
-    await writeHarnessContext(session, boundWorkflowForSession(session), workflowsCache);
+    await writeHarnessContext(
+      session,
+      boundWorkflowForSession(session),
+      workflowsCache,
+    );
   };
 
   const initializeSessionContext = async (
     session: HarnessSession,
   ): Promise<void> => {
-    await writeHarnessContextForLaunch(session, boundWorkflowForSession(session), workflowsCache);
+    await writeHarnessContextForLaunch(
+      session,
+      boundWorkflowForSession(session),
+      workflowsCache,
+    );
   };
 
   const prepareSessionContext = async (
     session: HarnessSession,
   ): Promise<void> => {
-    await prepareHarnessContextForResume(session, boundWorkflowForSession(session), workflowsCache);
+    await prepareHarnessContextForResume(
+      session,
+      boundWorkflowForSession(session),
+      workflowsCache,
+    );
   };
 
   // Declared before the launch-opts builder (rather than beside the ingest
@@ -601,7 +620,9 @@ export const startServer = async (
    * grows the store — enforcing the caps at the moment they can be exceeded
    * beats waiting for the next boot.
    */
-  const archiveSessionRecord = async (harnessSessionId: string): Promise<void> => {
+  const archiveSessionRecord = async (
+    harnessSessionId: string,
+  ): Promise<void> => {
     const record = await sessionRecordReader.readFromEvents(harnessSessionId);
     if (!record) return;
     if (!(await recordArchive.write(record))) return;
@@ -629,13 +650,18 @@ export const startServer = async (
    * doesn't apply to a single deliberate action). Null for a harness whose
    * transcript doesn't record a branch, and never throws.
    */
-  const priorGitBranch = async (record: SessionRecord): Promise<string | null> => {
+  const priorGitBranch = async (
+    record: SessionRecord,
+  ): Promise<string | null> => {
     if (!record.cwd || !record.agentSessionId) return null;
     const adapter = adapters[record.harness];
     if (!adapter) return null;
     try {
       const rows = await adapter.listPastSessions(record.cwd);
-      return rows.find((row) => row.agentSessionId === record.agentSessionId)?.gitBranch ?? null;
+      return (
+        rows.find((row) => row.agentSessionId === record.agentSessionId)
+          ?.gitBranch ?? null
+      );
     } catch {
       return null;
     }
@@ -650,10 +676,13 @@ export const startServer = async (
    * safe because nothing can create a session before the manager that creates
    * them exists.
    */
-  const resolveRehydrationBrief = (rehydrateFrom: string): Promise<string | null> =>
+  const resolveRehydrationBrief = (
+    rehydrateFrom: string,
+  ): Promise<string | null> =>
     buildRehydrationBrief(rehydrateFrom, {
       readRecord: (id) => sessionRecordReader.read(id),
-      readSummary: (harnessSessionId) => readRollingSummary(generatedRoot, harnessSessionId),
+      readSummary: (harnessSessionId) =>
+        readRollingSummary(generatedRoot, harnessSessionId),
       resolveContext: async (record) => {
         // The earliest merged session the registry still knows — the record's
         // own primary id first, so a conversation that spans a resume reports
@@ -669,7 +698,11 @@ export const startServer = async (
           title: prior?.title ?? null,
           gitBranch: await priorGitBranch(record),
           workflow: workflow
-            ? { name: workflow.name, path: workflow.path, definitionId: workflow.definitionId }
+            ? {
+                name: workflow.name,
+                path: workflow.path,
+                definitionId: workflow.definitionId,
+              }
             : null,
         };
       },
@@ -722,7 +755,11 @@ export const startServer = async (
     }
     const rehydratedFrom = session.rehydratedFrom;
     if (!session.ready || !rehydratedFrom) return;
-    if (systemPromptDeliveryFor(adapters[session.harness]) !== "post-ready-injection") return;
+    if (
+      systemPromptDeliveryFor(adapters[session.harness]) !==
+      "post-ready-injection"
+    )
+      return;
     if (briefsDelivered.has(session.id)) return;
     // Claimed before the await so a burst of status frames can't double-inject.
     briefsDelivered.add(session.id);
@@ -772,11 +809,15 @@ export const startServer = async (
   // last-N-turns, which is also the default for everyone with the setting off.
   const rollingSummarizer = createRollingSummarizer({
     generatedRoot,
-    enabled: async () => (await loadSettings(statePaths.settings)).rollingSummary === true,
-    readRecord: (harnessSessionId) => sessionRecordReader.read(harnessSessionId),
+    enabled: async () =>
+      (await loadSettings(statePaths.settings)).rollingSummary === true,
+    readRecord: (harnessSessionId) =>
+      sessionRecordReader.read(harnessSessionId),
     getSession: (harnessSessionId) => {
       const session = sessionManager.get(harnessSessionId);
-      return session ? { harness: session.harness, cwd: session.cwd } : undefined;
+      return session
+        ? { harness: session.harness, cwd: session.cwd }
+        : undefined;
     },
     runTask: (req) => taskManager.run(req),
   });
@@ -1240,7 +1281,8 @@ export const startServer = async (
       renderCanvas: async (harnessSessionId) => {
         const session = sessionManager.get(harnessSessionId);
         if (!session) return;
-        if (session.boundWorkflowPath) invalidateExtractionCache(session.boundWorkflowPath);
+        if (session.boundWorkflowPath)
+          invalidateExtractionCache(session.boundWorkflowPath);
         await renderCanvas(session);
       },
       injectInput: async (harnessSessionId, text, submit) => {
@@ -1338,7 +1380,8 @@ export const startServer = async (
       // store, so the archived record carries the whole conversation including
       // its `endedAt`. (The "exited" status handler archives too, for sessions
       // that never get here.)
-      if (event.type === "session.end") archiveSessionRecordDetached(event.harnessSessionId);
+      if (event.type === "session.end")
+        archiveSessionRecordDetached(event.harnessSessionId);
     },
     onError: (err) => console.error("[harness] ingest processing error:", err),
     seqCounter,

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -13,11 +13,28 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir: () => tmpHome };
 });
 
-import type { HarnessAdapter, HarnessKind, HarnessSession, MacroDef, SessionRecord, SessionSummary, SpawnSpec, WorkflowInfo } from "../shared/types.js";
+import type {
+  HarnessAdapter,
+  HarnessKind,
+  HarnessSession,
+  MacroDef,
+  SessionRecord,
+  SessionSummary,
+  SpawnSpec,
+  WorkflowInfo,
+} from "../shared/types.js";
 import { MAX_IMAGE_UPLOAD_BYTES } from "../shared/types.js";
-import { SessionManager, SessionNotReadyError, UnknownSessionError } from "../core/session-manager.js";
+import {
+  SessionManager,
+  SessionNotReadyError,
+  UnknownSessionError,
+} from "../core/session-manager.js";
 import type { SessionRecordReader } from "../core/session-record.js";
-import { AdapterNotFoundError, SessionAlreadyLiveError, SessionNotResumeableError } from "../core/errors.js";
+import {
+  AdapterNotFoundError,
+  SessionAlreadyLiveError,
+  SessionNotResumeableError,
+} from "../core/errors.js";
 import { createRestRouter, type RestRouterOptions } from "./rest.js";
 
 const TOKEN_HEADER = { "X-Harness-Token": "unused-in-router-tests" };
@@ -36,28 +53,38 @@ function fakeSessionManager(initial: HarnessSession[] = []) {
       const session = sessions.get(id);
       if (session) session.boundWorkflowPath = workflowPath;
     }),
-    registerHistorical: vi.fn((input: { agentSessionId: string; harness: HarnessKind; cwd: string; title: string; lastActiveAt: string }) => {
-      const session: HarnessSession = {
-        id: `adopted-${input.agentSessionId}`,
-        agentSessionId: input.agentSessionId,
-        harness: input.harness,
-        cwd: input.cwd,
-        title: input.title,
-        status: "exited",
-        createdAt: input.lastActiveAt,
-        lastActiveAt: input.lastActiveAt,
-        exitCode: null,
-        boundWorkflowPath: null,
-        ready: false,
-      };
-      sessions.set(session.id, session);
-      return session;
-    }),
+    registerHistorical: vi.fn(
+      (input: {
+        agentSessionId: string;
+        harness: HarnessKind;
+        cwd: string;
+        title: string;
+        lastActiveAt: string;
+      }) => {
+        const session: HarnessSession = {
+          id: `adopted-${input.agentSessionId}`,
+          agentSessionId: input.agentSessionId,
+          harness: input.harness,
+          cwd: input.cwd,
+          title: input.title,
+          status: "exited",
+          createdAt: input.lastActiveAt,
+          lastActiveAt: input.lastActiveAt,
+          exitCode: null,
+          boundWorkflowPath: null,
+          ready: false,
+        };
+        sessions.set(session.id, session);
+        return session;
+      },
+    ),
   } as unknown as RestRouterOptions["sessionManager"];
 }
 
 /** An exited registry session — the shape a past-sessions row is built from. */
-function exitedSession(overrides: Partial<HarnessSession> = {}): HarnessSession {
+function exitedSession(
+  overrides: Partial<HarnessSession> = {},
+): HarnessSession {
   return {
     id: "sess-1",
     agentSessionId: "agent-1",
@@ -76,15 +103,22 @@ function exitedSession(overrides: Partial<HarnessSession> = {}): HarnessSession 
 
 /** A history adapter whose resumability answer and transcript listing are both
  *  controllable — the two independent inputs the history endpoint merges. */
-function historyAdapter(opts: {
-  canResume?: HarnessAdapter["canResume"];
-  listPastSessions?: HarnessAdapter["listPastSessions"];
-} = {}): HarnessAdapter {
+function historyAdapter(
+  opts: {
+    canResume?: HarnessAdapter["canResume"];
+    listPastSessions?: HarnessAdapter["listPastSessions"];
+  } = {},
+): HarnessAdapter {
   return {
     id: "claude-code",
     eventSource: "hooks" as const,
     doctor: async () => [],
-    launch: (o): SpawnSpec => ({ command: "fake-claude", args: [], env: {}, cwd: o.cwd }),
+    launch: (o): SpawnSpec => ({
+      command: "fake-claude",
+      args: [],
+      env: {},
+      cwd: o.cwd,
+    }),
     resume: (agentSessionId, o): SpawnSpec => ({
       command: "fake-claude",
       args: ["--resume", agentSessionId],
@@ -233,7 +267,11 @@ describe("createRestRouter", () => {
 
       start({
         sessionManager: fakeSessionManager([session]),
-        identity: { userId: "user-1", tenantId: "user-1", organizationName: "Acme" },
+        identity: {
+          userId: "user-1",
+          tenantId: "user-1",
+          organizationName: "Acme",
+        },
         listWorkflows: async () => [workflow],
         listMacros: () => [macro],
       });
@@ -487,7 +525,10 @@ describe("createRestRouter", () => {
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     const PNG_DATA_URL = `data:image/png;base64,${PNG_BASE64}`;
 
-    function seededSession(cwd: string, harness: HarnessKind = "claude-code"): HarnessSession {
+    function seededSession(
+      cwd: string,
+      harness: HarnessKind = "claude-code",
+    ): HarnessSession {
       return {
         id: "sess-img",
         agentSessionId: null,
@@ -514,15 +555,25 @@ describe("createRestRouter", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { path: string; mediaType: string; bytes: number };
+      const body = (await res.json()) as {
+        path: string;
+        mediaType: string;
+        bytes: number;
+      };
       expect(body.mediaType).toBe("image/png");
       expect(body.bytes).toBeGreaterThan(0);
-      expect(body.path.startsWith(path.join(cwd, ".sapiom", "uploads"))).toBe(true);
+      expect(body.path.startsWith(path.join(cwd, ".sapiom", "uploads"))).toBe(
+        true,
+      );
       expect(body.path.endsWith(".png")).toBe(true);
       // The file really exists and the path (with a trailing space) was injected
       // into the pty without submitting, so the user can add a message.
       await expect(fs.stat(body.path)).resolves.toBeDefined();
-      expect(sessionManager.submitInput).toHaveBeenCalledWith("sess-img", `${body.path} `, false);
+      expect(sessionManager.submitInput).toHaveBeenCalledWith(
+        "sess-img",
+        `${body.path} `,
+        false,
+      );
 
       await fs.rm(cwd, { recursive: true, force: true });
     });
@@ -627,9 +678,9 @@ describe("createRestRouter", () => {
     it("409s when the session isn't ready yet (SessionNotReadyError)", async () => {
       const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "harness-img-"));
       const sessionManager = fakeSessionManager([seededSession(cwd)]);
-      (sessionManager.submitInput as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new SessionNotReadyError("sess-img"),
-      );
+      (
+        sessionManager.submitInput as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new SessionNotReadyError("sess-img"));
       start({ sessionManager });
 
       const res = await fetch(`${baseUrl}/sessions/sess-img/image`, {
@@ -744,7 +795,8 @@ describe("createRestRouter", () => {
 
       expect(res.status).toBe(400);
       expect(await res.json()).toEqual({
-        error: "Unknown agent path '/not/registered' — scan or connect it before binding a session to it",
+        error:
+          "Unknown agent path '/not/registered' — scan or connect it before binding a session to it",
       });
       expect(sessionManager.setBoundWorkflowPath).not.toHaveBeenCalled();
       expect(writeWorkspaceContext).not.toHaveBeenCalled();
@@ -866,9 +918,12 @@ describe("createRestRouter", () => {
 
   describe("GET /sessions/history — server-verified resumeMode", () => {
     async function history(cwd: string): Promise<SessionSummary[]> {
-      const res = await fetch(`${baseUrl}/sessions/history?cwd=${encodeURIComponent(cwd)}`, {
-        headers: TOKEN_HEADER,
-      });
+      const res = await fetch(
+        `${baseUrl}/sessions/history?cwd=${encodeURIComponent(cwd)}`,
+        {
+          headers: TOKEN_HEADER,
+        },
+      );
       expect(res.status).toBe(200);
       return (await res.json()) as SessionSummary[];
     }
@@ -876,12 +931,18 @@ describe("createRestRouter", () => {
     it("marks a registry row the agent still holds as agent-resume", async () => {
       start({
         sessionManager: fakeSessionManager([exitedSession()]),
-        adapters: { "claude-code": historyAdapter({ canResume: async () => true }) },
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => true }),
+        },
       });
 
       const rows = await history("/tmp/proj");
       expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ agentSessionId: "agent-1", source: "registry", resumeMode: "agent-resume" });
+      expect(rows[0]).toMatchObject({
+        agentSessionId: "agent-1",
+        source: "registry",
+        resumeMode: "agent-resume",
+      });
     });
 
     it("marks a PHANTOM registry row as rehydrate — an agentSessionId is not evidence of a conversation", async () => {
@@ -890,11 +951,16 @@ describe("createRestRouter", () => {
       // button whose only possible outcome was exit 1.
       start({
         sessionManager: fakeSessionManager([exitedSession()]),
-        adapters: { "claude-code": historyAdapter({ canResume: async () => false }) },
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => false }),
+        },
       });
 
       const rows = await history("/tmp/proj");
-      expect(rows[0]).toMatchObject({ source: "registry", resumeMode: "rehydrate" });
+      expect(rows[0]).toMatchObject({
+        source: "registry",
+        resumeMode: "rehydrate",
+      });
     });
 
     it("probes with the row's own agentSessionId and cwd", async () => {
@@ -929,12 +995,68 @@ describe("createRestRouter", () => {
       });
 
       const rows = await history("/tmp/proj");
-      expect(rows[0]).toMatchObject({ source: "transcript", resumeMode: "agent-resume" });
+      expect(rows[0]).toMatchObject({
+        source: "transcript",
+        resumeMode: "agent-resume",
+      });
+    });
+
+    it("keeps healthy history sources and registry rows when one adapter scan fails", async () => {
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      start({
+        sessionManager: fakeSessionManager([exitedSession()]),
+        adapters: {
+          "claude-code": historyAdapter({
+            listPastSessions: async () => {
+              throw new Error("Claude history is unreadable");
+            },
+            canResume: async () => false,
+          }),
+          codex: {
+            ...historyAdapter(),
+            id: "codex",
+            listPastSessions: async () => [
+              {
+                agentSessionId: "healthy-agent-session",
+                harness: "codex",
+                cwd: "/tmp/proj",
+                title: "Healthy source",
+                lastActiveAt: "2026-01-03T00:00:00.000Z",
+                source: "transcript",
+              },
+            ],
+          },
+        },
+      });
+
+      const rows = await history("/tmp/proj");
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agentSessionId: "agent-1",
+            resumeMode: "rehydrate",
+          }),
+          expect.objectContaining({
+            agentSessionId: "healthy-agent-session",
+            resumeMode: "agent-resume",
+          }),
+        ]),
+      );
+      expect(error).toHaveBeenCalledWith(
+        "[harness] claude-code history scan failed:",
+        expect.any(Error),
+      );
+      error.mockRestore();
     });
 
     it("resolves each row independently — a phantom and a live transcript in one directory", async () => {
       start({
-        sessionManager: fakeSessionManager([exitedSession({ id: "sess-phantom", agentSessionId: "agent-phantom" })]),
+        sessionManager: fakeSessionManager([
+          exitedSession({
+            id: "sess-phantom",
+            agentSessionId: "agent-phantom",
+          }),
+        ]),
         adapters: {
           "claude-code": historyAdapter({
             canResume: async (id) => id !== "agent-phantom",
@@ -952,7 +1074,12 @@ describe("createRestRouter", () => {
         },
       });
 
-      const byId = new Map((await history("/tmp/proj")).map((row) => [row.agentSessionId, row.resumeMode]));
+      const byId = new Map(
+        (await history("/tmp/proj")).map((row) => [
+          row.agentSessionId,
+          row.resumeMode,
+        ]),
+      );
       expect(byId.get("agent-phantom")).toBe("rehydrate");
       expect(byId.get("agent-real")).toBe("agent-resume");
     });
@@ -975,13 +1102,18 @@ describe("createRestRouter", () => {
       ]);
       start({
         sessionManager: fakeSessionManager([exitedSession()]),
-        adapters: { "claude-code": historyAdapter({ canResume, listPastSessions }) },
+        adapters: {
+          "claude-code": historyAdapter({ canResume, listPastSessions }),
+        },
       });
 
       const rows = await history("/tmp/proj");
       expect(rows).toHaveLength(1);
       // Registry row wins the merge (it carries live status) and is resumable.
-      expect(rows[0]).toMatchObject({ source: "registry", resumeMode: "agent-resume" });
+      expect(rows[0]).toMatchObject({
+        source: "registry",
+        resumeMode: "agent-resume",
+      });
       expect(listPastSessions).toHaveBeenCalledTimes(1);
       expect(canResume).not.toHaveBeenCalled();
     });
@@ -1010,7 +1142,12 @@ describe("createRestRouter", () => {
         },
       });
 
-      const byId = new Map((await history("/tmp/proj")).map((r) => [r.agentSessionId, r.resumeMode]));
+      const byId = new Map(
+        (await history("/tmp/proj")).map((r) => [
+          r.agentSessionId,
+          r.resumeMode,
+        ]),
+      );
       expect(byId.get("agent-found")).toBe("agent-resume");
       expect(byId.get("agent-missed")).toBe("rehydrate");
       expect(canResume.mock.calls).toEqual([["agent-missed", "/tmp/proj"]]);
@@ -1020,7 +1157,9 @@ describe("createRestRouter", () => {
       // e.g. an external-mode harness, or a kind persisted by another build:
       // unverifiable is not the same as resumable.
       start({
-        sessionManager: fakeSessionManager([exitedSession({ harness: "conductor" as HarnessKind })]),
+        sessionManager: fakeSessionManager([
+          exitedSession({ harness: "conductor" as HarnessKind }),
+        ]),
         adapters: {},
       });
 
@@ -1064,27 +1203,45 @@ describe("createRestRouter", () => {
 
     it("registers a transcript-only row and resumes it for real", async () => {
       const sessionManager = fakeSessionManager();
-      (sessionManager.resume as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => ({
-        ...exitedSession({ id, agentSessionId: body.agentSessionId }),
-        status: "running",
-      }));
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume: async () => true }) } });
+      (sessionManager.resume as ReturnType<typeof vi.fn>).mockImplementation(
+        async (id: string) => ({
+          ...exitedSession({ id, agentSessionId: body.agentSessionId }),
+          status: "running",
+        }),
+      );
+      start({
+        sessionManager,
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => true }),
+        },
+      });
 
       const res = await adopt(body);
       expect(res.status).toBe(200);
-      expect((await res.json()) as HarnessSession).toMatchObject({ status: "running" });
+      expect((await res.json()) as HarnessSession).toMatchObject({
+        status: "running",
+      });
       expect(sessionManager.registerHistorical).toHaveBeenCalledWith(body);
       // The whole point: a real resume, not a fresh session.
-      expect(sessionManager.resume).toHaveBeenCalledWith("adopted-agent-transcript");
+      expect(sessionManager.resume).toHaveBeenCalledWith(
+        "adopted-agent-transcript",
+      );
     });
 
     it("409s SESSION_NOT_RESUMEABLE without registering anything when the agent no longer holds it", async () => {
       const sessionManager = fakeSessionManager();
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume: async () => false }) } });
+      start({
+        sessionManager,
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => false }),
+        },
+      });
 
       const res = await adopt(body);
       expect(res.status).toBe(409);
-      expect((await res.json()) as { code: string }).toMatchObject({ code: "SESSION_NOT_RESUMEABLE" });
+      expect((await res.json()) as { code: string }).toMatchObject({
+        code: "SESSION_NOT_RESUMEABLE",
+      });
       // No phantom record left behind by a stale history row.
       expect(sessionManager.registerHistorical).not.toHaveBeenCalled();
       expect(sessionManager.resume).not.toHaveBeenCalled();
@@ -1093,17 +1250,33 @@ describe("createRestRouter", () => {
     it("re-verifies server-side — a client claiming resumability cannot force a registration", async () => {
       const sessionManager = fakeSessionManager();
       const canResume = vi.fn(async () => false);
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume }) } });
+      start({
+        sessionManager,
+        adapters: { "claude-code": historyAdapter({ canResume }) },
+      });
 
-      expect((await adopt({ ...body, resumeMode: "agent-resume" })).status).toBe(409);
+      expect(
+        (await adopt({ ...body, resumeMode: "agent-resume" })).status,
+      ).toBe(409);
       expect(canResume).toHaveBeenCalledWith(body.agentSessionId, body.cwd);
     });
 
     it("is idempotent: an already-tracked row resumes its existing record instead of duplicating it", async () => {
-      const existing = exitedSession({ id: "sess-existing", agentSessionId: body.agentSessionId });
+      const existing = exitedSession({
+        id: "sess-existing",
+        agentSessionId: body.agentSessionId,
+      });
       const sessionManager = fakeSessionManager([existing]);
-      (sessionManager.resume as ReturnType<typeof vi.fn>).mockResolvedValue({ ...existing, status: "running" });
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume: async () => true }) } });
+      (sessionManager.resume as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...existing,
+        status: "running",
+      });
+      start({
+        sessionManager,
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => true }),
+        },
+      });
 
       expect((await adopt(body)).status).toBe(200);
       expect(sessionManager.registerHistorical).not.toHaveBeenCalled();
@@ -1123,7 +1296,12 @@ describe("createRestRouter", () => {
       // `POST /sessions/:id` exists to catch it. This pins that, so adding
       // such a route later can't silently reroute adopt through resume().
       const sessionManager = fakeSessionManager();
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume: async () => false }) } });
+      start({
+        sessionManager,
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => false }),
+        },
+      });
 
       const res = await adopt(body);
       expect(res.status).toBe(409);
@@ -1135,11 +1313,18 @@ describe("createRestRouter", () => {
       (sessionManager.resume as ReturnType<typeof vi.fn>).mockRejectedValue(
         new SessionAlreadyLiveError("adopted-agent-transcript"),
       );
-      start({ sessionManager, adapters: { "claude-code": historyAdapter({ canResume: async () => true }) } });
+      start({
+        sessionManager,
+        adapters: {
+          "claude-code": historyAdapter({ canResume: async () => true }),
+        },
+      });
 
       const res = await adopt(body);
       expect(res.status).toBe(409);
-      expect((await res.json()) as { code: string }).toMatchObject({ code: "SESSION_ALREADY_LIVE" });
+      expect((await res.json()) as { code: string }).toMatchObject({
+        code: "SESSION_ALREADY_LIVE",
+      });
     });
   });
 
@@ -1176,7 +1361,10 @@ describe("createRestRouter", () => {
     it("surfaces each adapter's imageInput capability", async () => {
       start();
       const res = await fetch(`${baseUrl}/harnesses`);
-      const body = (await res.json()) as Array<{ id: string; imageInput: boolean }>;
+      const body = (await res.json()) as Array<{
+        id: string;
+        imageInput: boolean;
+      }>;
       for (const entry of body) {
         expect(typeof entry.imageInput).toBe("boolean");
       }
@@ -1377,7 +1565,9 @@ describe("createRestRouter", () => {
       limitations: [],
     };
 
-    function stubRecords(overrides: Partial<SessionRecordReader> = {}): SessionRecordReader {
+    function stubRecords(
+      overrides: Partial<SessionRecordReader> = {},
+    ): SessionRecordReader {
       const find = async (id: string): Promise<SessionRecord | null> =>
         id === "sess-1" || id === "agent-1" ? record : null;
       return {
@@ -1391,26 +1581,34 @@ describe("createRestRouter", () => {
 
     it("GET /sessions/:id/record returns the reconstructed record", async () => {
       start({ sessionRecords: stubRecords() });
-      const res = await fetch(`${baseUrl}/sessions/sess-1/record`, { headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sessions/sess-1/record`, {
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(record);
     });
 
     it("GET /sessions/:id/record resolves an agent session id too", async () => {
       start({ sessionRecords: stubRecords() });
-      const res = await fetch(`${baseUrl}/sessions/agent-1/record`, { headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sessions/agent-1/record`, {
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(200);
     });
 
     it("GET /sessions/:id/record is 404 when nothing was recorded for the session", async () => {
       start({ sessionRecords: stubRecords() });
-      const res = await fetch(`${baseUrl}/sessions/unknown/record`, { headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sessions/unknown/record`, {
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(404);
     });
 
     it("GET /sessions/:id/record is 501 when the server has no record reader", async () => {
       start();
-      const res = await fetch(`${baseUrl}/sessions/sess-1/record`, { headers: TOKEN_HEADER });
+      const res = await fetch(`${baseUrl}/sessions/sess-1/record`, {
+        headers: TOKEN_HEADER,
+      });
       expect(res.status).toBe(501);
     });
 
@@ -1427,11 +1625,17 @@ describe("createRestRouter", () => {
         lastActiveAt: "2026-07-01T10:00:05.000Z",
         ready: false,
       };
-      start({ sessionManager: fakeSessionManager([session]), sessionRecords: stubRecords() });
-
-      const res = await fetch(`${baseUrl}/sessions/history?cwd=${encodeURIComponent("/repo")}`, {
-        headers: TOKEN_HEADER,
+      start({
+        sessionManager: fakeSessionManager([session]),
+        sessionRecords: stubRecords(),
       });
+
+      const res = await fetch(
+        `${baseUrl}/sessions/history?cwd=${encodeURIComponent("/repo")}`,
+        {
+          headers: TOKEN_HEADER,
+        },
+      );
       expect(res.status).toBe(200);
       const body = (await res.json()) as SessionSummary[];
       expect(body).toHaveLength(1);
@@ -1460,9 +1664,12 @@ describe("createRestRouter", () => {
         }),
       });
 
-      const res = await fetch(`${baseUrl}/sessions/history?cwd=${encodeURIComponent("/repo")}`, {
-        headers: TOKEN_HEADER,
-      });
+      const res = await fetch(
+        `${baseUrl}/sessions/history?cwd=${encodeURIComponent("/repo")}`,
+        {
+          headers: TOKEN_HEADER,
+        },
+      );
       expect(res.status).toBe(200);
       const body = (await res.json()) as SessionSummary[];
       expect(body).toHaveLength(1);

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -40,10 +40,22 @@ import {
   MAX_IMAGE_UPLOAD_BYTES,
   SPAWNABLE_HARNESS_KINDS,
 } from "../shared/types.js";
-import { AdapterNotFoundError, ExternalHarnessError, SessionAlreadyLiveError, SessionNotResumeableError } from "../core/errors.js";
-import { SessionNotReadyError, UnknownSessionError, type SessionManager } from "../core/session-manager.js";
+import {
+  AdapterNotFoundError,
+  ExternalHarnessError,
+  SessionAlreadyLiveError,
+  SessionNotResumeableError,
+} from "../core/errors.js";
+import {
+  SessionNotReadyError,
+  UnknownSessionError,
+  type SessionManager,
+} from "../core/session-manager.js";
 import type { SessionRecordReader } from "../core/session-record.js";
-import { getHarnessAdapter, listHarnessAdapters } from "../core/adapters/registry.js";
+import {
+  getHarnessAdapter,
+  listHarnessAdapters,
+} from "../core/adapters/registry.js";
 import { resolveWithinRoot } from "../core/path-safety.js";
 import { loadSettings, saveSettings } from "../cli/settings.js";
 
@@ -170,7 +182,11 @@ export interface RestRouterOptions {
   adapters: Partial<Record<HarnessKind, HarnessAdapter>>;
   version: string;
   /** Sapiom identity from CLI auth; null when unauthenticated / --no-auth. */
-  identity: { userId: string; tenantId: string; organizationName: string } | null;
+  identity: {
+    userId: string;
+    tenantId: string;
+    organizationName: string;
+  } | null;
   listWorkflows: () => Promise<WorkflowInfo[]>;
   listMacros: () => MacroDef[];
   /** Look up a registered workflow by its path; null when not found. Backs
@@ -470,9 +486,17 @@ export function createRestRouter(options: RestRouterOptions): Router {
       const foundInStore = new Set<string>();
       for (const adapter of Object.values(adapters)) {
         if (!adapter) continue;
-        for (const record of await adapter.listPastSessions(cwd)) {
-          transcripts.push(record);
-          foundInStore.add(`${record.harness}\u0000${record.agentSessionId}`);
+        try {
+          for (const record of await adapter.listPastSessions(cwd)) {
+            transcripts.push(record);
+            foundInStore.add(`${record.harness}\u0000${record.agentSessionId}`);
+          }
+        } catch (err) {
+          // History is a union of independent sources. A missing/unreadable
+          // vendor store must not hide Studio's own durable registry rows or a
+          // second healthy adapter; rows missed by this scan are verified below
+          // through each adapter's never-throws canResume boundary.
+          console.error(`[harness] ${adapter.id} history scan failed:`, err);
         }
       }
 
@@ -480,7 +504,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
       // agent session — they carry live status the transcript can't know.
       const registryRows = sessionManager
         .list()
-        .filter((session) => session.cwd === cwd && session.agentSessionId != null);
+        .filter(
+          (session) => session.cwd === cwd && session.agentSessionId != null,
+        );
       // Only rows the scan did NOT account for need a direct probe — the
       // phantoms, plus the narrow case of a transcript that exists but holds
       // no line our parser understands (see ClaudeCodeAdapter.canResume, which
@@ -489,7 +515,12 @@ export function createRestRouter(options: RestRouterOptions): Router {
         registryRows.map(async (session) =>
           foundInStore.has(`${session.harness}\u0000${session.agentSessionId!}`)
             ? true
-            : agentHoldsConversation(adapters, session.harness, session.agentSessionId!, session.cwd),
+            : agentHoldsConversation(
+                adapters,
+                session.harness,
+                session.agentSessionId!,
+                session.cwd,
+              ),
         ),
       );
 
@@ -508,7 +539,10 @@ export function createRestRouter(options: RestRouterOptions): Router {
       });
       for (const record of transcripts) {
         if (byAgentSessionId.has(record.agentSessionId)) continue;
-        byAgentSessionId.set(record.agentSessionId, { ...record, resumeMode: "agent-resume" });
+        byAgentSessionId.set(record.agentSessionId, {
+          ...record,
+          resumeMode: "agent-resume",
+        });
       }
 
       const merged = Array.from(byAgentSessionId.values()).sort((a, b) =>
@@ -529,7 +563,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
         for (const summary of merged) {
           const turnCount =
             turnCounts.get(summary.agentSessionId) ??
-            (summary.harnessSessionId ? turnCounts.get(summary.harnessSessionId) : undefined);
+            (summary.harnessSessionId
+              ? turnCounts.get(summary.harnessSessionId)
+              : undefined);
           if (turnCount !== undefined) summary.turnCount = turnCount;
         }
       }
@@ -563,7 +599,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
       err instanceof SessionAlreadyLiveError ||
       err instanceof SessionNotResumeableError
     ) {
-      res.status(409).json({ error: err.message, code: (err as { code: string }).code });
+      res
+        .status(409)
+        .json({ error: err.message, code: (err as { code: string }).code });
       return true;
     }
     return false;
@@ -578,7 +616,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
   router.post("/sessions/adopt", async (req, res, next) => {
     const parsed = adoptSessionSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.issues.map((i) => i.message).join("; ") });
+      res
+        .status(400)
+        .json({ error: parsed.error.issues.map((i) => i.message).join("; ") });
       return;
     }
     const { agentSessionId, harness, cwd, title, lastActiveAt } = parsed.data;
@@ -586,7 +626,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
       // Never take the client's word for resumability — it's re-derived from
       // the agent's own store here, so a stale history row (transcript deleted
       // between the list and the click) can't leave a phantom record behind.
-      if (!(await agentHoldsConversation(adapters, harness, agentSessionId, cwd))) {
+      if (
+        !(await agentHoldsConversation(adapters, harness, agentSessionId, cwd))
+      ) {
         const label = getHarnessAdapter(harness).label;
         res.status(409).json({
           error: `${label} no longer has the conversation for session ${agentSessionId} in ${cwd} — there is nothing to resume. Start a new session in this directory instead.`,
@@ -598,8 +640,19 @@ export function createRestRouter(options: RestRouterOptions): Router {
       // record rather than minting a duplicate on every click.
       const existing = sessionManager
         .list()
-        .find((session) => session.agentSessionId === agentSessionId && session.cwd === cwd);
-      const target = existing ?? sessionManager.registerHistorical({ agentSessionId, harness, cwd, title, lastActiveAt });
+        .find(
+          (session) =>
+            session.agentSessionId === agentSessionId && session.cwd === cwd,
+        );
+      const target =
+        existing ??
+        sessionManager.registerHistorical({
+          agentSessionId,
+          harness,
+          cwd,
+          title,
+          lastActiveAt,
+        });
       res.json(await sessionManager.resume(target.id));
     } catch (err) {
       if (sendResumeError(res, err)) return;
@@ -619,7 +672,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
    */
   router.get("/sessions/:id/record", async (req, res, next) => {
     if (!options.sessionRecords) {
-      res.status(501).json({ error: "session records are not available on this server" });
+      res
+        .status(501)
+        .json({ error: "session records are not available on this server" });
       return;
     }
     try {
@@ -696,84 +751,105 @@ export function createRestRouter(options: RestRouterOptions): Router {
    * whose adapter declares `imageInput`, so an image never gets relayed to an
    * agent that can't consume it.
    */
-  router.post("/sessions/:id/image", imageUploadRateLimiter, async (req, res, next) => {
-    const parsed = attachImageSchema.safeParse(req.body);
-    if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.message });
-      return;
-    }
-
-    const session = sessionManager.get(req.params.id);
-    if (!session) {
-      res.status(404).json({ error: "session not found" });
-      return;
-    }
-
-    // Respect the adapter's declared image support — reject rather than write a
-    // file the agent will never look at.
-    if (!getHarnessAdapter(session.harness).imageInput) {
-      res.status(400).json({ error: `Harness '${session.harness}' does not support image input` });
-      return;
-    }
-
-    const match = DATA_URL_RE.exec(parsed.data.dataUrl);
-    if (!match) {
-      res.status(400).json({ error: "dataUrl must be a base64 data: URL" });
-      return;
-    }
-    const mediaType = match[1].toLowerCase();
-    if (!(ALLOWED_IMAGE_MEDIA_TYPES as readonly string[]).includes(mediaType)) {
-      res.status(400).json({
-        error: `Unsupported image type '${mediaType}' — allowed: ${ALLOWED_IMAGE_MEDIA_TYPES.join(", ")}`,
-      });
-      return;
-    }
-    const buffer = Buffer.from(match[2], "base64");
-    if (buffer.byteLength === 0) {
-      res.status(400).json({ error: "image payload is empty" });
-      return;
-    }
-    if (buffer.byteLength > MAX_IMAGE_UPLOAD_BYTES) {
-      res.status(413).json({
-        error: `Image is ${buffer.byteLength} bytes; the limit is ${MAX_IMAGE_UPLOAD_BYTES} bytes`,
-      });
-      return;
-    }
-
-    // Confine the write to the session cwd; the stored name is a fresh uuid
-    // (never the client-supplied filename) so an image can't be written outside
-    // the uploads directory regardless of what the browser reported.
-    const uploadsDir = resolveWithinRoot(session.cwd, HARNESS_UPLOADS_DIR);
-    if (!uploadsDir) {
-      res.status(500).json({ error: "could not resolve the uploads directory" });
-      return;
-    }
-    const ext = IMAGE_EXTENSIONS[mediaType as ImageMediaType];
-    const filePath = path.join(uploadsDir, `${randomUUID()}.${ext}`);
-
-    try {
-      await fs.mkdir(uploadsDir, { recursive: true });
-      await fs.writeFile(filePath, buffer);
-      // A trailing space so the user's own message doesn't run into the path.
-      const injected = await sessionManager.submitInput(req.params.id, `${filePath} `, false);
-      if (!injected) {
-        res.status(404).json({ error: "session not found or has no live pty" });
+  router.post(
+    "/sessions/:id/image",
+    imageUploadRateLimiter,
+    async (req, res, next) => {
+      const parsed = attachImageSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: parsed.error.message });
         return;
       }
-      const response: AttachImageResponse = {
-        path: filePath,
-        mediaType: mediaType as ImageMediaType,
-        bytes: buffer.byteLength,
-      };
-      res.json(response);
-    } catch (err) {
-      if (err instanceof SessionNotReadyError || err instanceof ExternalHarnessError) {
-        res.status(409).json({ error: err.message, code: err.code });
+
+      const session = sessionManager.get(req.params.id);
+      if (!session) {
+        res.status(404).json({ error: "session not found" });
         return;
       }
-      next(err);
-    }
-  });
+
+      // Respect the adapter's declared image support — reject rather than write a
+      // file the agent will never look at.
+      if (!getHarnessAdapter(session.harness).imageInput) {
+        res
+          .status(400)
+          .json({
+            error: `Harness '${session.harness}' does not support image input`,
+          });
+        return;
+      }
+
+      const match = DATA_URL_RE.exec(parsed.data.dataUrl);
+      if (!match) {
+        res.status(400).json({ error: "dataUrl must be a base64 data: URL" });
+        return;
+      }
+      const mediaType = match[1].toLowerCase();
+      if (
+        !(ALLOWED_IMAGE_MEDIA_TYPES as readonly string[]).includes(mediaType)
+      ) {
+        res.status(400).json({
+          error: `Unsupported image type '${mediaType}' — allowed: ${ALLOWED_IMAGE_MEDIA_TYPES.join(", ")}`,
+        });
+        return;
+      }
+      const buffer = Buffer.from(match[2], "base64");
+      if (buffer.byteLength === 0) {
+        res.status(400).json({ error: "image payload is empty" });
+        return;
+      }
+      if (buffer.byteLength > MAX_IMAGE_UPLOAD_BYTES) {
+        res.status(413).json({
+          error: `Image is ${buffer.byteLength} bytes; the limit is ${MAX_IMAGE_UPLOAD_BYTES} bytes`,
+        });
+        return;
+      }
+
+      // Confine the write to the session cwd; the stored name is a fresh uuid
+      // (never the client-supplied filename) so an image can't be written outside
+      // the uploads directory regardless of what the browser reported.
+      const uploadsDir = resolveWithinRoot(session.cwd, HARNESS_UPLOADS_DIR);
+      if (!uploadsDir) {
+        res
+          .status(500)
+          .json({ error: "could not resolve the uploads directory" });
+        return;
+      }
+      const ext = IMAGE_EXTENSIONS[mediaType as ImageMediaType];
+      const filePath = path.join(uploadsDir, `${randomUUID()}.${ext}`);
+
+      try {
+        await fs.mkdir(uploadsDir, { recursive: true });
+        await fs.writeFile(filePath, buffer);
+        // A trailing space so the user's own message doesn't run into the path.
+        const injected = await sessionManager.submitInput(
+          req.params.id,
+          `${filePath} `,
+          false,
+        );
+        if (!injected) {
+          res
+            .status(404)
+            .json({ error: "session not found or has no live pty" });
+          return;
+        }
+        const response: AttachImageResponse = {
+          path: filePath,
+          mediaType: mediaType as ImageMediaType,
+          bytes: buffer.byteLength,
+        };
+        res.json(response);
+      } catch (err) {
+        if (
+          err instanceof SessionNotReadyError ||
+          err instanceof ExternalHarnessError
+        ) {
+          res.status(409).json({ error: err.message, code: err.code });
+          return;
+        }
+        next(err);
+      }
+    },
+  );
 
   /**
    * POST /api/track — UI-interaction analytics.

--- a/packages/harness/src/server/state-isolation.test.ts
+++ b/packages/harness/src/server/state-isolation.test.ts
@@ -32,10 +32,14 @@ describe("state-root isolation", () => {
   let dir: string;
   let launchDir: string;
   let server: HarnessServer | undefined;
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
 
   beforeEach(async () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-state-isolation-"));
     fakeHome = path.join(dir, "home");
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
     launchDir = path.join(dir, "project");
     await fs.mkdir(fakeHome, { recursive: true });
     await fs.mkdir(launchDir, { recursive: true });
@@ -44,6 +48,10 @@ describe("state-root isolation", () => {
   afterEach(async () => {
     await server?.close();
     server = undefined;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
     await fs.rm(dir, { recursive: true, force: true });
   });
 
@@ -60,10 +68,15 @@ describe("state-root isolation", () => {
     });
 
     const baseUrl = `http://127.0.0.1:${server.port}`;
-    const headers = { "Content-Type": "application/json", "X-Harness-Token": "test-token" };
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Harness-Token": "test-token",
+    };
 
     // machine-id was created at boot (no machineId option passed), under stateRoot.
-    const machineId = (await fs.readFile(path.join(stateRoot, "machine-id"), "utf-8")).trim();
+    const machineId = (
+      await fs.readFile(path.join(stateRoot, "machine-id"), "utf-8")
+    ).trim();
     expect(machineId).toMatch(/^[0-9a-f-]{36}$/);
 
     // The boot-time launch-dir scan persisted the registry under stateRoot.
@@ -79,7 +92,9 @@ describe("state-root isolation", () => {
       body: JSON.stringify({ telemetryOptIn: true }),
     });
     expect(patchRes.status).toBe(200);
-    const stored = JSON.parse(await fs.readFile(path.join(stateRoot, "settings.json"), "utf-8")) as {
+    const stored = JSON.parse(
+      await fs.readFile(path.join(stateRoot, "settings.json"), "utf-8"),
+    ) as {
       telemetryOptIn: boolean;
     };
     expect(stored.telemetryOptIn).toBe(true);
@@ -114,8 +129,18 @@ describe("state-root isolation", () => {
     await fs.writeFile(
       path.join(stateRoot, "workflows.json"),
       JSON.stringify([
-        { name: "deleted-project", path: deadPath, definitionId: 1, source: "scan" },
-        { name: "project", path: launchDir, definitionId: null, source: "connect" },
+        {
+          name: "deleted-project",
+          path: deadPath,
+          definitionId: 1,
+          source: "scan",
+        },
+        {
+          name: "project",
+          path: launchDir,
+          definitionId: null,
+          source: "connect",
+        },
       ]),
     );
 
@@ -131,7 +156,9 @@ describe("state-root isolation", () => {
 
     const baseUrl = `http://127.0.0.1:${server.port}`;
     const headers = { "X-Harness-Token": "test-token" };
-    const workflows = (await (await fetch(`${baseUrl}/api/workflows`, { headers })).json()) as Array<{
+    const workflows = (await (
+      await fetch(`${baseUrl}/api/workflows`, { headers })
+    ).json()) as Array<{
       path: string;
     }>;
     expect(workflows.some((w) => w.path === deadPath)).toBe(false);
@@ -141,7 +168,9 @@ describe("state-root isolation", () => {
     // with this read (fs.writeFile isn't atomic) — poll until a complete,
     // parseable write is on disk.
     await vi.waitFor(async () => {
-      const persisted = JSON.parse(await fs.readFile(path.join(stateRoot, "workflows.json"), "utf-8")) as Array<{
+      const persisted = JSON.parse(
+        await fs.readFile(path.join(stateRoot, "workflows.json"), "utf-8"),
+      ) as Array<{
         path: string;
       }>;
       expect(persisted.some((w) => w.path === deadPath)).toBe(false);

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -12,7 +12,8 @@
 
 export const DEFAULT_PORT = 4100;
 
-/** All harness-owned state lives under this directory. Uninstall = delete it. */
+/** Default root for Harness-owned state. Shared credentials, analytics identity,
+ * coding-agent history, desktop userData, and agent projects live elsewhere. */
 export const HARNESS_HOME = "~/.sapiom/harness";
 
 export const HARNESS_PATHS = {

--- a/packages/harness/web/e2e/run-inspector.spec.ts
+++ b/packages/harness/web/e2e/run-inspector.spec.ts
@@ -61,19 +61,52 @@ const clickLocalButton = async (page: Page): Promise<void> => {
  *  canvas-inspector.spec.ts). */
 const publish = (page: Page, message: unknown): Promise<void> =>
   page.evaluate((msg) => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (m: unknown) => void } })
-      .__HARNESS_TEST__.publish(msg);
+    (
+      window as unknown as {
+        __HARNESS_TEST__: { publish: (m: unknown) => void };
+      }
+    ).__HARNESS_TEST__.publish(msg);
   }, message);
 
 /** Seed window.__MOCK_RUN_STATE__[executionId] so MockApi.getRunState returns
  *  a custom RunView on the next poll for that id — consumed and cleared once. */
-const seedRunState = (page: Page, executionId: string, view: RunView): Promise<void> =>
+const seedRunState = (
+  page: Page,
+  executionId: string,
+  view: RunView,
+): Promise<void> =>
   page.evaluate(
     ([id, v]) => {
-      const win = window as unknown as { __MOCK_RUN_STATE__?: Record<string, unknown> };
+      const win = window as unknown as {
+        __MOCK_RUN_STATE__?: Record<string, unknown>;
+      };
       win.__MOCK_RUN_STATE__ = { ...(win.__MOCK_RUN_STATE__ ?? {}), [id]: v };
     },
     [executionId, view] as [string, RunView],
+  );
+
+/** Make the next N mocked inspection calls fail and expose their call count. */
+const seedRunStateFailures = (
+  page: Page,
+  executionId: string,
+  failures: number,
+): Promise<void> =>
+  page.evaluate(
+    ([id, count]) => {
+      const win = window as unknown as {
+        __MOCK_RUN_STATE_FAILURES__?: Record<string, number>;
+        __MOCK_RUN_STATE_CALLS__?: Record<string, number>;
+      };
+      win.__MOCK_RUN_STATE_FAILURES__ = {
+        ...(win.__MOCK_RUN_STATE_FAILURES__ ?? {}),
+        [id]: count,
+      };
+      win.__MOCK_RUN_STATE_CALLS__ = {
+        ...(win.__MOCK_RUN_STATE_CALLS__ ?? {}),
+        [id]: 0,
+      };
+    },
+    [executionId, failures] as [string, number],
   );
 
 // ---------------------------------------------------------------------------
@@ -154,7 +187,12 @@ test.describe("offline stub run — run-local inspector", () => {
       // field regardless of target; the notice fields are independent.
       stubbed: true,
       steps: [
-        { id: "intake", name: "intake", status: "passed" as const, latencyMs: 100 },
+        {
+          id: "intake",
+          name: "intake",
+          status: "passed" as const,
+          latencyMs: 100,
+        },
       ],
       unusedStubs: [{ step: "intake", key: "contentGeneration.images.create" }],
       stubWarnings: ["intake: stub for records.read had wrong shape"],
@@ -258,6 +296,59 @@ test.describe("prod run — run-state poll via mocked endpoint", () => {
     await expect(draftRow.locator('[aria-label="passed"]')).toBeVisible();
   });
 
+  test("one transient inspection failure is retried instead of losing the run", async ({
+    page,
+  }) => {
+    const executionId = "exec-transient-inspection";
+    await seedRunStateFailures(page, executionId, 1);
+
+    await publish(page, {
+      type: "execution.started",
+      harnessSessionId: "sess-boot",
+      executionId,
+      target: "prod",
+    });
+
+    await expect(page.getByTestId("canvas-run-chip")).toContainText(
+      "prod run completed",
+      { timeout: 6_000 },
+    );
+    const calls = await page.evaluate((id) => {
+      const win = window as unknown as {
+        __MOCK_RUN_STATE_CALLS__?: Record<string, number>;
+      };
+      return win.__MOCK_RUN_STATE_CALLS__?.[id] ?? 0;
+    }, executionId);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("three consecutive inspection failures stop with an actionable message", async ({
+    page,
+  }) => {
+    const executionId = "exec-unavailable-inspection";
+    await seedRunStateFailures(page, executionId, 3);
+
+    await publish(page, {
+      type: "execution.started",
+      harnessSessionId: "sess-boot",
+      executionId,
+      target: "prod",
+    });
+
+    await expect(page.getByTestId("toast")).toContainText(
+      "Run inspection is temporarily unavailable",
+      { timeout: 7_000 },
+    );
+    await expect(page.getByTestId("toast")).toContainText("Sapiom dashboard");
+    const calls = await page.evaluate((id) => {
+      const win = window as unknown as {
+        __MOCK_RUN_STATE_CALLS__?: Record<string, number>;
+      };
+      return win.__MOCK_RUN_STATE_CALLS__?.[id] ?? 0;
+    }, executionId);
+    expect(calls).toBe(3);
+  });
+
   test("a running prod run shows each step's running/passed status as polls advance", async ({
     page,
   }) => {
@@ -266,7 +357,12 @@ test.describe("prod run — run-state poll via mocked endpoint", () => {
       executionId: "exec-run-in-progress",
       status: "running",
       steps: [
-        { id: "intake", name: "intake", status: "passed" as const, latencyMs: 110 },
+        {
+          id: "intake",
+          name: "intake",
+          status: "passed" as const,
+          latencyMs: 110,
+        },
         { id: "screen", name: "screen", status: "running" as const },
       ],
     });
@@ -291,7 +387,9 @@ test.describe("prod run — run-state poll via mocked endpoint", () => {
 
     // intake passed in both polls.
     await expect(
-      page.getByTestId("canvas-step-row-intake").locator('[aria-label="passed"]'),
+      page
+        .getByTestId("canvas-step-row-intake")
+        .locator('[aria-label="passed"]'),
     ).toBeVisible();
   });
 
@@ -302,8 +400,18 @@ test.describe("prod run — run-state poll via mocked endpoint", () => {
       executionId: "exec-fail-test",
       status: "failed",
       steps: [
-        { id: "intake", name: "intake", status: "passed" as const, latencyMs: 200 },
-        { id: "screen", name: "screen", status: "failed" as const, error: "Validation failed" },
+        {
+          id: "intake",
+          name: "intake",
+          status: "passed" as const,
+          latencyMs: 200,
+        },
+        {
+          id: "screen",
+          name: "screen",
+          status: "failed" as const,
+          error: "Validation failed",
+        },
       ],
     });
 
@@ -324,10 +432,14 @@ test.describe("prod run — run-state poll via mocked endpoint", () => {
 
     // intake passed, screen failed.
     await expect(
-      page.getByTestId("canvas-step-row-intake").locator('[aria-label="passed"]'),
+      page
+        .getByTestId("canvas-step-row-intake")
+        .locator('[aria-label="passed"]'),
     ).toBeVisible();
     await expect(
-      page.getByTestId("canvas-step-row-screen").locator('[aria-label="failed"]'),
+      page
+        .getByTestId("canvas-step-row-screen")
+        .locator('[aria-label="failed"]'),
     ).toBeVisible();
 
     // Cost-free contract: the Steps inspector must never show $ amounts.

--- a/packages/harness/web/src/components/DeadSessionPane.tsx
+++ b/packages/harness/web/src/components/DeadSessionPane.tsx
@@ -1,8 +1,22 @@
 import type { JSX } from "react";
-import type { HarnessSession, SessionRecord, SessionResumeMode, SessionSummary } from "@shared/types";
+import type {
+  HarnessSession,
+  SessionRecord,
+  SessionResumeMode,
+  SessionSummary,
+} from "@shared/types";
 
-import { HARNESS_LABELS, formatDuration, formatRelativeTime, historyRowMeta } from "../lib/history-meta";
-import { useSessionRecord, type SessionRecordState } from "../lib/use-session-record";
+import {
+  HARNESS_LABELS,
+  formatDuration,
+  formatRelativeTime,
+  historyRowMeta,
+} from "../lib/history-meta";
+import { deadSessionAction } from "../lib/dead-session-action";
+import {
+  useSessionRecord,
+  type SessionRecordState,
+} from "../lib/use-session-record";
 import { Icon } from "./Icon";
 import { SessionTranscript } from "./SessionTranscript";
 
@@ -10,10 +24,8 @@ interface DeadSessionPaneProps {
   session: HarnessSession;
   /**
    * Server-verified resumability for this session, from its history row.
-   * Undefined while that lookup is still in flight — Resume stays available in
-   * that window (the server's own pre-flight is the backstop and answers 409
-   * with the reason), but a resolved `rehydrate` disables the button outright
-   * rather than letting the user click a guaranteed failure.
+   * Undefined while that lookup is still in flight — neither continuation path
+   * is offered until the server answers.
    */
   resumeMode: SessionResumeMode | undefined;
   /** Fetches the reconstructed transcript; resolves null when nothing was recorded. */
@@ -75,7 +87,6 @@ export function DeadSessionPane({
   onContinue,
   onClose,
 }: DeadSessionPaneProps): JSX.Element {
-  const canResume = session.agentSessionId != null && resumeMode !== "rehydrate";
   const duration = formatDuration(session.createdAt, session.lastActiveAt);
   const record = useSessionRecord(session.id, loadRecord);
   // "empty" collapses the section entirely rather than showing an empty box:
@@ -85,10 +96,18 @@ export function DeadSessionPane({
   // unable to hand this conversation back while OUR recording of it is right
   // there. When both are true, the way forward is portable continue rather
   // than the dead end this pane used to be.
-  const canContinue = !canResume && record.status === "ready";
+  const action = deadSessionAction({
+    hasAgentSessionId: session.agentSessionId != null,
+    resumeMode,
+    recordReady: record.status === "ready",
+  });
 
   return (
-    <div className="dead-session-pane" data-testid="dead-session-pane" data-has-record={showRecord}>
+    <div
+      className="dead-session-pane"
+      data-testid="dead-session-pane"
+      data-has-record={showRecord}
+    >
       <div className="dead-session-summary">
         <span className="empty-state-icon" aria-hidden="true">
           <Icon name="SquareTerminal" size={18} />
@@ -121,8 +140,12 @@ export function DeadSessionPane({
           </div>
         </dl>
         <div className="dead-session-actions">
-          {canContinue ? (
-            <button className="btn-primary" data-testid="dead-session-continue" onClick={onContinue}>
+          {action === "continue" ? (
+            <button
+              className="btn-primary"
+              data-testid="dead-session-continue"
+              onClick={onContinue}
+            >
               Continue here
             </button>
           ) : (
@@ -130,20 +153,33 @@ export function DeadSessionPane({
               className="btn-primary"
               data-testid="dead-session-resume"
               onClick={onResume}
-              disabled={!canResume}
-              title={canResume ? undefined : resumeBlockedReason(session)}
+              disabled={action !== "resume"}
+              title={
+                action === "checking"
+                  ? "Checking Claude Code history…"
+                  : action === "resume"
+                    ? undefined
+                    : resumeBlockedReason(session)
+              }
             >
-              Resume
+              {action === "checking" ? "Checking…" : "Resume"}
             </button>
           )}
-          <button className="btn-ghost" data-testid="dead-session-close" onClick={onClose}>
+          <button
+            className="btn-ghost"
+            data-testid="dead-session-close"
+            onClick={onClose}
+          >
             Close
           </button>
         </div>
-        {!canResume && (
-          <div className="dead-session-resume-reason" data-testid="dead-session-resume-reason">
+        {(action === "continue" || action === "blocked") && (
+          <div
+            className="dead-session-resume-reason"
+            data-testid="dead-session-resume-reason"
+          >
             {resumeBlockedReason(session)}{" "}
-            {canContinue
+            {action === "continue"
               ? "Continuing opens a fresh session in this directory, seeded with the reconstruction below — a briefing about this session, not its context. The new coding agent will need to check the repository before relying on any of it."
               : "Start a new session in this directory instead; there is no recording of this one to carry over either."}
           </div>
@@ -217,20 +253,35 @@ export function PastSessionPane({
           </div>
         </div>
         <div className="dead-session-actions">
-          <button className="btn-primary" data-testid="past-session-start" onClick={onStart}>
-            {resumable ? "Resume" : canRehydrate ? "Continue here" : "New session here"}
+          <button
+            className="btn-primary"
+            data-testid="past-session-start"
+            onClick={onStart}
+          >
+            {resumable
+              ? "Resume"
+              : canRehydrate
+                ? "Continue here"
+                : "New session here"}
           </button>
-          <button className="btn-ghost" data-testid="past-session-close" onClick={onClose}>
+          <button
+            className="btn-ghost"
+            data-testid="past-session-close"
+            onClick={onClose}
+          >
             Close
           </button>
         </div>
       </header>
 
       {!resumable && (
-        <div className="dead-session-resume-reason" data-testid="past-session-reason">
-          {HARNESS_LABELS[summary.harness]} has no saved conversation for this session, so it can't
-          be reattached — sessions that end before their first prompt are never written to the
-          coding agent's history.{" "}
+        <div
+          className="dead-session-resume-reason"
+          data-testid="past-session-reason"
+        >
+          {HARNESS_LABELS[summary.harness]} has no saved conversation for this
+          session, so it can't be reattached — sessions that end before their
+          first prompt are never written to the coding agent's history.{" "}
           {canRehydrate
             ? "Continuing opens a fresh session here, seeded with the reconstruction below. The new coding agent gets a briefing about this session, not its context — it will need to check the repository before relying on any of it."
             : "Starting opens a fresh session in the same directory, with no context from this one."}
@@ -249,7 +300,11 @@ export function PastSessionPane({
  * transcript appears. An absent record is stated plainly — it is the one thing
  * this view must never quietly turn into "an empty session".
  */
-function SessionRecordBody({ state }: { state: SessionRecordState }): JSX.Element {
+function SessionRecordBody({
+  state,
+}: {
+  state: SessionRecordState;
+}): JSX.Element {
   if (state.status === "loading") {
     return (
       <div className="past-session-status" data-testid="past-session-loading">
@@ -270,9 +325,9 @@ function SessionRecordBody({ state }: { state: SessionRecordState }): JSX.Elemen
         <span className="empty-state-icon" aria-hidden="true">
           <Icon name="SquareTerminal" size={18} />
         </span>
-        No transcript for this session: Agent Studio has no recorded events for it. Sessions Agent
-        Studio didn't run — or ones whose events have aged out of the local log — show up here as
-        history rows only.
+        No transcript for this session: Agent Studio has no recorded events for
+        it. Sessions Agent Studio didn't run — or ones whose events have aged
+        out of the local log — show up here as history rows only.
       </div>
     );
   }

--- a/packages/harness/web/src/lib/analytics/before-send.test.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.test.ts
@@ -3,14 +3,22 @@ import { describe, expect, it } from "vitest";
 
 import { beforeSend, sanitizeUrl } from "./before-send";
 
-function capture(event: string, properties: Record<string, unknown>, extra?: Partial<CaptureResult>): CaptureResult {
+function capture(
+  event: string,
+  properties: Record<string, unknown>,
+  extra?: Partial<CaptureResult>,
+): CaptureResult {
   return { event, properties, ...extra } as CaptureResult;
 }
 
 describe("sanitizeUrl", () => {
   it("strips the query string (which carries the boot token) and the fragment", () => {
-    expect(sanitizeUrl("http://localhost:4100/?token=super-secret")).toBe("http://localhost:4100/");
-    expect(sanitizeUrl("http://localhost:4100/workbench?token=x#frag")).toBe("http://localhost:4100/workbench");
+    expect(sanitizeUrl("http://localhost:4100/?token=super-secret")).toBe(
+      "http://localhost:4100/",
+    );
+    expect(sanitizeUrl("http://localhost:4100/workbench?token=x#frag")).toBe(
+      "http://localhost:4100/workbench",
+    );
   });
 
   it("passes non-URL / empty values through unchanged", () => {
@@ -29,16 +37,26 @@ describe("beforeSend", () => {
     const result = capture(
       "$pageview",
       { $current_url: "http://localhost:4100/?token=secret" },
-      { $set_once: { $initial_current_url: "http://localhost:4100/?token=secret" } },
+      {
+        $set_once: {
+          $initial_current_url: "http://localhost:4100/?token=secret",
+        },
+      },
     );
     const out = beforeSend(result)!;
-    expect((out.properties as Record<string, unknown>).$current_url).toBe("http://localhost:4100/");
-    expect((out.$set_once as Record<string, unknown>).$initial_current_url).toBe("http://localhost:4100/");
+    expect((out.properties as Record<string, unknown>).$current_url).toBe(
+      "http://localhost:4100/",
+    );
+    expect(
+      (out.$set_once as Record<string, unknown>).$initial_current_url,
+    ).toBe("http://localhost:4100/");
   });
 
   it("truncates long click text on a normal surface but keeps it", () => {
     const long = "x".repeat(300);
-    const out = beforeSend(capture("$autocapture", { $el_text: long, surface: "agent_rail" }))!;
+    const out = beforeSend(
+      capture("$autocapture", { $el_text: long, surface: "agent_rail" }),
+    )!;
     const text = (out.properties as Record<string, unknown>).$el_text as string;
     expect(text.length).toBeLessThan(300);
     expect(text.endsWith("…")).toBe(true);
@@ -46,27 +64,41 @@ describe("beforeSend", () => {
 
   it("DROPS click text entirely on a secrets surface", () => {
     const out = beforeSend(
-      capture("$autocapture", { $el_text: "sk-live-abc123", surface: "secrets_panel" }),
+      capture("$autocapture", {
+        $el_text: "sk-live-abc123",
+        surface: "secrets_panel",
+      }),
     )!;
-    expect((out.properties as Record<string, unknown>).$el_text).toBeUndefined();
+    expect(
+      (out.properties as Record<string, unknown>).$el_text,
+    ).toBeUndefined();
   });
 
   it("scrubs $elements attributes on a secrets surface but keeps class/id", () => {
     const out = beforeSend(
       capture("$autocapture", {
         object: "secret",
-        $elements: [{ $el_text: "sk-live-abc", attr__aria_label: "copy sk-live-abc", attr__class: "btn", attr__id: "copy" }],
+        $elements: [
+          {
+            $el_text: "sk-live-abc",
+            attr__aria_label: "copy sk-live-abc",
+            attr__class: "btn",
+            attr__id: "copy",
+          },
+        ],
       }),
     )!;
-    const el = (out.properties as { $elements: Record<string, unknown>[] }).$elements[0];
+    const el = (out.properties as { $elements: Record<string, unknown>[] })
+      .$elements[0];
     expect(el.$el_text).toBeUndefined();
     expect(el.attr__aria_label).toBeUndefined();
     expect(el.attr__class).toBe("btn");
     expect(el.attr__id).toBe("copy");
   });
 
-  it("never throws — passes the event through if a property is malformed", () => {
-    // A getter that throws should not take down capture.
+  it("never throws and drops the event if redaction cannot complete", () => {
+    // A getter that throws should not take down capture or let the possibly
+    // sensitive, unredacted event leave the machine.
     const props: Record<string, unknown> = {};
     Object.defineProperty(props, "$current_url", {
       get() {
@@ -74,6 +106,6 @@ describe("beforeSend", () => {
       },
       enumerable: true,
     });
-    expect(() => beforeSend(capture("$autocapture", props))).not.toThrow();
+    expect(beforeSend(capture("$autocapture", props))).toBeNull();
   });
 });

--- a/packages/harness/web/src/lib/analytics/before-send.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.ts
@@ -20,8 +20,9 @@ import type { CaptureResult } from "posthog-js";
  *    a field value can be the secret itself.
  *
  * Never throws: posthog-js does not guard this callback, so an exception here
- * would take down capture for the whole page. On failure we pass the event
- * through unmodified rather than losing it.
+ * would take down capture for the whole page. On failure we drop the one event;
+ * an analytics gap is safer than sending a live boot token or secret-surface
+ * text that we could not prove was redacted.
  */
 
 /** Upper bound on retained click text — longer runs are likely user content. */
@@ -33,7 +34,10 @@ const MAX_EL_TEXT_LENGTH = 120;
  * place for a credential; everything else (aria-label, title, value, placeholder)
  * is dropped because any of them can carry the secret.
  */
-const KEPT_ELEMENT_ATTRIBUTES: ReadonlySet<string> = new Set(["attr__class", "attr__id"]);
+const KEPT_ELEMENT_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "attr__class",
+  "attr__id",
+]);
 
 /** `attr__href` values inside the serialized `$elements_chain` string. */
 const CHAIN_HREF_PATTERN = /attr__href="([^"]*)"/gi;
@@ -48,9 +52,18 @@ const URL_VALUED_PERSON_PROPERTIES = /(?:current_url|referrer|pathname)$/;
  * itself and we can redact without knowing a pathname (the harness has none).
  */
 function isSecretSurface(properties: Record<string, unknown>): boolean {
-  const surface = typeof properties.surface === "string" ? properties.surface.toLowerCase() : "";
-  const object = typeof properties.object === "string" ? properties.object.toLowerCase() : "";
-  return /secret|vault|credential/.test(surface) || /secret|vault|credential/.test(object);
+  const surface =
+    typeof properties.surface === "string"
+      ? properties.surface.toLowerCase()
+      : "";
+  const object =
+    typeof properties.object === "string"
+      ? properties.object.toLowerCase()
+      : "";
+  return (
+    /secret|vault|credential/.test(surface) ||
+    /secret|vault|credential/.test(object)
+  );
 }
 
 /**
@@ -74,15 +87,21 @@ export function sanitizeUrl(rawUrl: unknown): unknown {
 
 /** Truncate retained click text with an ellipsis marker. */
 function truncateElementText(text: string): string {
-  return text.length > MAX_EL_TEXT_LENGTH ? `${text.slice(0, MAX_EL_TEXT_LENGTH)}…` : text;
+  return text.length > MAX_EL_TEXT_LENGTH
+    ? `${text.slice(0, MAX_EL_TEXT_LENGTH)}…`
+    : text;
 }
 
 /** Scrub one entry of `properties.$elements`. */
-function scrubElement(element: Record<string, unknown>, isSecret: boolean): void {
+function scrubElement(
+  element: Record<string, unknown>,
+  isSecret: boolean,
+): void {
   if (isSecret) {
     delete element.$el_text;
     for (const key of Object.keys(element)) {
-      if (key.startsWith("attr__") && !KEPT_ELEMENT_ATTRIBUTES.has(key)) delete element[key];
+      if (key.startsWith("attr__") && !KEPT_ELEMENT_ATTRIBUTES.has(key))
+        delete element[key];
     }
     return;
   }
@@ -100,11 +119,15 @@ function scrubElement(element: Record<string, unknown>, isSecret: boolean): void
  * remote config, so both are handled — a server-side flip cannot silently start
  * leaking.
  */
-function scrubElementCarriers(properties: Record<string, unknown>, isSecret: boolean): void {
+function scrubElementCarriers(
+  properties: Record<string, unknown>,
+  isSecret: boolean,
+): void {
   const elements = properties.$elements;
   if (Array.isArray(elements)) {
     for (const element of elements) {
-      if (element && typeof element === "object") scrubElement(element as Record<string, unknown>, isSecret);
+      if (element && typeof element === "object")
+        scrubElement(element as Record<string, unknown>, isSecret);
     }
   }
 
@@ -113,10 +136,15 @@ function scrubElementCarriers(properties: Record<string, unknown>, isSecret: boo
     delete properties.$elements_chain;
     return;
   }
-  properties.$elements_chain = properties.$elements_chain.replace(CHAIN_HREF_PATTERN, (match, href: string) => {
-    const sanitized = sanitizeUrl(href);
-    return typeof sanitized === "string" ? `attr__href="${sanitized}"` : match;
-  });
+  properties.$elements_chain = properties.$elements_chain.replace(
+    CHAIN_HREF_PATTERN,
+    (match, href: string) => {
+      const sanitized = sanitizeUrl(href);
+      return typeof sanitized === "string"
+        ? `attr__href="${sanitized}"`
+        : match;
+    },
+  );
 }
 
 /**
@@ -125,7 +153,10 @@ function scrubElementCarriers(properties: Record<string, unknown>, isSecret: boo
  * writes `$initial_current_url` there, which would otherwise pin the boot-token
  * URL onto the person profile permanently.
  */
-function redactUrls(result: CaptureResult, properties: Record<string, unknown>): void {
+function redactUrls(
+  result: CaptureResult,
+  properties: Record<string, unknown>,
+): void {
   properties.$current_url = sanitizeUrl(properties.$current_url);
   properties.$referrer = sanitizeUrl(properties.$referrer);
 
@@ -133,13 +164,17 @@ function redactUrls(result: CaptureResult, properties: Record<string, unknown>):
     if (!bag) continue;
     const personProperties = bag as Record<string, unknown>;
     for (const key of Object.keys(personProperties)) {
-      if (URL_VALUED_PERSON_PROPERTIES.test(key)) personProperties[key] = sanitizeUrl(personProperties[key]);
+      if (URL_VALUED_PERSON_PROPERTIES.test(key))
+        personProperties[key] = sanitizeUrl(personProperties[key]);
     }
   }
 }
 
 /** Redact autocaptured click text — the top-level `$el_text` and the nested carriers. */
-function redactClickText(properties: Record<string, unknown>, isSecret: boolean): void {
+function redactClickText(
+  properties: Record<string, unknown>,
+  isSecret: boolean,
+): void {
   if (typeof properties.$el_text === "string") {
     if (isSecret) {
       delete properties.$el_text;
@@ -150,7 +185,7 @@ function redactClickText(properties: Record<string, unknown>, isSecret: boolean)
   scrubElementCarriers(properties, isSecret);
 }
 
-/** `before_send` implementation. Returns `null` to drop an event (never used today). */
+/** `before_send` implementation. Returns `null` when an event cannot be redacted safely. */
 export function beforeSend(result: CaptureResult | null): CaptureResult | null {
   if (!result) return result;
   try {
@@ -163,9 +198,8 @@ export function beforeSend(result: CaptureResult | null): CaptureResult | null {
     result.properties = properties;
     return result;
   } catch {
-    // Pass through unmodified — dropping telemetry is worse than un-redacted
-    // telemetry only in the sense that an unhandled throw here breaks capture
-    // page-wide; the URL/token risk is mitigated by posthog's own config too.
-    return result;
+    // Fail closed. The event may still contain the per-boot URL credential or
+    // secret-surface text, so it cannot leave the machine unredacted.
+    return null;
   }
 }

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1312,7 +1312,19 @@ class MockApi implements HarnessApi {
     if (typeof window !== "undefined") {
       const win = window as unknown as {
         __MOCK_RUN_STATE__?: Record<string, RunView>;
+        __MOCK_RUN_STATE_FAILURES__?: Record<string, number>;
+        __MOCK_RUN_STATE_CALLS__?: Record<string, number>;
       };
+      win.__MOCK_RUN_STATE_CALLS__ = {
+        ...(win.__MOCK_RUN_STATE_CALLS__ ?? {}),
+        [executionId]: (win.__MOCK_RUN_STATE_CALLS__?.[executionId] ?? 0) + 1,
+      };
+      const failuresRemaining =
+        win.__MOCK_RUN_STATE_FAILURES__?.[executionId] ?? 0;
+      if (failuresRemaining > 0) {
+        win.__MOCK_RUN_STATE_FAILURES__![executionId] = failuresRemaining - 1;
+        throw new Error("mock run-state inspection failure");
+      }
       const override = win.__MOCK_RUN_STATE__?.[executionId];
       if (override) {
         delete win.__MOCK_RUN_STATE__![executionId];

--- a/packages/harness/web/src/lib/dead-session-action.test.ts
+++ b/packages/harness/web/src/lib/dead-session-action.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { deadSessionAction } from "./dead-session-action";
+
+describe("deadSessionAction", () => {
+  it("offers nothing while server-backed resumability is unresolved", () => {
+    expect(
+      deadSessionAction({
+        hasAgentSessionId: true,
+        resumeMode: undefined,
+        recordReady: true,
+      }),
+    ).toBe("checking");
+  });
+
+  it("offers native Resume only for a verified agent conversation", () => {
+    expect(
+      deadSessionAction({
+        hasAgentSessionId: true,
+        resumeMode: "agent-resume",
+        recordReady: true,
+      }),
+    ).toBe("resume");
+  });
+
+  it("offers portable Continue only when a record is ready", () => {
+    expect(
+      deadSessionAction({
+        hasAgentSessionId: true,
+        resumeMode: "rehydrate",
+        recordReady: true,
+      }),
+    ).toBe("continue");
+    expect(
+      deadSessionAction({
+        hasAgentSessionId: false,
+        resumeMode: "rehydrate",
+        recordReady: false,
+      }),
+    ).toBe("blocked");
+  });
+});

--- a/packages/harness/web/src/lib/dead-session-action.ts
+++ b/packages/harness/web/src/lib/dead-session-action.ts
@@ -1,0 +1,22 @@
+import type { SessionResumeMode } from "@shared/types";
+
+export type DeadSessionAction = "checking" | "resume" | "continue" | "blocked";
+
+/**
+ * Resolves the one truthful primary action for an exited Studio session.
+ * Undefined resumeMode means the server-backed history check is still in
+ * flight; neither native Resume nor portable Continue is promised until it
+ * settles.
+ */
+export function deadSessionAction(input: {
+  hasAgentSessionId: boolean;
+  resumeMode: SessionResumeMode | undefined;
+  recordReady: boolean;
+}): DeadSessionAction {
+  if (input.hasAgentSessionId && input.resumeMode === undefined)
+    return "checking";
+  if (input.hasAgentSessionId && input.resumeMode === "agent-resume")
+    return "resume";
+  if (input.recordReady) return "continue";
+  return "blocked";
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -364,6 +364,8 @@ export function useHarnessState(): HarnessStateHook {
 
   // Poll one run until terminal. A new run for the same session replaces the
   // old POLLER only — the previous run's snapshot stays in runsByExecution.
+  // A transient inspection error is retried; three consecutive failures stop
+  // this poller with a visible recovery message instead of disappearing.
   const startRunPolling = useCallback(
     (sessionId: string, executionId: string, target: RunTarget) => {
       const existing = runPollers.current.get(sessionId);
@@ -390,9 +392,20 @@ export function useHarnessState(): HarnessStateHook {
         next.delete(sessionId);
         return next;
       });
+      let consecutiveFailures = 0;
+      let pollInFlight = false;
+      let timer: ReturnType<typeof setInterval>;
+      const stopCurrentPoller = (): void => {
+        if (runPollers.current.get(sessionId) !== timer) return;
+        clearInterval(timer);
+        runPollers.current.delete(sessionId);
+      };
       const poll = async (): Promise<void> => {
+        if (pollInFlight) return;
+        pollInFlight = true;
         try {
           const run = await api.getRunState(executionId);
+          consecutiveFailures = 0;
           setRunsByExecution((prev) =>
             new Map(prev).set(executionId, {
               run,
@@ -402,23 +415,26 @@ export function useHarnessState(): HarnessStateHook {
             }),
           );
           if (run.status !== "running") {
-            const timer = runPollers.current.get(sessionId);
-            if (timer) clearInterval(timer);
-            runPollers.current.delete(sessionId);
+            stopCurrentPoller();
           }
         } catch {
-          // Endpoint absent (server predates runtime analytics) or transient
-          // failure: stop polling quietly - the UI simply shows no run state.
-          const timer = runPollers.current.get(sessionId);
-          if (timer) clearInterval(timer);
-          runPollers.current.delete(sessionId);
+          consecutiveFailures += 1;
+          if (
+            consecutiveFailures >= 3 &&
+            runPollers.current.get(sessionId) === timer
+          ) {
+            stopCurrentPoller();
+            setToast(
+              "Run inspection is temporarily unavailable. Open the run in the Sapiom dashboard or start a new Prod Run to retry.",
+            );
+          }
+        } finally {
+          pollInFlight = false;
         }
       };
+      timer = setInterval(() => void poll(), 2000);
+      runPollers.current.set(sessionId, timer);
       void poll();
-      runPollers.current.set(
-        sessionId,
-        setInterval(() => void poll(), 2000),
-      );
     },
     [],
   );


### PR DESCRIPTION
## Summary

- make `--state-root` isolate consent, settings, local events, and identity migration while leaving shared credentials explicit
- keep a healthy Studio server alive when automatic browser opening fails, without repeating token-bearing output
- isolate history sources, preserve same-directory tracked project bindings for portable continuation, and remove the optimistic native-resume action
- retry transient production-run inspection failures, stop visibly after three consecutive failures, and prevent overlapping/stale pollers
- fail closed when interaction-event redaction cannot complete

## Verification

- `pnpm --filter @sapiom/harness... build`
- `pnpm --filter @sapiom/harness typecheck`
- `pnpm --filter @sapiom/harness lint` (passes with one pre-existing unused-import warning in `rest.test.ts`)
- focused Harness unit suites: 186/186 tests passed
- Analytics full Jest suite: 160/160 tests passed
- Harness performance suite: 4/4 tests passed
- focused Playwright continuation and Run Inspector suites: 14/14 tests passed
- real built-CLI dogfood with an explicit temporary state root: tokenized state request 200, bare request 401, isolated files created, shared Harness settings/machine ID and shared analytics identity unchanged

The full Harness unit run passed 1,702/1,703 tests. One macOS temporary watched-workspace cleanup hit `ENOTEMPTY`; the exact test passed immediately in isolation, and watcher code is unchanged here. The snag is recorded in the docs project ledger.

Linear: [SAP-2363](https://linear.app/sapiom/issue/SAP-2363/docs-split-agent-studio-reference-privacy-and-troubleshooting)
