### PR TITLE
feat(harness): add an Overview intro page to the account menu

### DIFF
--- a/.changeset/overview-intro-page.md
+++ b/.changeset/overview-intro-page.md
@@ -1,0 +1,20 @@
+---
+"@sapiom/harness": minor
+---
+
+Give the account menu's "Overview" its own page — a proper introduction to Agent Studio
+
+"Overview" used to be an alias for the composer home. It now opens a standalone
+Overview destination (`OverviewPanel`) that introduces the app: the
+build-with-your-coding-agent → shape-on-the-Canvas → run-on-Sapiom loop, a
+"How it works" trio, and a grid of what's in the window (embedded coding agent,
+Agents rail, Canvas, Templates, deploy, production run, Sapiom capabilities,
+zero config mutation). It renders as a full-width destination like Templates
+(`.app.is-browsing` hides the panes) with its own top bar, a Build-an-agent CTA
+into the composer, and a Start-from-a-template shortcut.
+
+The page follows the Studio brand: neutral chrome throughout, with the scarce
+green (`--brand`) spent only on the three "how it works" glyphs. First run warms
+the eyebrow to a welcome and, when signed out, hints at connecting a Sapiom
+account. "Create new" (the composer) is unchanged and remains the primary
+creative action.

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -192,39 +192,39 @@ test("the active session shows a busy pulse that clears once output goes quiet",
   await expect(busy).toHaveCount(0, { timeout: 6_000 });
 });
 
