### PR TITLE
test(langchain-classic): mock OpenAI token counting in tests

### DIFF
--- a/packages/langchain-classic/src/analytics.test.ts
+++ b/packages/langchain-classic/src/analytics.test.ts
@@ -147,6 +147,9 @@ describe("langchain-classic usage analytics", () => {
 
   beforeEach(async () => {
     jest.restoreAllMocks();
+    jest
+      .spyOn(SapiomChatOpenAI.prototype, "getNumTokens")
+      .mockResolvedValue(1);
     for (const key of ENV_KEYS) {
       savedEnv[key] = process.env[key];
       delete process.env[key];

--- a/packages/langchain-classic/src/models/openai.test.ts
+++ b/packages/langchain-classic/src/models/openai.test.ts
@@ -34,6 +34,9 @@ describe("SapiomChatOpenAI", () => {
   let mockClient: SapiomClient;
 
   beforeEach(() => {
+    jest
+      .spyOn(SapiomChatOpenAI.prototype, "getNumTokens")
+      .mockResolvedValue(1);
     mockClient = {
       transactions: {
         create: jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [x] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The OpenAI wrapper tests mock `ChatOpenAI.generate`, but they can still hit LangChain's `getNumTokens()` path before the mocked model call runs. Locally that made the tests depend on the tiktoken fetch path and caused the OpenAI analytics/model tests to time out.

## Summary and scope

Mocked `SapiomChatOpenAI.getNumTokens()` in the OpenAI-related test setup so these unit tests stay focused on wrapper behavior.

No production code changes.

## Related work

Related issue or discussion: N/A

## Validation

```text
pnpm --filter @sapiom/langchain-classic test — passed
pnpm --filter @sapiom/langchain-classic typecheck — passed
pnpm --filter @sapiom/langchain-classic lint — passed with existing warnings
pnpm --filter @sapiom/langchain-classic build — passed
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed with existing warnings
pnpm test — passed
git diff --check — passed
```

### Tests and documentation

Updated existing tests only. Documentation is N/A because this does not change user-facing behavior.

## Compatibility and release impact

- Breaking or externally visible changes: None
- Changeset: N/A, test-only change

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Used AI assistance to inspect the failing test path and draft the small test setup change. I verified the patch locally with the commands listed above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
