### PR TITLE
feat(examples): own onboarding-shelf eligibility in the registry (SAP-2080)

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -180,6 +180,7 @@
       "cadence": "scheduled",
       "complexity": "advanced",
       "sourcePath": "examples/content-repurposing-pipeline",
+      "onboarding": { "eligible": true, "order": 2 },
       "capabilities": [
         "models.run",
         "contentGeneration.images",
@@ -254,6 +255,7 @@
       "cadence": "on-demand",
       "complexity": "advanced",
       "sourcePath": "examples/eval-gate",
+      "onboarding": { "eligible": true, "order": 7 },
       "capabilities": ["models.run"],
       "steps": [
         {
@@ -307,6 +309,7 @@
       "cadence": "on-demand",
       "complexity": "moderate",
       "sourcePath": "examples/logged-in-screenshots",
+      "onboarding": { "eligible": true, "order": 4 },
       "capabilities": [
         "web.scrape",
         "browser.session",
@@ -372,6 +375,7 @@
       "cadence": "scheduled",
       "complexity": "advanced",
       "sourcePath": "examples/newsletter-autopilot",
+      "onboarding": { "eligible": true, "order": 1 },
       "capabilities": [
         "web.search",
         "web.scrape",
@@ -532,6 +536,7 @@
       "cadence": "on-demand",
       "complexity": "involved",
       "sourcePath": "examples/proposal-generator",
+      "onboarding": { "eligible": true, "order": 5 },
       "capabilities": [
         "models.run",
         "sandboxes.create",
@@ -606,6 +611,7 @@
       "cadence": "on-demand",
       "complexity": "advanced",
       "sourcePath": "examples/research-to-microsite",
+      "onboarding": { "eligible": true, "order": 3 },
       "capabilities": [
         "web.search",
         "web.scrape",
@@ -791,6 +797,7 @@
       "cadence": "scheduled",
       "complexity": "advanced",
       "sourcePath": "examples/scheduled-db-insight-report",
+      "onboarding": { "eligible": true, "order": 6 },
       "capabilities": [
         "database.get",
         "database.create",

--- a/examples/registry.schema.json
+++ b/examples/registry.schema.json
@@ -23,6 +23,16 @@
         "name": { "type": "string", "minLength": 1, "maxLength": 32, "description": "Display name shown on the card. Names the OUTCOME, not the machinery — the same axis `category` uses. No arrows, no slashes, no parentheticals, and no mechanism word (saga, engine, pipeline, runner, endpoint, gate, durable, keep-alive): those belong in `tags`, which is what drives search. Enforced by the `copy-name` check." },
         "description": { "type": "string", "maxLength": 160, "description": "One-line card description — one plain sentence." },
         "rank": { "type": "integer", "minimum": 1, "description": "Optional gallery ordering weight — lower = higher priority. Ranked templates lead the browse gallery in ascending rank; unranked templates keep registry (id) order behind them. Used to feature the strongest templates up front; most templates carry none. The backend owns the sort (single source of truth), so the frontend adds no sort of its own. Independent of `category` grouping and of runnability — a rank is an editorial choice, not a derived signal." },
+        "onboarding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eligible"],
+          "description": "First-impression (onboarding shelf) curation, owned HERE so the app never hard-codes template ids. The bar is STRICTER than the gallery's `setup.runsWithNoSetup`: a clean, side-effect-free, zero-setup run that leaves a REAL, impressive artifact worth showing a brand-new user — set only after verifying it against a fresh tenant. `eligible` gates membership in the onboarding suggestion pool; `order` is the shelf sequence (lower leads), independent of the gallery `rank`.",
+          "properties": {
+            "eligible": { "type": "boolean", "description": "True only when a fresh-tenant zero-setup run was verified to leave a real, impressive artifact. Absent = not eligible; never assert without evidence." },
+            "order": { "type": "integer", "minimum": 1, "description": "Onboarding shelf priority — lower leads the first-run grid. First-impression sequence, NOT browse ordering, so it is deliberately separate from `rank`. Eligible templates without an order sort after ordered ones." }
+          }
+        },
         "tags": { "type": "array", "items": { "type": "string" }, "description": "Freeform browse tags." },
         "category": {
           "type": "string",

--- a/scripts/examples-check.mjs
+++ b/scripts/examples-check.mjs
@@ -216,6 +216,33 @@ for (const t of templates) {
   }
 }
 
+// 4c. Onboarding-shelf discipline. `onboarding.eligible` is the STRICTER-than-gallery
+// first-impression bar the app renders as its onboarding suggestion shelf. The schema
+// gives it structure; these two rules give it integrity: (1) a template can only be a
+// good first impression if it runs with zero setup at all, so eligibility requires
+// `setup.runsWithNoSetup`; (2) `order` is the deterministic shelf sequence, so two
+// eligible templates must not claim the same slot.
+const shelfOrders = new Map();
+for (const t of templates) {
+  const ob = t.onboarding;
+  if (!ob || ob.eligible !== true) continue;
+  if (t.setup?.runsWithNoSetup !== true) {
+    errors.push(
+      `onboarding: "${t.id}" is onboarding.eligible but setup.runsWithNoSetup is not true — the shelf is a fresh-tenant first impression, so it must run with zero setup. Verify it, or drop the eligible flag.`,
+    );
+  }
+  if (typeof ob.order === "number") {
+    const prev = shelfOrders.get(ob.order);
+    if (prev) {
+      errors.push(
+        `onboarding: "${t.id}" and "${prev}" both declare onboarding.order ${ob.order} — the shelf order must be unique so the sequence is deterministic.`,
+      );
+    } else {
+      shelfOrders.set(ob.order, t.id);
+    }
+  }
+}
+
 // 4b. `discipline` agrees with `category`. A hard error, not a warning like the
 // complexity divergence below: that one compares an author's judgment against a
 // proxy and the author can be right, whereas a discipline outside its category's


### PR DESCRIPTION
## Summary
Moves onboarding-shelf curation to where the templates actually live. Today the Sapiom app hard-codes a `SHELF_TEMPLATE_IDS` allow-list and unit-tests membership of *this* catalog on its side — curating templates it doesn't own. This adds a data-driven `onboarding` field so the app can stop doing that.

## The field
Per registry entry:
```jsonc
"onboarding": { "eligible": true, "order": 1 }
```
- **`eligible`** — the stricter-than-gallery first-impression bar: a clean, side-effect-free, zero-setup run that leaves a **real** artifact, verified against a fresh tenant. Distinct from `setup.runsWithNoSetup` (the gallery bar).
- **`order`** — onboarding shelf sequence (lower leads), deliberately separate from the gallery `rank`.

Set on the seven verified templates, ordered by observed **view→clone conversion** so the strongest first-run picks lead:

| order | template |
|---|---|
| 1 | newsletter-autopilot |
| 2 | content-repurposing-pipeline |
| 3 | research-to-microsite |
| 4 | logged-in-screenshots |
| 5 | proposal-generator |
| 6 | scheduled-db-insight-report |
| 7 | eval-gate |

At the app's empty-state count of 4, orders 1–4 lead (the four best converters); the rest remain eligible for the answer-driven wizard (e.g. eval-gate is the product-engineering pick).

## Validation
`examples:check` now enforces: (1) `onboarding.eligible` requires `setup.runsWithNoSetup`; (2) eligible `order` values are unique.

## Companion change
The Sapiom backend surfaces `onboarding` into `TemplateSummary` and the frontend replaces `isShelfEligible(id)` with `template.onboarding?.eligible` + orders by `onboarding.order`, deleting `shelf-curation.ts` and its test (replaces sapiom/Sapiom#4161). Until that ships this field is inert — the backend tolerantly ignores unknown fields.

## Testing
- [x] `pnpm examples:check` passes (11 templates schema-valid)
- [x] `pnpm examples:check:test` — 126/126 pass

## Related
- Refs: SAP-2080 (data-driven shelf eligibility, anticipated in `shelf-curation.ts`'s own header)

## Checklist
- [x] Code follows project guidelines
- [x] No hardcoded secrets
- [x] Self-reviewed