### PR TITLE
feat(harness): sapiom:// deep link — open/clone an agent in Studio (SAP-2424)

### DIFF
--- a/packages/harness-desktop/electron-builder.yml
+++ b/packages/harness-desktop/electron-builder.yml
@@ -6,6 +6,14 @@ copyright: Copyright © Sapiom
 # with the `electron` devDependency.
 electronVersion: 33.4.11
 
+# Custom URL scheme for web→desktop deep links (the dashboard's "Open in Studio").
+# Populates macOS CFBundleURLTypes (Info.plist) and the Linux .desktop MimeType.
+# Windows registration is runtime-only, via app.setAsDefaultProtocolClient (index.ts).
+protocols:
+  - name: Sapiom
+    schemes:
+      - sapiom
+
 directories:
   output: release
   buildResources: assets

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -35,7 +35,15 @@ import { resolveWebDir } from "./paths.js";
 import { createMainWindow } from "./windows.js";
 import { ensureSapiomCli, installClaudeCode } from "./agent-install.js";
 import { installRuntimeShims } from "./runtime-shims.js";
-import { BOOT_PROGRESS, BOOT_ERROR, CONSENT_SUBMIT, RETRY, type BootProgress, type BootErrorPayload } from "./ipc.js";
+import {
+  BOOT_PROGRESS,
+  BOOT_ERROR,
+  CONSENT_SUBMIT,
+  RETRY,
+  type BootProgress,
+  type BootErrorPayload,
+  type DeepLinkTarget,
+} from "./ipc.js";
 
 export interface BootResult {
   server: HarnessServer;
@@ -241,6 +249,14 @@ export interface BootMode {
    * smoke pass still exercises PATH, asar paths, the server, and the windows.
    */
   smoke: boolean;
+  /**
+   * A `sapiom://` deep link present at COLD start (a macOS `open-url` that
+   * arrived before `whenReady`, or the URL in Windows/Linux argv). Its target is
+   * threaded onto the SPA load URL as `?agent=<id>` so the first render already
+   * has it — no IPC race. Links that arrive while the app is running are pushed
+   * over the DEEP_LINK_NAVIGATE channel instead (see index.ts).
+   */
+  deepLink?: DeepLinkTarget;
 }
 
 export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<BootResult> {
@@ -390,7 +406,7 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
   });
 
   // 9. Load the SPA in the main window; close setup once it renders.
