### PR TITLE
fix(build-manifest): validate pause resumeStep against steps map

### DIFF
--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -169,8 +169,12 @@ function buildForwardEdges(
           errors.push(
             `step '${name}' has a continue target '${t.target}' that is not in the steps map`,
           );
-      } else if (t.kind === "pause" && names.has(t.resumeStep)) {
-        targets.add(t.resumeStep);
+      } else if (t.kind === "pause") {
+        if (names.has(t.resumeStep)) targets.add(t.resumeStep);
+        else
+          errors.push(
+            `step '${name}' has a pause resumeStep '${t.resumeStep}' that is not in the steps map`,
+          );
       }
     }
     if (step.transitions.length === 0) {


### PR DESCRIPTION
Fixes #552

`buildForwardEdges` was validating `continue` targets but silently skipping invalid `pause.resumeStep` values. An agent with a misspelled resumeStep would pass `check` and `deploy`, then crash at runtime when the signal arrived.

This PR mirrors the same validation that already exists for `continue` targets.