### PR TITLE
docs(authoring): replace workflow copy with agent

### DIFF
--- a/examples/AUTHORING.md
+++ b/examples/AUTHORING.md
@@ -1,7 +1,7 @@
 # Authoring Sapiom templates
 
 A **template** is a working Sapiom agent, published in this repo, that anyone can browse in
-the gallery and turn into their own workflow with one click. This guide takes you from an
+the gallery and turn into their own agent with one click. This guide takes you from an
 empty directory to a merged, live template. Contributions are welcome — a human or an agent
 can follow it end to end.
 
@@ -469,7 +469,7 @@ it produces, then walk the flow in plain terms. Name capabilities in passing, ne
 words on who it's for instead of what it makes. 19 of the original 26 did this; none do now, and
 `pnpm examples:check` rejects a leading "For".
 
-Think of it as **named beats** — each sentence is one move the workflow makes:
+Think of it as **named beats** — each sentence is one move the agent makes:
 
 > Do the legwork, then wait for a person before spending money or doing anything irreversible.
 > It ranks your candidates by fit and emails the top pick for approval, falling to the next on
@@ -506,7 +506,7 @@ This is the field users hit when they want to actually run the thing. **Lead wit
 one-click webapp path; put the code/MCP path second, clearly optional.**
 
 1. **Use this template.** "Click **Use this template** — Sapiom builds and deploys it for you,
-   then run it from the workflow page. Your $5 signup credit covers first runs."
+   then run it from the agent page. Your $5 signup credit covers first runs."
 2. **Anything template-specific** the user must know to see it work — e.g. required inputs,
    a secret to set (BYO-API templates), or that it pauses on a real signal.
 3. **Advanced (only if relevant):** "Prefer to work from the code? Run it locally with

--- a/examples/the-brain/README.md
+++ b/examples/the-brain/README.md
@@ -1,9 +1,9 @@
 # The Brain
 
-A **fleet orchestrator** — a meta-workflow that coordinates a fleet of child
-workflows. The flagship "agents managing agents" template.
+A **fleet orchestrator** — a meta-agent that coordinates a fleet of child
+agents. The flagship "agents managing agents" template.
 
-A fleet is a handful of independent `@sapiom/agent` workflows (its _members_),
+A fleet is a handful of independent `@sapiom/agent` definitions (its _members_),
 each firing on its own cron and doing its own job. Nothing watches the _whole_:
 no one notices when a daily member silently missed today, or a weekly member is
 past its cadence, or a launch never reported back. The members are limbs with no
@@ -25,7 +25,7 @@ scan     read the event bus + fold the log into cadence/idempotency facts;
 assess   hand the situations to models.run with a FIXED allow-list of plays;
          re-validate the JSON against the allow-list (deterministic fallback).
 actuate  execute the plan behind six guardrails; launch each due member as a