-  const url = `http://127.0.0.1:${server.port}/?token=${bootToken}`;
+  const url = withAgentParam(`http://127.0.0.1:${server.port}/?token=${bootToken}`, mode.deepLink);
   const mainWindow = createMainWindow(url);
   mainWindow.webContents.once("did-finish-load", () => {
     if (!setupWin.isDestroyed()) setupWin.close();
@@ -398,4 +414,22 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
   progress(setupWin, { phase: "ready", message: "Ready.", status: "done" });
 
   return { server, mainWindow, url };
+}
+
+/**
+ * Thread a cold-start deep link's target onto the SPA load URL as query params.
+ * Query only — never a path segment: `isTrustedSender` (trusted-sender.ts) fails
+ * closed unless the top frame's pathname is exactly "/", so a path-based route
+ * here would break the update + folder-picker IPC.
+ */
+function withAgentParam(loadUrl: string, target: DeepLinkTarget | undefined): string {
+  if (!target) return loadUrl;
+  try {
+    const u = new URL(loadUrl);
+    u.searchParams.set("agent", target.definitionId);
+    if (target.slug) u.searchParams.set("agentSlug", target.slug);
+    return u.toString();
+  } catch {
+    return loadUrl;
+  }
 }

--- a/packages/harness-desktop/src/main/deep-link.test.ts
+++ b/packages/harness-desktop/src/main/deep-link.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { deepLinkFromArgv, parseDeepLink } from "./deep-link.js";
+
+describe("parseDeepLink", () => {
+  it("parses sapiom://agent/<id>", () => {
+    expect(parseDeepLink("sapiom://agent/188")).toEqual({ definitionId: "188" });
+  });
+
+  it("accepts the agents alias and a trailing slash", () => {
+    expect(parseDeepLink("sapiom://agents/188/")).toEqual({ definitionId: "188" });
+  });
+
+  it("is case-insensitive in the scheme and host", () => {
+    expect(parseDeepLink("SAPIOM://Agent/188")).toEqual({ definitionId: "188" });
+  });
+
+  it("carries optional slug and org hints", () => {
+    expect(parseDeepLink("sapiom://agent/188?slug=weather&org=acme")).toEqual({
+      definitionId: "188",
+      slug: "weather",
+      org: "acme",
+    });
+  });
+
+  it("decodes a percent-encoded id", () => {
+    expect(parseDeepLink("sapiom://agent/a%2Fb")).toEqual({ definitionId: "a/b" });
+  });
+
+  it("rejects a foreign scheme", () => {
+    expect(parseDeepLink("https://app.sapiom.ai/agents/188")).toBeNull();
+  });
+
+  it("rejects an unknown host", () => {
+    expect(parseDeepLink("sapiom://run/188")).toBeNull();
+  });
+
+  it("rejects a missing id", () => {
+    expect(parseDeepLink("sapiom://agent/")).toBeNull();
+    expect(parseDeepLink("sapiom://agent")).toBeNull();
+  });
+
+  it("rejects garbage", () => {
+    expect(parseDeepLink("not a url")).toBeNull();
+  });
+});
+
+describe("deepLinkFromArgv", () => {
+  it("finds the sapiom:// token anywhere in argv", () => {
+    expect(deepLinkFromArgv(["/path/to/electron", "--flag", "sapiom://agent/7"])).toBe("sapiom://agent/7");
+  });
+
+  it("returns null when no deep link is present", () => {
+    expect(deepLinkFromArgv(["/path/to/electron", "--dev"])).toBeNull();
+  });
+});

--- a/packages/harness-desktop/src/main/deep-link.ts
+++ b/packages/harness-desktop/src/main/deep-link.ts
@@ -1,0 +1,47 @@
+/**
+ * Parsing for the `sapiom://` custom URL scheme — the dashboard's "Open in
+ * Studio" deep link. Kept ELECTRON-FREE on purpose: vitest only loads modules
+ * that don't import electron, so the parser is unit-testable here the way
+ * `single-instance.ts` / `update-policy.ts` are, while the wiring that consumes
+ * it lives in `index.ts`.
+ */
+import type { DeepLinkTarget } from "./ipc.js";
+
+export type { DeepLinkTarget };
+
+/** The scheme we register (electron-builder.yml `protocols:` + setAsDefaultProtocolClient). */
+export const DEEP_LINK_SCHEME = "sapiom";
+
+/**
+ * Parse `sapiom://agent/<definitionId>` into a target. Tolerates the `agents`
+ * alias, a trailing slash, and mixed case in the scheme/host. Returns null for
+ * anything that isn't a well-formed agent deep link, so the caller can safely
+ * hand it any string (argv token, OS-delivered URL).
+ */
+export function parseDeepLink(rawUrl: string): DeepLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== `${DEEP_LINK_SCHEME}:`) return null;
+  // `sapiom://agent/<id>` parses with host="agent", pathname="/<id>". URL only
+  // lower-cases the host for special schemes, so normalise it ourselves.
+  const host = url.hostname.toLowerCase();
+  if (host !== "agent" && host !== "agents") return null;
+  const definitionId = decodeURIComponent(url.pathname.replace(/^\/+/, "").replace(/\/+$/, ""));
+  if (!definitionId) return null;
+  const slug = url.searchParams.get("slug") ?? undefined;
+  const org = url.searchParams.get("org") ?? undefined;
+  return { definitionId, ...(slug ? { slug } : {}), ...(org ? { org } : {}) };
+}
+
+/**
+ * Pull the first `sapiom://` argument out of a process argv array — how Windows
+ * and Linux deliver a deep link (as an argv token to a second instance, or on
+ * cold-start argv). Scans rather than indexing the tail, since flags may follow.
+ */
+export function deepLinkFromArgv(argv: readonly string[]): string | null {
+  return argv.find((arg) => arg.startsWith(`${DEEP_LINK_SCHEME}://`)) ?? null;
+}

--- a/packages/harness-desktop/src/main/index.ts
+++ b/packages/harness-desktop/src/main/index.ts
@@ -12,6 +12,7 @@
 // `spawn ENOTDIR`. See esbuild-binary.ts.
 import "./esbuild-binary.js";
 import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { app, dialog, Menu } from "electron";
 import { resolveInstanceLockAction } from "./single-instance.js";
 import { createSetupWindow } from "./windows.js";
