### PR TITLE
fix(harness-desktop): render the onboarding window in the Studio theme

### DIFF
--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -317,7 +317,9 @@ HOME=$(mktemp -d) SAPIOM_TELEMETRY_DISABLED=1 \
 
 `--smoke` (`src/main/smoke.ts`) boots the app and asserts the SPA is served from inside the asar, the
 REST surface answers and rejects an untokened request, a real session spawns, the setup window's
-preload bridge loaded, node-pty loads under Electron's ABI and can spawn, the plain-Node subprocess's
+preload bridge loaded and that window resolved its design-system layer in the Studio brand (tokens, the
+`themes/studio.css` preset and its nested agent-cloud import), node-pty loads under Electron's ABI and
+can spawn, the plain-Node subprocess's
 imports exist on disk, a deploy can bundle and a local run's child really starts (both spawn-from-asar
 bugs — see below), the agent inherits a clean environment, and the auto-update config is baked in. Exit
 code is the signal; CI runs it per OS after packaging.

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -17,7 +17,14 @@
 //
 // Keep the two in step: if the seam's probe or the file layout changes in
 // vite.config.ts, it changes here too.
-import { cp, mkdir } from "node:fs/promises";
+//
+// The design system's LAYOUT is preserved, not flattened: its files reference
+// each other relatively — `themes/studio.css` opens with
+// `@import "./agent-cloud.css"` and `fonts.css` asks for
+// `./assets/fonts/*.woff2`. Both breakages are silent (a failed CSS @import
+// throws nothing; a missing face just renders system-ui), so the copy keeps the
+// paths those references expect.
+import { cp, mkdir, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,19 +55,57 @@ function resolveDesignSystemDir() {
   }
 }
 
+/**
+ * Copy a part of the seam that may legitimately not exist, reporting whether it
+ * did. Probed with `stat` rather than try/catch'd around the `cp` itself: a
+ * catch there would also swallow EACCES, a wrong file type, or a HALF-FINISHED
+ * recursive copy — the exact class of silent packaging bug this script exists to
+ * prevent. Only ENOENT means "the seam doesn't ship this"; anything else throws.
+ */
+async function copyIfPresent(from, to, options) {
+  try {
+    await stat(from);
+  } catch (err) {
+    if (err.code === "ENOENT") return false;
+    throw err;
+  }
+  await cp(from, to, options);
+  return true;
+}
+
 await mkdir(outDir, { recursive: true });
 for (const file of ["setup.html", "setup.css"]) {
   await cp(join(srcDir, file), join(outDir, file));
 }
 
-// Flattened on the way out (no themes/ subdir) so setup.html's CSP-safe
-// same-origin <link href="./…"> stays a single flat directory.
 const { dir: dsDir, seam } = resolveDesignSystemDir();
-for (const [from, to] of [
-  ["tokens.css", "ds-tokens.css"],
-  [join("themes", "agent-cloud.css"), "ds-agent-cloud.css"],
-]) {
-  await cp(join(dsDir, from), join(outDir, to));
-}
 
