### PR TITLE
feat(harness-desktop): rebrand the onboarding window (logo, borderless macOS chrome, ink CTA)

### DIFF
--- a/.changeset/harness-desktop-onboarding-brand.md
+++ b/.changeset/harness-desktop-onboarding-brand.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Rebrand the desktop onboarding window to the new Sapiom identity
+
+The setup window now leads with the real Sapiom wordmark + `agent.studio` lockup — an inlined `currentColor` SVG, identical to the SPA's `BrandLogotype` — instead of a plain-text label, themed to ink in both light and dark.
+
+- **macOS chrome:** the window is borderless (`titleBarStyle: "hiddenInset"`) — no grey title bar, traffic lights kept — and the window itself is the card (paints `--s1` edge to edge; the OS rounds it and adds a shadow). Windows/Linux keep their native frame.
+- **CTA:** Continue / Retry use the design system's neutral ink button (`--btn`/`--btn-ink`), never green; the consent checkbox is ink too. Green stays reserved for semantic state.
+- **Copy:** the boot status reads "Starting…" (the wordmark already says Sapiom), the consent screen drops the redundant question line (the checkbox is the ask), any detail line that merely echoed the status is suppressed, and the error message is centered.
+- The window pre-paints in `--s1` so it no longer flashes before its stylesheet loads.
+
+Contract tests pin the inlined logo, the pre-paint background, and the design-system wiring against silent drift.

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -123,7 +123,10 @@ async function decideConsent(
   }
 
   // First run, interactive: ask in the setup window and wait for the answer.
