### PR TITLE
fix(agent-core): resolve source directory before typecheck

### DIFF
--- a/.changeset/fix-test-stability.md
+++ b/.changeset/fix-test-stability.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Fix local agent typechecking when the source directory is passed as a relative path.

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -28,13 +28,14 @@ import { AgentOperationError } from "./errors.js";
  * success. Throws `TYPECHECK_FAILED` with the compiler output on type errors.
  */
 export function runTypecheck(sourceDir: string): string | null {
-  const tscBin = path.join(sourceDir, "node_modules", ".bin", "tsc");
+  const projectDir = path.resolve(sourceDir);
+  const tscBin = path.join(projectDir, "node_modules", ".bin", "tsc");
   if (!existsSync(tscBin)) {
     return "typecheck skipped — TypeScript is not installed (run npm install first)";
   }
   try {
     execFileSync(tscBin, ["--noEmit"], {
-      cwd: sourceDir,
+      cwd: projectDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
     return null;


### PR DESCRIPTION
This fixes the relative `sourceDir` path case in `runTypecheck()`.

I hit this through the existing `check.spec` coverage: when `sourceDir` is relative, the function builds a relative `node_modules/.bin/tsc` path and also uses that same relative directory as the child process cwd. That makes the tsc path resolve from inside the source directory again, so the check reports a typecheck failure even though the fixture compiler exits cleanly.

The fix is just to resolve the project directory once, then use that absolute path for both the tsc lookup and the cwd.

Checked locally:

```bash
pnpm --filter @sapiom/agent-core exec jest src/check.spec.ts --runInBand --no-cache
pnpm --filter @sapiom/agent-core typecheck
pnpm --filter @sapiom/agent-core build
```
