### PR TITLE
fix(harness-desktop): pin launchDir to the harness home so new agents stay flat

### DIFF
--- a/.changeset/canvas-preparing-and-theme.md
+++ b/.changeset/canvas-preparing-and-theme.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/harness": patch
+---
+
+Fix the Canvas showing a raw "Render failed" esbuild dump (`Could not resolve
+"@sapiom/agent"` / `"zod/v4"`) on a freshly scaffolded agent, before its
+`npm install` has run. Studio now shows a calm "Preparing your agent…"
+placeholder while dependencies are missing and auto-renders the step graph the
+moment they land — no Retry click. Readiness waits for the whole declared
+dependency set (walking `node_modules` up the tree as esbuild does), so a
+partial install can't flash the error. The Canvas empty-state and "rendering…"
+pages are now theme-aware, matching the app's light/dark theme instead of always
+painting a white panel.

--- a/.changeset/flat-projects-launch-dir.md
+++ b/.changeset/flat-projects-launch-dir.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/harness-desktop": patch
+"@sapiom/harness": patch
+---
+
+Fix new agents nesting under `projects/<agent>/projects/…` in Studio, deepening
+on every launch. The desktop host derived its launch dir from the most-recent
+session dir, which drifted into a project folder — so `<launchDir>/projects`
+(where new agents are created) appended a second `projects/` inside it, and the
+new agent's session cwd fed back in to nest even further next time. Pin the
+launch dir to the harness home so every agent stays flat under one `projects/`
+and the rail scans them all. The same `projectRoot` pin also fixes the template
+destination, which nested (and failed with "Couldn't read that directory") for
+the same reason. The "Add existing agents" folder picker now opens on the
+project root where agents live.

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -29,6 +29,7 @@ import {
   type HarnessIdentity,
   type DoctorReport,
 } from "@sapiom/harness";
+import { resolveLaunchDir } from "./launch-dir.js";
 import { augmentProcessPath } from "./env.js";
 import { esbuildBinaryPath } from "./esbuild-binary.js";
 import { resolveWebDir } from "./paths.js";
@@ -162,20 +163,20 @@ function defaultProjectRoot(): string {
 /**
  * The directory the coding agent opens in. NEVER the app's own cwd (that would
  * open the agent inside the install dir), and NEVER an OS folder picker — a
- * one-click user shouldn't have to choose a path. Precedence:
- *   1. SAPIOM_LAUNCH_DIR env (explicit dev/testing override)
- *   2. most recent *valid* project dir (returning users)
- *   3. the default project root under ~/.sapiom (first launch / new project)
+ * one-click user shouldn't have to choose a path.
+ *
+ * Always the harness home (unless `SAPIOM_LAUNCH_DIR` overrides it): the launch
+ * dir is the stable scan root that `projectRoot = <launchDir>/projects` is
+ * derived from, so it must not drift into a project subfolder. See
+ * `resolveLaunchDir` for why deriving it from `recentDirs` nested every new
+ * agent one level deeper.
  */
 async function chooseLaunchDir(): Promise<string> {
-  const override = process.env.SAPIOM_LAUNCH_DIR;
-  if (isDir(override)) return override;
-
-  const settings = await loadSettings();
-  const lastValid = settings.recentDirs?.find(isDir);
-  if (lastValid) return lastValid;
-
-  const dir = defaultProjectRoot();
+  const dir = resolveLaunchDir({
+    override: process.env.SAPIOM_LAUNCH_DIR,
+    harnessHome: defaultProjectRoot(),
+    isDir,
+  });
   await fs.promises.mkdir(dir, { recursive: true });
   return dir;
 }

--- a/packages/harness-desktop/src/main/launch-dir.test.ts
+++ b/packages/harness-desktop/src/main/launch-dir.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveLaunchDir } from "./launch-dir.js";
+
+const HOME = "/Users/x/.sapiom/harness";
+
+describe("resolveLaunchDir", () => {
+  it("returns the harness home by default", () => {
+    expect(resolveLaunchDir({ harnessHome: HOME, isDir: () => false })).toBe(HOME);
+  });
+
+  it("uses a valid SAPIOM_LAUNCH_DIR override", () => {
+    const override = "/tmp/dev-workspace";
+    expect(
+      resolveLaunchDir({ override, harnessHome: HOME, isDir: (p) => p === override }),
+    ).toBe(override);
+  });
+
+  it("falls back to the harness home when the override isn't a real dir", () => {
+    expect(
+      resolveLaunchDir({ override: "/does/not/exist", harnessHome: HOME, isDir: () => false }),
+    ).toBe(HOME);
+  });
+
+  it("ignores an unset override", () => {
+    expect(
+      resolveLaunchDir({ override: undefined, harnessHome: HOME, isDir: () => false }),
+    ).toBe(HOME);
+  });
+
+  // The regression this module exists to prevent: the launch dir must never be
+  // a most-recent *project* dir — that is what nested `<launchDir>/projects/…`.
+  // resolveLaunchDir takes no recentDirs input at all, so a drifted history
+  // can't reach it; the harness home is the only non-override result.
+  it("never returns a project dir even when one was the most recent (no recentDirs input)", () => {
+    const recentProject = `${HOME}/projects/return-test/projects/pull-request-opens`;
+    // Even if that path exists, it can only be selected via `override`; the
+    // history path is gone, so the result is the stable home.
+    expect(
+      resolveLaunchDir({ harnessHome: HOME, isDir: (p) => p === recentProject }),
+    ).toBe(HOME);
+  });
+});

