### PR TITLE
fix(core): detect Sapiom-format 402 responses in payment error extraction

### DIFF
--- a/.changeset/fix-sapiom-payment-response-detection.md
+++ b/.changeset/fix-sapiom-payment-response-detection.md
@@ -1,0 +1,14 @@
+---
+'@sapiom/core': patch
+---
+
+fix(core): detect Sapiom-format 402 responses in payment error extraction
+
+The `isSapiomPaymentResponse` guard required a `paymentData` field that does not
+exist on `SapiomPaymentResponse` (whose fields are `requiresPayment`,
+`transactionId`, `x402`, `message`). It therefore rejected every real Sapiom 402
+body, leaving the wrapper branch in `extractX402` / `extractX402Response`
+unreachable — a Sapiom response nesting its x402 payload under `requiresPayment`
+was never detected. The guard now discriminates on `requiresPayment === true`.
+`extractTransactionId` returns the body `transactionId` only when present, so the
+`x-sapiom-transaction-id` header fallback still runs when the body omits it.

--- a/packages/core/src/errors/PaymentErrorDetection.test.ts
+++ b/packages/core/src/errors/PaymentErrorDetection.test.ts
@@ -1,6 +1,8 @@
 import {
   PaymentRequiredError,
   X402PaymentResponse,
+  extractX402Response,
+  extractTransactionId,
 } from "./PaymentErrorDetection";
 import { X402ResponseV1, X402ResponseV2 } from "../types/transaction";
 
@@ -132,6 +134,59 @@ describe("PaymentRequiredError", () => {
         "https://api.example.com/resource",
       );
       expect(error.x402Response).toBe(v2Response);
+    });
+  });
+});
+
+// ============================================================================
+// Sapiom-format 402 body detection (regression guard for the isSapiomPaymentResponse guard)
+// ============================================================================
+
+describe("Sapiom-format 402 detection", () => {
+  /** A Sapiom 402 error: the x402 payload is nested under a `requiresPayment` wrapper. */
+  function sapiomError(data: Record<string, unknown>, headers?: Record<string, string>) {
+    return { status: 402, message: "Payment Required", data, headers };
+  }
+
+  describe("extractX402Response", () => {
+    it("extracts the x402 payload nested in a Sapiom `requiresPayment` wrapper", () => {
+      // The wrapper is not itself an x402 response (no top-level x402Version/accepts),
+      // so this only works if the Sapiom guard accepts it — the branch that was dead
+      // while the guard demanded a non-existent `paymentData` field.
+      const error = sapiomError({
+        requiresPayment: true,
+        transactionId: "txn_abc",
+        x402: v2Response,
+      });
+      expect(extractX402Response(error)).toBe(v2Response);
+    });
+
+    it("still extracts a bare (unwrapped) x402 response", () => {
+      const error = sapiomError(
+        v2Response as unknown as Record<string, unknown>,
+      );
+      expect(extractX402Response(error)).toEqual(v2Response);
+    });
+  });
+
+  describe("extractTransactionId", () => {
+    it("returns the transactionId carried in a Sapiom body", () => {
+      const error = sapiomError({
+        requiresPayment: true,
+        transactionId: "txn_abc",
+        x402: v2Response,
+      });
+      expect(extractTransactionId(error)).toBe("txn_abc");
+    });
+
+    it("falls back to the x-sapiom-transaction-id header when the body has none", () => {
+      // Regression guard: a Sapiom body without its own transactionId must not
+      // short-circuit the header fallback.
+      const error = sapiomError(
+        { requiresPayment: true, x402: v2Response },
+        { "x-sapiom-transaction-id": "hdr_txn" },
+      );
+      expect(extractTransactionId(error)).toBe("hdr_txn");
     });
   });
 });

--- a/packages/core/src/errors/PaymentErrorDetection.ts
+++ b/packages/core/src/errors/PaymentErrorDetection.ts
@@ -113,12 +113,16 @@ function isX402Response(data: unknown): data is X402PaymentResponse {
 }
 
 function isSapiomPaymentResponse(data: unknown): data is SapiomPaymentResponse {
+  // The discriminant for a Sapiom 402 body is `requiresPayment === true`. Do
+  // NOT gate on `paymentData` — that field lives on the transaction-creation
+  // type, not on SapiomPaymentResponse (which carries transactionId/x402/
+  // message). Requiring it here rejected every real response, leaving the
+  // Sapiom-wrapper branch in extractX402 unreachable.
   return (
     data !== null &&
     typeof data === "object" &&
     "requiresPayment" in data &&
-    (data as any).requiresPayment === true &&
-    "paymentData" in data
+    (data as any).requiresPayment === true
   );
 }
 
@@ -243,7 +247,9 @@ export class HttpErrorDetector implements ErrorDetectorAdapter {
     const httpError = error as HttpError;
     const data = httpError.data;
 
-    if (isSapiomPaymentResponse(data)) {
+    // Prefer the id carried in a Sapiom-format body, but only when present —
+    // otherwise fall through so the header and generic fallbacks below still run.
+    if (isSapiomPaymentResponse(data) && data.transactionId) {
       return data.transactionId;
     }
 


### PR DESCRIPTION
## Summary

`isSapiomPaymentResponse` narrows to `SapiomPaymentResponse`, but it required a `paymentData` field that does not exist on that type — its fields are `requiresPayment`, `transactionId`, `x402`, `message` (`paymentData` lives on the transaction-creation type instead). The guard therefore returned `false` for **every** real Sapiom 402 body, so the wrapper branch in `extractX402` / `extractX402Response` was unreachable: a Sapiom response that nests its x402 payload under `requiresPayment` was never detected, and `wrapWith402Detection` could not surface a `PaymentRequiredError` for it.

## Changes

- `packages/core/src/errors/PaymentErrorDetection.ts`
  - `isSapiomPaymentResponse` now discriminates on `requiresPayment === true` and drops the phantom `paymentData` check.
  - `extractTransactionId` returns the body `transactionId` only when it is present, so the `x-sapiom-transaction-id` header fallback still runs when the body omits it (no regression from reviving the guard).
- `packages/core/src/errors/PaymentErrorDetection.test.ts` — first coverage of the Sapiom-format detection path: extracting a nested x402 payload from a `requiresPayment` wrapper, reading the body `transactionId`, and the header fallback when the body has none.
- changeset (`@sapiom/core`, patch).

## Testing

- `pnpm --filter @sapiom/core test` — all suites green, including the four new cases.
- Each new test was checked against the pre-fix code: the nested-x402 case fails without the guard fix, and the header-fallback case fails without the `extractTransactionId` change — so both are genuine regression guards.
- `pnpm --filter @sapiom/core typecheck`, `lint`, and `build` all pass.
