### PR TITLE
fix(run-local): expose limitExceeded when MAX_ADVANCES guard fires

### DIFF
--- a/packages/agent-core/src/local/run-local.ts
+++ b/packages/agent-core/src/local/run-local.ts
@@ -81,6 +81,9 @@ export interface LocalRunResult {
   /** Warnings about stub values that matched a key but had the wrong shape for
    *  the capability (the silent-wrong-data trap). Empty when none. */
   stubWarnings: string[];
+  /** `true` when the MAX_ADVANCES guard fires before a terminal state is
+   *  reached. The `outcome` field will be `"running"` in this case. */
+  limitExceeded?: boolean;
 }
 
 const MAX_ADVANCES = 1000; // backstop against a pathological non-terminating graph
@@ -145,6 +148,7 @@ export async function runLocal(opts: RunLocalOptions): Promise<LocalRunResult> {
     // 'running' (or just-resumed) → advance again
   }
 
+  const limitExceeded = guard > MAX_ADVANCES;
   const final = await store.loadExecution(executionId);
   // A local run never cancels; fold the unreachable 'cancelled' into 'failed'.
   const outcome: LocalRunOutcome =
@@ -167,6 +171,7 @@ export async function runLocal(opts: RunLocalOptions): Promise<LocalRunResult> {
     steps: dispatcher.trace,
     unusedStubs,
     stubWarnings: [...dispatcher.stubWarnings],
+    ...(limitExceeded ? { limitExceeded: true } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem
When `runLocal` hits the `MAX_ADVANCES = 1000` safety guard, the loop exits silently and returns `outcome: "running"` indistinguishable from a legitimately still running execution. Callers have no way to detect the limit was hit.

## Fix
- Add `limitExceeded?: boolean` to the `LocalRunResult` interface
- Detect guard exhaustion with `const limitExceeded = guard > MAX_ADVANCES` after the loop
- Include `limitExceeded: true` in the return value when triggered

Fixes #571