### PR TITLE
fix(harness): Studio UI review fixes + canvas-reveal de-flake

### DIFF
--- a/.changeset/studio-ui-bugfixes.md
+++ b/.changeset/studio-ui-bugfixes.md
@@ -11,3 +11,4 @@ Studio UI fixes from design review:
 - **"Create new"**: promoted above Search as the primary affirmative action, restyled to the app's solid ink-button CTA (the Deploy treatment) with the reserved brand-green plus; the empty-rail state keeps a brand halo.
 - **Rail spacing**: top-level rail rows share one icon size, icon–text gap, and left inset.
 - **Sign-out**: removed the duplicate Disconnect from the settings panel — signing out now lives once in the account menu, below "Check for updates" and only when signed in.
+- **Collapsed panels**: the expand control is now the mirror of the collapse icon (a panel-open glyph, same quiet style) instead of a menu/list icon; the rail's top tools line up with the icons below them; and the Templates header no longer collides with the macOS traffic lights when the left panel is collapsed.

--- a/.changeset/studio-ui-bugfixes.md
+++ b/.changeset/studio-ui-bugfixes.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio UI fixes from design review:
+
+- **Canvas chat input**: the "Ask about this agent/step" field is now a clean, boxless single row — no border, padding box, or separator hairline — that auto-grows upward up to five lines (then scrolls) with the Ask button bottom-anchored.
+- **Canvas overview card**: no longer repeats the step/exit count or the entry/step/terminal legend that the canvas board already shows; the card focuses on the description, Describe-with-AI, notes, and per-step detail.
+- **Rail brand header (frameless macOS)**: the Sapiom wordmark drops off the traffic-light line and reads inline as "sapiom agent.studio"; only the theme/collapse tools ride the lights' line.
+- **Account menu**: opening the account menu now collapses the settings card (and vice-versa) so the two never stack; the Workspaces ⋯ menu's Past-sessions sub-card also collapses when a grouping/sort choice is clicked.
+- **"Create new"**: promoted above Search as the primary affirmative action, restyled to the app's solid ink-button CTA (the Deploy treatment) with the reserved brand-green plus; the empty-rail state keeps a brand halo.
+- **Rail spacing**: top-level rail rows share one icon size, icon–text gap, and left inset.
+- **Sign-out**: removed the duplicate Disconnect from the settings panel — signing out now lives once in the account menu, below "Check for updates" and only when signed in.

--- a/.changeset/studio-ui-bugfixes.md
+++ b/.changeset/studio-ui-bugfixes.md
@@ -11,4 +11,5 @@ Studio UI fixes from design review:
 - **"Create new"**: promoted above Search as the primary affirmative action, restyled to the app's solid ink-button CTA (the Deploy treatment) with the reserved brand-green plus; the empty-rail state keeps a brand halo.
 - **Rail spacing**: top-level rail rows share one icon size, icon–text gap, and left inset.
 - **Sign-out**: removed the duplicate Disconnect from the settings panel — signing out now lives once in the account menu, below "Check for updates" and only when signed in.
+- **Canvas pane reveal**: an empty agent's board no longer snaps the canvas shut again right after you manually open it (a reveal race that also flaked CI); a live render still re-opens a pane you'd collapsed, and switching agents still follows the new board.
 - **Collapsed panels**: the expand control is now the mirror of the collapse icon (a panel-open glyph, same quiet style) instead of a menu/list icon; the rail's top tools line up with the icons below them; and the Templates header no longer collides with the macOS traffic lights when the left panel is collapsed.

--- a/.changeset/studio-ui-bugfixes.md
+++ b/.changeset/studio-ui-bugfixes.md
@@ -11,5 +11,6 @@ Studio UI fixes from design review:
 - **"Create new"**: promoted above Search as the primary affirmative action, restyled to the app's solid ink-button CTA (the Deploy treatment) with the reserved brand-green plus; the empty-rail state keeps a brand halo.
 - **Rail spacing**: top-level rail rows share one icon size, icon–text gap, and left inset.
 - **Sign-out**: removed the duplicate Disconnect from the settings panel — signing out now lives once in the account menu, below "Check for updates" and only when signed in.
