### PR TITLE
docs(tools): repair capability table links and the coding-run example

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # @sapiom/tools
 
-A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, email, domains, orchestrations, and schedules — authenticated to your tenant.
+A typed TypeScript client for Sapiom capabilities — sandboxes, git repositories, coding agents, file storage, content generation, search, email, domains, deployed agents, and schedules — authenticated to your tenant.
 
 These are the same capabilities your Sapiom agents call as tools; this package makes them callable directly from your own code.
 
@@ -71,12 +71,12 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | ------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `sandboxes`         | Isolated, ephemeral compute                                                                           | [src/sandboxes](./src/sandboxes/README.md)                   |
 | `repositories`      | Private, in-network git repos                                                                         | [src/repositories](./src/repositories/README.md)             |
-| `agent`             | Coding agents (LLM execution)                                                                         | [src/agent](./src/agent/README.md)                           |
+| `models`            | Coding agents (LLM execution)                                                                         | [src/models](./src/models/README.md)                         |
 | `fileStorage`       | Tenant-scoped object storage (presigned URLs)                                                         | [src/file-storage](./src/file-storage/README.md)             |
 | `contentGeneration` | Media generation (images + video; audio soon), with optional `storage`                                | [src/content-generation](./src/content-generation/README.md) |
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
-| `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
-| `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                             | [src/schedules](./src/schedules/README.md)                   |
+| `agents`            | Run a deployed agent, or dispatch one from a step and await its result                                | [src/agents](./src/agents/README.md)                         |
+| `schedules`         | Schedule a deployed agent to run on a cron, or once at a set time                                     | [src/schedules](./src/schedules/README.md)                   |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 | `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks               | [src/email](./src/email/README.md)                           |
 | `domains`           | Register domain names and manage their DNS records                                                    | [src/domains](./src/domains/README.md)                       |
@@ -84,10 +84,10 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 
 ## Composing capabilities
 
-Capabilities are designed to work together. A coding `agent` run hands back the live `Sandbox` it executed in, and a `Repository` can publish a working tree straight from that sandbox:
+Capabilities are designed to work together. A `models.coding` run hands back the live `Sandbox` it executed in, and a `Repository` can publish a working tree straight from that sandbox:
 
 ```typescript
-const run = await agent.coding.run({ task, gitRepository: repo });
+const run = await models.coding.run({ task, gitRepository: repo });
 await repo.pushFromSandbox(run.sandbox);
 ```
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -71,11 +71,11 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 | ------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `sandboxes`         | Isolated, ephemeral compute                                                                           | [src/sandboxes](./src/sandboxes/README.md)                   |
 | `repositories`      | Private, in-network git repos                                                                         | [src/repositories](./src/repositories/README.md)             |
-| `agent`             | Coding agents (LLM execution)                                                                         | [src/agent](./src/agent/README.md)                           |
+| `models`            | Coding agents (LLM execution)                                                                         | [src/models](./src/models/README.md)                         |
 | `fileStorage`       | Tenant-scoped object storage (presigned URLs)                                                         | [src/file-storage](./src/file-storage/README.md)             |
 | `contentGeneration` | Media generation (images + video; audio soon), with optional `storage`                                | [src/content-generation](./src/content-generation/README.md) |
 | `search`            | Search the web (`webSearch`), read a page (`scrape`), and look up professional emails (`emailSearch`) | [src/search](./src/search/README.md)                         |
-| `orchestrations`    | Run a deployed orchestration, or dispatch one from a step and await its result                        | [src/orchestrations](./src/orchestrations/README.md)         |
+| `agents`            | Run a deployed agent, or dispatch one from a step and await its result                                | [src/agents](./src/agents/README.md)                         |
 | `schedules`         | Schedule a deployed orchestration to run on a cron, or once at a set time                             | [src/schedules](./src/schedules/README.md)                   |
 | `database`          | On-demand Postgres databases, returned with direct connection credentials                             | [src/database](./src/database/README.md)                     |
 | `email`             | Transactional email — inboxes, messages, sending domains, threads, and inbound webhooks               | [src/email](./src/email/README.md)                           |
@@ -87,7 +87,7 @@ Each capability is a namespace, importable from the barrel or its own subpath (e
 Capabilities are designed to work together. A coding `agent` run hands back the live `Sandbox` it executed in, and a `Repository` can publish a working tree straight from that sandbox:
 
 ```typescript
-const run = await agent.coding.run({ task, gitRepository: repo });
+const run = await models.coding.run({ task, gitRepository: repo });
 await repo.pushFromSandbox(run.sandbox);
 ```
 

--- a/packages/tools/src/models/README.md
+++ b/packages/tools/src/models/README.md
@@ -1,4 +1,4 @@
-# agent
+# models
 
 Coding agents — give one a task in natural language and it edits a checkout inside a sandbox.
 


### PR DESCRIPTION
## Primary change type

- [x] Documentation

## Problem and motivation

The rename in #530 updated prose but left the capability table and the composition example in `packages/tools/README.md` pointing at namespaces that no longer exist. Both table links 404, and the example does not run.

| Was | Now | Why |
|---|---|---|
| `agent` -> `./src/agent/README.md` | `models` -> `./src/models/README.md` | There is no `src/agent/` directory. The row's description, "Coding agents (LLM execution)", is what `src/models/README.md` documents, and `client.ts` exposes `coding` under `models`. |
| `orchestrations` -> `./src/orchestrations/README.md` | `agents` -> `./src/agents/README.md` | There is no `src/orchestrations/` directory and no `orchestrations` namespace on the client. The row's description is what `src/agents/README.md` documents. Wording follows the linked README. |
| `agent.coding.run(...)` | `models.coding.run(...)` | Coding runs live on `models` per `client.ts`; the root README already shows `sapiom.models.coding.run(...)`. |
| `src/models/README.md` titled `# agent` | `# models` | Leftover from the same rename. |

## Summary and scope

Two README files: the capability table links, one code example, and one heading.

Out of scope: `src/models/README.md` is already Prettier-dirty on `main` (as are four other package READMEs), so reformatting it here would be unrelated churn. Left as-is.

## Related work

Related issue or discussion: N/A — direct PR, documentation correction under the direct-PR policy. Follows the rename in #530.

## Validation

```text
Every relative markdown link in the root README, packages/*/README.md and
packages/*/src/*/README.md resolved against the filesystem
  — 2 broken before this change, 0 after
Both namespace names cross-checked against the readonly members of the client
type in packages/tools/src/client.ts
  — `models` and `agents` present; `agent` and `orchestrations` absent
```

Re-verified on current `main` before updating this description: `packages/tools/src/` contains `agents/` and `models/` and no `agent/` or `orchestrations/`, and `client.ts` declares `readonly models` and `readonly agents`.

`build`, `typecheck`, `lint` and `test` are N/A: no source, build or configuration file is touched.

### Tests and documentation

Tests: N/A, documentation-only. The validation above is the check that applies to this change, since the failure mode is a link resolving or not.

Documentation: this PR is the documentation fix.

## Compatibility and release impact

- Breaking or externally visible changes: None. No published code changes.
- Changeset: N/A. Documentation-only, no published package behavior, API or release notes affected, per the Changesets section of CONTRIBUTING.md. Matches the precedent in #68 and #97.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability.

## AI assistance

- [x] I used AI assistance and have described it below.

I used Claude while reading through the package READMEs. Claude ran the link resolution over the README set and reported the two broken targets; I checked each one against the directory listing and against `client.ts` myself, and chose the replacement namespaces based on what the linked READMEs actually document rather than on name similarity. The wording of the changed rows is taken from the READMEs they point at.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
