### PR TITLE
fix(harness): stop Claude Code sessions exiting 1 before establishing a session id

### DIFF
--- a/.changeset/fix-session-exit-before-session-id.md
+++ b/.changeset/fix-session-exit-before-session-id.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/harness": patch
+---
+
+Fix Claude Code sessions that exit with code 1 before establishing a session id, and make the cause visible when they do.
+
+Some users saw a session die within seconds — "Session exited · exit code 1 … it exited before establishing a session id" — with no way to tell why. The session id is only ever set from Claude Code's `SessionStart` hook, so this always means `claude` itself exited before that hook fired. Three independent, environment-specific causes were addressed, each of which is ours to prevent:
+
+- **Version floor for `claude` (doctor).** The harness injects flags on every launch — notably `--plugin-dir`, which per the Claude Code changelog did not exist before the plugin system shipped in `2.0.12` — but nothing checked the installed version, so an older `claude` (a pre-existing global that shadows the app's install, or a stale one) rejected the unknown flag and exited 1 before the hook. `doctor` now enforces `MIN_CLAUDE_CODE_VERSION` (`2.1.0`, the range the harness's `--plugin-dir` skills usage is verified against): a below-floor `claude` reports NOT ok, so the desktop app installs a current one and the `npx` CLI shows an actionable upgrade remedy instead of every session crash-looping silently. A version we can't parse is left alone, so a future change to `claude --version`'s format can never mass-reject working installs.
+
+- **Quote the SessionStart hook command path.** The generated hook command interpolated the emitter-script path unquoted (`node <path> <event>`). Claude Code runs a `command` hook through a shell, so a home directory containing a space (`/Users/First Last/…`) word-split the path — `node` got a truncated path, the hook died, and the session id was never established. The path is now double-quoted.
+
+- **Preserve the agent's error line on abnormal exit.** A live pty's scrollback was discarded the instant it exited, so `claude`'s own error ("unknown option '--plugin-dir'", an auth failure, "Cannot find module …") was lost — which is why this was so hard to diagnose from a report. Sessions that exit with a non-zero code now keep a sanitized tail of their last output (`HarnessSession.exitTail`), shown in the exited-session pane. A clean exit keeps nothing.
+
+The shared ANSI stripper used for this and for Codex trust-prompt detection moved from the Codex adapter into `core/strip-ansi.ts`.

--- a/packages/harness/src/cli/doctor.test.ts
+++ b/packages/harness/src/cli/doctor.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect, vi } from "vitest";
 // drive the doctor-matrix below. Reset in each test rather than beforeEach so
 // each case's setup reads top-to-bottom next to its assertions.
 let presentBinaries: Set<string>;
