### PR TITLE
fix(harness): themed "preparing" canvas instead of the esbuild error on fresh scaffold

### DIFF
--- a/packages/harness/src/core/agent-deps.test.ts
+++ b/packages/harness/src/core/agent-deps.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { agentDepsInstalled, agentDepsInstalledSync } from "./agent-deps.js";
+
+const tmpDirs: string[] = [];
+async function tmp(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+/** Simulate a package landing in `<root>/node_modules/<pkg>` — with the
+ *  package.json esbuild reads, not just an empty directory. */
+async function installPkg(root: string, pkg: string): Promise<void> {
+  const dir = path.join(root, "node_modules", pkg);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: pkg }));
+}
+
+/** Write a project package.json declaring the given runtime dependencies. */
+async function writeManifest(projectDir: string, deps: string[]): Promise<void> {
+  await fs.writeFile(
+    path.join(projectDir, "package.json"),
+    JSON.stringify({ name: "agent", dependencies: Object.fromEntries(deps.map((d) => [d, "1.0.0"])) }),
+  );
+}
+
+describe("agentDepsInstalled", () => {
+  it("is false for a fresh project with no SDK anywhere up the tree", async () => {
+    const project = await tmp("agent-deps-none-");
+    expect(await agentDepsInstalled(project)).toBe(false);
+    expect(agentDepsInstalledSync(project)).toBe(false);
+  });
+
+  it("is true once the SDK is installed (no package.json → SDK fallback)", async () => {
+    const project = await tmp("agent-deps-own-");
+    await installPkg(project, "@sapiom/agent");
+    expect(await agentDepsInstalled(project)).toBe(true);
+    expect(agentDepsInstalledSync(project)).toBe(true);
+  });
+
+  it("resolves deps hoisted to an ANCESTOR node_modules (monorepo / repo fixtures)", async () => {
+    const root = await tmp("agent-deps-hoist-");
+    await installPkg(root, "@sapiom/agent");
+    const nested = path.join(root, "packages", "app", "agents", "leads");
+    await fs.mkdir(nested, { recursive: true });
+    expect(await agentDepsInstalled(nested)).toBe(true);
+    expect(agentDepsInstalledSync(nested)).toBe(true);
+  });
+
+  it("requires ALL declared deps — a partial install (SDK present, zod missing) is NOT ready", async () => {
+    const project = await tmp("agent-deps-partial-");
+    await writeManifest(project, ["@sapiom/agent", "@sapiom/tools", "zod"]);
+
+    // npm has written the SDK but not zod yet — the bundle would still fail on
+    // "Could not resolve zod/v4", so this must read as not-ready.
+    await installPkg(project, "@sapiom/agent");
+    await installPkg(project, "@sapiom/tools");
+    expect(await agentDepsInstalled(project)).toBe(false);
+    expect(agentDepsInstalledSync(project)).toBe(false);
+
+    // zod lands — now the full dependency set resolves.
+    await installPkg(project, "zod");
+    expect(await agentDepsInstalled(project)).toBe(true);
+    expect(agentDepsInstalledSync(project)).toBe(true);
+  });
+
+  it("ignores devDependencies — they don't affect the type-stripped bundle", async () => {
+    const project = await tmp("agent-deps-devonly-");
+    await fs.writeFile(
+      path.join(project, "package.json"),
+      JSON.stringify({
+        name: "agent",
+        dependencies: { "@sapiom/agent": "1.0.0" },
+        devDependencies: { typescript: "^5.4.2", prettier: "^3.2.5" },
+      }),
+    );
+    await installPkg(project, "@sapiom/agent"); // devDeps intentionally NOT installed
+    expect(await agentDepsInstalled(project)).toBe(true);
+  });
+});

