### PR TITLE
fix(harness): the canvas pane follows the active session's board

### DIFF
--- a/.changeset/canvas-follows-content.md
+++ b/.changeset/canvas-follows-content.md
@@ -1,0 +1,18 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio's canvas pane now simply follows the active session's board: whenever a
+session has a rendered board, the pane is shown; when it doesn't, it stays
+closed. This replaces the previous auto-reveal, which fired only once and only
+for sessions born from the composer — so a resumed session that built an agent,
+or opening an already-populated agent, left the freshly-rendered board sitting
+in a collapsed pane the user had to open by hand.
+
+Now any live render (a `canvas.reload` for the active session — a finished
+build, a re-render) opens the pane on its own, and switching to a populated
+session shows its board straight away. Trade-off of the simpler model: a manual
+collapse of the canvas is no longer a persisted arrangement — it lasts until the
+next render or session switch (the rail collapse and the Canvas/Steps/Code tab
+still persist). Exited sessions keep their pane open for the "resume to see it"
+invite.

--- a/packages/harness/web/e2e/canvas-reveal.spec.ts
+++ b/packages/harness/web/e2e/canvas-reveal.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * The canvas pane follows the ACTIVE session's board: shown whenever the
+ * session has one, and (re)opened the moment a live render delivers a board —
+ * even a pane the user had collapsed. This is the simple "populated ⇒ shown"
+ * contract that replaced the composer-only, one-shot auto-reveal, so a resumed
+ * session that builds an agent (a canvas.reload arrives), or a switch to an
+ * already-populated agent, shows its board without a manual open. All mock mode.
+ */
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+// The mock bus test hook: simulate the server's canvas.reload for a session,
+// the same event a finished render/build broadcasts.
+const publishReload = (page: Page, sessionId: string): Promise<void> =>
+  page.evaluate((id) => {
+    (
+      window as unknown as { __HARNESS_TEST__?: { publish?: (m: unknown) => void } }
+    ).__HARNESS_TEST__?.publish?.({ type: "canvas.reload", harnessSessionId: id });
+  }, sessionId);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+test("a populated session shows its board on load — no manual open", async ({ page }) => {
+  // sess-boot ships a board and is the active session at boot, so the pane is
+  // open straight away.
+  await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
+  await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
+});
+
+test("a live render re-opens a pane the user had collapsed", async ({ page }) => {
+  await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
+
+  // Fold it away to focus on the terminal.
+  await page.getByTestId("right-collapse").click();
+  await expect(page.locator(".right-pane")).toHaveClass(/is-collapsed/);
+
+  // The agent renders a board — a finished build, or any re-render. The pane
+  // pops back open on its own: content, once present, is shown. This is the
+  // behaviour the old composer-only, one-shot reveal missed for a resumed
+  // session.
+  await publishReload(page, "sess-boot");
+  await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
+});

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -765,24 +765,22 @@ test("the rail's ⋯ menu offers a Group by toggle (Workspace / Deployment)", as
 });
 
 test.describe("held arrangement", () => {
-  test("workspace collapse, right tab, and right-pane collapse survive a reload", async ({ page }) => {
+  test("workspace collapse and the right tab survive a reload", async ({ page }) => {
     // Collapse the rfq workspace group (plain header toggles on click).
     await page.getByTestId("workspace-group-rfq-agent").locator(".workspace-row-main").click();
     await expect(page.getByTestId("workflow-rfq")).toHaveCount(0);
 
-    // Pick the Steps tab, then fold the right pane away.
+    // Pick the Steps tab.
     await page.getByTestId("right-tab-steps").click();
-    await page.getByTestId("right-collapse").click();
 
     await page.reload();
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
-    // Restored: the group stays folded, the pane stays collapsed, and
-    // expanding it lands back on Steps.
+    // Restored: the group stays folded and the pane still remembers the Steps
+    // tab. The right pane's open/closed state is NOT a persisted arrangement —
+    // it follows the active session's board (a populated session shows it), so
+    // a fold does not survive a reload (the canvas auto-reveal contract).
     await expect(page.getByTestId("workflow-rfq")).toHaveCount(0);
-    const expand = page.getByTestId("right-expand");
-    await expect(expand).toBeVisible();
-    await expand.click();
     await expect(page.getByTestId("right-tab-steps")).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -38,8 +38,7 @@ import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
 import { WorkflowsRail } from "./components/WorkflowsRail";
-import { ApiError, boundWorkflowPathOf, isMockMode } from "./lib/api";
-import { hasMockCanvasDoc } from "./lib/mock-data";
+import { ApiError, boundWorkflowPathOf } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { historyDirs } from "./lib/history-meta";
 import {
@@ -107,18 +106,6 @@ export const App = (): JSX.Element => {
   // intent (Create new / the +); the home also shows whenever nothing else
   // claims the centre pane (first run, or every session closed).
   const [composing, setComposing] = useState(false);
-  // Sessions started terminal-first FROM THE COMPOSER, eligible for the canvas
-  // auto-reveal on first content — and, once revealed, the set of those already
-  // done so a later manual fold is never fought. A pre-existing session that
-  // simply loads with content (the boot session, or any session on mobile) is
-  // never in `pendingReveal`, so the reveal only ever applies to a brand-new
-  // composer session. Refs: they gate a callback, they must not trigger renders.
-  const pendingReveal = useRef<Set<string>>(new Set());
-  const autoRevealed = useRef<Set<string>>(new Set());
-  // Sessions known to have painted canvas content (from CanvasPane's
-  // onCanvasContent). Lets a session SWITCH show the pane immediately for a
-  // session whose board we've already seen, and hide it for one that has none.
-  const sessionsWithCanvas = useRef<Set<string>>(new Set());
   // The focused agent (or bare-scaffold folder) path — the rail's single
   // selection and the main panel's tab-strip subject. The active tab's
   // session is harness.activeSessionId.
@@ -549,10 +536,6 @@ export const App = (): JSX.Element => {
     setFocusedAgentPath(cwd);
     closeMobileDrawer();
     const session = await harness.createSession({ cwd, harness: agentHarness });
-    // Any new session is eligible for the canvas auto-reveal: the first time it
-    // paints a board (e.g. starting one on a populated/deployed workflow), the
-    // pane opens itself.
-    if (!isMobile) pendingReveal.current.add(session.id);
     track("session.created");
     trackProduct("session.started", { harness_kind: agentHarness, origin: "user" });
     return session;
@@ -665,7 +648,7 @@ export const App = (): JSX.Element => {
   // The composer home's two on-ramps. Both open a session in a FRESH project
   // folder under the project root (deduped so an existing folder is never
   // clobbered) and open the workbench terminal-only — the canvas reveals itself
-  // once the agent generates content (see CanvasPane's onCanvasContent below).
+  // once the agent generates content (see CanvasPane's onCanvasState below).
   const uniqueProjectDir = (base: string): string => {
     const taken = new Set<string>();
     for (const session of state.sessions) {
@@ -713,31 +696,11 @@ export const App = (): JSX.Element => {
     return found.length;
   };
 
-  // Canvas follows the session on an explicit switch: show the pane if that
-  // session's board is populated (either one we've already seen, or a mock
-  // session with a bundled doc), hide it if there's nothing yet — in which case
-  // it slides in later once content paints (onCanvasContent). Desktop only (the
-  // mobile sheet has its own collapse), and NOT run on initial load/reload, so a
-  // persisted manual fold still survives (held-arrangement contract).
-  const applyCanvasVisibility = (id: string | null): void => {
-    if (isMobile) return;
-    // No live session for this view (a focused agent with none) — nothing to
-    // inspect, so hide the pane.
-    if (id == null) {
-      setRightCollapsed(true);
-      return;
-    }
-    // A dead session keeps its own "resume to see it" invite; leave the pane.
-    if (state.sessions.find((s) => s.id === id)?.status === "exited") return;
-    const populated =
-      sessionsWithCanvas.current.has(id) || (isMockMode() && hasMockCanvasDoc(id));
-    if (populated) {
-      setRightCollapsed(false);
-    } else {
-      setRightCollapsed(true);
-      pendingReveal.current.add(id);
-    }
-  };
+  // The canvas pane follows the ACTIVE session's board rather than being toggled
+  // here: CanvasPane reports whether the session it's mounted for has a servable
+  // board (onCanvasState below), and that drives the pane open/closed. So a
+  // switch only has to move the active session — the pane reconciles itself once
+  // the new session's probe resolves. (Mobile keeps its own sheet control.)
 
   // Switch to a session (history-menu pick, palette hit): focus follows it so
   // the main panel shows its context (its bound agent, or its own folder).
@@ -749,7 +712,6 @@ export const App = (): JSX.Element => {
     const session = state.sessions.find((s) => s.id === id);
     if (session) setFocusedAgentPath(boundWorkflowPathOf(session) ?? session.cwd);
     harness.setActiveSessionId(id);
-    applyCanvasVisibility(id);
   };
 
   // Select a tab in the strip — same as openSession, but the tab always
@@ -759,7 +721,6 @@ export const App = (): JSX.Element => {
     setReviewSummary(null);
     setTemplatesOpen(false);
     harness.setActiveSessionId(id);
-    applyCanvasVisibility(id);
   };
 
 
@@ -799,9 +760,9 @@ export const App = (): JSX.Element => {
       ? harness.activeSessionId
       : (tabs[tabs.length - 1]?.id ?? null);
     if (nextActiveId !== harness.activeSessionId) harness.setActiveSessionId(nextActiveId);
-    // The canvas follows the focus target: shown for a populated session, hidden
-    // for one with nothing yet or an agent with no session at all.
-    applyCanvasVisibility(nextActiveId);
+    // The canvas follows the focus target automatically (onCanvasState): a
+    // populated session shows its board, an empty one or an agent with no
+    // session at all reports no content and the pane stays closed.
   };
 
   // Focus a deep-linked / just-cloned agent if the user has it locally; returns
@@ -1445,21 +1406,21 @@ export const App = (): JSX.Element => {
                 noSessionAgent={noSessionAgentName}
                 overviewActive={showComposer}
                 sessionExited={showDead}
-                onCanvasContent={() => {
-                  // Remember this session's board is populated, so a later switch
-                  // back to it shows the pane straight away.
-                  const id = harness.activeSessionId;
-                  if (!id) return;
-                  sessionsWithCanvas.current.add(id);
-                  // Slide the pane in the first time an ELIGIBLE session paints
-                  // content: one started terminal-first from the composer, or one
-                  // just switched to whose board we hadn't seen. A pre-existing
-                  // session on initial load (never marked pending) keeps its
-                  // collapse state, and mobile never auto-reveals its sheet.
-                  if (isMobile || !pendingReveal.current.has(id) || autoRevealed.current.has(id)) return;
-                  autoRevealed.current.add(id);
-                  pendingReveal.current.delete(id);
-                  setRightCollapsed(false);
+                onCanvasState={(hasContent) => {
+                  // The pane follows the active session's board: open it whenever
+                  // the session has one, close it when it doesn't. This fires on
+                  // the mount probe, on every canvas.reload, and on each session
+                  // switch — so a board an agent just rendered (a finished build,
+                  // a switch to a populated agent) opens the pane on its own, even
+                  // one you'd collapsed, and an empty session keeps it closed.
+                  // Mobile drives its sheet with its own control, not this.
+                  if (isMobile) return;
+                  // An exited session keeps the pane open even with no board, so
+                  // its "resume to see it" invite stays visible.
+                  const activeExited =
+                    state.sessions.find((s) => s.id === harness.activeSessionId)?.status ===
+                    "exited";
+                  setRightCollapsed(!hasContent && !activeExited);
                 }}
                 expanded={canvasExpanded}
                 onToggleExpanded={() => setCanvasExpanded((v) => !v)}

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -90,9 +90,13 @@ interface CanvasPaneProps {
    *  navigating to a launched workflow is an explicit act on it, so it
    *  rebinds, same as running a macro against it. */
   onOpenWorkflow: (path: string) => void;
-  /** Fired once per session the first time it paints canvas content, so the
-   *  workbench can reveal the pane it had kept collapsed until then. */
-  onCanvasContent?: () => void;
+  /** Reports whether THIS session currently has a servable canvas board, so the
+   *  workbench can follow it: shown when it has one, hidden when it doesn't.
+   *  Fires on the mount probe, on every canvas.reload, and whenever the session
+   *  changes — the reload case is what opens the pane the moment an agent
+   *  renders a board (a fresh build, a switch to a populated agent), even one
+   *  the user had collapsed. */
+  onCanvasState?: (hasContent: boolean) => void;
 }
 
 export function CanvasPane({
@@ -121,9 +125,14 @@ export function CanvasPane({
   onOpenCode,
   workflows,
   onOpenWorkflow,
-  onCanvasContent,
+  onCanvasState,
 }: CanvasPaneProps): JSX.Element {
   const [hasGeneratedContent, setHasGeneratedContent] = useState(false);
+  // Latest reporter, read from the content effects without listing it in their
+  // deps — otherwise a new inline callback each render would re-run them and
+  // re-report stale content (re-opening a pane the user just collapsed).
+  const onCanvasStateRef = useRef(onCanvasState);
+  onCanvasStateRef.current = onCanvasState;
   const [reloadKey, setReloadKey] = useState(0);
   const [theme, setTheme] = useState(getTheme());
   // True while the initial HEAD probe for this session is still in flight —
@@ -613,6 +622,7 @@ export function CanvasPane({
     setFrameLoading(true);
     if (!sessionId) {
       setHasGeneratedContent(false);
+      onCanvasStateRef.current?.(false);
       return;
     }
     // Mock mode ships no live probe. A mock session that ships a bundled canvas
@@ -621,14 +631,20 @@ export function CanvasPane({
     // empty pane. Sessions without a bundled doc stay honestly empty and never
     // mount an iframe (the invariant smoke.spec guards); no fabricated docs.
     if (isMockMode()) {
-      setHasGeneratedContent(hasMockCanvasDoc(sessionId));
+      const has = hasMockCanvasDoc(sessionId);
+      setHasGeneratedContent(has);
+      onCanvasStateRef.current?.(has);
       return;
     }
     setHasGeneratedContent(false);
     let cancelled = false;
     setProbing(true);
     fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
-      .then((res) => !cancelled && setHasGeneratedContent(res.ok))
+      .then((res) => {
+        if (cancelled) return;
+        setHasGeneratedContent(res.ok);
+        onCanvasStateRef.current?.(res.ok);
+      })
       .catch(() => {})
       .finally(() => !cancelled && setProbing(false));
     return () => {
@@ -645,6 +661,9 @@ export function CanvasPane({
       // keeps its honest empty state instead.
       if (isMockMode() && !hasMockCanvasDoc(sessionId)) return;
       setHasGeneratedContent(true);
+      // A live render just delivered a board — announce it so the workbench
+      // opens the pane, even one the user had collapsed.
+      onCanvasStateRef.current?.(true);
       setFrameLoading(true);
       setReloadKey((key) => key + 1);
     }
@@ -705,17 +724,6 @@ export function CanvasPane({
   const sessionHasServableDoc = sessionId != null && (!isMockMode() || hasMockCanvasDoc(sessionId));
   const showsContent = hasGeneratedContent && sessionHasServableDoc;
 
-  // Announce the first paint of content for THIS session, once, so the
-  // workbench can slide in a canvas pane it had kept collapsed until now. The
-  // per-session ref makes it fire once even though the pane re-renders and the
-  // callback identity may change.
-  const contentFiredForRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (showsContent && sessionId && contentFiredForRef.current !== sessionId) {
-      contentFiredForRef.current = sessionId;
-      onCanvasContent?.();
-    }
-  }, [showsContent, sessionId, onCanvasContent]);
 
   // The observability header for the Steps surface: a deploy landing (if one is
   // in flight/just landed) and the run summary card (if a run has been


### PR DESCRIPTION
## Problem

The Studio canvas pane didn't open when it should. Two reported cases:
1. A coding-agent session finishes **building** an agent → the graph renders, but the pane stays collapsed (you had to open it by hand).
2. Opening / starting a session in an **already-populated** agent → its board doesn't show.

Root cause: auto-reveal was a **one-shot** gated on how the session was *born* — only composer-created sessions were ever eligible (`pendingReveal`), and it fired once (`autoRevealed`). A resumed/boot session, or a switch to a populated agent, was never eligible, so a freshly-rendered board sat in a collapsed pane.

## Change

Replace the whole machinery (`pendingReveal` / `autoRevealed` / `sessionsWithCanvas` / `applyCanvasVisibility` / the reveal branches) with one reactive rule:

> **The pane follows the active session's board — populated ⇒ shown, empty ⇒ hidden.**

`CanvasPane` reports its content state via `onCanvasState(hasContent)` — on the mount HEAD probe, on every `canvas.reload`, and on each session switch — and `App` drives `rightCollapsed` off it. So any live render (a finished build, a re-render) opens the pane on its own, and switching to a populated session shows its board immediately.

Net: **App.tsx −33 lines**; the behavior is structural, not a set of special cases.

### Deliberate trade-off
A manual canvas collapse is no longer a *persisted arrangement* — it lasts until the next render / session switch (rail collapse and the Canvas/Steps/Code tab still persist). This is the "always show when populated" model chosen for the fix. Exited sessions keep the pane open for the "resume to see it" invite.

## Testing
- Typecheck clean
- Full e2e: **288 passed**
  - Updated the held-arrangement spec to the new contract (right-pane collapse no longer survives reload; rail + tab still do)
  - New `canvas-reveal.spec.ts`: a populated session shows its board on load, and a live `canvas.reload` re-opens a pane the user had collapsed
- Verified in the packaged-renderer **desktop** app

## Notes
- `patch` changeset for `@sapiom/harness` included (describes the trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)