+- **Composer**: dropped the redundant "New session" + from the top bar of the create-new composer — you're already starting one there.
 - **Canvas pane reveal**: an empty agent's board no longer snaps the canvas shut again right after you manually open it (a reveal race that also flaked CI); a live render still re-opens a pane you'd collapsed, and switching agents still follows the new board.
 - **Collapsed panels**: the expand control is now the mirror of the collapse icon (a panel-open glyph, same quiet style) instead of a menu/list icon; the rail's top tools line up with the icons below them; and the Templates header no longer collides with the macOS traffic lights when the left panel is collapsed.

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -188,7 +188,8 @@ test("deselect restores the overview: Esc, the panel's close, and empty board sp
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("canvas-step-inspector")).toHaveCount(0);
   await expect(panel).toContainText("Handles lease applications end to end");
-  await expect(panel).toContainText("4 steps");
+  // The step/exit count lives on the canvas board itself now (not repeated in
+  // this overview card), so the panel shows the description, not "N steps".
 
   // The panel's own close affordance does the same.
   await pickNode(page, "intake");

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -191,6 +191,13 @@ export const App = (): JSX.Element => {
   // both directions.
   const [paneSliding, setPaneSliding] = useState(false);
   const rightCollapsedRef = useRef(false);
+  // The (session + bound workflow) whose EMPTY board we've already auto-collapsed.
+  // onCanvasState fires on every probe/reload/re-render; content always reveals
+  // (even a pane the user had collapsed), but an empty board collapses only ONCE
+  // per (session, binding) — so a redundant "still empty" probe can't re-close a
+  // pane the user just expanded (the right-pane e2e race), while a genuine
+  // session/binding change still collapses.
+  const emptyCollapsedKeyRef = useRef<string | null>(null);
   const paneSlidingRef = useRef(false);
   const paneElRef = useRef<HTMLDivElement | null>(null);
   const paneObserverRef = useRef<ResizeObserver | null>(null);
@@ -1420,7 +1427,20 @@ export const App = (): JSX.Element => {
                   const activeExited =
                     state.sessions.find((s) => s.id === harness.activeSessionId)?.status ===
                     "exited";
-                  setRightCollapsed(!hasContent && !activeExited);
+                  if (hasContent || activeExited) {
+                    // Content present (or an exited session's invite) → always
+                    // reveal, re-opening even a pane the user had collapsed.
+                    emptyCollapsedKeyRef.current = null;
+                    setRightCollapsed(false);
+                    return;
+                  }
+                  // Empty board → collapse once per (session, bound workflow). A
+                  // redundant probe for the same one must not re-close a pane the
+                  // user just expanded; a new session or binding still collapses.
+                  const key = `${harness.activeSessionId ?? ""}::${rightPaneWorkflow?.path ?? ""}`;
+                  if (emptyCollapsedKeyRef.current === key) return;
+                  emptyCollapsedKeyRef.current = key;
+                  setRightCollapsed(true);
                 }}
                 expanded={canvasExpanded}
                 onToggleExpanded={() => setCanvasExpanded((v) => !v)}

--- a/packages/harness/web/src/components/BrandHeader.tsx
+++ b/packages/harness/web/src/components/BrandHeader.tsx
@@ -23,10 +23,10 @@ export function BrandHeader({ onCollapse }: { onCollapse: () => void }): JSX.Ele
     <header className="brand-header">
       <h1 className="brand-lockup">
         {/* The wordmark IS "Sapiom"; the accessible name comes from the two
-            parts together, so neither repeats the other. The mark is wrapped so
-            the frameless-mac layout can place it on the traffic-light line while
-            `agent.studio` drops to the line below; in a browser the wrapper is
-            `display:contents` and the lockup reads inline exactly as before. */}
+            parts together, so neither repeats the other. Mark + product read
+            inline as "sapiom agent.studio" (the wrapper is `display:contents`),
+            and the whole lockup drops below the traffic lights in the
+            frameless-mac frame — only the window tools ride the lights' line. */}
         <span className="brand-mark">
           <BrandLogotype height={13} aria-hidden />
           <span className="visually-hidden">Sapiom </span>
@@ -42,7 +42,7 @@ export function BrandHeader({ onCollapse }: { onCollapse: () => void }): JSX.Ele
           title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
           onClick={toggleTheme}
         >
