### PR TITLE
feat(examples): deliver stored assets via durable public permalinks

### DIFF
--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   IMAGE_RESULT_SIGNAL,
   VIDEO_RESULT_SIGNAL,
+  fileStorage,
   type ImageResultPayload,
   type VideoResultPayload,
 } from "@sapiom/tools";
@@ -203,12 +204,12 @@ export function isReservedAddress(email: string): boolean {
 }
 
 /** Resolve a single graphic's usable URL, re-minting from `fileId` when needed. */
-async function resolveGraphicUrl(
+function resolveGraphicUrl(
   graphic: Graphic,
-  getDownloadUrl: (fileId: string) => Promise<{ downloadUrl: string }>,
-): Promise<string> {
+  getPublicUrl: (fileId: string) => string,
+): string {
   if (graphic.downloadUrl) return graphic.downloadUrl;
-  if (graphic.fileId) return (await getDownloadUrl(graphic.fileId)).downloadUrl;
+  if (graphic.fileId) return getPublicUrl(graphic.fileId);
   throw new Error("quote graphic has no usable download URL");
 }
 
@@ -514,7 +515,9 @@ const graphics = defineStep({
     const handle = await ctx.sapiom.contentGeneration.images.launch({
       prompt: quote.imagePrompt,
       numImages: 1,
-      storage: { visibility: "private" },
+      // Public: quote graphics are linked from the emailed pack below, so they
+      // need a durable permalink rather than a presigned URL that expires in ~15min.
+      storage: { visibility: "public" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collectGraphic" });
   },
@@ -539,7 +542,11 @@ const collectGraphic = defineStep({
     const graphic: Graphic = {
       quote: quote.quote,
       ...(img.fileId !== undefined && { fileId: img.fileId }),
-      ...(img.downloadUrl !== undefined && { downloadUrl: img.downloadUrl }),
+      ...(img.fileId !== undefined
+        ? { downloadUrl: fileStorage.getPublicUrl(img.fileId) }
+        : img.downloadUrl !== undefined
+          ? { downloadUrl: img.downloadUrl }
+          : {}),
     };
     const nextGraphics = [...graphicsSoFar, graphic];
     const nextIndex = index + 1;
@@ -571,9 +578,9 @@ const clip = defineStep({
     const pack = must(ctx.shared.get("pack"), "pack");
     const graphicsList = must(ctx.shared.get("graphics"), "graphics");
     const frame = graphicsList[0];
-    const imageUrl = await resolveGraphicUrl(frame, async (fileId) => {
-      return await ctx.sapiom.fileStorage.getDownloadUrl(fileId);
-    });
+    const imageUrl = resolveGraphicUrl(frame, (fileId) =>
+      fileStorage.getPublicUrl(fileId),
+    );
     const model = ctx.shared.get("model") ?? DEFAULT_VIDEO_MODEL;
 
     ctx.logger.info("animating teaser clip", { from: frame.quote });
@@ -588,7 +595,9 @@ const clip = defineStep({
         aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
         seed: 42,
       },
-      storage: { visibility: "private" },
+      // Public: the teaser clip is linked from the emailed pack below, so it
+      // needs a durable permalink rather than a presigned URL that expires in ~15min.
+      storage: { visibility: "public" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collectClip" });
   },
@@ -601,7 +610,11 @@ const collectClip = defineStep({
     const out = result.outputs?.[0];
     const value: Clip = {
       ...(out?.fileId !== undefined && { fileId: out.fileId }),
-      ...(out?.downloadUrl !== undefined && { downloadUrl: out.downloadUrl }),
+      ...(out?.fileId !== undefined
+        ? { downloadUrl: fileStorage.getPublicUrl(out.fileId) }
+        : out?.downloadUrl !== undefined
+          ? { downloadUrl: out.downloadUrl }
+          : {}),
     };
     ctx.shared.set("clip", value);
     ctx.logger.info("collected teaser clip", {
@@ -624,20 +637,12 @@ const packageStep = defineStep({
     // `downloadUrlUnavailable` signal), so a graphic's usable URL must be minted
     // from its fileId here — the same resolution the `clip` step already does.
     // Without this, a run that skips the clip (renderClip=false) packages and
-    // delivers null graphic links yet still reports success. Best-effort: a mint
-    // hiccup drops that one link rather than failing the run (the pack ships inline).
+    // delivers null graphic links yet still reports success. `getPublicUrl` is
+    // pure/synchronous (no network call, so nothing to catch here), and durable —
+    // the graphics are stored public and this link is emailed below.
     for (const g of graphicsList) {
       if (!g.downloadUrl && g.fileId) {
-        try {
-          g.downloadUrl = (
-            await ctx.sapiom.fileStorage.getDownloadUrl(g.fileId)
-          ).downloadUrl;
-        } catch (err) {
-          ctx.logger.warn("quote graphic download URL mint failed", {
-            fileId: g.fileId,
-            err: String(err),
-          });
-        }
+        g.downloadUrl = fileStorage.getPublicUrl(g.fileId);
       }
     }
     ctx.shared.set("graphics", graphicsList);
@@ -662,7 +667,9 @@ const packageStep = defineStep({
           contentType: "text/markdown",
           fileName: `content-pack-${slug}.md`,
           fileSize: bytes.byteLength,
-          visibility: "private",
+          // Public: the pack's link is emailed below, so it needs a durable
+          // permalink rather than a presigned URL that expires in ~15min.
+          visibility: "public",
         });
       const putRes = await fetch(uploadUrl, {
         method: "PUT",
@@ -672,8 +679,7 @@ const packageStep = defineStep({
       if (!putRes.ok) {
         throw new Error(`PUT ${putRes.status} ${putRes.statusText}`);
       }
-      const { downloadUrl } =
-        await ctx.sapiom.fileStorage.getDownloadUrl(fileId);
+      const downloadUrl = fileStorage.getPublicUrl(fileId);
       ctx.shared.set("packFileId", fileId);
       ctx.shared.set("packDownloadUrl", downloadUrl);
       ctx.logger.info("packaged content pack", {

--- a/examples/content-repurposing-pipeline/package.json
+++ b/examples/content-repurposing-pipeline/package.json
@@ -11,8 +11,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.9.0",
-    "@sapiom/tools": "^0.25.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {

--- a/examples/newsletter-autopilot/index.ts
+++ b/examples/newsletter-autopilot/index.ts
@@ -5,6 +5,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { fileStorage } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -658,7 +659,12 @@ const illustrate = defineStep({
       });
       const img = result.images?.[0];
       if (img) {
-        headerImageUrl = img.downloadUrl ?? img.url;
+        // The header image is embedded as an `<img>` src in the emailed issue —
+        // a durable permalink survives in the inbox where a presigned URL
+        // (`downloadUrl`/`url`, ~15min TTL) would 404.
+        headerImageUrl = img.fileId
+          ? fileStorage.getPublicUrl(img.fileId)
+          : (img.downloadUrl ?? img.url);
         headerImageFileId = img.fileId ?? null;
       } else {
         ctx.logger.warn("header image returned no output; sending without it");

--- a/examples/newsletter-autopilot/package.json
+++ b/examples/newsletter-autopilot/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.9.0",
-    "@sapiom/tools": "^0.25.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -10,6 +10,7 @@ import {
 import {
   VIDEO_RESULT_SIGNAL,
   IMAGE_RESULT_SIGNAL,
+  fileStorage,
   type VideoResultPayload,
   type ImageResultPayload,
 } from "@sapiom/tools";
@@ -437,7 +438,9 @@ const renderImage = defineStep({
     const handle = await ctx.sapiom.contentGeneration.images.launch({
       prompt: buildPrompt(row, "image", style),
       numImages: 1,
-      storage: { visibility: "private" },
+      // Public: the render is emailed as a durable permalink below, not
+      // fetched in-process, so it needs to outlive a presigned URL's ~15min TTL.
+      storage: { visibility: "public" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collectImage" });
   },
@@ -459,7 +462,9 @@ const collectImage = defineStep({
       email: row.email,
       medium: "image",
       fileId: out?.fileId ?? null,
-      downloadUrl: out?.downloadUrl ?? null,
+      downloadUrl: out?.fileId
+        ? fileStorage.getPublicUrl(out.fileId)
+        : (out?.downloadUrl ?? null),
     };
     const nextAssets = [...assets, asset];
     const nextIndex = index + 1;
@@ -496,7 +501,9 @@ const renderClip = defineStep({
       params: {
         aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
       },
-      storage: { visibility: "private" },
+      // Public: the clip is emailed as a durable permalink below, not
+      // fetched in-process, so it needs to outlive a presigned URL's ~15min TTL.
+      storage: { visibility: "public" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collectClip" });
   },
@@ -518,7 +525,9 @@ const collectClip = defineStep({
       email: row.email,
       medium: "video",
       fileId: out?.fileId ?? null,
-      downloadUrl: out?.downloadUrl ?? null,
+      downloadUrl: out?.fileId
+        ? fileStorage.getPublicUrl(out.fileId)
+        : (out?.downloadUrl ?? null),
     };
     const nextAssets = [...assets, asset];
     const nextIndex = index + 1;

--- a/examples/personalized-media-at-scale/package.json
+++ b/examples/personalized-media-at-scale/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.8.0",
-    "@sapiom/tools": "^0.24.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "postgres": "^3.4.5",
     "zod": "^3.25.76 || ^4.0.0"
   },

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { fileStorage } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -513,7 +514,9 @@ const render = defineStep({
       contentType: "application/pdf",
       fileName,
       fileSize: bytes.length,
-      visibility: "private",
+      // Public: the PDF's link is emailed to the client below, so it needs a
+      // durable permalink rather than a presigned URL that expires in ~15min.
+      visibility: "public",
     });
     if (bytes.length > 0) {
       const res = await fetch(upload.uploadUrl, {
@@ -531,9 +534,9 @@ const render = defineStep({
         "no PDF bytes rendered — skipping upload PUT (local/stub)",
       );
     }
-    const link = await ctx.sapiom.fileStorage.getDownloadUrl(upload.fileId);
+    const downloadUrl = fileStorage.getPublicUrl(upload.fileId);
     ctx.shared.set("fileId", upload.fileId);
-    ctx.shared.set("downloadUrl", link.downloadUrl);
+    ctx.shared.set("downloadUrl", downloadUrl);
     ctx.logger.info("proposal rendered", {
       fileId: upload.fileId,
       bytes: bytes.length,

--- a/examples/proposal-generator/package.json
+++ b/examples/proposal-generator/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.6.5",
-    "@sapiom/tools": "^0.20.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {

--- a/examples/research-to-microsite/index.ts
+++ b/examples/research-to-microsite/index.ts
@@ -10,6 +10,7 @@ import {
   CODING_RESULT_SIGNAL,
   EXECUTION_ENVIRONMENT_BLAXEL_SANDBOX,
   IMAGE_RESULT_SIGNAL,
+  fileStorage,
   schedules,
   type CodingResultPayload,
   type ImageResultPayload,
@@ -896,26 +897,15 @@ const build = defineStep({
     const report = must(ctx.shared.get("report"), "report");
     const illustrations = ctx.shared.get("illustrations") ?? [];
 
-    // Refresh short-lived download URLs right before handing them to the
-    // coding agent — the same use-time refresh `scene-to-video`'s
-    // `resolveFrameUrl` applies to its keyframes, since the URL returned when
-    // an image finished may already be stale by the time `build` runs.
-    const resolved = await Promise.all(
-      illustrations.map(async (ill) => {
-        if (!ill.fileId) return ill;
-        try {
-          const { downloadUrl } = await ctx.sapiom.fileStorage.getDownloadUrl(
-            ill.fileId,
-          );
-          return { ...ill, downloadUrl };
-        } catch (err) {
-          ctx.logger.warn(
-            "could not refresh illustration download url; using the original",
-            { heading: ill.heading, err: String(err) },
-          );
-          return ill;
-        }
-      }),
+    // Mint a durable permalink from each illustration's `fileId` right before
+    // handing them to the coding agent. These become `<img>` srcs baked into a
+    // PUBLISHED static site, so a presigned download URL (~15min TTL) would
+    // 404 on the live site shortly after publish — `getPublicUrl` is pure and
+    // synchronous (no network call, so nothing to refresh or catch here).
+    const resolved = illustrations.map((ill) =>
+      ill.fileId
+        ? { ...ill, downloadUrl: fileStorage.getPublicUrl(ill.fileId) }
+        : ill,
     );
 
     // The coding agent's durable output is a git REPO, not its throwaway sandbox.

--- a/examples/research-to-microsite/package.json
+++ b/examples/research-to-microsite/package.json
@@ -11,8 +11,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.9.0",
-    "@sapiom/tools": "^0.25.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {

--- a/examples/scene-to-video/index.test.mjs
+++ b/examples/scene-to-video/index.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { fileStorage } from "@sapiom/tools";
+
 import { agent, normalizeClipDuration, resolveClipInputs } from "./index.ts";
 
-function stitchContext(clips, { create, getDownloadUrl } = {}) {
+function stitchContext(clips, { create } = {}) {
   const shared = new Map([
     ["scene", "paper boat"],
     ["clips", clips],
@@ -22,11 +24,6 @@ function stitchContext(clips, { create, getDownloadUrl } = {}) {
               throw new Error("merge should not run");
             }),
         },
-      },
-      fileStorage: {
-        getDownloadUrl:
-          getDownloadUrl ??
-          (async (fileId) => ({ downloadUrl: `https://clip/${fileId}` })),
       },
     },
     logger: { info() {}, warn() {}, error() {}, debug() {} },
@@ -75,6 +72,35 @@ test("rejects an empty clip collection before calling merge", async () => {
   );
 });
 
+test("collect records a durable public permalink for a clip carrying a fileId", async () => {
+  const shared = new Map([
+    ["shots", [{}]],
+    ["clips", []],
+    ["animateIndex", 0],
+  ]);
+  const ctx = {
+    shared: {
+      get: (key) => shared.get(key),
+      set: (key, value) => shared.set(key, value),
+    },
+    sapiom: {},
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+
+  await agent.steps.collect.run(
+    {
+      outputs: [
+        { fileId: "clip-file", downloadUrl: "https://presigned.example/clip" },
+      ],
+    },
+    ctx,
+  );
+
+  assert.deepEqual(shared.get("clips"), [
+    { fileId: "clip-file", downloadUrl: fileStorage.getPublicUrl("clip-file") },
+  ]);
+});
+
 test("stitch bypasses merge only for an actual one-clip scene", async () => {
   const directive = await agent.steps.stitch.run(
     {},
@@ -104,11 +130,32 @@ test("stitch sends every clip in order with a bounded polling fallback", async (
   );
 
   assert.deepEqual(calls[0].params.video_urls, [
-    "https://clip/first-file",
+    fileStorage.getPublicUrl("first-file"),
     "https://clip/second",
   ]);
   assert.equal(calls[0].timeoutMs, 12 * 60_000);
   assert.deepEqual(directive.input.outputs, [
     { downloadUrl: "https://provider/merged" },
+  ]);
+});
+
+test("stitch prefers a durable public permalink over the merge provider's own URL", async () => {
+  const directive = await agent.steps.stitch.run(
+    {},
+    stitchContext(
+      [{ fileId: "first-file" }, { downloadUrl: "https://clip/second" }],
+      {
+        create: async () => ({
+          video: { fileId: "merged-file", url: "https://provider/merged" },
+        }),
+      },
+    ),
+  );
+
+  assert.deepEqual(directive.input.outputs, [
+    {
+      fileId: "merged-file",
+      downloadUrl: fileStorage.getPublicUrl("merged-file"),
+    },
   ]);
 });

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   IMAGE_RESULT_SIGNAL,
   VIDEO_RESULT_SIGNAL,
+  fileStorage,
   type ImageResultPayload,
   type VideoResultPayload,
 } from "@sapiom/tools";
@@ -389,6 +390,9 @@ const keyframe = defineStep({
     const handle = await ctx.sapiom.contentGeneration.images.launch({
       prompt: shot.image_prompt,
       numImages: 1,
+      // Intentionally private: a keyframe is never returned or linked to a
+      // caller — it's only ever fed straight into `animate`'s `image_url`,
+      // consumed immediately in-process, so a presigned URL is correct here.
       storage: { visibility: "private" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collectKeyframe" });
@@ -460,7 +464,11 @@ const animate = defineStep({
         duration: String(normalizeClipDuration(shot.duration)),
         aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
       },
-      storage: { visibility: "private" },
+      // Public: this clip may become the run's headline shareable output (the
+      // single-clip bypass in `stitch`, or as merge input otherwise), so it
+      // needs a durable permalink rather than a presigned URL that expires in
+      // ~15min.
+      storage: { visibility: "public" },
     });
     return await pauseUntilSignal(handle, { resumeStep: "collect" });
   },
@@ -483,7 +491,13 @@ const collect = defineStep({
     }
     const clip: Clip = {
       ...(out?.fileId !== undefined && { fileId: out.fileId }),
-      ...(out?.downloadUrl !== undefined && { downloadUrl: out.downloadUrl }),
+      // Durable permalink over a presigned URL — this clip may end up as the
+      // run's headline shareable output.
+      ...(out?.fileId !== undefined
+        ? { downloadUrl: fileStorage.getPublicUrl(out.fileId) }
+        : out?.downloadUrl !== undefined
+          ? { downloadUrl: out.downloadUrl }
+          : {}),
     };
     const nextClips = [...clips, clip];
     const nextIndex = index + 1;
@@ -508,12 +522,15 @@ const stitch = defineStep({
   async run(_input: unknown, ctx: AgentExecutionContext<Shared>) {
     const scene = must(ctx.shared.get("scene"), "scene");
     const clips = must(ctx.shared.get("clips"), "clips");
-    // Ready-to-use URLs for the merge input. For a longer-lived reference re-mint
-    // from each clip's `fileId` via `ctx.sapiom.fileStorage.getDownloadUrl(fileId)`.
-    const resolved = await resolveClipInputs(
-      clips,
-      async (fileId) => await ctx.sapiom.fileStorage.getDownloadUrl(fileId),
-    );
+    // Ready-to-use URLs for the merge input. Each clip already carries a
+    // durable public permalink from `collect`; this callback only covers the
+    // defensive fallback (a clip with a `fileId` but no `downloadUrl` yet),
+    // re-minting via `getPublicUrl` rather than a presigned URL — the
+    // single-clip bypass below can hand this straight back as the run's
+    // headline output.
+    const resolved = await resolveClipInputs(clips, async (fileId) => ({
+      downloadUrl: fileStorage.getPublicUrl(fileId),
+    }));
     const videoUrls = resolved.map(({ url }) => url);
     ctx.logger.info("stitching clips", { clips: resolved.length });
 
@@ -539,7 +556,10 @@ const stitch = defineStep({
       model: MERGE_MODEL,
       prompt: scene,
       params: { video_urls: videoUrls },
-      storage: { visibility: "private" },
+      // Public: the merged video is the run's headline shareable output below,
+      // so it needs a durable permalink rather than a presigned URL that
+      // expires in ~15min.
+      storage: { visibility: "public" },
       timeoutMs: 12 * 60_000,
     });
     if (
@@ -551,7 +571,9 @@ const stitch = defineStep({
         `video merge completed without a usable output${merged.video?.storageError ? `: ${merged.video.storageError}` : ""}`,
       );
     }
-    const downloadUrl = merged.video.downloadUrl ?? merged.video.url;
+    const downloadUrl = merged.video.fileId
+      ? fileStorage.getPublicUrl(merged.video.fileId)
+      : (merged.video.downloadUrl ?? merged.video.url);
     return goto("finalize", {
       outputs: [
         {

--- a/examples/scene-to-video/package.json
+++ b/examples/scene-to-video/package.json
@@ -11,8 +11,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.9.0",
-    "@sapiom/tools": "^0.25.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { fileStorage } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -937,8 +938,9 @@ const chart = defineStep({
           headers: up.requiredHeaders,
           body: bytes,
         });
-        const dl = await ctx.sapiom.fileStorage.getDownloadUrl(up.fileId);
-        chartUrl = dl.downloadUrl;
+        // Durable permalink, not a presigned URL — the chart is embedded in the
+        // emailed report below, which can sit in an inbox well past a ~15min TTL.
+        chartUrl = fileStorage.getPublicUrl(up.fileId);
         ctx.logger.info("chart rendered + hosted", {
           fileId: up.fileId,
           bytes: bytes.byteLength,

--- a/examples/scheduled-db-insight-report/package.json
+++ b/examples/scheduled-db-insight-report/package.json
@@ -10,8 +10,8 @@
     "format:check": "prettier --check \"**/*.ts\""
   },
   "dependencies": {
-    "@sapiom/agent": "^0.8.0",
-    "@sapiom/tools": "^0.24.0",
+    "@sapiom/agent": "^0.9.3",
+    "@sapiom/tools": "^0.26.0",
     "postgres": "^3.4.5",
     "zod": "^3.25.76 || ^4.0.0"
   },


### PR DESCRIPTION
## Summary

SAP-2380: sweep the canonical `examples/` templates so any workflow that hands a **stored** file-storage asset link to an **external or published/durable** consumer (an emailed link, an `<img>` src on a published site, or a run's headline shareable output) emits a **durable permalink** (`fileStorage.getPublicUrl(fileId)`, backed by `storage: { visibility: "public" }`) instead of a ~15-minute presigned `downloadUrl` that dies in the inbox or 404s on a live site shortly after the run completes.

**Implementation note (important):** the currently published `@sapiom/tools@0.26.0` client does **not** wire `getPublicUrl` onto `ctx.sapiom.fileStorage` — only the pure, static `fileStorage.getPublicUrl(fileId)` export exists at that version (verified against the published npm package's `client.d.ts`/`client.js`, not just the local source tree). So every call site here does `import { fileStorage } from "@sapiom/tools"` and calls `fileStorage.getPublicUrl(fileId)` directly, matching the SDK's own documented "ambient auth" import pattern — it needs no transport/network call since the function is a pure string builder using the same base URL as `getDownloadUrl`. I also bumped `@sapiom/agent` to `^0.9.3` in every changed template: older `@sapiom/agent` versions (`^0.6.5`–`^0.9.0`) pin `@sapiom/tools` internally at `^0.24.0`/`^0.25.0`, which otherwise resolves a *second*, older nested copy of `@sapiom/tools` for the `ctx.sapiom` type and breaks `images.launch`/typechecking against the bumped top-level `@sapiom/tools`.

## Classification table

| Template | Changed? | What changed / why skipped |
|---|---|---|
| `personalized-media-at-scale` | Yes | Per-recipient rendered image/clip storage → `public`; `collectImage`/`collectClip` build the emailed link via `getPublicUrl(fileId)`. |
| `newsletter-autopilot` | Yes | Header image was already `public`; the `<img>` src emailed in the issue now uses `getPublicUrl(fileId)` (falls back to the generation result's `downloadUrl`/`url` if no `fileId`). |
| `proposal-generator` | Yes | Rendered PDF upload → `public`; the client-emailed link now uses `getPublicUrl(fileId)` instead of `getDownloadUrl`. |
| `content-repurposing-pipeline` | Yes | Quote-graphic and teaser-clip storage → `public`; `resolveGraphicUrl` is now sync (`getPublicUrl`, no network call); the packaged markdown brief's upload → `public` and its emailed link uses `getPublicUrl`. |
| `scheduled-db-insight-report` | Yes | Chart upload was already `public`; the emailed report's chart link now uses `getPublicUrl(fileId)` instead of `getDownloadUrl`. |
| `research-to-microsite` | Yes | Section illustrations become `<img>` srcs baked into a **published** static site — `build` now mints `getPublicUrl(fileId)` synchronously instead of a "refresh the presigned URL" round-trip that would 404 on the live site within ~15 min. |
| `scene-to-video` | Yes (judgment call) | Per-shot keyframe storage stays **private** — it's only ever fed straight into the next `animate`/`video.launch` call in-process, never returned or linked to a caller, so a presigned URL is correct there (called out explicitly in-code). The animated clip and the merged/stitched video — either of which can become the run's headline `downloadUrl` output — are now stored `public` and returned via `getPublicUrl(fileId)`. |
| `news-roundup` | No — reclassified | Ticket flagged `lib/storage.ts`'s `downloadFileBytes` (`getDownloadUrl` at ~line 47), but on inspection that function only fetches bytes **immediately, in-process** to re-upload them into the sandbox that serves the published site — the site's actual `<img>`/page URLs are sandbox-served (`${siteUrl}/images/...`), never a file-storage link at all. No externally-shared presigned URL exists here, so nothing was changed; noting the reclassification per the ticket's instructions. |
| `durable-backfill` | No — out of scope | Immediate in-process `fetch`, no externally-delivered asset link. |
| `dependency-upgrade` | No — out of scope | No stored-asset link. |
| `meeting-notes-crm` | No — out of scope | No stored-asset link. |
| `scheduled-compliance-audit` | No — out of scope | Report returned to caller, not externally delivered. |

## Test plan
- [x] `npm run typecheck` (per-template, `tsc --noEmit`) — clean for all 7 changed templates.
- [x] `npm test` (`tsx --test index.test.mjs`) — clean for `content-repurposing-pipeline` (6/6), `research-to-microsite` (15/15), `scene-to-video` (8/8, including 2 new tests covering the durable-permalink paths in `collect`/`stitch`).
- [x] `node scripts/examples-check.mjs` from repo root — registry/manifest validation clean.
- [x] Sanity check: `node -e "console.log(typeof require('@sapiom/tools').fileStorage.getPublicUrl)"` → `function`.
- [x] `npx prettier --check` on every file I touched (pre-existing, unrelated formatting debt in `newsletter-autopilot/index.ts` and `research-to-microsite/index.test.mjs` left untouched — confirmed those failures predate this change and aren't on lines I edited).

Refs: SAP-2380
Refs: SAP-2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7MfX8ZsGE8ffsGgmNW5pW
