### PR TITLE
fix(agent-core): install deps on scaffold + actionable Canvas bundle-error hint (SAP-2462)

### DIFF
--- a/.changeset/canvas-install-and-npm-hint.md
+++ b/.changeset/canvas-install-and-npm-hint.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/mcp": patch
+"@sapiom/harness": patch
+---
+
+Install a new agent's dependencies on scaffold, and turn the Canvas's "Could not resolve …" render error into an actionable "run npm install" hint
+
+The Canvas step-graph extraction (`check` / `loadDefinition`) esbuild-bundles a project's `index.ts` resolving its imports — `@sapiom/agent`, `zod`, … — from the project's own `node_modules`. A newly-scaffolded (or freshly-cloned) agent whose deps were never installed therefore failed its very first, unprompted Canvas render with a raw esbuild wall (`Could not resolve "@sapiom/agent" … Could not resolve "zod"`), which the failure panel relayed verbatim.
+
+Two fixes:
+
+- `scaffold()` gains an opt-in `installDependencies` flag (returned as `dependenciesInstalled`), and the `sapiom_dev_agents_scaffold` MCP tool — the Studio's create path — now passes it, so a new agent opens with a working Canvas. Best-effort and non-fatal: a missing/offline npm still yields a successful scaffold. The `installProjectDependencies` helper (previously demo-only inside the harness's example seed) now lives in `@sapiom/agent-core` and is shared by both.
+- `check` and `loadDefinition` now route bundle failures through `describeBundleFailure`, which detects the "no `node_modules` + unresolved import" case and returns `Dependencies are not installed. Run \`npm install\` in <dir>, then try again.` (preserving the raw esbuild detail). Every other bundle failure's message is unchanged.

--- a/packages/agent-core/src/bundle-error.spec.ts
+++ b/packages/agent-core/src/bundle-error.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for describeBundleFailure — the mapping that turns esbuild's raw
+ * "Could not resolve …" (by far the most common cause: a project whose deps
+ * were never installed) into a one-line "run npm install" instruction, while
+ * leaving every other bundle failure's message untouched.
+ */
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describeBundleFailure } from "./bundle-error";
+
+describe("describeBundleFailure", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "bundle-error-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("maps an unresolved import in a project with no node_modules to a run-npm-install hint", () => {
+    const esbuildErr = new Error(
+      "Build failed with 2 errors:\n" +
+        'index.ts:1:31: ERROR: Could not resolve "@sapiom/agent"\n' +
+        'index.ts:2:18: ERROR: Could not resolve "zod"',
+    );
+
+    const hint = describeBundleFailure(dir, esbuildErr);
+
+    // Actionable instruction naming the directory the user must install in.
+    expect(hint).toContain("Dependencies are not installed");
+    expect(hint).toContain("npm install");
+    expect(hint).toContain(dir);
+    // Raw esbuild detail is preserved for anyone who needs it.
+    expect(hint).toContain('Could not resolve "@sapiom/agent"');
+  });
+
+  it("leaves the raw message untouched when node_modules exists (a genuine bad import)", () => {
+    mkdirSync(path.join(dir, "node_modules"));
+    const esbuildErr = new Error(
+      'index.ts:1:31: ERROR: Could not resolve "not-a-real-pkg"',
+    );
+
+    const hint = describeBundleFailure(dir, esbuildErr);
+
+    // Deps are installed, so this is a real unresolved import — don't misdirect
+    // the user to `npm install`.
+    expect(hint).not.toContain("Dependencies are not installed");
+    expect(hint).toBe(
+      'index.ts:1:31: ERROR: Could not resolve "not-a-real-pkg"',
+    );
+  });
+
+  it("leaves a non-resolution failure (syntax error) untouched even without node_modules", () => {
+    const esbuildErr = new Error(
+      'index.ts:3:5: ERROR: Expected ";" but found "const"',
+    );
+
+    const hint = describeBundleFailure(dir, esbuildErr);
+
+    expect(hint).not.toContain("Dependencies are not installed");
+    expect(hint).toBe('index.ts:3:5: ERROR: Expected ";" but found "const"');
+  });
+
+  it("stringifies a non-Error thrown value", () => {
+    expect(describeBundleFailure(dir, "boom")).toBe("boom");
+  });
+});

