### PR TITLE
fix(mcp): enforce 0600 on a pre-existing credentials file

### DIFF
--- a/.changeset/lucky-moons-smile.md
+++ b/.changeset/lucky-moons-smile.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/mcp": patch
+---
+
+Enforce 0600 on a pre-existing `~/.sapiom/credentials.json`. `writeFile`'s
+`mode` option only applies when the file is created, so a credentials file left
+behind with looser permissions kept them while a fresh API key was written into
+it. Now chmod'd before the write, so the new key is never on disk under the
+older, wider mode.

--- a/.changeset/lucky-moons-smile.md
+++ b/.changeset/lucky-moons-smile.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/mcp": patch
+---
+
+Enforce 0600 on a pre-existing `~/.sapiom/credentials.json`. `writeFile`'s
+`mode` option only applies when the file is created, so a credentials file left
+behind with looser permissions kept them while a fresh API key was written into
+it. Now chmod'd after the write, matching the CLI session store and
+`@sapiom/analytics-core`'s identity store.

--- a/packages/mcp/src/credentials.test.ts
+++ b/packages/mcp/src/credentials.test.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
   vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"));
   vi.mocked(fs.writeFile).mockResolvedValue();
   vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+  vi.mocked(fs.chmod).mockResolvedValue();
 });
 
 afterEach(() => {
@@ -200,6 +201,38 @@ describe("writeCredentials", () => {
     expect(written.environments.production.credentials).toEqual(
       sampleCredentials,
     );
+  });
+
+  it("should chmod 0600 so a pre-existing file does not stay world-readable", async () => {
+    // `writeFile`'s `mode` is only honoured when the file is created. A
+    // credentials.json left behind with looser permissions would otherwise keep
+    // them while we write a fresh API key into it. `session.ts` and
+    // `analytics-core`'s identity store both chmod for this reason.
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(sampleFile));
+
+    await writeCredentials(
+      "production",
+      "https://app.sapiom.ai",
+      "https://api.sapiom.ai",
+      sampleCredentials,
+    );
+
+    expect(fs.chmod).toHaveBeenCalledWith(credentialsPath, 0o600);
+  });
+
+  it("should still write when chmod fails (best effort)", async () => {
+    vi.mocked(fs.chmod).mockRejectedValue(new Error("EPERM"));
+
+    await expect(
+      writeCredentials(
+        "production",
+        "https://app.sapiom.ai",
+        "https://api.sapiom.ai",
+        sampleCredentials,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(fs.writeFile).toHaveBeenCalled();
   });
 
   it("should update existing file preserving other environments", async () => {

--- a/packages/mcp/src/credentials.test.ts
+++ b/packages/mcp/src/credentials.test.ts
@@ -48,6 +48,7 @@ beforeEach(() => {
   );
   vi.mocked(fs.writeFile).mockResolvedValue();
   vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+  vi.mocked(fs.chmod).mockResolvedValue();
 });
 
 afterEach(() => {
@@ -246,6 +247,41 @@ describe("writeCredentials", () => {
     expect(written.environments.production.credentials).toEqual(
       sampleCredentials,
     );
+  });
+
+  it("should chmod 0600 before the write so a pre-existing file is never world-readable with the new key", async () => {
+    // `writeFile`'s `mode` is only honoured when the file is created. A
+    // credentials.json left behind with looser permissions would otherwise keep
+    // them while we write a fresh API key into it. Order matters: chmod'ing
+    // after the write would still expose the new key for the duration of it.
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(sampleFile));
+
+    await writeCredentials(
+      "production",
+      "https://app.sapiom.ai",
+      "https://api.sapiom.ai",
+      sampleCredentials,
+    );
+
+    expect(fs.chmod).toHaveBeenCalledWith(credentialsPath, 0o600);
+    expect(vi.mocked(fs.chmod).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(fs.writeFile).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should still write when chmod fails (best effort)", async () => {
+    vi.mocked(fs.chmod).mockRejectedValue(new Error("EPERM"));
+
+    await expect(
+      writeCredentials(
+        "production",
+        "https://app.sapiom.ai",
+        "https://api.sapiom.ai",
+        sampleCredentials,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(fs.writeFile).toHaveBeenCalled();
   });
 
   it("should update existing file preserving other environments", async () => {

--- a/packages/mcp/src/credentials.ts
+++ b/packages/mcp/src/credentials.ts
@@ -101,6 +101,16 @@ async function readCredentialsFile(): Promise<CredentialsFile | null> {
 async function writeCredentialsFile(file: CredentialsFile): Promise<void> {
   const filePath = getCredentialsPath();
   await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  // `mode` below only applies when the file is created, so a credentials.json
+  // left behind with looser permissions would keep them. Tighten first, then
+  // write: chmod'ing afterwards would leave a window in which the fresh API key
+  // is already on disk under the old, wider mode.
+  try {
+    await fs.chmod(filePath, 0o600);
+  } catch {
+    // No pre-existing file, or a filesystem that refuses chmod. The `mode`
+    // below covers the create case; best effort either way.
+  }
   await fs.writeFile(filePath, JSON.stringify(file, null, 2) + "\n", {
     mode: 0o600,
   });

--- a/packages/mcp/src/credentials.ts
+++ b/packages/mcp/src/credentials.ts
@@ -71,6 +71,12 @@ async function writeCredentialsFile(file: CredentialsFile): Promise<void> {
   await fs.writeFile(filePath, JSON.stringify(file, null, 2) + "\n", {
     mode: 0o600,
   });
+  try {
+    // `mode` only applies on creation; keep pre-existing files private too.
+    await fs.chmod(filePath, 0o600);
+  } catch {
+    // Best effort.
+  }
 }
 
 /**


### PR DESCRIPTION
## Primary change type

- [x] Bug fix

## Problem and motivation

`writeCredentialsFile` passes `mode: 0o600` to `fs.writeFile`, but that mode is only honoured when the file is *created*. Writing to a file that already exists leaves its permissions untouched.

So a `credentials.json` that ended up with looser permissions keeps them while a fresh API key is written into it. That can happen through an older SDK version that wrote without a mode, a permissive umask at first creation, a restore from backup or an archive that did not preserve modes, or a file copied between machines.

The intent in the code is already clear: the `mode: 0o600` argument says this file is meant to be private. This change makes that hold for the pre-existing case too.

## Summary and scope

After the write, `chmod(filePath, 0o600)`. The call is wrapped in a `try`/`catch` that swallows failures, since a filesystem that does not support POSIX modes should not break credential storage that otherwise succeeded.

Out of scope: the directory's permissions and the read path are unchanged.

## Related work

Related issue or discussion: N/A. See the Security section below.

## Validation

```text
pnpm --filter @sapiom/mcp test        — pass
pnpm --filter @sapiom/mcp typecheck   — pass
pnpm --filter @sapiom/mcp lint        — pass
pnpm build                            — pass
```

### Tests and documentation

Tests: added a case asserting `chmod` is called with `0o600` after the write, so a pre-existing file does not keep looser permissions.

Documentation: N/A, no user-facing API changed.

## Compatibility and release impact

- Breaking or externally visible changes: None. The file already had `0600` in the common case; this makes the uncommon case match.
- Changeset: Added (patch, `@sapiom/mcp`).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [ ] This pull request does not publicly disclose a suspected vulnerability.

I am leaving that box unchecked deliberately rather than ticking it for form's sake. I opened this before the current CONTRIBUTING.md, and reading it now ("even if it looks like a bug fix") I am not certain a direct PR was the right route.

My reasoning for treating it as ordinary hardening: the gap is a documented property of `fs.writeFile` rather than anything specific to this project, the file only becomes readable if it was already created with loose permissions locally, and the fix is three lines with no exploit involved. But if you would rather this had gone to team [at] sapiom.ai, tell me and I will close it and resend privately.

## AI assistance

- [x] I used AI assistance and have described it below.

I used Claude while reviewing the credential storage path. Claude pointed out that `mode` in `fs.writeFile` applies only at creation; I confirmed that against the Node documentation and by checking the behaviour myself before writing the fix. I decided to swallow `chmod` failures rather than propagate them, and I reviewed the diff and ran the package's checks before pushing.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
