### PR TITLE
fix(agent-core): run tsc via node entry so check works on Windows

### DIFF
--- a/.changeset/windows-typecheck-bin-shim.md
+++ b/.changeset/windows-typecheck-bin-shim.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/mcp": patch
+---
+
+Fix `check` / `sapiom_dev_agents_check` always failing with `TYPECHECK_FAILED` on Windows
+
+`runTypecheck` ran the project's compiler via the bare `node_modules/.bin/tsc` shim. On Windows that extensionless file is a POSIX sh script (npm ships the real launcher as `tsc.cmd`), which `execFileSync` cannot execute — it threw a spawn error with empty output, so the check reported `TYPECHECK_FAILED` with the generic "Run `tsc --noEmit` for details" hint even when the project's own `tsc --noEmit` passed cleanly. It now runs TypeScript's JS entry (`node_modules/typescript/bin/tsc`) under the current Node binary, which is platform-independent and avoids `.bin`/`.cmd`/PATHEXT/shell entirely.

--- a/packages/agent-core/src/check.spec.ts
+++ b/packages/agent-core/src/check.spec.ts
@@ -6,13 +6,7 @@
  * (not the CLI) means the sapiom_dev_agents_check MCP tool and the dashboard
  * canvas inherit the warning too.
  */
-import {
-  chmodSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -21,6 +15,19 @@ import {
   runTypecheck,
   type EntryContractManifest,
 } from "./check";
+import { AgentOperationError } from "./errors";
+
+/**
+ * Stand in for the project's TypeScript compiler at the path runTypecheck runs:
+ * node_modules/typescript/bin/tsc, invoked as `node <script>`. So it is a JS
+ * file (not the sh shim under .bin) — the .bin shim is what broke on Windows,
+ * where the extensionless `.bin/tsc` is a POSIX sh script Node cannot exec.
+ */
+function writeFakeTsc(dir: string, body: string): void {
+  const binDir = path.join(dir, "node_modules", "typescript", "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(path.join(binDir, "tsc"), body);
+}
 
 describe("entryInputSchemaWarning", () => {
   it("warns and names the entry step when it declares no inputSchema", () => {
@@ -73,17 +80,46 @@ describe("entryInputSchemaWarning", () => {
 });
 
 describe("check source directory", () => {
-  it("runs the project compiler when sourceDir is relative", async () => {
+  it("runs the project compiler when sourceDir is relative", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "sapiom-check-relative-"));
     try {
-      const binDir = path.join(dir, "node_modules", ".bin");
-      mkdirSync(binDir, { recursive: true });
-      const tsc = path.join(binDir, "tsc");
-      writeFileSync(tsc, "#!/bin/sh\nexit 0\n");
-      chmodSync(tsc, 0o755);
-      // Before source-directory normalization, execFile resolved this tsc path
-      // beneath cwd a second time and raised TYPECHECK_FAILED instead.
+      writeFakeTsc(dir, "process.exit(0);\n");
+      // runTypecheck passes the tsc script as an argv element the child Node
+      // resolves against cwd; without normalization a relative sourceDir would
+      // resolve it beneath cwd a second time and raise TYPECHECK_FAILED instead.
       expect(runTypecheck(path.relative(process.cwd(), dir))).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws TYPECHECK_FAILED with the compiler output on type errors", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sapiom-check-typeerr-"));
+    try {
+      // Mimic tsc: write diagnostics to stdout, exit non-zero.
+      writeFakeTsc(
+        dir,
+        "process.stdout.write('index.ts(1,1): error TS2322\\n');\nprocess.exit(1);\n",
+      );
+      try {
+        runTypecheck(dir);
+        throw new Error("expected runTypecheck to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(AgentOperationError);
+        const e = err as AgentOperationError;
+        expect(e.code).toBe("TYPECHECK_FAILED");
+        // The compiler's own output becomes the hint, not the generic fallback.
+        expect(e.hint).toContain("error TS2322");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips typecheck when TypeScript is not installed", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sapiom-check-nots-"));
+    try {
+      expect(runTypecheck(dir)).toContain("TypeScript is not installed");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -28,13 +28,27 @@ import { AgentOperationError } from "./errors.js";
  * success. Throws `TYPECHECK_FAILED` with the compiler output on type errors.
  */
 export function runTypecheck(sourceDir: string): string | null {
-  const tscBin = path.join(sourceDir, "node_modules", ".bin", "tsc");
-  if (!existsSync(tscBin)) {
+  // Resolve to an absolute path first: we pass the tsc script as an argv element
+  // that the child Node resolves against its own cwd, so a relative script path
+  // *and* a relative cwd would resolve it beneath cwd twice (the same
+  // double-resolution the check() caller guards against). Absolute keeps
+  // runTypecheck correct for any caller, relative input included.
+  const dir = path.resolve(sourceDir);
+  // Run TypeScript's own JS entry under this Node binary rather than the
+  // node_modules/.bin/tsc shim. On Windows that shim is tsc.cmd; the
+  // extensionless `.bin/tsc` beside it is a POSIX sh script npm ships for Git
+  // Bash, which execFileSync cannot execute — it threw a spawn error with empty
+  // output, so we reported TYPECHECK_FAILED even when tsc would have passed
+  // (and Node won't execFile a .cmd without shell: true post-CVE-2024-27980).
+  // Invoking the JS entry via process.execPath sidesteps .bin/.cmd/PATHEXT/shell
+  // entirely and is identical across platforms.
+  const tscScript = path.join(dir, "node_modules", "typescript", "bin", "tsc");
+  if (!existsSync(tscScript)) {
     return "typecheck skipped — TypeScript is not installed (run npm install first)";
   }
   try {
-    execFileSync(tscBin, ["--noEmit"], {
-      cwd: sourceDir,
+    execFileSync(process.execPath, [tscScript, "--noEmit"], {
+      cwd: dir,
       stdio: ["ignore", "pipe", "pipe"],
     });
     return null;


### PR DESCRIPTION
## Problem

Reported via Studio feedback ([Slack](https://sapiom.slack.com/archives/C0BM58QFQS3/p1786021788545689)) — client `sapiom-mcp 0.12.2`, Windows 11 (`win32/x64`): `sapiom_dev_agents_check` **always** fails with `TYPECHECK_FAILED` on a freshly scaffolded agent project, even though the project's own `tsc --noEmit` returns exit 0 with no errors.

## Root cause

`runTypecheck()` in `packages/agent-core/src/check.ts` invoked the compiler through the bare `node_modules/.bin/tsc` shim:

```ts
const tscBin = path.join(sourceDir, "node_modules", ".bin", "tsc"); // no extension
execFileSync(tscBin, ["--noEmit"], { cwd: sourceDir, ... });
```

On Windows npm installs three files in `.bin/`: `tsc.cmd`, `tsc.ps1`, and an **extensionless `tsc`** — a POSIX **sh** script present for Git Bash. `existsSync` finds that sh script (so the "TypeScript not installed" gate passes), but `execFileSync` **cannot execute an sh script on Windows**. It throws a spawn error whose `stdout`/`stderr` are empty, so the `catch` raises `TYPECHECK_FAILED` and — with no compiler output — falls back to the generic `"Run `tsc --noEmit` for details"` hint, masking that tsc never ran.

Swapping in `tsc.cmd` is not a fix either: Node refuses to `execFile` a `.cmd`/`.bat` without `shell: true` since the CVE-2024-27980 patch.

## Fix

Run TypeScript's own JS entry (`node_modules/typescript/bin/tsc`) under `process.execPath` instead of the `.bin` shim. This is identical across platforms and sidesteps `.bin`/`.cmd`/PATHEXT/shell entirely. `typescript` is a direct devDependency of the scaffold template, so the entry reliably exists after `npm install`.

`sourceDir` is also resolved to an absolute path at the top of `runTypecheck` — load-bearing, because the script path is passed as an argv element the child Node resolves against its own `cwd`; a relative script path *and* a relative cwd would resolve it twice (the same double-resolution the `check()` caller already guards against).

Considered but rejected: reusing `resolveSpawnTarget` from `@sapiom/harness` — that package depends on `@sapiom/agent-core`, so importing it here would invert the package layering. The `process.execPath` + JS-entry approach is self-contained and needs no new dependency.

## Tests

`packages/agent-core/src/check.spec.ts` updated to the new resolution (JS stub at `typescript/bin/tsc`), plus new cases:
- `runTypecheck` returns `null` for a **relative** `sourceDir` (guards the double-resolution regression under the new path).
- `TYPECHECK_FAILED` is thrown with the **compiler's own output** as the hint on real type errors.
- typecheck is **skipped** with the right message when TypeScript is absent.

These genuinely spawn `node` against a stub, so they exercise the real `execFileSync(process.execPath, ...)` path.

```
check.spec.ts — 7/7 pass
```

The pre-existing `run-local.spec.ts` `zod/v4` failures in this package are unrelated to this change (confirmed identical with this diff stashed).

## Shipping

Changeset added: `patch` for `@sapiom/agent-core` and `@sapiom/mcp` so the fix reaches the `sapiom-mcp` client that hit this.

## Not covered here

The true proof is a real `win32` run of `sapiom_dev_agents_check` against a freshly `npm install`ed scaffold. The fix removes all `.bin`/`.cmd`/shell handling so it is platform-independent by construction, but a Windows run would close the loop with the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC6bxEyUEw15q2Xv76kG4e