### PR TITLE
fix(mcp): compact-by-default projection for sapiom_dev_agents_inspect (SAP-2533)

### DIFF
--- a/packages/mcp/src/tools/agents.inspect.test.ts
+++ b/packages/mcp/src/tools/agents.inspect.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ExecutionProjection, StepProjection } from "@sapiom/agent-core";
+import type { ResolvedEnvironment } from "../credentials.js";
+
+vi.mock("../credentials.js", () => ({
+  readCredentials: vi.fn(),
+}));
+
+// Keep the real module but stub the networked reads so the inspect tool is
+// exercised without touching the backend. The projection under test runs on the
+// value these fns return, so the SDK contract stays a passthrough.
+vi.mock("@sapiom/agent-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sapiom/agent-core")>();
+  return {
+    ...actual,
+    inspect: vi.fn(),
+    waitForExecution: vi.fn(),
+  };
+});
+
+import { register } from "./agents.js";
+import { readCredentials } from "../credentials.js";
+import { inspect, waitForExecution } from "@sapiom/agent-core";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function createMockServer(): {
+  server: McpServer;
+  handlers: Map<string, ToolHandler>;
+} {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: vi.fn(
+      (_name: string, _desc: string, _schema: any, handler: ToolHandler) => {
+        handlers.set(_name, handler);
+      },
+    ),
+  } as unknown as McpServer;
+  return { server, handlers };
+}
+
+const env: ResolvedEnvironment = {
+  name: "production",
+  appURL: "https://app.sapiom.ai",
+  apiURL: "https://api.sapiom.ai",
+  services: {},
+  credentials: null,
+};
+
+const parse = (res: { content: Array<{ text: string }> }) =>
+  JSON.parse(res.content[0].text);
+
+/** A 3 MB step output — the pathological body the tool must never dump. */
+const HUGE_OUTPUT = "X".repeat(3_000_000);
+
+function makeStep(order: number, over: boolean): StepProjection {
+  const failed = order === 4;
+  return {
+    stepName: `step_${order}`,
+    stepOrder: order,
+    attempt: 1,
+    status: failed ? "failed" : "completed",
+    spanId: null,
+    startedAt: "2026-08-10T00:00:00.000Z",
+    finishedAt: "2026-08-10T00:00:01.000Z",
+    input: { order, payload: `input-for-${order}` },
+    output: over ? HUGE_OUTPUT : { ok: true, order },
+    sharedStateAfter: { counter: order },
+    nextDirective: { kind: "continue" },
+    cost: null,
+    logs: [{ ts: "t", level: "info", msg: `log ${order}` }],
+    events: [],
+    error: failed
+      ? {
+          message: `step ${order} blew up`,
+          trace: null,
+          traceUnavailableReason: "n/a",
+        }
+      : null,
+    dispatch: null,
+  };
+}
+
+function makeExecution(): ExecutionProjection {
+  const steps = Array.from({ length: 20 }, (_, i) =>
+    makeStep(i + 1, i + 1 === 4),
+  );
+  return {
+    id: "exec-1",
+    name: "my-agent",
+    organizationId: "org-1",
+    tenantId: "t-1",
+    status: "failed",
+    currentStep: "step_4",
+    currentStepAttempt: 1,
+    version: 3,
+    definitionId: "def-1",
+    buildRunId: "build-1",
+    idempotencyKey: null,
+    pausedSignalName: null,
+    pausedSignalCorrelationId: null,
+    pausedUntil: null,
+    startedAt: "2026-08-10T00:00:00.000Z",
+    finishedAt: "2026-08-10T00:00:20.000Z",
+    input: { seed: 1 },
+    sharedState: { counter: 20 },
+    output: null,
+    error: { message: "run failed at step_4" },
+    pausedStepInputSchema: null,
+    pausedStepInputExample: null,
+    traceRoot: "exec-1",
+    rootExecutionId: "exec-1",
+    traceParent: null,
+    parentExecutionId: null,
+    traceId: "trace-1",
+    children: [],
+    cost: null,
+    steps,
+  };
+}
+
+/** A generous char ceiling the bounded result must stay under regardless of the
+ *  3 MB body in the fixture. */
+const CEILING = 250_000;
+
+describe("sapiom_dev_agents_inspect compact projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readCredentials).mockResolvedValue({
+      apiKey: "sk_test",
+      tenantId: "t-1",
+      organizationName: "Org",
+      apiKeyId: "k-1",
+    } as never);
+  });
+
+  it("default (executionId only) is compact and bounded — no full bodies", async () => {
+    vi.mocked(inspect).mockResolvedValue(makeExecution());
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_agents_inspect")!({
+      executionId: "exec-1",
+    });
+
+    // SDK inspect() is called as a plain passthrough — no projection args leak in.
+    expect(inspect).toHaveBeenCalledWith(
+      { executionId: "exec-1" },
+      expect.anything(),
+    );
+
+    const text = res.content[0].text;
+    expect(text.length).toBeLessThan(CEILING);
+    // The 3 MB body must not be dumped anywhere in the result.
+    expect(text.includes("X".repeat(40_000))).toBe(false);
+
+    const out = parse(res);
+    expect(out.webappUrl).toContain("app.sapiom.ai");
+    expect(out.execution.steps).toHaveLength(20);
+
+    const failed = out.execution.steps.find(
+      (s: any) => s.stepName === "step_4",
+    );
+    expect(failed.status).toBe("failed");
+    expect(failed.errorMessage).toBe("step 4 blew up");
+    // Compact steps carry hints, not bodies.
+    expect(failed.has).toMatchObject({
+      input: true,
+      output: true,
+      error: true,
+    });
+    expect(failed.sizes.output).toBeGreaterThan(2_900_000);
+    expect(failed).not.toHaveProperty("output");
+    expect(failed).not.toHaveProperty("input");
+    expect(failed).not.toHaveProperty("logs");
+
+    // Heavy top-level fields are previews, not verbatim copies.
+    expect(out.execution.error.preview).toBeDefined();
+    expect(out.execution.errorMessage).toBe("run failed at step_4");
+  });
+
+  it("expands only the selected step's requested fields, still bounded", async () => {
+    vi.mocked(inspect).mockResolvedValue(makeExecution());
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_agents_inspect")!({
+      executionId: "exec-1",
+      step: "step_4",
+      include: ["input", "error"],
+    });
+
+    expect(res.content[0].text.length).toBeLessThan(CEILING);
+    const out = parse(res);
+    const step4 = out.execution.steps.find((s: any) => s.stepName === "step_4");
+    // Requested fields are expanded verbatim (small enough to fit budget).
+    expect(step4.input).toEqual({ order: 4, payload: "input-for-4" });
+    expect(step4.error.message).toBe("step 4 blew up");
+    // Non-requested heavy fields stay omitted, even on the selected step.
+    expect(step4).not.toHaveProperty("output");
+    expect(step4).not.toHaveProperty("logs");
+    // Other steps are untouched (no expansion leaked to them).
+    const step3 = out.execution.steps.find((s: any) => s.stepName === "step_3");
+    expect(step3).not.toHaveProperty("input");
+  });
+
+  it("truncates an over-budget expanded field with a marker citing webappUrl", async () => {
+    vi.mocked(inspect).mockResolvedValue(makeExecution());
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_agents_inspect")!({
+      executionId: "exec-1",
+      step: 4, // by order
+      include: ["output"],
+    });
+
+    expect(res.content[0].text.length).toBeLessThan(CEILING);
+    const out = parse(res);
+    const step4 = out.execution.steps.find((s: any) => s.stepOrder === 4);
+    expect(typeof step4.output).toBe("string");
+    expect(step4.output).toContain("[truncated");
+    expect(step4.output).toMatch(/truncated \d+ chars/);
+    expect(step4.output).toContain("app.sapiom.ai");
+  });
+
+  it("wait:true returns the same compact/budgeted shape as the snapshot branch", async () => {
+    vi.mocked(waitForExecution).mockResolvedValue({
+      execution: makeExecution(),
+      reason: "terminal",
+      done: true,
+    } as never);
+    const { server, handlers } = createMockServer();
+    register(server, env);
+
+    const res = await handlers.get("sapiom_dev_agents_inspect")!({
+      executionId: "exec-1",
+      wait: true,
+    });
+
+    const text = res.content[0].text;
+    expect(text.length).toBeLessThan(CEILING);
+    expect(text.includes("X".repeat(40_000))).toBe(false);
+
+    const out = parse(res);
+    expect(out.done).toBe(true);
+    expect(out.waiting).toBe(false);
+    expect(out.webappUrl).toContain("app.sapiom.ai");
+    expect(out.execution.steps).toHaveLength(20);
+    const failed = out.execution.steps.find((s: any) => s.stepOrder === 4);
+    expect(failed.has.output).toBe(true);
+    expect(failed).not.toHaveProperty("output");
+  });
+});

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -43,6 +43,11 @@ import {
 } from "@sapiom/agent-core";
 import { type ResolvedEnvironment } from "../credentials.js";
 import { registerTool } from "../register-tool.js";