-          <Icon name={theme === "dark" ? "Sun" : "Moon"} size={15} />
+          <Icon name={theme === "dark" ? "Sun" : "Moon"} size={14} />
         </button>
         <button
           className="theme-toggle"
@@ -51,7 +51,7 @@ export function BrandHeader({ onCollapse }: { onCollapse: () => void }): JSX.Ele
           title="Collapse workspace panel"
           onClick={onCollapse}
         >
-          <Icon name="PanelLeftClose" size={15} />
+          <Icon name="PanelLeftClose" size={14} />
         </button>
       </div>
     </header>

--- a/packages/harness/web/src/components/CanvasOverviewPanel.tsx
+++ b/packages/harness/web/src/components/CanvasOverviewPanel.tsx
@@ -249,20 +249,6 @@ export function CanvasOverviewPanel({
           <>
             <Icon name="Radio" size={13} />
             Overview
-            <span className="canvas-overview-stats">
-              {(overview?.stats ?? "").split("·").map((pair) => {
-                const part = pair.trim();
-                if (!part) return null;
-                const gap = part.indexOf(" ");
-                const value = gap === -1 ? part : part.slice(0, gap);
-                const label = gap === -1 ? "" : part.slice(gap + 1);
-                return (
-                  <span key={part} className="canvas-overview-stat">
-                    <strong>{value}</strong> {label}
-                  </span>
-                );
-              })}
-            </span>
             <button
               className="theme-toggle canvas-overview-close"
               data-testid="canvas-overview-toggle"
@@ -341,20 +327,6 @@ export function CanvasOverviewPanel({
                     ))}
                   </ul>
                 )}
-                <div className="canvas-legend-row" aria-hidden="true">
-                  <span>
-                    <span className="dot dot--entry" />
-                    entry / active step
-                  </span>
-                  <span>
-                    <span className="dot dot--step" />
-                    step
-                  </span>
-                  <span>
-                    <span className="dot dot--terminal" />
-                    terminal
-                  </span>
-                </div>
               </>
             )
           )}

