### PR TITLE
feat(harness): rail folder-on-create + canvas terminal fix + short agent names

### DIFF
--- a/.changeset/rail-optimistic-workspace.md
+++ b/.changeset/rail-optimistic-workspace.md
@@ -1,0 +1,24 @@
+---
+"@sapiom/harness": minor
+---
+
+Studio: a new agent's workspace folder now appears in the rail the instant you
+start creating it — from the composer or a template — as an optimistic
+"Creating agent…" row, pinned to the top and focusable. It stays put through
+session-landing and the clone, and across the brief window after the session
+binds but before its `sapiom.json` is registered, so switching sessions
+mid-creation can never strand the in-progress agent.
+
+Also fixes two rail/canvas issues:
+
+- **Canvas no longer clips the terminal step.** A revise loop (a step pointing
+  back to an earlier one) left a gap in the layer numbering; the SVG height was
+  derived from the layer *count* while nodes were positioned by their raw layer
+  *index*, so the deepest node (a terminal like `deliver`) fell below the
+  viewBox and was drawn off-screen with a dangling edge. Rows are now compacted
+  to consecutive positions, which also removes the empty band the gap produced.
+- **Cloned agents show a short name in the rail.** The row now reads
+  `newsletter-autopilot` rather than the full package name
+  `@sapiom/example-newsletter-autopilot` (npm scope and a leading `example-`
+  stripped for display only — the full name is on hover, and the raw name still
+  keys testids and lookups).

--- a/packages/harness/src/core/canvas-svg.test.ts
+++ b/packages/harness/src/core/canvas-svg.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CanvasGraph } from "./canvas-graph.js";
 import {
+  NODE_H,
   computeLayers,
   layoutGraph,
   renderGraphSvg,
@@ -101,6 +102,50 @@ describe("layoutGraph", () => {
     expect(layout.pos.auto_resolve!.x).not.toBe(layout.pos.escalate!.x);
     expect(layout.width).toBeGreaterThan(0);
     expect(layout.height).toBeGreaterThan(0);
+  });
+
+  it("keeps the terminal node inside the viewBox when a back-edge leaves a layer gap (no clipped last step, no dangling edge)", () => {
+    // A revise loop (selfEdit -> write) bumps `write` past an intermediate
+    // layer, so the raw layer numbering skips a value. The bug sized the SVG
+    // height from the layer COUNT while positioning nodes by their raw layer
+    // INDEX, so the deepest node (the terminal `deliver`) fell below the
+    // viewBox and was clipped, taking its incoming edge's arrowhead with it.
+    const looping: CanvasGraph = {
+      manifestName: "content-pipeline",
+      entry: "research",
+      warnings: [],
+      nodes: [
+        { id: "research", kind: "entry", label: "research" },
+        { id: "dedupe", kind: "step", label: "dedupe" },
+        { id: "write", kind: "step", label: "write" },
+        { id: "selfEdit", kind: "step", label: "selfEdit" },
+        { id: "illustrate", kind: "step", label: "illustrate" },
+        { id: "deliver", kind: "terminal-success", label: "deliver" },
+      ],
+      edges: [
+        { from: "research", to: "dedupe", kind: "sequential" },
+        { from: "dedupe", to: "write", kind: "sequential" },
+        { from: "write", to: "selfEdit", kind: "sequential" },
+        { from: "selfEdit", to: "write", kind: "branching" },
+        { from: "selfEdit", to: "illustrate", kind: "branching" },
+        { from: "illustrate", to: "deliver", kind: "sequential" },
+      ],
+    };
+    const layout = layoutGraph(looping);
+    const deliver = layout.pos["deliver"]!;
+    const maxY = Math.max(...Object.values(layout.pos).map((p) => p.y));
+    // The terminal is the deepest node and its box fits within the height.
+    expect(deliver.y).toBe(maxY);
+    expect(deliver.y + NODE_H).toBeLessThanOrEqual(layout.height);
+    // Rows are compacted to consecutive positions — no dead band from the gap.
+    const rows = [...new Set(Object.values(layout.pos).map((p) => p.y))].sort(
+      (a, b) => a - b,
+    );
+    expect(rows.length).toBe(5);
+    const step = rows[1]! - rows[0]!;
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i]! - rows[i - 1]!).toBe(step);
+    }
   });
 });
 

