### PR TITLE
fix(harness): hold a new session's first prompt until Claude is signed in

### DIFF
--- a/.changeset/hold-initial-prompt-until-claude-login.md
+++ b/.changeset/hold-initial-prompt-until-claude-login.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/harness": patch
+---
+
+Hold a new session's first prompt until Claude Code is signed in
+
+Starting a session from the composer (or a template/clone) created the session and then fired the initial prompt immediately, retrying only on a 409 for ~9s. But a Claude Code session only becomes injectable once its `SessionStart` hook fires — which doesn't happen until the user is past Claude's own login/onboarding. A first-time, not-yet-signed-in user therefore blew past the 9s window and the prompt was silently dropped.
+
+The prompt is now held per session and sent the moment the session reports ready (i.e. Claude is signed in and interactive). If the session is still not ready after a short grace, a hint points the user at the terminal login ("Sign in to Claude in the terminal — your prompt sends automatically once you're signed in"), so first-run intent is preserved instead of lost.

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -56,6 +56,44 @@ test("describing an outcome starts a session and hands the agent that outcome", 
     .toContain("Diff our competitors' pricing pages");
 });
 
+test("holds the prompt until the session is ready (Claude signed in), then sends it", async ({
+  page,
+}) => {
+  // Make the next session never reach ready on its own — the stand-in for a
+  // user still on Claude's login/onboarding screen, where SessionStart (and so
+  // session.ready) never fires until they finish signing in.
+  await page.addInitScript(() => {
+    (window as unknown as { __MOCK_WITHHOLD_READY__?: boolean }).__MOCK_WITHHOLD_READY__ = true;
+  });
+  await page.goto("/?seed=0");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+
+  await page.getByTestId("rail-create-new").click();
+  await page.getByTestId("composer-input").fill("Summarise my inbox every morning.");
+  await page.getByTestId("composer-send").click();
+
+  // The session exists (workbench shown) but the prompt is HELD, not injected,
+  // because the session never became ready.
+  await expect(page.getByTestId("agent-view")).toBeVisible();
+  expect(await lastInjectText(page)).toBe("");
+
+  // A hint appears pointing the user at the terminal login; the prompt is still
+  // held while it shows.
+  await expect(page.getByTestId("toast")).toContainText(/sign in to claude/i, {
+    timeout: 8_000,
+  });
+  expect(await lastInjectText(page)).toBe("");
+
+  // The user finishes signing in → the session reports ready → the held prompt
+  // fires itself, carrying the original intent.
+  await page.evaluate(() =>
+    (
+      window as unknown as { __HARNESS_TEST__?: { promoteReady?: () => void } }
+    ).__HARNESS_TEST__?.promoteReady?.(),
+  );
+  await expect.poll(() => lastInjectText(page)).toContain("Summarise my inbox every morning.");
+});
+
 test("a new session opens terminal-only; the canvas stays hidden until it has content", async ({
   page,
 }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -38,7 +38,7 @@ import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
 import { WorkflowsRail } from "./components/WorkflowsRail";
-import { ApiError, boundWorkflowPathOf } from "./lib/api";
+import { boundWorkflowPathOf } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { historyDirs } from "./lib/history-meta";
 import {
@@ -77,6 +77,22 @@ import {
 } from "./lib/workflow-deployment";
 
 type RightTab = "canvas" | "steps" | "code";
+
+/**
+ * How long a held initial prompt waits for the coding agent to become ready
+ * (i.e. the user to finish signing in) before we give up and surface the
+ * failure. The normal end of a hold is the session going ready (prompt sent)
+ * or exiting — this is only a leak-guard for a login the user walks away from.
+ */
+const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Grace before nudging the user toward the terminal login. A signed-in agent
+ * reports ready within a beat, so its held prompt sends before this fires and
+ * no hint shows; only a session still stuck (on the Claude login/onboarding
+ * screen) survives the grace and surfaces the hint.
+ */
+const HELD_PROMPT_HINT_DELAY_MS = 4_000;
 
 /**
  * Live sessions belonging to the focused subject, in tab order (oldest first,
@@ -162,6 +178,93 @@ export const App = (): JSX.Element => {
       return next;
     });
   };
+
+  // Session-then-prompt flows (scaffold, templates, clone) must NOT fire the
+  // first prompt while the coding agent is still on its own login/onboarding
+  // screen. Claude Code only becomes injectable once its SessionStart hook
+  // sets session.ready — and that hook does not fire until the user is signed
+  // in. So we HOLD the prompt keyed by session id and send it the moment the
+  // session reports ready, rather than racing a fixed retry window that expires
+  // mid-onboarding and silently drops the prompt (the reported first-run bug).
+  const pendingPromptsRef = useRef<
+    Map<
+      string,
+      { prompt: string; failMessage: string; timer: number; hintTimer: number }
+    >
+  >(new Map());
+  // Latest sessions, read from the hold's async continuation (a closure over
+  // `state` would go stale between the ready flip and the flush).
+  const sessionsRef = useRef<HarnessSession[]>([]);
+
+  // Forget a held prompt and stop both its timers. Returns the entry so a
+  // caller can act on it (send / report), or undefined if nothing was held.
+  const clearPending = useCallback((sessionId: string) => {
+    const pending = pendingPromptsRef.current.get(sessionId);
+    if (!pending) return undefined;
+    window.clearTimeout(pending.timer);
+    window.clearTimeout(pending.hintTimer);
+    pendingPromptsRef.current.delete(sessionId);
+    return pending;
+  }, []);
+
+  // Deliver a held prompt if its session is now ready; drop it (with the
+  // failure toast) if the session exited first. A no-op while still waiting.
+  const tryFlushPrompt = useCallback(
+    (sessionId: string): void => {
+      const pending = pendingPromptsRef.current.get(sessionId);
+      if (!pending) return;
+      const session = sessionsRef.current.find((s) => s.id === sessionId);
+      if (!session) return; // not in client state yet — a later session.status retries
+      if (session.ready) {
+        // Delete BEFORE injecting so an overlapping flush can't double-send.
+        clearPending(sessionId);
+        void harness
+          .injectInput(sessionId, pending.prompt)
+          .catch(() => harness.showToast(pending.failMessage));
+      } else if (session.status === "exited") {
+        clearPending(sessionId);
+        harness.showToast(pending.failMessage);
+      }
+    },
+    [clearPending, harness.injectInput, harness.showToast],
+  );
+
+  // Register a prompt to be sent once its session is ready (i.e. Claude is
+  // signed in). Sends immediately if already ready. While waiting, a delayed
+  // hint (only if the session is still not ready after a grace) points the
+  // user at the terminal login — so first-run intent is held, not lost.
+  const sendPromptWhenReady = useCallback(
+    (sessionId: string, prompt: string, failMessage: string): void => {
+      clearPending(sessionId);
+      const timer = window.setTimeout(() => {
+        if (clearPending(sessionId)) harness.showToast(failMessage);
+      }, HELD_PROMPT_TIMEOUT_MS);
+      const hintTimer = window.setTimeout(() => {
+        if (pendingPromptsRef.current.has(sessionId)) {
+          harness.showToast(
+            "Sign in to Claude in the terminal — your prompt sends automatically once you're signed in.",
+          );
+        }
+      }, HELD_PROMPT_HINT_DELAY_MS);
+      pendingPromptsRef.current.set(sessionId, {
+        prompt,
+        failMessage,
+        timer,
+        hintTimer,
+      });
+      tryFlushPrompt(sessionId);
+    },
+    [clearPending, harness.showToast, tryFlushPrompt],
+  );
+
+  // The ready/exited transition arrives as a session.status event → a new
+  // sessions array → this effect flushes any prompt whose session just became
+  // injectable. Event-driven, so no polling.
+  useEffect(() => {
+    sessionsRef.current = harness.state?.sessions ?? [];
+    if (pendingPromptsRef.current.size === 0) return;
+    for (const id of [...pendingPromptsRef.current.keys()]) tryFlushPrompt(id);
+  }, [harness.state?.sessions, tryFlushPrompt]);
   // Panel collapse: the rail unmounts (no state to preserve); the right pane
   // hides via CSS so a running Visualize enrichment survives the collapse.
   const [railCollapsed, setRailCollapsed] = useState(
@@ -552,23 +655,6 @@ export const App = (): JSX.Element => {
     await createSessionAt(cwd, agentHarness);
   };
 
-  // Session-then-prompt flows (scaffold, templates): the pty needs a beat to
-  // become interactive, so a 409 (session not ready) retries a few times.
-  const injectPromptWithRetry = (sessionId: string, prompt: string, failMessage: string): void => {
-    const inject = async (attempt: number): Promise<void> => {
-      try {
-        await harness.injectInput(sessionId, prompt);
-      } catch (err) {
-        if (attempt < 6 && err instanceof ApiError && err.status === 409) {
-          window.setTimeout(() => void inject(attempt + 1), 1500);
-          return;
-        }
-        harness.showToast(failMessage);
-      }
-    };
-    void inject(0);
-  };
-
   // The idea-to-agent path. Starts a session at the (new) folder, then
   // hands the agent the scaffold prompt.
   /**
@@ -589,7 +675,7 @@ export const App = (): JSX.Element => {
       `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, ` +
       "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
     const trimmedIdea = idea?.trim();
-    injectPromptWithRetry(
+    sendPromptWhenReady(
       session.id,
       trimmedIdea
         ? `${base} build this:\n\n${trimmedIdea}`
@@ -620,7 +706,7 @@ export const App = (): JSX.Element => {
   // with no agent yet. Ask that session to scaffold its first agent in place.
   const handleScaffoldInSession = (sessionId: string): void => {
     const cwd = state.sessions.find((session) => session.id === sessionId)?.cwd ?? ".";
-    injectPromptWithRetry(
+    sendPromptWhenReady(
       sessionId,
       `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to define the first agent.`,
       "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
@@ -643,7 +729,7 @@ export const App = (): JSX.Element => {
       template_id: template.id,
       surface,
     });
-    injectPromptWithRetry(
+    sendPromptWhenReady(
       session.id,
       useTemplatePrompt(template, cwd),
       template.kind === "gallery"
@@ -813,7 +899,7 @@ export const App = (): JSX.Element => {
     setRightCollapsed(true); // terminal-first, like the template flow
     try {
       const session = await createSessionAt(cwd, "claude-code");
-      injectPromptWithRetry(
+      sendPromptWhenReady(
         session.id,
         cloneDefinitionPrompt(target.definitionId, cwd),
         "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone.",

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -991,7 +991,7 @@ class MockApi implements HarnessApi {
     // mock-created session would stay unready forever and gate the action
     // bar. Reads the CURRENT copy at fire time so a bind that landed in
     // between is never clobbered.
-    setTimeout(() => {
+    const promote = (): void => {
       void import("./events").then(({ publishMockBusMessage }) => {
         const current = this.sessions.find((s) => s.id === session.id);
         if (!current || current.status === "exited") return;
@@ -1006,7 +1006,26 @@ class MockApi implements HarnessApi {
         );
         publishMockBusMessage({ type: "session.status", session: promoted });
       });
-    }, 700);
+    };
+    // Test-only: a session that never reaches ready on its own, so Playwright
+    // can exercise the hold-the-prompt-until-signed-in path (a not-logged-in
+    // Claude sits on its login screen and never fires SessionStart). The test
+    // fires readiness by hand via window.__HARNESS_TEST__.promoteReady().
+    const win =
+      typeof window === "undefined"
+        ? undefined
+        : (window as unknown as {
+            __MOCK_WITHHOLD_READY__?: boolean;
+            __HARNESS_TEST__?: Record<string, unknown>;
+          });
+    if (win?.__MOCK_WITHHOLD_READY__) {
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        promoteReady: promote,
+      };
+    } else {
+      setTimeout(promote, 700);
+    }
     return session;
   }
 


### PR DESCRIPTION
## Problem

Reported via Studio feedback ([Slack](https://sapiom.slack.com/archives/C0B6C9WDF3K/p1786060492506749)) — a first-time user couldn't tell how/when to sign in to Claude, and their first action never happened.

Root cause: the composer's "start from an idea" (and template/clone) flow creates the session and then calls the old `injectPromptWithRetry` (`App.tsx`) **immediately**, retrying only on HTTP `409` for **7 × 1.5s ≈ 9s**. A Claude Code session only becomes injectable once its `SessionStart` hook sets `session.ready` — and that hook doesn't fire until the user is past Claude's own login/onboarding TTY. A not-yet-signed-in newbie sits on the login screen far longer than 9s, so every inject `409`s and the prompt is **silently dropped**.

## Fix

`session.ready` is already the authoritative "Claude signed in + interactive" signal, and the SPA already receives it via `session.status` events — it just wasn't gated on. Now:

- **Hold** the initial prompt per session and **send it the moment the session reports ready**, instead of racing a fixed retry window. Event-driven off the `session.status` the SPA already gets — no polling.
- If the session is still not ready after a short grace (~4s), show a one-line hint: *"Sign in to Claude in the terminal — your prompt sends automatically once you're signed in."* The grace means an already-signed-in user (ready in ~1s) never sees the hint.
- Drop the hold with the existing failure toast if the session exits first, plus a 10-min leak-guard timeout for an abandoned login.

Purely client-side (`App.tsx`) — **no server, adapter, or boot changes**, so none of the harness dual-host setup pitfalls apply. Reuses the existing `session.ready` signal rather than adding a new Claude-login probe (there is none in the repo today; all `auth`/`login` code is Sapiom account auth). Alternatives considered and rejected: an adapter `detectBlockingPrompt` scrollback matcher (brittle) and a server-persisted pending prompt (more machinery than the requested minimal change — matches George's "no conductor flow").

## Tests
- New e2e (`new-session-composer.spec.ts`): a session that never reaches ready → assert the prompt is **held** (not injected) and the login hint appears → simulate sign-in (session goes ready) → assert the prompt is then sent with the original intent. Uses a new mock affordance (`__MOCK_WITHHOLD_READY__` + `__HARNESS_TEST__.promoteReady()`, mirroring the existing `__MOCK_INJECT_FAIL_ONCE__`).

Verification (all green, local):
- Web typecheck (server + `web/tsconfig.json`): clean
- Web unit (vitest): 411 passed
- Full e2e (`test:ui`, the `playwright-mock` gate): **292 passed** (291 prior + the new test)

## Not covered here
The real proof is a `win`/desktop run with Claude **logged out**: start from the composer → confirm the prompt is held + hint shown → complete Claude login in the terminal → confirm the held prompt sends automatically. The mock exercises the same ready-gated path, but a genuine logged-out desktop run closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC6bxEyUEw15q2Xv76kG4e