--- a/packages/harness-desktop/src/main/launch-dir.ts
+++ b/packages/harness-desktop/src/main/launch-dir.ts
@@ -1,0 +1,38 @@
+/**
+ * Which directory the desktop host opens the coding agent in — the launch dir.
+ *
+ * It is the STABLE scan root the rest of boot depends on: `startServer` derives
+ * `projectRoot = <launchDir>/projects` (where every NEW agent is created) from
+ * it, and the rail scans it recursively for agents. So it must stay pinned to
+ * the harness home and must NOT drift into a project subfolder.
+ *
+ * Deriving it from the most-recent session dir (as boot once did, via
+ * `settings.recentDirs`) broke exactly that invariant: sessions run *inside*
+ * `projects/<agent>`, so on the next launch the launch dir became a project
+ * folder and `<launchDir>/projects` nested every new agent one level deeper —
+ * `projects/a/projects/b/projects/c/…` — compounding on every launch. Keeping
+ * the launch dir at the harness home keeps all agents flat under one `projects/`
+ * and lets the rail see every one of them. "Reopen where I left off" is a SPA
+ * focus concern (which agent is selected), not a launch-dir one.
+ *
+ * The only escape hatch is an explicit `SAPIOM_LAUNCH_DIR` env override, for
+ * dev/testing against a scratch workspace.
+ */
+export interface ResolveLaunchDirInput {
+  /** `SAPIOM_LAUNCH_DIR` — an explicit dev/testing override (env var shape). */
+  override?: string | undefined;
+  /** The harness home (`~/.sapiom/harness`), the stable default. */
+  harnessHome: string;
+  /** Existence check for the override (injected so this stays pure/testable). */
+  isDir: (p: string | undefined) => boolean;
+}
+
+/**
+ * The launch dir: a valid `override` if one is set, otherwise always the
+ * harness home. Deliberately never consults `recentDirs` — that is what caused
+ * the nesting.
+ */
+export function resolveLaunchDir(input: ResolveLaunchDirInput): string {
+  if (input.isDir(input.override)) return input.override as string;
+  return input.harnessHome;
+}

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -508,8 +508,8 @@ test("Add existing agents: directory picker navigates and validates", async ({ p
   const primary = modal.locator(".modal-primary-cta");
   const input = page.getByTestId("dir-picker-input");
 
-  // Seeded from launchDir; browsing shows its subdirectories.
-  await expect(input).toHaveValue("/Users/demo/acme-app");
+  // Seeded from the project root (…/projects); browsing shows its subdirectories.
+  await expect(input).toHaveValue("/Users/demo/acme-app/projects");
   await expect(page.getByTestId("dir-picker-item-leasing")).toBeVisible();
 
   // Type-ahead: an unrecognized tail filters the nearest real ancestor's children.
@@ -1679,7 +1679,7 @@ test("directory picker: arrow keys move the highlight and Enter drills into it",
   await input.press("ArrowDown");
   await expect(page.getByTestId("dir-picker-item-src")).toHaveClass(/is-selected/);
   await input.press("Enter");
-  await expect(input).toHaveValue("/Users/demo/acme-app/src");
+  await expect(input).toHaveValue("/Users/demo/acme-app/projects/src");
 });
 
 test("canvas controls: the board widget zooms; the subheader's expand lifts the pane to an overlay", async ({ page }) => {

--- a/packages/harness/web/src/components/StartDialog.tsx
+++ b/packages/harness/web/src/components/StartDialog.tsx
@@ -19,8 +19,8 @@ import { Icon } from "./Icon";
  */
 interface StartDialogProps {
   recentDirs: string[];
-  /** The folder the picker opens on. Falls back to the first recent dir, then the
-   *  project root. */
+  /** Fallback for the folder the picker opens on, after the project root — the
+   *  harness home now that launchDir is pinned there. */
   launchDir?: string | null;
   projectRoot?: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
@@ -43,7 +43,10 @@ export function StartDialog({
   onScan,
   triggerRef,
 }: StartDialogProps): JSX.Element {
-  const [cwd, setCwd] = useState(launchDir ?? recentDirs[0] ?? projectRoot ?? "");
+  // Open on the project root (`…/projects`) where agents live, so "Add existing
+  // agents" lands on the folder that holds them. Falls back to launchDir (the
+  // harness home) then the most recent dir.
+  const [cwd, setCwd] = useState(projectRoot ?? launchDir ?? recentDirs[0] ?? "");
   const [outcome, setOutcome] = useState<FolderOutcome | null>(null);
   const [checking, setChecking] = useState(true);
   const [busy, setBusy] = useState(false);

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -432,7 +432,14 @@ export const MOCK_FS_TREE: Record<string, string[]> = {
   "/": ["Users"],
   "/Users": ["demo"],
   "/Users/demo": ["acme-app", "rfq-agent", "onboarding-flow", "scratch"],
-  "/Users/demo/acme-app": ["leasing", "src", "docs"],
+  "/Users/demo/acme-app": ["projects", "leasing", "src", "docs"],
+  // The project root (`<launchDir>/projects`, mirroring the Electron host — see
+  // MockApi.state's defaultProjectRoot). Present so the "Add existing agents"
+  // picker, which now opens on the project root, lands on a real directory.
+  "/Users/demo/acme-app/projects": ["leasing", "src", "docs"],
+  "/Users/demo/acme-app/projects/leasing": [],
+  "/Users/demo/acme-app/projects/src": [],
+  "/Users/demo/acme-app/projects/docs": [],
   "/Users/demo/acme-app/leasing": [],
   "/Users/demo/acme-app/src": [],
   "/Users/demo/acme-app/docs": [],


### PR DESCRIPTION
## Problem

New agents created in Agent Studio were nesting *inside* the current project instead of sitting flat under one `projects/` folder:

```
~/.sapiom/harness/projects/return-test/projects/pull-request-opens
~/.sapiom/harness/projects/return-test/projects/return-works
~/.sapiom/harness/projects/return-test/projects/fetch-recent-weather
```

…and the nesting deepened on **every launch** (a real user's `recentDirs` had already drifted to a `…/projects/…/projects/…` path).

## Root cause

`chooseLaunchDir()` (`boot.ts`) derived the launch dir from the **most-recent session dir** (`settings.recentDirs`). But sessions run *inside* `projects/<agent>`, so on the next launch the launch dir became a project folder, and `projectRoot = <launchDir>/projects` — where every new agent is created (`web/src/App.tsx` → `projectDirSuggestion`) — appended a **second** `projects/` inside it. Each new agent's session cwd then fed back into `recentDirs`, so the nesting compounded launch-over-launch.

This also violated the invariant the rest of `boot.ts` already assumes and documents: that `launchDir` is the stable scan root `~/.sapiom/harness` ("launchDir itself must stay put: it is the scan root").

## Fix

Pin the launch dir to the harness home (still overridable via `SAPIOM_LAUNCH_DIR` for dev/testing). All agents stay flat under one `projects/`, and the rail scans every one of them. "Reopen where I left off" is a SPA focus concern (which agent is selected), not a launch-dir one — so nothing user-facing is lost.

The decision is extracted into a pure, unit-tested `launch-dir.ts` that takes **no `recentDirs` input at all**, so the drift can't recur — and a test pins exactly that.

## Files
- `src/main/launch-dir.ts` — new pure `resolveLaunchDir` (override → harness home; never `recentDirs`)
- `src/main/launch-dir.test.ts` — tests, incl. the "never returns a drifted project dir" regression lock
- `src/main/boot.ts` — `chooseLaunchDir()` uses `resolveLaunchDir`

## Testing
- `pnpm --filter @sapiom/harness-desktop test` — **79 pass** (5 new); typecheck + build clean.
- Verified against a real drifted `~/.sapiom/harness/settings.json` whose `recentDirs[0]` was a deeply nested project: with the fix, `launchDir` resolves to `~/.sapiom/harness` and new agents land flat under `projects/`.

> Note: this stops *new* nesting. Existing already-nested agent folders are migrated separately (out of band on the affected machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Also: default the "Add existing agents" picker to the project root

A direct consequence of pinning `launchDir`: the "Add existing agents" folder picker (`StartDialog.tsx`) opened on `launchDir`, which is now `…/harness` instead of `…/projects`. It now opens on the **project root** (`…/projects`) where agents live, so the dialog lands on the folder holding them; `launchDir` and `recentDirs` remain fallbacks.

The same `projectRoot` pin also fixes the **template** flow, which derived its destination from `projectRoot` and was likewise nesting (`…/<project>/projects/<template>`) with a "Couldn't read that directory" error.