--- a/packages/harness/src/core/agent-deps.ts
+++ b/packages/harness/src/core/agent-deps.ts
@@ -1,0 +1,94 @@
+/**
+ * One shared notion of "this agent project's dependencies are installed",
+ * used by both the render pipeline (core/canvas-render.ts — decides whether to
+ * extract or show the "preparing" placeholder) and the install watcher
+ * (core/install-watcher.ts — decides when to re-render). Keeping the probe in
+ * one place stops those two from disagreeing about readiness, which would
+ * either flash the esbuild error or never re-render.
+ *
+ * "Ready" means EVERY runtime dependency the bundle imports is resolvable —
+ * the project's declared `dependencies` (e.g. `@sapiom/agent`, `@sapiom/tools`,
+ * `zod`), each found by walking `node_modules` up the directory tree exactly as
+ * Node/esbuild module resolution does. Three things this gets right:
+ *
+ *   - Requiring ALL declared deps, not just the SDK, closes the partial-install
+ *     window. `npm install` writes packages incrementally, so `@sapiom/agent`
+ *     can land before `zod`; keying on the SDK alone would let the watcher
+ *     re-render into a `Could not resolve "zod/v4"` failure — the very error
+ *     we're hiding. The graph appears only once the bundle can actually
+ *     succeed. (devDependencies — typescript, prettier — don't affect the
+ *     type-stripped bundle, so they're intentionally not required.)
+ *   - Checking each package's `package.json` (not just its directory) means a
+ *     dir npm created but hasn't populated yet still reads as "not ready".
+ *   - Walking UP resolves deps hoisted to a parent `node_modules` (a monorepo
+ *     checkout, the repo's own example fixtures), matching what the bundle can
+ *     resolve; a standalone fresh scaffold has no such ancestor, so it reads as
+ *     "preparing" until its own `npm install` lands.
+ *
+ * If `package.json` can't be read (a fixture without one), it falls back to the
+ * SDK package every agent project imports — never crashing the render on it.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+
+/** The SDK package every agent project imports — the fallback probe when a
+ *  project's package.json can't be read, and the source of the canonical
+ *  `Could not resolve "@sapiom/agent"` error on a fresh scaffold. */
+export const AGENT_SDK_PACKAGE = "@sapiom/agent";
+
+/** The `node_modules/<pkg>/package.json` candidate at each ancestor of
+ *  `projectDir` — the search path Node/esbuild walk to resolve a bare import. */
+function manifestCandidates(projectDir: string, pkg: string): string[] {
+  const candidates: string[] = [];
+  let dir = path.resolve(projectDir);
+  for (;;) {
+    candidates.push(path.join(dir, "node_modules", pkg, "package.json"));
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return candidates;
+}
+
+/** The runtime deps the bundle must resolve: the project's declared
+ *  `dependencies` keys, or the SDK alone if package.json is missing/unreadable. */
+function requiredDeps(projectDir: string): string[] {
+  try {
+    const raw = readFileSync(path.join(projectDir, "package.json"), "utf8");
+    const deps = (JSON.parse(raw) as { dependencies?: Record<string, string> }).dependencies;
+    const names = deps ? Object.keys(deps) : [];
+    return names.length > 0 ? names : [AGENT_SDK_PACKAGE];
+  } catch {
+    return [AGENT_SDK_PACKAGE];
+  }
+}
+
+function resolvesSync(projectDir: string, pkg: string): boolean {
+  return manifestCandidates(projectDir, pkg).some((c) => existsSync(c));
+}
+
+async function resolvesAsync(projectDir: string, pkg: string): Promise<boolean> {
+  for (const candidate of manifestCandidates(projectDir, pkg)) {
+    const found = await fsp
+      .access(candidate)
+      .then(() => true)
+      .catch(() => false);
+    if (found) return true;
+  }
+  return false;
+}
+
+/** Async readiness probe for the render pipeline — true iff every declared
+ *  runtime dependency resolves. */
+export async function agentDepsInstalled(projectDir: string): Promise<boolean> {
+  for (const dep of requiredDeps(projectDir)) {
+    if (!(await resolvesAsync(projectDir, dep))) return false;
+  }
+  return true;
+}
+
+/** Sync readiness probe for the install watcher's poll loop. */
+export function agentDepsInstalledSync(projectDir: string): boolean {
+  return requiredDeps(projectDir).every((dep) => resolvesSync(projectDir, dep));
+}

--- a/packages/harness/src/core/canvas-body.ts
+++ b/packages/harness/src/core/canvas-body.ts
@@ -196,6 +196,27 @@ export function buildErrorPanelHtml(title: string, reason: string): string {
 </section>`;
 }
 
+/** A calm, transient panel for a workflow whose dependencies aren't installed
+ *  yet (a freshly scaffolded project between `scaffold` and `npm install`).
+ *  Extraction WOULD fail here with esbuild "Could not resolve …" noise, so we
+ *  don't run it — we show this instead and let the install watcher re-render
+ *  once `node_modules` lands. Crucially it emits NO `#sapiom-render-error`
+ *  script, so the SPA shows no "render failed" card / Retry buttons: this is a
+ *  normal setup state, not an error the user has to act on. */
+export function buildPreparingPanelHtml(title: string): string {
+  return `<section class="canvas-panel">
+  <header class="canvas-header">
+    <div class="canvas-title-row">
+      <h1 class="canvas-title">${esc(title)}</h1>
+      <span class="canvas-badge">preparing</span>
+    </div>
+  </header>
+  <div class="canvas-diagram-panel">
+    <p class="canvas-empty-note">Preparing your agent — installing dependencies. The step graph appears here automatically once setup finishes.</p>
+  </div>
+</section>`;
+}
+
 /** Joins the workflow panel(s) into the final `#canvas-root` body — the string
  *  `renderCanvasDocument()` wraps. Each panel already carries its own legend
  *  footer (see `buildWorkflowPanelHtml`); there is no document-level footer. */

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -225,6 +225,74 @@ describe("renderCanvasForSession", () => {
   });
 });
 
+describe("dependencies not installed yet (fresh scaffold, pre-`npm install`)", () => {
+  // A temp dir under os.tmpdir() is OUTSIDE the repo, so no ancestor
+  // node_modules resolves @sapiom/agent — exactly a freshly scaffolded,
+  // not-yet-installed project. (The repo's own __fixtures__ resolve the SDK via
+  // the monorepo's node_modules, so they are NOT deps-missing.)
+  async function depsMissingProject(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canvas-render-noinstall-"));
+    tmpDirs.push(dir);
+    await fs.writeFile(
+      path.join(dir, "index.ts"),
+      `import { defineAgent } from "@sapiom/agent";\nexport default defineAgent({ name: "x", entry: "s", steps: {} });\n`,
+      "utf8",
+    );
+    return dir;
+  }
+
+  it("shows the calm 'preparing' placeholder — not the esbuild error — and flags depsMissing", async () => {
+    const cwd = await tmpCwd();
+    const project = await depsMissingProject();
+    const workflows: RenderableWorkflow[] = [{ path: project, name: "enrich-list-leads", definitionId: null }];
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: project }, workflows);
+
+    expect(outcome.depsMissing).toBe(true);
+    expect(outcome.extractionFailed).toEqual([]);
+    const html = await readRender(cwd, project);
+    expect(html).toContain("Preparing your agent");
+    // Crucially NOT the honest-error panel: no "render failed" badge, and no
+    // #sapiom-render-error script (which the SPA turns into the Retry card).
+    expect(html).not.toContain("render failed");
+    expect(html).not.toContain("Could not resolve");
+    expect(html).not.toContain('id="sapiom-render-error"');
+  });
+
+  it("preserves an existing good render on an unprompted deps-missing pass", async () => {
+    const cwd = await tmpCwd();
+    const project = await depsMissingProject();
+    const renderPath = renderFileFor(cwd, project);
+    await fs.mkdir(path.dirname(renderPath), { recursive: true });
+    await fs.writeFile(renderPath, "<!doctype html><!-- good -->", "utf8");
+    const workflows: RenderableWorkflow[] = [{ path: project, name: "enrich-list-leads", definitionId: null }];
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: project }, workflows, {
+      preserveExistingOnFailure: true,
+    });
+
+    expect(outcome.depsMissing).toBe(true);
+    expect(outcome.preservedExisting).toBe(true);
+    expect(await readRender(cwd, project)).toBe("<!doctype html><!-- good -->");
+  });
+
+  it("surfaceErrorOnMissingDeps forces the honest error (the install-timeout safety valve)", async () => {
+    const cwd = await tmpCwd();
+    const project = await depsMissingProject();
+    const workflows: RenderableWorkflow[] = [{ path: project, name: "enrich-list-leads", definitionId: null }];
+
+    const outcome = await renderCanvasForSession({ cwd, boundWorkflowPath: project }, workflows, {
+      surfaceErrorOnMissingDeps: true,
+    });
+
+    // Extraction runs and genuinely fails to resolve the SDK — the error panel
+    // (and its Retry/Ask actions) is restored, and depsMissing is NOT set.
+    expect(outcome.depsMissing).toBeUndefined();
+    expect(outcome.extractionFailed).toEqual(["enrich-list-leads"]);
+    expect(await readRender(cwd, project)).toContain("render failed");
+  });
+});
+
 describe("deterministic enrichment merged into renders", () => {
   const workflows: RenderableWorkflow[] = [{ path: ORDER_TRIAGE, name: "order-triage", definitionId: null }];
 

--- a/packages/harness/src/core/canvas-render.ts
+++ b/packages/harness/src/core/canvas-render.ts
@@ -25,6 +25,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { CANVAS_RENDERS_DIR } from "../shared/types.js";
+import { agentDepsInstalled } from "./agent-deps.js";
 import { renderCanvasDocument } from "./canvas-template.js";
 import { extractWorkflowGraphCached } from "./canvas-cache.js";
 import type { CanvasGraph } from "./canvas-graph.js";
@@ -33,6 +34,7 @@ import { deriveEnrichment } from "./canvas-derive.js";
 import {
   assembleCanvasBody,
   buildErrorPanelHtml,
+  buildPreparingPanelHtml,
   buildWorkflowPanelHtml,
 } from "./canvas-body.js";
 
@@ -89,6 +91,11 @@ export interface CanvasRenderOutcome {
   writeError?: string;
   /** True when `preserveExistingOnFailure` kept the existing render instead of writing an error panel over it. */
   preservedExisting?: boolean;
+  /** True when the workflow's `node_modules` isn't present yet, so extraction
+   *  was skipped and a calm "preparing" placeholder was written instead of an
+   *  esbuild error panel. The server arms an install watcher on this to
+   *  re-render once dependencies land — see server/index.ts. */
+  depsMissing?: boolean;
 }
 
 export interface RenderCanvasOptions {
@@ -101,6 +108,15 @@ export interface RenderCanvasOptions {
    * page IS the answer the user asked for.
    */
   preserveExistingOnFailure?: boolean;
+  /**
+   * Force extraction even when the project's dependencies aren't installed,
+   * so the honest esbuild error panel is written instead of the calm
+   * "preparing" placeholder. The install watcher's timeout path sets this to
+   * restore the Retry / Ask-coding-agent actions when an install never
+   * completes — otherwise the placeholder (and its `depsMissing` re-arm) would
+   * wait forever. Normal renders leave it off.
+   */
+  surfaceErrorOnMissingDeps?: boolean;
 }
 
 function badgesFor(workflow: RenderableWorkflow): string[] {
@@ -169,6 +185,35 @@ export async function renderWorkflowRenderFile(
   bound: RenderableWorkflow,
   options: RenderCanvasOptions = {},
 ): Promise<CanvasRenderOutcome> {
+  const renderPath = renderFileFor(cwd, bound.path);
+
+  // A freshly scaffolded project — between `scaffold` and the coding agent's
+  // `npm install` — has no installed SDK, so extraction (an esbuild bundle of
+  // the project's own index.ts) is guaranteed to fail with "Could not resolve
+  // @sapiom/agent / zod/v4". That's not an error the user caused or can act on;
+  // it self-resolves when install finishes. So skip extraction entirely and
+  // write a calm "preparing" placeholder, flagging `depsMissing` so the server
+  // arms an install watcher that re-renders once dependencies land. A bundle
+  // failure WITH deps installed stays a genuine error (below).
+  if (!options.surfaceErrorOnMissingDeps && !(await agentDepsInstalled(bound.path))) {
+    const outcome: CanvasRenderOutcome = {
+      mode: "single",
+      workflowPath: bound.path,
+      renderPath,
+      extractionFailed: [],
+      depsMissing: true,
+    };
+    // Preserve semantics: an unprompted render must not replace an existing
+    // (possibly good) diagram just because deps went missing — but still flag
+    // depsMissing so the watcher re-renders when they return.
+    if (options.preserveExistingOnFailure && (await pathExists(renderPath))) {
+      outcome.preservedExisting = true;
+      return outcome;
+    }
+    await writeRenderFile(renderPath, buildPreparingPanelHtml(bound.name), outcome);
+    return outcome;
+  }
+
   const { result, cached } = await extractWorkflowGraphCached(bound.path);
   const failed = !result.ok;
 
@@ -180,7 +225,6 @@ export async function renderWorkflowRenderFile(
 
   const body = buildSingleBody(bound, result.ok ? result.graph : null, result.ok ? null : result.reason, enrichment);
 
-  const renderPath = renderFileFor(cwd, bound.path);
   const outcome: CanvasRenderOutcome = {
     mode: "single",
     workflowPath: bound.path,
@@ -191,26 +235,39 @@ export async function renderWorkflowRenderFile(
   };
 
   // An unprompted render that failed to extract must not destroy an existing
-  // (possibly good) diagram for this workflow — e.g. a project that merely
-  // hasn't run `npm install` yet after a fresh clone.
-  if (options.preserveExistingOnFailure && failed) {
-    const exists = await fs
-      .access(renderPath)
-      .then(() => true)
-      .catch(() => false);
-    if (exists) {
-      outcome.preservedExisting = true;
-      return outcome;
-    }
+  // (possibly good) diagram for this workflow — e.g. an agent mid-edit whose
+  // sources are transiently un-buildable. (The deps-not-installed case is
+  // handled above; this is a genuine extraction failure with deps present.)
+  if (options.preserveExistingOnFailure && failed && (await pathExists(renderPath))) {
+    outcome.preservedExisting = true;
+    return outcome;
   }
 
+  await writeRenderFile(renderPath, body, outcome);
+  return outcome;
+}
+
+/** True if `p` exists (any type). */
+async function pathExists(p: string): Promise<boolean> {
+  return fs
+    .access(p)
+    .then(() => true)
+    .catch(() => false);
+}
+
+/** Writes the render file, skipping an identical rewrite (which would bump the
+ *  mtime and make the canvas watcher fire a needless iframe reload — a true
+ *  no-op now that any workflow source edit triggers a re-render). A write
+ *  failure (e.g. an unwritable cwd) is captured on `outcome.writeError`;
+ *  extraction success/failure is unaffected. */
+async function writeRenderFile(
+  renderPath: string,
+  body: string,
+  outcome: CanvasRenderOutcome,
+): Promise<void> {
   try {
     const document = renderCanvasDocument(body);
     const existing = await fs.readFile(renderPath, "utf8").catch(() => null);
-    // Skip the write when nothing changed: an identical rewrite would still
-    // bump the render file's mtime and make the canvas watcher fire a needless
-    // iframe reload. This matters now that any workflow source edit triggers a
-    // re-render — a save that doesn't change the diagram is a true no-op.
     if (existing !== document) {
       await fs.mkdir(path.dirname(renderPath), { recursive: true });
       await fs.writeFile(renderPath, document, "utf8");
@@ -218,5 +275,4 @@ export async function renderWorkflowRenderFile(
   } catch (err) {
     outcome.writeError = err instanceof Error ? err.message : String(err);
   }
-  return outcome;
 }

--- a/packages/harness/src/core/canvas-template.ts
+++ b/packages/harness/src/core/canvas-template.ts
@@ -403,6 +403,44 @@ ${bodyHtml}
 `;
 }
 
+/**
+ * A minimal, THEME-AWARE document for the canvas pane's non-graph states —
+ * the empty state and the "rendering…" placeholder the server serves for a
+ * session with nothing (yet) to draw. It reuses the SAME theme mechanism as
+ * `renderCanvasDocument` (the `?theme` reader + the ported token block), so
+ * these pages follow the app's light/dark theme instead of always painting a
+ * white panel inside a dark app. No graph, so it deliberately omits the
+ * run-state/pan-zoom script and SVG defs — just a centered title + subtitle on
+ * the themed canvas backdrop. `title`/`subtitle` are trusted, static server
+ * copy (never user input), so they're inlined without escaping.
+ */
+export function renderCanvasMessageDocument(title: string, subtitle: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agent Studio canvas</title>
+<script>
+${THEME_SCRIPT}
+</script>
+<style>
+${themeStyleBlock()}
+.canvas-message { text-align: center; padding: 0 2rem; max-width: 520px; }
+.canvas-message h1 { margin: 0 0 0.5rem; font-size: 1.1rem; font-weight: 600; color: var(--canvas-text); }
+.canvas-message p { margin: 0; font-size: 13px; color: var(--canvas-text-dim); }
+</style>
+</head>
+<body>
+<div class="canvas-message">
+  <h1>${title}</h1>
+  <p>${subtitle}</p>
+</div>
+</body>
+</html>
+`;
+}
+
 const TEMPLATE_BODY = `
 <!--
   ═══════════════════════════════════════════════════════════════════════

--- a/packages/harness/src/core/install-watcher.test.ts
+++ b/packages/harness/src/core/install-watcher.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { InstallWatcherManager } from "./install-watcher.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Simulate `npm install` completing — the SDK package esbuild must resolve
+ *  (its package.json present, as the readiness probe checks). The project has
+ *  no package.json, so the probe falls back to requiring just the SDK. */
+async function installDeps(projectDir: string): Promise<void> {
+  const dir = path.join(projectDir, "node_modules", "@sapiom/agent");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "@sapiom/agent" }));
+}
+
+let projectDir: string;
+let manager: InstallWatcherManager;
+let onInstalled: ReturnType<typeof vi.fn>;
+let onTimeout: ReturnType<typeof vi.fn>;
+
+describe("InstallWatcherManager", () => {
+  beforeEach(async () => {
+    // Outside the repo, so no ancestor node_modules resolves @sapiom/agent
+    // until this test creates it — a genuine pre-install project.
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-watch-"));
+    onInstalled = vi.fn();
+    onTimeout = vi.fn();
+    manager = new InstallWatcherManager(
+      { onInstalled, onTimeout },
+      { pollIntervalMs: 20, timeoutMs: 10_000 },
+    );
+  });
+
+  afterEach(async () => {
+    manager.stopAll();
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("fires onInstalled once deps land, then self-removes", async () => {
+    manager.start("sess-1", projectDir);
+    await sleep(60);
+    expect(onInstalled).not.toHaveBeenCalled();
+    expect(manager.size).toBe(1);
+
+    await installDeps(projectDir);
+    await sleep(80);
+
+    expect(onInstalled).toHaveBeenCalledWith("sess-1");
+    expect(onInstalled).toHaveBeenCalledTimes(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(manager.size).toBe(0); // one-shot: removed itself
+  });
+
+  it("fires onInstalled promptly when deps are already present at arm time", async () => {
+    await installDeps(projectDir);
+    manager.start("sess-1", projectDir);
+    await sleep(40);
+
+    expect(onInstalled).toHaveBeenCalledWith("sess-1");
+    expect(manager.size).toBe(0);
+  });
+
+  it("fires onTimeout (not onInstalled) when install never completes", async () => {
+    const timed = new InstallWatcherManager(
+      { onInstalled, onTimeout },
+      { pollIntervalMs: 20, timeoutMs: 60 },
+    );
+    timed.start("sess-1", projectDir);
+    await sleep(140);
+
+    expect(onTimeout).toHaveBeenCalledWith("sess-1");
+    expect(onInstalled).not.toHaveBeenCalled();
+    expect(timed.size).toBe(0);
+    timed.stopAll();
+  });
+
+  it("stop() cancels a pending watcher — no callback fires afterward", async () => {
+    manager.start("sess-1", projectDir);
+    await sleep(40);
+    manager.stop("sess-1");
+    expect(manager.size).toBe(0);
+
+    await installDeps(projectDir);
+    await sleep(80);
+    expect(onInstalled).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent for the same project — a repeated arm keeps one watcher and fires once", async () => {
+    manager.start("sess-1", projectDir);
+    manager.start("sess-1", projectDir);
+    manager.start("sess-1", projectDir);
+    expect(manager.size).toBe(1);
+
+    await installDeps(projectDir);
+    await sleep(80);
+    expect(onInstalled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/harness/src/core/install-watcher.ts
+++ b/packages/harness/src/core/install-watcher.ts
@@ -1,0 +1,154 @@
+/**
+ * Install watcher: bridges the gap between a freshly scaffolded agent project
+ * and its `npm install` finishing. A brand-new project renders a calm
+ * "preparing" placeholder because its dependencies aren't installed yet
+ * (core/canvas-render.ts's `depsMissing` path). Neither the canvas watcher nor
+ * the workspace watcher can re-fire the render when install completes — both
+ * deliberately ignore `node_modules` (it's high-churn, and a workflow marker
+ * never lives there). So without this, the placeholder would sit forever and
+ * the user would have to hit Retry. This watcher notices the SDK landing and
+ * lets the server re-render automatically.
+ *
+ * It POLLS a precise marker (core/agent-deps.ts — the SDK package esbuild must
+ * resolve) rather than `fs.watch`ing `node_modules`: polling one path avoids
+ * the churn both other watchers avoid, is deterministic, and — keyed on the
+ * exact package the bundle needs — never fires on a half-populated
+ * `node_modules`. One-shot: it fires `onInstalled` once and closes. If install
+ * never completes within a bounded window (offline, npm missing on PATH in a
+ * stripped host), it fires `onTimeout` so the server can restore the honest
+ * error panel — the placeholder is for the normal install window, not a dead
+ * end.
+ */
+import { agentDepsInstalledSync } from "./agent-deps.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 750;
+/** How long to wait for install before giving up and restoring the honest
+ *  error. Generous — a cold `npm install` on a slow network can run a while. */
+const DEFAULT_TIMEOUT_MS = 180_000;
+
+export interface InstallWatcherOptions {
+  /** Poll cadence in ms (test hook). */
+  pollIntervalMs?: number;
+  /** Max wait before `onTimeout` fires (test hook). */
+  timeoutMs?: number;
+}
+
+/** One session's install watcher — polls until the project's deps are
+ *  installed, then fires exactly once and stops itself. */
+class SessionInstallWatcher {
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly projectDir: string,
+    private readonly harnessSessionId: string,
+    private readonly onInstalled: (harnessSessionId: string) => void,
+    private readonly onTimeout: (harnessSessionId: string) => void,
+    options: InstallWatcherOptions = {},
+  ) {
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    // Deps may already be present the moment we arm (install finished between
+    // the render deciding `depsMissing` and the server arming us) — check on
+    // the next tick so the manager has finished registering this watcher
+    // before any callback can fire and re-enter it.
+    this.pollTimer = setInterval(() => this.check(), pollIntervalMs);
+    this.pollTimer.unref?.();
+    setTimeout(() => this.check(), 0).unref?.();
+
+    this.timeoutTimer = setTimeout(() => {
+      if (this.closed) return;
+      this.close();
+      this.onTimeout(this.harnessSessionId);
+    }, timeoutMs);
+    this.timeoutTimer.unref?.();
+  }
+
+  private check(): void {
+    if (this.closed) return;
+    if (!agentDepsInstalledSync(this.projectDir)) return;
+    this.close();
+    this.onInstalled(this.harnessSessionId);
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    if (this.timeoutTimer) clearTimeout(this.timeoutTimer);
+    this.pollTimer = null;
+    this.timeoutTimer = null;
+  }
+}
+
+export interface InstallWatcherManagerDeps {
+  /** Dependencies are now installed for this session's project — re-render. */
+  onInstalled(harnessSessionId: string): void;
+  /** Install didn't complete within the window — restore the honest error. */
+  onTimeout(harnessSessionId: string): void;
+}
+
+/** Registry of one SessionInstallWatcher per session currently waiting on an
+ *  install. Arm from a `depsMissing` render; it self-removes on fire. */
+export class InstallWatcherManager {
+  private readonly watchers = new Map<
+    string,
+    { projectDir: string; watcher: SessionInstallWatcher }
+  >();
+
+  constructor(
+    private readonly deps: InstallWatcherManagerDeps,
+    private readonly options: InstallWatcherOptions = {},
+  ) {}
+
+  /**
+   * Begin (or continue) watching `projectDir` for this session's install.
+   * Idempotent for the same project: a repeated `depsMissing` render must NOT
+   * reset the timeout. Re-arms only when the watched project actually changed
+   * (a rebind to a different workflow).
+   */
+  start(harnessSessionId: string, projectDir: string): void {
+    const existing = this.watchers.get(harnessSessionId);
+    if (existing) {
+      if (existing.projectDir === projectDir) return;
+      existing.watcher.close();
+    }
+    const watcher = new SessionInstallWatcher(
+      projectDir,
+      harnessSessionId,
+      (id) => this.fire(id, this.deps.onInstalled),
+      (id) => this.fire(id, this.deps.onTimeout),
+      this.options,
+    );
+    this.watchers.set(harnessSessionId, { projectDir, watcher });
+  }
+
+  /** Removes and closes this session's watcher, then invokes `cb`. Removal
+   *  happens first so the callback's own re-render can safely re-arm. */
+  private fire(
+    harnessSessionId: string,
+    cb: (harnessSessionId: string) => void,
+  ): void {
+    const entry = this.watchers.get(harnessSessionId);
+    if (entry) {
+      entry.watcher.close();
+      this.watchers.delete(harnessSessionId);
+    }
+    cb(harnessSessionId);
+  }
+
+  stop(harnessSessionId: string): void {
+    this.watchers.get(harnessSessionId)?.watcher.close();
+    this.watchers.delete(harnessSessionId);
+  }
+
+  stopAll(): void {
+    for (const harnessSessionId of [...this.watchers.keys()]) this.stop(harnessSessionId);
+  }
+
+  /** Test/debug helper — how many sessions currently have an active watcher. */
+  get size(): number {
+    return this.watchers.size;
+  }
+}

--- a/packages/harness/src/server/canvas.ts
+++ b/packages/harness/src/server/canvas.ts
@@ -24,6 +24,7 @@ import * as path from "node:path";
 import { Router, type Router as ExpressRouter, type Request, type Response } from "express";
 import { CANVAS_DIR, CANVAS_INDEX } from "../shared/types.js";
 import { slugForWorkflowPath } from "../core/canvas-render.js";
+import { renderCanvasMessageDocument } from "../core/canvas-template.js";
 import { isMachineGeneratedCanvas } from "../core/canvas-index-classify.js";
 import { resolveWithinRoot } from "../core/path-safety.js";
 
@@ -60,31 +61,22 @@ const CANVAS_CSP =
   "style-src 'self' 'unsafe-inline'; img-src * data: blob:; connect-src *; " +
   "object-src 'none'; frame-ancestors 'self'";
 
-const EMPTY_STATE_HTML = `<!doctype html>
-<html>
-<head><meta charset="utf-8"><title>Canvas — nothing here yet</title></head>
-<body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
-  <div>
-    <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Nothing rendered yet</h1>
-    <p style="margin: 0;">Select an agent in the rail and its step graph renders here automatically.</p>
-  </div>
-</body>
-</html>`;
+// Theme-aware (via renderCanvasMessageDocument's `?theme` reader) so these
+// follow the app's light/dark theme — the iframe src carries `?theme=<theme>`.
+// A plain white panel here read as broken inside a dark-themed app.
+const EMPTY_STATE_HTML = renderCanvasMessageDocument(
+  "Nothing rendered yet",
+  "Select an agent in the rail and its step graph renders here automatically.",
+);
 
 /** Served for a BOUND session whose render file hasn't been written yet
  *  (render in flight, or a server restart before any re-render). The pane
  *  hot-reloads the moment the render lands, so this is only ever briefly
  *  visible. */
-const PENDING_RENDER_HTML = `<!doctype html>
-<html>
-<head><meta charset="utf-8"><title>Canvas — rendering</title></head>
-<body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #444; text-align: center; padding: 0 2rem;">
-  <div>
-    <h1 style="font-size: 1.1rem; margin-bottom: 0.5rem;">Rendering agent diagram…</h1>
-    <p style="margin: 0;">This pane reloads automatically when the diagram is ready.</p>
-  </div>
-</body>
-</html>`;
+const PENDING_RENDER_HTML = renderCanvasMessageDocument(
+  "Rendering agent diagram…",
+  "This pane reloads automatically when the diagram is ready.",
+);
 
 export interface CanvasSession {
   cwd: string;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -83,6 +83,7 @@ import {
 } from "../core/inject/retention.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
 import { WorkspaceWatcherManager } from "../core/workspace-watcher.js";
+import { InstallWatcherManager } from "../core/install-watcher.js";
 import { ExecutionDetector } from "../core/execution-detector.js";
 import { PortDetector, portFromUrl } from "../core/port-detector.js";
 import { EventBus } from "../core/event-bus.js";
@@ -874,6 +875,34 @@ export const startServer = async (
     },
   });
 
+  // Bridges the scaffold→`npm install` gap: a brand-new project renders a calm
+  // "preparing" placeholder (core/canvas-render.ts's depsMissing path) because
+  // its deps aren't installed yet, and neither watcher above re-fires when
+  // install completes (both ignore node_modules). This one notices deps landing
+  // and re-renders, so the placeholder becomes the step graph with no Retry.
+  const installWatcher = new InstallWatcherManager({
+    onInstalled: (harnessSessionId) => {
+      const session = sessionManager.get(harnessSessionId);
+      if (session && session.status !== "exited") {
+        void autoRenderCanvas(session).catch((err: unknown) => {
+          console.error("[harness] post-install canvas render failed:", err);
+        });
+      }
+    },
+    onTimeout: (harnessSessionId) => {
+      // Install never completed within the window (offline, npm missing on
+      // PATH in a stripped host). Restore the honest error panel so the user
+      // regains the Retry / Ask-coding-agent actions instead of a placeholder
+      // that would wait forever.
+      const session = sessionManager.get(harnessSessionId);
+      if (session && session.status !== "exited") {
+        void renderCanvasSurfacingDepErrors(session).catch((err: unknown) => {
+          console.error("[harness] install-timeout canvas render failed:", err);
+        });
+      }
+    },
+  });
+
   // Sessions that have already had their one-time on-start workspace rescan.
   // onStatusChange also fires on later status broadcasts (including the
   // bind/unbind frames setBoundWorkflowPath emits), so this guard keeps the
@@ -911,6 +940,7 @@ export const startServer = async (
     } else if (session.status === "exited") {
       canvasWatcher.stop(session.id);
       workspaceWatcher.stop(session.id);
+      installWatcher.stop(session.id);
       portDetector.reset(session.id);
       executionDetector.reset(session.id);
       // Let a resumed session get a fresh on-start rescan.
@@ -1007,13 +1037,49 @@ export const startServer = async (
   // autoRenderCanvas is the UNPROMPTED variant (session-create/boot) that
   // won't replace a workflow's existing render with an error panel when its
   // extraction fails.
+  // A depsMissing render (fresh scaffold, pre-install) shows the "preparing"
+  // placeholder; arm the install watcher to re-render once deps land. Any other
+  // outcome means we no longer need to wait — cancel a pending watcher (no-op
+  // if none). Shared by every render trigger so the arm/disarm stays in lockstep
+  // with what the pane is actually showing.
+  const reactToRenderOutcome = (
+    session: HarnessSession,
+    outcome: Awaited<ReturnType<typeof renderCanvasForSession>>,
+  ): void => {
+    if (outcome.depsMissing && outcome.workflowPath) {
+      installWatcher.start(session.id, outcome.workflowPath);
+    } else {
+      installWatcher.stop(session.id);
+    }
+  };
   const renderCanvas = async (session: HarnessSession): Promise<void> => {
-    await renderCanvasForSession(session, await canvasWorkflowsForSession(session));
+    const outcome = await renderCanvasForSession(
+      session,
+      await canvasWorkflowsForSession(session),
+    );
+    reactToRenderOutcome(session, outcome);
   };
   const autoRenderCanvas = async (session: HarnessSession): Promise<void> => {
-    await renderCanvasForSession(session, await canvasWorkflowsForSession(session), {
-      preserveExistingOnFailure: true,
-    });
+    const outcome = await renderCanvasForSession(
+      session,
+      await canvasWorkflowsForSession(session),
+      { preserveExistingOnFailure: true },
+    );
+    reactToRenderOutcome(session, outcome);
+  };
+  // Used only by the install-watcher timeout: forces extraction even with deps
+  // missing so the honest esbuild error panel (and its Retry/Ask actions) is
+  // written instead of the placeholder. Does NOT re-arm the watcher — its
+  // outcome is an extraction failure, not depsMissing.
+  const renderCanvasSurfacingDepErrors = async (
+    session: HarnessSession,
+  ): Promise<void> => {
+    const outcome = await renderCanvasForSession(
+      session,
+      await canvasWorkflowsForSession(session),
+      { surfaceErrorOnMissingDeps: true },
+    );
+    reactToRenderOutcome(session, outcome);
   };
 
   const initialWorkflowScan = scanWorkflowsAndBroadcast(launchDir).catch(
@@ -1568,6 +1634,7 @@ export const startServer = async (
       clearInterval(ndjsonRetentionTimer);
       canvasWatcher.stopAll();
       workspaceWatcher.stopAll();
+      installWatcher.stopAll();
       for (const tailer of codexTailers.values()) tailer.stop();
       codexTailers.clear();
       // Closing the HTTP/WS server doesn't touch unrelated child processes


### PR DESCRIPTION
## Problem

Right after scaffolding a new agent in Agent Studio, the Canvas flashed a raw **"Render failed"** panel full of esbuild noise:

```
ERROR: Could not resolve "@sapiom/agent"
Could not resolve "zod/v4"
Build failed with 2 errors
```

It's a **timing bug, not an agent problem**. `sapiom_dev_agents_scaffold` writes the source + `sapiom.json` marker, the workspace watcher auto-binds and renders — but this happens *before* the coding agent's `npm install` runs, so esbuild can't resolve the project's own dependencies. And nothing re-rendered once install finished (both watchers ignore `node_modules`, and the extraction cache keys only on `.ts/.tsx` sources), so the user had to hit **Retry**.

While testing the fix, a second issue surfaced: the Canvas **empty-state / "rendering…" pages were hardcoded light**, so they painted a white panel inside a dark-themed app.

## Fix

**1. "Dependencies not installed" is now a distinct, non-error state.** `renderWorkflowRenderFile` — the single seam every render trigger funnels through — checks readiness first; if deps aren't installed it skips extraction and writes a calm **"Preparing your agent…"** placeholder that emits *no* render-error signal (so no Retry/Ask card). Readiness means **every declared runtime dependency resolves**, walking `node_modules` up the tree exactly as esbuild does (`core/agent-deps.ts`):
- Requiring *all* deps (not just the SDK) closes the partial-install window — npm writes packages incrementally, so `@sapiom/agent` can land before `zod`; keying on the SDK alone would re-render into a `Could not resolve "zod/v4"` failure.
- Walking up resolves deps hoisted to a monorepo parent (matches what the bundle can actually resolve).

**2. Auto-recovery.** A one-shot `InstallWatcherManager` (`core/install-watcher.ts`) polls for deps to land, then re-renders — the placeholder becomes the step graph **with no user action**. A bounded timeout restores the honest error panel (and its Retry/Ask actions) if install never completes.

**3. Theme fix.** Added `renderCanvasMessageDocument()` to the shared canvas shell, reusing the same `?theme` reader + token block, and routed the empty-state / "rendering…" pages through it. They now follow the app's light/dark theme like the graph shell — no duplicated token values.

A genuine bundle failure *with* deps installed still shows the honest error panel + Retry, unchanged.

## Files

- `core/canvas-render.ts` — deps-missing detection, `depsMissing` outcome, placeholder branch, `surfaceErrorOnMissingDeps` (timeout valve)
- `core/canvas-body.ts` — `buildPreparingPanelHtml` (no error-script emit)
- `core/agent-deps.ts` — shared readiness probe (all declared deps, walk-up)
- `core/install-watcher.ts` — one-shot per-session node_modules watcher
- `core/canvas-template.ts` + `server/canvas.ts` — themed empty-state / rendering pages
- `server/index.ts` — arm/stop the watcher from `depsMissing`, re-render on install, timeout fallback

## Testing

- `pnpm --filter @sapiom/harness build` + full suite: **1767 unit + 4 perf pass**; typecheck + lint clean.
- New tests: deps-missing → placeholder (not error), the walk-up + partial-install probe, the timeout safety valve, and the watcher's fire/timeout/idempotency behavior.
- Verified live in the desktop dev app (Agent Studio): scaffold → dark "Preparing…" placeholder (no red errors) → auto-renders the step graph on install completion, no Retry click; empty/rendering states now match the app theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
