### PR TITLE
docs: add contribution policy and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,68 @@
+<!--
+Thank you for contributing to sapiom-js.
+Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
+Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
+-->
+
+## Problem and motivation
+
+<!-- What problem does this solve, and why is the change needed? -->
+
+## Summary and scope
+
+<!-- Describe what changed, including what is intentionally out of scope. -->
+
+## Related work
+
+<!--
+Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
+Use N/A for a direct PR that does not need one.
+-->
+
+Related issue or discussion:
+
+## Validation
+
+<!-- List the exact commands or manual checks you ran and their results. -->
+
+```text
+# command — result
+```
+
+### Tests and documentation
+
+<!-- Describe tests and documentation added or updated. Use N/A with a reason when appropriate. -->
+
+## Compatibility and release impact
+
+- Breaking or externally visible changes: <!-- None, or describe the impact and migration path. -->
+- Changeset: <!-- Added, or N/A with a reason. -->
+
+## Security
+
+- [ ] I have not included secrets, credentials, private data, or unsanitized logs.
+- [ ] This pull request does not publicly disclose a suspected vulnerability. I
+      will follow the
+      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
+      private reporting.
+
+## AI assistance
+
+- [ ] I did not use AI assistance for this change.
+- [ ] I used AI assistance and have described it below.
+
+<!--
+If AI was used, name the tool, explain what it generated or changed, and
+describe how you verified the result.
+-->
+
+## Checklist
+
+- [ ] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
+- [ ] This pull request addresses one focused problem and contains no unrelated cleanup.
+- [ ] I added or updated tests, or explained above why tests are not applicable.
+- [ ] I ran the relevant build, typecheck, lint, and test commands, or explained
+      any N/A checks above.
+- [ ] I updated documentation for user-facing changes, or marked it N/A above.
+- [ ] I added a Changeset for a published-package change, or explained why it is not applicable.
+- [ ] I can explain and maintain every submitted change, including any AI-assisted work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,236 +1,279 @@
-# Contributing to Sapiom SDK
+# Contributing to sapiom-js
 
-Thank you for your interest in contributing to the Sapiom SDK! We welcome contributions from the community.
+Thank you for your interest in contributing to `sapiom-js`. We welcome focused,
+well-tested improvements from the community. This guide explains which changes
+can go straight to a pull request, which need maintainer agreement first, and
+what information we need to review your work efficiently.
 
