### PR TITLE
fix(agent): align local and hosted validation

### DIFF
--- a/.changeset/friendly-tools-rest.md
+++ b/.changeset/friendly-tools-rest.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/agent-runtime": patch
+---
+
+Fix CommonJS local agent loading, enforce JSON Schema URI formats, and make dispatched input-validation failures terminal instead of retryable.

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -21,6 +21,7 @@ import {
 import * as esbuild from "esbuild";
 
 import { AgentOperationError } from "./errors.js";
+import { importFreshModule } from "./native-import.js";
 
 /**
  * Run the project's TypeScript compiler in no-emit mode. Returns a warning
@@ -166,9 +167,7 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
     // `defineAgent` one and the pre-rename `defineOrchestration` one — the
     // definition shape is identical, so everything downstream (buildManifest,
     // graph validation) works unchanged on either.
-    const mod: Record<string, unknown> = await import(
-      `file://${bundlePath}?t=${Date.now()}`
-    );
+    const mod = await importFreshModule(bundlePath);
     const defs: unknown[] = [];
     for (const value of Object.values(mod)) {
       if (

--- a/packages/agent-core/src/local/load.ts
+++ b/packages/agent-core/src/local/load.ts
@@ -19,6 +19,7 @@ import {
 import * as esbuild from 'esbuild';
 
 import { AgentOperationError } from '../errors.js';
+import { importFreshModule } from '../native-import.js';
 
 const LOCAL_SDK_VERSION = '0.0.0-local';
 
@@ -59,7 +60,7 @@ export async function loadDefinition(sourceDir: string): Promise<LoadedDefinitio
       });
     }
 
-    const mod: Record<string, unknown> = await import(`file://${bundlePath}?t=${Date.now()}`);
+    const mod = await importFreshModule(bundlePath);
     const defs = Object.values(mod).filter(isAgentDefinition);
     if (defs.length === 0) {
       throw new AgentOperationError({

--- a/packages/agent-core/src/native-import.spec.ts
+++ b/packages/agent-core/src/native-import.spec.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import ts from "typescript";
+
+describe("importFreshModule", () => {
+  it("loads an ESM file when agent-core is running from its CJS build", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sapiom-native-import-"));
+    const modulePath = path.join(dir, "definition.mjs");
+    const helperPath = path.join(dir, "native-import.js");
+    writeFileSync(
+      modulePath,
+      "export const definition = { name: 'loaded' };\n",
+    );
+    const source = readFileSync(
+      path.join(__dirname, "native-import.ts"),
+      "utf8",
+    );
+    const compiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+        esModuleInterop: true,
+      },
+    }).outputText;
+    writeFileSync(helperPath, compiled);
+
+    try {
+      const output = execFileSync(
+        process.execPath,
+        [
+          "-e",
+          "require(process.argv[1]).importFreshModule(process.argv[2]).then((mod) => process.stdout.write(JSON.stringify(mod.definition)))",
+          helperPath,
+          modulePath,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(JSON.parse(output)).toEqual({ name: "loaded" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-core/src/native-import.ts
+++ b/packages/agent-core/src/native-import.ts
@@ -1,0 +1,18 @@
+import { pathToFileURL } from "node:url";
+
+// TypeScript rewrites `import(specifier)` to `require(specifier)` in the CJS
+// build. `require()` cannot load the ESM bundles produced by esbuild, so keep
+// this import native at runtime for both the CJS and ESM package outputs.
+const nativeDynamicImport = new Function(
+  "specifier",
+  "return import(specifier)",
+) as (specifier: string) => Promise<Record<string, unknown>>;
+
+/** Import an ESM file without reusing Node's module cache. */
+export function importFreshModule(
+  filePath: string,
+): Promise<Record<string, unknown>> {
+  const url = pathToFileURL(filePath);
+  url.searchParams.set("t", `${Date.now()}`);
+  return nativeDynamicImport(url.href);
+}

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@sapiom/agent": "workspace:^",
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1"
   },
   "peerDependencies": {
     "zod": "^4.1.0"

--- a/packages/agent-runtime/src/manifest-validation.spec.ts
+++ b/packages/agent-runtime/src/manifest-validation.spec.ts
@@ -1,0 +1,29 @@
+import { StepInputValidationError } from '@sapiom/agent';
+
+import { validateManifestStepInput } from './manifest-validation.js';
+
+describe('validateManifestStepInput', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      callbackUrl: { type: 'string', format: 'uri' },
+    },
+    required: ['callbackUrl'],
+  };
+
+  it('accepts a valid URI format', () => {
+    expect(() =>
+      validateManifestStepInput('entry', schema, {
+        callbackUrl: 'https://example.com/callback',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an invalid URI format', () => {
+    expect(() =>
+      validateManifestStepInput('entry', schema, {
+        callbackUrl: 'not a uri',
+      }),
+    ).toThrow(StepInputValidationError);
+  });
+});

--- a/packages/agent-runtime/src/manifest-validation.ts
+++ b/packages/agent-runtime/src/manifest-validation.ts
@@ -2,6 +2,7 @@ import { StepInputValidationError } from '@sapiom/agent';
 // Explicit `.js` so the emitted ESM resolves under Node's strict ESM loader
 // (the extensionless form only works for the CJS build).
 import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
 
 /**
  * AJV-based manifest input validation — a cheap pre-gate before paying to run a
@@ -14,6 +15,7 @@ import Ajv2020 from 'ajv/dist/2020.js';
  */
 
 const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
 
 /**
  * Validate `input` against `schema`. Throws `StepInputValidationError` when

--- a/packages/agent-runtime/src/runner-core.spec.ts
+++ b/packages/agent-runtime/src/runner-core.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentManifest } from '@sapiom/agent';
-import { DIRECTIVE_KIND } from '@sapiom/agent';
+import { DIRECTIVE_KIND, StepInputValidationError } from '@sapiom/agent';
 
 import { ADVANCE_RESULT_KIND } from './advance-result.js';
 import type { StepDispatcher } from './dispatch.js';
@@ -157,6 +157,38 @@ describe('AgentRunnerCore', () => {
   // ── (2) Step throws, retries exhaust at cap → FAILED ──────────────────────
 
   describe('retry cap exhaustion: FAILED', () => {
+    it('fails a remotely thrown StepInputValidationError without retrying', async () => {
+      const manifest = makeManifest({
+        entry: 'validate',
+        steps: {
+          validate: {
+            timeoutMs: null,
+            inputSchema: null,
+            transitions: [{ kind: 'terminate' }],
+          },
+        } as unknown as AgentManifest['steps'],
+      });
+
+      const { store, dispatcher, core } = setupCore();
+      let callCount = 0;
+      dispatcher.setSyncBody('validate', async () => {
+        callCount++;
+        const err = new Error('Invalid input for step validate');
+        err.name = StepInputValidationError.name;
+        throw err;
+      });
+
+      const executionId = await core.createExecution('test-workflow', 'validate', {}, { manifest });
+      const result = await core.advance(executionId, DEFAULT_MAX_ATTEMPTS_PER_STEP);
+
+      expect(result.kind).toBe(ADVANCE_RESULT_KIND.DISPATCHED);
+      const state = store.getExecution(executionId);
+      expect(state?.status).toBe(EXECUTION_STATUS.FAILED);
+      expect(state?.currentStepAttempt).toBe(0);
+      expect((state?.error as Error | undefined)?.name).toBe(StepInputValidationError.name);
+      expect(callCount).toBe(1);
+    });
+
     it('retries on throw and fails with RetryLimitExceededError when cap is reached', async () => {
       const manifest = makeManifest({
         entry: 'flaky',

--- a/packages/agent-runtime/src/runner-core.ts
+++ b/packages/agent-runtime/src/runner-core.ts
@@ -263,7 +263,20 @@ export class AgentRunnerCore {
         outcome: 'error',
         errorName: err.name,
       });
-      result = await this.handleRetryOrCap(row, stepRow.stepName, sharedSnapshot, maxAttemptsPerStep);
+      if (err.name === StepInputValidationError.name) {
+        const won = await this.deps.store.failExecution({
+          executionId: row.id,
+          expectedVersion: row.version,
+          error: err,
+          sharedState: sharedSnapshot,
+        });
+        if (!won) {
+          this.recordCasLoss('dispatched_input_validation_fail', row.id, row.version);
+        }
+        result = { kind: ADVANCE_RESULT_KIND.FAILED, error: err };
+      } else {
+        result = await this.handleRetryOrCap(row, stepRow.stepName, sharedSnapshot, maxAttemptsPerStep);
+      }
     } else {
       const stepResult = {
         output: payload.result?.output,
@@ -881,4 +894,3 @@ function rehydrateRemoteError(error: { name: string; message: string; stack?: st
   }
   return err;
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       ajv:
         specifier: ^8.12.0
         version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14


### PR DESCRIPTION
## Summary

- preserve native ESM bundle imports in the CommonJS agent-core build so `check` and `runLocalFromDir` work after publication
- register standard JSON Schema formats so manifest preflight rejects invalid URI values
- treat dispatched `StepInputValidationError` completions as terminal instead of consuming the retry budget
- add patch changesets for `@sapiom/agent-core` and `@sapiom/agent-runtime`

## Testing

- `pnpm build`
- `pnpm --filter @sapiom/agent-core test --runInBand` (160 tests)
- `pnpm --filter @sapiom/agent-runtime test --runInBand` (29 tests)
- typecheck and lint for both affected packages
- built CommonJS `loadDefinition` smoke test against the default agent template

## Follow-up

The production workflows engine has its own retry/validation boundary and needs a separate parity patch. Capability metadata normalization is also excluded because it requires a coordinated SDK/production contract change.