-console.log(`copied renderer assets + design-system tokens (${seam}) → dist/renderer`);
+// tokens.css is the one file flattened and renamed on the way out (the `ds-`
+// prefix marks the files this window does not own). Everything else keeps its
+// LAYOUT, because the design-system files reference each other relatively:
+//   themes/       stays a directory — themes/studio.css opens with
+//                 `@import "./agent-cloud.css"`, a sibling lookup. A flattened
+//                 copy breaks that import and silently restores the old accent.
+//   assets/fonts/ stays at the path ds-fonts.css asks for
+//                 (`url("./assets/fonts/Geist-Variable.woff2")`, resolved
+//                 relative to ds-fonts.css — i.e. dist/renderer/).
+// A subdirectory is still same-origin, so setup.html's CSP-safe
+// <link href="./…"> links are unaffected by the nesting.
+await cp(join(dsDir, "tokens.css"), join(outDir, "ds-tokens.css"));
+await cp(join(dsDir, "themes"), join(outDir, "themes"), { recursive: true });
+
+// The font layer is OPTIONAL — but only so an OFFICIAL build cannot hard-fail on
+// a file we cannot inspect from here (the private package is absent from this
+// repo and its lockfile; see web/vite.config.ts). The committed ds-neutral set
+// DOES ship both, and a unit test pins that, so this tolerance can never quietly
+// cover the seam every build here actually resolves. Degrading to system-ui is
+// what this window did before it loaded any faces at all.
+const fontCss = await copyIfPresent(join(dsDir, "fonts.css"), join(outDir, "ds-fonts.css"));
+const fontFiles = await copyIfPresent(join(dsDir, "assets", "fonts"), join(outDir, "assets", "fonts"), {
+  recursive: true,
+});
+
+console.log(
+  `copied renderer assets + design-system tokens (${seam}) → dist/renderer` +
+    (fontCss && fontFiles ? "" : ` — NOTE: ${seam} ships no font layer, this window falls back to system-ui`),
+);

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -16,7 +16,11 @@
  *   http-state      the REST surface answers with the boot token …
  *   http-authz      … and rejects a request without it
  *   preload-bridge  the setup window's preload actually loaded (an ESM/sandbox
- *                   mismatch once made onboarding hang forever with no error)
+ *                   mismatch once made onboarding hang forever with no error),
+ *                   and that window resolved its design-system layer in the
+ *                   STUDIO brand — that layer is a build-time COPY, so a path
+ *                   regression silently reverts the first screen's entire look
+ *                   (it shipped in the retired teal brand for months)
  *   node-pty        the native module loads under Electron's ABI and can spawn
  *                   (covers the rebuild AND the +x spawn-helper) — no agent needed
  *   unpacked-deps   what the plain-Node Canvas subprocess imports exists ON DISK,
@@ -124,19 +128,69 @@ async function checkPreloadBridge(): Promise<string> {
     // unstyled first-run window that every other check still passes. Assert the
     // tokens RESOLVE rather than that the files exist: a <link> that 404s and a
     // stylesheet that loaded but defined nothing fail identically here.
+    //
+    // Each probe names a token exactly ONE file defines, so nothing here
+    // hardcodes a brand value — the design system owns those and this gate must
+    // not pin them. Three layers, three independent silent failures:
+    //   --bg           tokens.css loaded
+    //   --type-display studio.css loaded AND its [data-product] scope matched,
+    //                  i.e. the window is in the Studio brand and not the old
+    //                  agent-cloud teal it silently shipped in for months
+    //   --violet       agent-cloud.css loaded — reachable ONLY through
+    //                  `@import "./agent-cloud.css"` inside themes/studio.css, so
+    //                  this is the only check that themes/ was copied as a
+    //                  directory rather than flattened. A failed CSS @import
+    //                  throws nothing, anywhere.
+    // Geist is REPORTED, not asserted: --font falls through to system-ui, so a
+    // face the renderer refuses to fetch over file:// is a legible window, not a
+    // broken one — and this line is how we learn, per OS, whether it fetches.
     const theme = (await win.webContents.executeJavaScript(
-      "(() => { const s = getComputedStyle(document.documentElement);" +
-        " return { sheets: document.styleSheets.length, bg: s.getPropertyValue('--bg').trim()," +
-        " brand: s.getPropertyValue('--brand').trim() }; })()",
-    )) as { sheets: number; bg: string; brand: string };
+      "(async () => { const s = getComputedStyle(document.documentElement);" +
+        " const faces = [...document.fonts].map((f) => f.family).join(',');" +
+        " const geist = await document.fonts.load('600 1rem Geist').then((f) => f.length" +
+        " ? 'loaded' : 'no-match', (e) => 'error: ' + e.message);" +
+        " return { sheets: document.styleSheets.length," +
+        " product: document.documentElement.dataset.product || ''," +
+        " mode: document.documentElement.dataset.theme || ''," +
+        " bg: s.getPropertyValue('--bg').trim(), brand: s.getPropertyValue('--brand').trim()," +
+        " display: s.getPropertyValue('--type-display').trim()," +
+        " violet: s.getPropertyValue('--violet').trim(), faces, geist }; })()",
+    )) as {
+      sheets: number;
+      product: string;
+      mode: string;
+      bg: string;
+      brand: string;
+      display: string;
+      violet: string;
+      faces: string;
+      geist: string;
+    };
     if (!theme.bg || !theme.brand) {
       throw new Error(
         `design-system tokens did not resolve (--bg="${theme.bg}", --brand="${theme.brand}", ` +
           `${theme.sheets} stylesheet(s) loaded) — check copy-renderer.mjs`,
       );
     }
