### PR TITLE
chore(github): add deterministic PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,63 @@
+"area: agents":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/agent/**
+          - packages/agent-core/**
+          - packages/agent-runtime/**
+
+"area: studio":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/agent-studio/**
+          - packages/harness/**
+          - packages/harness-desktop/**
+
+"area: sdk":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/core/**
+          - packages/analytics-core/**
+
+"area: integrations":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/axios/**
+          - packages/fetch/**
+          - packages/node-http/**
+          - packages/langchain/**
+          - packages/langchain-classic/**
+
+"area: platform-tools":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/cli/**
+          - packages/mcp/**
+          - packages/sandbox/**
+          - packages/sandbox-preview/**
+          - packages/tools/**
+          - plugins/**
+          - .claude/**
+          - .claude-plugin/**
+
+"area: examples-docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - examples/**
+          - "*.md"
+
+"area: ci-release":
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+          - .changeset/config.json
+          - .npmrc
+          - .prettierignore
+          - .prettierrc.json
+          - eslint.config.*
+          - package.json
+          - pnpm-lock.yaml
+          - pnpm-workspace.yaml
+          - PUBLISHING.md
+          - scripts/**
+          - tsconfig*.json

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,17 @@ Read CONTRIBUTING.md before submitting, and keep the pull request focused on one
 Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
 -->
 
+## Primary change type
+
+<!-- Select exactly one primary type. -->
+
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Feature
+- [ ] Tests
+- [ ] Dependency update
+- [ ] Maintenance or refactor
+
 ## Problem and motivation
 
 <!-- What problem does this solve, and why is the change needed? -->

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,146 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to classify
+        required: true
+        type: number
+      initialize_triage:
+        description: Add needs-triage when the pull request is external
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-labeler-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Classify pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply area labels
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          configuration-path: .github/labeler.yml
+          pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          sync-labels: "true"
+
+      # pull_request_target is privileged. Check out only the trusted base SHA;
+      # never fetch or execute the contributor-controlled head ref in this job.
+      - name: Check out trusted classifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+
+      - name: Apply deterministic classification labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EVENT_ACTION: ${{ github.event.action || 'workflow_dispatch' }}
+          INITIALIZE_TRIAGE: ${{ inputs.initialize_triage || false }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        with:
+          script: |
+            const path = await import("node:path");
+            const { pathToFileURL } = await import("node:url");
+            const classifierUrl = pathToFileURL(
+              path.join(
+                process.env.GITHUB_WORKSPACE,
+                "scripts",
+                "pr-label-classifier.mjs",
+              ),
+            ).href;
+            const {
+              classifyPullRequest,
+              reconcilePullRequestLabels,
+            } = await import(classifierUrl);
+
+            const pullNumber = Number.parseInt(process.env.PR_NUMBER, 10);
+            if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed("PR_NUMBER must be a positive integer");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pullRequest.base.ref !== "main") {
+              core.setFailed(
+                `PR #${pullNumber} targets ${pullRequest.base.ref}, not main`,
+              );
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const classification = classifyPullRequest({
+              pullRequest,
+              files,
+              eventAction: process.env.EVENT_ACTION,
+              initializeTriage: process.env.INITIALIZE_TRIAGE === "true",
+            });
+            const currentLabels = pullRequest.labels
+              .map((label) =>
+                typeof label === "string" ? label : label.name,
+              )
+              .filter(Boolean);
+            const changes = reconcilePullRequestLabels(
+              currentLabels,
+              classification,
+            );
+
+            core.info(
+              `PR #${pullNumber}: review size ${classification.reviewSize}; ` +
+                `add [${changes.add.join(", ")}]; ` +
+                `remove [${changes.remove.join(", ")}]`,
+            );
+            for (const reason of classification.templateReasons) {
+              core.info(`Template incomplete: ${reason}`);
+            }
+
+            for (const name of changes.remove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pullNumber,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            if (changes.add.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                labels: changes.add,
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Test repository content checks
         run: pnpm examples:check:test
 
+      - name: Test pull request classification
+        run: pnpm pr-labeler:check
+
   # NOTE: the harness web-e2e (playwright-mock) and desktop packaging
   # (desktop-smoke) jobs moved to .github/workflows/harness.yml, which is
   # path-filtered to the harness and its workspace dependencies — they only

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "terminology:check:test": "node --test scripts/agent-studio-terminology-check.test.mjs",
     "provider-copy:check": "node scripts/provider-neutral-copy-check.mjs",
     "provider-copy:check:test": "node --test scripts/provider-neutral-copy-check.test.mjs",
+    "pr-labeler:check": "node --test scripts/pr-label-classifier.test.mjs && prettier --check .github/labeler.yml .github/workflows/pr-labeler.yml .github/workflows/test.yml .github/pull_request_template.md package.json scripts/pr-label-classifier.mjs scripts/pr-label-classifier.test.mjs",
     "examples:sort": "node scripts/examples-sort.mjs",
     "examples:sync-setup": "node scripts/examples-sync-setup.mjs"
   },

--- a/scripts/pr-label-classifier.mjs
+++ b/scripts/pr-label-classifier.mjs
@@ -1,0 +1,430 @@
+const TYPE_OPTIONS = Object.freeze([
+  { text: "Bug fix", label: "bug" },
+  { text: "Documentation", label: "documentation" },
+  { text: "Feature", label: "enhancement" },
+  { text: "Tests", label: "testing" },
+  { text: "Dependency update", label: "dependencies" },
+  { text: "Maintenance or refactor", label: "maintenance" },
+]);
+
+export const TYPE_LABELS = Object.freeze(
+  TYPE_OPTIONS.map(({ label }) => label),
+);
+
+export const CONTRIBUTOR_LABELS = Object.freeze([
+  "contributor: member",
+  "contributor: external",
+]);
+
+export const SIZE_LABELS = Object.freeze([
+  "size: small",
+  "size: medium",
+  "size: large",
+  "size: xlarge",
+]);
+
+const CLASSIFICATION_LABELS = Object.freeze([
+  ...CONTRIBUTOR_LABELS,
+  ...SIZE_LABELS,
+  "contribution: incomplete",
+  "review: sensitive",
+  "review: manual",
+]);
+
+const REQUIRED_SECTIONS = Object.freeze([
+  "Problem and motivation",
+  "Summary and scope",
+  "Related work",
+  "Validation",
+  "Tests and documentation",
+  "Compatibility and release impact",
+  "Security",
+  "AI assistance",
+  "Checklist",
+]);
+
+const CHECKLIST_PREFIXES = Object.freeze([
+  "i read `contributing.md`",
+  "this pull request addresses one focused problem",
+  "i added or updated tests",
+  "i ran the relevant build",
+  "i updated documentation",
+  "i added a changeset",
+  "i can explain and maintain every submitted change",
+]);
+
+const SECURITY_PREFIXES = Object.freeze([
+  "i have not included secrets",
+  "this pull request does not publicly disclose a suspected vulnerability",
+]);
+
+const AI_PREFIXES = Object.freeze([
+  "i did not use ai assistance",
+  "i used ai assistance",
+]);
+
+function normalizeHeading(value) {
+  return String(value)
+    .replace(/\s+#+\s*$/, "")
+    .trim()
+    .toLowerCase();
+}
+
+function extractSection(body, heading) {
+  const source = String(body ?? "");
+  const headings = [...source.matchAll(/^(#{2,6})[ \t]+(.+?)[ \t]*$/gm)].map(
+    (match) => ({
+      index: match.index,
+      end: match.index + match[0].length,
+      title: normalizeHeading(match[2]),
+    }),
+  );
+
+  const wanted = normalizeHeading(heading);
+  const sectionIndex = headings.findIndex(({ title }) => title === wanted);
+  if (sectionIndex === -1) return null;
+
+  const current = headings[sectionIndex];
+  const next = headings[sectionIndex + 1];
+  return source.slice(current.end, next?.index ?? source.length);
+}
+
+function cleanSection(section) {
+  return String(section ?? "")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/^[ \t]*```[^\n]*$/gm, "")
+    .replace(/^[ \t]*# command\s+[—-]\s+result[ \t]*$/gim, "")
+    .trim();
+}
+
+function parseCheckboxes(section) {
+  return [
+    ...String(section ?? "").matchAll(
+      /^[ \t]*[-*][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/gm,
+    ),
+  ].map((match) => ({
+    checked: match[1].toLowerCase() === "x",
+    text: match[2].replace(/\s+/g, " ").trim(),
+  }));
+}
+
+function normalizeCheckboxText(value) {
+  return String(value).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function checkboxForPrefix(checkboxes, prefix) {
+  const normalizedPrefix = normalizeCheckboxText(prefix);
+  return checkboxes.filter(({ text }) =>
+    normalizeCheckboxText(text).startsWith(normalizedPrefix),
+  );
+}
+
+function validateExpectedCheckboxes(section, prefixes, selectionCount) {
+  const checkboxes = parseCheckboxes(section);
+  const expected = prefixes.map((prefix) =>
+    checkboxForPrefix(checkboxes, prefix),
+  );
+  if (expected.some((matches) => matches.length !== 1)) return false;
+
+  const expectedCheckboxes = expected.map(([checkbox]) => checkbox);
+  return (
+    expectedCheckboxes.filter(({ checked }) => checked).length ===
+    selectionCount
+  );
+}
+
+function isCheckboxChecked(section, prefix) {
+  const matches = checkboxForPrefix(parseCheckboxes(section), prefix);
+  return matches.length === 1 && matches[0].checked;
+}
+
+function stripCheckboxes(section) {
+  return cleanSection(section)
+    .replace(/^[ \t]*[-*][ \t]+\[[ xX]\][ \t]+.*(?:\n|$)/gm, "")
+    .trim();
+}
+
+function parseNa(value) {
+  const match = String(value)
+    .trim()
+    .match(/^(?:n\/?a|not applicable)\b[\s.:—-]*(.*)$/i);
+  if (!match) return { isNa: false, hasReason: false };
+  return { isNa: true, hasReason: match[1].trim().length > 0 };
+}
+
+function hasSubstantiveText(
+  section,
+  { allowBareNa = false, allowNaWithReason = false } = {},
+) {
+  const cleaned = cleanSection(section);
+  if (!cleaned) return false;
+
+  const na = parseNa(cleaned);
+  if (!na.isNa) return true;
+  if (allowBareNa) return true;
+  return allowNaWithReason && na.hasReason;
+}
+
+function extractRelatedWork(section) {
+  return cleanSection(section).replace(
+    /^[ \t]*Related issue or discussion:[ \t]*/im,
+    "",
+  );
+}
+
+function extractCompatibilityValue(section, field) {
+  const cleaned = cleanSection(section);
+  const expression = new RegExp(
+    `^[ \\t]*-[ \\t]+${field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:[ \\t]*(.+)$`,
+    "im",
+  );
+  return cleaned.match(expression)?.[1]?.trim() ?? "";
+}
+
+function parsePrimaryType(body) {
+  const section = extractSection(body, "Primary change type");
+  if (section === null) {
+    return { valid: false, label: null };
+  }
+
+  const checkboxes = parseCheckboxes(section);
+  const options = TYPE_OPTIONS.map(({ text, label }) => ({
+    label,
+    matches: checkboxForPrefix(checkboxes, text),
+  }));
+  if (
+    checkboxes.length !== TYPE_OPTIONS.length ||
+    options.some(({ matches }) => matches.length !== 1)
+  ) {
+    return { valid: false, label: null };
+  }
+
+  const selected = options.filter(
+    ({ matches: [checkbox] }) => checkbox.checked,
+  );
+  return selected.length === 1
+    ? { valid: true, label: selected[0].label }
+    : { valid: false, label: null };
+}
+
+export function validatePullRequestTemplate(body) {
+  const source = String(body ?? "");
+  const reasons = [];
+  const sections = Object.fromEntries(
+    REQUIRED_SECTIONS.map((heading) => [
+      heading,
+      extractSection(source, heading),
+    ]),
+  );
+
+  for (const [heading, section] of Object.entries(sections)) {
+    if (section === null) reasons.push(`Missing section: ${heading}`);
+  }
+
+  const primaryType = parsePrimaryType(source);
+  if (!primaryType.valid) {
+    reasons.push("Select exactly one primary change type");
+  }
+
+  if (!hasSubstantiveText(sections["Problem and motivation"])) {
+    reasons.push("Problem and motivation is empty");
+  }
+  if (!hasSubstantiveText(sections["Summary and scope"])) {
+    reasons.push("Summary and scope is empty");
+  }
+  if (
+    !hasSubstantiveText(extractRelatedWork(sections["Related work"]), {
+      allowBareNa: true,
+    })
+  ) {
+    reasons.push("Related work is empty");
+  }
+  if (!hasSubstantiveText(sections.Validation)) {
+    reasons.push("Validation is empty or still contains the placeholder");
+  }
+  if (
+    !hasSubstantiveText(sections["Tests and documentation"], {
+      allowNaWithReason: true,
+    })
+  ) {
+    reasons.push("Tests and documentation is empty or has an unexplained N/A");
+  }
+
+  const compatibility = sections["Compatibility and release impact"];
+  const breakingValue = extractCompatibilityValue(
+    compatibility,
+    "Breaking or externally visible changes",
+  );
+  const changesetValue = extractCompatibilityValue(compatibility, "Changeset");
+  if (!hasSubstantiveText(breakingValue)) {
+    reasons.push("Breaking-change impact is empty");
+  }
+  if (!hasSubstantiveText(changesetValue, { allowNaWithReason: true })) {
+    reasons.push("Changeset status is empty or has an unexplained N/A");
+  }
+
+  if (!validateExpectedCheckboxes(sections.Security, SECURITY_PREFIXES, 2)) {
+    reasons.push("Both security acknowledgements must be present and checked");
+  }
+  const aiSection = sections["AI assistance"];
+  if (!validateExpectedCheckboxes(aiSection, AI_PREFIXES, 1)) {
+    reasons.push("Select exactly one AI-assistance acknowledgement");
+  } else if (
+    isCheckboxChecked(aiSection, "i used ai assistance") &&
+    !hasSubstantiveText(stripCheckboxes(aiSection))
+  ) {
+    reasons.push("Describe the AI assistance and how the result was verified");
+  }
+  if (!validateExpectedCheckboxes(sections.Checklist, CHECKLIST_PREFIXES, 7)) {
+    reasons.push("Every final checklist acknowledgement must be checked");
+  }
+
+  return {
+    complete: reasons.length === 0,
+    reasons,
+    typeLabel: primaryType.label,
+    typeIsValid: primaryType.valid,
+  };
+}
+
+function normalizeFilename(filename) {
+  return String(filename ?? "")
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/, "");
+}
+
+function isLockfile(filename) {
+  const basename = filename.split("/").at(-1) ?? filename;
+  return (
+    basename === "pnpm-lock.yaml" ||
+    basename === "yarn.lock" ||
+    basename === "package-lock.json"
+  );
+}
+
+export function isReviewSizeExcluded(filename) {
+  const normalized = normalizeFilename(filename);
+  return (
+    normalized === "pnpm-lock.yaml" ||
+    normalized === "yarn.lock" ||
+    normalized === "package-lock.json" ||
+    normalized.endsWith("/package-lock.json") ||
+    normalized.startsWith("packages/tools/src/_generated/")
+  );
+}
+
+export function calculateReviewSize(files) {
+  const changedLines = files.reduce((total, file) => {
+    if (isReviewSizeExcluded(file.filename)) return total;
+    const additions = Number(file.additions) || 0;
+    const deletions = Number(file.deletions) || 0;
+    return total + additions + deletions;
+  }, 0);
+
+  let label = "size: xlarge";
+  if (changedLines <= 100) label = "size: small";
+  else if (changedLines <= 500) label = "size: medium";
+  else if (changedLines <= 1_000) label = "size: large";
+
+  return { changedLines, label };
+}
+
+export function isSensitivePath(filename) {
+  const normalized = normalizeFilename(filename);
+  const basename = normalized.split("/").at(-1) ?? normalized;
+
+  return (
+    normalized.startsWith(".github/") ||
+    normalized.startsWith(".claude/") ||
+    normalized.startsWith(".claude-plugin/") ||
+    normalized.startsWith("scripts/") ||
+    normalized === ".changeset/config.json" ||
+    normalized === ".npmrc" ||
+    normalized === "pnpm-workspace.yaml" ||
+    normalized === "PUBLISHING.md" ||
+    basename === "CODEOWNERS" ||
+    basename === "SECURITY.md" ||
+    basename === "package.json" ||
+    isLockfile(normalized)
+  );
+}
+
+function isOpaqueFile(file) {
+  return file.patch === undefined || file.patch === null;
+}
+
+export function classifyContributor(authorAssociation) {
+  const association = String(authorAssociation ?? "").toUpperCase();
+  return association === "OWNER" || association === "MEMBER"
+    ? "contributor: member"
+    : "contributor: external";
+}
+
+function shouldInitializeTriage(eventAction, initializeTriage) {
+  return (
+    eventAction === "opened" ||
+    eventAction === "reopened" ||
+    (eventAction === "workflow_dispatch" && initializeTriage === true)
+  );
+}
+
+export function classifyPullRequest({
+  pullRequest,
+  files,
+  eventAction,
+  initializeTriage = false,
+}) {
+  const contributorLabel = classifyContributor(pullRequest?.author_association);
+  const size = calculateReviewSize(files);
+  const template = validatePullRequestTemplate(pullRequest?.body);
+  const sensitive = files.some(({ filename }) => isSensitivePath(filename));
+  const reportedFileCount = Number(pullRequest?.changed_files) || files.length;
+  const opaque = files.some(isOpaqueFile) || reportedFileCount > files.length;
+  const external = contributorLabel === "contributor: external";
+  const manual =
+    external &&
+    (!template.complete ||
+      sensitive ||
+      size.label === "size: large" ||
+      size.label === "size: xlarge" ||
+      opaque);
+
+  const desiredLabels = new Set([contributorLabel, size.label]);
+  if (template.typeIsValid) desiredLabels.add(template.typeLabel);
+  if (!template.complete) desiredLabels.add("contribution: incomplete");
+  if (sensitive) desiredLabels.add("review: sensitive");
+  if (manual) desiredLabels.add("review: manual");
+
+  return {
+    addNeedsTriage:
+      external && shouldInitializeTriage(eventAction, initializeTriage),
+    desiredLabels: [...desiredLabels].sort((a, b) => a.localeCompare(b)),
+    hasOpaqueFile: opaque,
+    reviewSize: size.changedLines,
+    synchronizeTypeLabels: template.typeIsValid,
+    templateReasons: template.reasons,
+  };
+}
+
+export function reconcilePullRequestLabels(currentLabels, classification) {
+  const current = new Set(currentLabels);
+  const desired = new Set(classification.desiredLabels);
+  const managed = new Set(CLASSIFICATION_LABELS);
+  if (classification.synchronizeTypeLabels) {
+    for (const label of TYPE_LABELS) managed.add(label);
+  }
+
+  const add = [...desired].filter((label) => !current.has(label));
+  if (classification.addNeedsTriage && !current.has("needs-triage")) {
+    add.push("needs-triage");
+  }
+
+  const remove = [...current].filter(
+    (label) => managed.has(label) && !desired.has(label),
+  );
+
+  return {
+    add: add.sort((a, b) => a.localeCompare(b)),
+    remove: remove.sort((a, b) => a.localeCompare(b)),
+  };
+}

