### PR TITLE
feat(harness): observable Run / Test / Deploy in the Steps view

### DIFF
--- a/.changeset/observable-run-actions.md
+++ b/.changeset/observable-run-actions.md
@@ -1,0 +1,25 @@
+---
+"@sapiom/harness": minor
+---
+
+Make Test / Run / Deploy observable in Studio: clicking one now reveals the
+right pane and switches it to the Steps view (the unified activity surface),
+instead of the action landing silently.
+
+- **See it move.** A run's steps advance pending → running → passed in view; the
+  acting button carries a `data-running` pulse tied to the real run status (not
+  just the brief hand-off ring); and the demo prod run now progresses across
+  polls on a wall clock rather than snapping to "completed".
+- **Relevant final data up front.** A run-summary card headlines the Steps
+  surface — outcome, live progress, total duration, and the single most relevant
+  result CTA (the deployed agent's dashboard link → a dev-server preview →
+  URLs the run produced → the final step's output). Honest-absence throughout:
+  no cost fields, no latency on a still-running step, no fabricated values.
+- **Better payload CTAs.** Input / Output / Logs / Result share one disclosure
+  with a Copy button (the final Result renders expanded); nothing renders for a
+  payload a step never carried.
+- **Deploy as an action, not a toast.** Deploy lands in the same Steps surface
+  with a live linking → building → deployed banner, then a completion state that
+  links to the dashboard and jumps to the "Trigger from your code" snippet.
+
+Note: after an action, the persisted right-pane tab is Steps.

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -82,12 +82,12 @@ test("a board pick populates the inspector in place, with no tab switch", async 
   await expect(inspector).toContainText("records.read");
 
   // The drawer no longer carries step-navigation links — the chart is right
-  // there for that. "Open step" is the explicit full-pane drill, and it opens
-  // the picked step (still intake, since nothing retargeted the selection).
+  // there for that. "Open step" switches to the Steps tab and expands that
+  // step's row inline (its detail is a dropdown now, not a separate view).
   await page.getByTestId("canvas-inspector-open-steps").click();
   await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
-  await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "detail");
-  await expect(page.getByTestId("canvas-detail-title")).toHaveText("intake");
+  await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute("data-view", "steps");
+  await expect(page.getByTestId("canvas-step-expand-intake")).toContainText("Logs the incoming order");
 });
 
 test("a generic render failure names the agent graph", async ({ page }) => {

--- a/packages/harness/web/e2e/direct-action-feedback.spec.ts
+++ b/packages/harness/web/e2e/direct-action-feedback.spec.ts
@@ -204,9 +204,9 @@ test.describe("Fix 3 — deploy failure persists in Prod-run disabled reason", (
     await expect(deployBtn).toHaveClass(/session-action-primary/);
     // The mock persists a definition id before the failed first build, just
     // like production. That link must not enable Prod Run or Code snippets.
-    // Starting the rfq session collapsed the right pane (empty canvas — the
-    // failed build produced no doc); reopen it before inspecting canvas-tab-bar.
-    await page.getByTestId("right-expand").click();
+    // Clicking Deploy revealed the right pane and switched it to the Steps tab
+    // (the unified activity surface); switch to the Canvas tab for the pill.
+    await page.getByTestId("right-tab-canvas").click();
     const dashboardLink = page.getByTestId("workflow-dashboard-link");
     await expect(dashboardLink).toContainText("deploy failed");
     await expect(dashboardLink).toHaveAttribute("data-deployment-state", "failed");
@@ -265,6 +265,8 @@ test.describe("Fix 3 — deploy failure persists in Prod-run disabled reason", (
 
     // After success the agent is DEPLOYED: the "deployed" pill appears on the
     // Canvas tab, Run becomes enabled and takes over as the primary CTA.
+    // Deploy switched the pane to the Steps tab; go back to Canvas for the pill.
+    await page.getByTestId("right-tab-canvas").click();
     await expect(page.getByTestId("workflow-dashboard-link")).toContainText("deployed", {
       timeout: 3_000,
     });

--- a/packages/harness/web/e2e/direct-actions.spec.ts
+++ b/packages/harness/web/e2e/direct-actions.spec.ts
@@ -216,9 +216,8 @@ test.describe("Deploy button — direct route, NDJSON build stream, no pty write
     // bar: a deployed workflow now surfaces the "deployed" dashboard link in the
     // right-pane header (Canvas tab only) and makes Run enabled. MockApi.deploy
     // updates its local workflow copy, and refreshWorkflows re-reads it.
-    // Starting a session on rfq (empty canvas board) auto-collapsed the right
-    // pane; reopen it before inspecting the right-pane dashboard link.
-    await page.getByTestId("right-expand").click();
+    // Clicking Deploy reveals the right pane and lands on the Steps tab (the
+    // unified activity surface); switch to the Canvas tab for the dashboard link.
     await page.getByTestId("right-tab-canvas").click();
     await expect(page.getByTestId("workflow-dashboard-link")).toContainText("deployed", { timeout: 3_000 });
     await expect(page.getByTestId("session-step-run")).toBeEnabled();
@@ -271,13 +270,15 @@ test.describe("Prod-run button — direct route, executionId → inspector, no p
     // records what api.run() received — see MockApi.run).
     expect(direct.req.definitionId).toBe("4821");
 
-    // The returned executionId is fed into the run-inspector poller. Load the
-    // Steps tab to confirm the run appeared (the mock getRunState returns the
-    // completed leasing steps immediately).
-    await page.getByTestId("right-tab-steps").click();
-    // The run chip appears once the poller's first tick resolves.
+    // The returned executionId is fed into the run-inspector poller. Clicking
+    // Run already revealed the pane and switched it to the Steps tab (the
+    // unified activity surface) — no manual tab click needed.
+    await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
+    // The run shows up RUNNING, then advances to completed as the mock's
+    // wall-clock timeline ticks across polls (the observability the feature adds).
     const runChip = page.getByTestId("canvas-run-chip");
-    await expect(runChip).toContainText("prod run completed", { timeout: 5_000 });
+    await expect(runChip).toContainText("prod run");
+    await expect(runChip).toContainText("prod run completed", { timeout: 10_000 });
 
     // lastMacroRun must be absent — the direct route bypasses runMacro.
     const hook = await readTestHook(page);

--- a/packages/harness/web/e2e/popover-crop.spec.ts
+++ b/packages/harness/web/e2e/popover-crop.spec.ts
@@ -101,12 +101,4 @@ test("canvas run picker and step detail menu open uncropped at the right pane's 
   await page.getByTestId("canvas-run-chip").click();
   await expectUncropped(page, page.getByTestId("canvas-run-menu"));
   await page.keyboard.press("Escape");
-
-  // The step-detail ⋯ menu sits at the pane's far right — the down-end
-  // placement must still land fully on screen. "Full details" lives inside
-  // the expanded step row, so expand it first.
-  await page.getByTestId("canvas-step-row-approve").click();
-  await page.getByTestId("canvas-step-open-approve").click();
-  await page.getByTestId("canvas-detail-menu").click();
-  await expectUncropped(page, page.getByTestId("canvas-detail-menu-popover"));
 });

--- a/packages/harness/web/e2e/rich-step-detail.spec.ts
+++ b/packages/harness/web/e2e/rich-step-detail.spec.ts
@@ -314,9 +314,8 @@ test.describe("Capability calls block", () => {
     await expect(chip).toBeVisible({ timeout: 8000 });
     await expect(chip).toContainText("completed", { timeout: 8000 });
 
-    // Expand the 'approve' row then open full-pane detail.
+    // Expand the 'approve' row: the detail renders inline in its dropdown.
     await page.getByTestId("canvas-step-row-approve").click();
-    await page.getByTestId("canvas-step-open-approve").click();
 
     const detail = page.getByTestId("canvas-step-detail");
     await expect(detail).toBeVisible({ timeout: 5000 });
@@ -333,7 +332,6 @@ test("the entry-step detail says the agent starts here", async ({ page }) => {
   await loadBoard(page);
   await page.getByTestId("right-tab-steps").click();
   await page.getByTestId("canvas-step-row-intake").click();
-  await page.getByTestId("canvas-step-open-intake").click();
 
   const detail = page.getByTestId("canvas-step-detail");
   await expect(detail).toContainText("Entry point: the agent starts here.");

--- a/packages/harness/web/e2e/run-inspector.spec.ts
+++ b/packages/harness/web/e2e/run-inspector.spec.ts
@@ -173,13 +173,9 @@ test.describe("offline stub run — run-local inspector", () => {
     await expect(chip).toBeVisible({ timeout: 8000 });
     await expect(chip).toContainText("completed", { timeout: 8000 });
 
-    // Expand the intake step (only ran step) to reveal the CanvasStepDetail,
-    // which renders StubNoticeSection. The accordion row is a button; click it.
+    // Expand the intake step (only ran step): the CanvasStepDetail — with the
+    // run's StubNoticeSection — renders INLINE in the row's dropdown.
     await page.getByTestId("canvas-step-row-intake").click();
-    // CanvasStepDetail renders in the slide-pane (the "Full details" drill —
-    // open it to see the run's StubNoticeSection).
-    await page.getByTestId("canvas-step-open-intake").click();
-    // The detail pane is now visible — wait for the canvas-step-detail.
     const detail = page.getByTestId("canvas-step-detail");
     await expect(detail).toBeVisible({ timeout: 5000 });
 

--- a/packages/harness/web/e2e/run-observability.spec.ts
+++ b/packages/harness/web/e2e/run-observability.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Observable Run / Test / Deploy: clicking an action reveals the right pane and
+ * switches it to the Steps view, the acting button shows a running highlight
+ * tied to the REAL run status, the run advances visibly (running → completed),
+ * and the relevant final data (deployed dashboard link, result output) surfaces
+ * up front — never with fabricated cost. All in mock mode (VITE_MOCK=1).
+ *
+ * Fixtures (mock-data.ts): leasing is deployed (definitionId=4821, path
+ * /Users/demo/acme-app/leasing); the boot session is bound to leasing.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?seed=0");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await expect(page.getByTestId("session-steps")).toBeVisible();
+  await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
+});
+
+test.describe("Run/Test/Deploy observability", () => {
+  test("Run reveals the Steps view, highlights the running button, then shows a completed summary", async ({
+    page,
+  }) => {
+    // Collapse the pane first, to prove Run REVEALS it (not just switches tabs).
+    await page.getByTestId("right-collapse").click();
+    await expect(page.getByTestId("right-panel-canvas")).not.toBeVisible();
+
+    const runBtn = page.getByTestId("session-step-run");
+    await expect(runBtn).toBeEnabled();
+    await runBtn.click();
+
+    // Auto-switched to Steps AND revealed the pane.
+    await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
+    await expect(page.getByTestId("canvas-steps-surface")).toBeVisible();
+
+    // The run summary appears and reads as running; the acting button pulses.
+    const summary = page.getByTestId("run-summary");
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText("Running");
+    await expect(runBtn).toHaveAttribute("data-running", "true");
+
+    // The deployed agent's dashboard link is the headline result CTA.
+    await expect(page.getByTestId("run-summary-dashboard-link")).toBeVisible();
+
+    // It advances to completed; the highlight clears; a total duration shows.
+    await expect(summary).toContainText("Completed", { timeout: 12_000 });
+    await expect(runBtn).not.toHaveAttribute("data-running", "true");
+    await expect(page.getByTestId("run-summary-duration")).toBeVisible();
+  });
+
+  test("Test streams a local run into the Steps view with a copyable result", async ({ page }) => {
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.getByTestId("session-step-local").click();
+
+    await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
+    await expect(page.getByTestId("run-summary")).toBeVisible();
+
+    // A local run carries per-step output, so the final Result renders
+    // default-open with a Copy button that reuses the snippet-copy pattern.
+    const result = page.getByTestId("run-summary-output");
+    await expect(result).toBeVisible({ timeout: 6_000 });
+    const copy = page.getByTestId("payload-copy-result");
+    await expect(copy).toBeVisible();
+    await copy.click();
+    await expect(copy).toContainText("Copied");
+  });
+
+  test("Deploy shows a live banner in the Steps view that jumps to the Code snippet", async ({
+    page,
+  }) => {
+    await page.getByTestId("session-step-deploy").click();
+
+    // Deploy lands in the same Steps activity surface.
+    await expect(page.getByTestId("right-tab-steps")).toHaveClass(/is-active/);
+    const banner = page.getByTestId("deploy-status-banner");
+    await expect(banner).toBeVisible();
+
+    // It reaches the ready phase with the dashboard + code CTAs.
+    await expect(banner).toHaveAttribute("data-phase", "ready", { timeout: 6_000 });
+    await expect(page.getByTestId("deploy-open-dashboard")).toBeVisible();
+
+    // "Trigger from your code" jumps to the Code tab where the snippet lives.
+    await page.getByTestId("deploy-open-code").click();
+    await expect(page.getByTestId("right-panel-code")).toBeVisible();
+    await expect(page.getByTestId("snippet-panel")).toBeVisible();
+  });
+
+  test("no fabricated cost surfaces in the run summary or its result", async ({ page }) => {
+    await page.getByTestId("session-step-local").click();
+    const surface = page.getByTestId("canvas-steps-surface");
+    await expect(page.getByTestId("run-summary")).toBeVisible();
+    await expect(page.getByTestId("run-summary-output")).toBeVisible({ timeout: 6_000 });
+    // Latency and logs, never money.
+    await expect(surface).not.toContainText("$");
+  });
+});

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -1786,36 +1786,35 @@ test("steps tab drills into a step's real transitions and slides back", async ({
   // Grouped steps sit under their board band's label.
   await expect(page.getByTestId("canvas-steps-list")).toContainText("intake & screening");
 
-  // Rows are an ACCORDION: the first click expands in place with the step's
-  // description, input contract, and transitions; navigation is the explicit
-  // link inside.
+  // Rows are an ACCORDION: clicking one expands its FULL detail INLINE — a
+  // dropdown, NOT a separate slide-in view (data-view stays "steps").
   await approveRow.click();
   const expand = page.getByTestId("canvas-step-expand-approve");
   await expect(expand).toBeVisible();
-  await expect(expand).toContainText("score ≥ 620");
-  const inputCard = page.getByTestId("canvas-step-input-approve");
-  await expect(inputCard).toContainText("score");
-  await expect(inputCard).toContainText("number");
-  // Capabilities ride the posted graph (A4-04): the Sapiom services a step
-  // calls render as chips wherever the step's contract shows.
-  await expect(page.getByTestId("canvas-step-capabilities-approve")).toContainText("rules.evaluate");
   await expect(frame).toHaveAttribute("data-view", "steps");
 
-  // Full details slides the WHOLE pane; the subheader swaps to back
-  // (1×1, left-anchored) + step name + kind, with the main action and the
-  // ⋯ menu right-anchored.
-  await page.getByTestId("canvas-step-open-approve").click();
-  await expect(frame).toHaveAttribute("data-view", "detail");
-  const header = page.getByTestId("workflow-actions-header");
-  await expect(header.getByTestId("canvas-detail-back")).toBeVisible();
-  await expect(header.getByTestId("canvas-detail-title")).toHaveText("approve?");
-  const askCodingAgent = header.getByTestId("canvas-detail-ask");
-  await expect(askCodingAgent).toBeVisible();
-  await expect(askCodingAgent).toHaveAccessibleName("Ask coding agent");
-  await expect(askCodingAgent).toHaveAttribute("data-tooltip", "Ask the coding agent in the terminal");
-  await expect(askCodingAgent).toContainText("Ask coding agent");
-  await expect(header.getByTestId("canvas-detail-menu")).toBeVisible();
+  const detail = page.getByTestId("canvas-step-detail");
+  await expect(detail).toBeVisible();
 
+  // Real outgoing transitions with their branch conditions, both terminals.
+  await expect(detail).toContainText("draft-lease");
+  await expect(detail).toContainText("score ≥ 620");
+  await expect(detail).toContainText("manual-review");
+  await expect(detail).toContainText("declined");
+
+  // The Contract section renders the step's REAL declared input schema and the
+  // capabilities it calls.
+  const contract = detail.getByTestId("canvas-detail-input");
+  await expect(contract).toContainText("score");
+  await expect(contract).toContainText("number");
+  await expect(detail.getByTestId("canvas-detail-capabilities")).toContainText("rules.evaluate");
+
+  // Per-step coding-agent actions live in the dropdown (ported from the retired
+  // detail-pane header): "Ask coding agent" sends a step-scoped prompt (never a
+  // workflow-scoped one), and "Ask to modify" sends the modify prompt.
+  const askCodingAgent = detail.getByTestId("canvas-detail-ask");
+  await expect(askCodingAgent).toBeVisible();
+  await expect(askCodingAgent).toContainText("Ask coding agent");
   await askCodingAgent.click();
   await expect
     .poll(async () =>
@@ -1824,7 +1823,7 @@ test("steps tab drills into a step's real transitions and slides back", async ({
           .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
       ),
     )
-    .toContain('step of this agent');
+    .toContain("step of this agent");
   const askPrompt = await page.evaluate(() =>
     (window as unknown as { __HARNESS_TEST__?: { lastInjectInput?: { req: { text: string } } } })
       .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
@@ -1835,8 +1834,7 @@ test("steps tab drills into a step's real transitions and slides back", async ({
     const hook = (window as unknown as { __HARNESS_TEST__?: Record<string, unknown> }).__HARNESS_TEST__;
     if (hook) delete hook.lastInjectInput;
   });
-  await header.getByTestId("canvas-detail-menu").click();
-  await page.getByRole("menuitem", { name: "Ask coding agent to modify" }).click();
+  await detail.getByTestId("canvas-detail-modify").click();
   await expect
     .poll(async () =>
       page.evaluate(() =>
@@ -1844,26 +1842,13 @@ test("steps tab drills into a step's real transitions and slides back", async ({
           .__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
       ),
     )
-    .toContain('step of this agent');
-
-  // Real outgoing transitions with their branch conditions, both terminals.
-  const detail = page.getByTestId("canvas-step-detail");
-  await expect(detail).toContainText("draft-lease");
-  await expect(detail).toContainText("score ≥ 620");
-  await expect(detail).toContainText("manual-review");
-  await expect(detail).toContainText("declined");
-
-  // The Contract section renders the step's REAL declared input schema and
-  // the capabilities it calls (the thing Sapiom bills for).
-  const contract = detail.getByTestId("canvas-detail-input");
-  await expect(contract).toContainText("score");
-  await expect(contract).toContainText("number");
-  await expect(detail.getByTestId("canvas-detail-capabilities")).toContainText("rules.evaluate");
+    .toContain("step of this agent");
 
   await page.screenshot({ path: "web/e2e/screenshots/canvas-step-detail.png" });
 
-  // Back returns to the steps list; the Canvas tab still shows the board.
-  await page.getByTestId("canvas-detail-back").click();
+  // Collapsing the row hides the detail again; the list stays put.
+  await approveRow.click();
+  await expect(page.getByTestId("canvas-step-detail")).toHaveCount(0);
   await expect(frame).toHaveAttribute("data-view", "steps");
   await page.getByTestId("right-tab-canvas").click();
   await expect(frame).toHaveAttribute("data-view", "board");
@@ -1947,9 +1932,8 @@ test("an observed run renders per-step status and latency in the steps tab", asy
   await expect(page.getByTestId("canvas-run-chip")).toContainText("prod run completed");
   await expect(page.getByTestId("canvas-steps-run-note")).toHaveText("prod run");
 
-  // Detail carries the same run truth for the drilled step.
+  // Detail carries the same run truth for the drilled step (inline dropdown).
   await introRow.click();
-  await page.getByTestId("canvas-step-open-intake").click();
   const runSection = page.getByTestId("canvas-detail-run");
   await expect(runSection).toContainText("passed");
   await expect(runSection).toContainText("240ms");

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -67,7 +67,7 @@ import { describeWorkflowPrompt } from "./lib/describe-prompt";
 import { sessionDisplayName } from "./lib/session-name";
 import { loadUiPrefs, saveUiPrefs } from "./lib/ui-prefs";
 import { CANVAS_MIN, RAIL_MIN, isMobileShell, useMobileShell, usePaneWidths } from "./lib/use-pane-widths";
-import { useHarnessState, type ObservedRun } from "./lib/use-harness-state";
+import { useHarnessState, type ObservedRun, type RunTarget } from "./lib/use-harness-state";
 import {
   isWorkflowRunnable,
   workflowDeploymentState,
@@ -484,6 +484,11 @@ export const App = (): JSX.Element => {
           observedRunMatchesWorkflow(observed, boundWorkflowPath),
         )
     : [];
+  // The action button's honest "running" signal: tied to the SHOWN run's real
+  // status, not the brief `directActionSettleSeq` pending ring (which clears at
+  // hand-off). null unless the visible run is still running.
+  const runningTarget: RunTarget | null =
+    activeObservedRun?.run.status === "running" ? activeObservedRun.target : null;
 
   const closeMobileDrawer = (): void => {
     if (isMobile) setRailCollapsed(true);
@@ -782,6 +787,26 @@ export const App = (): JSX.Element => {
   // draw into the wrong root.
   const handleRunMacroForWorkflow = (workflow: WorkflowInfo | null, macro: MacroDef): void => {
     void (async () => {
+      // Deploy / Prod-run / Run-local run via the DIRECT harness routes (no
+      // Claude Code, no user LLM credits). Once a macro is a direct action we
+      // NEVER fall through to the pty-inject runMacro — the buttons are already
+      // gated (require a workflow / a deploy), so a missing prerequisite here is
+      // a no-op, never a silent revert to the Claude Code path.
+      const direct = directActionKind(macro.id);
+      // Reveal + focus the Steps pane the instant an action will actually run,
+      // BEFORE the (possibly slow) bind round-trip, so the run/deploy lands in a
+      // view the user is already looking at. Gated so a click that will only
+      // toast (prod-run with no ready build; run/deploy with no workflow) never
+      // yanks the view. Matches the dispatch guards below exactly.
+      const willActNow =
+        ((direct === "deploy" || direct === "run-local") && workflow != null) ||
+        (direct === "prod-run" &&
+          workflow?.definitionId != null &&
+          isWorkflowRunnable(workflow));
+      if (willActNow) {
+        setRightTab("steps");
+        setRightCollapsed(false);
+      }
       let sessionId = harness.activeSessionId;
       if (workflow) sessionId = (await handleBindWorkflow(workflow.path)) ?? sessionId;
       if (macro.action.kind === "open-url") {
@@ -789,12 +814,6 @@ export const App = (): JSX.Element => {
         return;
       }
       if (!sessionId) return;
-      // Deploy / Prod-run / Run-local run via the DIRECT harness routes (no
-      // Claude Code, no user LLM credits). Once a macro is a direct action we
-      // NEVER fall through to the pty-inject runMacro — the buttons are already
-      // gated (require a workflow / a deploy), so a missing prerequisite here is
-      // a no-op, never a silent revert to the Claude Code path.
-      const direct = directActionKind(macro.id);
       if (direct !== null) {
         if (direct === "deploy") {
           if (!workflow) {
@@ -1071,6 +1090,7 @@ export const App = (): JSX.Element => {
                     lastDeployError={harness.lastDeployErrorFor(boundWorkflow.path)}
                     authenticated={state.authenticated}
                     directActionSettleSeq={harness.directActionSettleSeq}
+                    runningTarget={runningTarget}
                   />
                 ) : null
               }
@@ -1332,6 +1352,23 @@ export const App = (): JSX.Element => {
                 runs={activeSessionRuns}
                 onSelectRun={(executionId) => {
                   if (harness.activeSessionId) harness.selectRun(harness.activeSessionId, executionId);
+                }}
+                preview={
+                  harness.activeSessionId
+                    ? (harness.previewBySession.get(harness.activeSessionId) ?? null)
+                    : null
+                }
+                deployState={
+                  rightPaneWorkflow
+                    ? (harness.deployStateByPath.get(rightPaneWorkflow.path) ?? null)
+                    : null
+                }
+                onDismissDeploy={() => {
+                  if (rightPaneWorkflow) harness.dismissDeployState(rightPaneWorkflow.path);
+                }}
+                onOpenCode={() => {
+                  setRightTab("code");
+                  setCodePanelEverShown(true);
                 }}
                 workflows={state.workflows}
                 onOpenWorkflow={(path) => void handleBindWorkflow(path)}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -6,9 +6,16 @@ import { isMockMode } from "../lib/api";
 import { MOCK_CANVAS_OVERVIEWS, hasMockCanvasDoc } from "../lib/mock-data";
 import { getTheme, subscribeTheme } from "../lib/theme";
 import { type CanvasGraph, formatGraphCounts, parseCanvasGraph } from "../lib/canvas-graph";
-import type { ObservedRun, RunTarget } from "../lib/use-harness-state";
+import type { DeployProgress, ObservedRun, RunTarget } from "../lib/use-harness-state";
 import { CanvasOverviewPanel } from "./CanvasOverviewPanel";
-import { CanvasChatPanel, CanvasStepDetail, CanvasStepsList, RunStepsList } from "./CanvasStepDetail";
+import {
+  CanvasChatPanel,
+  CanvasStepDetail,
+  CanvasStepsList,
+  DeployStatusBanner,
+  RunStepsList,
+  RunSummaryBlock,
+} from "./CanvasStepDetail";
 import { EmptyState } from "./EmptyState";
 import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
@@ -66,6 +73,18 @@ interface CanvasPaneProps {
   /** Every run observed for this session, oldest first (the run picker). */
   runs: ObservedRun[];
   onSelectRun: (executionId: string) => void;
+  /** Dev server the agent started in this session (port.detected), if any —
+   *  the run summary offers it as an "Open preview" result when the agent
+   *  isn't deployed. */
+  preview: { port: number; url: string } | null;
+  /** Live deploy progress for the bound workflow, or null — drives the deploy
+   *  banner in the Steps surface (linking → building → ready/error). */
+  deployState: DeployProgress | null;
+  /** Dismiss the deploy banner (clears the workflow's deploy progress). */
+  onDismissDeploy: () => void;
+  /** Switch the right pane to the Code tab — the deploy banner's "Trigger from
+   *  your code" jumps there, where the integration snippet lives. */
+  onOpenCode: () => void;
   /** Registry workflows — launched-workflow nodes navigate to theirs. */
   workflows: WorkflowInfo[];
   /** Binds and switches to another workflow (App's handleBindWorkflow) —
@@ -97,6 +116,10 @@ export function CanvasPane({
   runTarget,
   runs,
   onSelectRun,
+  preview,
+  deployState,
+  onDismissDeploy,
+  onOpenCode,
   workflows,
   onOpenWorkflow,
   onCanvasContent,
@@ -707,6 +730,31 @@ export function CanvasPane({
     }
   }, [showsContent, sessionId, onCanvasContent]);
 
+  // The observability header for the Steps surface: a deploy landing (if one is
+  // in flight/just landed) and the run summary card (if a run has been
+  // observed). Rendered at the top of every steps-surface path so Run/Test/Deploy
+  // each show progress + the relevant final data the moment the pane opens here.
+  const stepsHeader = (
+    <>
+      {deployState && (
+        <DeployStatusBanner
+          deployState={deployState}
+          workflow={boundWorkflow}
+          onDismiss={onDismissDeploy}
+          onOpenCode={onOpenCode}
+        />
+      )}
+      {run && (
+        <RunSummaryBlock
+          run={run}
+          runTarget={runTarget}
+          workflow={boundWorkflow}
+          preview={preview}
+        />
+      )}
+    </>
+  );
+
   return (
     <aside className="canvas-pane">
       {boundWorkflow && !overviewActive && (
@@ -817,11 +865,13 @@ export function CanvasPane({
           <span className="canvas-task-spinner" aria-hidden="true" />
           <p className="canvas-empty-hint">{surface === "steps" ? "Loading steps…" : "Loading canvas…"}</p>
         </div>
-      ) : !showsContent && surface === "steps" && run ? (
-        /* No diagram yet, but a run was observed: the live per-step data
-           renders instead of "No steps yet". */
+      ) : !showsContent && surface === "steps" && (run || deployState) ? (
+        /* No diagram yet, but a run was observed or a deploy is landing: the
+           live per-step data (or the deploy banner) renders instead of the
+           "No steps yet" empty state. */
         <div className="canvas-steps-surface" data-testid="canvas-steps-surface">
-          <RunStepsList run={run} target={runTarget} />
+          {stepsHeader}
+          {run && <RunStepsList run={run} target={runTarget} />}
         </div>
       ) : !showsContent && sessionExited ? (
         /* nothing was generated and the session is dead — a render here would
@@ -1098,6 +1148,7 @@ export function CanvasPane({
           </div>
           {surface === "steps" && (
             <div className="canvas-steps-surface" data-testid="canvas-steps-surface">
+              {stepsHeader}
               {graph && graph.nodes.length > 0 ? (
                 <CanvasStepsList
                   graph={graph}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -10,7 +10,6 @@ import type { DeployProgress, ObservedRun, RunTarget } from "../lib/use-harness-
 import { CanvasOverviewPanel } from "./CanvasOverviewPanel";
 import {
   CanvasChatPanel,
-  CanvasStepDetail,
   CanvasStepsList,
   DeployStatusBanner,
   RunStepsList,
@@ -452,12 +451,11 @@ export function CanvasPane({
   // title, reason}) — the app shows an actionable card instead of the
   // document's wall of text.
   const [postedError, setPostedError] = useState<{ title: string; reason: string } | null>(null);
-  // The real workflow graph the document posts — the source for the step
-  // drill-down. `detailStepId` is the step currently drilled into (null = the
-  // overview list).
+  // The real workflow graph the document posts — the source for the step list.
   const [graph, setGraph] = useState<CanvasGraph | null>(null);
-  const [detailStepId, setDetailStepId] = useState<string | null>(null);
-  // The steps list's accordion: which step row is expanded in place.
+  // The steps list's accordion: which step row is expanded in place. A row's
+  // full detail (Agent run, IO/logs, contract, lineage) renders INSIDE its
+  // expansion — clicking a step is a dropdown, not a separate slide-in view.
   const [expandedStepId, setExpandedStepId] = useState<string | null>(null);
   useEffect(() => {
     const onMessage = (event: MessageEvent): void => {
@@ -546,7 +544,6 @@ export function CanvasPane({
     setPostedOverview(null);
     setPostedError(null);
     setGraph(null);
-    setDetailStepId(null);
     setSelectedNodeId(null);
     setExpandedStepId(null);
     setOverviewOpen(true);
@@ -562,28 +559,18 @@ export function CanvasPane({
     setRestView({ zoom: 1, x: 0, y: 0 });
     userAdjustedRef.current = false;
   }, [sessionId, reloadKey]);
-  const detailNode = graph && detailStepId ? (graph.nodes.find((n) => n.id === detailStepId) ?? null) : null;
-  // The slide-out must not empty mid-flight: keep the LAST drilled step
-  // rendered in the off-going pane so back reads as the detail sliding away,
-  // not vanishing. Cleared with the graph (document swap).
-  const lastDetailRef = useRef<typeof detailNode>(null);
-  if (detailNode) lastDetailRef.current = detailNode;
-  if (!graph) lastDetailRef.current = null;
-  const renderedDetail = detailNode ?? lastDetailRef.current;
   // The board-picked node the bottom inspector shows — validated against the
   // live graph so a stale id (document re-render dropped the step) renders
   // the overview, never a ghost step.
   const selectedNode =
     graph && selectedNodeId ? (graph.nodes.find((n) => n.id === selectedNodeId) ?? null) : null;
-  // Keep the board's is-selected ring in sync with whichever selection is
-  // showing: the Steps tab's full-pane drill wins while open; otherwise the
-  // inspector's board pick. Both null clears the ring.
+  // Keep the board's is-selected ring in sync with the board pick; null clears it.
   useEffect(() => {
     frameRef.current?.contentWindow?.postMessage(
-      { type: "sapiom-canvas:select", id: detailStepId ?? selectedNodeId },
+      { type: "sapiom-canvas:select", id: selectedNodeId },
       "*",
     );
-  }, [detailStepId, selectedNodeId]);
+  }, [selectedNodeId]);
 
   // Run-state bridge: post live run status into the served canvas board so its
   // SVG nodes animate (is-running / is-passed / is-failed / is-pending). The
@@ -760,8 +747,8 @@ export function CanvasPane({
       {boundWorkflow && !overviewActive && (
         <WorkflowActionsHeader
           workflow={boundWorkflow}
-          detailStep={detailNode}
-          onBack={() => setDetailStepId(null)}
+          detailStep={null}
+          onBack={() => {}}
           onAskAgent={onInjectPrompt}
           surface={surface}
           stepsSummary={graph && graph.nodes.length > 0 ? formatGraphCounts(graph) : null}
@@ -902,13 +889,13 @@ export function CanvasPane({
       ) : (
         <div
           className={"canvas-frame-wrap" + (expanded ? " is-expanded" : "")}
-          data-view={surface === "board" ? "board" : detailNode ? "detail" : "steps"}
+          data-view={surface === "board" ? "board" : "steps"}
         >
-          {/* Full-pane slide: pane A is the active surface (board on the
-              Canvas tab, the steps list on the Steps tab), pane B the
-              drilled step. The subheader above swaps chrome per view
-              (WorkflowActionsHeader). The board stays MOUNTED under the
-              steps surface: the iframe is the graph's source of truth. */}
+          {/* The active surface: the board on the Canvas tab, the steps list on
+              the Steps tab. A step's detail opens inline in its list row (see
+              CanvasStepsList), so there is no separate detail pane. The board
+              stays MOUNTED under the steps surface: the iframe is the graph's
+              source of truth. */}
           <div className="canvas-slide-track">
           <div className="canvas-slide-pane">
           <div className={"canvas-visual" + (surface === "steps" ? " is-offstage" : "")}>
@@ -1156,9 +1143,9 @@ export function CanvasPane({
                   runTarget={runTarget}
                   workflows={workflows}
                   onOpenWorkflow={onOpenWorkflow}
+                  onAskAgent={onInjectPrompt}
                   expandedId={expandedStepId}
                   onToggle={(id) => setExpandedStepId((cur) => (cur === id ? null : id))}
-                  onOpenDetail={setDetailStepId}
                 />
               ) : run ? (
                 /* No structural graph, but a real run was observed:
@@ -1189,7 +1176,9 @@ export function CanvasPane({
               workflows={workflows}
               onOpenWorkflow={onOpenWorkflow}
               onOpenSteps={() => {
-                if (selectedNodeId) setDetailStepId(selectedNodeId);
+                // Board pick → Steps tab with that step's row already expanded
+                // (the detail is inline in the list now, not a separate view).
+                if (selectedNodeId) setExpandedStepId(selectedNodeId);
                 onOpenSteps();
               }}
               onDeselect={() => setSelectedNodeId(null)}
@@ -1213,17 +1202,6 @@ export function CanvasPane({
               onClose={() => setChatOpen(false)}
             />
           )}
-          </div>
-          <div className="canvas-slide-pane" aria-hidden={detailNode ? undefined : true}>
-            {renderedDetail && graph && (
-              <CanvasStepDetail
-                graph={graph}
-                node={renderedDetail}
-                run={run}
-                workflows={workflows}
-                onOpenWorkflow={onOpenWorkflow}
-              />
-            )}
           </div>
           </div>
         </div>

--- a/packages/harness/web/src/components/CanvasStepDetail.tsx
+++ b/packages/harness/web/src/components/CanvasStepDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { JSX } from "react";
+import type { JSX, MouseEvent } from "react";
 import type { RunView, StepView, WorkflowInfo } from "@shared/types";
 import { stepIsStubbed, stubNotice } from "@shared/stub-feedback";
 
@@ -11,7 +11,8 @@ import {
   extractStepContext,
   extractStepLinks,
 } from "../lib/extract-step-context";
-import type { RunTarget } from "../lib/use-harness-state";
+import type { DeployProgress, RunTarget } from "../lib/use-harness-state";
+import { agentUrl } from "../lib/urls";
 import { Icon } from "./Icon";
 
 /**
@@ -34,6 +35,70 @@ function StubbedChip(): JSX.Element {
 }
 
 /**
+ * A labelled disclosure for a run payload (Input / Output / Logs / Result) with
+ * a Copy button — the one place these render, so every payload gets the same
+ * copy affordance. `text` is pre-stringified by the caller (formatPayload for
+ * JSON values, the raw string for logs). Copying reuses the SnippetPanel copy
+ * pattern (writeText → "Copied" for 1.5s, errors swallowed). The Copy button
+ * lives in the summary but stops the click from toggling the disclosure.
+ * Callers gate on `!== undefined` so honest-absence still holds (this only
+ * renders a payload that exists).
+ */
+function PayloadBlock({
+  label,
+  text,
+  testid,
+  copyTestid,
+  className,
+  defaultOpen = false,
+}: {
+  label: string;
+  text: string;
+  testid?: string;
+  copyTestid?: string;
+  className?: string;
+  defaultOpen?: boolean;
+}): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const copy = (event: MouseEvent<HTMLButtonElement>): void => {
+    // Don't let the button toggle the <details> it sits inside.
+    event.stopPropagation();
+    event.preventDefault();
+    void navigator.clipboard?.writeText(text).then(
+      () => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      },
+      () => {
+        /* clipboard blocked — silent, mirrors SnippetPanel */
+      },
+    );
+  };
+  return (
+    <details
+      className={"canvas-run-logs payload-block" + (className ? " " + className : "")}
+      data-testid={testid}
+      open={defaultOpen}
+    >
+      <summary>
+        <span className="payload-block-label">{label}</span>
+        <button
+          type="button"
+          className={"payload-copy" + (copied ? " is-copied" : "")}
+          data-testid={copyTestid}
+          onClick={copy}
+          aria-label={`Copy ${label.toLowerCase()}`}
+        >
+          <Icon name={copied ? "Check" : "Copy"} size={11} />
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </summary>
+      <pre>{text}</pre>
+    </details>
+  );
+}
+
+/**
  * "Links" block: scans the step's output, log slice, and call results for
  * http(s) URLs and renders them as clickable thumbnails (images) or labelled
  * anchor links (other URLs). Rendered in BOTH surfaces (inspector + full pane).
@@ -42,45 +107,279 @@ function StubbedChip(): JSX.Element {
  * All links open in a new tab: image URLs render as thumbnails, other URLs as
  * a labelled "Open" anchor.
  */
+/** The clickable list of extracted URLs — image URLs as thumbnails, others as
+ *  labelled "Open" anchors. Shared by the per-step links block and the run
+ *  summary's aggregated results, so both render links identically. */
+function LinksList({
+  links,
+  testid,
+}: {
+  links: ReturnType<typeof extractStepLinks>;
+  testid?: string;
+}): JSX.Element {
+  return (
+    <div className="canvas-links-list" data-testid={testid}>
+      {links.map(({ url, kind }) =>
+        kind === "image" ? (
+          <a
+            key={url}
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="canvas-link-thumb-wrap"
+            data-testid="canvas-link-image"
+          >
+            <img src={url} alt="" className="canvas-link-thumb" loading="lazy" />
+          </a>
+        ) : (
+          <a
+            key={url}
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="canvas-link-item"
+            data-testid="canvas-link-other"
+          >
+            <Icon name="ExternalLink" size={12} />
+            <span className="canvas-link-url">Open</span>
+          </a>
+        ),
+      )}
+    </div>
+  );
+}
+
 function StepLinksBlock({ step }: { step: StepView }): JSX.Element | null {
   const links = extractStepLinks(step);
   if (links.length === 0) return null;
   return (
     <section className="canvas-detail-section" data-testid="canvas-detail-links">
       <h4>Links</h4>
-      <div className="canvas-links-list">
-        {links.map(({ url, kind }) =>
-          kind === "image" ? (
-            <a
-              key={url}
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className="canvas-link-thumb-wrap"
-              data-testid="canvas-link-image"
-            >
-              <img
-                src={url}
-                alt=""
-                className="canvas-link-thumb"
-                loading="lazy"
-              />
-            </a>
-          ) : (
-            <a
-              key={url}
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className="canvas-link-item"
-              data-testid="canvas-link-other"
-            >
-              <Icon name="ExternalLink" size={12} />
-              <span className="canvas-link-url">Open</span>
-            </a>
-          ),
+      <LinksList links={links} />
+    </section>
+  );
+}
+
+/** The run-status glyph for the summary header — reuses the per-step status
+ *  vocabulary. `running` is the bare pulse dot; terminal states get an icon. */
+function RunStatusGlyph({ status }: { status: RunView["status"] }): JSX.Element {
+  if (status === "completed")
+    return (
+      <span className="canvas-run-status is-passed" aria-label="completed">
+        <Icon name="Check" size={11} />
+      </span>
+    );
+  if (status === "failed")
+    return (
+      <span className="canvas-run-status is-failed" aria-label="failed">
+        <Icon name="X" size={11} />
+      </span>
+    );
+  if (status === "cancelled")
+    return (
+      <span className="canvas-run-status is-pending" aria-label="cancelled">
+        <Icon name="Minus" size={11} />
+      </span>
+    );
+  return <span className="canvas-run-status is-running" aria-label="running" />;
+}
+
+/**
+ * The run's headline card at the top of the Steps surface: outcome, live
+ * progress while running, total duration, and the single most relevant "final
+ * data" CTA so the user doesn't have to scroll into a step to find the payoff.
+ * Result priority: the deployed agent's dashboard link → a running dev-server
+ * preview → any URLs the run produced (aggregated across steps) → the final
+ * step's output. Every part is honest-absence: duration only when a step
+ * reported latency, the output only once the run is terminal, links only when
+ * some exist — never a fabricated value.
+ */
+export function RunSummaryBlock({
+  run,
+  runTarget,
+  workflow,
+  preview,
+}: {
+  run: RunView;
+  runTarget: RunTarget | null;
+  workflow: WorkflowInfo | null;
+  preview: { port: number; url: string } | null;
+}): JSX.Element {
+  const total = run.steps.length;
+  const passed = run.steps.filter((s) => s.status === "passed").length;
+  const running = run.status === "running";
+  const durationMs = run.steps.reduce((sum, s) => sum + (s.latencyMs ?? 0), 0);
+  const hasDuration = run.steps.some((s) => s.latencyMs !== undefined);
+
+  // Aggregate every URL the run produced, deduped, so the results surface at the
+  // top instead of hiding inside a per-step disclosure.
+  const seen = new Set<string>();
+  const links: ReturnType<typeof extractStepLinks> = [];
+  for (const step of run.steps) {
+    for (const link of extractStepLinks(step)) {
+      if (seen.has(link.url)) continue;
+      seen.add(link.url);
+      links.push(link);
+    }
+  }
+
+  const finalOutputStep = [...run.steps].reverse().find((s) => s.output !== undefined);
+  const dashboardUrl = workflow?.definitionId != null ? agentUrl(workflow.definitionId) : null;
+
+  const statusLabel = running
+    ? `Running — ${passed} of ${total} step${total === 1 ? "" : "s"}`
+    : run.status === "completed"
+      ? "Completed"
+      : run.status === "failed"
+        ? "Failed"
+        : "Cancelled";
+
+  return (
+    <section className="canvas-run-summary" data-testid="run-summary">
+      <div className="canvas-run-summary-head">
+        <span
+          className={"canvas-run-summary-status is-" + run.status}
+          data-testid="run-summary-status"
+        >
+          <RunStatusGlyph status={run.status} />
+          {statusLabel}
+        </span>
+        {hasDuration && (
+          <span className="canvas-run-summary-meta" data-testid="run-summary-duration">
+            {formatTimeout(durationMs)}
+          </span>
+        )}
+        {runTarget && (
+          <span className="canvas-run-summary-target">{runKindLabel(runTarget)}</span>
         )}
       </div>
+
+      {/* Final-data CTA, highest-signal first. Only one link CTA shows. */}
+      {dashboardUrl ? (
+        <a
+          className="status-tag status-tag-action run-summary-cta"
+          data-testid="run-summary-dashboard-link"
+          href={dashboardUrl}
+          target="_blank"
+          rel="noreferrer"
+          data-tooltip="Open this agent in the Sapiom dashboard"
+        >
+          <Icon name="Cloud" size={12} />
+          Open in Sapiom
+        </a>
+      ) : preview ? (
+        <a
+          className="status-tag status-tag-action run-summary-cta"
+          data-testid="run-summary-preview-link"
+          href={preview.url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Icon name="ExternalLink" size={12} />
+          Open preview
+        </a>
+      ) : null}
+
+      {links.length > 0 && (
+        <div className="run-summary-links">
+          <span className="canvas-input-label">Results</span>
+          <LinksList links={links} testid="run-summary-links" />
+        </div>
+      )}
+
+      {!running && finalOutputStep?.output !== undefined && (
+        <PayloadBlock
+          label="Result"
+          text={formatPayload(finalOutputStep.output)}
+          className="canvas-run-result"
+          testid="run-summary-output"
+          copyTestid="payload-copy-result"
+          defaultOpen
+        />
+      )}
+    </section>
+  );
+}
+
+/**
+ * A deploy landing in the Steps surface, so Deploy reads as an ACTION with
+ * progress and a payoff (like a run) rather than a silent toast. Shows the live
+ * phase (linking → building) with a spinner, and on `ready` a completion banner
+ * with the dashboard link + a jump to the integration snippet ("Trigger from
+ * your code"). Dismissable; on error it surfaces the server's message.
+ */
+export function DeployStatusBanner({
+  deployState,
+  workflow,
+  onDismiss,
+  onOpenCode,
+}: {
+  deployState: DeployProgress;
+  workflow: WorkflowInfo | null;
+  onDismiss: () => void;
+  onOpenCode: () => void;
+}): JSX.Element {
+  const dashboardUrl = workflow?.definitionId != null ? agentUrl(workflow.definitionId) : null;
+  const inFlight = deployState.phase === "linking" || deployState.phase === "building";
+  const label =
+    deployState.phase === "linking"
+      ? "Creating the agent on Sapiom…"
+      : deployState.phase === "building"
+        ? "Deploying — building on Sapiom…"
+        : deployState.phase === "ready"
+          ? "Deployed to Sapiom"
+          : "Deploy failed";
+  return (
+    <section
+      className={"deploy-status-banner is-" + deployState.phase}
+      data-testid="deploy-status-banner"
+      data-phase={deployState.phase}
+    >
+      <div className="deploy-status-head">
+        {inFlight ? (
+          <span className="canvas-task-spinner" aria-hidden="true" />
+        ) : (
+          <RunStatusGlyph status={deployState.phase === "ready" ? "completed" : "failed"} />
+        )}
+        <span className="deploy-status-label">{label}</span>
+        <button
+          type="button"
+          className="deploy-status-dismiss"
+          data-testid="deploy-status-dismiss"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+        >
+          <Icon name="X" size={12} />
+        </button>
+      </div>
+      {deployState.phase === "error" && deployState.message && (
+        <pre className="canvas-run-error">{deployState.message}</pre>
+      )}
+      {deployState.phase === "ready" && (
+        <div className="deploy-status-actions">
+          {dashboardUrl && (
+            <a
+              className="status-tag status-tag-action"
+              data-testid="deploy-open-dashboard"
+              href={dashboardUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Icon name="Cloud" size={12} />
+              Open in Sapiom
+            </a>
+          )}
+          <button
+            type="button"
+            className="status-tag status-tag-action"
+            data-testid="deploy-open-code"
+            onClick={onOpenCode}
+          >
+            <Icon name="Code" size={12} />
+            Trigger from your code
+          </button>
+        </div>
+      )}
     </section>
   );
 }
@@ -368,10 +667,11 @@ export function RunStepsList({ run, target }: { run: RunView; target: RunTarget 
               <div className="canvas-step-expand">
                 {step.error && <pre className="canvas-run-error">{step.error}</pre>}
                 {step.logSlice && (
-                  <details className="canvas-run-logs">
-                    <summary>Logs</summary>
-                    <pre>{step.logSlice}</pre>
-                  </details>
+                  <PayloadBlock
+                    label="Logs"
+                    text={step.logSlice}
+                    copyTestid={`payload-copy-logs-${step.id}`}
+                  />
                 )}
               </div>
             )}
@@ -586,23 +886,28 @@ export function CanvasStepDetail({
                 Capability, not model: these are the step's own payloads, with
                 no provider/model surfaced anywhere. */}
             {runStep.input !== undefined && (
-              <details className="canvas-run-logs" data-testid={`canvas-detail-run-input-${node.id}`}>
-                <summary>Input</summary>
-                <pre>{formatPayload(runStep.input)}</pre>
-              </details>
+              <PayloadBlock
+                label="Input"
+                text={formatPayload(runStep.input)}
+                testid={`canvas-detail-run-input-${node.id}`}
+                copyTestid={`payload-copy-input-${node.id}`}
+              />
             )}
             {runStep.output !== undefined && (
-              <details className="canvas-run-logs" data-testid={`canvas-detail-run-output-${node.id}`}>
-                <summary>Output</summary>
-                <pre>{formatPayload(runStep.output)}</pre>
-              </details>
+              <PayloadBlock
+                label="Output"
+                text={formatPayload(runStep.output)}
+                testid={`canvas-detail-run-output-${node.id}`}
+                copyTestid={`payload-copy-output-${node.id}`}
+              />
             )}
             {runStep.error && <pre className="canvas-run-error">{runStep.error}</pre>}
             {runStep.logSlice && (
-              <details className="canvas-run-logs">
-                <summary>Logs</summary>
-                <pre>{runStep.logSlice}</pre>
-              </details>
+              <PayloadBlock
+                label="Logs"
+                text={runStep.logSlice}
+                copyTestid={`payload-copy-logs-${node.id}`}
+              />
             )}
           </section>
         )}
@@ -784,23 +1089,29 @@ export function CanvasStepInspector({
       {/* Per-step IO — same honest-absence gate as the full-pane detail:
           gated on !==undefined so null/false/0/"" still render. */}
       {runStep?.input !== undefined && (
-        <details className="canvas-run-logs" data-testid={`canvas-inspector-run-input-${node.id}`}>
-          <summary>Input</summary>
-          <pre>{formatPayload(runStep.input)}</pre>
-        </details>
+        <PayloadBlock
+          label="Input"
+          text={formatPayload(runStep.input)}
+          testid={`canvas-inspector-run-input-${node.id}`}
+          copyTestid={`payload-copy-input-${node.id}`}
+        />
       )}
       {runStep?.output !== undefined && (
-        <details className="canvas-run-logs" data-testid={`canvas-inspector-run-output-${node.id}`}>
-          <summary>Output</summary>
-          <pre>{formatPayload(runStep.output)}</pre>
-        </details>
+        <PayloadBlock
+          label="Output"
+          text={formatPayload(runStep.output)}
+          testid={`canvas-inspector-run-output-${node.id}`}
+          copyTestid={`payload-copy-output-${node.id}`}
+        />
       )}
       {runStep?.error && <pre className="canvas-run-error">{runStep.error}</pre>}
       {runStep?.logSlice && (
-        <details className="canvas-run-logs" data-testid={`canvas-inspector-run-logs-${node.id}`}>
-          <summary>Logs</summary>
-          <pre>{runStep.logSlice}</pre>
-        </details>
+        <PayloadBlock
+          label="Logs"
+          text={runStep.logSlice}
+          testid={`canvas-inspector-run-logs-${node.id}`}
+          copyTestid={`payload-copy-logs-${node.id}`}
+        />
       )}
       {/* Capability calls: local runs carry per-call stub traces; absent for
           prod runs — that is correct, not a bug. */}

--- a/packages/harness/web/src/components/CanvasStepDetail.tsx
+++ b/packages/harness/web/src/components/CanvasStepDetail.tsx
@@ -81,6 +81,9 @@ function PayloadBlock({
       open={defaultOpen}
     >
       <summary>
+        <span className="payload-block-caret" aria-hidden="true">
+          <Icon name="ChevronRight" size={12} />
+        </span>
         <span className="payload-block-label">{label}</span>
         <button
           type="button"
@@ -226,6 +229,13 @@ export function RunSummaryBlock({
   const finalOutputStep = [...run.steps].reverse().find((s) => s.output !== undefined);
   const dashboardUrl = workflow?.definitionId != null ? agentUrl(workflow.definitionId) : null;
 
+  // The first produced URL is the run's payoff → the primary "Open result" CTA;
+  // any others drop to the secondary row. The dashboard link shows as secondary
+  // whenever it isn't already the primary (i.e. the run produced something).
+  const resultLink = links[0] ?? null;
+  const restLinks = resultLink ? links.slice(1) : [];
+  const secondaryDashboard = dashboardUrl != null && resultLink != null;
+
   const statusLabel = running
     ? `Running — ${passed} of ${total} step${total === 1 ? "" : "s"}`
     : run.status === "completed"
@@ -254,36 +264,75 @@ export function RunSummaryBlock({
         )}
       </div>
 
-      {/* Final-data CTA, highest-signal first. Only one link CTA shows. */}
-      {dashboardUrl ? (
+      {/* The payoff CTA. What the run PRODUCED (its first result URL) is the
+          primary, prominent action; a deployed dashboard link and preview drop
+          to secondary. When the run produced nothing, the dashboard (or
+          preview) takes the primary slot so there's always a real destination. */}
+      {resultLink ? (
         <a
-          className="status-tag status-tag-action run-summary-cta"
+          className="run-summary-open"
+          data-testid="run-summary-open"
+          href={resultLink.url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Icon name="ArrowUpRight" size={14} />
+          Open result
+        </a>
+      ) : preview ? (
+        <a
+          className="run-summary-open"
+          data-testid="run-summary-preview-link"
+          href={preview.url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Icon name="ArrowUpRight" size={14} />
+          Open preview
+        </a>
+      ) : dashboardUrl ? (
+        <a
+          className="run-summary-open"
           data-testid="run-summary-dashboard-link"
           href={dashboardUrl}
           target="_blank"
           rel="noreferrer"
           data-tooltip="Open this agent in the Sapiom dashboard"
         >
-          <Icon name="Cloud" size={12} />
+          <Icon name="Cloud" size={14} />
           Open in Sapiom
-        </a>
-      ) : preview ? (
-        <a
-          className="status-tag status-tag-action run-summary-cta"
-          data-testid="run-summary-preview-link"
-          href={preview.url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <Icon name="ExternalLink" size={12} />
-          Open preview
         </a>
       ) : null}
 
-      {links.length > 0 && (
-        <div className="run-summary-links">
-          <span className="canvas-input-label">Results</span>
-          <LinksList links={links} testid="run-summary-links" />
+      {/* Secondary destinations — flat links beneath the primary CTA. */}
+      {(secondaryDashboard || preview || restLinks.length > 0) && (
+        <div className="run-summary-secondary">
+          {secondaryDashboard && (
+            <a
+              className="status-tag status-tag-action run-summary-secondary-link"
+              data-testid="run-summary-dashboard-link"
+              href={dashboardUrl!}
+              target="_blank"
+              rel="noreferrer"
+              data-tooltip="Open this agent in the Sapiom dashboard"
+            >
+              <Icon name="Cloud" size={12} />
+              Open in Sapiom
+            </a>
+          )}
+          {resultLink && preview && (
+            <a
+              className="status-tag status-tag-action run-summary-secondary-link"
+              data-testid="run-summary-preview-link"
+              href={preview.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Icon name="ExternalLink" size={12} />
+              Open preview
+            </a>
+          )}
+          {restLinks.length > 0 && <LinksList links={restLinks} testid="run-summary-links" />}
         </div>
       )}
 
@@ -294,7 +343,6 @@ export function RunSummaryBlock({
           className="canvas-run-result"
           testid="run-summary-output"
           copyTestid="payload-copy-result"
-          defaultOpen
         />
       )}
     </section>
@@ -705,9 +753,9 @@ export function CanvasStepsList({
   runTarget,
   workflows,
   onOpenWorkflow,
+  onAskAgent,
   expandedId,
   onToggle,
-  onOpenDetail,
 }: {
   graph: CanvasGraph;
   /** The session's shown run; per-step status/latency render only
@@ -719,9 +767,11 @@ export function CanvasStepsList({
   /** Registry workflows — launched-workflow nodes link through to theirs. */
   workflows: WorkflowInfo[];
   onOpenWorkflow: (path: string) => void;
+  /** Sends a prompt to the terminal's coding agent (per-step actions in the
+   *  inline detail). */
+  onAskAgent: (text: string) => void;
   expandedId: string | null;
   onToggle: (id: string) => void;
-  onOpenDetail: (id: string) => void;
 }): JSX.Element {
   // Same validity rule as the board's group bands: a group referencing a
   // step that no longer exists is stale enrichment and renders nowhere, so
@@ -797,18 +847,16 @@ export function CanvasStepsList({
             </button>
             {open && (
               <div className="canvas-step-expand" data-testid={`canvas-step-expand-${node.id}`}>
-                {node.description && <p className="canvas-step-desc">{node.description}</p>}
-                <StepInputContract node={node} />
-                <StepCapabilities node={node} />
-                <StepTransitions graph={graph} node={node} />
-                <OpenLaunchedWorkflow node={node} workflows={workflows} onOpenWorkflow={onOpenWorkflow} />
-                <button
-                  className="canvas-step-open"
-                  data-testid={`canvas-step-open-${node.id}`}
-                  onClick={() => onOpenDetail(node.id)}
-                >
-                  Full details <Icon name="ArrowRight" size={12} />
-                </button>
+                {/* The full step detail lives HERE, inline — clicking a step
+                    opens it as a dropdown, not a separate slide-in view. */}
+                <CanvasStepDetail
+                  graph={graph}
+                  node={node}
+                  run={run}
+                  workflows={workflows}
+                  onOpenWorkflow={onOpenWorkflow}
+                  onAskAgent={onAskAgent}
+                />
               </div>
             )}
           </div>
@@ -828,14 +876,16 @@ interface CanvasStepDetailProps {
   /** Registry workflows — launched-workflow nodes link through to theirs. */
   workflows: WorkflowInfo[];
   onOpenWorkflow: (path: string) => void;
+  /** Sends a prompt to the terminal's coding agent — powers the per-step
+   *  "Ask coding agent" / "Ask to modify" actions. Absent = no actions row. */
+  onAskAgent?: (text: string) => void;
 }
 
 /**
- * Per-step drill-down BODY (its chrome — back, name, kind, actions — lives
- * in the canvas subheader; see WorkflowActionsHeader). Driven entirely by
- * the posted graph: the step's role and description, then its real
- * transitions — what it leads to (with branch condition / pause signal) and
- * what reaches it, shown as read-only lineage.
+ * Per-step detail, rendered INLINE inside the step's list-row dropdown (see
+ * CanvasStepsList) — the step's role and description, its per-step run IO/logs,
+ * capability calls, contract, and read-only lineage (what it leads to / what
+ * reaches it), plus a compact row of coding-agent actions.
  */
 export function CanvasStepDetail({
   graph,
@@ -843,6 +893,7 @@ export function CanvasStepDetail({
   run,
   workflows,
   onOpenWorkflow,
+  onAskAgent,
 }: CanvasStepDetailProps): JSX.Element {
   const runStep = runStepFor(run, node.id);
   const outgoing = graph.edges.filter((e) => e.from === node.id);
@@ -859,6 +910,48 @@ export function CanvasStepDetail({
           <p className="canvas-detail-groups">
             Part of {groups.map((g) => g.label).join(", ")}
           </p>
+        )}
+        {onAskAgent && (
+          <div className="canvas-detail-actions">
+            <button
+              type="button"
+              className="btn-ghost canvas-detail-ask"
+              data-testid="canvas-detail-ask"
+              data-tooltip="Ask the coding agent in the terminal"
+              onClick={() =>
+                onAskAgent(
+                  `Walk me through the "${node.label}" step of this agent: what it does, its inputs and outputs, and its transitions.`,
+                )
+              }
+            >
+              <Icon name="MessageSquare" size={13} />
+              Ask coding agent
+            </button>
+            <button
+              type="button"
+              className="btn-ghost"
+              data-testid="canvas-detail-modify"
+              data-tooltip="Ask the coding agent to change this step"
+              onClick={() =>
+                onAskAgent(
+                  `Modify the "${node.label}" step of this agent. Show me the step's code first, then propose the change.`,
+                )
+              }
+            >
+              <Icon name="Wand2" size={13} />
+              Ask to modify
+            </button>
+            <button
+              type="button"
+              className="btn-ghost"
+              data-testid="canvas-detail-copy-name"
+              data-tooltip="Copy the step name"
+              onClick={() => void navigator.clipboard?.writeText(node.label).catch(() => {})}
+            >
+              <Icon name="Copy" size={13} />
+              Copy name
+            </button>
+          </div>
         )}
         <OpenLaunchedWorkflow node={node} workflows={workflows} onOpenWorkflow={onOpenWorkflow} />
 

--- a/packages/harness/web/src/components/SessionStepsBar.tsx
+++ b/packages/harness/web/src/components/SessionStepsBar.tsx
@@ -5,6 +5,7 @@ import type { MacroDef, WorkflowInfo } from "@shared/types";
 import { Icon } from "./Icon";
 import { macroNeedsReadySession } from "../lib/macro-actions";
 import { macroDisabledReason } from "../lib/macro-gating";
+import type { RunTarget } from "../lib/use-harness-state";
 import { track } from "../lib/track";
 import { SAPIOM_DASHBOARD_ROOT, agentUrl } from "../lib/urls";
 import {
@@ -28,6 +29,10 @@ interface SessionStepsBarProps {
   /** Bumped by the parent on every direct-action settle, so the pending ring
    *  always clears even when neither deployment state nor `lastDeployError` flips. */
   directActionSettleSeq: number;
+  /** Target of the run currently in flight for this session ("local" ↔ Test,
+   *  "prod" ↔ Run), or null. Tied to the real run status (not the brief pending
+   *  ring), so the acting button pulses for the run's whole duration. */
+  runningTarget: RunTarget | null;
 }
 
 /**
@@ -55,6 +60,7 @@ export function SessionStepsBar({
   lastDeployError,
   authenticated,
   directActionSettleSeq,
+  runningTarget,
 }: SessionStepsBarProps): JSX.Element {
   const macroFor = (id: string): MacroDef | undefined => macros.find((m) => m.id === id);
   const deploymentState = workflowDeploymentState(workflow, lastDeployError);
@@ -181,12 +187,18 @@ export function SessionStepsBar({
           funnelReason ??
           readyReason ??
           (action.macro ? macroDisabledReason(action.macro, workflow, activeSessionId) : null);
+        // The run's REAL status drives this (not the hand-off pending ring), so
+        // Test/Run stay lit for the whole execution the user is watching.
+        const isRunningAction =
+          (runningTarget === "local" && action.id === "local") ||
+          (runningTarget === "prod" && action.id === "run");
         return (
           <button
             key={action.id}
             className={"session-step" + (action.primary ? " session-action-primary" : "")}
             data-testid={action.testId}
             data-pending={pendingId === action.id || undefined}
+            data-running={isRunningAction || undefined}
             disabled={Boolean(disabledReason)}
             data-tooltip={disabledReason ? `${action.label}: ${disabledReason}` : action.hint}
             aria-label={disabledReason ? `${action.label}: ${disabledReason}` : action.label}

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -1,6 +1,57 @@
 import { describe, expect, it } from "vitest";
 
-import { parseNdjsonLine, terminalDeployEvent, type DeployStreamEvent } from "./api";
+import {
+  parseNdjsonLine,
+  progressiveLeasingRun,
+  PROGRESSIVE_STEP_MS,
+  terminalDeployEvent,
+  type DeployStreamEvent,
+} from "./api";
+
+describe("progressiveLeasingRun", () => {
+  const at = (elapsed: number) => progressiveLeasingRun("exec-mock-prod-1", elapsed);
+
+  it("starts with the first step running, the rest pending, and no latencies", () => {
+    const run = at(0);
+    expect(run.status).toBe("running");
+    expect(run.steps.map((s) => s.status)).toEqual([
+      "running",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+    ]);
+    // Honest-absence: nothing has finished, so no step reports a duration.
+    expect(run.steps.every((s) => s.latencyMs === undefined)).toBe(true);
+  });
+
+  it("advances monotonically: earlier steps pass before later ones", () => {
+    // Two steps in: step 0 passed (with its latency), step 1 running (no latency).
+    const run = at(PROGRESSIVE_STEP_MS + 10);
+    expect(run.status).toBe("running");
+    expect(run.steps[0].status).toBe("passed");
+    expect(run.steps[0].latencyMs).toBeGreaterThan(0);
+    expect(run.steps[1].status).toBe("running");
+    expect(run.steps[1].latencyMs).toBeUndefined();
+  });
+
+  it("reports a running step with NO latencyMs, a passed step WITH it", () => {
+    const run = at(PROGRESSIVE_STEP_MS * 2 + 10);
+    for (const step of run.steps) {
+      if (step.status === "running" || step.status === "pending") {
+        expect(step.latencyMs).toBeUndefined();
+      }
+      if (step.status === "passed") expect(step.latencyMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("terminates as completed with every step passed and no cost fields", () => {
+    const run = at(PROGRESSIVE_STEP_MS * 6);
+    expect(run.status).toBe("completed");
+    expect(run.steps.every((s) => s.status === "passed")).toBe(true);
+    expect(JSON.stringify(run)).not.toMatch(/\$|cost/i);
+  });
+});
 
 describe("terminalDeployEvent", () => {
   it("returns the terminal ready event", () => {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   TemplateDetailView,
   TemplateListResponse,
   RunView,
+  StepView,
   WorkflowInfo,
 } from "@shared/types";
 
@@ -761,12 +762,47 @@ export function terminalDeployEvent(
 const delay = (ms = 180): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+// The demo leasing run's five steps (id, name, authored latency). Shared by the
+// terminal completed fixture and the progressive prod-run timeline so both tell
+// the same story. Latency is per-step duration only — there is no cost anywhere.
+const LEASING_RUN_STEPS: { id: string; name: string; latencyMs: number }[] = [
+  { id: "intake", name: "intake", latencyMs: 240 },
+  { id: "screen", name: "screen", latencyMs: 610 },
+  { id: "credit-check", name: "credit-check", latencyMs: 1900 },
+  { id: "approve", name: "approve", latencyMs: 130 },
+  { id: "draft-lease", name: "draft-lease", latencyMs: 800 },
+];
+
+// Wall-clock so the demo prod run visibly ADVANCES across the 2s poll cadence:
+// step i is `running` from i·STEP_MS and `passed` from (i+1)·STEP_MS, so the run
+// completes in ~6s no matter how the polls fall. Honest-absence: a `running`
+// step carries NO `latencyMs` (it isn't finished); latency appears only once it
+// passes; nothing carries cost. Used exclusively for `run()`-minted
+// `exec-mock-prod-*` ids, never the terminal default other ids rely on.
+export const PROGRESSIVE_STEP_MS = 900;
+export function progressiveLeasingRun(executionId: string, elapsedMs: number): RunView {
+  const steps: StepView[] = LEASING_RUN_STEPS.map((step, i) => {
+    if (elapsedMs >= (i + 1) * PROGRESSIVE_STEP_MS) {
+      return { id: step.id, name: step.name, status: "passed", latencyMs: step.latencyMs };
+    }
+    if (elapsedMs >= i * PROGRESSIVE_STEP_MS) {
+      return { id: step.id, name: step.name, status: "running" };
+    }
+    return { id: step.id, name: step.name, status: "pending" };
+  });
+  const done = steps.every((s) => s.status === "passed");
+  return { executionId, status: done ? "completed" : "running", steps };
+}
+
 /** In-memory, mutable copies of the fixtures — mutations persist for the tab's lifetime, reset on reload. */
 class MockApi implements HarnessApi {
   // Mock auth state: flipped by startAuth() / disconnect() so D7 e2e tests
   // can drive the full sign-in flow deterministically without a real browser.
   private _authenticated = false;
   private _organizationName: string | null = null;
+  // First-poll wall-clock per progressive prod run, so the timeline is measured
+  // from when the run was first observed (not module load) — see getRunState.
+  private progressiveRunStart = new Map<string, number>();
 
   async startAuth(): Promise<AuthStartResponse> {
     // Record the call for Playwright assertions (same pattern as runMacro/deploy).
@@ -1319,41 +1355,28 @@ class MockApi implements HarnessApi {
         return override;
       }
     }
+    // A run the user just STARTED (Run button → run() mints exec-mock-prod-*)
+    // advances step-by-step on a wall clock so the Steps view visibly moves.
+    // Every other id (the on-load demo receipt, Playwright's authored ids) keeps
+    // the terminal fixture below — several specs depend on that first poll being
+    // terminal so the poller stops.
+    if (executionId.startsWith("exec-mock-prod-")) {
+      let startedAt = this.progressiveRunStart.get(executionId);
+      if (startedAt === undefined) {
+        startedAt = Date.now();
+        this.progressiveRunStart.set(executionId, startedAt);
+      }
+      return progressiveLeasingRun(executionId, Date.now() - startedAt);
+    }
     return {
       executionId,
       status: "completed",
-      steps: [
-        {
-          id: "intake",
-          name: "intake",
-          status: "passed" as const,
-          latencyMs: 240,
-        },
-        {
-          id: "screen",
-          name: "screen",
-          status: "passed" as const,
-          latencyMs: 610,
-        },
-        {
-          id: "credit-check",
-          name: "credit-check",
-          status: "passed" as const,
-          latencyMs: 1900,
-        },
-        {
-          id: "approve",
-          name: "approve",
-          status: "passed" as const,
-          latencyMs: 130,
-        },
-        {
-          id: "draft-lease",
-          name: "draft-lease",
-          status: "passed" as const,
-          latencyMs: 800,
-        },
-      ],
+      steps: LEASING_RUN_STEPS.map((step) => ({
+        id: step.id,
+        name: step.name,
+        status: "passed" as const,
+        latencyMs: step.latencyMs,
+      })),
     };
   }
 

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -71,6 +71,16 @@ export interface ObservedRun {
   observedAt: number;
 }
 
+/** Live progress of a deploy, surfaced in the Steps pane. The wire stream has
+ *  a transient `warning` phase folded into `building` here — the banner only
+ *  needs "in flight" vs "landed" vs "failed". */
+export interface DeployProgress {
+  phase: "linking" | "building" | "ready" | "error";
+  /** A complete, user-facing sentence when the server supplied one (a warning
+   *  passthrough, or an error message); absent otherwise. */
+  message?: string;
+}
+
 export interface HarnessStateHook {
   state: AppState | null;
   loading: boolean;
@@ -150,6 +160,14 @@ export interface HarnessStateHook {
    * when a build has already been attempted and failed.
    */
   lastDeployErrorFor: (workflowPath: string) => string | null;
+  /**
+   * Live deploy progress per workflow path (linking → building → ready/error),
+   * so the Steps surface can show a deploy landing. In-memory only. Absent = no
+   * deploy observed this session (or the completion banner was dismissed).
+   */
+  deployStateByPath: Map<string, DeployProgress>;
+  /** Dismiss a workflow's deploy banner (clears its `deployStateByPath` entry). */
+  dismissDeployState: (workflowPath: string) => void;
   /**
    * Monotonic counter bumped on every direct-action settle (deploy or run,
    * success or failure). SessionStepsBar adds this to its `useEffect` deps so
@@ -319,6 +337,28 @@ export function useHarnessState(): HarnessStateHook {
   const [lastDeployErrorByPath, setLastDeployErrorByPath] = useState<
     Map<string, string>
   >(new Map());
+  // Live deploy progress per workflow path, so the Steps surface can show a
+  // deploy landing the same way a run does: linking → building → ready (or
+  // error). In-memory only (clears on reload); the durable "is deployed" truth
+  // stays the workflow registry's definitionId + the dashboard pill. Cleared to
+  // null when the user dismisses the completion banner.
+  const [deployStateByPath, setDeployStateByPath] = useState<
+    Map<string, DeployProgress>
+  >(new Map());
+  const setDeployProgress = useCallback(
+    (workflowPath: string, next: DeployProgress | null): void => {
+      setDeployStateByPath((prev) => {
+        if (next === null) {
+          if (!prev.has(workflowPath)) return prev;
+          const map = new Map(prev);
+          map.delete(workflowPath);
+          return map;
+        }
+        return new Map(prev).set(workflowPath, next);
+      });
+    },
+    [],
+  );
   // Monotonic settle counter for direct actions: bumped each time a deploy or
   // run (prod/local) reaches its terminal state — success OR failure. The
   // SessionStepsBar adds this to its useEffect deps so the pending ring clears
@@ -1175,6 +1215,7 @@ export function useHarnessState(): HarnessStateHook {
             // created first — say so, rather than claiming we're building.
             if (event.phase === "linking") {
               lastNonTerminalPhase = "linking";
+              setDeployProgress(workflowPath, { phase: "linking" });
               setToast(
                 `Deploying — creating the agent "${event.name}" on Sapiom…`,
               );
@@ -1189,6 +1230,7 @@ export function useHarnessState(): HarnessStateHook {
               setToast(event.message);
             } else if (event.phase === "building") {
               lastNonTerminalPhase = "building";
+              setDeployProgress(workflowPath, { phase: "building" });
               setToast("Deploying — building on Sapiom…");
               // The link is already durable at this point. Pull its mutable
               // build projection so the chip can say Building, not Deployed.
@@ -1196,6 +1238,7 @@ export function useHarnessState(): HarnessStateHook {
             }
           });
           if (terminal.phase === "ready") {
+            setDeployProgress(workflowPath, { phase: "ready" });
             setToast(
               pendingWarning
                 ? `Deployed to Sapiom. ${pendingWarning}`
@@ -1222,6 +1265,7 @@ export function useHarnessState(): HarnessStateHook {
             const msg = terminal.hint
               ? `${prefix}: ${terminal.message} (${terminal.hint})`
               : `${prefix}: ${terminal.message}`;
+            setDeployProgress(workflowPath, { phase: "error", message: msg });
             setToast(msg);
             // Persist the failure so the action bar can distinguish "last deploy
             // failed" from "never deployed" after the toast is dismissed.
@@ -1238,6 +1282,7 @@ export function useHarnessState(): HarnessStateHook {
             err instanceof ApiError && err.reason
               ? err.reason
               : (err as Error).message;
+          setDeployProgress(workflowPath, { phase: "error", message: msg });
           setToast(msg);
           // An exception from the deploy stream (e.g. network error) also counts
           // as a deploy failure — persist so the action bar reflects it.
@@ -1255,7 +1300,7 @@ export function useHarnessState(): HarnessStateHook {
       inFlightDeploys.current.set(workflowPath, run);
       return run;
     },
-    [refreshWorkflows, bumpDirectActionSettleSeq],
+    [refreshWorkflows, bumpDirectActionSettleSeq, setDeployProgress],
   );
 
   // Prod-run via the direct route: start the execution server-side, then feed
@@ -1366,6 +1411,8 @@ export function useHarnessState(): HarnessStateHook {
     injectInput,
     showToast,
     lastDeployErrorFor,
+    deployStateByPath,
+    dismissDeployState: (workflowPath: string) => setDeployProgress(workflowPath, null),
     directActionSettleSeq,
     listDir,
     lastMessage,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -4508,6 +4508,204 @@ input {
   word-break: break-word;
 }
 
+/* --------------------------------------------------------------------------
+   Run observability: the payload copy affordance, the run-summary card, and
+   the deploy banner. Motion-light and reduced-motion-aware; CTAs stay within
+   the flat .status-tag idiom (the cards are the only bordered chrome).
+   -------------------------------------------------------------------------- */
+
+/* PayloadBlock: label on the left, Copy on the right. The disclosure marker is
+   dropped in favour of the whole row being the toggle (scoped to .payload-block
+   so the capability-call disclosures keep their default triangle). */
+.payload-block summary {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  list-style: none;
+}
+.payload-block summary::-webkit-details-marker {
+  display: none;
+}
+.payload-block .payload-block-label {
+  margin-right: auto;
+}
+.payload-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-faint);
+  font-size: var(--type-micro);
+  font-weight: 510;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+.payload-copy:hover {
+  color: var(--text-dim);
+  border-color: var(--border-strong, var(--ui-line));
+}
+.payload-copy.is-copied {
+  color: var(--green-text, var(--green));
+  border-color: color-mix(in srgb, var(--green) 40%, var(--ui-line));
+}
+.payload-copy:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
+}
+
+/* Run-summary card: the headline of the Steps surface — outcome, duration,
+   the one relevant result CTA, and (terminal) the final output. */
+.canvas-run-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  padding: var(--sp3);
+  margin-bottom: var(--sp3);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+.canvas-run-summary-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+}
+.canvas-run-summary-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  font-size: var(--type-meta);
+  font-weight: 600;
+}
+.canvas-run-summary-status.is-completed {
+  color: var(--green-text, var(--green));
+}
+.canvas-run-summary-status.is-failed {
+  color: var(--red-text, var(--red));
+}
+.canvas-run-summary-status.is-running {
+  color: var(--text);
+}
+.canvas-run-summary-status.is-cancelled {
+  color: var(--text-faint);
+}
+.canvas-run-summary-meta {
+  font-family: var(--font-mono);
+  font-size: var(--type-micro);
+  color: var(--text-dim);
+}
+.canvas-run-summary-target {
+  margin-left: auto;
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+}
+/* Result CTA: a flat action tag in brand green so it reads as the primary
+   payoff (--brand is the hue; --brand-ink is the light-on-green text, wrong
+   here on a light card). */
+.run-summary-cta.status-tag-action {
+  align-self: flex-start;
+  color: var(--brand);
+  font-weight: 560;
+}
+.run-summary-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+}
+.run-summary-links .canvas-input-label {
+  color: var(--text-faint);
+}
+/* Final output gets a brand-tinted frame so it reads as the result, not a log. */
+.canvas-run-logs.canvas-run-result {
+  border: 1px solid color-mix(in srgb, var(--brand) 28%, var(--ui-line));
+  border-radius: var(--radius);
+  padding: var(--sp2) var(--sp2) var(--sp2) var(--sp2);
+  background: color-mix(in srgb, var(--brand) 4%, transparent);
+}
+.canvas-run-logs.canvas-run-result > summary .payload-block-label {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* Deploy banner: a deploy landing in the Steps surface — phase, then on ready
+   the dashboard + code CTAs. Reuses the .canvas-task-spinner while in flight. */
+.deploy-status-banner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  padding: var(--sp3);
+  margin-bottom: var(--sp3);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+.deploy-status-banner.is-ready {
+  border-color: color-mix(in srgb, var(--green) 35%, var(--ui-line));
+  background: color-mix(in srgb, var(--green) 6%, transparent);
+}
+.deploy-status-banner.is-error {
+  border-color: color-mix(in srgb, var(--red, #e05a57) 35%, var(--ui-line));
+  background: color-mix(in srgb, var(--red, #e05a57) 6%, transparent);
+}
+.deploy-status-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+}
+.deploy-status-label {
+  font-size: var(--type-meta);
+  font-weight: 590;
+  color: var(--text);
+}
+.deploy-status-dismiss {
+  margin-left: auto;
+  display: inline-flex;
+  padding: 2px;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.deploy-status-dismiss:hover {
+  color: var(--text-dim);
+}
+.deploy-status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp3);
+}
+.deploy-status-actions .status-tag-action {
+  color: var(--brand);
+  font-weight: 560;
+}
+
+/* Action button, RUN in progress: a brand pulse tied to the real run status,
+   distinct from the dashed [data-pending] hand-off ring. */
+.session-step[data-running] {
+  animation: session-step-running 1.4s ease-in-out infinite;
+}
+@keyframes session-step-running {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--brand) 42%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 22%, transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .session-step[data-running] {
+    animation: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 30%, transparent);
+  }
+}
+
 /* Steps subheader run chip: the flat .status-tag recipe — run truth is a
    labeled fact ("prod run completed"), mono because it is data. */
 .canvas-run-chip {

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -4063,31 +4063,21 @@ input {
   color: var(--text-faint);
 }
 
+/* The step detail now opens inline in its list row, so there is no board↔detail
+   slide — the track holds a single, full-width pane (the active surface). */
 .canvas-slide-track {
   display: flex;
-  width: 200%;
+  width: 100%;
   flex: 1;
   min-height: 0;
-  transform: translateX(0);
-  transition: transform 260ms var(--ease);
-}
-
-.canvas-frame-wrap[data-view="detail"] .canvas-slide-track {
-  transform: translateX(-50%);
 }
 
 .canvas-slide-pane {
-  width: 50%;
-  flex: 0 0 50%;
+  width: 100%;
+  flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .canvas-slide-track {
-    transition: none;
-  }
 }
 
 /* Detail subheader chrome: the main action sits right-anchored before the
@@ -4138,6 +4128,30 @@ input {
   flex-direction: column;
   gap: var(--sp2);
   padding: var(--sp1) var(--sp2) var(--sp3) calc(var(--sp2) + 7px + var(--sp2));
+}
+
+/* The step detail rendered INLINE inside a row's dropdown drops its full-pane
+   chrome: no independent scroll and no pane padding (the row already pads), and
+   it sizes to its content instead of filling a pane. */
+.canvas-step-expand .canvas-detail {
+  flex: initial;
+}
+.canvas-step-expand .canvas-detail-body {
+  overflow-y: visible;
+  padding: 0;
+  gap: var(--sp2);
+}
+
+/* Per-step coding-agent actions, a compact ghost-button row in the inline
+   detail (ported from the retired detail-pane header). */
+.canvas-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp1);
+}
+.canvas-detail-actions .btn-ghost {
+  gap: 4px;
+  font-size: var(--type-meta);
 }
 
 .canvas-step-desc {
@@ -4517,17 +4531,40 @@ input {
 /* PayloadBlock: label on the left, Copy on the right. The disclosure marker is
    dropped in favour of the whole row being the toggle (scoped to .payload-block
    so the capability-call disclosures keep their default triangle). */
-.payload-block summary {
+.payload-block > summary {
   display: flex;
   align-items: center;
-  gap: var(--sp2);
+  gap: var(--sp1);
   list-style: none;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  transition: background-color var(--transition-fast);
 }
-.payload-block summary::-webkit-details-marker {
+.payload-block > summary::-webkit-details-marker {
   display: none;
+}
+.payload-block > summary:hover {
+  background: var(--surface-hover, var(--bg-hover));
+}
+.payload-block-caret {
+  display: inline-flex;
+  color: var(--text-faint);
+  transition: transform var(--transition-fast);
+}
+.payload-block[open] > summary .payload-block-caret {
+  transform: rotate(90deg);
 }
 .payload-block .payload-block-label {
   margin-right: auto;
+  color: var(--text-dim);
+  font-weight: 560;
+}
+@media (prefers-reduced-motion: reduce) {
+  .payload-block-caret,
+  .payload-block > summary {
+    transition: none;
+  }
 }
 .payload-copy {
   display: inline-flex;
@@ -4604,21 +4641,51 @@ input {
   font-size: var(--type-micro);
   color: var(--text-faint);
 }
-/* Result CTA: a flat action tag in brand green so it reads as the primary
-   payoff (--brand is the hue; --brand-ink is the light-on-green text, wrong
-   here on a light card). */
-.run-summary-cta.status-tag-action {
+/* Primary "Open result" CTA: a FILLED brand button — the produced artifact is
+   the payoff, so this is the one prominent control in the otherwise-flat card.
+   (--brand-ink IS correct here: light text on the brand green.) */
+.run-summary-open {
   align-self: flex-start;
-  color: var(--brand);
-  font-weight: 560;
-}
-.run-summary-links {
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
+  align-items: center;
   gap: var(--sp1);
+  min-height: var(--control-h-xs, 28px);
+  padding: 4px 12px;
+  border-radius: var(--radius-md, var(--radius));
+  background: var(--brand);
+  color: var(--brand-ink, #fff);
+  font-size: var(--type-meta);
+  font-weight: 590;
+  text-decoration: none;
+  transition: filter var(--transition-fast);
 }
-.run-summary-links .canvas-input-label {
-  color: var(--text-faint);
+.run-summary-open svg {
+  flex: 0 0 auto;
+}
+.run-summary-open:hover {
+  filter: brightness(1.06);
+}
+.run-summary-open:active {
+  filter: brightness(0.96);
+}
+.run-summary-open:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .run-summary-open {
+    transition: none;
+  }
+}
+/* Secondary destinations — flat brand-green links under the primary. */
+.run-summary-secondary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp3);
+}
+.run-summary-secondary-link.status-tag-action {
+  color: var(--brand);
 }
 /* Final output gets a brand-tinted frame so it reads as the result, not a log. */
 .canvas-run-logs.canvas-run-result {


### PR DESCRIPTION
## What

Makes the **Test / Run / Deploy** actions observable. Before, clicking one changed almost nothing on screen — no view switch, no reveal, no success feedback, and the demo prod run snapped straight to "completed". Now each action reveals the right pane and switches it to the **Steps** view (one unified activity surface), the run visibly progresses, and the relevant final data surfaces up front.

## Behaviour

- **Auto-switch + reveal** — Run/Test/Deploy each open the pane to the Steps view. Gated so a click that would only toast (a prod-run with no ready build) never yanks the view.
- **See it move** — steps advance pending → running → passed in view; the acting button carries a `data-running` brand pulse tied to the *real* run status (not just the hand-off ring); the demo prod run now progresses across polls on a wall clock. (Progressive mock is gated strictly to `run()`-minted `exec-mock-prod-*` ids, so the existing terminal-fixture specs don't regress.)
- **Run-summary card** headlines the Steps surface — outcome, live "N of M steps", total duration (Σ step latencies). The run's **produced result is the primary CTA** (a filled brand button); the deployed dashboard link + dev-server preview drop to secondary flat links; when the run produced nothing, the dashboard takes the primary slot.
- **Step detail is an inline dropdown** — clicking a step expands its full detail *in place* (Agent run status/duration/IO/logs, capability calls, contract, and Leads-to/Reached-from lineage) with the per-step coding-agent actions (Ask coding agent / Ask to modify / Copy name). No separate slide-in view.
- **Payload CTAs** — Input / Output / Logs / Result share one disclosure with a rotating caret, readable label, hover row, and a Copy button; the Result is collapsed by default.
- **Deploy as an action, not a toast** — Deploy lands in the same Steps surface with a live linking → building → deployed banner, then a completion state that links to the dashboard and jumps to the "Trigger from your code" snippet.

## Honesty

No fabricated data: no cost anywhere (per-step cost isn't in the run model — Studio stays cost-agnostic; `cost-removed` still asserts no `$`), no latency on a still-running step, payload blocks gated on `!== undefined` so a truly-absent value renders nothing.

## Not in scope

Animating the **canvas board diagram** node-by-node is deferred — the demo board doc is stale and would need regenerating; the Steps-list observability delivers the "see it move" without it. Tracked as a follow-up.

## Tests

New `web/e2e/run-observability.spec.ts` (auto-switch, `data-running`, run-summary + primary CTA, copyable result, deploy banner → code, no `$`) + `progressiveLeasingRun` unit tests. Reworked smoke / direct-actions / direct-action-feedback / rich-step-detail / run-inspector / popover-crop / canvas-inspector for the Steps-view switch and the inline step-detail dropdown.

Gates: **typecheck · e2e 286 · canvas 10 · unit 1729 · terminology · build** all green. Rebased clean on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
