### PR TITLE
feat(harness): Studio rail, theme, and session-bar UX polish

### DIFF
--- a/.changeset/studio-rail-sessions-theme.md
+++ b/.changeset/studio-rail-sessions-theme.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/harness": minor
+---
+
+Studio shell polish — left rail, theme, and the session bar:
+
+- **Even rail spacing.** The workspace panel's top stack (agent.studio → Search → Create new → Templates → Workspaces) now sits on one uniform 8px rhythm instead of three different gaps.
+- **"Create new" CTA.** A standing button under Search opens the Add menu (new session / workspace / templates). When the rail has no agents yet it becomes the filled brand-green primary with a soft ring, so a first-run workspace has an obvious next step.
+- **Theme follows the OS by default.** With no saved choice the Studio mirrors the system light/dark preference and keeps tracking it across launches; a manual toggle still wins and persists.
+- **Session switcher in the title menu.** The current session is a single selector whose ⌄ menu lists every live session (disambiguated by name + last-active time, active one checked), plus New session and the session actions. This replaces the inline chips — sessions that share a base name no longer read as a row of near-identical labels — and the bound-agent line moves into that menu.

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -149,7 +149,10 @@ test("a launched-agent node keeps its private identifiers and navigates to the a
   await openAgent.click();
 
   await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-focused/);
+  // The binding now reads in the current session's ⌄ menu (moved off the bar).
+  await page.getByTestId("session-menu").click();
   await expect(page.getByTestId("session-workflow-chip")).toContainText("rfq");
