### PR TITLE
feat(harness): brand-coherent terminal colors via Claude Code ANSI-theme pinning

### DIFF
--- a/.changeset/terminal-ansi-palette.md
+++ b/.changeset/terminal-ansi-palette.md
@@ -1,0 +1,20 @@
+---
+"@sapiom/harness": patch
+---
+
+Recolor the embedded terminal so Claude Code's accent colors match the Studio
+brand, without touching the terminal background.
+
+Claude Code renders in 256-color by default, so the terminal's own 16-color
+palette never reached its output — its "blue", "green", etc. were Claude's, not
+Studio's. Each Claude session is now pinned to Claude Code's `dark-ansi` /
+`light-ansi` theme (matched to the app theme) through the generated `--settings`
+file, which routes Claude's colors through the terminal's ANSI ramp. That ramp
+(`Terminal.tsx`) is retuned to a brand-coherent palette: a calmer blue, the
+Studio green for success/live state, and harmonized red / yellow / cyan /
+magenta that read cleanly on the recessed `--bg` surface (which is unchanged).
+
+The app theme is threaded through session create and persisted on the session so
+resume keeps the same base; unthemed launches (server-side auto-create, a legacy
+session resumed from before this existed) omit the theme and keep Claude's
+default rendering.

--- a/packages/harness-desktop/CHANGELOG.md
+++ b/packages/harness-desktop/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @sapiom/harness-desktop
 
+## 0.2.3
+
+### Patch Changes
+
+- Brand-coherent terminal colors: Claude Code's accent colors now match the
+  Studio palette instead of Claude's defaults. Each session is pinned to Claude
+  Code's `dark-ansi` / `light-ansi` theme (matched to the app theme), routing
+  its colors through the terminal's 16-color ramp, which is retuned to a calmer
+  blue, the Studio green for success/live state, and harmonized red / yellow /
+  cyan / magenta. The recessed terminal background is unchanged. (Ships the
+  `@sapiom/harness` change ahead of the batched changeset release.)
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sapiom/harness-desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Agent Studio desktop app — a one-click native host for running Claude Code or Codex in a Sapiom-configured environment. The npx CLI (@sapiom/harness) remains the backup host over the same startServer().",
   "homepage": "https://sapiom.ai",

--- a/packages/harness/src/core/inject/claude-settings.test.ts
+++ b/packages/harness/src/core/inject/claude-settings.test.ts
@@ -72,6 +72,29 @@ describe("generateClaudeSettings", () => {
     expect(source).toContain("AbortController");
   });
 
