### PR TITLE
fix(examples): nl-db endpoint deploy + autonomous-pr self-review instrumentation (UAT sweep)

### DIFF
--- a/examples/autonomous-pr/index.ts
+++ b/examples/autonomous-pr/index.ts
@@ -443,18 +443,21 @@ const verify = defineStep({
     const cwd = resolved.cwd;
     ctx.shared.set("checkoutCwd", cwd);
 
-    // Capture what changed, for the self-review — uncommitted, so a plain
-    // `diff --stat` (no ref range) is exactly the agent's working-tree edits.
-    // `git -C <abs>` (not the `cwd` exec option) targets the checkout: `exec`'s
-    // `cwd` is relative to the sandbox's `workspaceRoot`, and `sandboxes.attach`
-    // has no way to know a coding run's checkout root, so it defaults that to
-    // `/` — a bare `{ cwd }` here would silently run against the sandbox's
-    // filesystem root instead of the checkout. Baking the confirmed absolute
-    // path straight into the command sidesteps that mismatch entirely.
+    // Capture what changed, for the self-review. The coding agent's edits are
+    // almost all NEW files, and a plain `git diff --stat` (working tree vs
+    // index) never shows untracked files — so it came back empty and the
+    // reviewer withheld approval, citing "conformance asserted, not
+    // demonstrated." Stage first (`add -A`, before install so no `node_modules`
+    // exists yet) and diff the index (`--cached`), which surfaces new files as
+    // additions against HEAD (or the empty tree on a first commit). `git -C
+    // <abs>` (not the `cwd` exec option) targets the checkout — see the
+    // resolveCheckoutCwd note for why the absolute path is baked in.
     try {
-      const diff = await box.exec(`git -C "${cwd}" --no-pager diff --stat`, {
-        timeout: 30_000,
-      });
+      await box.exec(`git -C "${cwd}" add -A`, { timeout: 30_000 });
+      const diff = await box.exec(
+        `git -C "${cwd}" --no-pager diff --cached --stat`,
+        { timeout: 30_000 },
+      );
       ctx.shared.set(
         "diffStat",
         (diff.stdout || diff.stderr || "").slice(0, 4000),
@@ -488,7 +491,16 @@ const verify = defineStep({
     const check = await box.exec(`cd "${cwd}" && ${checkCommand}`, {
       timeout: 300_000,
     });
-    ctx.shared.set("checkTail", tail(check.stdout, check.stderr));
+    // A passing check (e.g. `tsc --noEmit`) prints nothing, which left the
+    // review's "Check output" empty and undersold a green run — record the
+    // exit-0 explicitly so the reviewer sees the check actually ran and passed.
+    const checkOutput = tail(check.stdout, check.stderr);
+    ctx.shared.set(
+      "checkTail",
+      check.exitCode === 0
+        ? `\`${checkCommand}\` passed (exit 0).${checkOutput ? `\n${checkOutput}` : ""}`
+        : checkOutput,
+    );
     if (check.exitCode !== 0) {
       return goto("rejected", {
         reason: "check-failed",
@@ -572,8 +584,21 @@ const push = defineStep({
       workingDirectory: cwd,
     });
 
+    // `pushFromSandbox` doesn't always return the commit sha; read it back from
+    // the checkout it just committed so `summary` reports a real sha, not null.
+    let pushSha = result.sha;
+    if (!pushSha) {
+      try {
+        const rev = await box.exec(`git -C "${cwd}" rev-parse HEAD`, {
+          timeout: 15_000,
+        });
+        pushSha = rev.stdout.trim() || null;
+      } catch {
+        pushSha = null;
+      }
+    }
     ctx.shared.set("pushed", result.pushed);
-    ctx.shared.set("pushSha", result.sha);
+    ctx.shared.set("pushSha", pushSha);
     ctx.shared.set("pushBranch", result.branch ?? branchName);
     ctx.logger.info("pushed branch", {
       branch: result.branch ?? branchName,

--- a/examples/nl-db-query-endpoint/index.ts
+++ b/examples/nl-db-query-endpoint/index.ts
@@ -847,12 +847,28 @@ const deploy = defineStep({
         name: config.sandboxName,
         port: config.port,
       });
-      await box.writeFile("server.js", SERVER_SOURCE);
-      await box.writeFile("package.json", SERVER_PACKAGE_JSON);
+      // Write the server into an explicit absolute directory via `exec`, NOT
+      // `box.writeFile`: a relative `writeFile("server.js")` resolves against
+      // the sandbox's file root, which is one level below where the `fs` deploy
+      // actually runs `npm install` — so the files land outside the build's cwd
+      // and `npm install` fails with "no package.json". Anchoring the write AND
+      // the build/start to the same absolute `APP_DIR` (base64-piped so the
+      // source survives shell quoting) removes that mismatch entirely.
+      const appDir = "/blaxel/nl-db-app";
+      const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+      await box.exec(`mkdir -p "${appDir}"`, { timeout: 30_000 });
+      await box.exec(
+        `printf %s '${b64(SERVER_SOURCE)}' | base64 -d > "${appDir}/server.js"`,
+        { timeout: 30_000 },
+      );
+      await box.exec(
+        `printf %s '${b64(SERVER_PACKAGE_JSON)}' | base64 -d > "${appDir}/package.json"`,
+        { timeout: 30_000 },
+      );
       const res = await box.deployPreview({
         source: { kind: "fs" },
-        build: "npm install",
-        start: "node server.js",
+        build: `cd "${appDir}" && npm install`,
+        start: `cd "${appDir}" && node server.js`,
         port: config.port,
         env,
       });


### PR DESCRIPTION
Two defects found during the golden-set live UAT sweep (all 11 templates run `{}` on prod). Both fixes re-verified live.

## nl-db-query-endpoint — endpoint now **deploys** (was: never deployed)
`deploy` wrote `server.js`/`package.json` with `box.writeFile(relPath)`, which resolves one directory below where the `fs` `deployPreview` runs `npm install` → `npm` ENOENTed on `package.json` → `deployed:false`, `url:null`.

**Fix:** write both files via `exec` into an explicit absolute `APP_DIR` (`/blaxel/nl-db-app`) and `cd` there for `build`+`start`, so write-location and build-cwd can't disagree.

**Re-UAT (exec 158434/158450):** `deployed:true`, `GET /health` → **HTTP 200**; filesystem ground truth confirms `server.js` + `package.json` + populated `node_modules` all in `APP_DIR`. (Template-side workaround for the underlying platform `sandboxes.writeFile` path bug, ticketed separately.)

> ⚠️ **Necessary but not sufficient — nl-db is not yet end-to-end green.** With the endpoint now live, the sweep surfaced three further, independent issues (all ticketed, none fixable here): (1) `POST /query` 500s on every call — the endpoint's x402 **scoped-key settlement** 500s (platform/SDK; reproduced standalone in-sandbox); (2) the **2nd run 409s** on a fixed default `sandboxName`; (3) `deployPreview` **`unverified`** is treated as success, so it publishes an unprobed URL. This PR is the deploy fix only.

## autonomous-pr — self-review now sees the change (was: empty diff → withheld approval)
`verify` captured `git diff --stat`, which never lists untracked **new** files — exactly what a coding agent produces. `diffStat` was always empty and the reviewer withheld approval; `pushSha` was null.

**Fix:** stage first (`git add -A`, before install so no `node_modules` exists yet) and diff the index (`git diff --cached --stat`); backfill `pushSha` via `git rev-parse HEAD`; record the check's exit-0 in `checkTail`.

**Re-UAT (exec 158424, a reuse run):** `diffStat` lists the added files (`examples/word-count/… | 2 files changed, 18 insertions(+)`), `pushSha` real, `review.verdict` flipped **`request_changes` → `approve`**. Preview 200, branch clean.

Checks green: `tsc` (both examples), `examples-entry-schema-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)