+  await page.keyboard.press("Escape");
 });
 
 test("deselect restores the overview: Esc, the panel's close, and empty board space", async ({ page }) => {

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -52,30 +52,57 @@ test("viewport-locked shell: the page never scrolls even when terminal content o
   expect(root.scrollHeight).toBe(root.clientHeight);
 });
 
-test("theme: defaults to dark, toggles to light, and the choice persists across reload", async ({ page }) => {
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-  await page.screenshot({ path: "web/e2e/screenshots/theme-dark.png", fullPage: true });
+test.describe("theme — a manual choice overrides system and persists", () => {
+  // Pin the OS to dark so the default resolves to dark; the toggle then flips
+  // to light and the STORED choice must survive a reload even though the OS
+  // still prefers dark (persistence beats system).
+  test.use({ colorScheme: "dark" });
 
-  await page.getByTestId("theme-toggle").click();
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
-  await page.screenshot({ path: "web/e2e/screenshots/theme-light.png", fullPage: true });
+  test("toggles to light and the choice persists across reload", async ({ page }) => {
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await page.screenshot({ path: "web/e2e/screenshots/theme-dark.png", fullPage: true });
 
-  await page.reload();
-  await expect(page.locator(".rail-workflows")).toBeVisible();
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await page.getByTestId("theme-toggle").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await page.screenshot({ path: "web/e2e/screenshots/theme-light.png", fullPage: true });
 
-  await page.getByTestId("theme-toggle").click();
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-});
+    await page.reload();
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 
-test.describe("theme — system preference", () => {
-  // The Studio defaults to dark until the user sets a preference,
-  // regardless of the OS color scheme.
-  test.use({ colorScheme: "light" });
-
-  test("defaults to dark even when the system prefers light, absent a stored choice", async ({ page }) => {
+    await page.getByTestId("theme-toggle").click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   });
+});
+
+test.describe("theme — follows the system preference until the user chooses", () => {
+  // No stored choice → the app mirrors the OS color scheme in both directions
+  // (boot never persists, so it keeps tracking the system across launches).
+  test.describe("system prefers dark", () => {
+    test.use({ colorScheme: "dark" });
+    test("defaults to dark", async ({ page }) => {
+      await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    });
+  });
+
+  test.describe("system prefers light", () => {
+    test.use({ colorScheme: "light" });
+    test("defaults to light", async ({ page }) => {
+      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    });
+  });
+});
+
+test("rail: the Create-new CTA sits below Search and opens the Add menu", async ({ page }) => {
+  const cta = page.getByTestId("rail-create-new");
+  await expect(cta).toBeVisible();
+  await expect(cta).toContainText("Create new");
+
+  // It opens the SAME Add menu as the header + — anchored to itself — so the
+  // primary creative action is reachable straight from the nav.
+  await cta.click();
+  await expect(page.getByTestId("add-menu")).toBeVisible();
+  await expect(page.getByTestId("new-session-btn")).toBeVisible();
 });
 
 test("brand header shows the Sapiom wordmark and the demo-workspace identity", async ({ page }) => {
@@ -253,14 +280,18 @@ test("creation IA: the rail + adds projects; the tab strip + adds a session to t
 
   // Session creation lives in the session bar: the trailing + starts a NEW
   // session on the focused agent (leasing), no dialog. Leasing has two live
-  // sessions on load (active + one switch chip); the + makes it three, so a
-  // second switch chip joins and the new session becomes active.
+  // sessions on load (listed in the switcher menu); the + makes it three and
+  // the new session becomes active.
   const newBtn = page.getByTestId("session-new");
   await expect(newBtn).toHaveAttribute("aria-label", "New session");
-  await expect(page.locator(".session-switch")).toHaveCount(1);
+  await page.getByTestId("session-menu").click();
+  await expect(page.locator(".session-switch-item")).toHaveCount(2);
+  await page.keyboard.press("Escape");
   await newBtn.click();
-  await expect(page.locator(".session-switch")).toHaveCount(2);
   await expect(page.getByTestId("session-context-title")).toContainText("leasing");
+  await page.getByTestId("session-menu").click();
+  await expect(page.locator(".session-switch-item")).toHaveCount(3);
+  await page.keyboard.press("Escape");
   // No dialog — the + is a direct action.
   await expect(page.locator(".modal-new-session")).toHaveCount(0);
 });
@@ -336,14 +367,18 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await page.screenshot({ path: "web/e2e/screenshots/rail-explorer.png", fullPage: true });
   });
 
-  test("focusing an agent with sessions shows the active session plus inline switch chips", async ({ page }) => {
-    // Leasing is focused on load and carries two live sessions — the active one
-    // is the options dropdown (sess-boot); the other is an inline switch chip.
+  test("focusing an agent with sessions shows the active session and a switcher menu", async ({ page }) => {
+    // Leasing is focused on load and carries two live sessions. The bar shows a
+    // single selector (sess-boot); switching lives in its ⌄ menu, which lists
+    // both sessions with the active one checked.
     const header = page.getByTestId("session-context");
     await expect(header).toHaveAttribute("data-session-id", "sess-boot");
     await expect(page.getByTestId("session-menu")).toBeVisible();
-    await expect(page.locator(".session-switch")).toHaveCount(1);
+    await page.getByTestId("session-menu").click();
+    await expect(page.locator(".session-switch-item")).toHaveCount(2);
     await expect(page.getByTestId("session-switch-sess-leasing-2")).toBeVisible();
+    await expect(page.getByTestId("session-switch-sess-boot")).toHaveAttribute("aria-checked", "true");
+    await page.keyboard.press("Escape");
     // A + to add another session is always available.
     await expect(page.getByTestId("session-new")).toBeVisible();
     await page.screenshot({ path: "web/e2e/screenshots/session-tab-strip.png", fullPage: true });
@@ -356,7 +391,8 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
     await expect(page.locator(".canvas-iframe")).toBeVisible();
 
-    // Click the other session's switch chip to make it active.
+    // Switch to the other session from the current session's menu.
+    await page.getByTestId("session-menu").click();
     await page.getByTestId("session-switch-sess-leasing-2").click();
     await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-leasing-2");
     await expect(page.locator(".canvas-empty")).toContainText("Nothing generated yet");
@@ -365,20 +401,25 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await page.getByTestId("right-tab-steps").click();
     await expect(page.locator(".canvas-empty")).toContainText("No steps yet");
 
-    // sess-boot is now the switch chip — clicking it returns to the board.
+    // Switching back from the menu returns to the board.
+    await page.getByTestId("session-menu").click();
     await page.getByTestId("session-switch-sess-boot").click();
     await page.getByTestId("right-tab-canvas").click();
     await expect(page.locator(".canvas-iframe")).toBeVisible();
   });
 
   test("the + starts a new session on the focused agent", async ({ page }) => {
-    await expect(page.locator(".session-switch")).toHaveCount(1);
+    await page.getByTestId("session-menu").click();
+    await expect(page.locator(".session-switch-item")).toHaveCount(2);
+    await page.keyboard.press("Escape");
     await page.getByTestId("session-new").click();
 
-    // A third session joins, bound to the same agent, and becomes active — so a
-    // second switch chip appears.
-    await expect(page.locator(".session-switch")).toHaveCount(2);
+    // A third session joins, bound to the same agent, and becomes active — the
+    // switcher menu now lists three.
     await expect(page.getByTestId("session-context-title")).toContainText("leasing");
+    await page.getByTestId("session-menu").click();
+    await expect(page.locator(".session-switch-item")).toHaveCount(3);
+    await page.keyboard.press("Escape");
     await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
   });
 
@@ -392,18 +433,22 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(confirm).toBeVisible();
     await expect(confirm).toContainText("kills the live terminal");
 
-    // Keep cancels — nothing dies, the other session's chip stays.
+    // Keep cancels — nothing dies, both sessions remain in the switcher.
     await page.getByRole("button", { name: "Keep session" }).click();
     await expect(confirm).toHaveCount(0);
-    await expect(page.locator(".session-switch")).toHaveCount(1);
+    await page.getByTestId("session-menu").click();
+    await expect(page.locator(".session-switch-item")).toHaveCount(2);
+    await page.keyboard.press("Escape");
 
     // Confirming ends the active session; the workbench falls back to the other
-    // leasing session, which is now active (no more switch chips).
+    // leasing session, now active and the only one left in the switcher.
     await page.getByTestId("session-menu").click();
     await page.getByTestId("session-end-btn").click();
     await page.getByTestId("end-session-confirm-btn").click();
     await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-leasing-2");
-    await expect(page.locator(".session-switch")).toHaveCount(0);
+    await page.getByTestId("session-menu").click();
+    await expect(page.locator(".session-switch-item")).toHaveCount(1);
+    await page.keyboard.press("Escape");
     // Leasing stays focused throughout — ending a session never moves the rail.
     await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
   });
@@ -1645,19 +1690,25 @@ test.describe("resizable panes", () => {
   });
 });
 
-test("the canvas iframe carries the app's theme and flips on toggle", async ({ page }) => {
-  await page.evaluate(() => {
-    (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
-      type: "canvas.reload",
-      harnessSessionId: "sess-boot",
+test.describe("canvas iframe theme", () => {
+  // Pin the OS to dark so the default theme is deterministic (it now follows
+  // the system); the test then proves the iframe carries it and flips on toggle.
+  test.use({ colorScheme: "dark" });
+
+  test("the canvas iframe carries the app's theme and flips on toggle", async ({ page }) => {
+    await page.evaluate(() => {
+      (window as unknown as { __HARNESS_TEST__: { publish: (message: unknown) => void } }).__HARNESS_TEST__.publish({
+        type: "canvas.reload",
+        harnessSessionId: "sess-boot",
+      });
     });
+
+    const iframe = page.locator(".canvas-iframe");
+    await expect(iframe).toHaveAttribute("src", /theme=dark/);
+
+    await page.getByTestId("theme-toggle").click();
+    await expect(iframe).toHaveAttribute("src", /theme=light/);
   });
-
-  const iframe = page.locator(".canvas-iframe");
-  await expect(iframe).toHaveAttribute("src", /theme=dark/);
-
-  await page.getByTestId("theme-toggle").click();
-  await expect(iframe).toHaveAttribute("src", /theme=light/);
 });
 
 

--- a/packages/harness/web/index.html
+++ b/packages/harness/web/index.html
@@ -8,10 +8,14 @@
     <title>Agent Studio</title>
     <script>
       // Set the theme before first paint to avoid a flash of the wrong one.
-      // Storage key must match web/src/lib/theme.ts (this can't import it).
+      // Storage key + resolution must match web/src/lib/theme.ts (this can't
+      // import it): a stored choice wins, otherwise follow the OS preference.
       (function () {
         var stored = localStorage.getItem("sapiom-harness-theme");
-        var theme = stored === "light" || stored === "dark" ? stored : "dark";
+        var prefersDark =
+          window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme =
+          stored === "light" || stored === "dark" ? stored : prefersDark ? "dark" : "light";
         document.documentElement.dataset.theme = theme;
       })();
     </script>

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import type { JSX, ReactNode } from "react";
 import type { HarnessSession } from "@shared/types";
 
-import { HARNESS_LABELS } from "../lib/history-meta";
+import { HARNESS_LABELS, formatRelativeTime } from "../lib/history-meta";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { EndSessionConfirm } from "./EndSessionConfirm";
 import { Icon } from "./Icon";
@@ -92,6 +92,8 @@ export function SessionBar({
   };
 
   const others = activeSession ? sessions.filter((s) => s.id !== activeSession.id) : [];
+  // The switcher lists every live session of this agent, active one first.
+  const orderedSessions = activeSession ? [activeSession, ...others] : [];
 
   return (
     <div className="session-bar">
@@ -190,17 +192,6 @@ export function SessionBar({
                   <Icon name="ChevronDown" size={13} />
                 </button>
               )}
-              {/* Bound-agent suffix on the active session: a quiet metadata tail
-                  next to the title (styled in refine.css), never a boxed tag. */}
-              {boundWorkflowName && (
-                <span
-                  className="session-workflow-chip"
-                  data-testid="session-workflow-chip"
-                  data-tooltip={`Bound to ${boundWorkflowName}; shown in Canvas`}
-                >
-                  · {boundWorkflowName}
-                </span>
-              )}
               <AnchoredPopover
                 open={menuOpen}
                 anchorRef={menuTriggerRef}
@@ -210,6 +201,57 @@ export function SessionBar({
                 role="menu"
                 testid="session-menu-popover"
               >
+                {/* Switcher: every live session of this agent, the active one
+                    checked. Picking a row switches; the actions below act on the
+                    current session. One place to select or act — no inline chips
+                    crowding the bar. */}
+                <div className="session-menu-section">Sessions</div>
+                {orderedSessions.map((s) => {
+                  const isActive = s.id === activeSession.id;
+                  return (
+                    <button
+                      key={s.id}
+                      role="menuitemradio"
+                      aria-checked={isActive}
+                      className={"profile-menu-item session-switch-item" + (isActive ? " is-selected" : "")}
+                      data-testid={`session-switch-${s.id}`}
+                      onClick={() => {
+                        if (!isActive) onSelectSession?.(s.id);
+                        closeMenu();
+                      }}
+                    >
+                      <span className="session-dot" data-status={s.status} />
+                      <span className="session-switch-label">{labelOf ? labelOf(s) : s.title}</span>
+                      <span className="session-switch-meta">{formatRelativeTime(s.lastActiveAt)}</span>
+                      {isActive && <Icon name="Check" size={13} />}
+                    </button>
+                  );
+                })}
+                {onNewSession && (
+                  <button
+                    role="menuitem"
+                    className="profile-menu-item session-menu-new"
+                    data-testid="session-new-menu"
+                    onClick={() => {
+                      onNewSession();
+                      closeMenu();
+                    }}
+                  >
+                    <Icon name="Plus" size={13} />
+                    New session
+                  </button>
+                )}
+
+                <div className="session-menu-divider" role="separator" />
+
+                {/* Which agent's Canvas this session drives — moved off the bar
+                    into the menu, where it reads as metadata, not a session. */}
+                {boundWorkflowName && (
+                  <div className="session-menu-bound" data-testid="session-workflow-chip">
+                    Bound to <strong>{boundWorkflowName}</strong> · shown in Canvas
+                  </div>
+                )}
+
                 <button
                   role="menuitem"
                   className="profile-menu-item"
@@ -265,21 +307,6 @@ export function SessionBar({
                 )}
               </AnchoredPopover>
             </div>
-
-            {/* Other live sessions of this agent: click a chip to switch. */}
-            {others.map((s) => (
-              <button
-                key={s.id}
-                className="session-switch"
-                data-testid={`session-switch-${s.id}`}
-                title={labelOf ? labelOf(s) : s.title}
-                onClick={() => onSelectSession?.(s.id)}
-              >
-                <span className="session-dot" data-status={s.status} />
-                <span className="session-switch-label">{labelOf ? labelOf(s) : s.title}</span>
-              </button>
-            ))}
-
           </>
         ) : (
           <span className="session-context-none">No active session</span>

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -331,6 +331,9 @@ export function WorkflowsRail({
 }: WorkflowsRailProps): JSX.Element {
   const [addDialogMode, setAddDialogMode] = useState<"session" | "workspace" | null>(null);
   const connectTriggerRef = useRef<HTMLButtonElement>(null);
+  // The prominent "Create new" CTA in the nav opens the SAME Add menu as the
+  // header +; the popover anchors to whichever trigger the user pressed.
+  const createTriggerRef = useRef<HTMLButtonElement>(null);
   // The ⋯ menu opens BESIDE the rail (not over it), so it clears the whole
   // rail's right edge rather than just the header glyph's.
   const railRef = useRef<HTMLElement>(null);
@@ -349,6 +352,9 @@ export function WorkflowsRail({
    */
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [addDoor, setAddDoor] = useState<Door>("have");
+  // Which trigger the Add menu hangs off — the compact header + or the nav CTA
+  // — so the popover anchors to the button the user actually pressed.
+  const [addMenuFrom, setAddMenuFrom] = useState<"header" | "cta">("header");
   const closeAddMenu = useCallback(() => setAddMenuOpen(false), []);
 
   // The ⋯ overflow menu: how the tree is grouped, how it is sorted, and the
@@ -442,6 +448,10 @@ export function WorkflowsRail({
     recentDirs,
   );
 
+  // A first-run rail (no agents, no orphans) promotes the Create-new CTA to the
+  // primary style — the one action that gets the user their first agent.
+  const isEmpty = workspaces.length === 0 && orphanAgents.length === 0;
+
   const copyPath = (path: string): void => {
     void navigator.clipboard
       ?.writeText(path)
@@ -470,6 +480,29 @@ export function WorkflowsRail({
           <Icon name="Search" size={14} />
           <span>Search</span>
           <span className="rail-nav-kbd">{SHORTCUT_HINT}</span>
+        </button>
+
+        {/* The primary creative action, promoted out of the header + into a
+            standing CTA directly under Search: the fastest path to a first
+            agent. It opens the same Add menu as the + (anchored to itself), and
+            when the rail has nothing yet it becomes the filled primary button so
+            an empty workspace has an obvious next step. */}
+        <button
+          type="button"
+          ref={createTriggerRef}
+          className={"rail-nav-cta" + (isEmpty ? " is-empty" : "")}
+          data-testid="rail-create-new"
+          aria-label="Create new agent or workspace"
+          aria-haspopup="menu"
+          aria-expanded={addMenuOpen && addMenuFrom === "cta"}
+          onClick={() => {
+            setHistoryOpen(false);
+            setAddMenuFrom("cta");
+            setAddMenuOpen((open) => !open);
+          }}
+        >
+          <Icon name="Plus" size={14} />
+          <span>Create new</span>
         </button>
 
         <button
@@ -506,10 +539,11 @@ export function WorkflowsRail({
             className="theme-toggle rail-header-btn"
             data-testid="add-workspace"
             aria-label="Add workspace"
-            aria-expanded={addMenuOpen}
+            aria-expanded={addMenuOpen && addMenuFrom === "header"}
             title="Add a workspace: a folder containing an agent project (sapiom.json). Its agent appears in the rail."
             onClick={() => {
               setHistoryOpen(false);
+              setAddMenuFrom("header");
               setAddMenuOpen((open) => !open);
             }}
           >
@@ -526,11 +560,11 @@ export function WorkflowsRail({
             the catalog. */}
         <AnchoredPopover
           open={addMenuOpen}
-          anchorRef={connectTriggerRef}
+          anchorRef={addMenuFrom === "cta" ? createTriggerRef : connectTriggerRef}
           onDismiss={closeAddMenu}
-          // Beside the rail, not over it. The + is pinned to the rail's right
-          // edge, so a downward panel grows back across the workspace tree it
-          // is about to add to — covering the list you are checking against.
+          // Beside the rail, not over it. Both triggers are pinned to the rail's
+          // right edge, so a downward panel grows back across the workspace tree
+          // it is about to add to — covering the list you are checking against.
           placement="right-start"
           className="connect-card add-card"
           testid="add-menu"

--- a/packages/harness/web/src/lib/theme.ts
+++ b/packages/harness/web/src/lib/theme.ts
@@ -14,12 +14,14 @@ function systemPrefersDark(): boolean {
   return typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches === true;
 }
 
-/** No stored preference → dark, matching the Studio's default.
- *  The toggle and any stored choice still win. */
+/** No stored preference → follow the OS (prefers-color-scheme). Boot never
+ *  persists, so with no stored choice the app tracks the system theme across
+ *  launches; the toggle and any stored choice still win. Must match the inline
+ *  script in index.html, which resolves the same way before first paint. */
 export function getInitialTheme(): Theme {
   const stored = typeof window !== "undefined" ? window.localStorage.getItem(STORAGE_KEY) : null;
   if (stored === "light" || stored === "dark") return stored;
-  return "dark";
+  return systemPrefersDark() ? "dark" : "light";
 }
 
 let current: Theme = getInitialTheme();

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -401,7 +401,9 @@ input {
   grid-template-rows: var(--header-h) auto;
   align-items: center;
   height: auto;
-  padding: 0 var(--pane-pad-x) var(--sp2);
+  /* No bottom padding: the --sp2 gap below agent.studio is owned by the nav's
+     padding-top, so agent.studio → Search matches every other top-stack gap. */
+  padding: 0 var(--pane-pad-x);
   column-gap: var(--sp2);
 }
 
@@ -508,10 +510,15 @@ input {
 /* Search + Templates: the persistent labelled destinations above the tree.
    A quiet vertical stack of rows on the continuous rail surface — no boxed
    field, no divider. */
+/* One uniform gap (--sp2) sets the whole top stack's rhythm: the nav's
+   padding-top spaces it off the brand header, each row/CTA carries an --sp2
+   bottom margin, and the Workspaces header takes no top margin — so
+   agent.studio → Search → Create new → Templates → Workspaces are all evenly
+   spaced by the same 8px. */
 .rail-nav {
   display: flex;
   flex-direction: column;
-  padding: var(--sp2) 0 var(--sp1);
+  padding: var(--sp2) 0 0;
 }
 
 /* The unboxed shortcut hint on the Search row — right-aligned, quiet mono, no
@@ -717,7 +724,7 @@ input {
   align-items: center;
   gap: var(--sp2);
   width: calc(100% - var(--sp3));
-  margin: 0 var(--sp2) var(--sp1);
+  margin: 0 var(--sp2) var(--sp2);
   padding: var(--sp2);
   border: none;
   border-radius: var(--radius-sm);
@@ -747,6 +754,78 @@ input {
   font-weight: 550;
 }
 
+/* "Create new": the primary creative action, promoted out of the header + into
+   a standing CTA under Search. A real button (bordered fill, centered label,
+   brand-green plus) — distinct from the ghost Search/Templates rows, but the
+   same inset and --sp2 rhythm so the top stack stays evenly spaced. */
+.rail-nav-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp1);
+  width: calc(100% - var(--sp3));
+  margin: 0 var(--sp2) var(--sp2);
+  min-height: var(--control-h);
+  padding: 0 var(--sp2);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  text-align: center;
+  font-size: var(--type-ui);
+  font-weight: 550;
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+/* The plus is the create signal — the one reserved accent at rest, inheriting
+   the button ink once the CTA fills in for the empty state. */
+.rail-nav-cta svg {
+  color: var(--brand);
+}
+
+.rail-nav-cta:hover {
+  background: var(--surface-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.rail-nav-cta:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.rail-nav-cta:active {
+  transform: translateY(0);
+}
+
+/* Empty rail: fill with the brand green (the reserved accent) over its own
+   contrasting ink, ringed in a soft brand halo — so the one action a first-run
+   user needs is the loudest thing on an otherwise empty rail. --brand-ink flips
+   with the theme (white on the dark-green light brand, near-black on the
+   light-green dark brand), so it stays legible in both. */
+.rail-nav-cta.is-empty {
+  background: var(--brand);
+  border-color: transparent;
+  color: var(--brand-ink);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 22%, transparent);
+}
+
+.rail-nav-cta.is-empty svg {
+  color: var(--brand-ink);
+}
+
+.rail-nav-cta.is-empty:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--brand) 32%, transparent),
+    var(--shadow-soft);
+}
+
 .rail-header {
   position: relative;
   flex: 0 0 auto;
@@ -755,9 +834,10 @@ input {
   gap: var(--sp2);
   /* A compact section-label row (a peer of the Search/Templates nav rows and
      the folder rows below), not a 56px band — it reads as the header of the
-     tree it sits above, with a modest gap from the nav group. */
+     tree it sits above. Its gap from the nav group is the same --sp2 as every
+     other top-stack boundary, owned by the last nav row's bottom margin. */
   min-height: var(--control-h);
-  margin-top: var(--sp2);
+  margin-top: 0;
   /* One deliberate divider under the Workspaces header, setting the explorer
      tree off from the destinations above it (Search / Templates). It is the
      rail's only rule — the main shell panes carry none. */
@@ -2233,12 +2313,68 @@ input {
 }
 
 .session-menu {
-  min-width: 180px;
+  min-width: 220px;
 }
 
 .session-menu-danger:hover:not(:disabled) {
   color: var(--red-text);
   background: color-mix(in srgb, var(--red) 12%, transparent);
+}
+
+/* Session switcher inside the current-session menu ------------------------
+   The ⌄ on the current session opens a titled list of the agent's live
+   sessions (active one checked) plus this session's actions — one place to
+   pick a session or act on it, so the bar itself stays a single clean pill. */
+.session-menu-section {
+  padding: var(--sp2) var(--sp2) var(--sp1);
+  font-size: var(--type-micro);
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+/* Rows reuse .profile-menu-item; the active one carries the app's standard
+   "you are here" selected wash. The label grows; time trails, right-aligned. */
+.session-switch-item .session-switch-label {
+  flex: 1 1 auto;
+  max-width: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+}
+
+.session-switch-item.is-selected {
+  background: var(--active-shade);
+  color: var(--text);
+}
+
+.session-switch-meta {
+  margin-left: auto;
+  padding-left: var(--sp2);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--type-meta);
+  color: var(--text-faint);
+}
+
+.session-menu-divider {
+  height: 1px;
+  margin: var(--sp1) 0;
+  background: var(--ui-line);
+}
+
+/* Bound-agent line: which agent's Canvas this session drives. Quiet metadata,
+   not a boxed chip — it never reads as another session (the old bar chip did). */
+.session-menu-bound {
+  padding: var(--sp1) var(--sp2) var(--sp2);
+  font-size: var(--type-meta);
+  line-height: 1.4;
+  color: var(--text-faint);
+}
+.session-menu-bound strong {
+  color: var(--text-dim);
+  font-weight: 600;
 }
 
 
@@ -2283,24 +2419,6 @@ input {
   font-weight: 700;
   line-height: 14px;
   text-align: center;
-}
-
-/* Badge recipe (variant="active"): tinted fill + matching border + accent
-   text, rounded-md rather than a pill — the product's status chips are
-   small rounded rectangles, not fully-rounded tags. */
-.session-workflow-chip {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding: 2px 8px;
-  border-radius: var(--radius-md);
-  background: var(--accent-dim);
-  border: 1px solid var(--accent-border);
-  color: var(--text-dim);
-  font-size: var(--type-meta);
-  font-weight: 500;
 }
 
 /* Right-anchored status slot, pushed past the flexible title/cwd/chip run —

--- a/packages/harness/web/src/styles/refine.css
+++ b/packages/harness/web/src/styles/refine.css
@@ -124,20 +124,6 @@ body {
   background: transparent;
 }
 
-/* Bound-workflow suffix inside the active tab: quiet metadata text, not a
-   boxed tag. */
-.session-workflow-chip {
-  background: transparent;
-  border: 0;
-  padding: 0;
-  color: var(--text-faint);
-  font-size: var(--type-meta);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 /* ---- Shared buttons: pill + lift; primary is the inverted --btn -------- */
 .btn-ghost,
 .btn-primary {

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -234,8 +234,8 @@
     "id": "session-bar-private-css-and-test-id",
     "path": "packages/harness/web/src/components/SessionBar.tsx",
     "pattern": "^session-workflow-chip$",
-    "occurrences": 2,
-    "reason": "Private CSS classes and test IDs remain stable."
+    "occurrences": 1,
+    "reason": "The private bound-agent test ID remains stable (the e2e suite addresses the line by it)."
   },
   {
     "id": "tooltip-private-selector",
@@ -399,13 +399,6 @@
     "reason": "The private CSS selector remains stable with its React class name."
   },
   {
-    "id": "styles-session-workflow-chip-selector",
-    "path": "packages/harness/web/src/styles.css",
-    "pattern": "(?<![a-z0-9_-])session-workflow-chip(?![a-z0-9_-])",
-    "occurrences": 1,
-    "reason": "The private CSS selector remains stable with its React class name."
-  },
-  {
     "id": "styles-workflow-actions-header-selector",
     "path": "packages/harness/web/src/styles.css",
     "pattern": "(?<![a-z0-9_-])workflow-actions-header(?![a-z0-9_-])",
@@ -438,13 +431,6 @@
     "path": "packages/harness/web/src/styles/refine.css",
     "pattern": "(?<![a-z0-9_-])workflow-item(?![a-z0-9_-])",
     "occurrences": 2,
-    "reason": "The private refinement-layer CSS selector remains stable with its React class name."
-  },
-  {
-    "id": "refine-session-workflow-chip-selector",
-    "path": "packages/harness/web/src/styles/refine.css",
-    "pattern": "(?<![a-z0-9_-])session-workflow-chip(?![a-z0-9_-])",
-    "occurrences": 1,
     "reason": "The private refinement-layer CSS selector remains stable with its React class name."
   },
   {


### PR DESCRIPTION
## What

Studio shell polish, from a design pass over the left rail, theme default, and the top session bar. Three independent improvements shipping together.

### Left rail
- **Even spacing.** The top stack had three different gaps stacking margins + paddings (agent.studio → Search ≈16px, Search → Templates ≈4px, Templates → Workspaces ≈16px). Every boundary is now a uniform **8px** rhythm.
- **"Create new" CTA** under Search — a standing button that opens the Add menu (new session / workspace / templates). When the rail has no agents yet it promotes to the filled brand-green primary with a soft ring, so a first-run workspace has an obvious next step. Legible in light and dark (`--brand-ink` flips with the theme).

### Theme
- **Follows the OS by default.** With no saved choice the Studio mirrors `prefers-color-scheme` — resolved the same way in `getInitialTheme()` and the pre-paint inline script (so no flash). Boot never persists, so it keeps tracking the system across launches; a manual toggle still wins and persists.

### Session bar
- The caret used to open *actions* while switching happened through inline chips — and when sessions shared a base name, the active pill, the bound-agent chip, and the sibling chip all read as near-identical labels.
- Now the current session is a **single selector** whose ⌄ menu is the switcher: every live session listed (disambiguated by name + last-active time, active one checked), then **New session**, then the session actions. The bound-agent line moves into that menu as quiet metadata. One place to select or act; scales to any number of sessions.
- Removed the now-dead `.session-workflow-chip` CSS (styles.css + refine.css) and its two terminology-allowlist entries.

## Screens
Rail (light/dark, incl. empty-state CTA) and the session switcher (light/dark) were verified via Playwright against the mock build; screenshots are gitignored.

## Tests
Reworked the smoke session-switching + theme specs and the canvas-inspector bound-agent assertion for the new IA, and added a Create-new CTA smoke test.

- `test:ui` (e2e): **298 passed**
- `vitest` (unit): **1657 passed**
- `test:canvas`: **10 passed**
- `terminology:check`: pass (450 files) · `build`: pass · typecheck: pass

## Note
The **"add new" screen** is a separate, larger change coming next — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
