### PR TITLE
fix(scaffold): append to .npmrc instead of overwriting

### DIFF
--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -343,10 +343,12 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   if (!opts.versions) {
     const sapiomRegistry = registryFor("@sapiom/tools");
     if (sapiomRegistry !== DEFAULT_REGISTRY) {
-      writeFileSync(
-        path.join(targetDir, ".npmrc"),
-        `@sapiom:registry=${sapiomRegistry}\n`,
-      );
+      const npmrcPath = path.join(targetDir, ".npmrc");
+      const existing = existsSync(npmrcPath) ? readFileSync(npmrcPath, "utf8") : "";
+      const line = `@sapiom:registry=${sapiomRegistry}\n`;
+      if (!existing.includes(line)) {
+        writeFileSync(npmrcPath, existing + line);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
When `scaffold` detects a non-default `@sapiom` registry, it calls `writeFileSync` to write `.npmrc` unconditionally overwriting the file. If the template already copied a `_npmrc` → `.npmrc` with user-defined entries (e.g. a private registry for other scopes), those entries are silently erased.

## Fix
- Read the existing `.npmrc` content (or empty string if absent)
- Only append the `@sapiom:registry=` line if it isn't already present (idempotent)
- `existsSync` and `readFileSync` are already imported in the file

Fixes #573