-test("Overview heads the account menu and opens the composer home; opening an agent leaves it", async ({ page }) => {
-  // Reference/new-session home lives in the account menu now, not a pinned rail
-  // row — one click deep but always available, not just on first run.
+test("Overview heads the account menu and opens the introduction; opening an agent leaves it", async ({ page }) => {
+  // The introduction lives in the account menu now, not a pinned rail row —
+  // one click deep but always available, not just on first run.
   await page.getByTestId("brand-identity").click();
   await expect(page.getByTestId("profile-menu")).toBeVisible();
   const item = page.getByTestId("rail-overview");
   await expect(item).toBeVisible();
   await item.click();
 
-  // Selection closes the menu and opens the composer-first "new session" home
-  // in the centre pane. There is no session to name while composing, so the bar
-  // carries Back to the one behind it instead.
+  // Selection closes the menu and opens the Overview destination — a standalone
+  // introduction to the app — full-width in the centre.
   await expect(page.getByTestId("profile-menu")).toHaveCount(0);
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
-  await expect(page.getByTestId("session-context-title")).toHaveText("Back");
+  const overview = page.getByTestId("overview-panel");
+  await expect(overview).toBeVisible();
+  await expect(overview).toContainText("Build agents with your coding agent");
 
   // Opening the leasing agent returns to the terminal — acme-app's one live
   // session is bound to it, so opening the agent attaches to that session and
-  // leaves the composer.
+  // leaves the Overview.
   await page.getByTestId("workflow-leasing").locator(".workflow-item-trigger").click();
-  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  await expect(overview).toHaveCount(0);
   await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
 });
 
-test("Overview opens the composer, and Back returns to the session behind it", async ({ page }) => {
-  // The composer is a centre-pane screen, not an overlay: Back is how you return
-  // to the session it was opened over, and it leaves that session untouched.
+test("Overview opens the introduction, and Back returns to the session behind it", async ({ page }) => {
+  // The Overview is a centre-pane destination, not an overlay: Back returns to
+  // the session it was opened over, and leaves that session untouched.
   await page.getByTestId("brand-identity").click();
   await page.getByTestId("rail-overview").click();
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await expect(page.getByTestId("overview-panel")).toBeVisible();
 
-  await page.getByTestId("composer-back").click();
-  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  await page.getByTestId("overview-exit").click();
+  await expect(page.getByTestId("overview-panel")).toHaveCount(0);
   await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
 });
 

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -116,19 +116,19 @@ test("the dead-session pane shows the record's real metadata and the canvas invi
 });
 
 // ---------------------------------------------------------------------------
-// Overview mode canvas
+// Overview destination
 // ---------------------------------------------------------------------------
 
-test("the composer home hides the canvas, not showing the previous session's board", async ({
+test("the Overview hides the canvas, not showing the previous session's board", async ({
   page,
 }) => {
   await page.getByTestId("brand-identity").click();
   await page.getByTestId("rail-overview").click();
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await expect(page.getByTestId("overview-panel")).toBeVisible();
 
-  // No canvas while composing — the previous session's board is not on show,
-  // and there is nothing to Visualize because there is no session yet.
-  await expect(page.locator(".right-pane")).toHaveClass(/is-collapsed/);
+  // The Overview stands in for the workbench (`.app.is-browsing` hides the
+  // panes), so the previous session's board is not on show behind it.
+  await expect(page.locator(".right-pane")).toBeHidden();
   await expect(page.getByTestId("canvas-visualize-cta")).toHaveCount(0);
 });
 

--- a/packages/harness/web/e2e/welcome.spec.ts
+++ b/packages/harness/web/e2e/welcome.spec.ts
@@ -1,10 +1,13 @@
 /**
- * The first-run / Overview home is now the composer-first "new session" screen
+ * The first-run home is the composer-first "new session" screen
  * (NewSessionComposer), which replaced the WelcomePanel overlay. `/?mockState=fresh`
  * renders MockApi as a brand-new install: no sessions, no recent dirs, no
  * workflows, AppState.firstRun set — the state the real CLI produces on a machine
  * that has never run the harness. The default fixtures (a lived-in install)
  * double as the returning-user case, which boots straight into its session.
+ *
+ * The account menu's "Overview" no longer aliases the composer: it opens the
+ * Overview destination (OverviewPanel), a standalone introduction to the app.
  *
  * Recent-workspaces used to live on this surface; it now belongs to the left rail
  * (workspace tree), so those cases moved out with the overlay.
@@ -12,20 +15,20 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-/** Open the composer home from the account menu (Overview). */
+/** Open the Overview destination from the account menu. */
 async function openOverview(page: Page): Promise<void> {
   await page.getByTestId("brand-identity").click();
   await expect(page.getByTestId("profile-menu")).toBeVisible();
   await page.getByTestId("rail-overview").click();
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await expect(page.getByTestId("overview-panel")).toBeVisible();
 }
 
-/** Open the composer, then the templates catalog from its "Browse all". */
+/** Open the Overview, then the templates catalog from its "Start from a template". */
 async function openTemplates(page: Page): Promise<void> {
   await page.goto("/");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await openOverview(page);
-  await page.getByTestId("composer-browse-templates").click();
+  await page.getByTestId("overview-browse-templates").click();
   await expect(page.getByTestId("templates-panel")).toBeVisible();
 }
 
@@ -90,26 +93,60 @@ test.describe("returning user", () => {
     await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
   });
 
-  test("Overview opens the composer without the first-run greeting or opt-in", async ({ page }) => {
+  test("Overview opens the introduction, and Back returns to the session behind it", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
     await openOverview(page);
 
-    const composer = page.getByTestId("new-session-composer");
-    await expect(composer).toContainText("What should your agent do?");
-    // Greeted about a FIRST agent only on the first run, not every Overview.
-    await expect(page.getByTestId("composer-greeting")).not.toContainText("first agent");
-    // The one-time opt-in is a first-run surface only.
-    await expect(page.getByTestId("welcome-consent")).toHaveCount(0);
-    // The way back to the session it opened over.
-    await expect(page.getByTestId("composer-back")).toBeVisible();
-    await expect(page.getByTestId("composer-input")).toBeVisible();
-    await expect(page.getByTestId("composer-browse-templates")).toBeVisible();
+    const overview = page.getByTestId("overview-panel");
+    // It introduces the whole loop, not the composer.
+    await expect(overview).toContainText("Build agents with your coding agent");
+    await expect(overview).toContainText("How it works");
+    // Its two on-ramps into the app.
+    await expect(page.getByTestId("overview-create-new")).toBeVisible();
+    await expect(page.getByTestId("overview-browse-templates")).toBeVisible();
+    // The Overview is a destination, not the composer it used to alias.
+    await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+
+    // Back returns to the boot session that was behind it.
+    await page.getByTestId("overview-exit").click();
+    await expect(overview).toHaveCount(0);
+    await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
+  });
+
+  test("Overview's Build-an-agent CTA opens the composer", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await openOverview(page);
+    await page.getByTestId("overview-create-new").click();
+
+    await expect(page.getByTestId("overview-panel")).toHaveCount(0);
+    await expect(page.getByTestId("new-session-composer")).toBeVisible();
+    await expect(page.getByTestId("new-session-composer")).toContainText("What should your agent do?");
+  });
+
+  test("the palette's Browse templates, opened over the Overview, leaves it (never stacks)", async ({
+    page,
+  }) => {
+    // The palette is a global overlay reachable even while a full-width
+    // destination is up; navigating from it must dismiss the Overview rather
+    // than mount Templates behind it.
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await openOverview(page);
+    await page.getByTestId("palette-trigger").click();
+    await page.getByTestId("command-palette-input").fill("templates");
+    await page.getByTestId("command-palette-list").getByText("Browse templates").click();
+
+    await expect(page.getByTestId("templates-panel")).toBeVisible();
+    await expect(page.getByTestId("overview-panel")).toHaveCount(0);
   });
 });
 
-test.describe("templates browser, reached from the composer", () => {
+test.describe("templates browser, reached from the Overview", () => {
   test("shows the live catalog with facets, not a pinned pair", async ({ page }) => {
     await openTemplates(page);
     const panel = page.getByTestId("templates-panel");

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -36,6 +36,7 @@ import { Terminal } from "./components/Terminal";
 import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
+import { OverviewPanel } from "./components/OverviewPanel";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { boundWorkflowPathOf } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
@@ -161,6 +162,10 @@ export const App = (): JSX.Element => {
   // Template gallery opened from the command palette (browse is reachable
   // from anywhere, not only the add dialog / welcome panel entries).
   const [templatesOpen, setTemplatesOpen] = useState(false);
+  // The Overview: an introduction to the app, opened from the account menu's
+  // "Overview" item. A full-width destination like Templates (never the
+  // composer it used to alias), cleared by any navigation the same way.
+  const [overviewOpen, setOverviewOpen] = useState(false);
   // User session renames (no server rename endpoint yet, so names persist
   // client-side with the rest of the UI arrangement). State
   // here so the tab strip and the header re-render together on a rename.
@@ -364,6 +369,10 @@ export const App = (): JSX.Element => {
           e.preventDefault();
           setComposing(false);
           setReviewSummary(null);
+          // A tab jump is a navigation: leave any full-width destination that
+          // is standing in for the workbench, or it would linger over the tab.
+          setTemplatesOpen(false);
+          setOverviewOpen(false);
           harness.setActiveSessionId(target.id);
         }
       }
@@ -642,6 +651,7 @@ export const App = (): JSX.Element => {
   const createSessionAt = async (cwd: string, agentHarness: HarnessKind): Promise<HarnessSession> => {
     setComposing(false);
     setReviewSummary(null);
+    setOverviewOpen(false);
     setFocusedAgentPath(cwd);
     closeMobileDrawer();
     const session = await harness.createSession({ cwd, harness: agentHarness });
@@ -800,6 +810,7 @@ export const App = (): JSX.Element => {
     setComposing(false);
     setReviewSummary(null);
     setTemplatesOpen(false);
+    setOverviewOpen(false);
     closeMobileDrawer();
     const session = state.sessions.find((s) => s.id === id);
     if (session) setFocusedAgentPath(boundWorkflowPathOf(session) ?? session.cwd);
@@ -812,6 +823,7 @@ export const App = (): JSX.Element => {
     setComposing(false);
     setReviewSummary(null);
     setTemplatesOpen(false);
+    setOverviewOpen(false);
     harness.setActiveSessionId(id);
   };
 
@@ -821,6 +833,7 @@ export const App = (): JSX.Element => {
     setComposing(false);
     setReviewSummary(summary);
     setTemplatesOpen(false);
+    setOverviewOpen(false);
     closeMobileDrawer();
   };
 
@@ -843,6 +856,7 @@ export const App = (): JSX.Element => {
     setComposing(false);
     setReviewSummary(null);
     setTemplatesOpen(false);
+    setOverviewOpen(false);
     setFocusedAgentPath(path);
     closeMobileDrawer();
     const tabs = liveSessionsForFocus(state.sessions, path);
@@ -877,6 +891,7 @@ export const App = (): JSX.Element => {
     if (target.kind === "template") {
       setDeepLinkTemplateId(target.templateId);
       setTemplatesOpen(true);
+      setOverviewOpen(false);
       return;
     }
     if (focusExistingRef.current?.(target.definitionId)) return;
@@ -934,6 +949,7 @@ export const App = (): JSX.Element => {
     if (owner) {
       setComposing(false);
       setReviewSummary(null);
+      setOverviewOpen(false);
       if (owner.id !== harness.activeSessionId) harness.setActiveSessionId(owner.id);
       targetId = owner.id;
     } else {
@@ -1075,9 +1091,10 @@ export const App = (): JSX.Element => {
           }}
           onCollapse={() => setRailCollapsed(true)}
           onSelectSession={openSession}
-          overviewSelected={showComposer}
+          overviewSelected={overviewOpen}
           onSelectOverview={() => {
-            setComposing(true);
+            setOverviewOpen(true);
+            setComposing(false);
             setReviewSummary(null);
             setTemplatesOpen(false);
             closeMobileDrawer();
@@ -1085,6 +1102,7 @@ export const App = (): JSX.Element => {
           onNewSession={() => {
             setComposing(true);
             setTemplatesOpen(false);
+            setOverviewOpen(false);
           }}
           onReviewSummary={reviewPastSession}
           history={harness.history}
@@ -1097,7 +1115,10 @@ export const App = (): JSX.Element => {
           listHarnesses={harness.listHarnesses}
           onScaffoldSession={handleScaffoldSession}
           onScaffoldInSession={handleScaffoldInSession}
-          onBrowseTemplates={() => setTemplatesOpen(true)}
+          onBrowseTemplates={() => {
+            setTemplatesOpen(true);
+            setOverviewOpen(false);
+          }}
           templatesActive={templatesOpen}
           onScanWorkflows={handleScanWorkflows}
           onToast={harness.showToast}
@@ -1156,11 +1177,16 @@ export const App = (): JSX.Element => {
         <div
           className={
             "app" +
-            (templatesOpen ? " is-browsing" : "") +
+            // Templates AND the Overview are both full-width destinations that
+            // stand in for the workbench — `.is-browsing` hides the panes for
+            // either.
+            (templatesOpen || overviewOpen ? " is-browsing" : "") +
             // The workbench animates the canvas column open/closed (see
             // .app.canvas-animated). Off while browsing / composing / mobile,
             // where the single-column switch should be instant.
-            (!templatesOpen && !isMobile && !showComposer ? " canvas-animated" : "") +
+            (!templatesOpen && !overviewOpen && !isMobile && !showComposer
+              ? " canvas-animated"
+              : "") +
             // Present only DURING an open/close slide: it pins the pane content
             // to its expanded width so it CLIPS instead of squishing. Dropped
             // when settled, so a collapsed pane's content truly goes to zero.
@@ -1175,7 +1201,7 @@ export const App = (): JSX.Element => {
               // Browsing and the composer home take the whole width: a
               // two-column card grid inside half the shell is the letterbox this
               // view exists to escape, and the composer has no canvas yet.
-              templatesOpen || isMobile || showComposer
+              templatesOpen || overviewOpen || isMobile || showComposer
                 ? "minmax(0, 1fr)"
                 : // Two tracks always, so the canvas column can animate to 0 on
                   // collapse — the pane (and its left-edge shadow) slides shut,
@@ -1206,6 +1232,26 @@ export const App = (): JSX.Element => {
               listTemplates={harness.listTemplates}
               getTemplate={harness.getTemplate}
               openTemplateId={deepLinkTemplateId}
+            />
+          )}
+
+          {/* The Overview: the same destination shape as Templates — a sibling
+              of the panes, shown full-width with `.is-browsing` hiding them. */}
+          {overviewOpen && (
+            <OverviewPanel
+              firstRun={state.firstRun === true}
+              authenticated={state.authenticated}
+              appVersion={getDesktopBridge()?.appVersion ?? null}
+              onExit={() => setOverviewOpen(false)}
+              onCreateNew={() => {
+                setOverviewOpen(false);
+                setComposing(true);
+                setTemplatesOpen(false);
+              }}
+              onBrowseTemplates={() => {
+                setOverviewOpen(false);
+                setTemplatesOpen(true);
+              }}
             />
           )}
 
@@ -1591,7 +1637,10 @@ export const App = (): JSX.Element => {
           onSelectSession={openSession}
           onReviewSummary={reviewPastSession}
           onOpenPath={(cwd) => void handleCreateSession(cwd, "claude-code")}
-          onBrowseTemplates={() => setTemplatesOpen(true)}
+          onBrowseTemplates={() => {
+            setTemplatesOpen(true);
+            setOverviewOpen(false);
+          }}
           onClose={() => setPaletteOpen(false)}
         />
       )}

--- a/packages/harness/web/src/components/OverviewPanel.tsx
+++ b/packages/harness/web/src/components/OverviewPanel.tsx
@@ -1,0 +1,258 @@
+import type { JSX } from "react";
+
+import { BrandLogotype } from "./BrandLogotype";
+import { Icon } from "./Icon";
+import { SAPIOM_AGENTS_URL, SAPIOM_QUICKSTART_URL } from "../lib/urls";
+
+/**
+ * The Overview — a calm, self-contained introduction to Agent Studio, reached
+ * from the account menu's "Overview" item.
+ *
+ * It is a DESTINATION, not a dialog or an overlay: like TemplatesPanel it stands
+ * in for the workbench (`.app.is-browsing` hides the panes) and brings its own
+ * top bar with the way back. It exists to answer one question for someone who
+ * has just opened the app — "what is this, and how do I use it?" — so it names
+ * the whole loop (build locally with your coding agent → shape it on the Canvas
+ * → deploy and run it on the Sapiom cloud) and then lists what's in the window.
+ *
+ * Voice: overview, not a pitch. Sentence case, terse, second person, honest
+ * about cost. The one brand flourish is the scarce green (`--brand`): it tints
+ * only the three "how it works" glyphs — the narrative spine — while every
+ * feature-card glyph stays neutral, matching the app's rule that green is a
+ * deliberate accent, never chrome.
+ */
+
+interface OverviewStep {
+  icon: string;
+  title: string;
+  body: string;
+}
+
+/** The build → shape → ship loop, in the app's own vocabulary. */
+const STEPS: readonly OverviewStep[] = [
+  {
+    icon: "SquareTerminal",
+    title: "Build it locally",
+    body: "Describe the outcome you want. Your coding agent — Claude Code or Codex — scaffolds and authors a real Sapiom agent right in your workspace, pre-wired to Sapiom's tools.",
+  },
+  {
+    icon: "Workflow",
+    title: "Shape it on the Canvas",
+    body: "Watch the agent take shape as a graph of steps. Click into any one, iterate in the terminal, and test-run it locally against stubs — no cost.",
+  },
+  {
+    icon: "CloudUpload",
+    title: "Run it on Sapiom",
+    body: "Ship it to the Sapiom cloud in one action, then run and trigger it — on demand, on a schedule, or via API — and track every run on your dashboard.",
+  },
+];
+
+interface OverviewFeature {
+  icon: string;
+  title: string;
+  body: string;
+}
+
+/** What's actually in the window. Grounded in the app's own README. */
+const FEATURES: readonly OverviewFeature[] = [
+  {
+    icon: "SquareTerminal",
+    title: "Your coding agent, embedded",
+    body: "Claude Code or Codex runs in a terminal here — your subscription, your machine. Studio only wires it up to Sapiom.",
+  },
+  {
+    icon: "Folder",
+    title: "Agents rail",
+    body: "Every agent project in your workspace, discovered and tracked, with test, deploy, and production run one click away.",
+  },
+  {
+    icon: "Workflow",
+    title: "Canvas",
+    body: "A live pane renders your agent's step graph, the docs it writes, and previews of any dev server it starts.",
+  },
+  {
+    icon: "LayoutTemplate",
+    title: "Templates",
+    body: "Start from a runnable agent in the gallery instead of a blank folder — forked into a repo you own.",
+  },
+  {
+    icon: "CloudUpload",
+    title: "Deploy to the cloud",
+    body: "One action bundles, validates the manifest and graph, and ships your agent to the Sapiom engine.",
+  },
+  {
+    icon: "Zap",
+    title: "Run in production",
+    body: "Trigger and schedule deployed agents on Sapiom, then open any of them in your dashboard.",
+  },
+  {
+    icon: "Sparkles",
+    title: "Sapiom capabilities",
+    body: "Agents call metered Sapiom tools — sandboxes, git repos, coding models, web search, and storage.",
+  },
+  {
+    icon: "Check",
+    title: "Zero config mutation",
+    body: "Everything is injected per session; your global coding-agent settings are never touched.",
+  },
+];
+
+interface OverviewPanelProps {
+  /** Genuine first run: warms the eyebrow to a welcome and surfaces the
+   *  quick-start a newcomer needs, matching the composer home's first-run beat. */
+  firstRun: boolean;
+  /** Signed in to Sapiom — gates the honest "sign in to deploy" hint. */
+  authenticated: boolean;
+  /** The desktop build, shown quietly in the footer. Null in the browser host. */
+  appVersion?: string | null;
+  /** Leave the Overview and return to the workbench. */
+  onExit: () => void;
+  /** The primary action: open the composer-first "new session" home. */
+  onCreateNew: () => void;
+  /** The other on-ramp: browse the template catalog. */
+  onBrowseTemplates: () => void;
+}
+
+export function OverviewPanel({
+  firstRun,
+  authenticated,
+  appVersion,
+  onExit,
+  onCreateNew,
+  onBrowseTemplates,
+}: OverviewPanelProps): JSX.Element {
+  return (
+    <section className="overview-panel" data-testid="overview-panel" aria-label="Overview">
+      {/* Same height as the session bar it stands in for, so the shell's top
+          edge does not shift as you enter and leave. */}
+      <div className="overview-bar">
+        <button
+          type="button"
+          className="theme-toggle overview-back"
+          data-testid="overview-exit"
+          aria-label="Back to the session"
+          title="Back to the session"
+          onClick={onExit}
+        >
+          <Icon name="ArrowLeft" size={14} />
+        </button>
+        <span className="overview-bar-title">Overview</span>
+        <a
+          className="btn-line overview-bar-dash"
+          data-testid="overview-open-dashboard"
+          href={SAPIOM_AGENTS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Open Sapiom dashboard
+          <Icon name="ExternalLink" size={13} />
+        </a>
+      </div>
+
+      <div className="overview-scroll">
+        <div className="overview-measure">
+          <header className="overview-hero">
+            {/* The in-app lockup, verbatim: the wordmark IS "Sapiom", so the S
+                mark is never placed beside it; the product name is lowercase
+                mono, matching the rail header and terminal masthead. */}
+            <span className="overview-lockup">
+              <BrandLogotype height={13} aria-label="Sapiom" />
+              <span className="overview-lockup-product">agent.studio</span>
+            </span>
+            <p className="overview-eyebrow">
+              {firstRun ? "Welcome to Agent Studio." : "Agent Studio, in one screen."}
+            </p>
+            <h1 className="overview-hero-title">
+              Build agents with your coding agent. Run them on Sapiom.
+            </h1>
+            <p className="overview-hero-copy">
+              Agent Studio pairs Claude Code or Codex — running in an embedded terminal on
+              your machine — with the Sapiom cloud. Describe an outcome, watch the agent
+              take shape on the Canvas, then deploy and run it in production.
+            </p>
+            <div className="overview-hero-actions">
+              <button
+                type="button"
+                className="btn-primary overview-cta"
+                data-testid="overview-create-new"
+                onClick={onCreateNew}
+              >
+                <Icon name="Plus" size={14} />
+                Build an agent
+              </button>
+              <button
+                type="button"
+                className="btn-line overview-cta"
+                data-testid="overview-browse-templates"
+                onClick={onBrowseTemplates}
+              >
+                <Icon name="LayoutTemplate" size={14} />
+                Start from a template
+              </button>
+            </div>
+            {!authenticated && (
+              <p className="overview-signin-hint" data-testid="overview-signin-hint">
+                <Icon name="Info" size={13} />
+                Sign in to Sapiom from the account menu to deploy and run agents in the cloud.
+              </p>
+            )}
+          </header>
+
+          <section className="overview-steps">
+            <h2 className="overview-section-title">How it works</h2>
+            <ol className="overview-steps-list">
+              {STEPS.map((step, index) => (
+                <li key={step.title} className="overview-step">
+                  <span className="overview-step-glyph" aria-hidden="true">
+                    <Icon name={step.icon} size={18} />
+                  </span>
+                  <span className="overview-step-copy">
+                    <span className="overview-step-title">
+                      <span className="overview-step-index">{index + 1}</span>
+                      {step.title}
+                    </span>
+                    <span className="overview-step-body">{step.body}</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="overview-features">
+            <h2 className="overview-section-title">What's in the window</h2>
+            <div className="overview-feature-grid">
+              {FEATURES.map((feature) => (
+                <div key={feature.title} className="overview-feature">
+                  <span className="overview-feature-glyph" aria-hidden="true">
+                    <Icon name={feature.icon} size={16} />
+                  </span>
+                  <span className="overview-feature-title">{feature.title}</span>
+                  <span className="overview-feature-body">{feature.body}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <footer className="overview-foot">
+            <a
+              className="overview-foot-link"
+              data-testid="overview-quickstart"
+              href={SAPIOM_QUICKSTART_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Icon name="BookOpen" size={13} />
+              Read the quick start
+              <Icon name="ArrowUpRight" size={12} />
+            </a>
+            {appVersion && (
+              <span className="overview-foot-version" data-testid="overview-version">
+                agent.studio v{appVersion}
+              </span>
+            )}
+          </footer>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -48,8 +48,9 @@ interface WorkflowsRailProps {
   onCollapse: () => void;
   /** Selects a session from the history menu (a past/exited session). */
   onSelectSession: (id: string) => void;
-  /** Overview lives in the account menu: it shows the composer home in the
-   *  main slot. Selecting any session leaves it. */
+  /** Overview lives in the account menu: it opens the Overview destination —
+   *  an introduction to the app — in the main slot. Selecting any session,
+   *  agent, or other destination leaves it. */
   overviewSelected: boolean;
   onSelectOverview: () => void;
   /** The "Create new" CTA opens the composer-first "new session" home. */

--- a/packages/harness/web/src/lib/urls.ts
+++ b/packages/harness/web/src/lib/urls.ts
@@ -14,3 +14,10 @@ export const SAPIOM_AGENTS_URL = `${SAPIOM_DASHBOARD_ROOT}/agents`;
 export function agentUrl(definitionId: number): string {
   return `${SAPIOM_AGENTS_URL}/${definitionId}`;
 }
+
+/** Documentation home — a different host from the dashboard, kept here for the
+ *  same reason: the one place a docs/domain change is made. */
+export const SAPIOM_DOCS_URL = "https://docs.sapiom.ai";
+
+/** The quick-start the Overview and first-run composer both point newcomers at. */
+export const SAPIOM_QUICKSTART_URL = `${SAPIOM_DOCS_URL}/agents/quick-start`;

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -8315,3 +8315,302 @@ input {
 .composer-docs:hover {
   color: var(--text);
 }
+
+/* ── Overview: a DESTINATION that introduces the app ──────────────────────
+   Reached from the account menu, it stands in for the workbench the same way
+   Templates does (`.app.is-browsing` hides the panes) and brings its own bar
+   with the way back. Left-aligned on a reading measure — an overview, not a
+   centred pitch. Green is spent ONCE, on the three "how it works" glyphs (the
+   build → shape → ship spine); every other surface is neutral chrome, per the
+   app's rule that --brand is a deliberate accent and never the wash or line. */
+.overview-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* Matches the session bar's height, so the shell's top edge does not shift as
+   you enter and leave. */
+.overview-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  flex: 0 0 auto;
+  min-height: var(--pane-header-h);
+  padding: 0 var(--pane-pad-x);
+  border-bottom: 1px solid var(--border);
+}
+
+.overview-bar-title {
+  font-size: var(--type-ui);
+  font-weight: 550;
+  color: var(--text);
+}
+
+.overview-bar-dash {
+  margin-left: auto;
+  gap: var(--sp2);
+  text-decoration: none;
+}
+
+.overview-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* The reading measure — wide enough for a three-up feature grid, narrow enough
+   that hero copy keeps a comfortable line length on a wide monitor. */
+.overview-measure {
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: var(--sp7) var(--sp5) var(--sp8);
+  animation: refine-content-in var(--base, 0.22s) var(--ease) both;
+}
+
+.overview-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: var(--sp7);
+}
+
+/* The in-app lockup, verbatim: wordmark + lowercase-mono product name. The
+   wordmark IS "Sapiom", so the S mark is never set beside it. */
+.overview-lockup {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--sp2);
+  margin-bottom: var(--sp3);
+  color: var(--text);
+}
+
+.overview-lockup-product {
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  letter-spacing: 0.01em;
+  color: var(--text-dim);
+}
+
+.overview-eyebrow {
+  margin: 0 0 var(--sp2);
+  font-size: var(--type-ui);
+  color: var(--text-dim);
+}
+
+.overview-hero-title {
+  margin: 0;
+  max-width: 22ch;
+  font-size: clamp(1.6rem, 1.3rem + 1.2vw, 1.95rem);
+  font-weight: 640;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.overview-hero-copy {
+  margin: var(--sp3) 0 0;
+  max-width: 60ch;
+  font-size: var(--type-ui);
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.overview-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp2);
+  margin-top: var(--sp5);
+}
+
+/* Hero-scale CTAs: the shared button skins, sized up to the small-control step
+   with a leading glyph. */
+.overview-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp2);
+  height: var(--control-h-sm);
+  padding: 0 var(--sp4);
+  font-size: var(--type-label);
+}
+
+.overview-signin-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  margin: var(--sp4) 0 0;
+  font-size: var(--type-meta);
+  color: var(--text-faint);
+}
+
+.overview-section-title {
+  margin: 0 0 var(--sp4);
+  font-size: var(--type-h2);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+/* The build → shape → ship spine: three cards read left-to-right on a wide
+   window, stacking on a narrow one. */
+.overview-steps {
+  margin-bottom: var(--sp7);
+}
+
+.overview-steps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--sp3);
+}
+
+.overview-step {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  padding: var(--sp4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+/* The one deliberate green on the page: a tinted glyph tile per step. */
+.overview-step-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius);
+  color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brand) 22%, transparent);
+}
+
+.overview-step-copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+}
+
+.overview-step-title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--sp2);
+  font-size: var(--type-label);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.overview-step-index {
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-weight: 600;
+  color: var(--brand);
+}
+
+.overview-step-body {
+  font-size: var(--type-meta);
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+/* Feature grid: neutral throughout — glyph tiles are inset shade, not green. */
+.overview-features {
+  margin-bottom: var(--sp7);
+}
+
+.overview-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--sp3);
+}
+
+.overview-feature {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+  padding: var(--sp4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.overview-feature:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.overview-feature-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-bottom: var(--sp1);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  background: var(--surface-inset);
+}
+
+.overview-feature-title {
+  font-size: var(--type-label);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.overview-feature-body {
+  font-size: var(--type-meta);
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.overview-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp3);
+  padding-top: var(--sp4);
+  border-top: 1px solid var(--border);
+}
+
+.overview-foot-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  font-size: var(--type-label);
+  color: var(--text-dim);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.overview-foot-link:hover {
+  color: var(--text);
+}
+
+.overview-foot-version {
+  font-family: var(--font-mono);
+  font-size: var(--type-micro);
+  color: var(--text-faint);
+}
+
+@media (max-width: 640px) {
+  .overview-measure {
+    padding: var(--sp5) var(--sp4) var(--sp6);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overview-measure {
+    animation: none;
+  }
+}

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -210,6 +210,13 @@
     "reason": "The design-system Workflow icon identifier is private and remains unchanged."
   },
   {
+    "id": "overview-panel-icon-identifier",
+    "path": "packages/harness/web/src/components/OverviewPanel.tsx",
+    "pattern": "^Workflow$",
+    "occurrences": 2,
+    "reason": "The design-system Workflow icon identifier is private and remains unchanged (matches the CanvasPane allowlist entry)."
+  },
+  {
     "id": "canvas-step-private-identifiers",
     "path": "packages/harness/web/src/components/CanvasStepDetail.tsx",
     "pattern": "^(?:launched-workflow|canvas-open-workflow-)$",


### PR DESCRIPTION
## What

The account menu's **Overview** item used to be an alias for the composer home. It now opens a standalone **Overview destination** (`OverviewPanel`) — a proper introduction to Agent Studio for someone who has just opened the app.

It answers "what is this, and how do I use it?":
- **Hero** — the in-app lockup (`sapiom agent.studio`), the tagline *"Build agents with your coding agent. Run them on Sapiom."*, a one-paragraph value prop, and two on-ramps: **Build an agent** (→ composer) and **Start from a template**.
- **How it works** — the three-beat loop: *Build it locally* → *Shape it on the Canvas* → *Run it on Sapiom*.
- **What's in the window** — an 8-card grid: embedded coding agent, Agents rail, Canvas, Templates, deploy, production run, Sapiom capabilities, zero config mutation.
- **Footer** — a quick-start link, plus the desktop build version (on the packaged app).

## Design

It mirrors the existing **Templates destination** pattern — full-width, its own top bar (back + "Open Sapiom dashboard"), `.app.is-browsing` hides the panes. It uses only design-system tokens and honours the app's rule that green (`--brand`) is **scarce**: the mint/forest accent appears only on the three "how it works" glyphs (the narrative spine); everything else is neutral chrome. Works in dark + light, respects `prefers-reduced-motion`, and collapses the grids on narrow widths.

First run warms the eyebrow to *"Welcome to Agent Studio."* and, when signed out, hints at connecting a Sapiom account. "Create new" (the composer) is unchanged and remains the primary creative action.

## Wiring

`overviewOpen` is a new full-width destination state modelled on `templatesOpen`. **Every navigation** — open/select session, focus agent, review past session, create session, bind workflow, deep-link, command palette, `⌘/Ctrl+1..9` tab jump, Create-new, Browse-templates — clears it, so the Overview never lingers behind another view. (The `⌘1..9` and palette paths also fixed a pre-existing gap where `templatesOpen` could linger.)

## Testing

- Typecheck clean; `build:web` clean.
- Full mock-mode Playwright suite green locally (**290/290**), including 3 updated + 2 new Overview specs (open, back, Build-an-agent CTA, palette-over-Overview never stacks, templates-from-Overview).
- Reviewed in dark + light + first-run; verified all icons and the entrance keyframe resolve.

Reviewed in dark, light, and the first-run welcome variant. To see it locally: `pnpm --filter @sapiom/harness build` then run the app, and open the account menu → **Overview** (or in mock mode: `VITE_MOCK=1 vite --config web/vite.config.ts`, then account menu → Overview).

## Notes

- Includes a changeset (`@sapiom/harness` minor). The desktop app picks this up on its next release.
- Rebased cleanly onto `main` (it already carries the composer-removal #562 and prompt-hold #563); this branch adds only the 9 Overview files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC6bxEyUEw15q2Xv76kG4e