-  progress(setupWin, { phase: "consent", message: "Share anonymous usage data?", status: "active" });
+  // No subtitle: the checkbox below IS the question, so a "Share anonymous usage
+  // data?" detail line just duplicates it. "One quick question…" + the checkbox
+  // is the whole ask.
+  progress(setupWin, { phase: "consent", message: "", status: "active" });
   const optIn = await new Promise<boolean>((resolve) => {
     ipcMain.handleOnce(CONSENT_SUBMIT, (_e, value: boolean) => {
       resolve(Boolean(value));
@@ -262,7 +265,7 @@ export interface BootMode {
 
 export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<BootResult> {
   const { devMode, smoke } = mode;
-  progress(setupWin, { phase: "starting", message: "Starting Sapiom…", status: "active" });
+  progress(setupWin, { phase: "starting", message: "Starting…", status: "active" });
 
   // 1. PATH — must precede doctor so `which claude` works in a GUI app. Also
   //    materialize node/npm shims (Electron-as-Node) and put them first, so the

--- a/packages/harness-desktop/src/main/window-background.test.ts
+++ b/packages/harness-desktop/src/main/window-background.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The setup window sets a pre-paint `backgroundColor` (windows.ts) so it doesn't
+ * flash before its stylesheet loads. That colour is a HARDCODED hex in the main
+ * process — main can't read CSS — so it can silently drift from the token the
+ * renderer actually paints, which is exactly the class of silent brand drift this
+ * package guards elsewhere (see renderer/setup.html.test.ts).
+ *
+ * The window itself is the card now (setup.css `body` paints the raised surface
+ * --s1 edge to edge), so the pre-paint colour must be --s1, not --bg. Studio's
+ * preset (themes/studio.css) does NOT override --s1, so both themes take it
+ * straight from tokens.css: dark from the `:root`/`[data-theme="dark"]` block,
+ * light from the `[data-theme="light"]` block. Resolved against the ds-neutral
+ * fallback — the seam every build in THIS public repo actually copies in
+ * (web/vite.config.ts / copy-renderer.mjs). Asserted as TEXT (no electron
+ * import; see vitest.config.ts).
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const windowsSrc = readFileSync(new URL("./windows.ts", import.meta.url), "utf8");
+const dsNeutral = new URL("../../../harness/web/src/styles/ds-neutral/", import.meta.url);
+const tokensCss = readFileSync(new URL("tokens.css", dsNeutral), "utf8");
+
+/** The setup window's backgroundColor ternary → [darkHex, lightHex]. */
+const bg = windowsSrc.match(
+  /backgroundColor:\s*nativeTheme\.shouldUseDarkColors\s*\?\s*"(#[0-9a-fA-F]{3,8})"\s*:\s*"(#[0-9a-fA-F]{3,8})"/,
+);
+
+/** Every `--s1:` hex in document order — tokens.css has [0]=dark block, [1]=light block. */
+const s1 = [...tokensCss.matchAll(/--s1:\s*(#[0-9a-fA-F]{3,8})/g)].map((m) => m[1].toLowerCase());
+
+describe("setup window backgroundColor matches the Studio --s1 surface token", () => {
+  it("sets a themed pre-paint background at all (no flash)", () => {
+    expect(bg, "windows.ts should set backgroundColor from nativeTheme").not.toBeNull();
+  });
+
+  it("tokens.css declares --s1 for both themes", () => {
+    expect(s1.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("dark background == tokens.css dark --s1", () => {
+    expect(bg![1].toLowerCase()).toBe(s1[0]);
+  });
+
+  it("light background == tokens.css light --s1", () => {
+    // studio.css overrides --bg but NOT --s1, so light --s1 is tokens.css's own
+    // light-block value — the surface the renderer paints edge to edge.
+    expect(bg![2].toLowerCase()).toBe(s1[1]);
+  });
+});

--- a/packages/harness-desktop/src/main/windows.ts
+++ b/packages/harness-desktop/src/main/windows.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, shell } from "electron";
+import { BrowserWindow, app, nativeTheme, shell } from "electron";
 import { APP_VERSION_ARG } from "./ipc.js";
 import { desktopPreloadPath, setupHtmlPath, setupPreloadPath } from "./paths.js";
 
@@ -8,12 +8,27 @@ import { desktopPreloadPath, setupHtmlPath, setupPreloadPath } from "./paths.js"
  * contextIsolation; no direct Node in the renderer.
  */
 export function createSetupWindow(): BrowserWindow {
+  const isMac = process.platform === "darwin";
   const win = new BrowserWindow({
     width: 560,
     height: 460,
     resizable: false,
     show: true,
     title: "Sapiom",
+    // macOS: drop the grey title bar but KEEP the traffic lights (hiddenInset),
+    // inset into the card's top-left — no title-bar chrome, still closable and
+    // movable. The window itself IS the card (the renderer paints --s1 edge to
+    // edge) and keeps its standard rounded corners + drop shadow. Windows/Linux
+    // keep their native frame.
+    ...(isMac ? { titleBarStyle: "hiddenInset" as const, trafficLightPosition: { x: 16, y: 16 } } : {}),
+    // Pre-paint in the card surface (--s1) so there's no flash before the
+    // stylesheet loads. The renderer resolves the theme from stored-pref ??
+    // system before first paint; the main process can't read that storage, so it
+    // approximates with the system theme (nativeTheme) — exact on a first run and
+    // a single pre-paint frame at worst if a user stored the non-system theme.
+    // The hexes are ds-neutral --s1 (dark #12161d, light #ffffff);
+    // window-background.test.ts pins them to that token so this can't drift.
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#12161d" : "#ffffff",
     webPreferences: {
       preload: setupPreloadPath(),
       contextIsolation: true,

--- a/packages/harness-desktop/src/renderer/setup.css
+++ b/packages/harness-desktop/src/renderer/setup.css
@@ -24,18 +24,21 @@
  * 2000-line app stylesheet, and it carries the app's own bridge from the
  * upstream `--bg-0/--text/--accent` var names onto these tokens), so it
  * addresses the system tokens directly: --bg/--s1/--ink/--ink-muted/--line for
- * surfaces and ink, --brand/--brand-hover/--brand-ink for the accent, --red for
- * the error state.
+ * surfaces and ink, --btn/--btn-ink for the primary button, --red for the error
+ * state.
  *
- * NOTE on `--brand` vs `--accent`: the design system's shadcn alias block
- * defines `--accent` as a hover WASH, not the product accent — the SPA remaps it
- * in its bridge. A window without that bridge must say `--brand` for the accent
- * or the wordmark renders as a near-invisible translucent fill.
+ * This window spends NO green. Studio chrome is neutral: the wordmark is the
+ * brand name in ink (--ink), the affirmative CTA is the design system's ink
+ * button (--btn/--btn-ink), and the consent checkbox is ink too. Green (--brand)
+ * is a semantic STATE — live/success/on — and this window has no such state, so
+ * it is not used here. (Do NOT reach for --accent as a stand-in: the shadcn alias
+ * block defines it as a hover WASH, not a product accent, so it renders as a
+ * near-invisible translucent fill without the SPA's bridge.)
  *
  * The button lives here rather than in a shared primitives layer: it is the only
  * control in the only window this package renders, so a shared file would be one
- * consumer wide. It mirrors the SPA's `.btn-primary` (solid accent fill, no
- * border, 3px focus ring).
+ * consumer wide. It mirrors the SPA's `.btn-primary` (solid ink fill --btn,
+ * hover to --ink-muted, neutral focus ring).
  */
 
 * {
@@ -49,11 +52,17 @@ body {
 body {
   font: var(--type-ui) / 1.45 var(--font);
   -webkit-font-smoothing: antialiased;
-  background: var(--bg);
+  /* The window itself is the card: paint the raised surface (--s1) edge to edge.
+     A frameless macOS window is rounded + shadowed by the OS, so this reads as a
+     single floating card; framed platforms get an --s1-filled window. */
+  background: var(--s1);
   color: var(--ink);
   display: grid;
   place-items: center;
   padding: var(--sp5);
+  /* Frameless window has no title bar to drag by, so the body is the drag
+     handle; interactive/selectable bits opt out below. */
+  -webkit-app-region: drag;
 }
 
 /* Form controls do NOT inherit the document font — Chromium's UA sheet pins them
@@ -68,23 +77,58 @@ input {
   color: inherit;
 }
 
-.card {
-  width: 100%;
-  max-width: 420px;
-  padding: 36px var(--sp6);
-  text-align: center;
-  background: var(--s1);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+/* Frameless window: the body is the drag handle, so opt interactive and
+   selectable elements back out or they can't be clicked / their text copied. */
+.btn-primary,
+.consent-row,
+input,
+.error-message {
+  -webkit-app-region: no-drag;
 }
 
-.brand {
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--brand);
+.card {
+  /* Just the centered content column now — the window itself is the card surface
+     (see body), so this carries no background/border/shadow of its own. */
+  width: 100%;
+  max-width: 420px;
+  padding: 40px var(--sp6);
+  text-align: center;
+}
+
+/* The brand lockup — the Sapiom wordmark + the product name "agent.studio",
+   mirroring the SPA's .brand-header so the app names itself the same way in the
+   onboarding window it does in the shell it launches into. Addresses the system
+   tokens directly (--ink/--ink-muted/--mono/--type-meta) since this window can't
+   load the SPA's bridge. */
+.brand-lockup {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: var(--sp2);
+  margin: 0 0 12px;
+}
+
+/* The wordmark IS the name, so it is neutral ink, never green (green is scarce —
+   state/live/entry only). A replaced element has no baseline of its own, so drop
+   it onto the product name's text baseline by the descender the asset publishes
+   (the inline --brand-logotype-descender on the element). Width follows the
+   89×24 aspect from the viewBox. */
+.brand-logotype {
+  display: block;
+  height: 22px;
+  width: auto;
+  color: var(--ink);
+  transform: translateY(var(--brand-logotype-descender, 0));
+}
+
+/* Lowercase mono product name, matching the SPA's brand header and the terminal
+   masthead voice. */
+.brand-product {
+  font-family: var(--mono);
   font-size: var(--type-meta);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink-muted);
 }
 
 h1 {
@@ -100,6 +144,11 @@ h1 {
 h1[data-status="error"] {
   color: var(--red);
 }
+/* Some phases carry no heading (consent — the checkbox IS the question), so the
+   status line is empty; collapse it rather than leave a gap. */
+h1:empty {
+  display: none;
+}
 
 .detail {
   color: var(--ink-muted);
@@ -107,6 +156,11 @@ h1[data-status="error"] {
   margin: 0;
   white-space: pre-wrap;
   font-size: var(--type-ui);
+}
+/* When a phase has no extra detail, don't reserve a blank line — collapse it so
+   the status sits directly above the consent/error content. */
+.detail:empty {
+  min-height: 0;
 }
 
 .consent {
@@ -122,7 +176,9 @@ h1[data-status="error"] {
 }
 .consent-row input[type="checkbox"] {
   margin-top: 1px;
-  accent-color: var(--brand);
+  /* Neutral ink, not green: Studio chrome is neutral, and green is reserved for
+     semantic state. Matches the ink CTA above. */
+  accent-color: var(--ink);
   width: 15px;
   height: 15px;
   flex-shrink: 0;
@@ -130,7 +186,10 @@ h1[data-status="error"] {
 
 .error {
   margin-top: 22px;
-  text-align: left;
+  /* Centered to sit under the centered status/wordmark; text-align inherits into
+     the <pre> message and centers its (short, wrapped) lines, and the Retry
+     button already centers via margin auto. */
+  text-align: center;
 }
 .error-message {
   color: var(--red);
@@ -141,34 +200,92 @@ h1[data-status="error"] {
   margin: 0;
 }
 
-/* Mirrors the SPA's .btn-primary: solid accent fill, no visible border. */
+/* The affirmative CTA — the design system's neutral INK button (--btn/--btn-ink),
+   never green (green is a semantic STATE, not the primary action). Given the
+   modern "physical key" treatment the rest of the product uses: a crisp Geist
+   label, a fine top inset highlight and a soft layered shadow that lifts on
+   hover, presses on click.
+   COLLISION-PROOF LABEL: the fill and text fall back to --ink / --s1 — the two
+   tokens the card already proves resolve (it paints with them) — so if a token
+   layer ever ships --btn without --btn-ink, the label degrades to --s1 on --ink
+   (a real contrast pair) instead of inheriting --ink onto an --ink fill and
+   vanishing, which is the bug this replaces. */
 .btn-primary {
-  background: var(--brand);
-  border: 1px solid transparent;
-  color: var(--brand-ink);
-  font-weight: 500;
-  border-radius: var(--radius);
-  transition: background-color var(--fast) var(--ease);
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--btn, var(--ink));
+  color: var(--btn-ink, var(--s1));
+  border: none;
+  border-radius: 10px;
+  font-family: var(--font);
+  font-weight: 550;
+  font-size: 13.5px;
+  letter-spacing: -0.006em;
+  cursor: pointer;
+  /* Drop shadows stay BLACK on both themes — an --ink-tinted shadow turns into a
+     white glow in dark mode. On dark the white fill carries the elevation; the
+     shadow only grounds it. */
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 20%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.22),
+    0 4px 12px -3px rgba(0, 0, 0, 0.3);
+  transition:
+    transform var(--fast) var(--ease),
+    box-shadow var(--fast) var(--ease);
 }
 .btn-primary:hover:not(:disabled) {
-  background: var(--brand-hover);
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 24%, transparent),
+    0 2px 4px rgba(0, 0, 0, 0.24),
+    0 10px 22px -6px rgba(0, 0, 0, 0.36);
+}
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.16),
+    0 1px 2px rgba(0, 0, 0, 0.18);
 }
 .btn-primary:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px var(--focus-ring);
+  box-shadow:
+    0 0 0 3px var(--focus-ring),
+    0 4px 12px -3px rgba(0, 0, 0, 0.3);
 }
 .btn-primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-/* Centers the CTA. Its size is off-ladder too (Studio: --type-meta 12px,
-   --type-label 14px) and deliberately smaller than the body copy above it. */
+/* The lift is the only motion; honor a reduced-motion preference. */
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary {
+    transition: none;
+  }
+  .btn-primary:hover:not(:disabled),
+  .btn-primary:active:not(:disabled) {
+    transform: none;
+  }
+}
+
+/* Forced-colors / high-contrast (and some force-dark modes): hand the button to
+   the system palette so the label can never collide with the fill and vanish. */
+@media (forced-colors: active) {
+  .btn-primary {
+    background: ButtonFace;
+    color: ButtonText;
+    border: 1px solid ButtonText;
+    box-shadow: none;
+  }
+}
+
+/* Centered under the content, with real presence (min-width + generous padding)
+   instead of the old off-ladder pill. */
 .consent .btn-primary,
 .error .btn-primary {
   display: block;
   width: fit-content;
-  margin: 18px auto 0;
-  padding: var(--sp2) 14px;
-  font-size: 12.5px;
+  min-width: 132px;
+  margin: 22px auto 0;
+  padding: 11px 24px;
 }

--- a/packages/harness-desktop/src/renderer/setup.html
+++ b/packages/harness-desktop/src/renderer/setup.html
@@ -54,8 +54,37 @@
   </head>
   <body>
     <main class="card">
-      <div class="brand">Sapiom</div>
-      <h1 id="status" data-status="active">Starting Sapiom…</h1>
+      <!-- The brand lockup, exactly as the SPA's .brand-header names the app:
+           the Sapiom WORDMARK + the product name "agent.studio". The wordmark
+           is the shared official asset — the path is identical to
+           design-system/assets/sapiom-logotype.svg and the SPA's
+           BrandLogotype.tsx — inlined so a public clone renders it with no
+           binary and the CSP needs no img-src. It draws in currentColor, themed
+           to ink by .brand-logotype: the wordmark is the name, not a status, so
+           it is never green. The S mark is deliberately NOT placed beside it —
+           mark + wordmark reads as a third logo the brand system does not have
+           (see design-system/src/brand/index.tsx). --brand-logotype-descender
+           drops the wordmark onto the product name's text baseline. -->
+      <div class="brand-lockup" role="img" aria-label="Sapiom agent.studio">
+        <svg
+          class="brand-logotype"
+          style="--brand-logotype-descender: 3.72px"
+          width="82"
+          height="22"
+          viewBox="0 0 89 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M32.1834 7.36578L34.4714 5.81493H36.5941C39.3219 5.81493 41.5567 8.05816 41.5567 10.7996V14.9539C41.5567 17.7234 39.3247 19.9385 36.5941 19.9385H34.4714L32.1834 18.3877V24H29.4277V5.81493H32.1834V7.36578ZM23.7454 7.36578V5.81493H26.5012V19.9385H23.7454V18.3877L21.4574 19.9385H19.3347C16.6069 19.9385 14.3722 17.6953 14.3722 14.9539V10.7996C14.3722 8.03001 16.6041 5.81493 19.3347 5.81493H21.4574L23.7454 7.36578ZM50.2802 17.169H54.0945V19.9385H43.7074V17.169H47.5245V8.58449H43.7074V5.81493H50.2802V17.169ZM73.2556 7.36296L75.5436 5.81212H76.9774C78.4645 5.81212 79.7667 6.60584 80.492 7.79359L81.1557 7.36296L83.4466 5.81212H84.8805C87.1516 5.81212 89 7.66975 89 9.94957V19.9385H86.3199V10.0284C86.3199 9.21495 85.6898 8.58168 84.8805 8.58168H84.3008L81.1585 10.7151V19.9357H78.4001V9.79195C78.2909 9.09675 77.7084 8.58449 76.9802 8.58449H76.4005L73.2556 10.718V19.9385H70.4998V5.81212H73.2556V7.36296ZM64.4479 5.73331C66.3944 5.73331 67.9682 7.31511 67.9682 9.27125V16.2571L64.0923 19.8456L64.0783 19.8569H59.5807C57.6372 19.8569 56.0605 18.2751 56.0605 16.319V9.33316L59.9363 5.74457L59.9504 5.73331H64.4479ZM9.23606 5.81493L11.5549 7.38829V10.7405L8.3539 8.5676H3.91231C2.66607 8.61545 2.63808 10.079 3.62665 10.4618L9.69534 12.3926C11.0284 12.8176 11.9385 14.0616 11.9385 15.4662V16.4907C11.9385 17.5968 11.3925 18.6297 10.4795 19.249L9.65053 19.8119H2.28801L0 18.261V14.9088L3.29339 17.1436H7.53336C7.55015 17.1436 9.29767 17.1859 9.36488 16.0741C9.38729 15.5928 9.12683 15.1059 8.62835 14.9005L2.88732 13.0738C1.16781 12.5249 -0.0476086 10.9515 0.210037 9.16429C0.33886 7.88365 1.34424 5.80931 4.19515 5.83183H4.20356L9.23606 5.82056V5.81493ZM32.1834 10.718V15.0383L35.3284 17.1717H36.5969C37.8096 17.1717 38.8009 16.1754 38.8009 14.9567V10.8024C38.8009 9.58367 37.8096 8.5873 36.5969 8.5873H35.3284L32.1834 10.7208V10.718ZM19.3347 8.58449C18.122 8.58449 17.1307 9.58086 17.1307 10.7996V14.9539C17.1307 16.1726 18.122 17.169 19.3347 17.169H20.6033L23.7454 15.0383V10.718L20.6033 8.58449H19.3347ZM58.7881 10.5378V16.1642C58.7881 16.6764 59.1999 17.0902 59.7096 17.0902H63.0421L65.2377 15.058V9.43168C65.2377 8.91942 64.8261 8.50568 64.3164 8.50568H60.9837L58.7881 10.5378ZM50.283 2.76956H47.2501V0H50.283V2.76956Z"
+            fill="currentColor"
+          />
+        </svg>
+        <span class="brand-product" aria-hidden="true">agent.studio</span>
+      </div>
+      <h1 id="status" data-status="active">Starting…</h1>
       <p id="detail" class="detail"></p>
 
       <section id="consent" class="consent" hidden>

--- a/packages/harness-desktop/src/renderer/setup.html.test.ts
+++ b/packages/harness-desktop/src/renderer/setup.html.test.ts
@@ -57,6 +57,34 @@ describe("setup.html design-system wiring", () => {
   });
 });
 
+describe("setup.html brand lockup", () => {
+  // The wordmark's official path (design-system/assets/sapiom-logotype.svg,
+  // identical to the SPA's BrandLogotype.tsx). Its opening command is enough to
+  // prove the REAL asset is inlined, not a placeholder or a redrawn glyph.
+  const LOGOTYPE_PATH_HEAD = "M32.1834 7.36578L34.4714 5.81493";
+
+  it("inlines the real Sapiom wordmark, in currentColor", () => {
+    // Inlined (not <img>) so a public clone needs no binary and the CSP needs no
+    // img-src; currentColor so .brand-logotype can theme it to ink.
+    expect(html).toContain('class="brand-logotype"');
+    expect(html).toContain(LOGOTYPE_PATH_HEAD);
+    expect(html).toMatch(/<path\b[^>]*\bfill="currentColor"/);
+  });
+
+  it("names the app 'Sapiom agent.studio', the same lockup as the SPA header", () => {
+    // One accessible name on the lockup (the wordmark itself is aria-hidden), and
+    // the product name visible in text beside the mark.
+    expect(html).toMatch(/aria-label="Sapiom agent\.studio"/);
+    expect(html).toMatch(/class="brand-product"[^>]*>agent\.studio</);
+  });
+
+  it("drops the old plain-text wordmark — the logo replaces it", () => {
+    // The window shipped a text `<div class="brand">Sapiom</div>` before; the
+    // real logo supersedes it, so the placeholder must be gone.
+    expect(html).not.toMatch(/<div class="brand">/);
+  });
+});
+
 describe("copy-renderer.mjs puts every linked file in dist/renderer", () => {
   it("copies something for each stylesheet setup.html links", () => {
     for (const href of stylesheets) {

--- a/packages/harness-desktop/src/renderer/setup.ts
+++ b/packages/harness-desktop/src/renderer/setup.ts
@@ -24,19 +24,24 @@ const errorMsgEl = document.getElementById("error-message")!;
 const retryBtn = document.getElementById("retry") as HTMLButtonElement;
 
 const PHASE_LABEL: Record<BootProgress["phase"], string> = {
-  starting: "Starting Sapiom…",
+  starting: "Starting…",
   doctor: "Checking your environment…",
   "installing-agent": "Setting up your coding agent…",
   auth: "Signing you in…",
-  consent: "One quick question…",
+  consent: "",
   "choosing-folder": "Preparing your workspace…",
   launching: "Launching…",
   ready: "Ready.",
 };
 
 bridge.onProgress((p: BootProgress) => {
-  statusEl.textContent = PHASE_LABEL[p.phase] ?? p.message;
-  detailEl.textContent = p.message;
+  const label = PHASE_LABEL[p.phase] ?? p.message;
+  statusEl.textContent = label;
+  // Show the detail line only when the message ADDS to the status. Most phases
+  // send a message equal to their label, so echoing it as a muted subtitle is
+  // just the same line twice; collapse those and reserve the detail for
+  // genuinely extra info (e.g. the agent-install progress lines).
+  detailEl.textContent = p.message === label ? "" : p.message;
   statusEl.dataset.status = p.status;
   if (p.phase === "consent" && p.status === "active") {
     consentEl.hidden = false;


### PR DESCRIPTION
## What

Brings the desktop **onboarding (setup) window** up to the new Sapiom brand. Previously it showed a plain-text "Sapiom" label inside a native-framed window with a green CTA; now it's a single branded card.

- **Logo:** real Sapiom wordmark + `agent.studio` lockup — an inlined `currentColor` SVG (identical path to the SPA's `BrandLogotype` / `design-system/assets/sapiom-logotype.svg`), themed to ink in both light and dark. Inlined (not `<img>`) so a public clone needs no binary and the CSP needs no `img-src`.
- **macOS chrome:** borderless via `titleBarStyle: "hiddenInset"` — no grey title bar, traffic lights kept (so it's still closable/movable). The window itself is the card (paints `--s1` edge to edge; the OS rounds it + adds a shadow). Windows/Linux keep their native frame.
- **CTA:** Continue / Retry are the design system's neutral ink button (`--btn`/`--btn-ink`), never green; the consent checkbox is ink too. Green stays reserved for semantic state, per the brand rules.
- **Copy:** status reads "Starting…" (the wordmark already says Sapiom); the consent screen drops the redundant question line (the checkbox is the ask); any detail line that merely echoed the status is suppressed; the error message is centered.
- **No flash:** the window pre-paints in `--s1` (`nativeTheme`-derived) so it doesn't flash before its stylesheet loads.

## Why

The onboarding window is the first thing a desktop user sees and it still carried the old, off-brand treatment. It already consumed the design-system token layer — this closes the gap on the logo, chrome, and CTA, and trims filler copy.

## Notes

- All changes are in `@sapiom/harness-desktop`; no `@sapiom/harness` (SPA) changes. Changeset: `@sapiom/harness-desktop` patch.
- The window reads system tokens directly (`--ink`/`--s1`/`--btn`/…), never redefining one, and the CTA falls back to `--ink`/`--s1` so its label can never collide with the fill.
- Three contract tests guard silent drift: the inlined logo + lockup (`setup.html.test.ts`), the pre-paint background pinned to the `--s1` token (`window-background.test.ts`), and the existing design-system wiring.

## Testing

- `pnpm --filter @sapiom/harness-desktop test` → **86 pass**
- `pnpm --filter @sapiom/harness-desktop typecheck` → clean
- `pnpm --filter @sapiom/harness-desktop build` → resolves the design-system layer via the `ds-neutral` fallback and inlines the logo into `dist/renderer`
- Rendered the built `setup.html` in the **real Electron runtime** (`webContents.capturePage`) across dark/light × starting/consent/error — labels legible, error centered, no stray title bar. Frameless-with-traffic-lights chrome confirmed on macOS via a live Electron window.
- Not run here (needs packaging/CI): the packaged `--smoke` launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