--- a/packages/agent-core/src/bundle-error.ts
+++ b/packages/agent-core/src/bundle-error.ts
@@ -1,0 +1,33 @@
+/**
+ * bundle-error — turn esbuild's raw bundle failure into an actionable hint.
+ *
+ * The Canvas render, `check`, and `run_local` all esbuild-bundle a project's
+ * `index.ts` resolving its imports from the project's own `node_modules`. By
+ * far the most common failure is "Could not resolve …" against a project whose
+ * dependencies were simply never installed (a fresh clone, or a scaffold whose
+ * install was skipped/failed). Relaying esbuild's raw message — a wall of
+ * "Could not resolve \"@sapiom/agent\" … Could not resolve \"zod\"" with deep
+ * relative paths — leaves the user staring at noise. This maps that exact case
+ * to a one-line instruction, while preserving the original detail for any other
+ * bundle failure (a genuine bad import, a syntax error).
+ */
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Describe an esbuild bundle failure for `sourceDir`. When the project has no
+ * `node_modules` and esbuild reported an unresolved import, returns an
+ * actionable "run npm install" hint (with the raw detail appended). Otherwise
+ * returns the raw error message unchanged.
+ */
+export function describeBundleFailure(sourceDir: string, err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const nodeModules = path.join(sourceDir, "node_modules");
+  if (!existsSync(nodeModules) && /Could not resolve/.test(raw)) {
+    return (
+      `Dependencies are not installed. Run \`npm install\` in ${sourceDir}, then try again. ` +
+      `(esbuild: ${raw})`
+    );
+  }
+  return raw;
+}

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -20,6 +20,7 @@ import {
 } from "@sapiom/agent";
 import * as esbuild from "esbuild";
 
+import { describeBundleFailure } from "./bundle-error.js";
 import { AgentOperationError } from "./errors.js";
 
 /**
@@ -170,7 +171,7 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
       throw new AgentOperationError({
         code: "BUNDLE_FAILED",
         message: "Failed to bundle the agent.",
-        hint: err instanceof Error ? err.message : String(err),
+        hint: describeBundleFailure(sourceDir, err),
       });
     }
 

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -53,6 +53,11 @@ export type {
   ResolvedVersions,
 } from "./scaffold.js";
 
+// Best-effort dependency install + bundle-failure hinting — shared by scaffold,
+// the example seed, and the Canvas/check/run-local bundle paths.
+export { installProjectDependencies } from "./install-deps.js";
+export { describeBundleFailure } from "./bundle-error.js";
+
 // check (no Sapiom service call; imports author code while deriving the manifest)
 export { check } from "./check.js";
 export type { CheckOptions, CheckResult } from "./check.js";

--- a/packages/agent-core/src/install-deps.spec.ts
+++ b/packages/agent-core/src/install-deps.spec.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { installProjectDependencies } from "./install-deps";
 
 describe("installProjectDependencies", () => {
-  it("returns false (never throws) when the install cannot run", () => {
+  it("resolves false (never rejects) when the install cannot run", async () => {
     // A directory that does not exist makes the npm spawn fail immediately —
     // no network, deterministic — exercising the best-effort catch.
     const missing = path.join(
@@ -21,7 +21,6 @@ describe("installProjectDependencies", () => {
       `${process.pid}`,
     );
 
-    expect(() => installProjectDependencies(missing)).not.toThrow();
-    expect(installProjectDependencies(missing)).toBe(false);
+    await expect(installProjectDependencies(missing)).resolves.toBe(false);
   });
 });

--- a/packages/agent-core/src/install-deps.spec.ts
+++ b/packages/agent-core/src/install-deps.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit test for installProjectDependencies — it must be soft: any failure
+ * (here, a non-existent working directory) returns false rather than throwing,
+ * so a scaffold/seed that can't install still completes.
+ */
+import path from "node:path";
+
+import { installProjectDependencies } from "./install-deps";
+
+describe("installProjectDependencies", () => {
+  it("returns false (never throws) when the install cannot run", () => {
+    // A directory that does not exist makes the npm spawn fail immediately —
+    // no network, deterministic — exercising the best-effort catch.
+    const missing = path.join(
+      "/",
+      "definitely",
+      "not",
+      "a",
+      "real",
+      "dir",
+      `${process.pid}`,
+    );
+
+    expect(() => installProjectDependencies(missing)).not.toThrow();
+    expect(installProjectDependencies(missing)).toBe(false);
+  });
+});