-## Getting Started
+## Before you start
+
+Choose the path that matches your contribution:
+
+### Open a pull request directly
+
+You can usually open a pull request without prior discussion for:
+
+- focused bug fixes with a clear reproduction;
+- documentation corrections;
+- fixes to existing examples;
+- new templates that follow [`examples/AUTHORING.md`](examples/AUTHORING.md) and
+  are limited to one template; and
+- tests that clarify existing behavior.
+
+Keep direct pull requests small and limited to one problem.
+
+### Open an issue first
+
+Please [open an issue](https://github.com/sapiom/sapiom-js/issues) and wait for
+maintainer agreement before investing in:
+
+- new features, integrations, or packages;
+- public API changes or changes to documented compatibility or behavior
+  contracts;
+- new or replaced dependencies;
+- cross-package architectural changes; or
+- broad performance work, refactors, or migrations.
+
+Early discussion helps confirm that the change fits the project's direction and
+prevents contributors from spending time on work we may not be able to accept.
+
+### Report security vulnerabilities privately
+
+Even if it looks like a bug fix, do not open a public issue or pull request for
+a suspected vulnerability. Follow our [Security Policy](SECURITY.md) instead.
+
+### Changes we normally decline
+
+We normally close contributions that contain:
+
+- unsolicited broad refactors or migrations;
+- formatting-only or style-only churn unrelated to a functional change;
+- multiple unrelated changes in one pull request;
+- changes that disable, bypass, or hide failing quality checks;
+- unexplained generated or bulk changes; or
+- AI-assisted changes the contributor cannot explain and validate.
+
+Maintainers may also decline work that does not fit the project's current
+direction or maintenance capacity. Opening an issue or pull request does not
+guarantee that the change will be accepted.
+
+## Development setup
 
 ### Prerequisites
 
-- Node.js 18.0.0 or higher
-- pnpm 8.0.0 or higher
+- Node.js 20.0.0 or higher for full-workspace development and CI. Individual
+  SDK packages may retain Node.js 18 runtime support.
+- pnpm 10.0.0 or higher (the repository pins pnpm 10.34.3)
 
 ### Setup
 
-1. Fork the repository
-2. Clone your fork:
+1. Fork the repository.
+2. Clone your fork and configure the upstream repository:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/sdk.git
-   cd sdk
+   git clone https://github.com/YOUR_USERNAME/sapiom-js.git
+   cd sapiom-js
+   git remote add upstream https://github.com/sapiom/sapiom-js.git
    ```
 
-3. Install dependencies:
+3. Install dependencies from the lockfile:
 
    ```bash
-   pnpm install
+   pnpm install --frozen-lockfile
    ```
 
-4. Build all packages:
+4. Build and test the workspace:
 
    ```bash
    pnpm build
-   ```
-
-5. Run tests:
-   ```bash
    pnpm test
    ```
 
-## Development Workflow
+This repository is a monorepo. Published and internal workspace packages live
+under [`packages/`](packages/); browse that directory and its package manifests
+for the current package list rather than relying on a static catalog.
 
-### Project Structure
+## Development workflow
 
-This is a monorepo containing multiple packages:
-
-- `@sapiom/core` - Core SDK functionality
-- `@sapiom/axios` - Axios integration
-- `@sapiom/fetch` - Fetch API integration
-- `@sapiom/node-http` - Node.js HTTP/HTTPS integration
-- `@sapiom/langchain` - LangChain integration
-
-### Working on a Package
+Create a descriptive branch from the latest `main`:
 
 ```bash
-# Navigate to a specific package
-cd packages/core
-
-# Build in watch mode
-pnpm dev
-
-# Run tests in watch mode
-pnpm test:watch
-
-# Run linter
-pnpm lint
-
-# Format code
-pnpm format
+git fetch upstream
+git checkout -b fix/short-description upstream/main
 ```
 
-### Making Changes
-
-1. Create a new branch for your changes:
-
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-2. Make your changes and ensure:
-   - Tests pass: `pnpm test`
-   - Builds succeed: `pnpm build`
-   - Types check: `pnpm typecheck`
-   - Linting passes: `pnpm lint`
-
-3. Write or update tests for your changes
-
-4. Add a changeset describing your changes:
-   ```bash
-   pnpm changeset
-   ```
-   Follow the prompts to describe your changes. This helps with version management and changelog generation.
-
-## Code Standards
-
-### TypeScript
-
-- Use TypeScript for all source code
-- Enable strict mode
-- Provide proper type annotations
-- Avoid `any` types when possible
-
-### Testing
-
-- Write unit tests for all new functionality
-- Maintain or improve code coverage
-- Use descriptive test names
-- Test both success and error cases
-
-### Code Style
-
-- Follow the existing code style
-- Use Prettier for formatting (runs automatically)
-- Follow ESLint rules
-- Write clear, self-documenting code
-- Add comments for complex logic
-
-### Commit Messages
-
-We follow conventional commits:
-
-- `feat:` - New features
-- `fix:` - Bug fixes
-- `docs:` - Documentation changes
-- `test:` - Test changes
-- `refactor:` - Code refactoring
-- `chore:` - Maintenance tasks
-
-Example:
-
-```
-feat(core): add transaction polling support
-
-- Implement TransactionPoller class
-- Add polling configuration options
-- Update documentation
-```
-
-## Pull Request Process
-
-1. Update documentation for any API changes
-2. Add tests for new functionality
-3. Ensure all tests pass and builds succeed
-4. Create a changeset with `pnpm changeset`
-5. Push your changes to your fork
-6. Open a Pull Request against the `main` branch
-7. Fill out the PR template with:
-   - Clear description of changes
-   - Link to related issues
-   - Testing steps
-   - Breaking changes (if any)
-
-### PR Requirements
-
-Before submitting:
-
-- [ ] Tests pass (`pnpm test`)
-- [ ] Build succeeds (`pnpm build`)
-- [ ] Types check (`pnpm typecheck`)
-- [ ] Linting passes (`pnpm lint`)
-- [ ] Changeset created (`pnpm changeset`)
-- [ ] Documentation updated
-- [ ] No merge conflicts
-
-## Running Tests
+While iterating, you can run commands for one package with pnpm filters:
 
 ```bash
-# Run all tests
-pnpm test
-
-# Run tests with coverage
-pnpm test:coverage
-
-# Run tests for specific package
+pnpm --filter @sapiom/core build
 pnpm --filter @sapiom/core test
-
-# Watch mode
 pnpm --filter @sapiom/core test:watch
 ```
 
-### Mutation Testing
+Replace `@sapiom/core` with the package you are changing.
 
-`@sapiom/analytics-core` uses [StrykerJS](https://stryker-mutator.io/) to check that its tests actually catch bugs, not just execute lines. Stryker plants small bugs ("mutants") in the source — flipped comparisons, removed statements, changed constants — and re-runs the tests against each one. A mutant that no test fails on ("survived") is a gap where a real bug would slip through silently.
+## Quality standards
 
-It is scoped to the delivery-critical logic (envelope builder, consent resolver, batch queue, data truncation, HTTP sender) — see `packages/analytics-core/stryker.conf.json`.
+### Keep changes focused
 
-**When to run it:** it is not part of per-PR CI (it's slow). A nightly [Mutation Testing workflow](.github/workflows/mutation.yml) runs it on a schedule and uploads the HTML report as an artifact. Run it locally when you change any of the mutated modules or their tests:
+- Solve one problem per pull request.
+- Follow the existing design and code style in the affected package.
+- Run the affected package's format script when it provides one.
+- Avoid drive-by cleanup and unrelated dependency updates.
+- Explain non-obvious behavior and tradeoffs in code or documentation.
+
+### TypeScript
+
+- Use TypeScript for source code.
+- Preserve strict type safety and avoid `any` when a precise type is practical.
+- Document public APIs and externally visible behavior.
+
+### Testing
+
+- Add or update tests for changed behavior.
+- Cover relevant success and error paths.
+- Use descriptive test names that state the expected behavior.
+- Maintain or improve coverage in the changed area.
+
+For source, build, or configuration changes, run the root checks before opening
+a pull request:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+pnpm test
+```
+
+When a command does not exercise a documentation-only or test-only change, mark
+it as not applicable in the pull request and explain what you validated instead.
+All CI checks that run for the pull request must pass.
+
+If you change the example gallery or its manifests, also run the relevant
+repository content checks:
+
+```bash
+pnpm examples:sort
+pnpm examples:check
+pnpm examples:check:test
+pnpm terminology:check
+```
+
+### Mutation testing
+
+`@sapiom/analytics-core` uses
+[StrykerJS](https://stryker-mutator.io/) to check whether its tests detect bugs
+instead of merely executing lines. Mutation testing is scoped to
+delivery-critical logic; see `packages/analytics-core/stryker.conf.json`.
+
+The test is too slow for per-PR CI, so a nightly
+[Mutation Testing workflow](.github/workflows/mutation.yml) runs it separately.
+Run it locally when you change one of the mutated modules or its tests:
 
 ```bash
 pnpm --filter @sapiom/analytics-core test:mutation
 ```
 
-**How to read the report:** the run prints a score table per file and writes an interactive HTML report to `packages/analytics-core/reports/mutation/mutation.html`. Open it in a browser, click into a file, and look at the surviving (❌) mutants — each one shows the exact code change no test noticed. Fix survivors by strengthening tests (assert on the behavior the mutant broke); don't chase 100%, some mutants are equivalent to the original code and unkillable. Thresholds live in `stryker.conf.json`: the run fails below 60 (break), 70+ is expected, 85+ is good.
+The command writes an interactive report to
+`packages/analytics-core/reports/mutation/mutation.html`. Investigate surviving
+mutants and strengthen tests where they reveal a real gap. Thresholds live in
+`stryker.conf.json`: the run fails below 60, 70 or higher is expected, and 85 or
+higher is good. Some mutants are equivalent to the original code and cannot be
+killed meaningfully.
 
-## Building
+### Documentation
+
+For user-facing changes:
+
+- update the relevant README or guide;
+- add or update JSDoc for public APIs;
+- include an example when it materially improves understanding; and
+- call out compatibility or migration requirements.
+
+### Changesets
+
+Add a Changeset when a change affects a published package's behavior, API, or
+release notes:
 
 ```bash
-# Build all packages
-pnpm build
-
-# Build specific package
-pnpm --filter @sapiom/core build
-
-# Clean build artifacts
-pnpm clean
+pnpm changeset
 ```
 
-## Documentation
+A Changeset is normally not needed for documentation-only changes, tests,
+repository tooling, or other changes that do not affect a published package.
+Mark the Changeset as not applicable in the pull request and explain why.
 
-- Update README.md files for user-facing changes
-- Add JSDoc comments for public APIs
-- Include code examples in documentation
-- Update CHANGELOG.md via changesets
+### Commit messages
 
-## Reporting Issues
+Use conventional commit prefixes:
 
-When reporting issues, please include:
+- `feat:` for new features
+- `fix:` for bug fixes
+- `docs:` for documentation changes
+- `test:` for test changes
+- `refactor:` for refactoring
+- `chore:` for maintenance
 
-- SDK version
-- Node.js version
-- Operating system
-- Minimal reproduction steps
-- Expected vs actual behavior
-- Error messages or logs
+Add a package scope when it makes the change clearer, for example:
 
-## Questions?
+```text
+fix(core): preserve transaction errors during polling
+```
 
-- Open a GitHub issue for bugs or feature requests
-- Check existing issues before creating new ones
-- Be respectful and constructive in discussions
+## Pull request process
+
+1. Rebase or merge the latest `upstream/main` into your branch.
+2. Run the checks relevant to your change.
+3. Push the branch to your fork.
+4. Open a pull request against `sapiom/sapiom-js:main`.
+5. Complete every applicable section of the pull request template. Use `N/A`
+   with a short explanation instead of silently deleting a section.
+6. Respond to review feedback and keep the branch focused as it evolves.
+
+Maintainers review contributions for correctness, compatibility, scope,
+security, maintainability, and fit with the project. They may request changes or
+close work that falls outside the policy above. Contributors remain responsible
+for the submitted code throughout review, including code produced with AI tools.
+
+## AI-assisted contributions
+
+AI-assisted contributions are allowed, but they are held to the same standards
+as any other contribution. If you used an AI tool:
+
+- disclose its use in the pull request;
+- describe what it generated or materially changed;
+- explain how you reviewed and validated the result;
+- make sure you understand and can defend every submitted change; and
+- never include secrets, credentials, private data, or code you do not have the
+  right to contribute in prompts or generated output.
+
+Maintainers may decline AI-assisted changes that are unverified, unnecessarily
+large, or not understood by the contributor.
+
+## Reporting bugs and requesting features
+
+Search [existing issues](https://github.com/sapiom/sapiom-js/issues) before
+opening a new one.
+
+For bugs, include:
+
+- the affected SDK version;
+- Node.js and pnpm versions;
+- operating system;
+- a minimal reproduction;
+- expected and actual behavior; and
+- relevant error messages or sanitized logs.
+
+For feature requests, explain the problem or use case before proposing an API.
+Never include credentials, private data, or undisclosed vulnerability details in
+a public issue.
+
+## Community expectations
+
+Be respectful, constructive, and patient in issues, pull requests, and reviews.
+Disagreement is welcome; harassment and personal attacks are not.
 
 ## License
 
-By contributing to Sapiom SDK, you agree that your contributions will be licensed under the MIT License.
-
-## Code of Conduct
-
-Please note that this project follows a Code of Conduct. By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
+By contributing to `sapiom-js`, you agree that your contributions will be
+licensed under the repository's [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

Establishes a curated-open contribution policy for sapiom-js and adds the missing default pull request template. Contributors can now distinguish direct fixes from issue-first work and private security reports before investing in a change.

## Changes

- Define direct-PR, issue-first, private security, and normally-declined contribution paths.
- Correct clone, Node, pnpm, package-layout, test, Changeset, and mutation-testing guidance.
- Document expectations for focused and AI-assisted contributions.
- Add structured PR fields for motivation, scope, validation, compatibility, security, Changesets, and AI disclosure.

## Testing

- [x] pnpm build
- [x] pnpm typecheck
- [x] pnpm lint (0 errors; existing warnings only)
- [x] pnpm test
- [x] pnpm examples:check
- [x] pnpm examples:check:test
- [x] pnpm terminology:check
- [x] pnpm exec prettier --check CONTRIBUTING.md .github/pull_request_template.md
- [x] GitHub-flavored Markdown rendering and link validation

## Related

- Closes: [SAP-2498](https://linear.app/sapiom/issue/SAP-2498/sdk-establish-a-curated-contribution-policy-and-pr-template)

## Checklist

- [x] Scope is limited to the two approved contributor-facing files.
- [x] No SDK runtime or public API behavior changes.
- [x] No secrets or private review processes included.
- [x] Changeset is not applicable for documentation and repository community configuration.
- [x] Self-reviewed against the ticket acceptance criteria.