--- a/packages/harness/src/core/canvas-svg.ts
+++ b/packages/harness/src/core/canvas-svg.ts
@@ -109,6 +109,14 @@ export function layoutGraph(
   }
   applyLaneOrder(byLayer, graph, laneOrder);
   const layers = [...byLayer.keys()].sort((a, b) => a - b);
+  // Longest-path layering leaves GAPS when a back-edge bumps a node past an
+  // otherwise-empty layer (e.g. a step that loops back to an earlier one). The
+  // raw layer index then no longer maps to a row on screen: a gap opens a dead
+  // band, and — because the height below is derived from the layer COUNT while
+  // y used the raw INDEX — the deepest node (a terminal) fell outside the
+  // viewBox and was clipped, taking its incoming edge's arrowhead with it.
+  // Collapse the sorted layers to consecutive rows so index and count agree.
+  const rowOf = new Map<number, number>(layers.map((l, i) => [l, i]));
 
   const idSet = new Set(graph.nodes.map((n) => n.id));
   const parentsOf = new Map<string, string[]>(graph.nodes.map((n) => [n.id, []]));
@@ -151,7 +159,7 @@ export function layoutGraph(
     for (const id of byLayer.get(l)!) {
       pos[id] = {
         x: cx.get(id)! + shiftX - NODE_W / 2,
-        y: MARGIN + l * (NODE_H + LAYER_GAP),
+        y: MARGIN + rowOf.get(l)! * (NODE_H + LAYER_GAP),
       };
     }
   }

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -131,6 +131,31 @@ test("a new session opens terminal-only; the canvas stays hidden until it has co
   }).toPass({ timeout: 10_000 });
 });
 