-         child workflow with an idempotency key; append a member.launched row.
+         child agent with an idempotency key; append a member.launched row.
 report   post a briefing to a low-noise channel, append a brain.briefing row,
          advance the cursor, terminate.
 ```
@@ -88,7 +88,7 @@ surfaces `cooldown_due`. Swap the slugs for your real fleet.
   slug→definitionId from a cached `/definitions` list plus a static fallback map
   (`DEF_IDS` in `index.ts`). **Migrate to `agents.launch` if/when it is fixed.**
 - **definitionIds are environment-specific** — a child's definitionId does not
-  exist until it is deployed. **Deploy your child workflows first** (e.g.
+  exist until it is deployed. **Deploy your child agents first** (e.g.
   `hello-agent`), capture each definitionId, and seed it into `DEF_IDS`. The live
   `/definitions` lookup will also resolve them if it lists them; `launchChild`
   throws a clear error if a slug still can't be resolved.

--- a/examples/the-brain/index.ts
+++ b/examples/the-brain/index.ts
@@ -10,9 +10,9 @@ import { z } from "zod/v4";
 
 /**
  * the-brain — a fleet orchestrator ("central nervous system") over a set of
- * child workflows. The flagship "agents managing agents" template.
+ * child agents. The flagship "agents managing agents" template.
  *
- * A fleet is a handful of independent `@sapiom/agent` workflows (its *members*),
+ * A fleet is a handful of independent `@sapiom/agent` definitions (its *members*),
  * each firing on its own cron and doing its own job. Nothing watches the *whole*:
  * no one notices that a daily member silently missed its run today, or that a
  * weekly member is now past its cadence, or that a launch never reported back.
@@ -32,7 +32,7 @@ import { z } from "zod/v4";
  *   - actuate  executes the plan deterministically behind six guardrails
  *              (allow-list re-check, escalate-only, only-surfaced-targets,
  *              per-day cooldown, single-open, fan-out cap), launching each member
- *              as a child workflow and appending a member.launched row.
+ *              as a child agent and appending a member.launched row.
  *   - report   posts a briefing to a low-noise channel, appends a brain.briefing
  *              row, advances the cursor, and terminates.
  *
@@ -537,18 +537,18 @@ async function slackPost(
     throw new Error(`slack chat.postMessage failed: ${String(json.error)}`);
 }
 
-// ── child-workflow launch (the key detail + risk) ──
+// ── child-agent launch (the key detail + risk) ──
 // This launches children directly against the engine API by definitionId, using
 // the API key present in the runtime, rather than through the SDK's
 // ctx.sapiom.agents.launch. That route was reported as 404ing, but the report was
 // never reproduced against production — treat it as unverified, and prefer the SDK
 // once it is confirmed working.
 // Derived from the environment, NOT hardcoded: a fork running against a local or
-// staging stack must not launch child workflows into production, which is exactly
+// staging stack must not launch child agents into production, which is exactly
 // what a baked-in prod URL does.
 const WF_BASE = `${(process.env.SAPIOM_API_BASE_URL ?? "https://api.sapiom.ai").replace(/\/+$/, "")}/v1/workflows`;
 // Static fallback slug->definitionId map. definitionIds are ENVIRONMENT-SPECIFIC:
-// they don't exist until you deploy the child workflows. After deploying your
+// they don't exist until you deploy the child agents. After deploying your
 // children (e.g. `hello-agent`), capture each definitionId and seed it here.
 // Left empty by default: resolveDefId first tries the live /definitions lookup,
 // and launchChild throws a clear error if a slug still can't be resolved.
@@ -608,9 +608,9 @@ async function resolveDefId(
 /** Human-readable reasons a play produced no launch. */
 const LAUNCH_SKIP_REASONS: Record<string, string> = {
   "no-api-key":
-    "no API key was available in the run, so no child workflow was started",
+    "no API key was available in the run, so no child agent was started",
   "child-not-deployed":
-    "the child workflow is not deployed in this tenant yet, so there was nothing to launch",
+    "the child agent is not deployed in this tenant yet, so there was nothing to launch",
   "no-tenant-id":
     "the execution had no tenant id, so the child definition could not be resolved safely",
   "no-execution-id":
@@ -618,7 +618,7 @@ const LAUNCH_SKIP_REASONS: Record<string, string> = {
 };
 
 /**
- * Launch a child workflow fire-and-forget.
+ * Launch a child agent fire-and-forget.
  *
  * Returns `{ skipped }` rather than throwing when the child cannot be resolved: a
  * fresh tenant has not deployed the children yet, and a missing sibling is an
@@ -862,7 +862,7 @@ const assess = defineStep({
     }
 
     const system =
-      "You are the brain (a fleet coordinator) for a set of child workflows. Given the situations that " +
+      "You are the brain (a fleet coordinator) for a set of child agents. Given the situations that " +
       "need attention and the plays available, decide what to do. You may ONLY choose from these plays: " +
       `${ALLOWED_PLAYS.join(", ")}. launch_member(target=memberId) launches the named fleet member; ` +
       "escalate_to_human(target=short description) flags something for a person; no_action to skip. Rules: " +

--- a/examples/wait-for-webhook/README.md
+++ b/examples/wait-for-webhook/README.md
@@ -5,7 +5,7 @@ external async job, then **suspends indefinitely at $0** until a webhook/callbac
 fires — no polling loop, no held worker, no billed idle time — and resumes
 exactly where it left off when the external world is ready.
 
-The direct counter to "agents are too expensive to run": a workflow can wait
+The direct counter to "agents are too expensive to run": an agent run can wait
 days on a third-party callback and cost nothing until the signal arrives.
 
 ## What it does

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -145,7 +145,7 @@ Things to know:
     return pauseUntilSignal(run, { resumeStep: "review" });
   }
   ```