@@ -20,6 +21,8 @@ import { runSmokeChecks, reportSmoke } from "./smoke.js";
 import { initUpdater } from "./updater.js";
 import { initDialogs } from "./dialogs.js";
 import { setTrustedWindow } from "./trusted-sender.js";
+import { parseDeepLink, deepLinkFromArgv, DEEP_LINK_SCHEME } from "./deep-link.js";
+import { DEEP_LINK_NAVIGATE } from "./ipc.js";
 
 const devMode = process.argv.includes("--dev");
 /** `--smoke`: boot, verify the packaged bundle, print results, exit. See smoke.ts. */
@@ -55,6 +58,45 @@ function shutdownServer(): Promise<void> {
   return shuttingDown;
 }
 
+/**
+ * A `sapiom://` deep link buffered until the main window can receive it (no
+ * window yet, or its first page still loading). Consumed by the cold-start query
+ * param (boot) or the did-finish-load flush below.
+ */
+let pendingDeepLink: string | null = null;
+
+/** Deliver a received deep link: focus the window and push the target, or buffer it. */
+function handleDeepLink(rawUrl: string): void {
+  const target = parseDeepLink(rawUrl);
+  if (!target) return; // not one of ours — ignore
+  const win = bootResult?.mainWindow;
+  if (win && !win.isDestroyed() && !win.webContents.isLoading()) {
+    if (win.isMinimized()) win.restore();
+    win.focus();
+    win.webContents.send(DEEP_LINK_NAVIGATE, target);
+  } else {
+    pendingDeepLink = rawUrl;
+  }
+}
+
+/**
+ * Register Studio as the OS handler for `sapiom://`. Skipped under --smoke (CI
+ * must not mutate LaunchServices/HKCU). electron-builder writes the macOS
+ * Info.plist + Linux .desktop entries at package time; this call covers Windows
+ * (HKCU) and the unpackaged `pnpm dev` case.
+ */
+function registerDeepLinkScheme(): void {
+  if (smokeMode) return;
+  if (process.defaultApp) {
+    // Unpackaged: Electron itself is the launcher, so register execPath + entry.
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME, process.execPath, [resolve(process.argv[1])]);
+    }
+  } else {
+    app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
+  }
+}
+
 // Single-instance: focus the existing window instead of booting twice — except
 // under --smoke, where losing the lock means the run verified NOTHING and must
 // say so instead of exiting 0. See single-instance.ts.
