### PR TITLE
fix(examples): stop hardcoding a global sender username in email templates (SAP-2450)

### DIFF
--- a/examples/AUTHORING.md
+++ b/examples/AUTHORING.md
@@ -96,6 +96,39 @@ turns a clean rejection into a 404 mid-run. Declare it under `resources[]` and p
 stop with a stated reason. A **connection** is a third-party credential: never default it and
 never fake it — read it, and when it is absent, skip the side effect and say so.
 
+### Provisioning an inbox: never pin a global identifier
+
+Sending email needs an inbox to send from. Provision it, but let the platform pick the address —
+**never pass a fixed `username` to `inboxes.create`.** AgentMail addresses are globally unique, so
+a hardcoded local part (`"newsletter"`, `"outreach"`) can be owned by only ONE account across the
+whole platform: the first tenant to run your template claims it, and every other tenant's `create`
+then 409s with "Email address is already taken" — an uncaught throw that fails the very first
+zero-setup run. Omit `username` so the address is auto-generated, reuse an existing inbox first,
+and treat a 409 as "someone already provisioned one" (the non-atomic window between `list` and
+`create`) rather than a crash:
+
+```ts
+import { EmailHttpError } from "@sapiom/tools";
+
+async function resolveSenderInbox(ctx: Ctx): Promise<string> {
+  const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+  if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({ displayName: "My Agent" });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
+}
+```
+
+The same caution applies to anything keyed by a platform-global name: prefer a tenant-scoped
+handle or a platform-generated identifier over a string every tenant would otherwise reuse.
+
 ### Pause discipline
 
 Before you write a pause, decide **who fires the signal**, because a zero-config run has no

--- a/examples/approval-chain/index.ts
+++ b/examples/approval-chain/index.ts
@@ -7,6 +7,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -81,9 +82,6 @@ import { z } from "zod/v4";
 // ─────────────────────────────────────────────────────────────── config ──
 /** The signal a party fires to approve / reject (or nudge / time out) a gate. */
 const APPROVAL_SIGNAL = "approval.decision";
-
-/** Username for the inbox we send notifications from (created once, then reused). */
-const SENDER_USERNAME = "approvals";
 
 /** Reminders sent before a silent gate escalates. */
 const DEFAULT_MAX_REMINDERS = 2;
@@ -193,15 +191,32 @@ function normalizeApprovers(raw: Approver[]): Approver[] {
   }));
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Approvals",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Approvals",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/examples/cold-outreach-engine/index.ts
+++ b/examples/cold-outreach-engine/index.ts
@@ -7,6 +7,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -65,8 +66,6 @@ import { z } from "zod/v4";
 // ─────────────────────────────────────────────────────────────── config ──
 /** Postgres handle the engine owns — created on first run, reused after. */
 const DEFAULT_DB_HANDLE = "cold-outreach-engine";
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "cold-outreach";
 /** The named signal a reply-webhook fires to end the drip early. */
 const REPLY_SIGNAL = "reply.received";
 /** Cap the lead list so cost + latency stay bounded. */