+  it("omits the theme key by default (Claude keeps its default rendering)", async () => {
+    const { settingsPath } = await generateClaudeSettings({
+      harnessSessionId: "session-abc",
+      generatedRoot: tmpDir,
+    });
+    const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+    expect(settings).not.toHaveProperty("theme");
+    expect(settings.hooks).toBeDefined();
+  });
+
+  it("pins the ANSI theme when claudeTheme is given, alongside the hooks", async () => {
+    // The ANSI theme is what makes the terminal's own palette control Claude's
+    // colors; the hooks must still be written next to it.
+    const { settingsPath } = await generateClaudeSettings({
+      harnessSessionId: "session-abc",
+      generatedRoot: tmpDir,
+      claudeTheme: "light-ansi",
+    });
+    const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+    expect(settings.theme).toBe("light-ansi");
+    expect(Object.keys(settings.hooks)).toHaveLength(6);
+  });
+
   it("is safe to regenerate for the same session (overwrites in place)", async () => {
     const first = await generateClaudeSettings({
       harnessSessionId: "session-abc",

--- a/packages/harness/src/core/inject/claude-settings.ts
+++ b/packages/harness/src/core/inject/claude-settings.ts
@@ -27,6 +27,18 @@ const HOOK_EVENTS = [
 
 export type ClaudeHookEvent = (typeof HOOK_EVENTS)[number];
 
+/**
+ * The two Claude Code themes that paint with the terminal's own 16-color ANSI
+ * palette (`ansi:<name>`) instead of hardcoded 256-color hex. Selecting one of
+ * these is what makes the embedded xterm's palette (Terminal.tsx's
+ * DARK_ANSI/LIGHT_ANSI) authoritative over Claude's accent colors — without it
+ * Claude emits fixed 256-color indices the palette can't touch. `theme` is not
+ * a documented settings.json key but is honoured by Claude Code (verified on
+ * 2.1.220); an older/newer build that ignores it simply falls back to its
+ * default 256-color rendering, so this degrades gracefully rather than failing.
+ */
+export type ClaudeAnsiTheme = "dark-ansi" | "light-ansi";
+
 export interface GenerateClaudeSettingsOptions {
   /** The harness session this config is generated for. */
   harnessSessionId: string;
@@ -36,6 +48,13 @@ export interface GenerateClaudeSettingsOptions {
    * tests to avoid touching the real home directory.
    */
   generatedRoot?: string;
+  /**
+   * ANSI theme to pin for this session so the app's terminal palette controls
+   * Claude's colors. Match it to the app theme (dark app → `dark-ansi`) or
+   * secondary/dim text loses contrast. Omitted → no `theme` key is written and
+   * Claude keeps its default (256-color) rendering.
+   */
+  claudeTheme?: ClaudeAnsiTheme;
 }
 
 export interface GeneratedClaudeSettings {
@@ -156,6 +175,7 @@ function settingsDirFor(root: string, harnessSessionId: string): string {
 export async function generateClaudeSettings(
   options: GenerateClaudeSettingsOptions,
 ): Promise<GeneratedClaudeSettings> {
+  const { claudeTheme } = options;
   const root = expandHome(options.generatedRoot ?? HARNESS_PATHS.generated);
   const dir = settingsDirFor(root, options.harnessSessionId);
   await fs.mkdir(dir, { recursive: true });
@@ -192,7 +212,8 @@ export async function generateClaudeSettings(
   }
 
   const settingsPath = path.join(dir, "settings.json");
-  await fs.writeFile(settingsPath, JSON.stringify({ hooks }, null, 2) + "\n", "utf8");
+  const settings = claudeTheme ? { theme: claudeTheme, hooks } : { hooks };
+  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
 
   return { settingsPath, emitScriptPath };
 }

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -231,7 +231,7 @@ export type SessionActivityListener = (harnessSessionId: string) => void;
  */
 export type LaunchOptsBuilder = (
   harnessSessionId: string,
-  req: Pick<CreateSessionRequest, "cwd" | "harness" | "profile" | "rehydrateFrom">,
+  req: Pick<CreateSessionRequest, "cwd" | "harness" | "profile" | "rehydrateFrom" | "theme">,
 ) => Omit<LaunchOpts, "harnessSessionId" | "cwd"> | Promise<Omit<LaunchOpts, "harnessSessionId" | "cwd">>;
 
 const defaultBuildLaunchOpts: LaunchOptsBuilder = () => ({});
@@ -453,6 +453,10 @@ export class SessionManager {
       // nothing for yields no brief, and this stays null so nothing downstream
       // presents an empty-handed fresh session as a continuation.
       rehydratedFrom: opts.rehydratedFrom ?? null,
+      // Persisted so resume() regenerates the same ANSI base — otherwise a
+      // resumed session would fall back to the server default and its dim text
+      // could lose contrast against a differently-themed terminal.
+      ...(req.theme ? { theme: req.theme } : {}),
       ready: false,
     };
     this.sessions.set(id, session);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -337,9 +337,21 @@ function createDefaultBuildLaunchOpts(
     const viaSystemPrompt =
       brief !== null && rehydration?.deliveryFor(req.harness) === "launch-flag";
 
+    // Pin Claude's ANSI theme to the app theme so the terminal's own palette
+    // (Terminal.tsx DARK_ANSI/LIGHT_ANSI) controls its colors — matched base or
+    // dim text loses contrast. Only when the theme is known: an unthemed path
+    // (server-side auto-create, a legacy session resumed before this existed)
+    // omits it and Claude keeps its default 256-color rendering, exactly as before.
+    const claudeTheme =
+      req.theme === "light" ? "light-ansi" : req.theme === "dark" ? "dark-ansi" : undefined;
+
     const [settings, mcpConfigFile, systemPromptFile, pluginDir] =
       await Promise.all([
-        generateClaudeSettings({ harnessSessionId, generatedRoot }),
+        generateClaudeSettings({
+          harnessSessionId,
+          generatedRoot,
+          ...(claudeTheme ? { claudeTheme } : {}),
+        }),
         generateMcpConfig(harnessSessionId, {
           environment: process.env.SAPIOM_ENVIRONMENT,
           apiKey,

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -77,6 +77,7 @@ const createSessionSchema = z.object({
   harness: z.enum(SPAWNABLE_HARNESS_KINDS),
   profile: z.string().optional(),
   rehydrateFrom: z.string().min(1).optional(),
+  theme: z.enum(["light", "dark"]).optional(),
 }) satisfies z.ZodType<CreateSessionRequest>;
 
 const injectInputSchema = z.object({

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -164,6 +164,12 @@ export interface HarnessSession {
   status: SessionStatus;
   createdAt: string;
   lastActiveAt: string;
+  /**
+   * The app's UI theme at launch, mapped to Claude Code's matching ANSI theme
+   * so the terminal palette controls its colors. Persisted so resume reuses the
+   * same base. Absent on sessions created before this existed → server default.
+   */
+  theme?: UiTheme;
   /** Exit code when status === "exited". */
   exitCode?: number | null;
   /**
@@ -932,6 +938,9 @@ export interface SessionRecord {
 // POST   /api/track                     UiTrackRequest → { ok: true }  (UI-interaction analytics)
 // POST   /ingest                        (hook payloads; bearer = ingest token)
 
+/** The app's active UI theme, as tracked client-side (web/src/lib/theme.ts). */
+export type UiTheme = "light" | "dark";
+
 export interface CreateSessionRequest {
   cwd: string;
   harness: HarnessKind;
@@ -950,6 +959,14 @@ export interface CreateSessionRequest {
    * directory) on a summary that was never going to exist.
    */
   rehydrateFrom?: string;
+  /**
+   * The app's active UI theme when this session was launched. The server maps
+   * it to Claude Code's matching ANSI theme (`dark`→`dark-ansi`) so the
+   * terminal's own palette controls Claude's colors and its dim text keeps
+   * contrast. Persisted on the session so resume reuses the same base. Omitted
+   * → server default (see createDefaultBuildLaunchOpts).
+   */
+  theme?: UiTheme;
 }
 
 /**

--- a/packages/harness/web/src/components/Terminal.tsx
+++ b/packages/harness/web/src/components/Terminal.tsx
@@ -55,42 +55,50 @@ function readToken(name: string, fallback: string): string {
 }
 
 // ANSI 16-color ramps: terminal DATA colors (what CLIs paint with), not app
-// chrome — kept as constants per theme, same as a data-viz scale.
+// chrome — kept as constants per theme, same as a data-viz scale. Brand-coherent
+// and authoritative over Claude Code's colors: the harness pins Claude to its
+// `dark-ansi`/`light-ansi` theme (see core/inject/claude-settings.ts), so what
+// Claude calls "blue"/"green"/etc. is literally whatever these slots hold. Green
+// is the Studio brand green; blue is a calmer, less-saturated tone; the rest are
+// harmonized to read cleanly on --bg without any one hue shouting.
 const DARK_ANSI: Partial<ITheme> = {
   black: "#1a1a1e",
-  red: "#f87171",
-  green: "#4ade80",
-  yellow: "#f59e0b",
-  blue: "#3b82f6",
-  magenta: "#9b8fc4",
-  cyan: "#22d3ee",
-  white: "#f3f3f5",
-  brightBlack: "#404046",
-  brightRed: "#ff9b96",
-  brightGreen: "#86efac",
-  brightYellow: "#ffd966",
-  brightBlue: "#60a5fa",
-  brightMagenta: "#c4b5fd",
-  brightCyan: "#67e8f9",
+  red: "#e88a84",
+  green: "#6be195", // Studio brand green (dark)
+  yellow: "#e6b96f",
+  blue: "#6f9ae0", // calmer blue
+  magenta: "#b7a6dd",
+  cyan: "#74c8d4",
+  white: "#e8e8ec",
+  brightBlack: "#565661", // dim text — bumped from #404046 for legibility
+  brightRed: "#f4a7a1",
+  brightGreen: "#8ceab0", // brand green hover (dark)
+  brightYellow: "#f2cf93",
+  brightBlue: "#8fb5ea",
+  brightMagenta: "#ccbdf0",
+  brightCyan: "#97dce7",
   brightWhite: "#ffffff",
 };
 
 const LIGHT_ANSI: Partial<ITheme> = {
   black: "#3a3a3e",
-  red: "#dc2626",
-  green: "#16a34a",
-  yellow: "#b45309",
-  blue: "#2563eb",
-  magenta: "#7c3aed",
-  cyan: "#0891b2",
-  white: "#d4d4d8",
-  brightBlack: "#6b6b75",
-  brightRed: "#ef4444",
-  brightGreen: "#22c55e",
-  brightYellow: "#f59e0b",
-  brightBlue: "#3b82f6",
-  brightMagenta: "#9b8fc4",
-  brightCyan: "#22d3ee",
+  red: "#c0392b",
+  green: "#167e3a", // Studio brand green (light)
+  yellow: "#a86414",
+  blue: "#4f7cc4", // calmer blue
+  magenta: "#7a4fb0",
+  cyan: "#0e7d94",
+  // Mid grey, not near-white: near-white foreground is invisible on the light
+  // --bg anyway, and this keeps dim text legible if a dark-base session's
+  // `white` slot ends up mapped here after a mid-session theme toggle.
+  white: "#a6a6ae",
+  brightBlack: "#6b6b75", // dim text
+  brightRed: "#d64a3d",
+  brightGreen: "#1f9a4a", // brand green (brighter, light)
+  brightYellow: "#c67d1a",
+  brightBlue: "#6f9ae0",
+  brightMagenta: "#9268c4",
+  brightCyan: "#1596ad",
   brightWhite: "#ffffff",
 };
 

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -31,6 +31,8 @@ import type {
 
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
+import { getTheme } from "./theme";
+
 import {
   MOCK_FS_TREE,
   MOCK_HARNESSES,
@@ -380,9 +382,11 @@ class RealApi implements HarnessApi {
   }
 
   createSession(req: CreateSessionRequest): Promise<HarnessSession> {
+    // Default the launch theme to the app's live theme so the terminal palette
+    // controls Claude's colors (Terminal.tsx). An explicit req.theme still wins.
     return this.request<HarnessSession>("/api/sessions", {
       method: "POST",
-      body: JSON.stringify(req),
+      body: JSON.stringify({ theme: getTheme(), ...req }),
     });
   }
 


### PR DESCRIPTION
## What & why

In the Studio terminal, Claude Code's accent colors read as *Claude's* colors, not the Studio brand (e.g. the periwinkle blue in the trust dialog). Root cause: Claude Code renders in **256-color** by default (`TERM=xterm-256color`, no `COLORTERM`), so the terminal's own 16-color palette never reached its output — retuning the xterm ramp alone had no effect.

## Approach

- **Pin Claude to an ANSI theme.** Each session's generated `--settings` now sets Claude Code's `dark-ansi` / `light-ansi` theme (matched to the app theme), which routes Claude's colors through the terminal's 16-color ANSI ramp. Verified against `claude` 2.1.220: the ANSI themes emit basic-16 SGR codes and paint **no background** (the recessed `--bg` surface is untouched, as intended).
- **Retune the ramp** (`Terminal.tsx` `DARK_ANSI`/`LIGHT_ANSI`) to a brand-coherent palette: calmer blue, Studio green for success/live, harmonized red/yellow/cyan/magenta, all legible on `--bg`.
- **Thread the app theme** through session create (`CreateSessionRequest.theme`) and persist it on the session so resume keeps the same base. Unthemed paths (server-side auto-create, legacy resume) omit the theme and keep Claude's default rendering — no regression.

## Trade-off

ANSI mode makes *all* of Claude's output 16-color (incl. code/diff highlighting), flatter than its native 256-color themes. That's the only way to control its accents, and it's the normal look for a themed terminal.

## Notes

- Background is deliberately unchanged (validated with the real trust-dialog bytes recolored through the new ramp).
- Known limitation: theme is fixed at launch; a mid-session app-theme toggle re-applies the xterm palette but not Claude's ANSI base until the next session.

## Test

- `pnpm --filter @sapiom/harness typecheck` — clean
- `pnpm --filter @sapiom/harness build` — clean (SPA + server)
- New unit tests in `claude-settings.test.ts` (theme key written when set / omitted by default); full `claude-settings` / `session-manager` / `rest` suites pass
- Launched the desktop app and confirmed the recolored terminal live

Changeset included (`@sapiom/harness` patch → cascades `@sapiom/harness-desktop` to 0.2.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)