--- a/packages/agent-core/src/install-deps.ts
+++ b/packages/agent-core/src/install-deps.ts
@@ -13,32 +13,47 @@
  * Deliberately best-effort and non-fatal: if npm is missing or offline the
  * caller still succeeds, and the Canvas degrades to its existing "run
  * npm install / ask your agent to fix it" prompt (see describeBundleFailure).
+ *
+ * Async on purpose: this runs on the interactive create path (the
+ * `sapiom_dev_agents_scaffold` MCP tool), and the MCP server is a single event
+ * loop. A synchronous `execFileSync` would freeze the whole server for the
+ * entire install — no other JSON-RPC message, cancellation, or ping serviced —
+ * so we spawn the child and await it instead.
  */
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 /** Hard ceiling on the install so a pathological dependency tree can't block a
  *  scaffold/seed indefinitely. */
 const INSTALL_TIMEOUT_MS = 120_000;
 
+/** Bound the captured stdout/stderr — `--loglevel=error` keeps npm nearly
+ *  silent, but a large error dump shouldn't reject with ENOBUFS. */
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
 /**
- * Run `npm install` in `projectDir`. Returns true on success, false on any
- * failure (npm missing, offline, non-zero exit, timeout) — never throws, so a
+ * Run `npm install` in `projectDir`. Resolves true on success, false on any
+ * failure (npm missing, offline, non-zero exit, timeout) — never rejects, so a
  * caller can treat a failed install as a soft degrade rather than a hard error.
  *
  * `shell: true` on Windows lets the OS resolve the `npm.cmd` shim; `cwd` (which
  * may contain spaces) is passed via options, not interpolated into a command
  * line, so it stays safe.
  */