@@ -78,12 +120,23 @@ if (lock.action === "fail") {
 } else if (lock.action === "quit") {
   app.quit();
 } else {
-  app.on("second-instance", () => {
+  registerDeepLinkScheme();
+  // macOS delivers deep links to the primary instance via open-url, and it can
+  // fire BEFORE whenReady on a cold start — register at top level so the handler
+  // buffers into pendingDeepLink until the window exists.
+  app.on("open-url", (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
+  });
+  app.on("second-instance", (_event, argv) => {
     const win = bootResult?.mainWindow;
     if (win && !win.isDestroyed()) {
       if (win.isMinimized()) win.restore();
       win.focus();
     }
+    // Windows/Linux deliver a deep link as an argv token to this second launch.
+    const link = deepLinkFromArgv(argv);
+    if (link) handleDeepLink(link);
   });
 
   app.whenReady().then(async () => {
@@ -94,7 +147,12 @@ if (lock.action === "fail") {
     Menu.setApplicationMenu(null);
     const setupWin = createSetupWindow();
     try {
-      bootResult = await boot(setupWin, { devMode, smoke: smokeMode });
+      // A deep link present at cold start — a macOS open-url already buffered, or
+      // the URL in Windows/Linux argv — rides onto the SPA load URL as ?agent=.
+      const coldLink = pendingDeepLink ?? deepLinkFromArgv(process.argv);
+      pendingDeepLink = null;
+      const coldTarget = coldLink ? parseDeepLink(coldLink) : null;
+      bootResult = await boot(setupWin, { devMode, smoke: smokeMode, deepLink: coldTarget ?? undefined });
       if (devMode || smokeMode) {
         // Dev/smoke hook: print the tokened URL so a harness can verify the
         // server booted without driving the GUI.
@@ -134,6 +192,14 @@ if (lock.action === "fail") {
         app.exit(code);
         return;
       }
+      // A deep link that landed during the load gap (window created, first page
+      // not yet finished) was buffered — deliver it once the SPA is ready. Only
+      // on the non-smoke path; the smoke branch returned above.
+      bootResult.mainWindow.webContents.once("did-finish-load", () => {
+        const buffered = pendingDeepLink;
+        pendingDeepLink = null;
+        if (buffered) handleDeepLink(buffered);
+      });
     } catch (err) {
       if (smokeMode) {
         // A boot failure IS the smoke result — report it as one and fail fast

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -70,6 +70,31 @@ export const UPDATE_CHECK = "update:check";
  * `/` may open it.
  */
 export const CHOOSE_DIRECTORY = "dialog:choose-directory";
+
+/**
+ * main → renderer (push): a `sapiom://` deep link was received; navigate the SPA
+ * to the target agent. A main→renderer SEND, not an invoke, so it is NOT subject
+ * to `isTrustedSender` (which guards renderer→main invokes) — it opens no attack
+ * surface, it only pushes a target the SPA is free to act on or ignore.
+ *
+ * Cold-start links (the one that launched the app) are delivered instead as an
+ * `agent=` query param on the load URL, so the first render already has them with
+ * no IPC race; this channel carries links that arrive while the app is running.
+ */
+export const DEEP_LINK_NAVIGATE = "deep-link:navigate";
+
+/**
+ * A parsed `sapiom://agent/<definitionId>` deep link. `definitionId` is the raw
+ * URL segment (a string); the SPA stringifies its numeric `WorkflowInfo.definitionId`
+ * to match. `slug` is a display-only hint; `org` lets the SPA notice a link minted
+ * for a different signed-in organization. Mirrored on the SPA side in
+ * `harness/web/src/lib/desktop.ts`.
+ */
+export interface DeepLinkTarget {
+  definitionId: string;
+  slug?: string;
+  org?: string;
+}
 /*
  * There is deliberately NO "apply the update" channel. The restart is destructive —
  * it ends every running agent session — and the page that would call it is the same

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -607,8 +607,9 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
     "({ bridge: typeof window.sapiomDesktop," +
       " check: typeof window.sapiomDesktop?.checkForUpdates," +
       " choose: typeof window.sapiomDesktop?.chooseDirectory," +
+      " deep: typeof window.sapiomDesktop?.onDeepLink," +
       " version: window.sapiomDesktop?.appVersion })",
-  )) as { bridge: string; check: string; choose: string; version: unknown };
+  )) as { bridge: string; check: string; choose: string; deep: string; version: unknown };
 
   if (shape.bridge !== "object") {
     throw new Error("window.sapiomDesktop is missing — the main window's preload did not run");
@@ -623,6 +624,12 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
   if (shape.choose !== "function") {
     throw new Error(`bridge incomplete — chooseDirectory missing: ${JSON.stringify(shape)}`);
   }
+  // Shape-only, like chooseDirectory: onDeepLink is a receive-only subscription
+  // (main → renderer push), so there is nothing to invoke here — asserting the
+  // wrapped method is present is the honest check.
+  if (shape.deep !== "function") {
+    throw new Error(`bridge incomplete — onDeepLink missing: ${JSON.stringify(shape)}`);
+  }
   // The bridge must stay MINIMAL as well as present. Only two members are allowed
   // beyond appVersion: checkForUpdates (no destructive counterpart — applying an
   // update is a native dialog, see ipc.ts) and chooseDirectory (returns only a
@@ -630,7 +637,7 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
   // restart method, by contrast, would let same-origin agent-authored content end
   // every running session — so anything new here has to be a deliberate addition.
   const extra = (await win.webContents.executeJavaScript(
-    "Object.keys(window.sapiomDesktop).filter((k) => k !== 'appVersion' && k !== 'checkForUpdates' && k !== 'chooseDirectory')",
+    "Object.keys(window.sapiomDesktop).filter((k) => k !== 'appVersion' && k !== 'checkForUpdates' && k !== 'chooseDirectory' && k !== 'onDeepLink')",
   )) as string[];
   if (extra.length > 0) {
     throw new Error(`bridge exposes unexpected members to page code: ${extra.join(", ")}`);
@@ -680,7 +687,7 @@ async function checkDesktopBridge(boot: BootResult): Promise<string> {
   }
 
   return (
-    `window.sapiomDesktop exposes checkForUpdates + chooseDirectory (v${shape.version}); ` +
+    `window.sapiomDesktop exposes checkForUpdates + chooseDirectory + onDeepLink (v${shape.version}); ` +
     `trusted-sender round-trip returned "${outcome.kind}: ${outcome.reason}"`
   );
 }

--- a/packages/harness-desktop/src/preload/desktop.mts
+++ b/packages/harness-desktop/src/preload/desktop.mts
@@ -13,7 +13,14 @@
  * on and `ipcRenderer` is never handed to the page.
  */
 import { contextBridge, ipcRenderer } from "electron";
-import { APP_VERSION_ARG, CHOOSE_DIRECTORY, UPDATE_CHECK, type UpdateCheckOutcome } from "../main/ipc.js";
+import {
+  APP_VERSION_ARG,
+  CHOOSE_DIRECTORY,
+  DEEP_LINK_NAVIGATE,
+  UPDATE_CHECK,
+  type DeepLinkTarget,
+  type UpdateCheckOutcome,
+} from "../main/ipc.js";
 
 const api = {
   /** The desktop app's version — NOT the harness's (the SPA already knows that one). */
@@ -30,6 +37,20 @@ const api = {
    */
   chooseDirectory(defaultPath?: string): Promise<string | null> {
     return ipcRenderer.invoke(CHOOSE_DIRECTORY, defaultPath) as Promise<string | null>;
+  },
+  /**
+   * Subscribe to `sapiom://` deep links that arrive while the app is running.
+   * Returns an unsubscribe fn. RECEIVE-only (main → renderer push): the page
+   * still never gets `ipcRenderer`, and there is nothing to invoke — a link is a
+   * target the SPA may act on or ignore. Cold-start links arrive via the `agent=`
+   * load-URL param instead, so the one that opened the app isn't re-delivered here.
+   */
+  onDeepLink(callback: (target: DeepLinkTarget) => void): () => void {
+    const listener = (_event: unknown, target: DeepLinkTarget): void => callback(target);
+    ipcRenderer.on(DEEP_LINK_NAVIGATE, listener);
+    return () => {
+      ipcRenderer.removeListener(DEEP_LINK_NAVIGATE, listener);
+    };
   },
   // No restart method, on purpose — see ipc.ts. An update that is ready to install
   // is confirmed through a native dialog, so nothing the page can call ends a

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -51,7 +51,11 @@ import {
 } from "./lib/project-dir";
 import { observedRunMatchesWorkflow } from "./lib/run-workflow-filter";
 import { agentUrl } from "./lib/urls";
+import { getDesktopBridge } from "./lib/desktop";
+import { agentFromSearch, type DeepLinkAgentTarget } from "./lib/deep-link";
+import { CloneAgentConfirm } from "./components/CloneAgentConfirm";
 import {
+  cloneDefinitionPrompt,
   starterScaffoldInstruction,
   useTemplatePrompt,
   type GalleryTemplate,
@@ -119,6 +123,19 @@ export const App = (): JSX.Element => {
   // selection and the main panel's tab-strip subject. The active tab's
   // session is harness.activeSessionId.
   const [focusedAgentPath, setFocusedAgentPath] = useState<string | null>(null);
+  // "Open in Studio" deep links (sapiom://agent/<id>). The applier is a ref
+  // because it needs `state`/`handleFocusAgent`, which exist only past the loading
+  // guard; the effects below reach it through the ref. The cold-start target rides
+  // in on the ?agent= load-URL param; warm links come via the desktop bridge.
+  const applyDeepLinkRef = useRef<((target: DeepLinkAgentTarget) => void) | null>(null);
+  const focusExistingRef = useRef<((definitionId: string) => boolean) | null>(null);
+  const coldDeepLinkRef = useRef<DeepLinkAgentTarget | null>(agentFromSearch());
+  const coldDeepLinkHandledRef = useRef(false);
+  // A clone kicked off from a remote-only deep link: focus the agent once the
+  // workspace rescan surfaces it locally.
+  const pendingCloneFocusRef = useRef<string | null>(null);
+  // The remote-only agent a deep link is offering to clone (drives the confirm).
+  const [cloneRequest, setCloneRequest] = useState<DeepLinkAgentTarget | null>(null);
   // Lifted so the telemetry chip in the session bar can open the settings
   // popover from outside SessionBar's own gear button.
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -394,6 +411,32 @@ export const App = (): JSX.Element => {
       describeTaskStatus.current.set(task.id, task.status);
     }
   }, [harness.tasks, harness.showToast]);
+
+  // Warm deep link: the desktop bridge pushes a target while the app is running.
+  useEffect(() => {
+    const bridge = getDesktopBridge();
+    if (!bridge?.onDeepLink) return;
+    return bridge.onDeepLink((target) => applyDeepLinkRef.current?.(target));
+  }, []);
+
+  // Cold-start deep link (?agent=): apply once, after the state has loaded, so a
+  // locally-connected agent is matched instead of prompting to clone.
+  useEffect(() => {
+    if (harness.loading) return;
+    const target = coldDeepLinkRef.current;
+    if (!target || coldDeepLinkHandledRef.current) return;
+    coldDeepLinkHandledRef.current = true;
+    applyDeepLinkRef.current?.(target);
+  }, [harness.loading]);
+
+  // After a deep-link clone lands, the workspace rescan surfaces the agent with a
+  // matching definitionId — focus it then, closing the "clone → display" loop.
+  useEffect(() => {
+    const wantId = pendingCloneFocusRef.current;
+    if (wantId && focusExistingRef.current?.(wantId)) {
+      pendingCloneFocusRef.current = null;
+    }
+  }, [harness.state?.workflows]);
 
   if (harness.loading) {
     return <div className="app-status">Loading Agent Studio…</div>;
@@ -739,6 +782,52 @@ export const App = (): JSX.Element => {
     // The canvas follows the focus target: shown for a populated session, hidden
     // for one with nothing yet or an agent with no session at all.
     applyCanvasVisibility(nextActiveId);
+  };
+
+  // Focus a deep-linked / just-cloned agent if the user has it locally; returns
+  // whether it was found. Assigned here (not in an effect) because it closes over
+  // `state` + `handleFocusAgent`, which exist only past the loading guard — the
+  // deep-link effects above reach it through the ref.
+  focusExistingRef.current = (definitionId: string): boolean => {
+    const match = state.workflows.find(
+      (w) => w.definitionId != null && String(w.definitionId) === definitionId,
+    );
+    if (!match) return false;
+    handleFocusAgent(match.path);
+    return true;
+  };
+
+  // Resolve a deep-link target (`sapiom://agent/<id>`): focus it if present, else
+  // offer to clone it locally — the remote-only fallback.
+  applyDeepLinkRef.current = (target: DeepLinkAgentTarget): void => {
+    if (focusExistingRef.current?.(target.definitionId)) return;
+    setCloneRequest(target);
+  };
+
+  // Clone a remote-only deep-linked agent locally (confirmed): open a session in a
+  // fresh folder and hand the coding agent the clone-by-definitionId prompt — the
+  // same agent-driven path "Use template" uses. The workspace rescan then surfaces
+  // the cloned agent, and the pending-focus effect above displays it.
+  const handleCloneDefinition = async (target: DeepLinkAgentTarget): Promise<void> => {
+    setCloneRequest(null);
+    const cwd = uniqueProjectDir(target.slug?.trim() || `agent-${target.definitionId}`);
+    if (!cwd) {
+      harness.showToast("Set a project folder first — use the + to open one.");
+      return;
+    }
+    pendingCloneFocusRef.current = target.definitionId;
+    setRightCollapsed(true); // terminal-first, like the template flow
+    try {
+      const session = await createSessionAt(cwd, "claude-code");
+      injectPromptWithRetry(
+        session.id,
+        cloneDefinitionPrompt(target.definitionId, cwd),
+        "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone.",
+      );
+    } catch (err) {
+      pendingCloneFocusRef.current = null;
+      harness.showToast((err as Error).message || "Couldn't start a session to clone the agent.");
+    }
   };
 
   // Binds a workflow to a live session in its own workspace and focuses it —
@@ -1414,6 +1503,14 @@ export const App = (): JSX.Element => {
           onOpenPath={(cwd) => void handleCreateSession(cwd, "claude-code")}
           onBrowseTemplates={() => setTemplatesOpen(true)}
           onClose={() => setPaletteOpen(false)}
+        />
+      )}
+
+      {cloneRequest && (
+        <CloneAgentConfirm
+          agentLabel={cloneRequest.slug ? `“${cloneRequest.slug}”` : `Agent ${cloneRequest.definitionId}`}
+          onCancel={() => setCloneRequest(null)}
+          onConfirm={() => void handleCloneDefinition(cloneRequest)}
         />
       )}
 

--- a/packages/harness/web/src/components/CloneAgentConfirm.tsx
+++ b/packages/harness/web/src/components/CloneAgentConfirm.tsx
@@ -1,0 +1,62 @@
+import { useRef } from "react";
+import type { JSX } from "react";
+
+import { useDismissable } from "../lib/use-dismissable";
+import { Icon } from "./Icon";
+
+/**
+ * Confirm before cloning a deep-linked agent that isn't on this machine. Opening
+ * `sapiom://agent/<id>` for an agent the user hasn't connected locally offers to
+ * clone it — a real git clone + npm install the coding agent runs — so it takes a
+ * deliberate click rather than happening silently from a link.
+ *
+ * Dismisses like the other modals: Escape and a backdrop click both cancel; only
+ * the explicit button clones.
+ */
+export function CloneAgentConfirm({
+  agentLabel,
+  onCancel,
+  onConfirm,
+}: {
+  agentLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): JSX.Element {
+  const confirmRef = useRef<HTMLDivElement>(null);
+  useDismissable(true, { onDismiss: onCancel, containerRef: confirmRef });
+
+  return (
+    <div className="modal-backdrop" onClick={onCancel}>
+      <div
+        ref={confirmRef}
+        className="modal modal-confirm"
+        role="alertdialog"
+        aria-label="Clone agent"
+        data-testid="clone-agent-confirm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          Clone this agent?
+          <button className="theme-toggle modal-close" aria-label="Close" title="Close" onClick={onCancel}>
+            <Icon name="X" size={14} />
+          </button>
+        </div>
+        <div className="modal-body">
+          <p className="modal-copy">
+            {agentLabel} isn’t on this machine yet. Cloning checks it out locally — a git clone and
+            npm install the coding agent runs — then opens it here.
+          </p>
+        </div>
+        <div className="modal-actions">
+          {/* Initial focus lands on the safe action; cloning takes a deliberate Tab or click. */}
+          <button className="btn-ghost" autoFocus onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn-primary" data-testid="clone-agent-confirm-btn" onClick={onConfirm}>
+            Clone locally
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/deep-link.ts
+++ b/packages/harness/web/src/lib/deep-link.ts
@@ -1,0 +1,24 @@
+/**
+ * Cold-start deep-link target, read from the SPA's load URL.
+ *
+ * When the desktop app is opened by a `sapiom://agent/<id>` link, the Electron
+ * host threads that id onto the load URL as `?agent=<id>` (harness-desktop's
+ * boot.ts), so the very first render already knows the target — no IPC race.
+ * Links that arrive while the app is already running come through the desktop
+ * bridge instead (`getDesktopBridge().onDeepLink`). A plain browser under `npx`
+ * simply never carries the param, so this reads as "no target" there.
+ */
+export interface DeepLinkAgentTarget {
+  definitionId: string;
+  slug?: string;
+}
+
+export function agentFromSearch(
+  search = typeof window === "undefined" ? "" : window.location.search,
+): DeepLinkAgentTarget | null {
+  const params = new URLSearchParams(search);
+  const definitionId = params.get("agent");
+  if (!definitionId) return null;
+  const slug = params.get("agentSlug");
+  return slug ? { definitionId, slug } : { definitionId };
+}

--- a/packages/harness/web/src/lib/desktop.ts
+++ b/packages/harness/web/src/lib/desktop.ts
@@ -17,6 +17,13 @@
  * "no bridge".
  */
 
+/** A `sapiom://` deep-link target. Mirrors the desktop app's `DeepLinkTarget` (ipc.ts). */
+export interface DeepLinkTarget {
+  definitionId: string;
+  slug?: string;
+  org?: string;
+}
+
 /** Result of an on-demand update check. Mirrors the desktop app's `UpdateCheckOutcome`. */
 export type UpdateCheckOutcome =
   | { kind: "available"; version: string }
@@ -39,6 +46,14 @@ export interface DesktopBridge {
    * back to the in-app directory listing, never assume it.
    */
   chooseDirectory?: (defaultPath?: string) => Promise<string | null>;
+  /**
+   * Subscribe to `sapiom://` deep links that arrive while the app is running
+   * (main → renderer push); returns an unsubscribe fn. Optional on purpose: a
+   * plain browser has no bridge, and a desktop build older than this SPA won't
+   * expose it — callers must feature-detect it. Cold-start links arrive via the
+   * `agent=` load-URL param (see `deep-link.ts`), not this channel.
+   */
+  onDeepLink?: (callback: (target: DeepLinkTarget) => void) => () => void;
   // No restart method: applying an update is confirmed by a native dialog in the
   // desktop app, so page code — which shares an origin with agent-authored files
   // the harness serves — has no way to end a user's sessions.
@@ -80,6 +95,9 @@ export function getDesktopBridge(host: DesktopHost | undefined = defaultHost()):
     // Optional: only surfaced when the desktop build actually provides it, so an
     // older app degrades to the in-app listing rather than a rejecting call.
     chooseDirectory: typeof bridge.chooseDirectory === "function" ? bridge.chooseDirectory : undefined,
+    // Optional for the same reason: an older desktop build (or a browser) simply
+    // never delivers a warm deep link, and cold links still ride the load-URL param.
+    onDeepLink: typeof bridge.onDeepLink === "function" ? bridge.onDeepLink : undefined,
   };
 }
 

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -257,6 +257,24 @@ export function useTemplatePrompt(
   );
 }
 
+/**
+ * Prompt handed to a session's agent to clone a DEPLOYED agent by its Sapiom
+ * definition id — the deep-link ("Open in Studio") fallback when the agent isn't
+ * on this machine yet. Mirrors the gallery branch of `useTemplatePrompt` but names
+ * `definitionId`: the clone tool writes that id into the checkout's `sapiom.json`,
+ * so the folder lands pre-linked and the server's workspace rescan surfaces it as
+ * a workflow the SPA can focus.
+ */
+export function cloneDefinitionPrompt(definitionId: string, dir: string): string {
+  return (
+    `Clone the deployed Sapiom agent (definition ${definitionId}) into this directory: ` +
+    `call the sapiom_dev_agents_clone tool with dir "${dir}" and definitionId "${definitionId}". ` +
+    "If it reports you are not authenticated, run sapiom_authenticate first and retry. " +
+    "After the clone, read the project's AGENTS.md and run npm install. " +
+    "When the project is ready, offer a local test run with no Sapiom capability spend (sapiom_dev_agents_run_local) as the next step."
+  );
+}
+
 /** Exact local MCP handoff shared by every bundled-starter entry point. */
 export function starterScaffoldInstruction(
   dir: string,


### PR DESCRIPTION
Refs: SAP-2424

## What

Registers a `sapiom://` URL scheme so the dashboard's **Open in Studio** action can hand an agent off to the desktop app, and routes the deep link inside the SPA. Desktop half of SAP-2424 (web half shipped in sapiom/Sapiom).

## Behavior

`sapiom://agent/<definitionId>?slug=<slug>`:
- **Cloned locally** → focus that agent.
- **Remote-only** → **"Clone this agent?"** confirm → agent-driven `sapiom_dev_agents_clone` (by definitionId) → focus it once the workspace rescan surfaces it. The `slug` names the clone folder.

## Changes
- **Protocol registration** — `protocols:` in `electron-builder.yml` (macOS `CFBundleURLTypes` + Linux MimeType); `setAsDefaultProtocolClient` in `index.ts` (skipped under `--smoke`).
- **Delivery** — one `handleDeepLink` funnel: macOS `open-url` (warm + cold, buffered), Windows/Linux `second-instance` argv + cold-start argv, flushed on `did-finish-load`.
- **Pure parser** — new `src/main/deep-link.ts` (`parseDeepLink`, `deepLinkFromArgv`), electron-free + unit-tested (11 tests).
- **Into the SPA** — cold start via `?agent=`/`?agentSlug=` on the load URL (**query-only**, to respect `trusted-sender`'s `/`-only rule); warm via a new `DEEP_LINK_NAVIGATE` push channel + `onDeepLink` on the preload bridge. `desktop-bridge` smoke check allow-list + shape assertion updated; `harness/web/src/lib/desktop.ts` mirror is optional/feature-detected.
- **Resolver** (`App.tsx`) — focus-local-else-clone, with `CloneAgentConfirm` + `cloneDefinitionPrompt`.

## Verification
- `pnpm --filter @sapiom/harness-desktop typecheck` + `@sapiom/harness typecheck` — clean
- `pnpm --filter @sapiom/harness-desktop test` — 64 pass (11 new deep-link), `desktop.test.ts` 12 pass
- End-to-end against the **packaged macOS app**: cold-start + warm `open sapiom://…` focus a local agent and clone a remote-only one; verified on prod.

## Note
Dev-mode `electron . --dev` can't reliably receive macOS `open-url` (LaunchServices binds the bundle, not a CLI-launched dev process) — the packaged app is the real test, which is where this was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)