-- **Outside a workflow nothing changes** — `await launch().wait()` the capability as
+- **Outside an agent run nothing changes** — `await launch().wait()` the capability as
   usual; the pause wiring only engages when a step pauses on the handle.
 
 ### Compatible capabilities

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -8,7 +8,7 @@ import type { StepDefinition } from "./step.js";
 import type { AgentDefinition } from "./agent.js";
 
 /**
- * Generate a AgentManifest from a workflow definition and build metadata.
+ * Generate an AgentManifest from an agent definition and build metadata.
  *
  * - Walks def.steps; for each step:
  *   - timeoutMs: step.timeoutMs if declared, null otherwise.
@@ -143,7 +143,7 @@ export function assertValidGraph(manifest: AgentManifest): string[] {
   const { errors, warnings } = validateGraph(manifest);
   if (errors.length > 0) {
     throw new Error(
-      `Invalid workflow graph for '${manifest.name}':\n  - ${errors.join("\n  - ")}`,
+      `Invalid agent graph for '${manifest.name}':\n  - ${errors.join("\n  - ")}`,
     );
   }
   return warnings;
@@ -199,7 +199,7 @@ function terminalReachabilityWarnings(
     .map(([name]) => name);
   if (sinks.length === 0) {
     return [
-      "no step can terminate or fail — the workflow has no terminal state",
+      "no step can terminate or fail — the agent has no terminal state",
     ];
   }
 

--- a/packages/agent/src/graph.spec.ts
+++ b/packages/agent/src/graph.spec.ts
@@ -153,6 +153,6 @@ describe('validateGraph', () => {
       artifact: ARTIFACT,
       steps: { a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' as const }] } },
     };
-    expect(() => assertValidGraph(bad)).toThrow(/Invalid workflow graph/);
+    expect(() => assertValidGraph(bad)).toThrow(/Invalid agent graph/);
   });
 });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -100,7 +100,7 @@ A typical loop: `scaffold` → write step code → `run_local` until green → `
 
 ## How capabilities fit in
 
-Workflows authored here call Sapiom capabilities — sandboxes, repositories,
+Agents authored here call Sapiom capabilities — sandboxes, repositories,
 coding agents, search, storage, content generation — through
 [`@sapiom/tools`](../tools) (`ctx.sapiom.*`). `run_local` resolves those calls
 from stubs; deploy and production run cross into authenticated cloud operations

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -169,7 +169,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       input: z
         .unknown()
         .optional()
-        .describe("The workflow's entry-step input (any JSON value)."),
+        .describe("The agent's entry-step input (any JSON value)."),
       stubs: z
         .unknown()
         .optional()
@@ -266,7 +266,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     server,
     "sapiom_dev_agents_clone",
     [
-      "Materialize a Sapiom workflow locally. Given a template id (from the gallery) it forks the template into a repo you own; given an existing fork id it re-clones that fork; given a deployed workflow's definitionId it clones the engine's live build-repo source directly (no fork step, always current) and pre-links the checkout. Either way it mints a short-lived, repo-scoped clone credential, git-clones the repo into <dir>, and writes sapiom.json recording the provenance.",
+      "Materialize a Sapiom agent locally. Given a template id (from the gallery) it forks the template into a repo you own; given an existing fork id it re-clones that fork; given a deployed agent's definitionId it clones the engine's live build-repo source directly (no fork step, always current) and pre-links the checkout. Either way it mints a short-lived, repo-scoped clone credential, git-clones the repo into <dir>, and writes sapiom.json recording the provenance.",
       "After cloning: read the project's AGENTS.md, install its dependencies, then _check → _run_local. Before cloud work, authenticate and run _link → _deploy → _run → _inspect. A templateId/forkId clone is source only and has no dashboard agent until link/deploy; a definitionId clone is already linked because sapiom.json contains its definitionId.",
       "Pass exactly one of templateId, forkId, or definitionId. The clone credential is single-repo, read-only, and ~1h-lived — it is used for the clone and discarded (never stored in sapiom.json).",
     ].join("\n"),
@@ -293,7 +293,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         .union([z.string(), z.number()])
         .optional()
         .describe(
-          "Deployed workflow's definition id to pull local (e.g. from the dashboard URL or a prior link/deploy). Clones the engine's current build-repo source directly, skipping the fork step, and pre-links the checkout (sapiom.json is written with this id, so sapiom_dev_agents_link is not needed before deploy). Accepts a number or string — the engine id is a bigint. Mutually exclusive with templateId and forkId.",
+          "Deployed agent's definition id to pull local (e.g. from the dashboard URL or a prior link/deploy). Clones the engine's current build-repo source directly, skipping the fork step, and pre-links the checkout (sapiom.json is written with this id, so sapiom_dev_agents_link is not needed before deploy). Accepts a number or string — the engine id is a bigint. Mutually exclusive with templateId and forkId.",
         ),
     },
     async ({ dir, templateId, forkId, definitionId }) => {
@@ -371,7 +371,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       input: z
         .unknown()
         .optional()
-        .describe("The workflow's entry-step input (any JSON value)."),
+        .describe("The agent's entry-step input (any JSON value)."),
     },
     async ({ dir, input }) => {
       const client = await gatewayClient(env);

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -41,7 +41,7 @@ There are two ways to authenticate, both exposing the identical capability surfa
   const sapiom = createClient({ apiKey: process.env.SAPIOM_API_KEY });
   await sapiom.sandboxes.create({ name: "demo" });
   ```
-- **Ambient** — import the namespaces directly and they resolve credentials from `SAPIOM_API_KEY` (or, inside a Sapiom workflow step, from the client the runtime provides):
+- **Ambient** — import the namespaces directly and they resolve credentials from `SAPIOM_API_KEY` (or, inside a Sapiom agent step, from the client the runtime provides):
   ```typescript
   import { sandboxes, repositories, agent } from "@sapiom/tools";
   await sandboxes.create({ name: "demo" });
@@ -59,7 +59,7 @@ const sapiom = createClient({
 // every call this client makes is now attributed to digest-bot / traceId
 ```
 
-Inside a Sapiom workflow you don't set this at all — the runtime constructs the client with the running execution's attribution, so every tool call is attributed automatically.
+Inside a Sapiom agent run you don't set this at all — the runtime constructs the client with the running execution's attribution, so every tool call is attributed automatically.
 
 If a single process makes calls on behalf of more than one agent or trace, derive a client per context with `sapiom.withAttribution({ ... })`.
 

--- a/packages/tools/src/_client/index.ts
+++ b/packages/tools/src/_client/index.ts
@@ -75,7 +75,7 @@ export interface Attribution {
 }
 
 export interface TransportConfig {
-  /** Explicit tenant API key. Omit inside a workflow step — the engine injects it ambiently. */
+  /** Explicit tenant API key. Omit inside an agent step — the engine injects it ambiently. */
   apiKey?: string;
   /** Inject a fetch (tests / non-standard runtimes). Defaults to global fetch. */
   fetch?: typeof globalThis.fetch;