+    if (theme.product !== "sapiom-studio" || !theme.display) {
+      throw new Error(
+        `the Studio preset is not applied (data-product="${theme.product}", ` +
+          `--type-display="${theme.display}") — setup.html must carry ` +
+          `data-product="sapiom-studio" on <html> and link ./themes/studio.css`,
+      );
+    }
+    if (!theme.violet) {
+      throw new Error(
+        'themes/studio.css loaded but its `@import "./agent-cloud.css"` did not ' +
+          "(--violet is unset) — copy-renderer.mjs must copy themes/ as a directory",
+      );
+    }
 
-    return `window.sapiomSetup exposes onProgress + submitConsent; tokens resolve (--bg ${theme.bg})`;
+    return (
+      "window.sapiomSetup exposes onProgress + submitConsent; Studio tokens resolve " +
+      `(${theme.mode}, --bg ${theme.bg}, --brand ${theme.brand}); Geist ${theme.geist}` +
+      `${theme.faces.includes("Geist") ? "" : ` (WARNING: no Geist @font-face registered — faces: ${theme.faces || "none"})`}`
+    );
   } finally {
     if (!win.isDestroyed()) win.destroy();
   }

--- a/packages/harness-desktop/src/renderer/setup.css
+++ b/packages/harness-desktop/src/renderer/setup.css
@@ -4,10 +4,19 @@
  * Tokens come from the design system, resolved through the SAME seam the SPA
  * uses: `scripts/copy-renderer.mjs` probes for the private
  * `@sapiom/design-system` package and falls back to the harness's committed
- * `web/src/styles/ds-neutral` token set, then copies the resolved files in as
- * `ds-tokens.css` + `ds-agent-cloud.css`. So this window and the SPA read the
- * same token VALUES from the same source, and a public clone still renders
- * legibly. See `packages/harness/web/vite.config.ts` for the seam's rationale.
+ * `web/src/styles/ds-neutral` token set, then copies the resolved layer in as
+ * `ds-fonts.css` + `ds-tokens.css` + `themes/` (a directory) + `assets/fonts/`.
+ * `setup.html` links fonts → tokens → `themes/studio.css` → this file: the same
+ * three design-system files, in the same order, as the SPA's `styles.css`
+ * imports. So this window and the SPA read the same token VALUES from the same
+ * source, in the same brand, and a public clone still renders legibly. See
+ * `packages/harness/web/vite.config.ts` for the seam's rationale and
+ * `setup.html` for why agent-cloud.css is never linked separately.
+ *
+ * The Studio preset is scoped to `[data-product="sapiom-studio"]`, set on <html>
+ * in `setup.html`. It owns the deliberate overrides of shared names — `--radius`,
+ * `--type-label`, `--type-meta`, `--focus-ring`, `--brand*` — so this file must
+ * NOT restate them.
  *
  * The one rule this file inherits: **never redefine a design-system token.**
  * Everything below reads tokens via `var()` and declares no `--custom-property`
@@ -47,6 +56,18 @@ body {
   padding: var(--sp5);
 }
 
