### PR TITLE
chore(release): @sapiom/harness-desktop@0.2.2 — Open in Studio deep link (SAP-2424)

### DIFF
--- a/packages/harness-desktop/CHANGELOG.md
+++ b/packages/harness-desktop/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @sapiom/harness-desktop
 
+## 0.2.2
+
+### Patch Changes
+
+- Open in Studio (SAP-2424): register a `sapiom://` URL scheme so the dashboard's
+  "Open in Studio" action opens the desktop app and routes to the agent —
+  focusing it when it's already cloned locally, or offering to clone it (by
+  definition id) and then focusing it. Handles macOS `open-url` and
+  Windows/Linux argv for both warm and cold launches, with a download-page
+  fallback when the app isn't installed.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sapiom/harness-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Agent Studio desktop app — a one-click native host for running Claude Code or Codex in a Sapiom-configured environment. The npx CLI (@sapiom/harness) remains the backup host over the same startServer().",
   "homepage": "https://sapiom.ai",


### PR DESCRIPTION
Refs: SAP-2424

## What

Desktop-only release bump so the `sapiom://` **Open in Studio** deep-link feature reaches users. The code is already on `main` (merged in #537); the last published desktop build (`0.2.1`) was tagged **before** that merge, so installed/auto-updated users don't have it yet. This cuts **0.2.2** from `main` to package it.

- `packages/harness-desktop/package.json`: `0.2.1` → `0.2.2`
- `packages/harness-desktop/CHANGELOG.md`: 0.2.2 entry documenting the deep link

**No code change.** Leaves the batched changeset-release **#532** (harness 0.4.0, cli 3.0.0 major, npm publish) untouched — this is desktop-only.

## Release step (after merge)

Tag `harness-desktop-v0.2.2` on the merge commit → `desktop-release.yml` builds installers on all three OSes and publishes to GitHub Releases on the `latest` channel.

## Verified
The deep link was tested end-to-end against a packaged macOS build off this same `main` (cold-start + warm `open sapiom://…` → focus/clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)