### PR TITLE
feat(mcp): return webapp run URL from agents_inspect and run

### DIFF
--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -44,6 +44,7 @@ import {
 import { type ResolvedEnvironment } from "../credentials.js";
 import { registerTool } from "../register-tool.js";
 import { fail, gatewayClient, NOT_AUTHED, ok } from "./shared.js";
+import { webappRunUrl } from "./webapp-url.js";
 
 /**
  * Coerce a tool argument that may arrive as a JSON string (some MCP clients
@@ -381,12 +382,20 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         // stringify object-valued args), mirroring run_local — the execution API
         // requires an object, so a raw `"{}"` string would be rejected. Default an
         // absent input to {} (the entry step's empty input).
-        return ok(
-          await run(
-            { definitionId: cfg.definitionId, input: coerceJson(input) ?? {} },
-            client,
-          ),
+        const started = await run(
+          { definitionId: cfg.definitionId, input: coerceJson(input) ?? {} },
+          client,
         );
+        // Hand back the webapp link so the caller can open the run it just
+        // started without reconstructing the route.
+        return ok({
+          ...started,
+          webappUrl: webappRunUrl(
+            env.appURL,
+            cfg.definitionId,
+            started.executionId,
+          ),
+        });
       } catch (err) {
         return fail(err);
       }
@@ -396,7 +405,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_inspect",
-    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
+    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local. When inspecting an execution, the result includes a `webappUrl` to open that run in the webapp.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
     {
       dir: z
         .string()
@@ -453,6 +462,11 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
               execution,
               done,
               waiting: !done,
+              webappUrl: webappRunUrl(
+                env.appURL,
+                execution.definitionId,
+                execution.id,
+              ),
               ...(hint ? { hint } : {}),
             });
           }
@@ -462,7 +476,15 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
           const hint = isExecutionTerminal(execution.status)
             ? undefined
             : `Execution is '${execution.status}', not terminal — call inspect with wait:true to block until it finishes instead of polling manually.`;
-          return ok({ execution, ...(hint ? { hint } : {}) });
+          return ok({
+            execution,
+            webappUrl: webappRunUrl(
+              env.appURL,
+              execution.definitionId,
+              execution.id,
+            ),
+            ...(hint ? { hint } : {}),
+          });
         }
         return ok(await listExecutions(client));
       } catch (err) {

--- a/packages/mcp/src/tools/webapp-url.test.ts
+++ b/packages/mcp/src/tools/webapp-url.test.ts
@@ -1,0 +1,45 @@
+/**
+ * `webappRunUrl` — the run-link contract. The canonical shape
+ * (`/agents/<def>/runs/<run>`) mirrors the frontend `runHref`; the null-definition
+ * fallback (`/agents/runs/<run>`) mirrors the webapp's id-only resolver route.
+ */
+import { describe, it, expect } from "vitest";
+import { webappRunUrl } from "./webapp-url.js";
+
+describe("webappRunUrl", () => {
+  it("builds the canonical /agents/<def>/runs/<run> URL", () => {
+    expect(webappRunUrl("https://app.sapiom.ai", "538", "159777")).toBe(
+      "https://app.sapiom.ai/agents/538/runs/159777",
+    );
+  });
+
+  it("falls back to the id-only resolver when definitionId is absent", () => {
+    expect(webappRunUrl("https://app.sapiom.ai", null, "159777")).toBe(
+      "https://app.sapiom.ai/agents/runs/159777",
+    );
+    expect(webappRunUrl("https://app.sapiom.ai", undefined, "159777")).toBe(
+      "https://app.sapiom.ai/agents/runs/159777",
+    );
+  });
+
+  it("honours staging and local origins", () => {
+    expect(webappRunUrl("https://app.sapiom.dev", "538", "159777")).toBe(
+      "https://app.sapiom.dev/agents/538/runs/159777",
+    );
+    expect(webappRunUrl("http://localhost:2999", "538", "159777")).toBe(
+      "http://localhost:2999/agents/538/runs/159777",
+    );
+  });
+
+  it("tolerates a trailing slash on the origin", () => {
+    expect(webappRunUrl("https://app.sapiom.ai/", "538", "159777")).toBe(
+      "https://app.sapiom.ai/agents/538/runs/159777",
+    );
+  });
+
+  it("percent-encodes ids containing URL-significant characters", () => {
+    expect(webappRunUrl("https://app.sapiom.ai", "def/1", "run 2")).toBe(
+      "https://app.sapiom.ai/agents/def%2F1/runs/run%202",
+    );
+  });
+});

--- a/packages/mcp/src/tools/webapp-url.ts
+++ b/packages/mcp/src/tools/webapp-url.ts
@@ -1,0 +1,24 @@
+/**
+ * Build the canonical webapp URL for one agent run, so run-returning tools can
+ * hand the caller a link to open instead of leaving the model to guess a route
+ * (it guessed a non-existent `/agents/<id>/executions/<id>` before this existed).
+ *
+ * The origin comes from the resolved environment's `appURL`
+ * (https://app.sapiom.ai in prod, https://app.sapiom.dev in staging,
+ * http://localhost:2999 locally). The path mirrors the frontend's `runHref`
+ * (`/agents/<definitionId>/runs/<runId>`); when a run predates definition
+ * linkage and has no `definitionId`, fall back to the id-only resolver route
+ * (`/agents/runs/<runId>`), which the webapp resolves to the owning definition.
+ */
+export function webappRunUrl(
+  appURL: string,
+  definitionId: string | null | undefined,
+  runId: string,
+): string {
+  const path = definitionId
+    ? `/agents/${encodeURIComponent(definitionId)}/runs/${encodeURIComponent(runId)}`
+    : `/agents/runs/${encodeURIComponent(runId)}`;
+  // `new URL(path, appURL)` joins the origin robustly whether or not `appURL`
+  // carries a trailing slash, matching the backend's link-building idiom.
+  return new URL(path, appURL).toString();
+}


### PR DESCRIPTION
## Problem

When asked to *"open the run in the webapp,"* the stdio MCP had no canonical URL in its run payload, so the model **guessed** — and guessed a route that doesn't exist: `/agents/<id>/executions/<id>`. The real scheme is `/agents/<definitionId>/runs/<runId>`.

## Fix (native, no backend change)

The MCP already resolves the webapp origin as `env.appURL` (`https://app.sapiom.ai` prod, `https://app.sapiom.dev` staging, `http://localhost:2999` local), and every run object already carries both `definitionId` and the run id. So the MCP can build the link itself instead of leaving the model to guess.

- New `webappRunUrl(appURL, definitionId, runId)` helper (`packages/mcp/src/tools/webapp-url.ts`):
  - canonical `/agents/<def>/runs/<run>` (mirrors the frontend `runHref`)
  - falls back to the id-only resolver `/agents/runs/<run>` when a run predates definition linkage (`definitionId` null)
  - joins the origin with `new URL(...)` (trailing-slash safe) and percent-encodes ids
- `sapiom_dev_agents_inspect`: adds `webappUrl` to both single-run return branches (snapshot + `wait`), and notes it in the tool description.
- `sapiom_dev_agents_run`: adds `webappUrl` to the start result — the natural "here's your run" moment.

Considered but rejected: embedding the URL in the backend run payload (Option 1). That's cross-repo — the Sapiom backend `ExecutionDetailDto` **and** this repo's `ExecutionProjection` type + decoder would both need the field, coordinated across two deploys. Building it in the MCP layer is a single self-contained change.

### Out of scope (follow-ups)
- `buildRunId` inspect branch (builds have a different webapp surface) and the `listExecutions` branch.
- The backend MCP twin `sapiom_workflow_get_run` (`formatExecution`) in the Sapiom monorepo — same idea, different repo.

## Verification
- `pnpm -F @sapiom/mcp typecheck` ✓
- `pnpm -F @sapiom/mcp test` ✓ (97 passed, incl. new `webapp-url.test.ts`)
- `pnpm -F @sapiom/mcp lint` ✓ · prettier ✓ · `terminology:check` ✓ · `provider-copy:check` ✓
- `webappRunUrl('https://app.sapiom.ai', '538', '159777')` → `https://app.sapiom.ai/agents/538/runs/159777` (the URL the model *should* have produced); null-definition → `https://app.sapiom.ai/agents/runs/159777`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)