-export function installProjectDependencies(projectDir: string): boolean {
+export async function installProjectDependencies(
+  projectDir: string,
+): Promise<boolean> {
   try {
-    execFileSync(
+    await execFileAsync(
       "npm",
       ["install", "--no-audit", "--no-fund", "--loglevel=error"],
       {
         cwd: projectDir,
-        stdio: "ignore",
         shell: process.platform === "win32",
         timeout: INSTALL_TIMEOUT_MS,
+        maxBuffer: MAX_BUFFER_BYTES,
       },
     );
     return true;

--- a/packages/agent-core/src/install-deps.ts
+++ b/packages/agent-core/src/install-deps.ts
@@ -1,0 +1,48 @@
+/**
+ * install-deps — best-effort `npm install` for a freshly-scaffolded (or
+ * freshly-cloned) agent project.
+ *
+ * Why this is its own module: the Canvas step-graph extraction (`check()`)
+ * esbuild-bundles the project's `index.ts` and resolves its imports —
+ * `@sapiom/agent`, `zod`, … — from the project's own `node_modules`. A project
+ * whose deps were never installed therefore fails its very first Canvas render
+ * with "Could not resolve …". Running the install as part of create/seed means
+ * a new agent opens with a working Canvas instead of an error the user has to
+ * ask their coding agent to fix.
+ *
+ * Deliberately best-effort and non-fatal: if npm is missing or offline the
+ * caller still succeeds, and the Canvas degrades to its existing "run
+ * npm install / ask your agent to fix it" prompt (see describeBundleFailure).
+ */
+import { execFileSync } from "node:child_process";
+
+/** Hard ceiling on the install so a pathological dependency tree can't block a
+ *  scaffold/seed indefinitely. */
+const INSTALL_TIMEOUT_MS = 120_000;
+
+/**
+ * Run `npm install` in `projectDir`. Returns true on success, false on any
+ * failure (npm missing, offline, non-zero exit, timeout) — never throws, so a
+ * caller can treat a failed install as a soft degrade rather than a hard error.
+ *
+ * `shell: true` on Windows lets the OS resolve the `npm.cmd` shim; `cwd` (which
+ * may contain spaces) is passed via options, not interpolated into a command
+ * line, so it stays safe.
+ */
+export function installProjectDependencies(projectDir: string): boolean {
+  try {
+    execFileSync(
+      "npm",
+      ["install", "--no-audit", "--no-fund", "--loglevel=error"],
+      {
+        cwd: projectDir,
+        stdio: "ignore",
+        shell: process.platform === "win32",
+        timeout: INSTALL_TIMEOUT_MS,
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent-core/src/local/load.ts
+++ b/packages/agent-core/src/local/load.ts
@@ -4,10 +4,10 @@
  * does, but returns the live definition object (with runnable step bodies) so
  * the local dispatcher can execute steps in-process.
  */
-import { createHash } from 'node:crypto';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   type AgentDefinition,
@@ -15,12 +15,13 @@ import {
   buildManifest,
   isAgentDefinition,
   agentManifestSchema,
-} from '@sapiom/agent';
-import * as esbuild from 'esbuild';
+} from "@sapiom/agent";
+import * as esbuild from "esbuild";
 
-import { AgentOperationError } from '../errors.js';
+import { describeBundleFailure } from "../bundle-error.js";
+import { AgentOperationError } from "../errors.js";
 
-const LOCAL_SDK_VERSION = '0.0.0-local';
+const LOCAL_SDK_VERSION = "0.0.0-local";
 
 export interface LoadedDefinition {
   definition: AgentDefinition;
@@ -28,58 +29,67 @@ export interface LoadedDefinition {
 }
 
 /** Bundle + import + manifest a project directory's index.ts. */
-export async function loadDefinition(sourceDir: string): Promise<LoadedDefinition> {
-  const entryFile = path.join(sourceDir, 'index.ts');
+export async function loadDefinition(
+  sourceDir: string,
+): Promise<LoadedDefinition> {
+  const entryFile = path.join(sourceDir, "index.ts");
   if (!existsSync(entryFile)) {
     throw new AgentOperationError({
-      code: 'NO_ENTRY',
+      code: "NO_ENTRY",
       message: `No index.ts found in ${sourceDir}.`,
-      hint: 'Run this from an agent project, or pass its directory.',
+      hint: "Run this from an agent project, or pass its directory.",
     });
   }
 
-  const tmp = mkdtempSync(path.join(tmpdir(), 'sapiom-run-'));
-  const bundlePath = path.join(tmp, 'definition.mjs');
+  const tmp = mkdtempSync(path.join(tmpdir(), "sapiom-run-"));
+  const bundlePath = path.join(tmp, "definition.mjs");
   try {
     try {
       await esbuild.build({
         entryPoints: [entryFile],
         outfile: bundlePath,
         bundle: true,
-        platform: 'node',
-        target: 'node20',
-        format: 'esm',
-        logLevel: 'silent',
+        platform: "node",
+        target: "node20",
+        format: "esm",
+        logLevel: "silent",
       });
     } catch (err) {
       throw new AgentOperationError({
-        code: 'BUNDLE_FAILED',
-        message: 'Failed to bundle the agent.',
-        hint: err instanceof Error ? err.message : String(err),
+        code: "BUNDLE_FAILED",
+        message: "Failed to bundle the agent.",
+        hint: describeBundleFailure(sourceDir, err),
       });
     }
 
-    const mod: Record<string, unknown> = await import(`file://${bundlePath}?t=${Date.now()}`);
+    const mod: Record<string, unknown> = await import(
+      `file://${bundlePath}?t=${Date.now()}`
+    );
     const defs = Object.values(mod).filter(isAgentDefinition);
     if (defs.length === 0) {
       throw new AgentOperationError({
-        code: 'NO_DEFINITION',
-        message: 'No agent was exported from index.ts.',
-        hint: 'Export the result of defineAgent({ … }).',
+        code: "NO_DEFINITION",
+        message: "No agent was exported from index.ts.",
+        hint: "Export the result of defineAgent({ … }).",
       });
     }
     if (defs.length > 1) {
       throw new AgentOperationError({
-        code: 'MULTIPLE_DEFINITIONS',
-        message: 'index.ts exports more than one agent.',
-        hint: 'Export exactly one defineAgent({ … }) result.',
+        code: "MULTIPLE_DEFINITIONS",
+        message: "index.ts exports more than one agent.",
+        hint: "Export exactly one defineAgent({ … }) result.",
       });
     }
 
     const definition = defs[0];
-    const sha256 = createHash('sha256').update(readFileSync(bundlePath)).digest('hex');
+    const sha256 = createHash("sha256")
+      .update(readFileSync(bundlePath))
+      .digest("hex");
     const manifest = agentManifestSchema.parse(
-      buildManifest(definition, { sdkVersion: LOCAL_SDK_VERSION, artifact: { sha256, entryFile: 'definition.mjs' } }),
+      buildManifest(definition, {
+        sdkVersion: LOCAL_SDK_VERSION,
+        artifact: { sha256, entryFile: "definition.mjs" },
+      }),
     ) as AgentManifest;
 
     return { definition, manifest };

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 
 import { writeConfig } from "./config.js";
 import { AgentOperationError } from "./errors.js";
+import { installProjectDependencies } from "./install-deps.js";
 import { VERSION_FALLBACK } from "./version-fallback.generated.js";
 
 /**
@@ -294,6 +295,17 @@ export interface ScaffoldOptions {
    * the npm registry (may add ~5 s on slow connections).
    */
   versions?: ResolvedVersions;
+  /**
+   * Run a best-effort `npm install` in the new project so the Canvas can
+   * esbuild-bundle it on first render (its extraction resolves `@sapiom/agent`,
+   * `zod`, … from the project's own `node_modules`). Defaults to false so the
+   * CLI's `init` — which prints `npm install` as an explicit next step — and
+   * tests stay offline/fast. The Studio create path (the MCP scaffold tool)
+   * opts in with true so a newly-created agent opens with a working Canvas
+   * instead of a "Could not resolve …" render error. Non-fatal: a failed
+   * install (npm missing/offline) still returns a successful scaffold.
+   */
+  installDependencies?: boolean;
 }
 
 export interface ScaffoldResult {
@@ -302,6 +314,10 @@ export interface ScaffoldResult {
   projectName: string;
   /** Whether a git repo with an initial commit was created (false if `git` was unavailable). */
   gitInitialized: boolean;
+  /** Whether `npm install` ran and succeeded (always false when
+   *  `installDependencies` was not requested; false too when npm is
+   *  missing/offline — the Canvas then degrades to its "run npm install" hint). */
+  dependenciesInstalled: boolean;
 }
 
 /**
@@ -366,7 +382,20 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   // Studio's lifecycle metrics read ("default" = bare/from-scratch scaffold).
   writeConfig(targetDir, { starterId: template });
 
+  // Install deps BEFORE git init so the (gitignored) node_modules is present
+  // for the Canvas's first bundle while staying out of git history. Best-effort:
+  // a failed install (npm missing/offline) still yields a successful scaffold.
+  const dependenciesInstalled = opts.installDependencies
+    ? installProjectDependencies(targetDir)
+    : false;
+
   const gitInitialized = initGitRepo(targetDir);
 
-  return { targetDir, template, projectName, gitInitialized };
+  return {
+    targetDir,
+    template,
+    projectName,
+    gitInitialized,
+    dependenciesInstalled,
+  };
 }

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -386,7 +386,7 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   // for the Canvas's first bundle while staying out of git history. Best-effort:
   // a failed install (npm missing/offline) still yields a successful scaffold.
   const dependenciesInstalled = opts.installDependencies
-    ? installProjectDependencies(targetDir)
+    ? await installProjectDependencies(targetDir)
     : false;
 
   const gitInitialized = initGitRepo(targetDir);

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -39,7 +39,13 @@ import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 
-import { resolveVersions, scaffold, writeConfig, type ResolvedVersions } from "@sapiom/agent-core";
+import {
+  installProjectDependencies,
+  resolveVersions,
+  scaffold,
+  writeConfig,
+  type ResolvedVersions,
+} from "@sapiom/agent-core";
 
 import { TEMPLATE_HTML, renderCanvasDocument } from "./canvas-template.js";
 
@@ -61,31 +67,6 @@ function agentCoreTemplatesDir(): string {
 function tryGit(cwd: string, args: string[]): boolean {
   try {
     execFileSync("git", args, { cwd, stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Best-effort `npm install` in the freshly-scaffolded project. The Canvas
- * step-graph extraction esbuild-bundles the project, so without its declared
- * deps (`@sapiom/agent`, `zod`, …) installed the very first render fails with
- * "Could not resolve …". Installing here means a freshly-seeded project opens
- * with a working Canvas instead of an error the user has to ask the agent to
- * fix. Non-fatal: if npm is missing or offline, seeding still succeeds and the
- * Canvas falls back to its existing "ask your agent to fix it" prompt.
- * `shell: true` lets Windows resolve the `npm.cmd` shim; cwd (which may contain
- * spaces) is passed via options, not the command line, so it stays safe.
- */
-function tryInstallDependencies(projectDir: string): boolean {
-  try {
-    execFileSync("npm", ["install", "--no-audit", "--no-fund", "--loglevel=error"], {
-      cwd: projectDir,
-      stdio: "ignore",
-      shell: process.platform === "win32",
-      timeout: 120_000,
-    });
     return true;
   } catch {
     return false;
@@ -304,7 +285,9 @@ export interface SeedExampleProjectResult {
  * older/partial seed shouldn't leave the canvas pane empty), but a canvas
  * the user's agent has since regenerated is left alone.
  */
-export async function seedExampleProject(options: SeedExampleProjectOptions): Promise<SeedExampleProjectResult> {
+export async function seedExampleProject(
+  options: SeedExampleProjectOptions,
+): Promise<SeedExampleProjectResult> {
   const root = path.resolve(options.targetRoot);
   const projectDir = path.join(root, SAMPLE_PROJECT_NAME);
   const canvasDir = path.join(root, ".sapiom", "canvas");
@@ -322,13 +305,23 @@ export async function seedExampleProject(options: SeedExampleProjectOptions): Pr
       await fs.writeFile(canvasTemplateFile, TEMPLATE_HTML, "utf8");
     }
     if (overwrite || !existsSync(canvasFile)) {
-      await fs.writeFile(canvasFile, renderCanvasDocument(ORDER_TRIAGE_CANVAS_BODY), "utf8");
+      await fs.writeFile(
+        canvasFile,
+        renderCanvasDocument(ORDER_TRIAGE_CANVAS_BODY),
+        "utf8",
+      );
     }
   };
 
   if (alreadySeeded && !options.force) {
     await writeCanvasPair(false);
-    return { root, projectDir, created: false, gitInitialized: false, dependenciesInstalled: false };
+    return {
+      root,
+      projectDir,
+      created: false,
+      gitInitialized: false,
+      dependenciesInstalled: false,
+    };
   }
 
   // Wipe a stale copy before rescaffolding — scaffold() refuses a non-empty dir.
@@ -349,17 +342,29 @@ export async function seedExampleProject(options: SeedExampleProjectOptions): Pr
     versions,
   });
 
-  await fs.writeFile(path.join(projectDir, "index.ts"), ORDER_TRIAGE_INDEX_TS, "utf8");
+  await fs.writeFile(
+    path.join(projectDir, "index.ts"),
+    ORDER_TRIAGE_INDEX_TS,
+    "utf8",
+  );
   writeConfig(projectDir, { name: SAMPLE_PROJECT_NAME });
 
   // Install deps BEFORE the initial commit so the (gitignored) node_modules is
   // present for the Canvas's first bundle, while staying out of git history.
   const dependenciesInstalled =
-    (options.installDependencies ?? true) ? tryInstallDependencies(projectDir) : false;
+    (options.installDependencies ?? true)
+      ? installProjectDependencies(projectDir)
+      : false;
 
   commitCustomizations(projectDir);
 
   await writeCanvasPair(true);
 
-  return { root, projectDir, created: true, gitInitialized: result.gitInitialized, dependenciesInstalled };
+  return {
+    root,
+    projectDir,
+    created: true,
+    gitInitialized: result.gitInitialized,
+    dependenciesInstalled,
+  };
 }

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -353,7 +353,7 @@ export async function seedExampleProject(
   // present for the Canvas's first bundle, while staying out of git history.
   const dependenciesInstalled =
     (options.installDependencies ?? true)
-      ? installProjectDependencies(projectDir)
+      ? await installProjectDependencies(projectDir)
       : false;
 
   commitCustomizations(projectDir);

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -99,7 +99,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_scaffold",
-    "Scaffold a new Sapiom agent project into <dir>. Produces an npm-install-ready TypeScript project with a starter agent in index.ts. After scaffolding, the author writes step definitions and uses sapiom_dev_agents_run_local to test them.",
+    "Scaffold a new Sapiom agent project into <dir>. Produces a TypeScript project with a starter agent in index.ts and its dependencies installed (best-effort; if the install was skipped offline, run `npm install` in <dir>). After scaffolding, the author writes step definitions and uses sapiom_dev_agents_run_local to test them.",
     {
       dir: z
         .string()
@@ -121,6 +121,13 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
             targetDir: dir,
             template,
             templatesDir: coreTemplatesDir(),
+            // Install deps up front so the Studio Canvas can bundle the new
+            // project on its first (unprompted) render — its extraction resolves
+            // @sapiom/agent, zod, … from the project's own node_modules, so a
+            // never-installed project would otherwise open with a
+            // "Could not resolve …" render error. Best-effort: a failed install
+            // still returns a successful scaffold.
+            installDependencies: true,
           }),
         );
       } catch (err) {


### PR DESCRIPTION
## Problem

A newly-created (or freshly-cloned) agent fails its very first Studio **Canvas render** with a raw esbuild wall — `Could not resolve "@sapiom/agent"` / `Could not resolve "zod"` — which the "Render failed" panel relays verbatim. Nothing is wrong with the agent; its dependencies were just never installed.

The Canvas extracts the step graph by **fully esbuild-bundling** `index.ts` from disk (`runManifestCheck` → `check()`, `bundle: true`, no `packages: 'external'`), so it must resolve `@sapiom/agent`/`zod` from the **project's own `node_modules`**. This auto-render fires unprompted on session boot and every source save. Two gaps let it reach users:

1. `scaffold()` never installs deps, yet the rail renders the project immediately. The one helper that did install (`tryInstallDependencies` in the harness `example-seed.ts`) is demo-only and no longer wired into the app.
2. The error surfaced is raw esbuild output, not the actionable "run `npm install`" cause — despite the render path being full of comments that already know this is the missing-install case.

Fixes SAP-2462.

## Changes

- **Install on create.** `scaffold()` gains an opt-in `installDependencies` flag (returns `dependenciesInstalled`); the `sapiom_dev_agents_scaffold` MCP tool — the Studio create path — passes it. Best-effort and non-fatal (missing/offline npm still yields a successful scaffold). `installProjectDependencies` now lives in `@sapiom/agent-core` and is shared with the example seed, removing the demo-only duplication.
- **Actionable error.** New `describeBundleFailure()` maps "no `node_modules` + unresolved import" to `Dependencies are not installed. Run \`npm install\` in <dir>, then try again.` (raw esbuild detail preserved). Wired into both `check()` and `loadDefinition()`. Every other bundle failure's message is unchanged.
- CLI `init` behavior unchanged (still prints `npm install` as an explicit next step); deploy path (`bundle.ts`, `packages: 'external'`) untouched.

## Tests

- `bundle-error.spec.ts` — maps the missing-deps case; leaves a genuine bad import / syntax error / non-Error untouched.
- `install-deps.spec.ts` — returns `false` (never throws) when the install can't run.
- Existing `scaffold.test.ts`, `example-seed.test.ts`, canvas render/graph, and MCP agents-tool suites pass. Full `@sapiom/agent-core` suite green (166); `@sapiom/mcp` green (97). Typecheck + lint clean across the three packages.

## Follow-up (not in this PR)

Optional hardening noted on SAP-2462: resolve the SDK from the harness's own `node_modules` via esbuild aliases so common-case extraction needs no project install at all (the manifest brand is a global `Symbol.for`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)