### PR TITLE
docs(contributing): fix clone URL, pnpm floor, and stale package list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to the Sapiom SDK! We welcome contri
 ### Prerequisites
 
 - Node.js 18.0.0 or higher
-- pnpm 8.0.0 or higher
+- pnpm 10.0.0 or higher (the repo pins `pnpm@10.34.3` via `packageManager`)
 
 ### Setup
 
@@ -15,8 +15,8 @@ Thank you for your interest in contributing to the Sapiom SDK! We welcome contri
 2. Clone your fork:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/sdk.git
-   cd sdk
+   git clone https://github.com/YOUR_USERNAME/sapiom-js.git
+   cd sapiom-js
    ```
 
 3. Install dependencies:
@@ -42,17 +42,42 @@ Thank you for your interest in contributing to the Sapiom SDK! We welcome contri
 
 This is a monorepo containing multiple packages:
 
+**Build & run agents**
+
+- `@sapiom/agent` - Authoring contract: `defineAgent`, `defineStep`, directives, types
+- `@sapiom/tools` - Typed client for Sapiom capabilities (sandboxes, repos, models, …)
+- `@sapiom/cli` - Command line: scaffold, validate, deploy, and schedule agents
+- `@sapiom/mcp` - Local developer MCP server (`sapiom-dev`)
+
+**Runtime internals**
+
+- `@sapiom/agent-core` - Pure functions for scaffolding, validating, and operating agents
+- `@sapiom/agent-runtime` - Host-agnostic graph-walker runtime
+- `@sapiom/analytics-core` - Zero-dependency usage analytics emitter
+- `@sapiom/sandbox-preview` - Client-side flow for deploying a web-app preview to a sandbox
+
+**Agent Studio**
+
+- `@sapiom/harness` - CLI-launched local web app that runs your coding agent
+- `@sapiom/harness-desktop` - Electron desktop host for the harness (private)
+- `@sapiom/agent-studio` - Studio workspace package
+
+**Core SDK**
+
 - `@sapiom/core` - Core SDK functionality
-- `@sapiom/axios` - Axios integration
 - `@sapiom/fetch` - Fetch API integration
-- `@sapiom/node-http` - Node.js HTTP/HTTPS integration
-- `@sapiom/langchain` - LangChain integration
+
+**Deprecated** — not accepting new features; fixes only
+
+- `@sapiom/sandbox` - superseded by `sapiom.sandboxes.*` in `@sapiom/tools`
+- `@sapiom/axios`, `@sapiom/node-http` - legacy HTTP integrations
+- `@sapiom/langchain`, `@sapiom/langchain-classic` - unmaintained, no longer published
 
 ### Working on a Package
 
 ```bash
 # Navigate to a specific package
-cd packages/core
+cd packages/agent
 
 # Build in watch mode
 pnpm dev
@@ -170,10 +195,10 @@ pnpm test
 pnpm test:coverage
 
 # Run tests for specific package
-pnpm --filter @sapiom/core test
+pnpm --filter @sapiom/agent test
 
 # Watch mode
-pnpm --filter @sapiom/core test:watch
+pnpm --filter @sapiom/agent test:watch
 ```
 
 ### Mutation Testing
@@ -197,7 +222,7 @@ pnpm --filter @sapiom/analytics-core test:mutation
 pnpm build
 
 # Build specific package
-pnpm --filter @sapiom/core build
+pnpm --filter @sapiom/agent build
 
 # Clean build artifacts
 pnpm clean


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` has drifted from the repository. A contributor following
Getting Started either clones a URL that 404s or installs with a pnpm major
that cannot read the committed lockfile.

Four corrections:

- **Clone URL** pointed at `sdk.git`; the repository is `sapiom-js`.
- **pnpm floor** said 8.0.0, but `engines.pnpm` is `>=10.0.0` and
  `packageManager` pins `pnpm@10.34.3`. pnpm 8 fails against the pnpm 10
  lockfile that CI installs with `--frozen-lockfile`.
- **Project Structure** listed 5 of 18 packages, and 3 of those 5 (`axios`,
  `node-http`, `langchain`) carry a Deprecated banner in their own READMEs,
  with the langchain packages unpublished since #442. None of `agent`,
  `tools`, `cli`, `mcp`, `agent-core`, `agent-runtime` or the harness
  packages appeared, so the onboarding doc pointed contributors exclusively
  at legacy surface. Now lists all 18, grouped, deprecations flagged.
- **Worked examples** (`cd packages/core`, `pnpm --filter @sapiom/core …`)
  now use `@sapiom/agent`.

## Testing

- `prettier --check CONTRIBUTING.md` passes
- Every `@sapiom/*` name in the doc resolves to a real `packages/*/package.json`
  (18 cited, 18 on disk, no drift either direction)
- Each deprecation claim checked against the corresponding package README
- `packages/agent` verified to expose the `dev`, `test`, `test:watch`, `build`,
  `lint`, `format` scripts the doc now points contributors at

## Changeset

Omitted deliberately: no package source is touched. Matches #68 and #97, which
were also root docs-only changes shipped without one.