--- a/packages/harness/web/src/components/CanvasStepDetail.tsx
+++ b/packages/harness/web/src/components/CanvasStepDetail.tsx
@@ -1311,7 +1311,7 @@ export function CanvasChatPanel({
             className="canvas-inspector-freeform-input"
             data-testid="canvas-freeform-input"
             placeholder={node ? "Ask about this step…" : "Ask about this agent…"}
-            rows={2}
+            rows={1}
             value={freeformText}
             onChange={(e) => setFreeformText(e.target.value)}
             onKeyDown={(e) => {

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -106,13 +106,13 @@ export function SessionBar({
     <div className="session-bar">
       {onExpandRail && (
         <button
-          className="gear-btn"
+          className="theme-toggle"
           data-testid="rail-expand"
           aria-label="Expand workspace panel"
           title="Expand workspace panel"
           onClick={onExpandRail}
         >
-          <Icon name="Menu" size={15} />
+          <Icon name="PanelLeftOpen" size={14} />
         </button>
       )}
 
@@ -356,13 +356,13 @@ export function SessionBar({
 
       {onExpandRight && (
         <button
-          className="gear-btn"
+          className="theme-toggle"
           data-testid="right-expand"
           aria-label="Expand canvas panel"
           title="Expand canvas panel"
           onClick={onExpandRight}
         >
-          <Icon name="List" size={15} />
+          <Icon name="PanelRightOpen" size={15} />
         </button>
       )}
 

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -340,7 +340,9 @@ export function SessionBar({
 
       {/* + : add a session — OUTSIDE the scrollable queue so it stays visible
           however long the session list grows. */}
-      {onNewSession && (activeSession || composing) && (
+      {/* No "new session" + while the composer IS the new-session screen — it's
+          redundant there. Only alongside a live session. */}
+      {onNewSession && activeSession && !composing && (
         <button
           className="session-new"
           data-testid="session-new"

--- a/packages/harness/web/src/components/SettingsPopover.tsx
+++ b/packages/harness/web/src/components/SettingsPopover.tsx
@@ -4,6 +4,7 @@ import type { AppState } from "@shared/types";
 import { HARNESS_PATHS } from "@shared/types";
 
 import type { AuthStartResponse } from "../lib/api";
+import { isMockMode } from "../lib/api";
 import { Icon } from "./Icon";
 import { track } from "../lib/track";
 
@@ -161,7 +162,12 @@ export function SettingsPopover({
         </div>
       )}
 
-      {authenticated && (
+      {/* Sign-out lives in the account menu (below "Check for updates", shown
+          only when signed in) — NOT here. The one exception is the demo/mock
+          build, where that account-menu slot is a "Connect Sapiom account" CTA
+          instead of a sign-out, so Settings carries Disconnect there (and it's
+          the surface the auth e2e suite drives). Hidden in the real app. */}
+      {isMockMode() && authenticated && (
         <div className="settings-auth-row">
           <button
             type="button"

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -351,10 +351,14 @@ export function WorkflowsRail({
   const pickGrouping = (next: RailGrouping): void => {
     setGrouping(next);
     saveUiPrefs({ railGrouping: next });
+    // A click that changes the section also collapses the Past-sessions
+    // sub-card, matching the hover behaviour on the fixed choices.
+    setPastOpen(false);
   };
   const pickSort = (next: RailSort): void => {
     setSort(next);
     saveUiPrefs({ railSort: next });
+    setPastOpen(false);
   };
   const historyTriggerRef = useRef<HTMLButtonElement>(null);
   // Closing the menu also folds its Past-sessions sub-card, so it never
@@ -442,30 +446,18 @@ export function WorkflowsRail({
     <aside ref={railRef} className="rail rail-workflows" style={{ width, minWidth }}>
       <BrandHeader onCollapse={onCollapse} />
 
-      {/* Search and Templates are the two persistent labelled destinations
-          above the workspace tree: Search opens the command palette (carrying
-          the unboxed ⌘K / Ctrl+K shortcut), Templates opens the catalog. They
-          read as rows, not a boxed field or a bare magnifier — a destination is
-          not chrome, and an unlabelled magnifier made the app's broadest way in
-          the one thing you had to already know about. */}
+      {/* The rail's top stack of labelled destinations. "Create new" leads as
+          the primary affirmative action (a solid ink button — the app's primary
+          CTA, like Deploy); Search opens the command palette (carrying the
+          unboxed ⌘K / Ctrl+K shortcut) and Templates opens the catalog. Search
+          and Templates read as rows, not a boxed field or a bare magnifier — a
+          destination is not chrome. */}
       <nav className="rail-nav" aria-label="Primary">
-        <button
-          type="button"
-          className="rail-nav-row"
-          data-testid="palette-trigger"
-          aria-label="Search sessions, agents, and paths"
-          onClick={onOpenPalette}
-        >
-          <Icon name="Search" size={14} />
-          <span>Search</span>
-          <span className="rail-nav-kbd">{SHORTCUT_HINT}</span>
-        </button>
-
-        {/* The primary creative action, promoted out of the header + into a
-            standing CTA directly under Search: the fastest path to a new agent.
-            It opens the composer-first "new session" home; when the rail has
-            nothing yet it becomes the filled primary button so an empty
-            workspace has an obvious next step. */}
+        {/* The primary creative action, promoted out of the header + ABOVE
+            Search: the fastest path to a new agent. It opens the composer-first
+            "new session" home. A standing ink-button CTA; when the rail has
+            nothing yet it gains a soft brand halo so an empty workspace has an
+            obvious next step. */}
         <button
           type="button"
           className={"rail-nav-cta" + (isEmpty ? " is-empty" : "")}
@@ -478,6 +470,18 @@ export function WorkflowsRail({
         >
           <Icon name="Plus" size={14} />
           <span>Create new</span>
+        </button>
+
+        <button
+          type="button"
+          className="rail-nav-row"
+          data-testid="palette-trigger"
+          aria-label="Search sessions, agents, and paths"
+          onClick={onOpenPalette}
+        >
+          <Icon name="Search" size={14} />
+          <span>Search</span>
+          <span className="rail-nav-kbd">{SHORTCUT_HINT}</span>
         </button>
 
         <button
@@ -971,7 +975,13 @@ function ProfileRow({
         aria-haspopup="menu"
         aria-expanded={menuOpen}
         title={demo ? "Static demo. No Sapiom account, server, or agent is connected." : "Account"}
-        onClick={() => setMenuOpen((open) => !open)}
+        onClick={() => {
+          // Opening the account menu collapses the settings card so the two
+          // never stack — one section of the profile is open at a time.
+          const willOpen = !menuOpen;
+          setMenuOpen(willOpen);
+          if (willOpen) closeSettings();
+        }}
       >
         <span className="rail-profile-avatar" aria-hidden="true">
           {initial}
@@ -987,7 +997,7 @@ function ProfileRow({
             {meta}
           </span>
         </span>
-        <Icon name="ChevronDown" size={13} />
+        <Icon name="ChevronDown" size={14} />
       </button>
 
       <AnchoredPopover

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -379,7 +379,10 @@ input {
   align-items: center;
   justify-content: space-between;
   height: var(--pane-header-h);
-  padding: 0 var(--pane-pad-x);
+  /* Wordmark keeps the pane inset on the left; the tool cluster on the right
+     sits at --sp2 so its icons line up with the Workspaces ⋯ and the tree's
+     status icons (which sit at the same --sp2 right inset). */
+  padding: 0 var(--sp2) 0 var(--pane-pad-x);
   /* Transparent — the rail block's surface shows through, so the wordmark row
      is never a different colour from the rail beneath it. */
   background: transparent;
@@ -403,8 +406,10 @@ input {
   align-items: center;
   height: auto;
   /* No bottom padding: the --sp2 gap below agent.studio is owned by the nav's
-     padding-top, so agent.studio → Search matches every other top-stack gap. */
-  padding: 0 var(--pane-pad-x);
+     padding-top, so agent.studio → Search matches every other top-stack gap.
+     Right inset is --sp2 so the tool cluster lines up with the ⋯ / status
+     icons below (see the browser-frame .brand-header note). */
+  padding: 0 var(--sp2) 0 var(--pane-pad-x);
   column-gap: var(--sp2);
 }
 
@@ -441,7 +446,8 @@ input {
    session bar becomes the top-left element — leading with its rail-expand
    button, the affordance that brings the rail back. It takes over the
    clearance so the lights never land on that button. */
-:root[data-window-frame="macos"] .app-shell[data-rail-collapsed] .session-bar {
+:root[data-window-frame="macos"] .app-shell[data-rail-collapsed] .session-bar,
+:root[data-window-frame="macos"] .app-shell[data-rail-collapsed] .templates-bar {
   padding-left: 78px;
 }
 
@@ -2717,34 +2723,6 @@ input {
    subtle shadow, and — in light mode — a solid accent fill on hover (the
    product's `hover:bg-accent`); dark mode keeps the more restrained neutral
    hover the outline variant uses there. */
-.gear-btn {
-  width: var(--control-h-xs);
-  height: var(--control-h-xs);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-2);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-xs);
-  color: var(--text-dim);
-  transition:
-    background-color var(--transition-fast),
-    border-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.gear-btn:hover {
-  background: var(--surface-hover);
-  border-color: var(--ui-line-strong);
-  color: var(--text);
-}
-
-.gear-btn:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
-}
-
 /* Portaled off the rail's profile row (AnchoredPopover, matchWidth): the
    surface comes from the ONE popover recipe; only the roomier content
    padding is its own. */
@@ -6669,7 +6647,7 @@ input {
   border-bottom: 1px solid var(--ui-line);
 }
 
-/* Matches Button variant="outline" size="icon" — see .gear-btn. */
+/* Matches Button variant="outline" size="icon": a 32px square icon button. */
 .dir-picker-up {
   flex: 0 0 auto;
   width: var(--control-h-xs);

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -392,9 +392,10 @@ input {
    applies in a browser (npx), which never sets the attribute: a header padded
    for lights that are not there, or a drag region that cannot drag, would be
    wrong anywhere but the frameless window. */
-/* Two-row rail header: the wordmark + tools sit on the traffic-light line, and
-   `agent.studio` drops to the line below — into the space under the lights.
-   Only the rail's header grows; the session bar and tabs stay one 56px line. */
+/* Two-row rail header: only the window tools ride the traffic-light line; the
+   whole "sapiom agent.studio" lockup drops to the line below — into the space
+   under the lights, never pinned beside them. Only the rail's header grows; the
+   session bar and tabs stay one 56px line. */
 :root[data-window-frame="macos"] .brand-header {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -407,29 +408,19 @@ input {
   column-gap: var(--sp2);
 }
 
-/* Re-materialize the lockup's parts as grid items. */
-:root[data-window-frame="macos"] .brand-header .brand-lockup {
-  display: contents;
-}
-
-:root[data-window-frame="macos"] .brand-header .brand-mark {
-  display: flex;
-  align-items: center;
-  grid-column: 1;
-  grid-row: 1;
-  /* Clear the traffic-light group (it ends ~71px in) — only on this top line. */
-  padding-left: calc(78px - var(--pane-pad-x));
-}
-
+/* The window tools (theme + collapse) ride the traffic-light line, to the RIGHT
+   of the OS lights; the left of that line stays empty for the lights. */
 :root[data-window-frame="macos"] .brand-header .brand-header-tools {
   grid-column: 2;
   grid-row: 1;
 }
 
-:root[data-window-frame="macos"] .brand-header .brand-product {
-  grid-column: 1 / -1;
+/* The lockup drops in full to the line below the lights, reading inline as
+   "sapiom agent.studio" (its default baseline-flex layout) at the rail's normal
+   left inset — no traffic-light clearance, because nothing shares this line. */
+:root[data-window-frame="macos"] .brand-header .brand-lockup {
+  grid-column: 1;
   grid-row: 2;
-  /* Below the lights — no clearance; sits at the rail's normal left inset. */
 }
 
 /* The app's top line is the window's drag handle; every control on it opts back
@@ -513,7 +504,7 @@ input {
 /* One uniform gap (--sp2) sets the whole top stack's rhythm: the nav's
    padding-top spaces it off the brand header, each row/CTA carries an --sp2
    bottom margin, and the Workspaces header takes no top margin — so
-   agent.studio → Search → Create new → Templates → Workspaces are all evenly
+   agent.studio → Create new → Search → Templates → Workspaces are all evenly
    spaced by the same 8px. */
 .rail-nav {
   display: flex;
@@ -754,42 +745,43 @@ input {
   font-weight: 550;
 }
 
-/* "Create new": the primary creative action, promoted out of the header + into
-   a standing CTA under Search. A real button (bordered fill, centered label,
-   brand-green plus) — distinct from the ghost Search/Templates rows, but the
-   same inset and --sp2 rhythm so the top stack stays evenly spaced. */
+/* "Create new": the primary affirmative action, promoted out of the header and
+   ABOVE Search. It's the app's primary CTA — a solid ink button (the same
+   --btn/--btn-ink treatment as Deploy / .btn-primary) — so it stays visually
+   distinct from the ghost Search/Templates rows while keeping their inset and
+   --sp2 rhythm. */
 .rail-nav-cta {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--sp1);
+  gap: var(--sp2);
   width: calc(100% - var(--sp3));
   margin: 0 var(--sp2) var(--sp2);
   min-height: var(--control-h);
   padding: 0 var(--sp2);
-  border: 1px solid var(--ui-line-strong);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  background: var(--surface-raised);
+  background: var(--btn);
+  box-shadow: var(--shadow-xs);
   text-align: center;
   font-size: var(--type-ui);
   font-weight: 550;
-  color: var(--text);
+  color: var(--btn-ink);
   cursor: pointer;
   transition:
     background-color var(--transition-fast),
-    border-color var(--transition-fast),
     box-shadow var(--transition-fast),
     transform var(--transition-fast);
 }
 
-/* The plus is the create signal — the one reserved accent at rest, inheriting
-   the button ink once the CTA fills in for the empty state. */
+/* The plus is the create signal — the one reserved brand accent, riding the ink
+   button. Mixed toward the button's ink so the green stays legible whichever way
+   the ink button flips with the theme (dark-in-light, light-in-dark). */
 .rail-nav-cta svg {
-  color: var(--brand);
+  color: color-mix(in srgb, var(--brand) 65%, var(--btn-ink));
 }
 
 .rail-nav-cta:hover {
-  background: var(--surface-hover);
   transform: translateY(-1px);
   box-shadow: var(--shadow-soft);
 }
@@ -803,26 +795,19 @@ input {
   transform: translateY(0);
 }
 
-/* Empty rail: fill with the brand green (the reserved accent) over its own
-   contrasting ink, ringed in a soft brand halo — so the one action a first-run
-   user needs is the loudest thing on an otherwise empty rail. --brand-ink flips
-   with the theme (white on the dark-green light brand, near-black on the
-   light-green dark brand), so it stays legible in both. */
+/* Empty rail: keep the ink button but ring it in a soft brand halo, so the one
+   action a first-run user needs is the loudest thing on an otherwise empty rail
+   — without spending the reserved green as a full fill. */
 .rail-nav-cta.is-empty {
-  background: var(--brand);
-  border-color: transparent;
-  color: var(--brand-ink);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 22%, transparent);
-}
-
-.rail-nav-cta.is-empty svg {
-  color: var(--brand-ink);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--brand) 24%, transparent),
+    var(--shadow-xs);
 }
 
 .rail-nav-cta.is-empty:hover {
   transform: translateY(-1px);
   box-shadow:
-    0 0 0 4px color-mix(in srgb, var(--brand) 32%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--brand) 34%, transparent),
     var(--shadow-soft);
 }
 
@@ -2774,6 +2759,50 @@ input {
   padding-bottom: 10px;
   margin-bottom: 10px;
   border-bottom: 1px solid var(--border);
+}
+
+/* Sign-out row. Disconnect is the quiet OUTLINE counterpart to the ink
+   "Connect account" — a bordered ghost at rest, leaning on the readable danger
+   hue only on hover to say it signs you out. (Was unstyled, so it fell back to
+   the browser's default grey button.) */
+.settings-auth-row {
+  margin-bottom: 14px;
+}
+
+.settings-disconnect-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  height: var(--control-h-xs);
+  padding: 0 var(--sp3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: var(--type-label);
+  font-weight: 510;
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.settings-disconnect-btn:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--red-text) 50%, var(--border-strong));
+  background: color-mix(in srgb, var(--red-text) 9%, transparent);
+  color: var(--red-text);
+}
+
+.settings-disconnect-btn:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.settings-disconnect-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .settings-toggle-row {
@@ -5164,32 +5193,6 @@ input {
   margin-left: var(--sp1);
 }
 
-/* The step count and entry point are the header's meta, not a body line. */
-/* Stat pairs on the head's right edge: the COUNT is the signal (ink,
-   tabular), the unit stays quiet — "5 steps · intake entry" reads as data,
-   not prose. */
-.canvas-overview-stats {
-  margin-left: auto;
-  display: flex;
-  align-items: baseline;
-  gap: var(--sp2);
-  font-size: var(--type-meta);
-  font-weight: 400;
-  color: var(--text-faint);
-}
-
-.canvas-overview-stat strong {
-  color: var(--text);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.canvas-overview-stat + .canvas-overview-stat::before {
-  content: "·";
-  margin-right: var(--sp2);
-  color: var(--text-faint);
-}
-
 .canvas-overview-body {
   flex: 1;
   min-height: 0;
@@ -5256,19 +5259,15 @@ input {
   font-variant-numeric: tabular-nums;
 }
 
-/* Debug macros: an actions band under the run facts, set off by a hairline.
-   The macro buttons stack full-width (they inherit .btn-ghost / .btn-primary);
-   the free-form ask spans the full width below. These rules own only the band
-   layout and the textarea — all on shared inspector tokens, so the section
-   reads as native to the panel above it. */
+/* The chat body: an actions band inside the chat panel. When a step is selected
+   it holds the macro pills (they inherit .btn-ghost / .btn-primary); the
+   free-form ask always spans the full width below. No hairline — the chat head
+   already sets this off from the panel above. */
 .canvas-inspector-macros {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: var(--sp1);
-  margin-top: var(--sp1);
-  padding-top: var(--sp2);
-  border-top: 1px solid var(--ui-line);
+  gap: var(--sp2);
 }
 
 /* The three macros ride as a single wrapping row of pills (they inherit
@@ -5279,30 +5278,42 @@ input {
   text-align: center;
 }
 
-/* The free-form ask always drops to its own full-width row below the pills. */
+/* The free-form ask spans a full-width row below the pills: a single clean
+   line with the Ask button bottom-anchored, so it holds the baseline as the
+   textarea grows upward. */
 .canvas-inspector-freeform {
   flex: 1 0 100%;
   display: flex;
-  flex-direction: column;
-  gap: var(--sp1);
+  flex-direction: row;
+  align-items: flex-end;
+  gap: var(--sp2);
 }
 
+/* Borderless, boxless input — a bare text row (mirrors .composer-input). It
+   auto-grows with its content up to five lines, then scrolls. */
 .canvas-inspector-freeform-input {
-  width: 100%;
-  resize: vertical;
-  padding: var(--sp1) var(--sp2);
+  flex: 1;
+  min-width: 0;
+  resize: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font: inherit;
   font-size: var(--type-label);
+  line-height: 1.5;
   color: var(--text);
-  background: var(--surface-raised);
-  border: 1px solid var(--ui-line);
-  border-radius: var(--radius-md);
+  field-sizing: content;
+  min-height: 1.5em;
+  max-height: calc(1.5em * 5);
+  overflow-y: auto;
+}
+
+.canvas-inspector-freeform-input::placeholder {
+  color: var(--text-faint);
 }
 
 .canvas-inspector-freeform-input:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 1px;
-  border-color: var(--ui-line-strong);
+  outline: none;
 }
 
 .canvas-inspector-freeform-ask {
@@ -5371,22 +5382,6 @@ input {
   display: flex;
   flex-direction: column;
   gap: var(--sp1);
-}
-
-.canvas-legend-row {
-  display: flex;
-  align-items: center;
-  gap: var(--sp3);
-  color: var(--text-faint);
-  font-size: var(--type-meta);
-}
-
-.canvas-legend-row .dot {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  margin-right: 5px;
 }
 
 .dot--entry { background: var(--brand); }


### PR DESCRIPTION
Addresses the design-review items on the Studio SPA (from Tidjane), a few follow-up polish items, and a pre-existing canvas-reveal race that was intermittently reddening CI.

## Design-review fixes
- **Chat panel**: the "Ask about this agent/step" field is a clean, boxless single row — no border/box, no separator hairline — that auto-grows upward to 5 lines then scrolls, with **Ask** bottom-anchored.
- **Canvas overview card**: no longer repeats the step/exit count and entry/step/terminal legend the board already shows (the board is the single source); removed the dead CSS.
- **Nested popovers**: the account and settings cards are now mutually exclusive, and the Workspaces ⋯ "Past sessions" sub-card collapses on a grouping/sort click.
- **Brand header (frameless macOS)**: the wordmark drops off the traffic-light line and reads inline as "sapiom agent.studio"; only the window tools ride the lights' line.
- **"Create new"**: promoted above Search as the primary affirmative CTA — a solid ink button (the Deploy treatment) with the reserved brand-green plus.
- **Rail spacing**: top-level rows share one icon size / gap / left inset; the top tools now line up with the ⋯ and the tree's status icons.
- **Sign-out**: removed the duplicate Disconnect from the settings panel — it lives once in the account menu, below "Check for updates" and only when signed in (kept in the demo/mock build, where that menu slot is the connect CTA and the e2e suite uses it).

## Follow-up polish
- **Collapsed panels**: the expand control mirrors the collapse icon (panel-open glyph, same quiet style) instead of a menu/list icon.
- **Templates + collapsed rail (macOS)**: the Templates bar takes the traffic-light clearance, so its Back button and title no longer sit under the OS window controls.
- **Composer**: dropped the redundant "New session" + from the top bar of the create-new screen — you're already starting one there.

## Canvas-reveal de-flake (also fixes a flake currently on `main`)
`onCanvasState` (canvas-follows-content, #550) re-ran `setRightCollapsed(!hasContent)` on every probe/reload, so an empty board could snap the pane shut right after a manual open — a real glitch that also flaked the right-pane e2e (`new-session-composer`, `direct-action-feedback`) intermittently. Now: **content always reveals** (re-opening even a pane you'd collapsed), and an **empty board auto-collapses only once per (session, bound workflow)** — a redundant probe can't fight a manual expand, while a genuine session/binding change still collapses.

## Verification
Client-side only. Typecheck, `build:web`, terminology check, and the full mock e2e suite all green — **291/291 across repeated runs** (previously flaked 290/1). Fixes verified live in both themes (and the macOS frame) via Chrome DevTools. Changeset: `@sapiom/harness` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)