+// The version string `claude --version` reports — mutated per test to exercise
+// the minimum-version floor. Defaults to a supported version in each test.
+let claudeVersion: string;
 
 vi.mock("node:child_process", () => ({
   execFile: (
@@ -22,7 +25,7 @@ vi.mock("node:child_process", () => ({
       return;
     }
     if (file === "claude" && args[0] === "--version") {
-      callback(null, { stdout: "1.2.3 (Claude Code)\n", stderr: "" });
+      callback(null, { stdout: `${claudeVersion}\n`, stderr: "" });
       return;
     }
     if (file === "codex" && args[0] === "--version") {
@@ -38,15 +41,17 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { runDoctor, pickDefaultHarness, CLAUDE_INSTALL_COMMAND, CODEX_INSTALL_COMMAND } from "./doctor.js";
+import { MIN_CLAUDE_CODE_VERSION } from "../core/adapters/claude-code.js";
 
 describe("runDoctor", () => {
   it("passes when node, claude, and git are present and codex is absent", async () => {
     presentBinaries = new Set(["claude", "git"]);
+    claudeVersion = "2.1.4 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
     expect(byName.node.ok).toBe(true);
-    expect(byName.claude).toEqual({ name: "claude", ok: true, detail: "1.2.3 (Claude Code)" });
+    expect(byName.claude).toEqual({ name: "claude", ok: true, detail: "2.1.4 (Claude Code)" });
     expect(byName.git).toEqual({ name: "git", ok: true, detail: "git version 2.43.0" });
     expect(byName.codex.ok).toBe(false);
 
@@ -56,8 +61,34 @@ describe("runDoctor", () => {
     expect(report.availableHarnesses).toEqual(["claude-code"]);
   });
 
+  it("marks a present-but-too-old claude unavailable, with an upgrade remedy", async () => {
+    // Present on PATH and answers --version, but predates the flags every
+    // launch injects (notably --plugin-dir) — so it exit-1s each session
+    // before establishing a session id. Doctor must report it NOT ok.
+    presentBinaries = new Set(["claude", "git"]);
+    claudeVersion = "1.9.9 (Claude Code)";
+    const report = await runDoctor();
+    const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
+
+    expect(byName.claude.ok).toBe(false);
+    expect(byName.claude.detail).toContain(MIN_CLAUDE_CODE_VERSION);
+    expect(byName.claude.detail).toContain(CLAUDE_INSTALL_COMMAND);
+    expect(report.availableHarnesses).not.toContain("claude-code");
+    // No other agent present, so the whole report fails — the CLI then refuses
+    // to start with the upgrade remedy instead of crash-looping every session.
+    expect(report.ok).toBe(false);
+  });
+
+  it("accepts a claude at exactly the minimum version", async () => {
+    presentBinaries = new Set(["claude", "git"]);
+    claudeVersion = `${MIN_CLAUDE_CODE_VERSION} (Claude Code)`;
+    const report = await runDoctor();
+    expect(report.availableHarnesses).toEqual(["claude-code"]);
+  });
+
   it("passes on codex alone, with claude's check carrying the exact install remedy", async () => {
     presentBinaries = new Set(["codex", "git"]);
+    claudeVersion = "2.1.4 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
@@ -70,6 +101,7 @@ describe("runDoctor", () => {
 
   it("fails only when neither claude nor codex is present, surfacing both install remedies", async () => {
     presentBinaries = new Set(["git"]);
+    claudeVersion = "2.1.4 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
@@ -81,6 +113,7 @@ describe("runDoctor", () => {
 
   it("prefers claude-code when both agents are present", async () => {
     presentBinaries = new Set(["claude", "codex", "git"]);
+    claudeVersion = "2.1.4 (Claude Code)";
     const report = await runDoctor();
 
     expect(report.ok).toBe(true);

--- a/packages/harness/src/cli/doctor.ts
+++ b/packages/harness/src/cli/doctor.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { DoctorCheck, HarnessKind } from "../shared/types.js";
+import { MIN_CLAUDE_CODE_VERSION, isClaudeVersionSupported } from "../core/adapters/claude-code.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -39,10 +40,20 @@ async function binaryCheck(
   bin: string,
   versionArgs: string[],
   notFoundDetail: string,
+  /**
+   * Optional version gate. Receives the reported version line (or null when
+   * `--version` produced nothing) and returns an error detail when the binary
+   * is present but too old to use, or null when it is acceptable. Keeps the
+   * "how old is too old" policy with the caller that knows the flags it sends,
+   * so this stays a generic presence-plus-version check.
+   */
+  versionGate?: (versionLine: string | null) => string | null,
 ): Promise<DoctorCheck> {
   const found = await which(bin);
   if (!found) return { name, ok: false, detail: notFoundDetail };
   const v = await version(bin, versionArgs);
+  const gateError = versionGate?.(v);
+  if (gateError) return { name, ok: false, detail: gateError };
   return { name, ok: true, detail: v ?? found };
 }
 
@@ -73,6 +84,14 @@ export async function runDoctor(): Promise<DoctorReport> {
       "claude",
       ["--version"],
       `not found on PATH — install: ${CLAUDE_INSTALL_COMMAND}`,
+      // A claude older than the flags we inject exit-1s every session before it
+      // can establish a session id. Report it as unavailable so the desktop
+      // host installs a current one and the CLI shows an upgrade remedy, rather
+      // than letting a green check hide a binary that crash-loops on launch.
+      (v) =>
+        isClaudeVersionSupported(v)
+          ? null
+          : `${v ?? "unknown version"} is too old — need >= ${MIN_CLAUDE_CODE_VERSION}; upgrade: ${CLAUDE_INSTALL_COMMAND}`,
     ),
     binaryCheck("codex", "codex", ["--version"], `not found on PATH — install: ${CODEX_INSTALL_COMMAND}`),
     binaryCheck("git", "git", ["--version"], "not found on PATH"),

--- a/packages/harness/src/core/adapters/claude-code.test.ts
+++ b/packages/harness/src/core/adapters/claude-code.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DEFAULT_SYSTEM_PROMPT } from "../../profiles/default.js";
-import { ClaudeCodeAdapter, encodeProjectPath } from "./claude-code.js";
+import {
+  ClaudeCodeAdapter,
+  encodeProjectPath,
+  isClaudeVersionSupported,
+  parseClaudeVersion,
+  MIN_CLAUDE_CODE_VERSION,
+} from "./claude-code.js";
 
 describe("ClaudeCodeAdapter", () => {
   describe("launch/resume — pluginDir flag", () => {
@@ -154,6 +160,32 @@ describe("ClaudeCodeAdapter", () => {
       const checks = await adapter.doctor();
       expect(checks).toHaveLength(1);
       expect(checks[0]).toMatchObject({ name: "claude", ok: false });
+    });
+  });
+
+  describe("version floor", () => {
+    it("parses the semver out of a claude --version line", () => {
+      expect(parseClaudeVersion("2.1.3 (Claude Code)")).toEqual([2, 1, 3]);
+      expect(parseClaudeVersion("1.0.62")).toEqual([1, 0, 62]);
+      expect(parseClaudeVersion("")).toBeNull();
+      expect(parseClaudeVersion(null)).toBeNull();
+      expect(parseClaudeVersion("no version here")).toBeNull();
+    });
+
+    it("rejects a version below the floor and accepts the floor and above", () => {
+      expect(isClaudeVersionSupported("1.9.9 (Claude Code)")).toBe(false);
+      expect(isClaudeVersionSupported("0.5.0")).toBe(false);
+      expect(isClaudeVersionSupported(`${MIN_CLAUDE_CODE_VERSION} (Claude Code)`)).toBe(true);
+      expect(isClaudeVersionSupported("2.4.1 (Claude Code)")).toBe(true);
+      expect(isClaudeVersionSupported("10.0.0")).toBe(true);
+    });
+
+    it("treats an absent or unparseable version as supported (never mass-rejects on a format change)", () => {
+      // The floor exists to catch provably-ancient binaries, not to gate on our
+      // own parser's limits — an unreadable version is left alone on purpose.
+      expect(isClaudeVersionSupported(null)).toBe(true);
+      expect(isClaudeVersionSupported("")).toBe(true);
+      expect(isClaudeVersionSupported("some future format with no dotted number")).toBe(true);
     });
   });
 

--- a/packages/harness/src/core/adapters/claude-code.ts
+++ b/packages/harness/src/core/adapters/claude-code.ts
@@ -19,6 +19,70 @@ import type {
   PastSessionRecord,
   SpawnSpec,
 } from "../../shared/types.js";
+
+/**
+ * Minimum `claude` version the harness supports.
+ *
+ * Below this, the binary predates flags {@link ClaudeCodeAdapter.launch} /
+ * `resume` inject on EVERY spawn — most importantly `--plugin-dir`. A
+ * commander-style CLI aborts on an unknown option with a fast `exit 1`, BEFORE
+ * it ever runs its SessionStart hook, so the session dies with no
+ * `agentSessionId` and only an opaque exit code (the pty's stderr is discarded
+ * on exit) — exactly the "exited before establishing a session id" failure
+ * users report. `doctor()` reports a below-floor claude as NOT ok so the
+ * desktop host installs a current one and the CLI surfaces an actionable
+ * upgrade remedy, instead of every session crash-looping silently.
+ *
+ * Why 2.1.0, from the Claude Code CHANGELOG:
+ * - The plugin system did not exist before the "Plugin System Released" entry
+ *   in `2.0.12`, so no `1.x` or `2.0.0`–`2.0.11` build can recognize
+ *   `--plugin-dir` — they reject it outright.
+ * - The changelog itemizes `--plugin-dir` only as modifications from `2.1.74`
+ *   onward, and the harness's own `--plugin-dir` skills usage is verified
+ *   against `2.1.x` (see core/inject/skills-plugin.ts). `2.1.x` is thus the
+ *   earliest range we can GUARANTEE both recognizes the flag and loads our
+ *   skills.
+ * We floor at `2.1.0` — the earliest verified-safe version — rather than the
+ * `2.0.12` plugin-system release, because we can't prove `--plugin-dir` is
+ * present across the whole `2.0.x` line, and a spurious "please upgrade" for a
+ * rare old-`2.0.x` install is far cheaper than the silent exit-1 crash-loop
+ * this floor exists to prevent. This is the SINGLE source of truth — bump it
+ * whenever the adapter starts sending a flag, or relying on behavior, a newer
+ * `claude` introduced.
+ */
+export const MIN_CLAUDE_CODE_VERSION = "2.1.0";
+
+/**
+ * Extract a leading `major.minor.patch` from a `claude --version` line such as
+ * `"2.1.3 (Claude Code)"`. Returns null when no semver is present.
+ */
+export function parseClaudeVersion(
+  versionLine: string | null | undefined,
+): [number, number, number] | null {
+  const m = /(\d+)\.(\d+)\.(\d+)/.exec(versionLine ?? "");
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/**
+ * Whether a `claude --version` line is at least {@link MIN_CLAUDE_CODE_VERSION}.
+ *
+ * Deliberately surgical: the ONLY case treated as unsupported is a version we
+ * can parse AND that is below the floor. An absent or unparseable version
+ * returns `true` (supported) so a future change to claude's `--version` format
+ * can never mass-reject working installs — the floor exists to catch provably
+ * ancient binaries, not to gate on our own parser's limits.
+ */
+export function isClaudeVersionSupported(versionLine: string | null | undefined): boolean {
+  const parsed = parseClaudeVersion(versionLine);
+  if (!parsed) return true;
+  const floor = parseClaudeVersion(MIN_CLAUDE_CODE_VERSION)!;
+  for (let i = 0; i < 3; i++) {
+    if (parsed[i] > floor[i]) return true;
+    if (parsed[i] < floor[i]) return false;
+  }
+  return true;
+}
+
 /**
  * Maps a project cwd to the directory name Claude Code uses for its transcript
  * store under `~/.claude/projects/`. Claude Code applies this encoding before
@@ -318,9 +382,10 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   }
 
   async doctor(): Promise<DoctorCheck[]> {
+    let versionLine: string;
     try {
       const { stdout } = await execFileAsync(this.binary, ["--version"], { timeout: 5_000 });
-      return [{ name: "claude", ok: true, detail: stdout.trim() || "installed" }];
+      versionLine = stdout.trim();
     } catch {
       return [
         {
@@ -330,6 +395,19 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         },
       ];
     }
+    // A too-old claude passes "is it on PATH" but rejects the flags we inject on
+    // every launch (see MIN_CLAUDE_CODE_VERSION), so it must report NOT ok — a
+    // green doctor for a binary that exit-1s every session is worse than none.
+    if (!isClaudeVersionSupported(versionLine)) {
+      return [
+        {
+          name: "claude",
+          ok: false,
+          detail: `\`${this.binary}\` is ${versionLine || "an unknown version"}, older than the required ${MIN_CLAUDE_CODE_VERSION}. Upgrade Claude Code: https://docs.claude.com/en/docs/claude-code/setup`,
+        },
+      ];
+    }
+    return [{ name: "claude", ok: true, detail: versionLine || "installed" }];
   }
 
   launch(opts: LaunchOpts): SpawnSpec {

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -32,6 +32,7 @@ import type {
   PastSessionRecord,
   SpawnSpec,
 } from "../../shared/types.js";
+import { stripAnsi } from "../strip-ansi.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -56,30 +57,6 @@ const MAX_SCAN_DEPTH = 4; // ~/.codex/sessions/YYYY/MM/DD/*.jsonl
  * be relied on standalone, unlike Claude Code's).
  */
 const TRUST_PROMPT_PATTERN = /trust\s*the\s*contents\s*of\s*this\s*directory/i;
-
-/** Strips ANSI/CSI/OSC control sequences a pty stream is otherwise full of,
- *  so text pattern-matching (e.g. `TRUST_PROMPT_PATTERN`) sees the words a
- *  human would actually read rather than raw terminal-control bytes. Not
- *  exhaustive of every escape sequence a TUI could emit, but covers what
- *  Codex's TUI is confirmed (via real captures) to use: CSI (cursor moves,
- *  SGR color/style) and OSC (window title) sequences. */
-export function stripAnsi(text: string): string {
-  /* eslint-disable no-control-regex -- matching literal ESC (\x1b) / BEL
-   * (\x07) bytes is the entire point of an ANSI-sequence stripper; there's
-   * no non-control-character way to express "a real escape sequence". */
-  return text
-    // Lazy (`*?`), not greedy: a greedy `[^\x07]*` doesn't exclude `\x1b\\`
-    // (ST) from what it can consume, so it backtracks from the END of the
-    // whole string looking for the last reachable terminator instead of the
-    // next one — silently swallowing everything (including real prompt
-    // text) between an OSC sequence and some unrelated, much-later BEL/ST.
-    // Confirmed against a real capture: this exact bug made the trust-
-    // prompt regex below never match a full multi-KB scrollback buffer.
-    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "") // OSC ... BEL or ST
-    .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "") // CSI sequences
-    .replace(/\x1b[()>=][A-Za-z0-9]?/g, ""); // charset/keypad-mode selection
-  /* eslint-enable no-control-regex */
-}
 
 export interface CodexAdapterOptions {
   /** Overridable for tests. */

--- a/packages/harness/src/core/inject/claude-settings.test.ts
+++ b/packages/harness/src/core/inject/claude-settings.test.ts
@@ -32,8 +32,28 @@ describe("generateClaudeSettings", () => {
 
     for (const event of events) {
       const command = settings.hooks[event][0].hooks[0].command;
-      expect(command).toBe(`node ${emitScriptPath} ${event}`);
+      expect(command).toBe(`node "${emitScriptPath}" ${event}`);
     }
+  });
+
+  it("double-quotes the hook command's script path so a home dir with a space still runs", async () => {
+    // A space in the home directory is the real-world trigger: Claude Code
+    // runs the command hook through a shell, so an unquoted path word-splits
+    // and the SessionStart hook never fires (agentSessionId stays null).
+    const spacedRoot = path.join(tmpDir, "First Last", ".sapiom", "generated");
+    const { emitScriptPath } = await generateClaudeSettings({
+      harnessSessionId: "session-space",
+      generatedRoot: spacedRoot,
+    });
+    expect(emitScriptPath).toContain(" ");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(spacedRoot, "session-space", "settings.json"), "utf8"),
+    );
+    const command = settings.hooks.SessionStart[0].hooks[0].command;
+    expect(command).toBe(`node "${emitScriptPath}" SessionStart`);
+    // Guard against a regression to the unquoted form that word-splits on the space.
+    expect(command).not.toBe(`node ${emitScriptPath} SessionStart`);
   });
 
   it("writes a self-contained CommonJS emit.cjs with no requires", async () => {

--- a/packages/harness/src/core/inject/claude-settings.ts
+++ b/packages/harness/src/core/inject/claude-settings.ts
@@ -171,7 +171,20 @@ export async function generateClaudeSettings(
         hooks: [
           {
             type: "command",
-            command: `node ${emitScriptPath} ${event}`,
+            // The script path is double-quoted because Claude Code runs a
+            // `command` hook through a shell (`/bin/sh -c …`; `cmd.exe` on
+            // Windows). An unquoted path under a home directory that contains a
+            // space (`/Users/First Last/.sapiom/harness/generated/…/emit.cjs`)
+            // word-splits, so `node` receives `/Users/First` and the hook dies
+            // with "Cannot find module" — the SessionStart hook then never
+            // POSTs and the session's agentSessionId is never established
+            // (the exact "exited before establishing a session id" failure).
+            // Double quotes group the path on both sh and cmd.exe and are
+            // stripped before `node` sees the argument. This is the harness
+            // CLAUDE.md's "paths contain spaces — never hand a shell an
+            // unquoted path" rule. The event name is a fixed identifier from
+            // HOOK_EVENTS, so it needs no quoting.
+            command: `node "${emitScriptPath}" ${event}`,
           },
         ],
       },

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessAdapter, HarnessKind, HarnessSession, SpawnSpec } from "../shared/types.js";
-import { SessionManager, type PtySpawnFn, type SessionManagerOptions } from "./session-manager.js";
+import {
+  SessionManager,
+  sanitizeExitTail,
+  type PtySpawnFn,
+  type SessionManagerOptions,
+} from "./session-manager.js";
 import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
 
 /** Minimal fake IPty: lets tests drive onData/onExit and observe write/resize/kill.
@@ -244,6 +249,82 @@ describe("SessionManager", () => {
       expect(ok).toBe(false);
       // Still just the one write from before the pty exited — no trailing \r.
       expect(spawns[0]?.pty.write).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("exit output capture (exitTail)", () => {
+    it("preserves the tail of output when a session exits abnormally (non-zero code)", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      spawns[0]?.emitData("\x1b[31merror\x1b[0m: unknown option '--plugin-dir'\n");
+      spawns[0]?.emitExit(1);
+      await manager.flush();
+
+      const exited = manager.get(session.id);
+      expect(exited?.status).toBe("exited");
+      expect(exited?.exitCode).toBe(1);
+      // The agent's own error line survives — with ANSI stripped — which is the
+      // whole point: a startup crash is no longer an opaque exit code.
+      expect(exited?.exitTail).toContain("error: unknown option '--plugin-dir'");
+      expect(exited?.exitTail).not.toContain("\x1b");
+    });
+
+    it("captures nothing for a clean exit (code 0)", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      spawns[0]?.emitData("all good, bye\n");
+      spawns[0]?.emitExit(0);
+      await manager.flush();
+
+      expect(manager.get(session.id)?.exitTail ?? null).toBeNull();
+    });
+
+    it("captures nothing when an abnormal exit produced no readable output", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      // Only cursor/clear control noise — nothing a human could read.
+      spawns[0]?.emitData("\x1b[2J\x1b[H");
+      spawns[0]?.emitExit(1);
+      await manager.flush();
+
+      expect(manager.get(session.id)?.exitTail ?? null).toBeNull();
+    });
+
+    it("captures nothing for a user-initiated kill, even when the pty reports a non-zero signal code", async () => {
+      const { manager, spawns } = makeManager();
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      spawns[0]?.emitData("some normal session output the user was looking at\n");
+      // kill() marks the handle; node-pty then reports 143 (128 + SIGTERM) on
+      // some platforms — a non-zero code, but NOT a crash to diagnose.
+      const killed = manager.kill(session.id);
+      spawns[0]?.emitExit(143);
+      await killed;
+      await manager.flush();
+
+      const exited = manager.get(session.id);
+      expect(exited?.exitCode).toBe(143);
+      expect(exited?.exitTail ?? null).toBeNull();
+    });
+  });
+
+  describe("sanitizeExitTail", () => {
+    it("strips ANSI and trailing control noise, keeping readable text", () => {
+      expect(sanitizeExitTail("\x1b[31mboom\x1b[0m\r\n")).toBe("boom");
+    });
+
+    it("returns null when nothing readable remains", () => {
+      expect(sanitizeExitTail("\x1b[2J\x1b[H")).toBeNull();
+      expect(sanitizeExitTail("")).toBeNull();
+    });
+
+    it("keeps only the final window of a large buffer", () => {
+      const out = sanitizeExitTail("x".repeat(10_000) + "TAIL_MARKER");
+      expect(out?.endsWith("TAIL_MARKER")).toBe(true);
+      expect((out ?? "").length).toBeLessThanOrEqual(4_096);
     });
   });
 

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -24,6 +24,7 @@ import {
 import { expandHome } from "./paths.js";
 import { HOST_ESBUILD_PIN } from "./asar-path.js";
 import { resolveSpawnTarget } from "./spawn-target.js";
+import { stripAnsi } from "./strip-ansi.js";
 import {
   AdapterNotFoundError,
   ExternalHarnessError,
@@ -99,6 +100,21 @@ const DEFAULT_ROWS = 24;
 /** Bytes of terminal output retained per session for replay on WS (re)attach. */
 const SCROLLBACK_BYTES = 131_072;
 /**
+ * Readable output preserved from a session that exited ABNORMALLY (see
+ * {@link HarnessSession.exitTail}). Enough to hold a startup error banner —
+ * "error: unknown option '--plugin-dir'", an auth failure, "Cannot find
+ * module …" — without bloating the persisted registry. The live pty's
+ * scrollback (up to SCROLLBACK_BYTES) is discarded the instant it exits,
+ * taking the coding agent's own error line with it; this is the one place
+ * that line survives.
+ *
+ * Measured in JS string length (UTF-16 code units), matching SCROLLBACK_BYTES
+ * — an approximation of bytes that's exact for the ASCII error text this
+ * targets and close enough for the rest; the point is a small bound, not a
+ * precise byte count.
+ */
+const EXIT_TAIL_BYTES = 4_096;
+/**
  * Delay between writing prompt text and a trailing Enter, when submitting
  * non-empty text in one call (see `submitInput`). Claude Code — like many
  * bracketed-paste-aware TUIs — treats a single write containing both text
@@ -170,6 +186,32 @@ const defaultIsPidAlive = (pid: number): boolean => {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Reduce a dying session's raw terminal bytes to the human-readable text worth
+ * persisting as {@link HarnessSession.exitTail}: strips ANSI escapes, drops
+ * carriage-return redraws and other control bytes, collapses blank runs, and
+ * keeps only the final {@link EXIT_TAIL_BYTES}. Best-effort — a window sliced
+ * mid-escape can leave a fragment — but the abnormal-exit case it serves is
+ * almost always a plain error banner rather than a full-screen TUI, so the
+ * common result is clean. Returns null when nothing readable remains, so the
+ * UI collapses the section instead of showing an empty box.
+ *
+ * Exported for direct unit testing.
+ */
+export function sanitizeExitTail(raw: string): string | null {
+  // Only the end can be the tail; bound the work rather than clean a full
+  // 128 KB scrollback (a redraw frame is a few KB, so this is ample headroom).
+  const cleaned = stripAnsi(raw.slice(-4 * EXIT_TAIL_BYTES))
+    .replace(/\r/g, "")
+    // Any control bytes stripAnsi left behind (a lone ESC from a truncated
+    // sequence, NUL padding), keeping tab and newline.
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+  const trimmed = cleaned.replace(/\n{3,}/g, "\n\n").trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(-EXIT_TAIL_BYTES);
 }
 
 export type SessionStatusListener = (session: HarnessSession) => void;
@@ -268,6 +310,14 @@ interface PtyHandle {
   exited: Promise<void>;
   /** Internal resolver — called exactly once by markExited(). */
   resolveExited: () => void;
+  /**
+   * Set by `kill()` before it signals the pty, so `markExited()` knows this
+   * death was intentional and skips the exit-tail capture. A session the user
+   * closed is not a crash to diagnose — and node-pty can report a non-zero
+   * code for a signalled process (e.g. 143 = 128 + SIGTERM on some platforms),
+   * which would otherwise be mistaken for an abnormal exit worth a tail.
+   */
+  killed: boolean;
 }
 
 export class SessionManager {
@@ -574,6 +624,9 @@ export class SessionManager {
       }
       return Promise.resolve(false);
     }
+    // Mark before signalling so markExited() (whichever path reports the death)
+    // knows this exit was intentional and skips the exit-tail capture.
+    handle.killed = true;
     handle.pty.kill();
     // Root-caused via instrumented real-process runs: node-pty's `onExit`
     // can simply never fire for a pty killed within milliseconds of being
@@ -916,7 +969,7 @@ export class SessionManager {
     const exited = new Promise<void>((resolve) => {
       resolveExited = resolve;
     });
-    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now(), exited, resolveExited };
+    const handle: PtyHandle = { pty, buffer: "", emitter, spawnedAt: Date.now(), exited, resolveExited, killed: false };
     this.ptys.set(session.id, handle);
 
     session.status = "running";
@@ -948,6 +1001,20 @@ export class SessionManager {
    */
   private markExited(id: string, handle: PtyHandle, exitCode: number | null): void {
     if (this.ptys.get(id) !== handle) return;
+    // Preserve the tail of output BEFORE the handle (and its buffer) is dropped
+    // — this is the only chance to keep the agent's own error line. Worth it
+    // only for a genuine, unprompted non-zero exit: a clean exit (0) has
+    // nothing to diagnose, and a death WE caused (`handle.killed`, or a
+    // synthesized null exit from kill()/sweep) is not a crash whose reason the
+    // output would explain — even if node-pty reports a non-zero signal code
+    // for it. Best-effort: it captures whatever onData has delivered into
+    // `handle.buffer` by now, which for a fast startup crash is normally the
+    // error banner, but a build that exits before its final chunk drains can
+    // leave it short (hence `sanitizeExitTail` returning null over an empty box).
+    const exitTail =
+      !handle.killed && exitCode != null && exitCode !== 0
+        ? sanitizeExitTail(handle.buffer)
+        : null;
     this.ptys.delete(id);
     this.lastActivityBroadcast.delete(id);
     // Resolve after the pty map is cleaned up. transitionExited runs
@@ -955,7 +1022,7 @@ export class SessionManager {
     handle.resolveExited();
     const session = this.sessions.get(id);
     if (!session) return;
-    void this.transitionExited(session, exitCode);
+    void this.transitionExited(session, exitCode, { exitTail });
   }
 
   /**
@@ -969,10 +1036,15 @@ export class SessionManager {
   private transitionExited(
     session: HarnessSession,
     exitCode: number | null,
-    { stampLastActive = true }: { stampLastActive?: boolean } = {},
+    { stampLastActive = true, exitTail = null }: { stampLastActive?: boolean; exitTail?: string | null } = {},
   ): Promise<void> {
     session.status = "exited";
     session.exitCode = exitCode;
+    // Only markExited (a live-pty death) has output to preserve; every other
+    // caller (pre-pty create/resume failure, kill()'s ghost path, the sweep)
+    // passes nothing, which clears any stale tail from a previous life — a
+    // resume that fails before spawning must not still show the last crash's.
+    session.exitTail = exitTail;
     // `stampLastActive: false` is for reconciling a resume that never got a
     // pty: "we noticed it's dead" is not activity, and stamping it there is
     // what made an untouched session's duration grow on every failed Resume.

--- a/packages/harness/src/core/strip-ansi.test.ts
+++ b/packages/harness/src/core/strip-ansi.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+
+import { stripAnsi } from "./strip-ansi.js";
+
+describe("stripAnsi", () => {
+  it("removes SGR colour/style sequences, keeping the text", () => {
+    expect(stripAnsi("\x1b[31merror\x1b[0m: boom")).toBe("error: boom");
+  });
+
+  it("removes cursor-addressing (CSI) sequences", () => {
+    // Codex renders words positioned by cursor moves with no literal spaces.
+    expect(stripAnsi("trust\x1b[3;16Hthe\x1b[3;20Hcontents")).toBe("trustthecontents");
+  });
+
+  it("removes an OSC window-title sequence without swallowing later text", () => {
+    // The lazy match must stop at the FIRST terminator, not consume through a
+    // much-later one — otherwise real output after the sequence disappears.
+    expect(stripAnsi("\x1b]0;my title\x07real output")).toBe("real output");
+  });
+
+  it("removes charset/keypad-mode selects", () => {
+    expect(stripAnsi("\x1b(Bplain")).toBe("plain");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(stripAnsi("no escapes here")).toBe("no escapes here");
+  });
+});

--- a/packages/harness/src/core/strip-ansi.ts
+++ b/packages/harness/src/core/strip-ansi.ts
@@ -1,0 +1,28 @@
+/**
+ * Strip ANSI terminal-control sequences from a string so text pattern-matching
+ * (blocking-prompt detection, an exited session's last-output tail) sees the
+ * words a human would read rather than raw control bytes.
+ *
+ * Not exhaustive of every escape a TUI could emit, but covers what real
+ * captures show in practice: OSC (window title), CSI (cursor moves, SGR
+ * colour/style), and charset/keypad-mode selects. Lives here — rather than in
+ * one adapter — because more than one consumer needs it (the Codex adapter's
+ * trust-prompt detection and SessionManager's exit-tail sanitizer).
+ */
+export function stripAnsi(text: string): string {
+  /* eslint-disable no-control-regex -- matching literal ESC (\x1b) / BEL
+   * (\x07) bytes is the entire point of an ANSI-sequence stripper; there's
+   * no non-control-character way to express "a real escape sequence". */
+  return text
+    // Lazy (`*?`), not greedy: a greedy `[^\x07]*` doesn't exclude `\x1b\\`
+    // (ST) from what it can consume, so it backtracks from the END of the
+    // whole string looking for the last reachable terminator instead of the
+    // next one — silently swallowing everything (including real prompt
+    // text) between an OSC sequence and some unrelated, much-later BEL/ST.
+    // Confirmed against a real capture: this exact bug made the Codex trust-
+    // prompt regex never match a full multi-KB scrollback buffer.
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "") // OSC ... BEL or ST
+    .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "") // CSI sequences
+    .replace(/\x1b[()>=][A-Za-z0-9]?/g, ""); // charset/keypad-mode selection
+  /* eslint-enable no-control-regex */
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -163,6 +163,19 @@ export interface HarnessSession {
   lastActiveAt: string;
   /** Exit code when status === "exited". */
   exitCode?: number | null;
+  /**
+   * The tail of terminal output captured when the session exited ABNORMALLY
+   * (a non-zero `exitCode`). This is the one place the coding agent's own
+   * error line survives: a live pty's scrollback is discarded the moment it
+   * exits, so without this a session that dies at startup — `claude` rejecting
+   * an unknown flag, a failed auth/provider init, a broken hook command —
+   * leaves only a bare exit code with no way to tell WHICH of those happened
+   * (the "exited before establishing a session id" reports). ANSI escapes are
+   * stripped to human-readable text (see `sanitizeExitTail`). Null/absent for
+   * a clean exit (code 0), a synthesized/killed exit, a session that produced
+   * no readable output, or one persisted by a build from before this existed.
+   */
+  exitTail?: string | null;
   /** The deployable agent (by path) this session is currently bound to, if any. Set
    *  via `PATCH /api/sessions/:id/workflow`; mirrored into
    *  HARNESS_CONTEXT_FILE in the session's cwd so the coding agent can read it. */

--- a/packages/harness/web/src/components/DeadSessionPane.tsx
+++ b/packages/harness/web/src/components/DeadSessionPane.tsx
@@ -47,8 +47,12 @@ function resumeBlockedReason(session: HarnessSession): string {
  * no obvious way out) is the wrong default. Always offers a way forward.
  *
  * Context comes from the session record itself: title, agent, duration, when
- * it ended, exit code. The registry keeps no scrollback for an exited pty, so
- * there is no last-output tail to show.
+ * it ended, exit code. The live pty's scrollback is gone once it exits, but a
+ * session that exited ABNORMALLY (non-zero code) carries `exitTail` — the last
+ * readable output the harness preserved at exit — which is shown here. That is
+ * the one place the coding agent's own error line survives (e.g. `claude`
+ * rejecting a flag, a failed auth), so a startup crash is no longer just an
+ * opaque exit code.
  *
  * What it CAN show is the conversation, rebuilt from the harness's own recorded
  * events (see {@link SessionTranscript}) — the pty's scrollback is gone, our
@@ -149,6 +153,13 @@ export function DeadSessionPane({
           </div>
         )}
       </div>
+
+      {session.exitTail && (
+        <div className="dead-session-exit-tail" data-testid="dead-session-exit-tail">
+          <div className="dead-session-exit-tail-label">Last output before exit</div>
+          <pre className="dead-session-exit-tail-body">{session.exitTail}</pre>
+        </div>
+      )}
 
       {showRecord && (
         <div className="dead-session-record" data-testid="dead-session-record">

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -3465,6 +3465,41 @@ input {
   margin-top: 4px;
 }
 
+/* Last-output tail from a session that exited abnormally — the coding agent's
+   own error line (e.g. "unknown option --plugin-dir"), preserved at exit. Left-
+   aligned monospace block, not part of the centred metadata card: it is raw
+   output, so it reads like a terminal and scrolls on its own rather than
+   forcing the pane wide. */
+.dead-session-exit-tail {
+  align-self: stretch;
+  max-width: 640px;
+  width: 100%;
+  margin: var(--sp3) auto 0;
+  text-align: left;
+}
+
+.dead-session-exit-tail-label {
+  color: var(--text-faint);
+  font-size: var(--type-label);
+  margin-bottom: var(--sp1);
+}
+
+.dead-session-exit-tail-body {
+  margin: 0;
+  max-height: 180px;
+  overflow: auto;
+  padding: var(--sp2);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--surface-raised);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 /* Past session: the reconstructed transcript ---------------------------
    Unlike .dead-session-pane (a centred metadata card), this one is a
    document: a fixed header with the actions, and a scrolling body. The


### PR DESCRIPTION
## Problem

Some users hit a dead session seconds after starting one:

> **Session exited · exit code 1** … *This session can't be resumed: it exited before establishing a session id.*

The session id is only ever set from Claude Code's `SessionStart` hook, so this always means the `claude` process itself exited **before** that hook fired — and the pty's scrollback is discarded on exit, so `claude`'s own error line was lost, making it near-impossible to diagnose from a user report. It reproduces only for *some* users, i.e. the cause is environment-specific.

## Root causes fixed (each is ours to prevent)

1. **`claude` version mismatch → unknown flag → exit 1.** The adapter injects flags on every launch — notably `--plugin-dir`, which per the [Claude Code changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) did not exist before the plugin system shipped in `2.0.12` — but nothing checked the installed version. An older/shadowing `claude` (pre-existing global, stale install) rejects the flag and exits 1 before the hook. `doctor` now enforces `MIN_CLAUDE_CODE_VERSION` (**2.1.0**, the range our `--plugin-dir` skills usage is verified against): a below-floor `claude` reports **not ok**, so the desktop app installs a current one (existing `availableHarnesses`-empty branch) and the `npx` CLI shows an actionable upgrade remedy. An unparseable version is left alone, so a future `--version` format change can never mass-reject working installs.

2. **Space in `$HOME` broke the SessionStart hook.** The generated hook command interpolated the emitter-script path **unquoted** (`node <path> <event>`). Claude Code runs a `command` hook through a shell, so a home dir like `/Users/First Last/…` word-split the path, the hook died, and the id was never established. Now double-quoted.

3. **The agent's error line was thrown away.** Sessions that exit with a **non-zero** code now keep a sanitized tail of their last output (`HarnessSession.exitTail`), surfaced in the exited-session pane — so `unknown option '--plugin-dir'`, an auth failure, or `Cannot find module …` is visible instead of a bare exit code. Clean exits and user-initiated kills keep nothing.

The shared ANSI stripper used here and by Codex trust-prompt detection was lifted from the Codex adapter into `core/strip-ansi.ts`.

## Not included (deliberate)

- **Scrubbing inherited `ANTHROPIC_*` / `CLAUDE_CODE_USE_*` env before spawn** — the investigation rated this an equally-plausible cause (a dead proxy / revoked key / Bedrock-Vertex with no creds makes `claude` fail provider init in seconds), but it needs a product call on *which* provider env we intend to honor vs. strip. With fix #3 shipped, the next affected user's `exitTail` will tell us definitively whether it's this. Follow-up.

## Testing

- `146` targeted tests pass (added coverage for the version floor + parser, the quoted hook path incl. a spaced-home case, `exitTail` capture / clean-exit / killed-session / no-readable-output, and `stripAnsi`); full harness unit suite green.
- `typecheck` (server + web) and `lint` clean.

All touched files are byte-identical between `main` and the current `feature/studio-desktop-redesign` base, so this is independent of the redesign and merges into it without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