+test("the new agent's folder appears in the rail at once and is never lost mid-creation", async ({
+  page,
+}) => {
+  const groups = page.locator(".rail-list .workspace-group");
+  const before = await groups.count();
+
+  await page.getByTestId("rail-create-new").click();
+  await page
+    .getByTestId("composer-input")
+    .fill("Diff competitor pricing pages every morning.");
+  await page.getByTestId("composer-send").click();
+
+  // It shows up immediately — before the session POST resolves and the workbench
+  // settles — as a focusable "creating agent" placeholder, so switching away
+  // mid-creation can never strand the in-progress agent.
+  const pending = page.locator('[data-testid^="workspace-pending-"]').first();
+  await expect(pending).toBeVisible();
+  await expect(pending).toHaveAttribute("aria-busy", "true");
+
+  // And it stays: as the session lands the placeholder becomes a real folder
+  // row — one more group than before, continuously present (no vanish/flicker).
+  await expect(page.getByTestId("agent-view")).toBeVisible();
+  await expect(groups).toHaveCount(before + 1);
+});
+
 test("Back returns to the session the composer was opened over", async ({
   page,
 }) => {

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -245,6 +245,13 @@ test.describe("templates journey (from the composer)", () => {
       "web-research-digest",
     );
 
+    // The workspace folder joins the rail from the instant the clone starts (a
+    // "creating agent" placeholder first), so switching away mid-clone can never
+    // lose the in-progress agent — on a fresh install this is the very first row.
+    await expect(
+      page.getByTestId("workspace-group-web-research-digest"),
+    ).toBeVisible();
+
     // The injected prompt names the real operation and its arguments, and ends
     // with the run continuation: use → edit → run is one path.
     await expect

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -727,11 +727,22 @@ export const App = (): JSX.Element => {
     setReviewSummary(null);
     setOverviewOpen(false);
     setFocusedAgentPath(cwd);
+    // Show the folder in the rail immediately — before the session POST, the pty
+    // spawn, and the agent's scaffold/clone all resolve — so switching away
+    // mid-creation never loses the in-progress agent. Cleared on failure so a
+    // rejected create leaves no ghost row; cleared automatically on success once
+    // the real session/agent lands (see the store's pruning effect).
+    harness.addPendingWorkspace(cwd);
     closeMobileDrawer();
-    const session = await harness.createSession({ cwd, harness: agentHarness });
-    track("session.created");
-    trackProduct("session.started", { harness_kind: agentHarness, origin: "user" });
-    return session;
+    try {
+      const session = await harness.createSession({ cwd, harness: agentHarness });
+      track("session.created");
+      trackProduct("session.started", { harness_kind: agentHarness, origin: "user" });
+      return session;
+    } catch (err) {
+      harness.removePendingWorkspace(cwd);
+      throw err;
+    }
   };
 
   const handleCreateSession = async (cwd: string, agentHarness: HarnessKind): Promise<void> => {
@@ -1169,6 +1180,7 @@ export const App = (): JSX.Element => {
           minWidth={RAIL_MIN}
           workflows={state.workflows}
           sessions={state.sessions}
+          pendingWorkspaces={harness.pendingWorkspaces}
           activeSessionId={harness.activeSessionId}
           focusedAgentPath={focusedAgentPath}
           onFocusAgent={handleFocusAgent}

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -4,6 +4,7 @@ import type { RunView, WorkflowInfo } from "@shared/types";
 
 import type { CanvasGraphNode } from "../lib/canvas-graph";
 import { nodeKindLabel } from "../lib/canvas-graph";
+import { displayAgentName } from "../lib/agent-name";
 import { relativeTimeLabel } from "../lib/relative-time";
 import type { ObservedRun, RunTarget } from "../lib/use-harness-state";
 import { AnchoredPopover } from "./AnchoredPopover";
@@ -160,7 +161,9 @@ export function WorkflowActionsHeader({
         className={"workflow-actions-header" + (run ? " has-run" : "")}
         data-testid="workflow-actions-header"
       >
-        <span className="workflow-actions-name">{workflow.name}</span>
+        <span className="workflow-actions-name" title={workflow.name}>
+          {displayAgentName(workflow.name)}
+        </span>
         <span className="workflow-actions-count" data-testid="canvas-steps-count">
           {stepsSummary ?? "no steps"}
         </span>

--- a/packages/harness/web/src/components/WorkflowRow.tsx
+++ b/packages/harness/web/src/components/WorkflowRow.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import type { WorkflowInfo } from "@shared/types";
 
 import { Icon } from "./Icon";
+import { displayAgentName } from "../lib/agent-name";
 import { workflowDeploymentState } from "../lib/workflow-deployment";
 
 /**
@@ -48,7 +49,9 @@ export function WorkflowRow({
         aria-pressed={isFocused}
         data-tooltip={isFocused ? "Focused agent" : "Focus this agent"}
       >
-        <span className="tree-row-label">{workflow.name}</span>
+        <span className="tree-row-label" title={workflow.name}>
+          {displayAgentName(workflow.name)}
+        </span>
         <span
           className="workflow-status"
           data-deployed={deployed}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -27,6 +27,7 @@ import { HARNESS_LABELS, historyDirs, historyRowMeta, sessionRowState } from "..
 import { loadUiPrefs, saveUiPrefs } from "../lib/ui-prefs";
 import { buildWorkspaceTree } from "../lib/workspace-tree";
 import type { RailGrouping, RailSort } from "../lib/workspace-tree";
+import type { PendingWorkspace } from "../lib/use-harness-state";
 import { SAPIOM_AGENTS_URL } from "../lib/urls";
 import { getTheme, subscribeTheme, toggleTheme } from "../lib/theme";
 
@@ -36,6 +37,10 @@ interface WorkflowsRailProps {
   minWidth: number;
   workflows: WorkflowInfo[];
   sessions: HarnessSession[];
+  /** Folders whose agent is being created but has not yet landed in
+   *  `workflows`/`sessions` — rendered as optimistic "Creating agent…" rows so
+   *  a mid-creation agent is always findable in the rail. */
+  pendingWorkspaces: PendingWorkspace[];
   /** The active session — highlights its own row in the history menu. */
   activeSessionId: string | null;
   /** The focused agent (or bare folder) path — the single filled selection. */
@@ -222,6 +227,46 @@ function BareFolderRow({
 }
 
 /**
+ * Optimistic folder for an agent still being created: its session and definition
+ * have not landed yet, so nothing else in the rail would show it. It reads as
+ * busy (a spinner + "Creating agent…") but stays focusable, so switching away
+ * mid-creation never loses the in-progress agent — clicking it returns focus to
+ * the folder. The real bare-folder / agent rows replace it the moment they
+ * arrive (same `cwd` key), so there is no flip or duplicate.
+ */
+function PendingFolderRow({
+  label,
+  cwd,
+  isFocused,
+  onFocus,
+}: {
+  label: string;
+  cwd: string;
+  isFocused: boolean;
+  onFocus: (path: string) => void;
+}): JSX.Element {
+  return (
+    <div
+      className={"workspace-row" + (isFocused ? " is-selected" : "")}
+      data-testid={`workspace-group-${label}`}
+    >
+      <button
+        className="workspace-row-main"
+        data-testid={`workspace-pending-${label}`}
+        aria-label={`Creating agent in ${label}`}
+        aria-busy="true"
+        data-tooltip="Creating agent…"
+        onClick={() => onFocus(cwd)}
+      >
+        <Icon name="Folder" size={13} />
+        <span className="tree-row-label">{label}</span>
+      </button>
+      <span className="workspace-row-spinner" aria-hidden="true" />
+    </div>
+  );
+}
+
+/**
  * Merged past-sessions row: exited registry sessions and history entries share
  * this anatomy — title, then one meta line carrying everything else.
  *
@@ -294,6 +339,7 @@ export function WorkflowsRail({
   minWidth,
   workflows,
   sessions,
+  pendingWorkspaces,
   activeSessionId,
   focusedAgentPath,
   onFocusAgent,
@@ -439,6 +485,7 @@ export function WorkflowsRail({
     grouping,
     sort,
     recentDirs,
+    pendingWorkspaces.map((p) => p.cwd),
   );
 
   // A first-run rail (no agents, no orphans) promotes the Create-new CTA to the
@@ -757,6 +804,22 @@ export function WorkflowsRail({
 
           {workspaces.map((workspace) => {
             const collapsed = collapsedCwds.has(workspace.cwd);
+            // Being created: the folder is known but its session/agent has not
+            // landed yet. A focusable, busy placeholder so the in-progress agent
+            // is always findable — replaced by the bare/agent rows below once
+            // real content arrives at the same cwd.
+            if (workspace.pending) {
+              return (
+                <div key={workspace.cwd} className="workspace-group">
+                  <PendingFolderRow
+                    label={workspace.label}
+                    cwd={workspace.cwd}
+                    isFocused={workspace.cwd === focusedAgentPath}
+                    onFocus={onFocusAgent}
+                  />
+                </div>
+              );
+            }
             // Bare case: no agents, a live scaffold session — the folder row
             // itself is the focus target (the only clickable folder row).
             const bare = workspace.agents.length === 0 && workspace.bareSessions.length > 0;

--- a/packages/harness/web/src/lib/agent-name.test.ts
+++ b/packages/harness/web/src/lib/agent-name.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { displayAgentName } from "./agent-name";
+
+describe("displayAgentName", () => {
+  it("strips the npm scope and a leading example- from gallery clones", () => {
+    expect(displayAgentName("@sapiom/example-newsletter-autopilot")).toBe(
+      "newsletter-autopilot",
+    );
+    expect(displayAgentName("@sapiom/example-content-repurposing-pipeline")).toBe(
+      "content-repurposing-pipeline",
+    );
+  });
+
+  it("strips a bare npm scope with no example- prefix", () => {
+    expect(displayAgentName("@acme/rfq-agent")).toBe("rfq-agent");
+  });
+
+  it("leaves an already-short, unscoped name untouched", () => {
+    expect(displayAgentName("rfq")).toBe("rfq");
+    expect(displayAgentName("leasing")).toBe("leasing");
+  });
+
+  it("falls back to the raw name when stripping would leave nothing", () => {
+    expect(displayAgentName("@sapiom/")).toBe("@sapiom/");
+    expect(displayAgentName("example-")).toBe("example-");
+  });
+});

--- a/packages/harness/web/src/lib/agent-name.ts
+++ b/packages/harness/web/src/lib/agent-name.ts
@@ -1,0 +1,18 @@
+/**
+ * The name to SHOW for an agent in the rail and other chrome.
+ *
+ * The registry's `WorkflowInfo.name` is the cloned project's `package.json`
+ * name — a scoped, often long string like `@sapiom/example-newsletter-autopilot`
+ * that truncates in the narrow rail. Strip the npm scope and a leading
+ * `example-` (the gallery templates' naming convention) so the row reads as the
+ * short, human name (`newsletter-autopilot`).
+ *
+ * DISPLAY ONLY. The raw `name` still keys testids (`workflow-${name}`) and any
+ * lookups — callers pass `workflow.name` to those unchanged. Falls back to the
+ * raw name if stripping would leave nothing (e.g. a bare scope).
+ */
+export function displayAgentName(name: string): string {
+  const unscoped = name.replace(/^@[^/]+\//, "");
+  const cleaned = unscoped.replace(/^example-/, "").trim();
+  return cleaned || name;
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -88,6 +88,18 @@ export interface DeployProgress {
   message?: string;
 }
 
+/**
+ * An optimistic rail entry for a folder whose agent is still being created.
+ * `sessionSeen` records that a live session for this `cwd` has appeared at least
+ * once — the pruning logic uses it to tell "the create hasn't produced a session
+ * yet" (keep waiting) from "a session came and went without producing an agent"
+ * (abandoned — drop the ghost row).
+ */
+export interface PendingWorkspace {
+  cwd: string;
+  sessionSeen: boolean;
+}
+
 export interface HarnessStateHook {
   state: AppState | null;
   loading: boolean;
@@ -175,6 +187,20 @@ export interface HarnessStateHook {
   deployStateByPath: Map<string, DeployProgress>;
   /** Dismiss a workflow's deploy banner (clears its `deployStateByPath` entry). */
   dismissDeployState: (workflowPath: string) => void;
+  /**
+   * Folders whose agent is being created but whose session/agent has not yet
+   * landed in `state`. Presentational overlay only — never enters `sessions`/
+   * `workflows` — so the rail can show a "Creating agent…" row from the instant
+   * creation starts. Newest first. Pruned automatically once a real session or
+   * agent covers the `cwd` (or the create fails / is abandoned). */
+  pendingWorkspaces: PendingWorkspace[];
+  /** Optimistically mark `cwd` as a workspace being created (call synchronously
+   *  at the start of the create flow, before the network round-trip). No-op if
+   *  already pending. */
+  addPendingWorkspace: (cwd: string) => void;
+  /** Drop the optimistic entry for `cwd` — used when session creation fails so
+   *  no ghost row lingers. */
+  removePendingWorkspace: (cwd: string) => void;
   /**
    * Monotonic counter bumped on every direct-action settle (deploy or run,
    * success or failure). SessionStepsBar adds this to its `useEffect` deps so
@@ -375,6 +401,72 @@ export function useHarnessState(): HarnessStateHook {
     },
     [],
   );
+  // Optimistic rail rows for folders whose agent is being created. The `cwd` is
+  // known synchronously at the start of the create flow, long before the session
+  // POST resolves or the scaffolded `sapiom.json` is registered, so this bridges
+  // the whole window during which the rail would otherwise show nothing to
+  // return to. Presentational only — never enters `sessions`/`workflows`.
+  const [pendingWorkspaces, setPendingWorkspaces] = useState<PendingWorkspace[]>(
+    [],
+  );
+  const addPendingWorkspace = useCallback((cwd: string): void => {
+    setPendingWorkspaces((prev) =>
+      prev.some((p) => p.cwd === cwd)
+        ? prev
+        : [{ cwd, sessionSeen: false }, ...prev],
+    );
+  }, []);
+  const removePendingWorkspace = useCallback((cwd: string): void => {
+    setPendingWorkspaces((prev) =>
+      prev.some((p) => p.cwd === cwd)
+        ? prev.filter((p) => p.cwd !== cwd)
+        : prev,
+    );
+  }, []);
+  // Reconcile the optimistic entries against real state. One folder-owns-path
+  // rule (a path is under `cwd` if it equals it or sits below it):
+  //  - an agent (workflow) is now registered under the cwd → creation reached
+  //    its goal, drop the entry;
+  //  - a live session has appeared under the cwd → remember it (`sessionSeen`),
+  //    so we can later tell an abandoned create from one still in flight;
+  //  - a session was seen but none is live any more → the create produced no
+  //    agent (exited/abandoned), drop the entry so no ghost row lingers.
+  // The row itself stays visible across the bind→register flicker because in
+  // that window there is still a live (now bound) session under the cwd, so the
+  // entry is kept while the rail renders it as pending.
+  useEffect(() => {
+    if (pendingWorkspaces.length === 0) return;
+    const sessions = state?.sessions ?? [];
+    const workflows = state?.workflows ?? [];
+    const isUnder = (path: string, cwd: string): boolean =>
+      path === cwd || path.startsWith(`${cwd}/`);
+    setPendingWorkspaces((prev) => {
+      let changed = false;
+      const next: PendingWorkspace[] = [];
+      for (const entry of prev) {
+        const hasAgent = workflows.some((w) => isUnder(w.path, entry.cwd));
+        if (hasAgent) {
+          changed = true;
+          continue;
+        }
+        const hasLiveSession = sessions.some(
+          (s) => s.status !== "exited" && isUnder(s.cwd, entry.cwd),
+        );
+        if (entry.sessionSeen && !hasLiveSession) {
+          changed = true;
+          continue;
+        }
+        if (hasLiveSession && !entry.sessionSeen) {
+          next.push({ ...entry, sessionSeen: true });
+          changed = true;
+          continue;
+        }
+        next.push(entry);
+      }
+      return changed ? next : prev;
+    });
+  }, [state?.sessions, state?.workflows, pendingWorkspaces]);
+
   // Monotonic settle counter for direct actions: bumped each time a deploy or
   // run (prod/local) reaches its terminal state — success OR failure. The
   // SessionStepsBar adds this to its useEffect deps so the pending ring clears
@@ -1505,6 +1597,9 @@ export function useHarnessState(): HarnessStateHook {
     lastDeployErrorFor,
     deployStateByPath,
     dismissDeployState: (workflowPath: string) => setDeployProgress(workflowPath, null),
+    pendingWorkspaces,
+    addPendingWorkspace,
+    removePendingWorkspace,
     directActionSettleSeq,
     listDir,
     lastMessage,

--- a/packages/harness/web/src/lib/workspace-logic.test.ts
+++ b/packages/harness/web/src/lib/workspace-logic.test.ts
@@ -117,6 +117,60 @@ describe("buildWorkspaceTree (explorer: folders > agents)", () => {
   });
 });
 
+describe("buildWorkspaceTree — optimistic pending workspaces", () => {
+  it("shows a pending folder with no session or agent, marked pending", () => {
+    const tree = buildWorkspaceTree([], [], "workspace", "recent", [], ["/home/dev/new-agent"]);
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]?.cwd).toBe("/home/dev/new-agent");
+    expect(tree.workspaces[0]?.label).toBe("new-agent");
+    expect(tree.workspaces[0]?.pending).toBe(true);
+    expect(tree.workspaces[0]?.agents).toEqual([]);
+    expect(tree.workspaces[0]?.bareSessions).toEqual([]);
+  });
+
+  it("floats a pending folder above real folders on either sort", () => {
+    const sessions = [session({ id: "a", cwd: "/home/dev/aaa", boundWorkflowPath: null })];
+    const workflows = [workflow({ name: "zzz", path: "/home/dev/zzz/zzz" })];
+    const recent = buildWorkspaceTree(workflows, sessions, "workspace", "recent", [], ["/home/dev/mmm"]);
+    expect(recent.workspaces[0]?.cwd).toBe("/home/dev/mmm");
+    const byName = buildWorkspaceTree(workflows, sessions, "workspace", "name", [], ["/home/dev/mmm"]);
+    expect(byName.workspaces[0]?.cwd).toBe("/home/dev/mmm");
+  });
+
+  it("stops being pending once a live unbound session lands (renders bare)", () => {
+    const sessions = [session({ id: "s", cwd: "/home/dev/new-agent", boundWorkflowPath: null })];
+    const tree = buildWorkspaceTree([], sessions, "workspace", "recent", [], ["/home/dev/new-agent"]);
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]?.pending).toBe(false);
+    expect(tree.workspaces[0]?.bareSessions.map((s) => s.id)).toEqual(["s"]);
+  });
+
+  it("stops being pending once the agent is registered under the cwd", () => {
+    const workflows = [workflow({ name: "new-agent", path: "/home/dev/new-agent/new-agent" })];
+    const tree = buildWorkspaceTree(workflows, [], "workspace", "recent", [], ["/home/dev/new-agent"]);
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]?.pending).toBe(false);
+    expect(tree.workspaces[0]?.agents.map((a) => a.workflow.name)).toEqual(["new-agent"]);
+  });
+
+  it("stays visible across the bind→register flicker (bound session, agent not yet listed)", () => {
+    // The server has bound the session to the (soon-to-be) agent path, but the
+    // workflow list has not caught up. Neither bare (bound) nor an agent row
+    // (not listed) — the pending row keeps the folder on screen.
+    const sessions = [
+      session({ id: "s", cwd: "/home/dev/new-agent", boundWorkflowPath: "/home/dev/new-agent/new-agent" }),
+    ];
+    const tree = buildWorkspaceTree([], sessions, "workspace", "recent", [], ["/home/dev/new-agent"]);
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]?.pending).toBe(true);
+  });
+
+  it("ignores pending workspaces in the deployment grouping (no cwd axis)", () => {
+    const tree = buildWorkspaceTree([], [], "deployment", "recent", [], ["/home/dev/new-agent"]);
+    expect(tree.workspaces).toEqual([]);
+  });
+});
+
 describe("macro gating", () => {
   const macros: MacroDef[] = [
     { id: "visualize", label: "Visualize", icon: "Sparkles", action: { kind: "render-canvas" } },

--- a/packages/harness/web/src/lib/workspace-tree.ts
+++ b/packages/harness/web/src/lib/workspace-tree.ts
@@ -53,6 +53,12 @@ export interface WorkspaceFolder {
    *  in the bare case (agents empty): the folder row becomes a focusable
    *  workspace row whose sessions open as tabs. */
   bareSessions: HarnessSession[];
+  /** An optimistic folder for an agent still being created: its `cwd` is known
+   *  up front but no session or agent exists under it yet. Set only when the
+   *  folder is otherwise empty (no agents, no bareSessions), so it self-clears
+   *  the moment real content arrives. The rail renders it as a "Creating agent…"
+   *  placeholder. Only ever set in Workspace grouping. */
+  pending?: boolean;
 }
 
 export interface WorkspaceTree {
@@ -87,9 +93,12 @@ export function buildWorkspaceTree(
   grouping: RailGrouping = "workspace",
   sort: RailSort = "recent",
   recentDirs: string[] = [],
+  pendingCwds: readonly string[] = [],
 ): WorkspaceTree {
+  // Deployment buckets have no `cwd` axis, so a pending workspace has nowhere to
+  // land there — pending rows are a Workspace-grouping concept only.
   if (grouping === "deployment") return byDeployment(workflows, sort);
-  return byWorkspace(workflows, sessions, sort, recentDirs);
+  return byWorkspace(workflows, sessions, sort, recentDirs, pendingCwds);
 }
 
 /**
@@ -123,9 +132,18 @@ function byWorkspace(
   sessions: HarnessSession[],
   sort: RailSort,
   recentDirs: string[],
+  pendingCwds: readonly string[] = [],
 ): WorkspaceTree {
   const liveSessions = sessions.filter((session) => session.status !== "exited");
   const remaining = new Set(workflows);
+
+  // Folders whose agent is still being created: `cwd` is known before any
+  // session or agent exists, so it seeds a candidate the tree would otherwise
+  // not see. `pendingRank` (creation order, newest first) floats them to the top
+  // ahead of every real folder, since a folder you are creating right now is the
+  // most relevant thing in the rail.
+  const pendingSet = new Set(pendingCwds);
+  const pendingRank = new Map(pendingCwds.map((cwd, index) => [cwd, index]));
 
   // Newest activity per directory, for folders `recentDirs` has not heard of.
   const newestByCwd = new Map<string, string>();
@@ -139,7 +157,7 @@ function byWorkspace(
   // used project directories, newest first") — already persisted, deduped, and
   // pruned of dead paths at every boot. Session activity only widens the
   // candidate set for folders recentDirs has not yet recorded.
-  const candidateCwds = new Set([...newestByCwd.keys(), ...recentDirs]);
+  const candidateCwds = new Set([...newestByCwd.keys(), ...recentDirs, ...pendingCwds]);
 
   // recentDirs is MRU and survives session pruning, so it is the better recency
   // key; session activity only answers for folders missing from it.
@@ -152,6 +170,14 @@ function byWorkspace(
   };
 
   const orderedCwds = Array.from(candidateCwds).sort((a, b) => {
+    // A folder mid-creation outranks everything, on either sort — the user's
+    // attention is on it. Among several pending folders, newest first.
+    const ra = pendingRank.get(a);
+    const rb = pendingRank.get(b);
+    if (ra !== undefined || rb !== undefined) {
+      if (ra !== undefined && rb !== undefined) return ra - rb;
+      return ra !== undefined ? -1 : 1;
+    }
     if (sort === "name") return basename(a).localeCompare(basename(b)) || a.localeCompare(b);
     return byRecency(a, b) || a.localeCompare(b);
   });
@@ -181,9 +207,14 @@ function byWorkspace(
     const bareSessions = liveSessions
       .filter((session) => session.boundWorkflowPath == null && ownerCwdOf(session.cwd) === cwd)
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.id.localeCompare(b.id));
-    // Nothing to show: no agents and no live session to keep the folder alive.
-    if (agents.length === 0 && bareSessions.length === 0) continue;
-    workspaces.push({ cwd, label: basename(cwd), isDirectory: true, agents, bareSessions });
+    // A folder mid-creation earns a row before any session or agent exists, so
+    // the user can find it the instant they start. It self-clears: once a real
+    // session or agent lands under `cwd`, one of the two lists above is
+    // non-empty, so `pending` is false and the row renders normally.
+    const pending = pendingSet.has(cwd) && agents.length === 0 && bareSessions.length === 0;
+    // Nothing to show: no agents, no live session, and not being created.
+    if (agents.length === 0 && bareSessions.length === 0 && !pending) continue;
+    workspaces.push({ cwd, label: basename(cwd), isDirectory: true, agents, bareSessions, pending });
   }
 
   const orphanAgents: AgentNode[] = Array.from(remaining)

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -1792,6 +1792,28 @@ input {
   color: var(--text);
 }
 
+/* Optimistic "creating agent" folder: a spinning ring in the trailing action
+   slot marks the row as busy while the agent's session/definition is still on
+   its way. Reuses the canvas run spinner's keyframe. */
+.workspace-row-spinner {
+  flex: none;
+  width: 11px;
+  height: 11px;
+  margin-right: var(--tree-pad-x);
+  border: 1.5px solid var(--brand);
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: canvas-run-spin 0.9s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-row-spinner {
+    animation: none;
+    border-right-color: var(--brand);
+    opacity: 0.5;
+  }
+}
+
 /* The merged row's trailing state dot: always visible, centered on the same
    14px trailing axis as the child rows' dots (16px slot + row pad). */
 .workspace-row-trail {


### PR DESCRIPTION
## Why

Three Studio issues found while creating agents in the desktop app:

1. **A mid-creation agent had no rail row.** The rail is a pure projection of `workflows` + `sessions` + `recentDirs`, and both create flows only register the session *after* the `POST /api/sessions` round-trip — so during the composer animation, the POST, the pty spawn, and the whole template clone there was nothing in the rail. Switching sessions mid-creation lost the in-progress agent.
2. **The Canvas didn't draw the terminal step.** A revise loop (a step pointing back to an earlier one, e.g. `selfEdit → write`) left a gap in the layer numbering; the SVG height was sized from the layer *count* while nodes were positioned by their raw layer *index*, so the deepest node (a terminal like `deliver`) fell below the viewBox and was clipped, leaving a dangling edge.
3. **Cloned agent names were too long.** The rail showed the cloned project's `package.json` name (`@sapiom/example-newsletter-autopilot`), which truncated in the narrow rail.

## What changed (all in `@sapiom/harness`)

- **Optimistic "pending workspace"** keyed on `cwd` — a presentational overlay that never enters the `sessions`/`workflows` models. Registered synchronously at the `createSessionAt` choke point (covers composer, templates, and deep-link clone), floated to the top of the rail, rendered as a focusable "Creating agent…" row with a spinner, and pruned once a real session/agent covers the folder (or on failure). Also bridges the brief bind→register flicker.
- **Canvas layout**: `layoutGraph` now positions nodes by a **dense** row index, so a layer gap no longer clips the terminal node — and the empty band the gap produced is gone too. Regression test added.
- **`displayAgentName()`** (display-only): strips the npm scope and a leading `example-` for the rail/header label; full name on hover; testids and keys stay on the raw name.

## Related: destination-root nesting

While testing, the template dialog proposed a destination nested inside an agent folder. That was the **installed 0.2.7 release**, which predates the launch-dir fix (`0b0784c`) already on `main`. Verified against a current dev build: `defaultProjectRoot = ~/.sapiom/harness/projects`, so new agents/templates are proposed flat at `…/projects/<name>`. No code change needed here — flagging so it's not re-investigated.

## Testing

- Unit **464 pass** (new `agent-name.test.ts`, `workspace-logic.test.ts` pending cases, `canvas-svg.test.ts` gap/clip regression).
- e2e **292** (composer "folder appears + persists", templates "folder in rail"). One `smoke.spec.ts:139x` timeout flake, green on rerun.
- Typecheck, terminology (388 files), `build:web` green.
- Verified live in the desktop dev build: short names in the rail, flat project root, terminal node drawn. (Existing agents' Canvas renders are cached on disk — re-run Visualize to pick up the fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)