### PR TITLE
fix(agent): drop nested defaulted fields from manifest schema required

### DIFF
--- a/.changeset/agent-drop-nested-defaulted-required.md
+++ b/.changeset/agent-drop-nested-defaulted-required.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent": patch
+"@sapiom/agent-runtime": patch
+---
+
+Generated step-input JSON Schemas no longer force a nested field with a Zod `default` to be required.
+
+`z.toJSONSchema()` (Zod v4) marks a defaulted field as required at every level, but a `z.object()` supplies the default on parse when the caller omits it. `buildManifest` already dropped such fields from the top-level `required`; it now does so at every level (nested objects, `items`, and `oneOf`/`anyOf`/`allOf` branches), matching how `additionalProperties: false` is already relaxed recursively. The runtime AJV pre-check applies the same relaxation, so a manifest built by an older SDK is corrected at validation time too.
+
+Additive and non-breaking. A step whose `inputSchema` nests a defaulted field now accepts input that omits it — the same input its Zod parse already accepted — instead of failing the pre-check with a spurious "must have required property" error.

--- a/packages/agent-runtime/src/manifest-validation.spec.ts
+++ b/packages/agent-runtime/src/manifest-validation.spec.ts
@@ -1,0 +1,52 @@
+import { StepInputValidationError } from '@sapiom/agent';
+
+import { validateManifestStepInput } from './manifest-validation.js';
+
+/**
+ * A step-input JSON Schema shaped like `z.toJSONSchema()` output for
+ * `z.object({ title, options: z.object({ tone: z.string().default('formal') }) })`.
+ * The nested `tone` carries a `default` yet is listed in the nested `required` —
+ * exactly what an older SDK (which relaxed only the top level) would emit into a
+ * manifest. Written as a literal so the test exercises the runtime pre-check's
+ * own relaxation, not `buildManifest`'s.
+ */
+function schemaWithNestedDefaultedRequired(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      options: {
+        type: 'object',
+        properties: {
+          tone: { type: 'string', default: 'formal' },
+        },
+        required: ['tone'],
+        additionalProperties: false,
+      },
+    },
+    required: ['title', 'options'],
+    additionalProperties: false,
+  };
+}
+
+describe('validateManifestStepInput', () => {
+  it('accepts input omitting a nested field that carries a default (pre-check must not be stricter than Zod)', () => {
+    const schema = schemaWithNestedDefaultedRequired();
+    // Zod would supply `tone: 'formal'` here — the pre-check must let it through.
+    expect(() =>
+      validateManifestStepInput('start', schema, { title: 'hello', options: {} }),
+    ).not.toThrow();
+  });
+
+  it('still rejects a genuinely missing nested field that has no default', () => {
+    const schema = schemaWithNestedDefaultedRequired();
+    // `title` has no default, so omitting it is a real error — relaxation is narrow.
+    expect(() =>
+      validateManifestStepInput('start', schema, { options: {} }),
+    ).toThrow(StepInputValidationError);
+  });
+
+  it('is a no-op when the schema is null', () => {
+    expect(() => validateManifestStepInput('start', null, { anything: true })).not.toThrow();
+  });
+});

--- a/packages/agent-runtime/src/manifest-validation.ts
+++ b/packages/agent-runtime/src/manifest-validation.ts
@@ -29,7 +29,9 @@ export function validateManifestStepInput(
     return;
   }
 
