### PR TITLE
fix(harness-desktop): space-free NSIS artifact name so Windows auto-update resolves

### DIFF
--- a/.changeset/windows-update-manifest-name.md
+++ b/.changeset/windows-update-manifest-name.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Fix Windows auto-update: the NSIS installer now uses a space-free artifact name
+(`Sapiom-Setup-<version>.exe`), so the filename electron-builder records in
+`latest.yml` matches the asset GitHub actually stores. Previously the default
+spaced name (`Sapiom Setup <version>.exe`) was sanitised to hyphens in the
+manifest but to dots in the uploaded asset, so every Windows client 404'd on
+update. The release workflow now also fails if any published manifest references
+an asset that isn't attached, so this class of mismatch can't ship silently again.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -506,6 +506,37 @@ jobs:
           fi
           echo "All three channel manifests present for \"$channel\"."
 
+      # A present manifest is not a working one. electron-updater resolves every
+      # `url:` in the manifest against the release assets, so a manifest naming a
+      # file that isn't attached 404s on every client — exactly what a
+      # `${productName} Setup ${version}` (spaced) NSIS name did: builder wrote a
+      # hyphenated url, GitHub stored a dotted asset, and Windows updates broke
+      # silently for four releases. The name-match holds pre-upload because our
+      # artifact names are space-free (see electron-builder.yml nsis.artifactName)
+      # — so on-disk == manifest url == the name GitHub will keep.
+      - name: Verify each manifest's referenced assets are attached
+        run: |
+          set -euo pipefail
+          cd dist-artifacts
+          shopt -s nullglob globstar
+          fail=0
+          for manifest in **/latest*.yml **/beta*.yml; do
+            # `url:` lines list the installer(s); dedupe since `path:` repeats one.
+            refs="$(grep -oE 'url:[[:space:]]*[^[:space:]]+' "$manifest" | awk '{print $2}' | sort -u)"
+            while IFS= read -r ref; do
+              [ -n "$ref" ] || continue
+              if [ -z "$(find . -name "$ref" -print -quit)" ]; then
+                echo "::error::$manifest references \"$ref\" but no such asset is attached — installed apps will 404 on update."
+                fail=1
+              fi
+            done < <(printf '%s\n' "$refs")
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "Attached assets:"; find . -type f -printf '  %f\n' | sort -u
+            exit 1
+          fi
+          echo "Every manifest-referenced asset is attached."
+
       # Make the channels a hierarchy rather than two dead ends.
       #
       # A beta install reads `beta.yml`. Final releases only publish `latest*.yml`,

--- a/packages/harness-desktop/electron-builder.yml
+++ b/packages/harness-desktop/electron-builder.yml
@@ -119,6 +119,12 @@ win:
   asar: false
 
 nsis:
+  # Space-free, so the on-disk name survives GitHub's upload sanitisation
+  # unchanged and matches the `url` electron-builder writes into `latest.yml`.
+  # The default `${productName} Setup ${version}.${ext}` has a space: builder
+  # sanitises that to a hyphen in the manifest, GitHub rewrites it to a dot in
+  # the asset, and the two disagree — every Windows client then 404s on update.
+  artifactName: Sapiom-Setup-${version}.${ext}
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true


### PR DESCRIPTION
## Problem

Every recent desktop release (0.2.4 → 0.2.7) ships a **broken Windows update manifest**. `latest.yml` points the updater at:

```
url:  Sapiom-Setup-0.2.7.exe   ← hyphens
path: Sapiom-Setup-0.2.7.exe
```

but the asset actually attached to the release is `Sapiom.Setup.0.2.7.exe` (**dots**). No `Sapiom-Setup-0.2.7.exe` exists, so a Windows client that reads the manifest **404s on both the installer and its `.exe.blockmap`, on every check** — it never updates.

Verified from the published manifests (downloaded from the GitHub Releases), not inferred. macOS and Linux are healthy: their manifest urls match their assets exactly.

## Root cause

The `nsis:` block set no `artifactName`, so it fell back to the default `${productName} Setup ${version}.${ext}` = `Sapiom Setup 0.2.7.exe` — the only artifact name containing **spaces**. electron-builder sanitises those spaces to **hyphens** when writing the `url` into `latest.yml`; GitHub sanitises the uploaded filename's spaces to **dots**. The two disagree. macOS/Linux avoid it because their artifact names already contain no spaces.

Severity is currently latent — the repo treats Windows as pre-GA (build leg is `continue-on-error`, unsigned) — but it breaks Windows auto-update the moment it goes live, and no existing check catches it.

## Fix

1. **`packages/harness-desktop/electron-builder.yml`** — add `nsis.artifactName: Sapiom-Setup-${version}.${ext}`. The installer now writes to disk with no spaces, so on-disk name == manifest `url` == the asset name GitHub keeps. The `.exe.blockmap` inherits the same name, so differential updates line up too.
2. **`.github/workflows/desktop-release.yml`** — new publish-job step that parses every `url:` from each `latest*/beta*.yml` and fails the release if a referenced asset isn't attached. The existing step only checked manifests *existed*; this checks they're *usable* — the exact gap this bug slipped through.

## Verification

- Both YAML files parse (`js-yaml`).
- Publish job is `ubuntu-latest`, so the step's GNU `find -printf` / `shopt -s globstar` are valid (globstar matches the two adjacent existing steps).
- Ran the new step's logic against fixtures: **fails** on the broken shape (hyphen url + dot asset), **passes** on the fixed shape incl. the macOS two-url manifest.
- Not verifiable locally (needs a Windows runner): a full `.exe` pack. Recommend a `workflow_dispatch` run to confirm the installer is `Sapiom-Setup-<v>.exe` and `latest.yml` matches before the next tagged release.

## Note

This changes the Windows installer filename. The first post-fix release is a clean cutover (old manifests were already broken, nothing regresses). The human-download link `Sapiom-Windows-x64.exe` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)