--- a/scripts/pr-label-classifier.test.mjs
+++ b/scripts/pr-label-classifier.test.mjs
@@ -1,0 +1,542 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  calculateReviewSize,
+  classifyContributor,
+  classifyPullRequest,
+  isReviewSizeExcluded,
+  isSensitivePath,
+  reconcilePullRequestLabels,
+  validatePullRequestTemplate,
+} from "./pr-label-classifier.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const TYPE_OPTIONS = [
+  ["Bug fix", "bug"],
+  ["Documentation", "documentation"],
+  ["Feature", "enhancement"],
+  ["Tests", "testing"],
+  ["Dependency update", "dependencies"],
+  ["Maintenance or refactor", "maintenance"],
+];
+
+const CHECKLIST = [
+  "I read `CONTRIBUTING.md`, and this contribution follows the policy.",
+  "This pull request addresses one focused problem.",
+  "I added or updated tests.",
+  "I ran the relevant build, typecheck, lint, and test commands.",
+  "I updated documentation.",
+  "I added a Changeset or explained why it is not applicable.",
+  "I can explain and maintain every submitted change.",
+];
+
+function checkbox(checked, text) {
+  return `- [${checked ? "x" : " "}] ${text}`;
+}
+
+function pullRequestBody({
+  type = "Bug fix",
+  selectedTypes = [type],
+  problem = "The SDK returns the wrong value for a documented input.",
+  summary = "Correct the focused behavior and cover it with a regression test.",
+  related = "N/A",
+  validation = "`pnpm test` — passed",
+  tests = "Added a regression test and updated the affected documentation.",
+  breaking = "None",
+  changeset = "N/A — no published package behavior changes",
+  security = [true, true],
+  ai = [true, false],
+  aiDetails = "",
+  checklist = CHECKLIST.map(() => true),
+} = {}) {
+  const types = TYPE_OPTIONS.map(([text]) =>
+    checkbox(selectedTypes.includes(text), text),
+  ).join("\n");
+  const finalChecklist = CHECKLIST.map((text, index) =>
+    checkbox(checklist[index], text),
+  ).join("\n");
+
+  return `## Primary change type
+
+${types}
+
+## Problem and motivation
+
+${problem}
+
+## Summary and scope
+
+${summary}
+
+## Related work
+
+Related issue or discussion: ${related}
+
+## Validation
+
+${validation}
+
+### Tests and documentation
+
+${tests}
+
+## Compatibility and release impact
+
+- Breaking or externally visible changes: ${breaking}
+- Changeset: ${changeset}
+
+## Security
+
+${checkbox(security[0], "I have not included secrets, credentials, private data, or unsanitized logs.")}
+${checkbox(security[1], "This pull request does not publicly disclose a suspected vulnerability.")}
+
+## AI assistance
+
+${checkbox(ai[0], "I did not use AI assistance for this change.")}
+${checkbox(ai[1], "I used AI assistance and have described it below.")}
+
+${aiDetails}
+
+## Checklist
+
+${finalChecklist}
+`;
+}
+
+function changedFile(
+  filename,
+  additions,
+  deletions = 0,
+  patch = "@@ -1 +1 @@",
+) {
+  return { filename, additions, deletions, patch };
+}
+
+test("a complete PR body passes structural validation", () => {
+  const result = validatePullRequestTemplate(pullRequestBody());
+  assert.equal(result.complete, true);
+  assert.equal(result.typeIsValid, true);
+  assert.equal(result.typeLabel, "bug");
+  assert.deepEqual(result.reasons, []);
+});
+
+test("the checked-in PR template and classifier remain structurally aligned", () => {
+  let body = readFileSync(
+    path.join(ROOT, ".github", "pull_request_template.md"),
+    "utf8",
+  );
+  body = body
+    .replace("- [ ] Bug fix", "- [x] Bug fix")
+    .replace(
+      "<!-- What problem does this solve, and why is the change needed? -->",
+      "The documented behavior fails for a reproducible SDK input.",
+    )
+    .replace(
+      "<!-- Describe what changed, including what is intentionally out of scope. -->",
+      "Correct the focused behavior without changing the public API.",
+    )
+    .replace("Related issue or discussion:", "Related issue or discussion: N/A")
+    .replace(
+      "```text\n# command — result\n```",
+      "```text\npnpm test — passed\n```",
+    )
+    .replace(
+      "<!-- Describe tests and documentation added or updated. Use N/A with a reason when appropriate. -->",
+      "Added a focused regression test; documentation is unchanged.",
+    )
+    .replace(
+      "<!-- None, or describe the impact and migration path. -->",
+      "None",
+    )
+    .replace(
+      "<!-- Added, or N/A with a reason. -->",
+      "N/A — no published package behavior changes",
+    )
+    .replace(
+      "- [ ] I did not use AI assistance for this change.",
+      "- [x] I did not use AI assistance for this change.",
+    );
+
+  for (const heading of ["Security", "Checklist"]) {
+    const expression = new RegExp(`(## ${heading}\\n[\\s\\S]*?)(?=\\n## |$)`);
+    body = body.replace(expression, (section) =>
+      section.replaceAll("- [ ]", "- [x]"),
+    );
+  }
+
+  const result = validatePullRequestTemplate(body);
+  assert.equal(result.complete, true, result.reasons.join("; "));
+  assert.equal(result.typeLabel, "bug");
+});
+
+test("every primary change type maps to the intended repository label", () => {
+  for (const [type, label] of TYPE_OPTIONS) {
+    const result = validatePullRequestTemplate(pullRequestBody({ type }));
+    assert.equal(result.complete, true, type);
+    assert.equal(result.typeLabel, label, type);
+  }
+});
+
+test("zero or multiple primary types are incomplete", () => {
+  for (const selectedTypes of [[], ["Bug fix", "Tests"]]) {
+    const result = validatePullRequestTemplate(
+      pullRequestBody({ selectedTypes }),
+    );
+    assert.equal(result.complete, false);
+    assert.equal(result.typeIsValid, false);
+    assert.match(result.reasons.join("; "), /exactly one primary change type/);
+  }
+});
+
+test("blank, placeholder-only, and unexplained N/A fields are rejected", () => {
+  const result = validatePullRequestTemplate(
+    pullRequestBody({
+      problem: "<!-- What problem does this solve? -->",
+      validation: "```text\n# command — result\n```",
+      tests: "N/A",
+      changeset: "N/A",
+    }),
+  );
+
+  assert.equal(result.complete, false);
+  assert.match(result.reasons.join("; "), /Problem and motivation is empty/);
+  assert.match(result.reasons.join("; "), /Validation is empty/);
+  assert.match(result.reasons.join("; "), /unexplained N\/A/);
+});
+
+test("N/A is accepted only where the template permits it", () => {
+  const accepted = validatePullRequestTemplate(
+    pullRequestBody({
+      related: "N/A",
+      tests: "N/A — documentation-only change",
+      changeset: "N/A — no published packages changed",
+    }),
+  );
+  assert.equal(accepted.complete, true);
+
+  const rejected = validatePullRequestTemplate(
+    pullRequestBody({ problem: "N/A — no problem supplied" }),
+  );
+  assert.equal(rejected.complete, false);
+  assert.match(rejected.reasons.join("; "), /Problem and motivation is empty/);
+});
+
+test("security, AI, and final acknowledgements are enforced", () => {
+  const cases = [
+    pullRequestBody({ security: [true, false] }),
+    pullRequestBody({ ai: [false, false] }),
+    pullRequestBody({ ai: [true, true] }),
+    pullRequestBody({
+      checklist: CHECKLIST.map((_, index) => index !== 3),
+    }),
+  ];
+
+  for (const body of cases) {
+    assert.equal(validatePullRequestTemplate(body).complete, false);
+  }
+
+  const missingAiDetails = validatePullRequestTemplate(
+    pullRequestBody({ ai: [false, true] }),
+  );
+  assert.equal(missingAiDetails.complete, false);
+  assert.match(
+    missingAiDetails.reasons.join("; "),
+    /AI assistance and how the result was verified/,
+  );
+
+  const disclosedAiDetails = validatePullRequestTemplate(
+    pullRequestBody({
+      ai: [false, true],
+      aiDetails:
+        "Used Codex for implementation and verified all repository checks.",
+    }),
+  );
+  assert.equal(disclosedAiDetails.complete, true);
+});
+
+test("only OWNER and MEMBER associations are classified as members", () => {
+  for (const association of ["OWNER", "MEMBER", "owner", "member"]) {
+    assert.equal(classifyContributor(association), "contributor: member");
+  }
+
+  for (const association of [
+    "COLLABORATOR",
+    "CONTRIBUTOR",
+    "FIRST_TIMER",
+    "FIRST_TIME_CONTRIBUTOR",
+    "NONE",
+    "MANNEQUIN",
+    undefined,
+  ]) {
+    assert.equal(classifyContributor(association), "contributor: external");
+  }
+});
+
+test("review-size labels honor every boundary", () => {
+  for (const [lines, label] of [
+    [100, "size: small"],
+    [101, "size: medium"],
+    [500, "size: medium"],
+    [501, "size: large"],
+    [1_000, "size: large"],
+    [1_001, "size: xlarge"],
+  ]) {
+    assert.deepEqual(calculateReviewSize([changedFile("src/a.ts", lines)]), {
+      changedLines: lines,
+      label,
+    });
+  }
+});
+
+test("lockfiles and generated tool sources do not inflate review size", () => {
+  for (const filename of [
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "examples/fetch/package-lock.json",
+    "yarn.lock",
+    "packages/tools/src/_generated/client.ts",
+  ]) {
+    assert.equal(isReviewSizeExcluded(filename), true, filename);
+  }
+  assert.equal(isReviewSizeExcluded("examples/fetch/yarn.lock"), false);
+  assert.equal(isReviewSizeExcluded("examples/fetch/pnpm-lock.yaml"), false);
+
+  const result = calculateReviewSize([
+    changedFile("pnpm-lock.yaml", 5_000),
+    changedFile("examples/fetch/package-lock.json", 2_000),
+    changedFile("packages/core/src/index.ts", 40, 10),
+  ]);
+  assert.deepEqual(result, { changedLines: 50, label: "size: small" });
+});
+
+test("sensitive paths cover automation, policy, dependency, and release files", () => {
+  for (const filename of [
+    ".github/workflows/test.yml",
+    ".claude/skills/example/SKILL.md",
+    ".claude-plugin/plugin.json",
+    ".changeset/config.json",
+    ".npmrc",
+    "pnpm-workspace.yaml",
+    "PUBLISHING.md",
+    "scripts/publish-local.mjs",
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    "SECURITY.md",
+    "package.json",
+    "packages/core/package.json",
+    "pnpm-lock.yaml",
+    "examples/fetch/package-lock.json",
+  ]) {
+    assert.equal(isSensitivePath(filename), true, filename);
+  }
+
+  for (const filename of [
+    "packages/core/src/index.ts",
+    "docs/getting-started.md",
+    ".changeset/bright-birds.md",
+  ]) {
+    assert.equal(isSensitivePath(filename), false, filename);
+  }
+});
+
+test("external intake gets deterministic type, size, contributor, and triage labels", () => {
+  const classification = classifyPullRequest({
+    pullRequest: {
+      author_association: "FIRST_TIME_CONTRIBUTOR",
+      body: pullRequestBody(),
+    },
+    files: [changedFile("packages/core/src/index.ts", 20, 5)],
+    eventAction: "opened",
+  });
+
+  assert.deepEqual(classification.desiredLabels, [
+    "bug",
+    "contributor: external",
+    "size: small",
+  ]);
+  assert.equal(classification.addNeedsTriage, true);
+  assert.equal(classification.synchronizeTypeLabels, true);
+});
+
+test("incomplete, sensitive, large, and opaque external PRs route to manual review", () => {
+  const cases = [
+    {
+      body: pullRequestBody({ selectedTypes: [] }),
+      files: [changedFile("packages/core/src/index.ts", 5)],
+    },
+    {
+      body: pullRequestBody(),
+      files: [changedFile(".github/workflows/test.yml", 5)],
+    },
+    {
+      body: pullRequestBody(),
+      files: [changedFile("packages/core/src/index.ts", 700)],
+    },
+    {
+      body: pullRequestBody(),
+      files: [changedFile("docs/diagram.png", 0, 0, null)],
+    },
+    {
+      body: pullRequestBody(),
+      changedFiles: 3_001,
+      files: [changedFile("docs/renamed.md", 0, 0)],
+    },
+  ];
+
+  for (const fixture of cases) {
+    const result = classifyPullRequest({
+      pullRequest: {
+        author_association: "NONE",
+        body: fixture.body,
+        changed_files: fixture.changedFiles,
+      },
+      files: fixture.files,
+      eventAction: "synchronize",
+    });
+    assert.ok(result.desiredLabels.includes("review: manual"));
+  }
+});
+
+test("member PRs retain risk metadata without external manual routing", () => {
+  const result = classifyPullRequest({
+    pullRequest: { author_association: "MEMBER", body: pullRequestBody() },
+    files: [changedFile(".github/workflows/test.yml", 10)],
+    eventAction: "opened",
+  });
+
+  assert.ok(result.desiredLabels.includes("contributor: member"));
+  assert.ok(result.desiredLabels.includes("review: sensitive"));
+  assert.ok(!result.desiredLabels.includes("review: manual"));
+  assert.equal(result.addNeedsTriage, false);
+});
+
+test("needs-triage is initialized only on external intake or explicit backfill", () => {
+  const input = {
+    pullRequest: { author_association: "NONE", body: pullRequestBody() },
+    files: [changedFile("packages/core/src/index.ts", 5)],
+  };
+
+  for (const action of ["opened", "reopened"]) {
+    assert.equal(
+      classifyPullRequest({ ...input, eventAction: action }).addNeedsTriage,
+      true,
+    );
+  }
+  for (const action of [
+    "edited",
+    "synchronize",
+    "ready_for_review",
+    "converted_to_draft",
+    "workflow_dispatch",
+  ]) {
+    assert.equal(
+      classifyPullRequest({ ...input, eventAction: action }).addNeedsTriage,
+      false,
+      action,
+    );
+  }
+  assert.equal(
+    classifyPullRequest({
+      ...input,
+      eventAction: "workflow_dispatch",
+      initializeTriage: true,
+    }).addNeedsTriage,
+    true,
+  );
+});
+
+test("reconciliation replaces managed labels and preserves maintainer state", () => {
+  const classification = classifyPullRequest({
+    pullRequest: { author_association: "MEMBER", body: pullRequestBody() },
+    files: [changedFile("packages/core/src/index.ts", 5)],
+    eventAction: "synchronize",
+  });
+  const changes = reconcilePullRequestLabels(
+    [
+      "contributor: external",
+      "size: large",
+      "documentation",
+      "review: manual",
+      "needs-triage",
+      "help wanted",
+      "area: sdk",
+    ],
+    classification,
+  );
+
+  assert.deepEqual(changes.add, ["bug", "contributor: member", "size: small"]);
+  assert.deepEqual(changes.remove, [
+    "contributor: external",
+    "documentation",
+    "review: manual",
+    "size: large",
+  ]);
+  assert.ok(!changes.remove.includes("needs-triage"));
+  assert.ok(!changes.remove.includes("help wanted"));
+  assert.ok(!changes.remove.includes("area: sdk"));
+});
+
+test("invalid type selection preserves existing type labels", () => {
+  const classification = classifyPullRequest({
+    pullRequest: {
+      author_association: "NONE",
+      body: pullRequestBody({ selectedTypes: [] }),
+    },
+    files: [changedFile("packages/core/src/index.ts", 5)],
+    eventAction: "edited",
+  });
+  const changes = reconcilePullRequestLabels(
+    ["bug", "dependencies", "needs-triage"],
+    classification,
+  );
+
+  assert.equal(classification.synchronizeTypeLabels, false);
+  assert.ok(!changes.remove.includes("bug"));
+  assert.ok(!changes.remove.includes("dependencies"));
+  assert.ok(!changes.remove.includes("needs-triage"));
+});
+
+test("the path-labeler config declares every intended area mapping", () => {
+  const config = readFileSync(
+    path.join(ROOT, ".github", "labeler.yml"),
+    "utf8",
+  );
+  const expected = {
+    "area: agents": ["packages/agent/**", "packages/agent-runtime/**"],
+    "area: studio": ["packages/agent-studio/**", "packages/harness/**"],
+    "area: sdk": ["packages/core/**", "packages/analytics-core/**"],
+    "area: integrations": ["packages/axios/**", "packages/langchain/**"],
+    "area: platform-tools": ["packages/mcp/**", ".claude-plugin/**"],
+    "area: examples-docs": ["docs/**", "examples/**", '"*.md"'],
+    "area: ci-release": [".github/**", "scripts/**", "pnpm-lock.yaml"],
+  };
+
+  for (const [label, globs] of Object.entries(expected)) {
+    assert.ok(config.includes(`"${label}":`), label);
+    for (const glob of globs) assert.ok(config.includes(glob), glob);
+  }
+});
+
+test("the privileged workflow stays pinned and never references PR head code or secrets", () => {
+  const workflow = readFileSync(
+    path.join(ROOT, ".github", "workflows", "pr-labeler.yml"),
+    "utf8",
+  );
+
+  for (const sha of [
+    "bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13",
+    "3d3c42e5aac5ba805825da76410c181273ba90b1",
+    "3a2844b7e9c422d3c10d287c895573f7108da1b3",
+  ]) {
+    assert.ok(workflow.includes(sha), sha);
+  }
+  assert.match(workflow, /pull_request_target:/);
+  assert.match(workflow, /contents: read/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.doesNotMatch(workflow, /pull_request\.head|head\.sha|secrets\./);
+});


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Pull requests currently arrive without deterministic contributor, size, type, completeness, area, or risk metadata. That forces maintainers to perform mechanical classification and leaves no trusted routing signal for the later gated Claude-review workflow.

## Summary and scope

- add a required primary-change-type choice to the PR template;
- add official path-based area labeling and a pure, tested classifier for contributor, size, type, completeness, and risk labels;
- add a least-privilege `pull_request_target` workflow that checks out only the trusted base commit and never executes contributor code;
- add the classifier check to normal unprivileged CI; and
- pre-create the approved repository labels with their specified colors and descriptions.

This PR does not enable Claude review, alter branch protection, or change SDK runtime behavior. It is stacked on #578 because that PR introduces the curated PR template; after #578 merges, this PR can be retargeted to `main`.

## Related work

Related issue or discussion: [SAP-2516](https://linear.app/sapiom/issue/SAP-2516/sdk-add-deterministic-pr-labels-and-review-routing), [SAP-2498](https://linear.app/sapiom/issue/SAP-2498/sdk-establish-a-curated-contribution-policy-and-pr-template), and #578

## Validation

```text
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed with existing warnings and no errors
pnpm test — passed
pnpm examples:check — passed
pnpm terminology:check — passed
pnpm examples:check:test — passed (145 tests)
pnpm pr-labeler:check — passed (19 tests and Prettier check)
git diff --check — passed
```

### Tests and documentation

Added classifier coverage for all size boundaries, contributor associations, type selections, template completeness and permitted N/A cases, AI disclosure, sensitive and excluded paths, binary/truncated file lists, manual routing, one-way triage, reconciliation, area configuration, and workflow security invariants. Updated the contributor-facing PR template and CI configuration; no SDK documentation changes are needed.

## Compatibility and release impact

- Breaking or externally visible changes: The GitHub PR template now requires one primary change type, and merged automation will maintain the approved classification labels. There are no SDK API or runtime changes.
- Changeset: N/A — only repository automation and contributor metadata change; no published package behavior changes.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex helped implement and review the workflow, classifier, and tests. I verified the result with the focused 19-case suite, all repository content checks, build, typecheck, lint, the full package test suite, a manual security review of the privileged workflow, and live verification of the GitHub label metadata.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
