### PR TITLE
fix(mcp): capText can exceed its own char budget

### DIFF
--- a/.changeset/captext-budget-overshoot.md
+++ b/.changeset/captext-budget-overshoot.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/mcp": patch
+---
+
+Fix `capText` (used by `sapiom_dev_agents_inspect` to bound expanded/previewed
+step fields) appending its truncation marker after slicing to the budget
+instead of within it, so a capped field could exceed its own char budget by
+the marker's length — worse with a `webappUrl`, since the marker then also
+carries the URL. Reserves room for the marker inside the budget before
+slicing, so a capped field never exceeds the budget it was given.

--- a/packages/mcp/src/tools/shared.test.ts
+++ b/packages/mcp/src/tools/shared.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { capText } from "./shared.js";
+
+describe("capText", () => {
+  it("returns text unchanged when it already fits the budget", () => {
+    const text = "x".repeat(50);
+    expect(capText(text, 100)).toBe(text);
+    expect(capText(text, 50)).toBe(text);
+  });
+
+  it("never exceeds the budget, without a webappUrl", () => {
+    const text = "x".repeat(5000);
+    const result = capText(text, 2000);
+    expect(result.length).toBeLessThanOrEqual(2000);
+    expect(result).toContain("[truncated");
+  });
+
+  it("never exceeds the budget, with a webappUrl (the case that previously overshot)", () => {
+    const text = "x".repeat(5000);
+    const result = capText(
+      text,
+      2000,
+      "https://app.sapiom.ai/executions/abc123def456",
+    );
+    expect(result.length).toBeLessThanOrEqual(2000);
+    expect(result).toContain("[truncated");
+    expect(result).toContain("app.sapiom.ai");
+  });
+
+  it("stays within budget at the default field budget (32k) on a multi-MB body", () => {
+    const text = "x".repeat(3_000_000);
+    const result = capText(
+      text,
+      32_000,
+      "https://app.sapiom.ai/executions/abc123def456",
+    );
+    expect(result.length).toBeLessThanOrEqual(32_000);
+  });
+
+  it("stays within budget at the small preview budget (2k)", () => {
+    const text = "x".repeat(50_000);
+    const result = capText(
+      text,
+      2_000,
+      "https://app.sapiom.ai/executions/abc123def456",
+    );
+    expect(result.length).toBeLessThanOrEqual(2_000);
+  });
+
+  it("reports an honest dropped-char count that matches what was actually kept", () => {
+    const text = "x".repeat(5000);
+    const result = capText(
+      text,
+      2000,
+      "https://app.sapiom.ai/executions/abc123def456",
+    );
+    const match = result.match(/\[truncated (\d+) chars/);
+    expect(match).not.toBeNull();
+    const reportedDropped = Number(match![1]);
+    // The slice kept plus the reported drop count must reconstruct the
+    // original length — the count has to describe the actual output, not
+    // a stale estimate from before the marker's own size was accounted for.
+    const markerStart = result.indexOf("…[truncated");
+    const keptLen = markerStart === -1 ? result.length : markerStart;
+    expect(keptLen + reportedDropped).toBe(text.length);
+  });
+
+  it("degrades gracefully when the budget is smaller than the marker itself", () => {
+    const text = "x".repeat(50);
+    // No realistic caller passes a budget this small (defaults are 2_000 and
+    // 32_000), but the function should still terminate and produce a
+    // well-formed marker rather than slicing negatively or looping forever.
+    const result = capText(text, 10);
+    expect(result).toContain("[truncated");
+    expect(() => capText(text, 0)).not.toThrow();
+  });
+});

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -37,6 +37,19 @@ export type ToolResult = {
  * fits. This is the primitive the execution projection uses to guarantee a tool
  * result can never exceed its char budget regardless of how large the underlying
  * step input/output/logs were (a single step output can be multiple MB).
+ *
+ * The marker itself is *appended after* slicing to `budget`, so naively
+ * returning `slice(0, budget) + marker` would make the result longer than
+ * `budget` by the marker's own length (worse with a `webappUrl`, whose
+ * length isn't known in advance) — silently breaking the "can never exceed
+ * its char budget" guarantee this function exists to provide. Reserve room
+ * for the marker inside `budget` instead. The marker's length depends on how
+ * many characters were dropped, which depends on how much of `text` is kept —
+ * two passes converges: size the marker for keeping up to `budget`, shrink the
+ * kept slice to leave room for it, then re-measure once more in case shrinking
+ * changed `dropped`'s digit count enough to grow the marker itself (e.g. 999 ->
+ * 1000 dropped chars). Only pathological budgets smaller than the marker's own
+ * length can still overshoot — the marker has to say something.
  */
 export function capText(
   text: string,
@@ -44,9 +57,14 @@ export function capText(
   webappUrl?: string,
 ): string {
   if (text.length <= budget) return text;
-  const dropped = text.length - budget;
   const where = webappUrl ? ` — open ${webappUrl} for the full value` : "";
-  return `${text.slice(0, budget)}…[truncated ${dropped} chars${where}]`;
+  const markerFor = (sliceLen: number): string =>
+    `…[truncated ${text.length - sliceLen} chars${where}]`;
+  let sliceLen = budget;
+  for (let i = 0; i < 2; i++) {
+    sliceLen = Math.max(0, budget - markerFor(sliceLen).length);
+  }
+  return `${text.slice(0, sliceLen)}${markerFor(sliceLen)}`;
 }
 
 export function ok(data: unknown): ToolResult {


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

capText's whole purpose is to guarantee an expanded/previewed field in the sapiom_dev_agents_inspect result can never exceed a given char budget, regardless of how large the underlying step input/output/logs were. But it sliced text to exactly `budget` chars and then appended the truncation marker on top, so the returned string was actually `budget + marker.length` chars — worse with a webappUrl, since the marker then also carries the URL.

Concretely: capText(text, 2000, webappUrl) on a 5000-char string returned a 2095-char string, 95 chars over budget. At the default 32_000 field budget the overshoot is the same ~95 chars, and at the 2_000 preview budget used for every top-level input/output/error/sharedState field it is proportionally worse.

This went unnoticed because the only existing coverage (agents.inspect.test.ts) asserts against a much larger, coarser CEILING on the whole serialized tool result, and checks that a truncation marker is present — never that an individual capped field actually respects its own budget.

## Summary and scope

Reserves room for the marker inside `budget` before slicing, via a two-pass fixed point (the marker's length depends on how many chars were dropped, which depends on how much of `text` is kept). No callers change — capText is only consumed via projectExecutionForTool (execution-projection.ts), which has no dedicated test file yet, so the new coverage is added at the primitive instead.

## Related work

Related issue or discussion: N/A — found while auditing packages/mcp/src/tools/execution-projection.ts, not tied to an existing issue.

## Validation

```text
pnpm --filter @sapiom/mcp build — pass
pnpm --filter @sapiom/mcp typecheck — pass
pnpm --filter @sapiom/mcp lint — 0 errors
pnpm exec prettier --check packages/mcp/src/tools/shared.ts packages/mcp/src/tools/shared.test.ts — pass
pnpm --filter @sapiom/mcp test — 108/108 passed, including 7 new tests in shared.test.ts
Reverted the fix locally to confirm the new tests actually catch the regression: 4 tests failed with the exact predicted overshoots (32098/32000, 2096/2000). Restored the fix — full suite green again.
```

### Tests and documentation

Added packages/mcp/src/tools/shared.test.ts covering capText: unchanged-when-fits, stays within budget with/without webappUrl, stays within budget at both real budgets used in the codebase (2_000 preview / 32_000 default field), the dropped-char count in the marker reconstructs the original length, and graceful behavior when the budget is smaller than the marker itself. No user-facing documentation to update — capText is an internal primitive, its contract is unchanged (still "never exceeds budget"), only now actually honored.

## Compatibility and release impact

- Breaking or externally visible changes: None. Output of capText is shorter/equal for any input compared to before; no caller's behavior depends on the previous overshoot.
- Changeset: Added (.changeset/captext-budget-overshoot.md, patch on @sapiom/mcp).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the Security Policy for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Used Claude to investigate the module, find the bug, write the fix and tests, and validate them (build/typecheck/lint/prettier/test all run and passing, plus a regression check confirming the new tests fail against the old code before the fix was applied). I reviewed the diff and test output before submitting.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.