+import {
+  INCLUDABLE_FIELDS,
+  projectExecutionForTool,
+  type ProjectExecutionOptions,
+} from "./execution-projection.js";
 import { fail, gatewayClient, NOT_AUTHED, ok } from "./shared.js";
 import { webappRunUrl } from "./webapp-url.js";
 
@@ -412,7 +417,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_inspect",
-    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local. When inspecting an execution, the result includes a `webappUrl` to open that run in the webapp.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
+    "Inspect a cloud execution (its steps and errors) by executionId, a build by buildRunId, or list recent executions when neither is given. On a failed step, pull its input here to reproduce the failure locally with run_local. When inspecting an execution, the result includes a `webappUrl` to open that run in the webapp.\n\nBy default the execution is returned COMPACT: identity/status/timestamps + a per-step summary (name/order/attempt/status/error-message) with a `has` flag-set and a `sizes` hint (char counts of the omitted input/output/logs/events/sharedState bodies). Full step bodies are NOT included by default — they can be multiple MB. To pull a specific step's heavy fields, pass `step` (its name or order, from the compact list) with `include` (e.g. ['input','error']); optionally narrow to one `attempt`. Debug loop: inspect(executionId) → see step N failed → inspect(executionId, step:'<name>', include:['input','error']) → feed that input to run_local. Every field is capped to a char budget; an over-budget value is truncated with a marker pointing at `webappUrl`.\n\nReads are a fresh point-in-time snapshot. To wait for a still-running execution to finish, set wait:true (the tool polls until it settles or the wait window elapses) — do NOT sleep-and-poll this tool yourself. If a wait returns waiting:true, just call inspect again with wait:true.",
     {
       dir: z
         .string()
@@ -425,6 +430,25 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         .string()
         .optional()
         .describe("Build to inspect (requires a linked project)."),
+      step: z
+        .union([z.string(), z.number()])
+        .optional()
+        .describe(
+          "Expand one step's heavy fields: its stepName or stepOrder (from the compact step list). Pair with `include` to choose which fields.",
+        ),
+      attempt: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Restrict expansion to a single attempt of the selected `step` (a retried step has several). Omit to expand every attempt of that step.",
+        ),
+      include: z
+        .array(z.enum(INCLUDABLE_FIELDS))
+        .optional()
+        .describe(
+          "Heavy step fields to expand for the selected `step`: 'input' | 'output' | 'logs' | 'events' | 'sharedState' | 'error'. Ignored without `step`. Each is capped to the char budget.",
+        ),
       wait: z
         .boolean()
         .optional()
