### PR TITLE
feat(harness): split deploy metrics by agent provenance (template / starter / scratch)

### DIFF
--- a/packages/agent-core/src/__tests__/scaffold.test.ts
+++ b/packages/agent-core/src/__tests__/scaffold.test.ts
@@ -67,13 +67,33 @@ describe("scaffold", () => {
       expect(result.projectName).toBe("my-orch");
       expect(result.template).toBe("default");
       expect(existsSync(path.join(targetDir, "index.ts"))).toBe(true);
-      expect(readFileSync(path.join(targetDir, "sapiom.json"), "utf8")).toBe("{}\n");
+      // The marker is unlinked but records starter provenance.
+      expect(
+        JSON.parse(readFileSync(path.join(targetDir, "sapiom.json"), "utf8")),
+      ).toEqual({ starterId: "default" });
 
       // Replacements applied: __PROJECT_NAME__ → my-orch in package.json
       const pkg = JSON.parse(
         readFileSync(path.join(targetDir, "package.json"), "utf8"),
       );
       expect(pkg.name).toBe("my-orch");
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("records starterId 'default' when template is omitted (the from-scratch marker)", async () => {
+    const base = makeTmp();
+    const targetDir = path.join(base, "bare");
+    try {
+      await scaffold({
+        targetDir,
+        versions: { agent: "1.0.0", tools: "1.0.0", zod: "3.0.0" },
+      });
+
+      expect(
+        JSON.parse(readFileSync(path.join(targetDir, "sapiom.json"), "utf8")),
+      ).toEqual({ starterId: "default" });
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -228,6 +248,10 @@ describe("scaffold", () => {
         expect(text).not.toMatch(
           /\b(?:workflow|workflows|orchestration|orchestrations)\b/i,
         );
+        expect(
+          JSON.parse(readFileSync(path.join(targetDir, "sapiom.json"), "utf8"))
+            .starterId,
+        ).toBe(template);
       } finally {
         rmSync(base, { recursive: true, force: true });
       }

--- a/packages/agent-core/src/config.ts
+++ b/packages/agent-core/src/config.ts
@@ -29,6 +29,12 @@ export interface SapiomConfig {
   templateId?: string;
   /** Fork record id (`github_user_repos.id`) — re-mint a clone token against it. */
   forkId?: string;
+  /**
+   * Bundled-starter provenance: the starter id `scaffold` was given;
+   * `"default"` = bare scaffold. Written by `scaffold` itself (template clones
+   * get their provenance from `clone` as `templateId`). Never a credential.
+   */
+  starterId?: string;
   /** Full repo name `owner/repo` of the per-fork repo. */
   repoFullName?: string;
   /** Default branch of the per-fork repo. */

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -362,7 +362,9 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
 
   // The marker is intentionally valid but unlinked. Agent Studio discovers
   // agent projects by this file; deploy/link fill in server identity later.
-  writeConfig(targetDir, {});
+  // It also records which starter produced the project — the provenance the
+  // Studio's lifecycle metrics read ("default" = bare/from-scratch scaffold).
+  writeConfig(targetDir, { starterId: template });
 
   const gitInitialized = initGitRepo(targetDir);
 

--- a/packages/harness/src/core/agent-project-discovery.test.ts
+++ b/packages/harness/src/core/agent-project-discovery.test.ts
@@ -21,14 +21,22 @@ describe("agent project marker reads", () => {
   });
 
   it("reads the fixed marker directly beneath the selected directory", async () => {
+    // Includes the provenance fields to pin the parser's wholesale cast:
+    // fields it doesn't know by name still round-trip.
+    const marker = {
+      definitionId: 42,
+      name: "approval-agent",
+      templateId: "tmpl-1",
+      forkId: "fork-1",
+      starterId: "coding-pause",
+    };
     await fs.writeFile(
       path.join(root, AGENT_PROJECT_MARKER),
-      JSON.stringify({ definitionId: 42, name: "approval-agent" }),
+      JSON.stringify(marker),
     );
 
-    const expected = { definitionId: 42, name: "approval-agent" };
-    expect(await readAgentProjectMarker(root)).toEqual(expected);
-    expect(readAgentProjectMarkerSync(root)).toEqual(expected);
+    expect(await readAgentProjectMarker(root)).toEqual(marker);
+    expect(readAgentProjectMarkerSync(root)).toEqual(marker);
   });
 
   it("rejects a marker symlink instead of following it to another file", async () => {

--- a/packages/harness/src/core/agent-project-discovery.ts
+++ b/packages/harness/src/core/agent-project-discovery.ts
@@ -25,6 +25,12 @@ export interface AgentProjectMarker {
   definitionId?: number | null;
   /** The agent's `defineAgent({ name })`, cached by `link`. */
   name?: string;
+  /** Gallery-template provenance, written by clone (a clone carries `forkId` too). */
+  templateId?: string | null;
+  /** Fork record id, written by clone. */
+  forkId?: string | null;
+  /** Bundled-starter id, written by scaffold; `"default"` = bare scaffold. */
+  starterId?: string | null;
 }
 
 /**

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -5,9 +5,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { WorkflowRegistry } from "./workflow-registry.js";
 
-async function writeMarker(dir: string, definitionId: number | null): Promise<void> {
+async function writeMarker(
+  dir: string,
+  definitionId: number | null,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(path.join(dir, "sapiom.json"), JSON.stringify({ definitionId }));
+  await fs.writeFile(
+    path.join(dir, "sapiom.json"),
+    JSON.stringify({ definitionId, ...extra }),
+  );
 }
 
 describe("WorkflowRegistry", () => {
@@ -58,6 +65,9 @@ describe("WorkflowRegistry", () => {
       path: path.join(tmpRoot, "proj-a"),
       definitionId: 42,
       definitionSlug: null,
+      templateId: null,
+      forkId: null,
+      starterId: null,
       source: "scan",
     });
     expect(byPath.get(path.join(tmpRoot, "proj-b"))).toEqual({
@@ -65,6 +75,9 @@ describe("WorkflowRegistry", () => {
       path: path.join(tmpRoot, "proj-b"),
       definitionId: null,
       definitionSlug: null,
+      templateId: null,
+      forkId: null,
+      starterId: null,
       source: "scan",
     });
     expect(byPath.has(path.join(tmpRoot, "a", "b", "c"))).toBe(true);
@@ -113,6 +126,9 @@ describe("WorkflowRegistry", () => {
       path: projectDir,
       definitionId: null,
       definitionSlug: null,
+      templateId: null,
+      forkId: null,
+      starterId: null,
       source: "connect",
     });
     expect(await registry.list()).toEqual([info]);
@@ -124,6 +140,55 @@ describe("WorkflowRegistry", () => {
 
     const info = await registry.connectPath(projectDir);
     expect(info.definitionId).toBe(99);
+  });
+
+  it("passes marker provenance through both scan and connectPath", async () => {
+    // A gallery clone writes templateId AND forkId; a scaffold writes starterId.
+    const cloned = path.join(tmpRoot, "cloned");
+    await writeMarker(cloned, null, {
+      templateId: "web-research-digest",
+      forkId: "fork-1",
+    });
+    const scaffolded = path.join(tmpRoot, "scaffolded");
+    await writeMarker(scaffolded, null, { starterId: "coding-pause" });
+
+    const byPath = new Map(
+      (await registry.scan(tmpRoot)).map((workflow) => [workflow.path, workflow]),
+    );
+    expect(byPath.get(cloned)).toMatchObject({
+      templateId: "web-research-digest",
+      forkId: "fork-1",
+      starterId: null,
+    });
+    expect(byPath.get(scaffolded)).toMatchObject({
+      templateId: null,
+      forkId: null,
+      starterId: "coding-pause",
+    });
+
+    // The connect flow must carry the same fields — provenance that appears
+    // for scanned agents but not connected ones reads as flaky analytics.
+    expect(await registry.connectPath(cloned)).toMatchObject({
+      templateId: "web-research-digest",
+      forkId: "fork-1",
+      starterId: null,
+    });
+  });
+
+  it("a re-scan refreshes provenance written to the marker after first discovery", async () => {
+    // Clone writes provenance after the files land — a row registered from a
+    // pre-provenance marker must pick the fields up on the next scan's merge.
+    const projectDir = path.join(tmpRoot, "late-provenance");
+    await writeMarker(projectDir, null);
+    await registry.scan(tmpRoot);
+
+    await writeMarker(projectDir, null, { templateId: "tmpl-x" });
+    await registry.scan(tmpRoot);
+
+    const entry = (await registry.list()).find(
+      (workflow) => workflow.path === projectDir,
+    );
+    expect(entry?.templateId).toBe("tmpl-x");
   });
 
   it("a scan does not overwrite a connect-sourced entry's source", async () => {

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -95,6 +95,9 @@ async function scanDir(
       path: safeDir,
       definitionId: marker.definitionId ?? null,
       definitionSlug: marker.name ?? null,
+      templateId: marker.templateId ?? null,
+      forkId: marker.forkId ?? null,
+      starterId: marker.starterId ?? null,
       source: "scan",
     });
     return;
@@ -284,6 +287,9 @@ export class WorkflowRegistry {
         path: absolutePath,
         definitionId: marker?.definitionId ?? null,
         definitionSlug: marker?.name ?? null,
+        templateId: marker?.templateId ?? null,
+        forkId: marker?.forkId ?? null,
+        starterId: marker?.starterId ?? null,
         source: "connect",
       };
       const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1390,6 +1390,17 @@ export interface WorkflowInfo {
    */
   activeBuildRunId?: string | null;
   activeBuildRunStatus?: string | null;
+  /**
+   * Provenance from sapiom.json: the gallery template this project was cloned
+   * from. Distinct from `source` below, which records how the REGISTRY learned
+   * of the path. Optional for compatibility with older harness servers; null
+   * when the marker doesn't carry the field.
+   */
+  templateId?: string | null;
+  /** Fork record id from sapiom.json (a gallery clone carries this too). */
+  forkId?: string | null;
+  /** Bundled-starter id from sapiom.json; `"default"` = bare scaffold. */
+  starterId?: string | null;
   /** How it entered the registry. */
   source: "scan" | "connect";
 }

--- a/packages/harness/web/e2e/product-events.spec.ts
+++ b/packages/harness/web/e2e/product-events.spec.ts
@@ -58,6 +58,13 @@ test.describe("agent-lifecycle product events → PostHog", () => {
     expect(started?.properties?.workflow_slug).toBe("leasing");
     expect(succeeded?.properties?.workflow_slug).toBe("leasing");
     expect(typeof succeeded?.properties?.duration_ms).toBe("number");
+    // Provenance: leasing is a gallery-template clone in mock data (it also
+    // carries a forkId — template must win), and both terminals must agree
+    // with started: provenance is computed once at deploy start.
+    expect(started?.properties?.source).toBe("template");
+    expect(started?.properties?.template_id).toBe("leasing-copilot");
+    expect(succeeded?.properties?.source).toBe("template");
+    expect(succeeded?.properties?.template_id).toBe("leasing-copilot");
 
     // Honest payloads: no absolute paths, no cost anywhere.
     const json = JSON.stringify(events);
@@ -90,6 +97,9 @@ test.describe("agent-lifecycle product events → PostHog", () => {
       (e) => e.event === "agent.template_cloned",
     );
     expect(cloned?.properties?.template_slug).toBe("web-research-digest");
+    // template_id duplicates template_slug (deprecated) so all lifecycle
+    // events speak one name — this is the only automated check of that emit.
+    expect(cloned?.properties?.template_id).toBe("web-research-digest");
     expect(cloned?.properties?.surface).toBe("template_gallery");
   });
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -644,7 +644,11 @@ export const App = (): JSX.Element => {
     // Product metric — "templates used". Fires at the choke point every
     // template surface funnels through; `agent.created` fires later when the
     // clone produces a real sapiom.json, so built ≥ templates holds.
-    trackProduct("agent.template_cloned", { template_slug: template.id, surface });
+    trackProduct("agent.template_cloned", {
+      template_slug: template.id,
+      template_id: template.id,
+      surface,
+    });
     injectPromptWithRetry(
       session.id,
       useTemplatePrompt(template, cwd),

--- a/packages/harness/web/src/lib/analytics/events.ts
+++ b/packages/harness/web/src/lib/analytics/events.ts
@@ -1,6 +1,7 @@
 import posthog from "posthog-js";
 
 import { type HarnessView, type Journey, journeyForView } from "./journeys";
+import { type AgentSource } from "./lifecycle";
 
 /**
  * Typed event registry for the Studio (SAP-1988; ported from the web app's
@@ -46,7 +47,13 @@ export interface AnalyticsEventMap {
    * scaffolding (already autocaptured) — the scaffold itself runs async in the
    * coding agent, so we count the agent that actually appeared, not the intent.
    */
-  "agent.created": { workflow_slug?: string };
+  "agent.created": {
+    workflow_slug?: string;
+    /** Provenance bucket from the project's sapiom.json — see lifecycle.ts `agentSource`. */
+    source?: AgentSource;
+    /** Public id of what it was made from: gallery template id or bundled starter id. Absent for fork/scratch. */
+    template_id?: string;
+  };
 
   /** A workflow/agent run was triggered from the Studio. */
   "agent.run_started": {
@@ -67,16 +74,36 @@ export interface AnalyticsEventMap {
     error_kind?: string;
   };
 
-  /** A deploy was initiated from the Studio. */
-  "agent.deploy_started": { workflow_slug?: string };
+  /** A deploy was initiated from the Studio. `source`/`template_id` as on `agent.created` — built and deployed split on the same dimension. */
+  "agent.deploy_started": {
+    workflow_slug?: string;
+    source?: AgentSource;
+    template_id?: string;
+  };
   /** A deploy completed successfully. */
-  "agent.deploy_succeeded": { workflow_slug?: string; duration_ms?: number };
+  "agent.deploy_succeeded": {
+    workflow_slug?: string;
+    duration_ms?: number;
+    source?: AgentSource;
+    template_id?: string;
+  };
   /** A deploy failed. `error_kind` is an enum, never a message. */
-  "agent.deploy_failed": { workflow_slug?: string; error_kind?: string };
+  "agent.deploy_failed": {
+    workflow_slug?: string;
+    error_kind?: string;
+    source?: AgentSource;
+    template_id?: string;
+  };
 
   /** A template was cloned into a new workspace/agent. */
   "agent.template_cloned": {
+    /**
+     * @deprecated Pre-provenance name — always the same value as `template_id`.
+     * Kept so existing dashboard breakdowns keep working; do not add readers.
+     */
     template_slug?: string;
+    /** The template's public id — the one name the registry speaks, matching the other lifecycle events. */
+    template_id?: string;
     /** Where the clone was initiated from, for the on-ramp breakdown. */
     surface?: "welcome" | "template_gallery" | "template_detail";
   };

--- a/packages/harness/web/src/lib/analytics/lifecycle.test.ts
+++ b/packages/harness/web/src/lib/analytics/lifecycle.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { deployErrorKind, newAgentPaths, slugFromPath } from "./lifecycle";
+import {
+  agentProvenance,
+  agentSource,
+  deployErrorKind,
+  newAgentPaths,
+  slugFromPath,
+} from "./lifecycle";
 
 describe("slugFromPath", () => {
   it("returns the last segment of an absolute path", () => {
@@ -51,6 +57,71 @@ describe("newAgentPaths", () => {
     expect(newAgentPaths(seen, [wf("/a")])).toEqual([]);
     // /a still seen; nothing new.
     expect(newAgentPaths(seen, [wf("/a")])).toEqual([]);
+  });
+});
+
+describe("agentSource", () => {
+  it("templateId → template", () => {
+    expect(agentSource({ templateId: "web-research-digest" })).toBe("template");
+  });
+
+  it("templateId wins over forkId — every gallery clone writes BOTH", () => {
+    expect(agentSource({ templateId: "web-research-digest", forkId: "fork-1" })).toBe(
+      "template",
+    );
+  });
+
+  it("a named starterId → starter", () => {
+    expect(agentSource({ starterId: "coding-pause" })).toBe("starter");
+  });
+
+  it("starterId 'default' is the bare-scaffold marker → scratch", () => {
+    expect(agentSource({ starterId: "default" })).toBe("scratch");
+  });
+
+  it("forkId alone (a re-clone of an existing fork) → fork", () => {
+    expect(agentSource({ forkId: "fork-1" })).toBe("fork");
+  });
+
+  it("check order: a default starterId does not shadow a forkId", () => {
+    expect(agentSource({ starterId: "default", forkId: "fork-1" })).toBe("fork");
+  });
+
+  it("no provenance at all → scratch (pre-provenance agents, older servers)", () => {
+    expect(agentSource({})).toBe("scratch");
+    // The registry's normal form: fields present but null.
+    expect(agentSource({ templateId: null, forkId: null, starterId: null })).toBe(
+      "scratch",
+    );
+  });
+
+  it("non-string junk in the user-editable marker does not count", () => {
+    expect(agentSource({ templateId: "" })).toBe("scratch");
+  });
+});
+
+describe("agentProvenance", () => {
+  it("returns {} when the registry entry was not found — omit, don't claim scratch", () => {
+    expect(agentProvenance(undefined)).toEqual({});
+    expect(agentProvenance(null)).toEqual({});
+  });
+
+  it("template carries template_id = templateId", () => {
+    expect(
+      agentProvenance({ templateId: "web-research-digest", forkId: "fork-1" }),
+    ).toEqual({ source: "template", template_id: "web-research-digest" });
+  });
+
+  it("starter carries template_id = starterId", () => {
+    expect(agentProvenance({ starterId: "coding-pause" })).toEqual({
+      source: "starter",
+      template_id: "coding-pause",
+    });
+  });
+
+  it("fork and scratch carry source only — a fork id is a per-user record id", () => {
+    expect(agentProvenance({ forkId: "fork-1" })).toEqual({ source: "fork" });
+    expect(agentProvenance({ starterId: "default" })).toEqual({ source: "scratch" });
   });
 });
 

--- a/packages/harness/web/src/lib/analytics/lifecycle.ts
+++ b/packages/harness/web/src/lib/analytics/lifecycle.ts
@@ -49,3 +49,52 @@ export function deployErrorKind(
   if (isException) return "exception";
   return lastNonTerminalPhase === "linking" ? "link_failed" : "build_failed";
 }
+
+/** The provenance bucket carried as `source` on the lifecycle events. */
+export type AgentSource = "template" | "starter" | "fork" | "scratch";
+
+/**
+ * The marker-derived provenance subset of WorkflowInfo. Deliberately excludes
+ * `WorkflowInfo["source"]` ("scan"/"connect" — how the REGISTRY learned of the
+ * path), which is a different dimension from the event `source` computed here.
+ */
+type ProvenanceFields = Pick<WorkflowInfo, "templateId" | "forkId" | "starterId">;
+
+/** Only a non-empty string counts — the marker is user-editable JSON that the
+ *  server casts wholesale, and events.ts promises ids stay strings. */
+function asId(value: string | null | undefined): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * Which provenance bucket a project falls in, from its sapiom.json fields.
+ * Order matters: a gallery clone writes `templateId` AND `forkId`, so template
+ * must win over fork; `starterId === "default"` is the bare/from-scratch
+ * scaffold marker, not a named starter. No fields at all is `scratch` too —
+ * that covers agents that predate provenance (and older harness servers).
+ */
+export function agentSource(workflow: ProvenanceFields): AgentSource {
+  if (asId(workflow.templateId)) return "template";
+  const starter = asId(workflow.starterId);
+  if (starter && starter !== "default") return "starter";
+  if (asId(workflow.forkId)) return "fork";
+  return "scratch";
+}
+
+/**
+ * The spreadable `source`/`template_id` payload fragment for the lifecycle
+ * events. `template_id` is the public id of what the agent was made from —
+ * gallery template id or bundled starter id; omitted for fork (a fork id is a
+ * per-user record id, useless for breakdowns) and scratch. `{}` when the
+ * registry entry wasn't found at all: an absent property reads "(not set)" in
+ * PostHog and points at a wiring bug instead of silently inflating `scratch`.
+ */
+export function agentProvenance(
+  workflow: ProvenanceFields | null | undefined,
+): { source?: AgentSource; template_id?: string } {
+  if (!workflow) return {};
+  const source = agentSource(workflow);
+  if (source === "template") return { source, template_id: asId(workflow.templateId) };
+  if (source === "starter") return { source, template_id: asId(workflow.starterId) };
+  return { source };
+}

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -848,6 +848,10 @@ export const MOCK_WORKFLOWS: WorkflowInfo[] = [
     definitionSlug: "leasing",
     activeBuildRunId: "build-leasing-ready",
     activeBuildRunStatus: "ready",
+    // A gallery clone writes templateId AND forkId — the deploy e2e asserts
+    // this provenance resolves to source "template".
+    templateId: "leasing-copilot",
+    forkId: "fork-leasing-1",
     source: "scan",
   },
   {
@@ -868,6 +872,9 @@ export const MOCK_WORKFLOWS: WorkflowInfo[] = [
     definitionSlug: "onboarding-flow",
     activeBuildRunId: "build-onboarding-ready",
     activeBuildRunStatus: "ready",
+    // Scaffolded from a bundled starter — keeps all three provenance buckets
+    // visible in mock mode (rfq stays bare = scratch).
+    starterId: "coding-pause",
     source: "connect",
   },
 ];

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -34,7 +34,12 @@ import { type ConnectivityErrorInput } from "./connectivity";
 import { mergeHistory } from "./history-meta";
 import { subscribeEvents } from "./events";
 import { track as trackProduct } from "./analytics/events";
-import { deployErrorKind, newAgentPaths, slugFromPath } from "./analytics/lifecycle";
+import {
+  agentProvenance,
+  deployErrorKind,
+  newAgentPaths,
+  slugFromPath,
+} from "./analytics/lifecycle";
 import { renderLocalRun } from "@shared/render-local-run";
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
@@ -273,6 +278,15 @@ export function useHarnessState(): HarnessStateHook {
    */
   const settingsRef = useRef<HarnessSettings | null>(null);
   settingsRef.current = settings;
+  /**
+   * Mirror of `state.workflows` for deploy()'s provenance lookup. deploy is
+   * memoised WITHOUT state in its deps on purpose — inFlightDeploys dedupes
+   * double-clicks by handing back the same in-flight promise, which only works
+   * while the callback stays stable — so it reads the registry through this
+   * ref. Same render-phase mirror contract as settingsRef above.
+   */
+  const workflowsRef = useRef<WorkflowInfo[]>([]);
+  workflowsRef.current = state?.workflows ?? [];
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Boot-error facts (HTTP status / network-throw flag), shaped for the
@@ -756,7 +770,10 @@ export function useHarnessState(): HarnessStateHook {
           }
           for (const path of newAgentPaths(seen, workflows)) {
             seen.add(path);
-            trackProduct("agent.created", { workflow_slug: slugFromPath(path) });
+            trackProduct("agent.created", {
+              workflow_slug: slugFromPath(path),
+              ...agentProvenance(workflows.find((w) => w.path === path)),
+            });
           }
         });
       } else if (message.type === "execution.started") {
@@ -1236,8 +1253,15 @@ export function useHarnessState(): HarnessStateHook {
         // Product metric — "agents deployed". Slug is the folder basename (never
         // the absolute path); duration is measured across the stream.
         const slug = slugFromPath(workflowPath);
+        // Provenance (source/template_id) is computed ONCE from the registry
+        // snapshot at deploy start, so all deploy_* events for this deploy
+        // agree even though refreshWorkflows() runs mid-deploy (on `building`
+        // and after both terminals).
+        const provenance = agentProvenance(
+          workflowsRef.current.find((w) => w.path === workflowPath),
+        );
         const startedAt = performance.now();
-        trackProduct("agent.deploy_started", { workflow_slug: slug });
+        trackProduct("agent.deploy_started", { workflow_slug: slug, ...provenance });
         // Which non-terminal phase was last seen, so a terminal `error` can
         // say whether linking or building failed — both are the same wire
         // shape, told apart only by what preceded them.
@@ -1288,6 +1312,7 @@ export function useHarnessState(): HarnessStateHook {
             trackProduct("agent.deploy_succeeded", {
               workflow_slug: slug,
               duration_ms: Math.round(performance.now() - startedAt),
+              ...provenance,
             });
             outcomeSettled = true;
             setToast(
@@ -1320,6 +1345,7 @@ export function useHarnessState(): HarnessStateHook {
             trackProduct("agent.deploy_failed", {
               workflow_slug: slug,
               error_kind: deployErrorKind(lastNonTerminalPhase, false),
+              ...provenance,
             });
             outcomeSettled = true;
             setToast(msg);
@@ -1346,6 +1372,7 @@ export function useHarnessState(): HarnessStateHook {
             trackProduct("agent.deploy_failed", {
               workflow_slug: slug,
               error_kind: deployErrorKind(lastNonTerminalPhase, true),
+              ...provenance,
             });
           }
           setToast(msg);


### PR DESCRIPTION
## Why

#534 gave the Studio its lifecycle counters (`agent.created`, `agent.deploy_started/_succeeded/_failed`), but they only report **how many** agents get built and deployed — not **what kind**. This splits the built→deployed funnel by provenance, using what's (mostly) already on disk in `sapiom.json`: clone writes `templateId`/`forkId`; the starter id flowed all the way to `scaffold()` and was discarded on its last line. Client events only; no backend change.

## Buckets

Events now carry `source` + `template_id`, resolved from the project's `sapiom.json` in this order:

| `source` | Condition | How it got there |
|---|---|---|
| `template` | `templateId` set | gallery clone (also writes `forkId` — template must win) |
| `starter` | `starterId` set and ≠ `"default"` | bundled starter via scaffold |
| `fork` | `forkId` set | re-clone of an existing fork |
| `scratch` | else (`starterId === "default"`, or nothing) | composer "build this" / bare scaffold |

`template_id` is the public id of what the agent was made from (gallery template id, or starter id for `starter`); omitted for `fork` (a fork id is a per-user record id) and `scratch`. Names match the dashboard and backend (`WorkflowDeploySource`, `template_id`) so PostHog breakdowns line up across surfaces.

## How

- **`agent-core`** — `scaffold()` records `starterId` in the marker it already writes (`"default"` = bare scaffold); `SapiomConfig` documents the field. `writeConfig` merges, so later `link` writes preserve it.
- **`harness/src`** — `AgentProjectMarker` + `WorkflowInfo` gain `templateId`/`forkId`/`starterId` (optional on `WorkflowInfo` for older-server compat, `null` when the marker lacks them), mapped at both registry construction sites (`scanDir` + `connectPath`). The parser already casts wholesale; enrichment spreads, so REST carries them for free.
- **`harness/web`** — pure `agentSource()`/`agentProvenance()` helpers in `analytics/lifecycle.ts` implement the bucket table. `deploy()` computes provenance **once** at deploy start (through a new render-phase `workflowsRef` mirror — its `useCallback` deliberately excludes `state` so the in-flight dedupe keeps working), so all four deploy events agree even though the registry refreshes mid-deploy. `agent.created` resolves it from the freshly-refreshed list it already holds. `agent.template_cloned` gains `template_id` beside `template_slug` (kept, `@deprecated`, for dashboard continuity).

## Verification

- `agent-core` Jest: scaffold provenance asserted for named starter, explicit `"default"`, and omitted template. (5 unrelated suites fail identically on a clean `main` checkout — pre-existing.)
- `harness` Vitest (1754 tests): marker round-trip through the wholesale-cast parser, passthrough at **both** registry construction sites, re-scan refresh of late-written provenance, and a case per bucket incl. `templateId`-wins-over-`forkId` and `starterId: "default"` → `scratch`.
- Playwright e2e: the existing deploy flow asserts `source`/`template_id` on both `deploy_started` and `deploy_succeeded` (mock `leasing` is now a gallery clone carrying both `templateId` and `forkId`), and the template flow asserts the `template_slug`/`template_id` dual-emit. Privacy assertions (no absolute paths, no `$`) still pass.
- Cross-package smoke: scaffolded via the **built** agent-core dist and scanned with the real registry — `starterId` lands on `WorkflowInfo`.
- `typecheck` + `lint` clean.

## Known gaps (read the dashboard accordingly)

- **No backfill** — agents created before this ships have no provenance on disk and read as `scratch`; same for agents served by an older harness server. The split is only clean going forward.
- **`definitionId` clones** (pulling an already-deployed agent) write no provenance and read as `scratch`.
- **Persisted-registry staleness** — rows persisted before the upgrade lack provenance until the next watcher/manual scan re-reads the marker (the scan merge self-heals it).
- **Consent gating means floors, not totals** — pre-existing property of the whole Studio event set, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)