### PR TITLE
feat(harness): route sapiom://templates/<id> deep links to the gallery

### DIFF
--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -406,7 +406,7 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
   });
 
   // 9. Load the SPA in the main window; close setup once it renders.
-  const url = withAgentParam(`http://127.0.0.1:${server.port}/?token=${bootToken}`, mode.deepLink);
+  const url = withDeepLinkParams(`http://127.0.0.1:${server.port}/?token=${bootToken}`, mode.deepLink);
   const mainWindow = createMainWindow(url);
   mainWindow.webContents.once("did-finish-load", () => {
     if (!setupWin.isDestroyed()) setupWin.close();
@@ -420,14 +420,20 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
  * Thread a cold-start deep link's target onto the SPA load URL as query params.
  * Query only — never a path segment: `isTrustedSender` (trusted-sender.ts) fails
  * closed unless the top frame's pathname is exactly "/", so a path-based route
- * here would break the update + folder-picker IPC.
+ * here would break the update + folder-picker IPC. The SPA reads these back in
+ * `web/src/lib/deep-link.ts`.
  */
-function withAgentParam(loadUrl: string, target: DeepLinkTarget | undefined): string {
+function withDeepLinkParams(loadUrl: string, target: DeepLinkTarget | undefined): string {
   if (!target) return loadUrl;
   try {
     const u = new URL(loadUrl);
-    u.searchParams.set("agent", target.definitionId);
-    if (target.slug) u.searchParams.set("agentSlug", target.slug);
+    if (target.kind === "agent") {
+      u.searchParams.set("agent", target.definitionId);
+      if (target.slug) u.searchParams.set("agentSlug", target.slug);
+    } else {
+      u.searchParams.set("template", target.templateId);
+      if (target.slug) u.searchParams.set("templateSlug", target.slug);
+    }
     return u.toString();
   } catch {
     return loadUrl;

--- a/packages/harness-desktop/src/main/deep-link.test.ts
+++ b/packages/harness-desktop/src/main/deep-link.test.ts
@@ -2,21 +2,22 @@ import { describe, expect, it } from "vitest";
 
 import { deepLinkFromArgv, parseDeepLink } from "./deep-link.js";
 
-describe("parseDeepLink", () => {
+describe("parseDeepLink — agent", () => {
   it("parses sapiom://agent/<id>", () => {
-    expect(parseDeepLink("sapiom://agent/188")).toEqual({ definitionId: "188" });
+    expect(parseDeepLink("sapiom://agent/188")).toEqual({ kind: "agent", definitionId: "188" });
   });
 
   it("accepts the agents alias and a trailing slash", () => {
-    expect(parseDeepLink("sapiom://agents/188/")).toEqual({ definitionId: "188" });
+    expect(parseDeepLink("sapiom://agents/188/")).toEqual({ kind: "agent", definitionId: "188" });
   });
 
   it("is case-insensitive in the scheme and host", () => {
-    expect(parseDeepLink("SAPIOM://Agent/188")).toEqual({ definitionId: "188" });
+    expect(parseDeepLink("SAPIOM://Agent/188")).toEqual({ kind: "agent", definitionId: "188" });
   });
 
   it("carries optional slug and org hints", () => {
     expect(parseDeepLink("sapiom://agent/188?slug=weather&org=acme")).toEqual({
+      kind: "agent",
       definitionId: "188",
       slug: "weather",
       org: "acme",
@@ -24,9 +25,35 @@ describe("parseDeepLink", () => {
   });
 
   it("decodes a percent-encoded id", () => {
-    expect(parseDeepLink("sapiom://agent/a%2Fb")).toEqual({ definitionId: "a/b" });
+    expect(parseDeepLink("sapiom://agent/a%2Fb")).toEqual({ kind: "agent", definitionId: "a/b" });
+  });
+});
+
+describe("parseDeepLink — template", () => {
+  it("parses sapiom://templates/<id>", () => {
+    expect(parseDeepLink("sapiom://templates/support-resolution")).toEqual({
+      kind: "template",
+      templateId: "support-resolution",
+    });
   });
 
+  it("accepts the template alias and a trailing slash", () => {
+    expect(parseDeepLink("sapiom://template/newsletter-autopilot/")).toEqual({
+      kind: "template",
+      templateId: "newsletter-autopilot",
+    });
+  });
+
+  it("carries an optional slug hint and decodes the id", () => {
+    expect(parseDeepLink("sapiom://templates/a%2Fb?slug=demo")).toEqual({
+      kind: "template",
+      templateId: "a/b",
+      slug: "demo",
+    });
+  });
+});
+
+describe("parseDeepLink — rejects", () => {
   it("rejects a foreign scheme", () => {
     expect(parseDeepLink("https://app.sapiom.ai/agents/188")).toBeNull();
   });
@@ -38,6 +65,7 @@ describe("parseDeepLink", () => {
   it("rejects a missing id", () => {
     expect(parseDeepLink("sapiom://agent/")).toBeNull();
     expect(parseDeepLink("sapiom://agent")).toBeNull();
+    expect(parseDeepLink("sapiom://templates/")).toBeNull();
   });
 
   it("rejects garbage", () => {

--- a/packages/harness-desktop/src/main/deep-link.ts
+++ b/packages/harness-desktop/src/main/deep-link.ts
@@ -13,10 +13,11 @@ export type { DeepLinkTarget };
 export const DEEP_LINK_SCHEME = "sapiom";
 
 /**
- * Parse `sapiom://agent/<definitionId>` into a target. Tolerates the `agents`
- * alias, a trailing slash, and mixed case in the scheme/host. Returns null for
- * anything that isn't a well-formed agent deep link, so the caller can safely
- * hand it any string (argv token, OS-delivered URL).
+ * Parse a `sapiom://` deep link into a target — either `sapiom://agent/<id>` or
+ * `sapiom://templates/<id>`. Tolerates the `agents`/`template` aliases, a trailing
+ * slash, and mixed case in the scheme/host. Returns null for anything that isn't a
+ * well-formed link of either kind, so the caller can safely hand it any string
+ * (argv token, OS-delivered URL).
  */
 export function parseDeepLink(rawUrl: string): DeepLinkTarget | null {
   let url: URL;
@@ -26,15 +27,21 @@ export function parseDeepLink(rawUrl: string): DeepLinkTarget | null {
     return null;
   }
   if (url.protocol !== `${DEEP_LINK_SCHEME}:`) return null;
-  // `sapiom://agent/<id>` parses with host="agent", pathname="/<id>". URL only
+  // `sapiom://<host>/<id>` parses with host=<host>, pathname="/<id>". URL only
   // lower-cases the host for special schemes, so normalise it ourselves.
   const host = url.hostname.toLowerCase();
-  if (host !== "agent" && host !== "agents") return null;
-  const definitionId = decodeURIComponent(url.pathname.replace(/^\/+/, "").replace(/\/+$/, ""));
-  if (!definitionId) return null;
-  const slug = url.searchParams.get("slug") ?? undefined;
-  const org = url.searchParams.get("org") ?? undefined;
-  return { definitionId, ...(slug ? { slug } : {}), ...(org ? { org } : {}) };
+  const id = decodeURIComponent(url.pathname.replace(/^\/+/, "").replace(/\/+$/, ""));
+  if (!id) return null;
+  if (host === "agent" || host === "agents") {
+    const slug = url.searchParams.get("slug") ?? undefined;
+    const org = url.searchParams.get("org") ?? undefined;
+    return { kind: "agent", definitionId: id, ...(slug ? { slug } : {}), ...(org ? { org } : {}) };
+  }
+  if (host === "template" || host === "templates") {
+    const slug = url.searchParams.get("slug") ?? undefined;
+    return { kind: "template", templateId: id, ...(slug ? { slug } : {}) };
+  }
+  return null;
 }
 
 /**

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -73,9 +73,9 @@ export const CHOOSE_DIRECTORY = "dialog:choose-directory";
 
 /**
  * main → renderer (push): a `sapiom://` deep link was received; navigate the SPA
- * to the target agent. A main→renderer SEND, not an invoke, so it is NOT subject
- * to `isTrustedSender` (which guards renderer→main invokes) — it opens no attack
- * surface, it only pushes a target the SPA is free to act on or ignore.
+ * to the target (an agent or a template). A main→renderer SEND, not an invoke, so
+ * it is NOT subject to `isTrustedSender` (which guards renderer→main invokes) — it
+ * opens no attack surface, it only pushes a target the SPA is free to act on or ignore.
  *
  * Cold-start links (the one that launched the app) are delivered instead as an
  * `agent=` query param on the load URL, so the first render already has them with
@@ -84,16 +84,35 @@ export const CHOOSE_DIRECTORY = "dialog:choose-directory";
 export const DEEP_LINK_NAVIGATE = "deep-link:navigate";
 
 /**
- * A parsed `sapiom://agent/<definitionId>` deep link. `definitionId` is the raw
- * URL segment (a string); the SPA stringifies its numeric `WorkflowInfo.definitionId`
- * to match. `slug` is a display-only hint; `org` lets the SPA notice a link minted
- * for a different signed-in organization. Mirrored on the SPA side in
+ * A parsed `sapiom://` deep link. Discriminated on `kind` so a new target type
+ * can't be silently handled as an agent — the same reasoning the discriminated
+ * `UpdateCheckOutcome` above is built on. Mirrored on the SPA side in
  * `harness/web/src/lib/desktop.ts`.
  */
-export interface DeepLinkTarget {
+export type DeepLinkTarget = DeepLinkAgentTarget | DeepLinkTemplateTarget;
+
+/**
+ * `sapiom://agent/<definitionId>`. `definitionId` is the raw URL segment (a
+ * string); the SPA stringifies its numeric `WorkflowInfo.definitionId` to match.
+ * `slug` is a display-only hint; `org` lets the SPA notice a link minted for a
+ * different signed-in organization.
+ */
+export interface DeepLinkAgentTarget {
+  kind: "agent";
   definitionId: string;
   slug?: string;
   org?: string;
+}
+
+/**
+ * `sapiom://templates/<id>` — the web app's template-detail "Open in Studio".
+ * `templateId` is a registry slug (the same id the gallery route uses); `slug` is
+ * an optional display/folder hint.
+ */
+export interface DeepLinkTemplateTarget {
+  kind: "template";
+  templateId: string;
+  slug?: string;
 }
 /*
  * There is deliberately NO "apply the update" channel. The restart is destructive —

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -51,8 +51,8 @@ import {
 } from "./lib/project-dir";
 import { observedRunMatchesWorkflow } from "./lib/run-workflow-filter";
 import { agentUrl } from "./lib/urls";
-import { getDesktopBridge } from "./lib/desktop";
-import { agentFromSearch, type DeepLinkAgentTarget } from "./lib/deep-link";
+import { getDesktopBridge, type DeepLinkAgentTarget, type DeepLinkTarget } from "./lib/desktop";
+import { deepLinkFromSearch } from "./lib/deep-link";
 import { CloneAgentConfirm } from "./components/CloneAgentConfirm";
 import {
   cloneDefinitionPrompt,
@@ -126,16 +126,20 @@ export const App = (): JSX.Element => {
   // "Open in Studio" deep links (sapiom://agent/<id>). The applier is a ref
   // because it needs `state`/`handleFocusAgent`, which exist only past the loading
   // guard; the effects below reach it through the ref. The cold-start target rides
-  // in on the ?agent= load-URL param; warm links come via the desktop bridge.
-  const applyDeepLinkRef = useRef<((target: DeepLinkAgentTarget) => void) | null>(null);
+  // in on the ?agent=/?template= load-URL param; warm links come via the desktop bridge.
+  const applyDeepLinkRef = useRef<((target: DeepLinkTarget) => void) | null>(null);
   const focusExistingRef = useRef<((definitionId: string) => boolean) | null>(null);
-  const coldDeepLinkRef = useRef<DeepLinkAgentTarget | null>(agentFromSearch());
+  const coldDeepLinkRef = useRef<DeepLinkTarget | null>(deepLinkFromSearch());
   const coldDeepLinkHandledRef = useRef(false);
   // A clone kicked off from a remote-only deep link: focus the agent once the
   // workspace rescan surfaces it locally.
   const pendingCloneFocusRef = useRef<string | null>(null);
   // The remote-only agent a deep link is offering to clone (drives the confirm).
   const [cloneRequest, setCloneRequest] = useState<DeepLinkAgentTarget | null>(null);
+  // A template a deep link asked to open (`sapiom://templates/<id>`): the id is
+  // handed to the templates browser, which resolves it against the live catalog
+  // and opens its detail. Null when no template deep link is pending.
+  const [deepLinkTemplateId, setDeepLinkTemplateId] = useState<string | null>(null);
   // Lifted so the telemetry chip in the session bar can open the settings
   // popover from outside SessionBar's own gear button.
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -813,9 +817,15 @@ export const App = (): JSX.Element => {
     return true;
   };
 
-  // Resolve a deep-link target (`sapiom://agent/<id>`): focus it if present, else
-  // offer to clone it locally — the remote-only fallback.
-  applyDeepLinkRef.current = (target: DeepLinkAgentTarget): void => {
+  // Resolve a deep-link target. A template (`sapiom://templates/<id>`) opens the
+  // templates browser on that template; an agent (`sapiom://agent/<id>`) focuses
+  // it if present, else offers to clone it locally — the remote-only fallback.
+  applyDeepLinkRef.current = (target: DeepLinkTarget): void => {
+    if (target.kind === "template") {
+      setDeepLinkTemplateId(target.templateId);
+      setTemplatesOpen(true);
+      return;
+    }
     if (focusExistingRef.current?.(target.definitionId)) return;
     setCloneRequest(target);
   };
@@ -1142,6 +1152,7 @@ export const App = (): JSX.Element => {
               onUse={handleUseTemplate}
               listTemplates={harness.listTemplates}
               getTemplate={harness.getTemplate}
+              openTemplateId={deepLinkTemplateId}
             />
           )}
 

--- a/packages/harness/web/src/components/TemplatesPanel.tsx
+++ b/packages/harness/web/src/components/TemplatesPanel.tsx
@@ -39,6 +39,14 @@ interface TemplatesPanelProps {
   /** The live catalog fetchers (the server relays core; the key stays there). */
   listTemplates: () => Promise<TemplateListResponse>;
   getTemplate: (id: string) => Promise<TemplateDetailView>;
+  /**
+   * A template id to open on arrival — a `sapiom://templates/<id>` deep link,
+   * routed here by App. Resolved against the live catalog (and bundled starters)
+   * once they load; an unknown id falls through to the gallery. Applied only when
+   * the id changes, so the user can navigate back afterwards without being yanked
+   * forward again.
+   */
+  openTemplateId?: string | null;
 }
 
 /**
@@ -72,6 +80,7 @@ export function TemplatesPanel({
   onUse,
   listTemplates,
   getTemplate,
+  openTemplateId,
 }: TemplatesPanelProps): JSX.Element {
   const [catalog, setCatalog] = useState<TemplateListResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -124,6 +133,21 @@ export function TemplatesPanel({
           ),
     [filter],
   );
+
+  // Open a deep-linked template's detail once it can be resolved. Keyed on the id
+  // via a ref so navigating back (setOpened(null)) isn't undone on the next render,
+  // while a later, different deep link still opens. Unknown/not-yet-loaded ids just
+  // leave the gallery showing.
+  const openedByDeepLinkRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!openTemplateId || openedByDeepLinkRef.current === openTemplateId) return;
+    const match =
+      gallery.find((template) => template.id === openTemplateId) ??
+      STARTER_TEMPLATES.find((template) => template.id === openTemplateId);
+    if (!match) return;
+    openedByDeepLinkRef.current = openTemplateId;
+    setOpened(match);
+  }, [openTemplateId, gallery]);
 
   const loading = catalog === null && loadError === null;
 

--- a/packages/harness/web/src/lib/deep-link.ts
+++ b/packages/harness/web/src/lib/deep-link.ts
@@ -1,24 +1,32 @@
 /**
  * Cold-start deep-link target, read from the SPA's load URL.
  *
- * When the desktop app is opened by a `sapiom://agent/<id>` link, the Electron
- * host threads that id onto the load URL as `?agent=<id>` (harness-desktop's
- * boot.ts), so the very first render already knows the target — no IPC race.
- * Links that arrive while the app is already running come through the desktop
- * bridge instead (`getDesktopBridge().onDeepLink`). A plain browser under `npx`
- * simply never carries the param, so this reads as "no target" there.
+ * When the desktop app is opened by a `sapiom://agent/<id>` or
+ * `sapiom://templates/<id>` link, the Electron host threads it onto the load URL
+ * as `?agent=<id>` / `?template=<id>` (harness-desktop's boot.ts), so the very
+ * first render already knows the target — no IPC race. Links that arrive while
+ * the app is already running come through the desktop bridge instead
+ * (`getDesktopBridge().onDeepLink`). A plain browser under `npx` simply never
+ * carries the param, so this reads as "no target" there.
  */
-export interface DeepLinkAgentTarget {
-  definitionId: string;
-  slug?: string;
-}
+import type { DeepLinkTarget } from "./desktop";
 
-export function agentFromSearch(
+export function deepLinkFromSearch(
   search = typeof window === "undefined" ? "" : window.location.search,
-): DeepLinkAgentTarget | null {
+): DeepLinkTarget | null {
   const params = new URLSearchParams(search);
+
   const definitionId = params.get("agent");
-  if (!definitionId) return null;
-  const slug = params.get("agentSlug");
-  return slug ? { definitionId, slug } : { definitionId };
+  if (definitionId) {
+    const slug = params.get("agentSlug");
+    return { kind: "agent", definitionId, ...(slug ? { slug } : {}) };
+  }
+
+  const templateId = params.get("template");
+  if (templateId) {
+    const slug = params.get("templateSlug");
+    return { kind: "template", templateId, ...(slug ? { slug } : {}) };
+  }
+
+  return null;
 }

--- a/packages/harness/web/src/lib/desktop.ts
+++ b/packages/harness/web/src/lib/desktop.ts
@@ -17,11 +17,25 @@
  * "no bridge".
  */
 
-/** A `sapiom://` deep-link target. Mirrors the desktop app's `DeepLinkTarget` (ipc.ts). */
-export interface DeepLinkTarget {
+/**
+ * A `sapiom://` deep-link target. Mirrors the desktop app's `DeepLinkTarget`
+ * (harness-desktop `ipc.ts`) — a discriminated union of the two link kinds.
+ */
+export type DeepLinkTarget = DeepLinkAgentTarget | DeepLinkTemplateTarget;
+
+/** `sapiom://agent/<definitionId>` — focus or clone that agent locally. */
+export interface DeepLinkAgentTarget {
+  kind: "agent";
   definitionId: string;
   slug?: string;
   org?: string;
+}
+
+/** `sapiom://templates/<id>` — open that template in the gallery. */
+export interface DeepLinkTemplateTarget {
+  kind: "template";
+  templateId: string;
+  slug?: string;
 }
 
 /** Result of an on-demand update check. Mirrors the desktop app's `UpdateCheckOutcome`. */


### PR DESCRIPTION
## Summary
Extends the existing `sapiom://` deep-link scheme (which already handled `sapiom://agent/<id>`) with a **template** target, so the web app's template-detail **"Open in Studio"** opens that template *inside* the desktop app instead of only bringing the window forward. Builds directly on the agent deep-link machinery shipped in #540.

## Changes
### Desktop main process
- `DeepLinkTarget` is now a discriminated union — `DeepLinkAgentTarget { kind: "agent" }` | `DeepLinkTemplateTarget { kind: "template"; templateId }` (`ipc.ts`).
- `parseDeepLink` recognizes `sapiom://templates/<id>` (with `template` alias, trailing slash, percent-decoding), alongside the existing `agent`/`agents` (`deep-link.ts`).
- Cold-start threading generalized (`withAgentParam` → `withDeepLinkParams`): agent links ride in as `?agent=`, template links as `?template=` (`boot.ts`). Query-only, preserving the `isTrustedSender` pathname==`/` invariant.

### SPA (renderer)
- Bridge + cold-start mirrors updated to the union (`lib/desktop.ts`, `lib/deep-link.ts`; `agentFromSearch` → `deepLinkFromSearch`).
- `applyDeepLink` branches on `kind`: agent → existing focus/clone; **template → open the templates browser on that id**.
- `TemplatesPanel` takes an `openTemplateId` prop and resolves it against the live catalog (+ bundled starters), opening its detail; an unknown/not-yet-loaded id falls through to the gallery. Keyed on the id so navigating back isn't undone.

The **agent deep-link path is unchanged** — only extended.

## Testing
- [x] `deep-link.test.ts` extended (14 tests pass): agent cases now assert `kind: "agent"`; new template cases cover the alias, trailing slash, percent-decoding, optional slug, and rejection of unknown hosts / missing ids.
- [x] Changed files typecheck clean locally; full `tsc`/build deferred to CI (worktree deps not fully built).
- [ ] Manual desktop deeplink smoke (needs a packaged build with the scheme registered) — follow-up.

## Related
- Builds on the agent deep-link scheme from #540.
- Pairs with the web app's template "Open in Studio" button (separate Sapiom monorepo PR).

## Checklist
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed
- [x] One logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143Q8XqKSp34LyAK1Lnhhqd