@@ -438,7 +462,16 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
           "Max seconds to wait when wait:true (default 45, capped at 55). On timeout it returns the latest snapshot with waiting:true — call again to keep waiting.",
         ),
     },
-    async ({ dir, executionId, buildRunId, wait, maxWaitSeconds }) => {
+    async ({
+      dir,
+      executionId,
+      buildRunId,
+      step,
+      attempt,
+      include,
+      wait,
+      maxWaitSeconds,
+    }) => {
       const client = await gatewayClient(env);
       if (!client) return NOT_AUTHED;
       try {
@@ -452,6 +485,13 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
           );
         }
         if (executionId) {
+          // Compact-by-default projection options, shared by both return
+          // branches so wait:true and the snapshot yield the same bounded shape.
+          const projectOpts: Omit<ProjectExecutionOptions, "webappUrl"> = {
+            step,
+            attempt,
+            include,
+          };
           if (wait) {
             const maxWaitMs =
               Math.min(Math.max(maxWaitSeconds ?? 45, 1), 55) * 1000;
@@ -465,15 +505,19 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
                 : reason === "needs-signal"
                   ? `Paused on signal '${execution.pausedSignalName ?? "?"}' — deliver it with sapiom_dev_agents_signal to resume.`
                   : undefined;
+            const webappUrl = webappRunUrl(
+              env.appURL,
+              execution.definitionId,
+              execution.id,
+            );
             return ok({
-              execution,
+              execution: projectExecutionForTool(execution, {
+                ...projectOpts,
+                webappUrl,
+              }),
               done,
               waiting: !done,
-              webappUrl: webappRunUrl(
-                env.appURL,
-                execution.definitionId,
-                execution.id,
-              ),
+              webappUrl,
               ...(hint ? { hint } : {}),
             });
           }
@@ -483,13 +527,17 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
           const hint = isExecutionTerminal(execution.status)
             ? undefined
             : `Execution is '${execution.status}', not terminal — call inspect with wait:true to block until it finishes instead of polling manually.`;
+          const webappUrl = webappRunUrl(
+            env.appURL,
+            execution.definitionId,
+            execution.id,
+          );
           return ok({
-            execution,
-            webappUrl: webappRunUrl(
-              env.appURL,
-              execution.definitionId,
-              execution.id,
-            ),
+            execution: projectExecutionForTool(execution, {
+              ...projectOpts,
+              webappUrl,
+            }),
+            webappUrl,
             ...(hint ? { hint } : {}),
           });
         }

--- a/packages/mcp/src/tools/execution-projection.ts
+++ b/packages/mcp/src/tools/execution-projection.ts
@@ -1,0 +1,311 @@
+/**
+ * Compact-by-default projection of an execution for the `sapiom_dev_agents_inspect`
+ * tool result (SAP-2533).
+ *
+ * The canonical {@link ExecutionProjection} carries every step's full
+ * input/output/shared-state/logs/events/stack-trace plus the whole child-run
+ * tree, uncapped. On a real multi-step (retry-fattened) run that is a 365K–3.3M
+ * char payload that overflows the consuming model's context — so the debug tool
+ * self-destructs exactly when it is needed most.
+ *
+ * This projection lives at the MCP-tool layer only; the SDK `inspect()` /
+ * `decode` passthrough and the CLI `logs` view still receive the full
+ * projection. It does three things:
+ *
+ *  1. **Compact by default.** Identity/status/timestamps are kept as-is (already
+ *     small). Every step is reduced to its name/order/attempt/status/timestamps
+ *     + error message, plus a `has` flag-set and a `sizes` hint (char counts of
+ *     the omitted heavy bodies) so the caller can see WHERE the weight is
+ *     without paying for it. Heavy top-level fields (input/sharedState/
+ *     output/error/paused-step schema+example) are previewed or budgeted, never
+ *     copied verbatim.
+ *  2. **Selective expansion.** `step` (name or order) + optional `attempt` pick
+ *     step-attempt(s); `include` names which heavy fields to expand for them.
+ *     The debug loop is: inspect(id) → compact list shows step 4 failed →
+ *     inspect(id, step:'validate', include:['input','error']) → exactly the
+ *     payload run_local needs.
+ *  3. **Hard char budget.** Every expanded or previewed field is capped, so the
+ *     result is bounded for ANY argument combination — the property the raw
+ *     projection lacks. Over-budget values truncate with an honest marker that
+ *     cites the dropped count and the run's webappUrl.
+ */
+import type { ExecutionProjection, StepProjection } from "@sapiom/agent-core";
+
+import { capText } from "./shared.js";
+
+/** Heavy step fields the caller may ask to expand via `include`. */
+export const INCLUDABLE_FIELDS = [
+  "input",
+  "output",
+  "logs",
+  "events",
+  "sharedState",
+  "error",
+] as const;
+
+export type IncludableField = (typeof INCLUDABLE_FIELDS)[number];
+
+export interface ProjectExecutionOptions {
+  /** Step to expand: a step name, or a step order (number or numeric string). */
+  step?: string | number;
+  /** Restrict expansion to a single attempt of the selected step. */
+  attempt?: number;
+  /** Heavy step fields to expand for the selected step(s). */
+  include?: IncludableField[];
+  /** Per-field character budget for expanded / budgeted fields. */
+  budget?: number;
+  /** The run's webapp URL, cited in truncation markers. */
+  webappUrl?: string;
+}
+
+/** Per-field cap for expanded step fields and budgeted top-level fields. A single
+ *  step output can be multiple MB; 32K keeps a truncated body readable while
+ *  bounding the result. */
+const DEFAULT_FIELD_BUDGET = 32_000;
+
+/** Small preview cap for message-only top-level fields (output/error/input/
+ *  sharedState) in the compact view — presence + first N chars, no full body. */
+const PREVIEW_BUDGET = 2_000;
+
+/** Serialized char size of a value; null/undefined count as 0 (honest absence). */
+function charSize(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** True when a heavy field carries an actual body worth expanding. */
+function hasBody(value: unknown): boolean {
+  return value !== undefined && value !== null && charSize(value) > 0;
+}
+
+/**
+ * Budget an arbitrary value: return it verbatim (structured) when its serialized
+ * form fits `budget`, otherwise a truncated string preview with an honest marker.
+ * Returning the value verbatim when it fits keeps a small step input directly
+ * usable by run_local; truncating only over-budget values bounds the result.
+ */
+function budgetValue(
+  value: unknown,
+  budget: number,
+  webappUrl?: string,
+): unknown {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (err) {
+    return `[unserializable: ${err instanceof Error ? err.message : String(err)}]`;
+  }
+  if (serialized.length <= budget) return value;
+  return capText(serialized, budget, webappUrl);
+}
+
+/** A message-only preview of a heavy top-level field: presence + first N chars,
+ *  never the full body. Returns null for an absent value so the key still
+ *  signals "nothing here" rather than vanishing. */
+function previewValue(
+  value: unknown,
+  webappUrl?: string,
+): { chars: number; preview: unknown } | null {
+  if (value === undefined || value === null) return null;
+  const chars = charSize(value);
+  return { chars, preview: budgetValue(value, PREVIEW_BUDGET, webappUrl) };
+}
+
+/** Extract a human message from an arbitrary top-level error value (which may be
+ *  a structured `{ message }`, a string, or something else). */
+function errorMessageOf(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "object" &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string"
+  ) {
+    return (value as { message: string }).message;
+  }
+  return null;
+}
+
+interface CompactStep {
+  stepName: string;
+  stepOrder: number;
+  attempt: number;
+  status: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  errorMessage: string | null;
+  has: Record<IncludableField | "dispatch", boolean>;
+  sizes: Record<IncludableField, number>;
+  dispatch?: StepProjection["dispatch"];
+  cost?: StepProjection["cost"];
+  // Expanded heavy fields, present only when the step is selected + included.
+  input?: unknown;
+  output?: unknown;
+  logs?: unknown;
+  events?: unknown;
+  sharedState?: unknown;
+  error?: unknown;
+}
+
+/** The heavy value backing each includable field on a step. */
+function stepFieldValue(step: StepProjection, field: IncludableField): unknown {
+  switch (field) {
+    case "input":
+      return step.input;
+    case "output":
+      return step.output;
+    case "logs":
+      return step.logs;
+    case "events":
+      return step.events;
+    case "sharedState":
+      return step.sharedStateAfter;
+    case "error":
+      return step.error;
+  }
+}
+
+/** Does this step-attempt match the caller's `step` / `attempt` selector? */
+function stepMatches(
+  step: StepProjection,
+  selector: string | number | undefined,
+  attempt: number | undefined,
+): boolean {
+  if (selector === undefined) return false;
+  if (attempt !== undefined && step.attempt !== attempt) return false;
+  // A numeric selector (or numeric string) matches by stepOrder; otherwise by name.
+  const asNumber = typeof selector === "number" ? selector : Number(selector);
+  if (
+    typeof selector === "number" ||
+    (selector.trim() !== "" && !Number.isNaN(asNumber))
+  ) {
+    return step.stepOrder === asNumber || step.stepName === String(selector);
+  }
+  return step.stepName === selector;
+}
+
+function compactStep(
+  step: StepProjection,
+  expand: IncludableField[],
+  budget: number,
+  webappUrl?: string,
+): CompactStep {
+  const sizes: Record<IncludableField, number> = {
+    input: charSize(step.input),
+    output: charSize(step.output),
+    logs: charSize(step.logs),
+    events: charSize(step.events),
+    sharedState: charSize(step.sharedStateAfter),
+    error: charSize(step.error),
+  };
+  const out: CompactStep = {
+    stepName: step.stepName,
+    stepOrder: step.stepOrder,
+    attempt: step.attempt,
+    status: step.status,
+    startedAt: step.startedAt,
+    finishedAt: step.finishedAt,
+    errorMessage: step.error?.message ?? null,
+    has: {
+      input: hasBody(step.input),
+      output: hasBody(step.output),
+      logs: hasBody(step.logs),
+      events: hasBody(step.events),
+      sharedState: hasBody(step.sharedStateAfter),
+      error: step.error !== null && step.error !== undefined,
+      dispatch: step.dispatch !== null && step.dispatch !== undefined,
+    },
+    sizes,
+  };
+  // Dispatch and cost are small, bounded structured nodes — keep them verbatim so
+  // the compact view still tells the "which child run / what did it cost" story.
+  if (step.dispatch) out.dispatch = step.dispatch;
+  if (step.cost) out.cost = step.cost;
+  for (const field of expand) {
+    out[field] = budgetValue(stepFieldValue(step, field), budget, webappUrl);
+  }
+  return out;
+}
+
+/**
+ * Project a full {@link ExecutionProjection} into the bounded compact shape the
+ * inspect tool returns. Identity/status/timestamps/tree/cost are kept as-is;
+ * every step is compacted (with a `has`/`sizes` hint); heavy top-level fields are
+ * previewed or budgeted; and the selected `step`/`attempt` gets its `include`
+ * fields expanded within the per-field budget.
+ */
+export function projectExecutionForTool(
+  execution: ExecutionProjection,
+  opts: ProjectExecutionOptions = {},
+): Record<string, unknown> {
+  const budget = opts.budget ?? DEFAULT_FIELD_BUDGET;
+  const webappUrl = opts.webappUrl;
+  const include = opts.include ?? [];
+  const wantsExpansion = opts.step !== undefined && include.length > 0;
+
+  const steps = execution.steps.map((step) => {
+    const expand =
+      wantsExpansion && stepMatches(step, opts.step, opts.attempt)
+        ? include
+        : [];
+    return compactStep(step, expand, budget, webappUrl);
+  });
+
+  return {
+    // ── identity / status (kept as-is; already small) ──
+    id: execution.id,
+    name: execution.name,
+    organizationId: execution.organizationId,
+    tenantId: execution.tenantId,
+    status: execution.status,
+    currentStep: execution.currentStep,
+    currentStepAttempt: execution.currentStepAttempt,
+    version: execution.version,
+    definitionId: execution.definitionId,
+    buildRunId: execution.buildRunId,
+    idempotencyKey: execution.idempotencyKey,
+    pausedSignalName: execution.pausedSignalName,
+    pausedSignalCorrelationId: execution.pausedSignalCorrelationId,
+    pausedUntil: execution.pausedUntil,
+    startedAt: execution.startedAt,
+    finishedAt: execution.finishedAt,
+
+    // ── tree / trace (lightweight refs; kept as-is) ──
+    traceRoot: execution.traceRoot,
+    rootExecutionId: execution.rootExecutionId,
+    traceParent: execution.traceParent,
+    parentExecutionId: execution.parentExecutionId,
+    traceId: execution.traceId,
+    children: execution.children,
+
+    // ── run-level cost rollup (small structured node) ──
+    cost: execution.cost,
+
+    // ── heavy top-level detail: message-only previews / budgeted, never verbatim ──
+    input: previewValue(execution.input, webappUrl),
+    sharedState: previewValue(execution.sharedState, webappUrl),
+    output: previewValue(execution.output, webappUrl),
+    error: previewValue(execution.error, webappUrl),
+    errorMessage: errorMessageOf(execution.error),
+    // Paused-step schema/example matter for resume; budget (verbatim when small).
+    pausedStepInputSchema: budgetValue(
+      execution.pausedStepInputSchema,
+      budget,
+      webappUrl,
+    ),
+    pausedStepInputExample: budgetValue(
+      execution.pausedStepInputExample,
+      budget,
+      webappUrl,
+    ),
+
+    // ── steps (compacted; selected step's included fields expanded) ──
+    steps,
+  };
+}

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -30,6 +30,25 @@ export type ToolResult = {
   isError?: boolean;
 };
 
+/**
+ * Truncate `text` to `budget` characters, appending an honest marker that
+ * records how many characters were dropped and — when a `webappUrl` is given —
+ * where the full value can be read. Returns the input unchanged when it already
+ * fits. This is the primitive the execution projection uses to guarantee a tool
+ * result can never exceed its char budget regardless of how large the underlying
+ * step input/output/logs were (a single step output can be multiple MB).
+ */
+export function capText(
+  text: string,
+  budget: number,
+  webappUrl?: string,
+): string {
+  if (text.length <= budget) return text;
+  const dropped = text.length - budget;
+  const where = webappUrl ? ` — open ${webappUrl} for the full value` : "";
+  return `${text.slice(0, budget)}…[truncated ${dropped} chars${where}]`;
+}
+
 export function ok(data: unknown): ToolResult {
   let text: string;
   try {


### PR DESCRIPTION
## Summary

`sapiom_dev_agents_inspect` returned the **entire** execution projection — every step's full input/output/shared-state/logs/events/stack traces plus the whole child-run tree, pretty-printed with no truncation, cap, or pagination. On a real multi-step run that produces 365K–3.3M-char payloads that overflow the consuming model's context, so the debug tool self-destructs exactly when it is needed most (session forensics found this hit 8/8 reconstructed external builders).

Fixes [SAP-2533](https://linear.app/sapiom/issue/SAP-2533/fix-sapiom-dev-agents-inspect-token-blowout-compact-by-default).

## Approach

The fix lives entirely at the **MCP-tool layer** — the SDK `inspect()`/`decode` passthrough contract and the CLI `logs` view are untouched.

1. **Compact by default** (`packages/mcp/src/tools/execution-projection.ts`, new): identity/status/timestamps kept as-is; each step reduced to `{ stepName, stepOrder, attempt, status, startedAt, finishedAt, errorMessage }` plus a `has` flag-set and a `sizes` char-count hint for the omitted bodies; heavy top-level fields (`input`/`sharedState`/`output`/`error`/paused-step schema+example) previewed or budgeted, never verbatim; `children` kept (lightweight refs).
2. **Selective expansion**: new optional schema fields `step` (name or order) + `attempt` + `include: ('input'|'output'|'logs'|'events'|'sharedState'|'error')[]` expand only the requested heavy fields for the requested step(s). Debug loop: `inspect(id)` → compact list shows step 4 failed → `inspect(id, step:'validate', include:['input','error'])` → exactly the payload `run_local` needs.
3. **Hard per-field char budget** (`capText` in `shared.ts`): applied to every expanded/budgeted field, so the result is bounded for **any** argument combination. Over-budget values truncate with an honest marker citing the dropped count and the run's `webappUrl`.

Both `inspect` return branches (`wait:true` and the plain snapshot) yield the same compact/budgeted shape; `webappUrl`/`hint`/`waiting`/`done` are preserved.

## Acceptance criteria

- [x] Default (executionId only) returns a bounded compact projection — no full input/output/logs/events bodies, just per-step status/name/attempt/error-message + size hints
- [x] `include` + `step`/`attempt` expand only the requested heavy fields for the requested step(s)
- [x] Every returned field capped to the char budget; over-budget values truncated with a marker pointing at `webappUrl`
- [x] Total tool-result size bounded for any argument combination (verified with a synthetic ~20-step / 3 MB-output fixture)
- [x] `wait:true` branch returns the same compact/budgeted shape as the non-wait branch
- [x] `webappUrl` and existing `hint`/`waiting`/`done` fields preserved
- [x] SDK `inspect()`, `decode`, and CLI `logs` output unchanged (only `packages/mcp/**` touched)

## Testing

`packages/mcp/src/tools/agents.inspect.test.ts` (4 tests, all passing):
1. Default compact projection on a 20-step / 3 MB-output fixture → result under a fixed ceiling, no full body present, per-step `sizes`/`has` hints present.
2. `step:'step_4', include:['input','error']` → only that step's input + error expanded, others untouched.
3. Over-budget expanded `output` → truncation marker with char count + `webappUrl`.
4. `wait:true` → same compact/budgeted shape, `done`/`waiting`/`webappUrl` preserved.

Verified locally: `pnpm build`, `pnpm typecheck`, `pnpm lint`, prettier, and the test file all green.

## Follow-up (out of scope)

Server-side `?fields=`/pagination on `GET /executions/:id` (Sapiom backend) remains the right long-term home; it's cross-repo and tracked separately. This MCP-layer projection unblocks the debug loop now, self-contained in `sapiom-js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)