@@ -234,7 +234,7 @@ export class Transport {
     if (!this.apiKey) {
       throw new Error(
         "@sapiom/tools: no tenant credential. Pass createClient({ apiKey }) for standalone use, " +
-          "or run inside a Sapiom workflow (the engine injects SAPIOM_API_KEY).",
+          "or run inside a Sapiom agent run (the engine injects SAPIOM_API_KEY).",
       );
     }
     const startedAt = Date.now();

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -85,8 +85,8 @@ const handle = await sapiom.contentGeneration.video.launch({
 const out = await handle.wait(); // polls until ready
 out.video?.fileId; // + out.video?.downloadUrl for a ready-to-use URL
 
-// Option B — suspend a workflow step until the video is ready, then resume:
-// (Inside a Sapiom workflow step; the orchestration engine handles the rest.)
+// Option B — suspend an agent step until the video is ready, then resume:
+// (Inside a Sapiom agent step; the orchestration engine handles the rest.)
 const handle = await sapiom.contentGeneration.video.launch({
   prompt: "a calm ocean wave at sunset",
 });
@@ -101,7 +101,7 @@ defaults when `wait()` is called without arguments, so the two APIs stay in sync
 ### `VIDEO_RESULT_SIGNAL`
 
 The capability-stable signal constant — use it in the static `pause: { signal }`
-declaration on a workflow step so the engine knows which signal to listen for:
+declaration on an agent step so the engine knows which signal to listen for:
 
 ```typescript
 import { VIDEO_RESULT_SIGNAL } from "@sapiom/tools";

--- a/packages/tools/src/database/README.md
+++ b/packages/tools/src/database/README.md
@@ -31,7 +31,7 @@ await sapiom.database.delete(db.id); // or delete("analytics")
 ```
 
 `list()` is **read-only** — it never creates, mutates, or removes anything. Use it
-to discover a handle you (or another of your workflows) already provisioned before
+to discover a handle you (or another of your agents) already provisioned before
 deciding whether to reuse it.
 
 Ambient import works too: `import { database } from "@sapiom/tools"`.

--- a/packages/tools/src/domains/README.md
+++ b/packages/tools/src/domains/README.md
@@ -2,7 +2,7 @@
 
 Register domain names and manage their DNS. The same domains capability your
 agents call over MCP, callable directly from your code or from within a Sapiom
-workflow step.
+agent step.
 
 ```typescript
 import { createClient } from "@sapiom/tools";

--- a/packages/tools/src/email/README.md
+++ b/packages/tools/src/email/README.md
@@ -3,7 +3,7 @@
 Programmatic transactional email. Create real, addressable inboxes, send and
 receive messages, manage custom sending domains, read conversation threads, and
 register webhooks for inbound events. Call it directly from your code, or from
-within Sapiom workflow steps.
+within Sapiom agent steps.
 
 ```typescript
 import { createClient } from "@sapiom/tools";

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -34,7 +34,7 @@
  *   // …and in the resumed step (input: LlmRouteResultPayload):
  *   const reply = await ctx.sapiom.llm.redeem(input.link!, savedRequestBody);
  *
- * Inside a workflow the engine's resume token (ambient on the transport) rides the
+ * Inside an agent run the engine's resume token (ambient on the transport) rides the
  * `x-sapiom-workflow-token` header; the gateway echoes it in its webhook so the
  * engine's forwarder can resume the paused step. Standalone callers can instead
  * poll `handle.wait()` — same admission, no pause.
@@ -63,7 +63,7 @@ const DEFAULT_BASE_URL = resolveServiceUrl("llm", process.env.SAPIOM_LLM_URL);
 /**
  * Capability-stable signal a routed job fires when it reaches a terminal state
  * (granted OR failed — it carries the result either way, the resumed step
- * branches). A workflow step paused on a submit handle resumes on this; it is the
+ * branches). An agent step paused on a submit handle resumes on this; it is the
  * value carried in the handle's `dispatch.resultSignal`.
  */
 export const LLM_ROUTE_RESULT_SIGNAL = "llm.route.result";
@@ -98,8 +98,8 @@ export interface LlmRunSpec {
    * Guarantee an answer by spilling to the label's declared fallback when the
    * preferred capacity is saturated (never-429). DEFAULTS TO TRUE here: the
    * gateway's own direct default is OFF (drop-in callers get plain 429 +
-   * backoff), but a workflow step usually can't retry-with-backoff cheaply, so
-   * the SDK opts workflows in. Set `false` to take 429s and handle them.
+   * backoff), but an agent step usually can't retry-with-backoff cheaply, so
+   * the SDK opts agent runs in. Set `false` to take 429s and handle them.
    * Note: spilling can serve a costlier deployment.
    */
   neverFail?: boolean;
@@ -131,7 +131,7 @@ export interface LlmSubmitSpec {
   /** Explicit complexity/capacity weight override (gateway clamps to its bounds). */
   complexity?: number;
   /**
-   * Where the gateway reports the grant (or failure). Inside a workflow leave it
+   * Where the gateway reports the grant (or failure). Inside an agent run leave it
    * unset — the engine injects `SAPIOM_LLM_WEBHOOK_URL` (its resume forwarder).
    * Standalone callers must pass one, or rely purely on `handle.wait()` polling
    * via a URL of their own.
@@ -205,7 +205,7 @@ export const llmRouteResultSchema = {
 /**
  * A submitted-but-not-awaited routed job. Satisfies {@link DispatchHandle}, so it
  * can be handed straight to `pauseUntilSignal(handle, { resumeStep })` to suspend
- * a workflow step until the gateway grants (or fails) it — or `wait()`-ed inline
+ * an agent step until the gateway grants (or fails) it — or `wait()`-ed inline
  * for standalone use (polls the gateway's status endpoint).
  */
 export interface LlmRouteHandle extends DispatchHandle {
@@ -284,7 +284,7 @@ function submitHeaders(spec: LlmSubmitSpec, resumeToken: string | undefined) {
   const webhookUrl = spec.webhookUrl ?? process.env.SAPIOM_LLM_WEBHOOK_URL;
   if (!webhookUrl) {
     throw new Error(
-      "llm.submit: no webhook URL. Inside a workflow the engine injects " +
+      "llm.submit: no webhook URL. Inside an agent run the engine injects " +
         "SAPIOM_LLM_WEBHOOK_URL; standalone callers must pass { webhookUrl }.",
     );
   }
@@ -319,7 +319,7 @@ export async function run<T = Record<string, unknown>>(
 ): Promise<T> {
   const headers: Record<string, string> = {};
   if (spec.model) headers["x-sapiom-model"] = spec.model;
-  // Workflow surface defaults to never-fail ON (see LlmRunSpec.neverFail) —
+  // Agent surface defaults to never-fail ON (see LlmRunSpec.neverFail) —
   // sent explicitly either way so the behavior never rides a gateway default.
   headers["x-sapiom-never-fail"] = String(spec.neverFail ?? true);
   if (spec.complexity !== undefined)
@@ -455,7 +455,7 @@ export interface LlmSessionCreateSpec {
    */
   neverFail?: boolean;
   /**
-   * Where the gateway reports readiness. Inside a workflow leave it unset —
+   * Where the gateway reports readiness. Inside an agent run leave it unset —
    * the engine's `SAPIOM_LLM_WEBHOOK_URL` (resume forwarder) is used when
    * present. Unlike `submit`, a webhook is OPTIONAL: standalone callers may
    * rely purely on `handle.wait()` polling.
@@ -548,7 +548,7 @@ export async function createSession(
     body.budget = budget;
   }
   if (spec.neverFail !== undefined) body.never_fail = spec.neverFail;
-  // Webhook is optional (poll-only is a legitimate mode). Inside a workflow the
+  // Webhook is optional (poll-only is a legitimate mode). Inside an agent run the
   // engine's forwarder URL + the ambient resume token wire up pause/resume.
   const webhookUrl = spec.webhookUrl ?? process.env.SAPIOM_LLM_WEBHOOK_URL;
   if (webhookUrl) {


### PR DESCRIPTION
## Summary

- replace product-facing workflow terminology in SDK authoring docs, examples, MCP descriptions, user-visible errors, and matching assertions
- keep workflow routes, headers, entity keys, and compatibility contracts unchanged
- align package guidance around building and deploying agents

## Testing

- pnpm build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm terminology:check
- pnpm examples:check