@@ -341,18 +340,35 @@ async function initSchema(sql: Sql): Promise<void> {
     )`;
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(
   ctx: Ctx,
   displayName: string,
 ): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName,
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName,
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -7,6 +7,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import {
+  EmailHttpError,
   IMAGE_RESULT_SIGNAL,
   VIDEO_RESULT_SIGNAL,
   fileStorage,
@@ -156,8 +157,6 @@ const DEFAULT_SCHEDULE = "0 9 * * 1";
 /** Fan-out bounds on the pull-quote list. */
 const DEFAULT_NUM_QUOTES = 2;
 const MAX_QUOTES = 4;
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "content-repurposing";
 
 /** Title paired with `SAMPLE_SOURCE`. */
 const SAMPLE_TITLE = "Why small teams ship faster";
@@ -695,15 +694,32 @@ const packageStep = defineStep({
   },
 });
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Content Pack",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Content Pack",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 const deliver = defineStep({

--- a/examples/error-triage-digest/index.ts
+++ b/examples/error-triage-digest/index.ts
@@ -7,6 +7,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -69,8 +70,6 @@ const SAMPLE_ERRORS = [
     service: "payments",
   },
 ];
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "error-triage";
 /** The named signal an external error pipeline fires to push a batch in. */
 const SIGNAL = "errors.pushed";
 /** Cap the batch handed to the model so cost + latency stay bounded. */
@@ -183,15 +182,32 @@ async function pullErrors(url: string): Promise<RawError[]> {
   return normalizeErrors(arr);
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Error Triage Digest",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Error Triage Digest",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /** Open a Postgres client for a live run, or null in dryRun / when unavailable. */

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -52,9 +53,6 @@ const APPROVER_PREVIEW = 5;
 const APPROVAL_SIGNAL = "approval.decision";
 /** The signal a candidate fires to accept or decline a provisional offer. */
 const CONFIRM_SIGNAL = "candidate.confirm";
-
-/** Username for the inbox we send notifications from (created once, then reused). */
-const SENDER_USERNAME = "approvals";
 
 // ─────────────────────────────────────────────────────────────── shapes ──
 /** String-only config bag (matches how templates receive their `config`). */
@@ -143,15 +141,32 @@ function must<T>(value: T | undefined, name: string): T {
   return value;
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Approvals",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Approvals",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/examples/meeting-notes-crm/index.ts
+++ b/examples/meeting-notes-crm/index.ts
@@ -7,6 +7,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -57,8 +58,6 @@ const SAMPLE_TRANSCRIPT =
   "rollout and wants a security review before signing. I'll send the SOC 2 " +
   "report by Friday and Dana will loop in their CISO next week. Deal looks like " +
   "it's moving to contract stage.";
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "meeting-crm";
 /** The named signal a note-taker fires to push a finished transcript in. */
 const SIGNAL = "transcript.ready";
 /** Cap the transcript the model sees — full-call transcripts can be enormous. */
@@ -179,15 +178,32 @@ function stableId(input: string): string {
   return `ai_${h.toString(16)}`;
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Meeting Notes CRM",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Meeting Notes CRM",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /** Open a Postgres client for a live run, or null in dryRun / when unavailable. */

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -8,6 +8,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import {
+  EmailHttpError,
   VIDEO_RESULT_SIGNAL,
   IMAGE_RESULT_SIGNAL,
   fileStorage,
@@ -68,8 +69,6 @@ const MAX_LIMIT = 25;
 const DEFAULT_SCHEDULE = "0 9 * * *";
 /** Default async text-to-video model alias (resolved server-side). */
 const DEFAULT_VIDEO_MODEL = "veo3-fast";
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "personalized-media";
 
 // ─────────────────────────────────────────────────────────────── shapes ──
 type Medium = "image" | "video";
@@ -258,15 +257,32 @@ function isReservedAddress(email: string): boolean {
   );
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Personalized Media",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Personalized Media",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──

--- a/examples/pr-review-bot/index.ts
+++ b/examples/pr-review-bot/index.ts
@@ -6,6 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
+import { EmailHttpError } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -52,8 +53,6 @@ type Config = Record<string, string>;
  * environment. The template says what the credential IS, never where it lives.
  */
 const BOT_TOKEN_KEY = "SLACK_BOT_TOKEN";
-/** Username for the inbox we send review emails from (created once, reused). */
-const SENDER_USERNAME = "pr-review-bot";
 /** The named signal the PR webhook fires to resume this run. */
 const SIGNAL = "pr.opened";
 
@@ -215,15 +214,32 @@ async function registerWebhook(
   }
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "PR Review Bot",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "PR Review Bot",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/examples/proposal-generator/index.ts
+++ b/examples/proposal-generator/index.ts
@@ -6,7 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
-import { fileStorage } from "@sapiom/tools";
+import { EmailHttpError, fileStorage } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -65,9 +65,6 @@ import { z } from "zod/v4";
 // ─────────────────────────────────────────────────────────────── config ──
 /** The signal a human fires to approve or reject the drafted proposal. */
 const DECISION_SIGNAL = "proposal.decision";
-
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "proposals";
 
 /** Package the sandbox installs to lay out the PDF (pure JS, no native deps). */
 const PDF_PACKAGE = "pdf-lib@1.17.1";
@@ -185,15 +182,32 @@ function quoteNumberFor(executionId: string): string {
   return `Q-${tail || "000000"}`;
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Proposals",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Proposals",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/examples/scheduled-db-insight-report/index.ts
+++ b/examples/scheduled-db-insight-report/index.ts
@@ -6,7 +6,7 @@ import {
   terminate,
   type AgentExecutionContext,
 } from "@sapiom/agent";
-import { fileStorage } from "@sapiom/tools";
+import { EmailHttpError, fileStorage } from "@sapiom/tools";
 import postgres from "postgres";
 import { z } from "zod/v4";
 
@@ -77,8 +77,6 @@ const DEFAULT_DB_HANDLE = "db-insight-demo";
  * `template.json` and the platform injects it into this step's environment.
  */
 const DATABASE_URL_KEY = "REPORT_DATABASE_URL";
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "db-insight-report";
 /** Default cadence documented for the cron trigger: 08:00 every day. */
 const DEFAULT_SCHEDULE = "0 8 * * *";
 /** Cap the queries a single run will execute — bounds cost + latency. */
@@ -488,15 +486,32 @@ async function ensureSeeded(ctx: Ctx, sql: Sql): Promise<boolean> {
   return true;
 }
 
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "DB Insight Report",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "DB Insight Report",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/examples/scheduled-research-brief/index.ts
+++ b/examples/scheduled-research-brief/index.ts
@@ -6,6 +6,7 @@ import {
   type AgentExecutionContext,
 } from "@sapiom/agent";
 import type { Sapiom } from "@sapiom/tools";
+import { EmailHttpError } from "@sapiom/tools";
 import { z } from "zod/v4";
 
 /**
@@ -54,8 +55,6 @@ const MAX_BODY_CHARS = 1200;
  * brief that follows a successful run.
  */
 const DEFAULT_TOPIC = "AI agent reliability incidents";
-/** Username for the inbox we send from (created once, then reused). */
-const SENDER_USERNAME = "research-brief";
 
 // ─────────────────────────────────────────────────────────────── shapes ──
 interface EntryInput {
@@ -105,15 +104,32 @@ interface Shared extends Record<string, unknown> {
 type Ctx = AgentExecutionContext<Shared>;
 
 // ─────────────────────────────────────────────────────────────── helpers ──
-/** Reuse an existing inbox to send from, else provision one. */
+/**
+ * Reuse an existing inbox to send from, else provision one.
+ *
+ * We deliberately omit `username`. AgentMail addresses are globally unique, so a
+ * fixed local part can only ever be owned by ONE account across the whole
+ * platform — every other tenant's `create` 409s with "Email address is already
+ * taken", which fails the step. Omitting it lets AgentMail auto-generate a
+ * globally-unique address, so a fresh tenant's first run succeeds and two
+ * tenants never collide. `create` still isn't atomic against the `list`, so a
+ * 409 is treated as "someone already provisioned one" — re-list and reuse.
+ */
 async function resolveSenderInbox(ctx: Ctx): Promise<string> {
   const existing = await ctx.sapiom.email.inboxes.list({ limit: 1 });
   if (existing.inboxes.length > 0) return existing.inboxes[0].inboxId;
-  const inbox = await ctx.sapiom.email.inboxes.create({
-    username: SENDER_USERNAME,
-    displayName: "Research Brief",
-  });
-  return inbox.inboxId;
+  try {
+    const inbox = await ctx.sapiom.email.inboxes.create({
+      displayName: "Research Brief",
+    });
+    return inbox.inboxId;
+  } catch (err) {
+    if (err instanceof EmailHttpError && err.status === 409) {
+      const retry = await ctx.sapiom.email.inboxes.list({ limit: 1 });
+      if (retry.inboxes.length > 0) return retry.inboxes[0].inboxId;
+    }
+    throw err;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────── steps ──


### PR DESCRIPTION
## Summary
`resolveSenderInbox` in 11 email templates provisioned its send-from inbox with a **fixed `username`** (`"cold-outreach"`, `"proposals"`, `"approvals"`, …). AgentMail addresses are globally unique, so a hardcoded local part can be owned by only **one account platform-wide** — the first tenant to run the template claims it, and every other tenant's `inboxes.create` deterministically **409s with "Email address is already taken"**, an uncaught throw that fails the first zero-setup run on any fresh tenant.

This is the same defect [SAP-2450](https://linear.app/sapiom/issue/SAP-2450) fixed for `newsletter-autopilot` (#551), ported to the rest of the email-sending templates.

## Why it matters
Three of the affected templates — **proposal-generator, meeting-notes-crm, scheduled-db-insight-report** — are in the onboarding "golden shelf" a new user sees first, so this was a live new-user first-run failure. Observed in prod as `cold-outreach-engine` runs failing 100% (all `outcome: failed`).

## Changes
Applied the SAP-2450 pattern identically to all 11 templates:
- **Omit `username`** on `inboxes.create` so AgentMail auto-generates a globally-unique address (no cross-tenant collision).
- **Catch a 409** from `create` and re-list/reuse an existing inbox — covers the non-atomic `list`→`create` window under concurrency.
- Remove the now-unused `SENDER_USERNAME` constants.
- The list-first reuse guard is unchanged, so tenants that already own an inbox keep reusing it.

Templates: `cold-outreach-engine`, `approval-chain`, `human-in-the-loop`, `error-triage-digest`, `content-repurposing-pipeline`, `pr-review-bot`, `meeting-notes-crm`, `proposal-generator`, `personalized-media-at-scale`, `scheduled-research-brief`, `scheduled-db-insight-report`.

### Prevention
Documented the rule in `examples/AUTHORING.md` §1a ("Make it runnable with nothing") so future hand-authored templates **and codegen** don't reintroduce a global identifier for a per-tenant resource.

## Testing
- [x] `pnpm examples:check` passes (registry + 11 manifests schema-valid, terminology checked)
- [x] `pnpm build` (packages) succeeds
- [x] Change is byte-identical in pattern to the merged, CI-passing #551 fix
- [ ] Manual: zero-setup run on a fresh tenant for a shelf template (recommend before/after merge)

## Related
- Refs: SAP-2450

## Checklist
- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed