### PR TITLE
fix(agent): defineAgent no longer mutates the caller's definition object

### DIFF
--- a/.changeset/fix-define-agent-immutable.md
+++ b/.changeset/fix-define-agent-immutable.md
@@ -1,0 +1,13 @@
+---
+'@sapiom/agent': patch
+---
+
+fix(agent): defineAgent no longer mutates the caller's definition object
+
+`defineAgent` now builds and returns a shallow copy instead of mutating the
+object passed in. Previously it reassigned `def.steps` (when folding an
+agent-level `inputSchema`) and attached the `AGENT_DEFINITION_BRAND` symbol
+directly onto the caller's object, so both mutations were observable on the
+original reference the caller still held. Callers should keep using the value
+returned by `defineAgent` (they already do); the object passed in is now left
+untouched. Closes #572.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -139,9 +139,12 @@ export function isLegacyOrchestrationDefinition(val: unknown): val is AgentDefin
  * which now carries it. Declaring a *different* schema in both places is a
  * conflict and throws; declaring the identical schema object in both is allowed.
  *
- * Attaches a non-enumerable brand symbol (`AGENT_DEFINITION_BRAND`) so
- * the object can be detected by `isAgentDefinition` after bundling +
- * dynamic import without relying on duck-typed property names.
+ * Returns a shallow copy of `def` carrying a non-enumerable brand symbol
+ * (`AGENT_DEFINITION_BRAND`) so the definition can be detected by
+ * `isAgentDefinition` after bundling + dynamic import without relying on
+ * duck-typed property names. The caller's `def` object is left unmutated —
+ * its `steps` reference is not reassigned and the brand is not attached to it
+ * (#572) — so always use the returned value, never the object you passed in.
  *
  * Static validation of every `continue` target is intentionally NOT
  * done — most are computed at runtime inside `run()`. PR review is the
@@ -167,27 +170,35 @@ export function defineAgent<TInput = unknown, TShared extends Record<string, unk
       throw new Error(`Agent '${def.name}' step name mismatch at key '${key}': step.name='${step.name}'`);
     }
   }
+  // Build the returned definition on a shallow copy of `def`. Everything below —
+  // folding the input contract, attaching the brand — happens on `result`, so the
+  // caller's original object is never mutated: its `steps` reference is not
+  // reassigned and the brand symbol is not added to it. Callers routinely hold a
+  // reference to the object literal they pass in; mutating it in place is a
+  // surprising side effect (#572). Downstream code uses the returned value.
+  const result: AgentDefinition<TInput, TShared> = { ...def };
+
   // Fold the agent-level input contract onto the entry step (see the doc above).
-  if (def.inputSchema) {
-    const entryStep = def.steps[def.entry];
-    if (entryStep.inputSchema && entryStep.inputSchema !== def.inputSchema) {
+  if (result.inputSchema) {
+    const entryStep = result.steps[result.entry];
+    if (entryStep.inputSchema && entryStep.inputSchema !== result.inputSchema) {
       throw new Error(
-        `Agent '${def.name}' declares a different inputSchema at the agent level and on its entry step '${def.entry}'. ` +
+        `Agent '${result.name}' declares a different inputSchema at the agent level and on its entry step '${result.entry}'. ` +
           `Declare the input contract once and reference that single schema object in both places (or remove one).`,
       );
     }
     if (!entryStep.inputSchema) {
       // The entry step declared no schema: the agent-level contract becomes it.
-      // Copy-on-write — build a FRESH steps map with a fresh entry step rather
-      // than mutating the caller's (Readonly) `steps` object in place. Mutating
-      // it would corrupt a `steps` literal shared across two `defineAgent` calls
-      // (the first fold would rewrite the second's entry step) and would throw on
-      // an `Object.freeze()`d map. The step's `run` and routing declarations are
+      // Build a FRESH steps map with a fresh entry step and assign it onto the
+      // copy — never onto the caller's `steps`. Mutating the caller's map would
+      // corrupt a `steps` literal shared across two `defineAgent` calls (the
+      // first fold would rewrite the second's entry step) and would throw on an
+      // `Object.freeze()`d map. The step's `run` and routing declarations are
       // carried over by the spread, so downstream readers of
       // `steps[entry].inputSchema` pick up the contract without special-casing.
-      (def as { steps: Record<string, StepDefinition<TShared>> }).steps = {
-        ...def.steps,
-        [def.entry]: { ...entryStep, inputSchema: def.inputSchema as ZodType<unknown> },
+      (result as { steps: Record<string, StepDefinition<TShared>> }).steps = {
+        ...result.steps,
+        [result.entry]: { ...entryStep, inputSchema: result.inputSchema as ZodType<unknown> },
       };
     }
   }
@@ -195,11 +206,11 @@ export function defineAgent<TInput = unknown, TShared extends Record<string, unk
   //   - survives esbuild bundling (symbol properties pass through)
   //   - survives dynamic import (the imported object is the same reference)
   //   - doesn't pollute JSON.stringify or for...in iteration
-  Object.defineProperty(def, AGENT_DEFINITION_BRAND, {
+  Object.defineProperty(result, AGENT_DEFINITION_BRAND, {
     value: 1,
     enumerable: false,
     writable: false,
     configurable: false,
   });
-  return def;
+  return result;
 }

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -297,6 +297,40 @@ describe('defineAgent agent-level inputSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 1c. defineAgent — leaves the caller's def object unmutated (#572)
+// ---------------------------------------------------------------------------
+
+describe('defineAgent — does not mutate the caller def object (#572)', () => {
+  const contract = z.object({ companyId: z.number() });
+
+  it('returns a fresh object rather than the input reference', () => {
+    const def = { name: 'wf', entry: 'start', steps: { start: makeStep('start') } };
+    expect(defineAgent(def)).not.toBe(def);
+  });
+
+  it('attaches the brand to the returned copy, not to the caller object', () => {
+    const def = { name: 'wf', entry: 'start', steps: { start: makeStep('start') } };
+    const result = defineAgent(def);
+    // The returned value is branded...
+    expect(isAgentDefinition(result)).toBe(true);
+    // ...but the object the caller passed in is left plain.
+    expect(isAgentDefinition(def)).toBe(false);
+    expect((def as unknown as Record<symbol, unknown>)[AGENT_DEFINITION_BRAND]).toBeUndefined();
+  });
+
+  it('does not reassign the caller object steps reference when folding inputSchema', () => {
+    const originalSteps = { start: makeStep('start') };
+    const def = { name: 'wf', entry: 'start', inputSchema: contract, steps: originalSteps };
+    const result = defineAgent(def);
+    // The fold landed on the returned copy's steps map...
+    expect(result.steps.start.inputSchema).toBe(contract);
+    // ...while the caller's object still points at its own untouched map.
+    expect(def.steps).toBe(originalSteps);
+    expect(def.steps.start.inputSchema).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isAgentDefinition type guard
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`defineAgent` mutated the object passed in by the caller. It reassigned `def.steps` when folding an agent-level `inputSchema`, and attached `AGENT_DEFINITION_BRAND` directly onto `def` via `Object.defineProperty`. Both mutations were observable on the caller's original reference (see #572).

This builds the returned definition on a shallow copy (`const result = { ...def }`) and applies the input-contract fold and the brand to `result`, leaving the caller's `def` untouched. Callers already consume the value returned by `defineAgent`, so behaviour for correct usage is unchanged — only the surprising side effect on the input object goes away.

## Changes

- `packages/agent/src/agent.ts` — operate on a shallow copy and return it instead of the input; doc comment updated to state the input is not mutated.
- `packages/agent/src/sdk.spec.ts` — regression tests: fresh return value, brand only on the copy, and the caller's `steps` reference preserved when folding `inputSchema`.
- changeset (`@sapiom/agent`, patch).

## Testing

- `pnpm --filter @sapiom/agent test` — all suites green, including the three new tests (verified they fail against the pre-fix implementation).
- `pnpm --filter @sapiom/agent typecheck`
- `pnpm --filter @sapiom/agent lint`

Closes #572