-  const validate = ajv.compile(relaxAdditionalProperties(schema) as Record<string, unknown>);
+  const validate = ajv.compile(
+    relaxAdditionalProperties(dropDefaultedFromRequired(schema)) as Record<string, unknown>,
+  );
   const valid = validate(input);
   if (!valid) {
     const issues = mapAjvErrors(validate.errors ?? []);
@@ -61,6 +63,50 @@ function relaxAdditionalProperties(value: unknown): unknown {
         continue;
       }
       out[key] = relaxAdditionalProperties(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Recursively drop from every object schema's `required` array any key whose
+ * `properties` entry declares a `default`.
+ *
+ * `z.toJSONSchema()` marks a defaulted field required at every level, but the
+ * authoritative Zod parse supplies the default when the caller omits it — so a
+ * pre-gate that keeps the field required would be stricter than the parse it
+ * fronts (rejecting input the step would happily run). We relax the pre-gate to
+ * match, at every level, for the same reason `relaxAdditionalProperties` does.
+ *
+ * Applied here (not only in `buildManifest`) so a manifest built by an older SDK
+ * — which relaxed only the top level — is still corrected at validation time.
+ */
+function dropDefaultedFromRequired(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(dropDefaultedFromRequired);
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const required = obj.required;
+    const properties = obj.properties;
+    const defaultedHere =
+      Array.isArray(required) && properties && typeof properties === 'object'
+        ? new Set(
+            required.filter((key) => {
+              if (typeof key !== 'string') return false;
+              const prop = (properties as Record<string, unknown>)[key];
+              return prop && typeof prop === 'object' && 'default' in prop;
+            }),
+          )
+        : null;
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(obj)) {
+      if (key === 'required' && defaultedHere) {
+        out[key] = (v as unknown[]).filter((k) => !defaultedHere.has(k));
+      } else {
+        out[key] = dropDefaultedFromRequired(v);
+      }
     }
     return out;
   }

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -274,31 +274,44 @@ function relaxAdditionalProperties(value: unknown): unknown {
 }
 
 /**
- * Remove from the JSON Schema's top-level `required` array any key whose
+ * Recursively remove from every object schema's `required` array any key whose
  * `properties` entry declares a `default`. A caller may omit such a field — Zod
  * supplies the default on parse — so it should not be reported as missing.
- * Operates only on the top level; nested objects are out of scope.
+ *
+ * Applied at every object node (top-level and nested), so a defaulted field
+ * inside a nested object, `items`, or a `oneOf`/`anyOf`/`allOf` branch is
+ * treated the same as a top-level one. This mirrors `relaxAdditionalProperties`:
+ * both walk the whole schema so the AJV pre-check is never stricter than the
+ * Zod parse it fronts. `z.toJSONSchema()` marks a defaulted field required at
+ * every level, so the same relaxation has to reach every level.
  */
-function dropDefaultedFromRequired(
-  schema: Record<string, unknown>,
-): Record<string, unknown> {
-  const required = schema.required;
-  const properties = schema.properties;
-  if (
-    !Array.isArray(required) ||
-    !properties ||
-    typeof properties !== "object"
-  ) {
-    return schema;
+function dropDefaultedFromRequired(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(dropDefaultedFromRequired);
   }
-  const props = properties as Record<string, unknown>;
-  const filtered = required.filter((key) => {
-    if (typeof key !== "string") return true;
-    const prop = props[key];
-    return !(prop && typeof prop === "object" && "default" in prop);
-  });
-  if (filtered.length === required.length) {
-    return schema;
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const required = obj.required;
+    const properties = obj.properties;
+    const defaultedHere =
+      Array.isArray(required) && properties && typeof properties === "object"
+        ? new Set(
+            required.filter((key) => {
+              if (typeof key !== "string") return false;
+              const prop = (properties as Record<string, unknown>)[key];
+              return prop && typeof prop === "object" && "default" in prop;
+            }),
+          )
+        : null;
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(obj)) {
+      if (key === "required" && defaultedHere) {
+        out[key] = (v as unknown[]).filter((k) => !defaultedHere.has(k));
+      } else {
+        out[key] = dropDefaultedFromRequired(v);
+      }
+    }
+    return out;
   }
-  return { ...schema, required: filtered };
+  return value;
 }

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -306,6 +306,37 @@ describe("buildManifest", () => {
     expect(required).not.toContain("count");
   });
 
+  it("defaulted field NESTED in an object is NOT in that object's required (AJV pre-check must not be stricter than Zod)", () => {
+    // A default on a nested field makes it optional to Zod exactly as a top-level
+    // default does — `z.object({ options: { tone } }).parse({ options: {} })`
+    // supplies `tone`. But zod.toJSONSchema marks the nested field required, and
+    // the manifest's AJV pre-check runs without useDefaults, so leaving it in
+    // `required` rejects an input the authoritative Zod parse accepts.
+    const schema = z.object({
+      title: z.string(),
+      options: z.object({
+        tone: z.string().default("formal"),
+      }),
+    });
+    const def = defineAgent({
+      name: "wf",
+      entry: "step",
+      steps: { step: makeStep("step", { inputSchema: schema }) },
+    });
+    const manifest = buildManifest(def, {
+      sdkVersion: DUMMY_SDK_VERSION,
+      artifact: DUMMY_ARTIFACT,
+    });
+    const stepSchema = manifest.steps.step.inputSchema!;
+    const props = stepSchema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const nestedRequired = props.options.required as string[] | undefined;
+    // `tone` (has a default) must not be reported as missing on the nested object.
+    expect(nestedRequired ?? []).not.toContain("tone");
+  });
+
   it("strips additionalProperties:false from the schema (top-level AND nested) so inputs with extra fields are accepted", () => {
     // z.toJSONSchema marks every object as closed (additionalProperties:false).
     // A plain z.object() parse ignores extra keys rather than rejecting them, so


### PR DESCRIPTION
## Problem

`z.toJSONSchema()` (Zod v4) marks a field with a `default` as required, even though `z.object()` supplies that default on parse when the caller omits it. The AJV pre-check therefore rejects input that the subsequent Zod parse would have accepted.

`buildManifest` already compensates for this — but only at the top level. A defaulted field nested inside an object, inside `items`, or inside a `oneOf`/`anyOf`/`allOf` branch is still marked required, so omitting it fails the pre-check with a spurious "must have required property" error.

This is the same class of mismatch #83 fixed for `additionalProperties: false`, and for the same stated reason: the pre-gate must not be stricter than Zod. That normalization was made recursive; this one was left at the top level.

## Fix

`dropDefaultedFromRequired` now recurses, mirroring the traversal `relaxAdditionalProperties` already uses — nested object properties, `items`, and composition branches.

Applied in both places that carry the normalization:

- `packages/agent/src/build-manifest.ts` — so newly built manifests are correct
- `packages/agent-runtime/src/manifest-validation.ts` — so a manifest built by an older SDK is corrected at validation time

## Tests

`packages/agent/src/manifest.spec.ts` — a defaulted field nested in an object is no longer in that object's `required`. Verified failing-first: with the fix reverted, this test fails with `Expected value: not "tone" / Received array: ["tone"]`, which is exactly the reported behaviour.

`packages/agent-runtime/src/manifest-validation.spec.ts` — three cases covering the runtime path: the pre-check accepts input omitting a nested defaulted field, still rejects a genuinely missing field that has no default, and is a no-op on a null schema.

The "still rejects" case is the important one — it confirms the relaxation is narrow and doesn't weaken validation for fields that really are required.

Typecheck and lint pass for both packages.

## Changeset

`patch` for both `@sapiom/agent` and `@sapiom/agent-runtime`, matching the bump #83 used for the comparable fix.

## Formatting note

I matched each file's local style rather than running prettier — the repo isn't uniformly formatted (the two packages differ in quote style, and both touched files are already flagged by the root config), so reformatting would have buried the change in noise.