+/* Form controls do NOT inherit the document font — Chromium's UA sheet pins them
+   to Arial 13.333px, so without this the CTA and the checkbox render in Arial
+   while the card around them is Geist. The SPA resets this globally
+   (styles.css's `button`/`input` rules); this window needs the same reset or
+   loading the faces above buys nothing for the one control it has. `inherit`
+   redefines no token — it reads whatever `body` resolved. */
+button,
+input {
+  font: inherit;
+  color: inherit;
+}
+
 .card {
   width: 100%;
   max-width: 420px;
@@ -54,11 +75,7 @@ body {
   text-align: center;
   background: var(--s1);
   border: 1px solid var(--line);
-  /* Literal, not a token override: the app pins ONE 0.5rem radius for every
-     surface (its documented deviation from the system's r-sm/r/r-lg/r-xl
-     scale — see styles.css). Matching that literally keeps the first screen a
-     user sees consistent with the app, without redeclaring `--radius` here. */
-  border-radius: 0.5rem;
+  border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
 
@@ -71,6 +88,9 @@ body {
 }
 
 h1 {
+  /* Off-ladder on purpose: Studio steps 16px (--type-h2) → 22px (--type-title),
+     and this is the hero line of a 420px card, not an app pane. Either token is a
+     visible re-scale of the most prominent element in the window. */
   font-size: 19px;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -127,7 +147,7 @@ h1[data-status="error"] {
   border: 1px solid transparent;
   color: var(--brand-ink);
   font-weight: 500;
-  border-radius: 0.5rem;
+  border-radius: var(--radius);
   transition: background-color var(--fast) var(--ease);
 }
 .btn-primary:hover:not(:disabled) {
@@ -142,7 +162,8 @@ h1[data-status="error"] {
   cursor: not-allowed;
 }
 
-/* Centers the CTA and matches the SPA welcome panel's CTA sizing. */
+/* Centers the CTA. Its size is off-ladder too (Studio: --type-meta 12px,
+   --type-label 14px) and deliberately smaller than the body copy above it. */
 .consent .btn-primary,
 .error .btn-primary {
   display: block;

--- a/packages/harness-desktop/src/renderer/setup.html
+++ b/packages/harness-desktop/src/renderer/setup.html
@@ -1,5 +1,11 @@
 <!doctype html>
-<html lang="en">
+<!-- data-product scopes the design-system's named "sapiom-studio" preset
+     (compact IDE density, scarce green brand, neutral focus/selection), exactly
+     as the SPA does in web/index.html. It must sit on the SAME element as
+     data-theme, which the script below sets on <html>: studio.css keys the brand
+     on the compound selector [data-product="sapiom-studio"][data-theme="…"], so
+     on <body> or .card light mode would silently lose its brand and its --bg. -->
+<html lang="en" data-product="sapiom-studio">
   <head>
     <meta charset="utf-8" />
     <meta
@@ -27,13 +33,23 @@
         document.documentElement.dataset.theme = theme;
       })();
     </script>
-    <!-- Design-system token layer, resolved at build time through the same seam
-         the SPA uses (private @sapiom/design-system if installed, else the
-         harness's committed ds-neutral set) and copied in by
-         scripts/copy-renderer.mjs. Order matters: tokens → accent/brand layer →
-         this window's own layout. -->
+    <!-- Design-system layer, resolved at build time through the same seam the SPA
+         uses (private @sapiom/design-system if installed, else the harness's
+         committed ds-neutral set) and copied in by scripts/copy-renderer.mjs.
+         The same three files in the same order as the SPA's styles.css imports:
+         fonts register the Geist faces (fonts.css: "Import this BEFORE
+         tokens.css"), tokens.css is the token source of truth, and the named
+         studio.css preset layers the Studio decisions on top. Then this window's
+         own layout.
+
+         agent-cloud.css is NEVER linked here. studio.css @imports it as its first
+         rule, and the two carry equal specificity — so a second <link> after
+         studio.css would win on source order alone and silently restore the old
+         teal accent. themes/ is a real subdirectory for the same reason: that
+         @import is a sibling lookup. -->
+    <link rel="stylesheet" href="./ds-fonts.css" />
     <link rel="stylesheet" href="./ds-tokens.css" />
-    <link rel="stylesheet" href="./ds-agent-cloud.css" />
+    <link rel="stylesheet" href="./themes/studio.css" />
     <link rel="stylesheet" href="./setup.css" />
   </head>
   <body>

--- a/packages/harness-desktop/src/renderer/setup.html.test.ts
+++ b/packages/harness-desktop/src/renderer/setup.html.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The onboarding window's brand wiring is a contract across TWO files, and every
+ * way of breaking it is silent: the window still renders, just in the wrong
+ * brand. It shipped in the old Agent Cloud teal for months for exactly that
+ * reason, while every other check stayed green.
+ *
+ *  - `data-product="sapiom-studio"` missing from <html> and every
+ *    `[data-product="sapiom-studio"][data-theme="…"]` rule in studio.css misses.
+ *    Green, the neutral focus ring and the compact type ladder all vanish. It has
+ *    to be on <html>, because that is where the pre-paint script puts
+ *    `data-theme` and studio's brand rules are COMPOUND selectors on one element.
+ *  - a stray <link> to agent-cloud.css AFTER studio.css restores the teal
+ *    outright. studio.css @imports agent-cloud itself and their selectors carry
+ *    equal specificity, so the winner is decided by source order alone.
+ *  - a link whose file the build never copies just 404s. A <link> that fails and
+ *    a stylesheet that loaded but defined nothing are indistinguishable from the
+ *    page, so this file asserts BOTH halves — what the HTML asks for, and what
+ *    `scripts/copy-renderer.mjs` puts in dist/renderer.
+ *
+ * Text assertions over a DOM, deliberately: this package's vitest run never
+ * imports `electron` (see vitest.config.ts). The packaged `preload-bridge` smoke
+ * check (src/main/smoke.ts) is the other half — it reads COMPUTED token values in
+ * the real window, the only place "the cascade actually produced Studio" can be
+ * observed.
+ */
+import { existsSync, readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const html = readFileSync(new URL("./setup.html", import.meta.url), "utf8");
+const copyScript = readFileSync(new URL("../../scripts/copy-renderer.mjs", import.meta.url), "utf8");
+
+/** Every linked stylesheet, in document order — the order IS the contract. */
+const stylesheets = [...html.matchAll(/<link rel="stylesheet" href="([^"]+)" \/>/g)].map((m) => m[1]);
+
+describe("setup.html design-system wiring", () => {
+  it("scopes the Studio preset on <html>, where data-theme also lives", () => {
+    expect(html).toMatch(/<html lang="en" data-product="sapiom-studio">/);
+  });
+
+  it("links fonts → tokens → studio → own layout, in that order", () => {
+    // The same three design-system files, in the same order, as the SPA's
+    // styles.css imports them. fonts.css must precede tokens.css (its own header
+    // says so), and setup.css must come last so it can read every token above it.
+    expect(stylesheets).toEqual([
+      "./ds-fonts.css",
+      "./ds-tokens.css",
+      "./themes/studio.css",
+      "./setup.css",
+    ]);
+  });
+
+  it("never LINKS agent-cloud — studio.css @imports it, and a later link would win", () => {
+    // Matched against the links, not the whole file: setup.html's comment names
+    // agent-cloud on purpose, to explain why it must not be linked separately.
+    expect(stylesheets.filter((href) => href.includes("agent-cloud"))).toEqual([]);
+  });
+});
+
+describe("copy-renderer.mjs puts every linked file in dist/renderer", () => {
+  it("copies something for each stylesheet setup.html links", () => {
+    for (const href of stylesheets) {
+      // "./themes/studio.css" → "themes"; "./ds-tokens.css" → "ds-tokens.css".
+      // Derived from the HTML so this keeps working when a fifth link is added.
+      const target = href.replace("./", "").split("/")[0];
+      expect(copyScript, `${href} is linked but nothing copies "${target}"`).toContain(target);
+    }
+  });
+
+  it("copies the font layer, including the woff2 at the path ds-fonts.css asks for", () => {
+    expect(copyScript).toMatch(/"fonts\.css"[\s\S]{0,60}"ds-fonts\.css"/);
+    expect(copyScript).toMatch(/"assets",\s*"fonts"/);
+  });
+
+  it("copies themes/ as a directory instead of flattening it", () => {
+    // studio.css's first rule is `@import "./agent-cloud.css"` — a sibling lookup
+    // that a flattened copy breaks in total silence. Bounded window so this
+    // cannot accidentally match a `recursive` far away in the file.
+    expect(copyScript).toMatch(/"themes"[\s\S]{0,120}recursive: true/);
+    expect(copyScript).not.toContain("ds-agent-cloud");
+  });
+
+  it("the committed fallback really ships what the copy treats as optional", () => {
+    // The font copy tolerates absence so an official build against the private
+    // package cannot hard-fail on a file we cannot inspect from here. That
+    // tolerance must never quietly cover THIS repo's seam — the one every build
+    // actually resolves (see web/vite.config.ts's TODO).
+    const dsNeutral = new URL("../../../harness/web/src/styles/ds-neutral/", import.meta.url);
+    for (const file of [
+      "tokens.css",
+      "fonts.css",
+      "themes/studio.css",
+      "themes/agent-cloud.css",
+      "assets/fonts/Geist-Variable.woff2",
+      "assets/fonts/GeistMono-Variable.woff2",
+    ]) {
+      expect(existsSync(new URL(file, dsNeutral)), `ds-neutral is missing ${file}`).toBe(true);
+    }
+  });
+});

--- a/packages/harness-desktop/vitest.config.ts
+++ b/packages/harness-desktop/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vitest/config";
 
 // Only the main process's PURE helpers are unit-tested here — the modules that
-// don't import `electron` (env.ts, paths.ts). boot.ts and friends are covered by
-// the packaged `--smoke` launch instead (see src/main/smoke.ts): every bug this
-// app has shipped came from the real environment differing from our assumptions,
-// so mocking `electron` to unit-test boot would just re-assert the wrong ones.
+// don't import `electron` (env.ts, paths.ts) — plus the static renderer assets,
+// asserted as TEXT (no DOM, no electron; see renderer/setup.html.test.ts).
+// boot.ts and friends are covered by the packaged `--smoke` launch instead (see
+// src/main/smoke.ts): every bug this app has shipped came from the real
+// environment differing from our assumptions, so mocking `electron` to unit-test
+// boot would just re-assert the wrong ones.
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],

--- a/packages/harness/CLAUDE.md
+++ b/packages/harness/CLAUDE.md
@@ -124,10 +124,14 @@ The SPA resolves `@sapiom/design-system` through a build seam (`web/vite.config.
 `designSystemAlias()`): the private branded package when it's installed, else the committed
 `web/src/styles/ds-neutral` token set — this repo is public, so a clone with no private assets must
 still build and render. `harness-desktop/scripts/copy-renderer.mjs` runs the **same probe** and copies
-the resolved `tokens.css` / `themes/agent-cloud.css` into the Electron setup window as
-`ds-tokens.css` / `ds-agent-cloud.css` (that window has no bundler — `setup.html` links plain
-stylesheets — so a copy replaces the alias). Change the probe or the file layout in one and you must
-change the other; nothing else fails first.
+the resolved layer into the Electron setup window: `tokens.css` → `ds-tokens.css`, `fonts.css` →
+`ds-fonts.css`, and `themes/` plus `assets/fonts/` with their **layout intact** (that window has no
+bundler — `setup.html` links plain stylesheets — so a copy replaces the alias). The layout is preserved
+because the design-system files reference each other relatively: `themes/studio.css` opens with
+`@import "./agent-cloud.css"` and `fonts.css` asks for `./assets/fonts/*.woff2`. Flattening either
+breaks it in total silence — a failed CSS `@import` throws nothing and a missing face just renders
+system-ui. Change the probe or the file layout in one and you must change the other; nothing else
+fails first.
 
 - Never redefine a design-system token. Read tokens with `var()`; a local snapshot of token VALUES
   drifts the moment a token changes, which is exactly what the seam exists to prevent.
@@ -137,6 +141,12 @@ change the other; nothing else fails first.
   which addresses system tokens directly since it can't load the SPA's bridge.
 - Dark mode keys on `[data-theme="dark"]`, not `prefers-color-scheme` alone — the onboarding window
   sets the attribute itself before first paint.
+- The onboarding window links the SAME three design-system files in the SAME order as `styles.css`
+  imports them (fonts → tokens → `themes/studio.css`) and carries `data-product="sapiom-studio"` on
+  `<html>`, next to `data-theme` — studio.css keys its brand on the compound
+  `[data-product="sapiom-studio"][data-theme="…"]`, so both attributes must be on one element. Never
+  link `agent-cloud.css` separately: studio.css `@import`s it, the two tie on specificity, and a second
+  link after it wins on source order and restores the retired teal.
 - Compose stylesheets through JS imports in `web/src/main.tsx`, not CSS `@import` (an `@import`
   triggers a stricter re-parse that chokes on our CSS nesting).
 


### PR DESCRIPTION
The Studio desktop app's onboarding window still rendered in the retired **Agent Cloud** brand — teal accent, teal focus ring, system-ui type — while the SPA has shipped **Studio** since #512 / #519. It's the first screen a user ever sees, so it contradicted the app it launches.

This is **not a cosmetic tweak.** It was three independent wiring bugs, and every one of them fails silently — the window renders fine, just in the wrong brand, which is why it survived this long.

The "two screens" are one window (`src/renderer/setup.html`) showing two boot phases from `boot.ts`: `auth` ("Signing you in…") and `consent` ("Share anonymous usage data?").

## The three causes

**1 — Wrong theme layer.** `setup.html` linked `./ds-agent-cloud.css` (teal `#1fbdd1` / `#05a9bc`). The Studio preset is a *different file*, `themes/studio.css`, which was never copied or linked.

**2 — The preset could not activate even if it had been linked.** Everything in `studio.css` is scoped to `[data-product="sapiom-studio"]`, and `setup.html` was a bare `<html lang="en">` — so causes 1 and 2 had to be fixed together, or linking studio.css applies literally nothing. The attribute goes on `<html>` **specifically**, because studio.css keys the brand on a *compound* selector:

```css
[data-product="sapiom-studio"][data-theme="light"] { --brand: #167e3a; --bg: #f0f2f5; }
```

Both attributes must be on the same element, and the pre-paint script already puts `data-theme` on `<html>`. On `<body>` or `.card`, light mode silently loses both its brand *and* its `--bg`.

**3 — Geist was never loaded.** `tokens.css` names `"Geist"` in `--font`, but `copy-renderer.mjs` copied only `tokens.css` and one theme — never `fonts.css` or `assets/fonts/*.woff2`. `fonts.css`'s own header describes this exact failure: *"nothing ever LOADED it … system-ui has no 500, so every `--fw-medium` silently rounded up to Semibold and chrome read as bold."*

## Changes

**`scripts/copy-renderer.mjs`** — also copies `fonts.css` → `ds-fonts.css`, `assets/fonts/`, and `themes/` **as a directory**. Layout is preserved rather than flattened because the design-system files reference each other *relatively*: `themes/studio.css` opens with `@import "./agent-cloud.css"` (a sibling lookup) and `fonts.css` asks for `./assets/fonts/*.woff2`. A flattened copy breaks that `@import` in total silence — a failed CSS `@import` throws nothing.

The font layer is copied *tolerantly* (ENOENT only; every other error still throws) so an official build against the private `@sapiom/design-system` — absent from this repo and its lockfile, so genuinely unverifiable from here — cannot hard-fail on it. A unit test pins that the committed `ds-neutral` seam really does ship it, so that tolerance can never quietly cover the branch we actually build.

**`setup.html`** — `data-product="sapiom-studio"` on `<html>`, and the links become `ds-fonts` → `ds-tokens` → `themes/studio.css` → `setup.css` (the same three DS files in the same order as the SPA's `styles.css`; `fonts.css` says *"Import this BEFORE tokens.css"*).

**The `ds-agent-cloud.css` link is removed, not kept.** `:root` and `[data-product="sapiom-studio"]` have equal specificity (0,1,0), so **source order decides the accent**. studio.css wins only because it `@import`s agent-cloud at its top; a separate link *after* studio.css puts teal straight back and the fix looks like it did nothing.

**`setup.css`** — both `border-radius: 0.5rem` literals → `var(--radius)` (identical value under the preset, so zero pixels change; it just removes the drift risk), plus a `button, input { font: inherit }` reset. Form controls don't inherit `font-family` — Chromium's UA sheet pins them to Arial 13.333px — so without it the CTA rendered in **Arial** while the card around it was Geist, defeating the point of loading the faces. The SPA has the same reset (`styles.css:224-233`). I only caught this by rendering the window; it's invisible in a CSS diff.

## Guardrails

Since every failure mode here is silent, both halves are guarded:

- **`src/renderer/setup.html.test.ts`** (new) asserts what the HTML asks for *and* what `copy-renderer.mjs` puts in `dist/renderer` — a HTML-only test passes forever while the build stops copying a linked file. Includes the negative assertion that no link references agent-cloud, which is the one that catches a future re-break of the source-order footgun.
- **`smoke.ts`** probes the *packaged* window for tokens that exactly one file defines: `--type-display` (studio.css loaded **and** its `[data-product]` scope matched) and `--violet` (reachable *only* through studio's nested `@import`, making it the only check that `themes/` was copied as a directory). No brand hex is hardcoded — the design system owns those, and the probes name which layer broke. Geist is *reported*, not asserted: `--font` falls through to system-ui, so a face the renderer refuses over `file://` is a legible window, not a broken one.

## Verification

- 71 unit tests pass. All 4 new guards **mutation-tested** — re-adding the agent-cloud link, dropping `data-product`, flattening `themes/`, and dropping the font copy each fail on the intended assertion.
- **Packaged smoke: 13/13**, reporting `Studio tokens resolve (dark, --bg #0B0E13, --brand #6be195); Geist loaded` — from inside `app.asar`. That also settles the `file://` font question on macOS: the woff2 loads, so **no `font-src` is needed**.
- Consent and error screens rendered and inspected in both themes. Light mode correctly picks up Studio's `--bg: #f0f2f5` behind a white card; error text is Geist Mono at 14px and wraps inside the card.
- `typecheck` clean; `pnpm terminology:check` passes (379 files).

## Notes for review

- **No changeset.** `harness-desktop` is `private: true` and no changeset has ever named it (versions move in explicit `chore(desktop): release …` commits). The `@sapiom/harness` change is documentation only.
- Two type sizes shift as an intended consequence of adopting the preset: `.brand` 11→12px and `.error-message` 12→14px. The `19px` h1 and `12.5px` CTA are deliberately left off-ladder (Studio steps 16px → 22px, so either token is a visible ±16% re-scale of the window's headline) and now carry comments saying so.
- `setup.css`'s docstring still claims `.btn-primary` "mirrors the SPA's `.btn-primary`". It no longer does — the SPA's is the neutral `var(--btn)` button. Left as-is to keep this PR to the theming fix; the green fill here is a deliberate call for the first-run confirmation CTA, matching `.rail-nav-cta.is-empty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
