### PR TITLE
fix(harness): repair the Templates info popover and let nav dismiss the screen

### DIFF
--- a/.changeset/template-info-and-nav.md
+++ b/.changeset/template-info-and-nav.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/harness": patch
+---
+
+Fix two issues on the Templates screen in Studio:
+
+- The info (i) spec sheet popover rendered with no surface — its background,
+  border, and shadow were missing, so the Steps / Trigger / Complexity /
+  Capabilities list and the Preview / Use buttons painted directly over the card
+  behind it. `.template-facts` now opts into the shared popover elevation recipe.
+- The Templates destination hid the workbench, but the rail's other nav actions
+  never cleared it, so clicking Create new, Search, or an agent/session row left
+  you stranded on the browser until you used the back arrow. Navigating anywhere
+  now dismisses the Templates screen the same way the back arrow does.

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -397,6 +397,28 @@ test("the rail navigates to templates, and says so while you are there", async (
   await expect(page.locator(".center-pane")).toBeHidden();
 });
 
+test("the rail navigates away from templates: another nav row dismisses the browser", async ({
+  page,
+}) => {
+  // The browsing destination hid the workbench and used to swallow the rail's
+  // other nav rows — the only way out was the back arrow. Any real navigation
+  // (here, Create new) must leave templates the same way the back arrow does.
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+
+  await page.getByTestId("rail-templates").click();
+  await expect(page.getByTestId("templates-panel")).toBeVisible();
+  await expect(page.locator(".center-pane")).toBeHidden();
+
+  await page.getByTestId("rail-create-new").click();
+
+  // The template destination is gone and the workbench is back — you actually
+  // navigated, rather than staying stranded on the browser.
+  await expect(page.getByTestId("templates-panel")).toHaveCount(0);
+  await expect(page.getByTestId("rail-templates")).not.toHaveClass(/is-selected/);
+  await expect(page.locator(".center-pane")).toBeVisible();
+});
+
 test("the command palette's Browse templates action opens the browser from anywhere", async ({
   page,
 }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -736,6 +736,7 @@ export const App = (): JSX.Element => {
   const openSession = (id: string): void => {
     setComposing(false);
     setReviewSummary(null);
+    setTemplatesOpen(false);
     closeMobileDrawer();
     const session = state.sessions.find((s) => s.id === id);
     if (session) setFocusedAgentPath(boundWorkflowPathOf(session) ?? session.cwd);
@@ -748,6 +749,7 @@ export const App = (): JSX.Element => {
   const selectTab = (id: string): void => {
     setComposing(false);
     setReviewSummary(null);
+    setTemplatesOpen(false);
     harness.setActiveSessionId(id);
     applyCanvasVisibility(id);
   };
@@ -757,6 +759,7 @@ export const App = (): JSX.Element => {
   const reviewPastSession = (summary: SessionSummary): void => {
     setComposing(false);
     setReviewSummary(summary);
+    setTemplatesOpen(false);
     closeMobileDrawer();
   };
 
@@ -778,6 +781,7 @@ export const App = (): JSX.Element => {
   const handleFocusAgent = (path: string): void => {
     setComposing(false);
     setReviewSummary(null);
+    setTemplatesOpen(false);
     setFocusedAgentPath(path);
     closeMobileDrawer();
     const tabs = liveSessionsForFocus(state.sessions, path);
@@ -1008,9 +1012,13 @@ export const App = (): JSX.Element => {
           onSelectOverview={() => {
             setComposing(true);
             setReviewSummary(null);
+            setTemplatesOpen(false);
             closeMobileDrawer();
           }}
-          onNewSession={() => setComposing(true)}
+          onNewSession={() => {
+            setComposing(true);
+            setTemplatesOpen(false);
+          }}
           onReviewSummary={reviewPastSession}
           history={harness.history}
           historyLoading={harness.historyLoading}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1201,7 +1201,8 @@ input {
 .composer-library,
 .profile-menu,
 .session-menu,
-.settings-popover {
+.settings-popover,
+.template-facts {
   display: flex;
   flex-direction: column;
   gap: var(--tree-row-gap);
@@ -1221,7 +1222,8 @@ input {
   .connect-card,
   .profile-menu,
   .session-menu,
-  .settings-popover {
+  .settings-popover,
+  .template-facts {
     animation: none;
   }
 }


### PR DESCRIPTION
## What

Two fixes on the Studio Templates screen, both reported from the desktop app.

### 1. Info (i) popover rendered transparent
The shared "floating panel" CSS recipe (background + border + shadow + `z-index`) is opted into by class name. The template spec-sheet class `.template-facts` was never added to that list, so the popover rendered with **no surface** — the Steps / Trigger / Complexity / Capabilities list and the Preview / Use buttons painted directly over the card text behind them.

**Fix:** add `.template-facts` to the recipe (and its `prefers-reduced-motion` group). Its own later rule keeps its richer padding/width; the recipe only supplies the missing surface.

### 2. Couldn't leave the Templates screen via other nav
Templates is a sibling view gated by a `templatesOpen` boolean that hides the workbench via CSS — not a modal. The rail's other nav rows fired their handlers, but none reset `templatesOpen`, so the screen stayed painted on top and appeared to do nothing. Only the back arrow escaped.

**Fix:** clear `templatesOpen` in the navigation entry points (`openSession`, `selectTab`, `reviewPastSession`, `handleFocusAgent`, and the Create new / Overview rail actions), consistent with how they already reset `composing`. Any navigation now dismisses the screen the way the back arrow does.

## Testing
- Typecheck clean
- Full e2e suite: **287 passed** (includes a new regression test, `templates.spec.ts` — "the rail navigates away from templates")
- Verified visually in both the mock SPA and the packaged-renderer **desktop** app

## Notes
- Bug-fix `patch` changeset for `@sapiom/harness` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)