### PR TITLE
feat(harness-desktop): replace native update dialog with a designed window

### DIFF
--- a/.changeset/update-window-redesign.md
+++ b/.changeset/update-window-redesign.md
@@ -1,0 +1,13 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Replace the native "update ready" dialog with a designed, on-brand update window
+
+electron-updater's "Sapiom X is ready to install" prompt was a native OS dialog — unstyleable and generic. It's now a custom frameless window, built the same way as the setup window (bundled, CSP-locked HTML themed through the design-system seam), so it reads as Sapiom instead of a system alert.
+
+- **Design:** the Sapiom "S" mark (in a neutral ink chip) + wordmark + `agent.studio <version>` lockup, a concise "`<version>` is ready to install. Restart ends running agent sessions." line, and an ink primary **Restart now** with secondary **Later** and **Skip this version**. Light and dark.
+- **Skip this version** is persisted (a desktop-local `update-prefs.json`): that version is never re-offered, a newer one still is, and "Check for updates" clears skips.
+- **Automatically download and install updates** toggle: when on (the default), a downloaded update installs on the next ordinary quit (`autoInstallOnAppQuit`) — never a surprise mid-session restart; off keeps the prompt-only behaviour. This reverses the former hardcoded no-auto-install default, now that the user controls it.
+- **Theme sync:** the window follows the app's current light/dark theme. Its `file://` origin can't read the SPA's (`http://localhost`) theme storage, so the main process reads the SPA window's live `data-theme` and hands it in — no drift to the OS default when the user has picked a non-OS theme.
+- **Safety preserved:** "Later" is the keyboard default (Esc/Return defer); restarting needs an explicit click. The new IPC channels are scoped to the update window's own renderer (sender-gated, registered only while it is open), so page/agent content still cannot trigger a restart.

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -1,5 +1,5 @@
-// Copies the setup window's static assets into dist/renderer.
-// tsc emits only setup.js from src/renderer; the .html/.css must be copied.
+// Copies the renderer windows' static assets into dist/renderer.
+// tsc emits only the .js from src/renderer; the .html/.css must be copied.
 //
 // We ALSO resolve and copy the design-system token layer, so the onboarding
 // window reads the SAME token values as the SPA instead of carrying its own
@@ -74,7 +74,7 @@ async function copyIfPresent(from, to, options) {
 }
 
 await mkdir(outDir, { recursive: true });
-for (const file of ["setup.html", "setup.css"]) {
+for (const file of ["setup.html", "setup.css", "update.html", "update.css"]) {
   await cp(join(srcDir, file), join(outDir, file));
 }
 

--- a/packages/harness-desktop/src/main/index.ts
+++ b/packages/harness-desktop/src/main/index.ts
@@ -23,6 +23,9 @@ import { initDialogs } from "./dialogs.js";
 import { setTrustedWindow } from "./trusted-sender.js";
 import { parseDeepLink, deepLinkFromArgv, DEEP_LINK_SCHEME } from "./deep-link.js";
 import { DEEP_LINK_NAVIGATE } from "./ipc.js";
+// Dev-only: preview the update window without waiting for a real update.
+import { showUpdatePrompt } from "./update-window.js";
+import { loadUpdatePrefs, saveUpdatePrefs, updatePrefsPathIn } from "./update-prefs.js";
 
 const devMode = process.argv.includes("--dev");
 /** `--smoke`: boot, verify the packaged bundle, print results, exit. See smoke.ts. */
@@ -181,6 +184,20 @@ if (lock.action === "fail") {
       // the same reason as initUpdater: invoke on an unhandled channel rejects, so
       // the handler must exist regardless of which branch of boot we exit through.
       initDialogs({ mainWindow: bootResult.mainWindow });
+      // Dev-only preview: `SAPIOM_PREVIEW_UPDATE_WINDOW=1 pnpm dev` opens the update
+      // window with a sample version so it can be eyeballed (and its toggle/skip
+      // persistence exercised) without a real update. Double-gated on devMode, so it
+      // can never fire in a packaged build.
+      if (devMode && process.env.SAPIOM_PREVIEW_UPDATE_WINDOW) {
+        const prefsPath = updatePrefsPathIn(app.getPath("userData"));
+        void showUpdatePrompt(bootResult.mainWindow, {
+          version: "0.0.0-preview",
+          autoUpdate: (await loadUpdatePrefs(prefsPath)).autoUpdate,
+          onAutoUpdateChange: async (on) => {
+            await saveUpdatePrefs({ ...(await loadUpdatePrefs(prefsPath)), autoUpdate: on }, prefsPath);
+          },
+        }).then((choice) => console.log(`[preview] update window choice: ${choice}`));
+      }
       if (smokeMode) {
         // Verify the packaged bundle, then leave — never wait for a user. The
         // exit code is the CI signal. `app.exit` skips the before-quit handler,

--- a/packages/harness-desktop/src/main/ipc.ts
+++ b/packages/harness-desktop/src/main/ipc.ts
@@ -115,12 +115,47 @@ export interface DeepLinkTemplateTarget {
   slug?: string;
 }
 /*
- * There is deliberately NO "apply the update" channel. The restart is destructive —
- * it ends every running agent session — and the page that would call it is the same
- * origin as the agent-authored files the harness serves at `/canvas/:sessionId/*`.
- * Rather than exposing that and guarding it, the confirmation lives in a native
- * dialog the main process raises: page content cannot reach it at all.
+ * There is deliberately NO "apply the update" channel reachable from the MAIN
+ * window. The restart is destructive — it ends every running agent session — and
+ * the main window shares its origin with the agent-authored files the harness
+ * serves at `/canvas/:sessionId/*`, so any channel it could reach would be
+ * reachable by that content too.
+ *
+ * The apply confirmation therefore lives in a separate, main-process-owned window
+ * (see `update-window.ts`) that loads ONLY our bundled `update.html` — never remote
+ * or agent content — carries its own dedicated preload (none of `sapiomDesktop`),
+ * and answers on the two channels below. Both are gated on the sender BEING that
+ * exact window's `webContents`, and are registered only while it is open, so no
+ * other renderer — not the SPA, not a canvas/preview window — can reach them. The
+ * invariant is intact: page content still cannot trigger a restart.
  */
+
+/** The user's choice in the update window. `later` also covers closing the window. */
+export type UpdateChoice = "restart" | "later" | "skip";
+
+/**
+ * update window → main (invoke): the user picked an action, resolving the
+ * `showUpdatePrompt` promise. Sender-gated to the update window (see above), NOT
+ * via `isTrustedSender` — that guard is specific to the main window's SPA.
+ */
+export const UPDATE_DECIDE = "update:decide";
+
+/**
+ * update window → main (invoke): the "Automatically download and install updates"
+ * toggle changed. Persisted (`update-prefs.ts`) and applied live to
+ * `autoUpdater.autoInstallOnAppQuit`. Separate from UPDATE_DECIDE so flipping the
+ * toggle and THEN closing the window still keeps the change. Same sender gate.
+ */
+export const UPDATE_SET_AUTO = "update:set-auto";
+
+/**
+ * argv prefixes carrying the update window's initial state into its preload — the
+ * offered version, and the auto-update toggle state ("1"/"0"). Same documented
+ * `additionalArguments` mechanism as APP_VERSION_ARG (a `process.env` read would
+ * depend on a renderer inheriting a var mutated after startup).
+ */
+export const UPDATE_VERSION_ARG = "--sapiom-update-version=";
+export const UPDATE_AUTO_ARG = "--sapiom-update-auto=";
 
 /**
  * The result of an on-demand check.

--- a/packages/harness-desktop/src/main/paths.ts
+++ b/packages/harness-desktop/src/main/paths.ts
@@ -34,3 +34,14 @@ export function setupPreloadPath(): string {
 export function desktopPreloadPath(): string {
   return path.join(mainDir, "..", "preload", "desktop.mjs");
 }
+
+/** This app's update-window HTML (copied to dist/renderer by the build). */
+export function updateHtmlPath(): string {
+  return path.join(mainDir, "..", "renderer", "update.html");
+}
+
+/** Preload for the update window — exposes `window.sapiomUpdate`. Same `.mjs` +
+ *  sandbox-off requirement as the setup preload. */
+export function updatePreloadPath(): string {
+  return path.join(mainDir, "..", "preload", "update.mjs");
+}

--- a/packages/harness-desktop/src/main/update-prefs.test.ts
+++ b/packages/harness-desktop/src/main/update-prefs.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `update-prefs.ts` is kept free of an `electron` import precisely so it can be
+ * unit-tested like `update-policy.ts` (the toggle + skip list are the load-bearing
+ * state behind the update window, and a silently-corrupt read would either nag a
+ * user who skipped a version or auto-install one they didn't want). These exercise
+ * the pure sanitize/merge and the read-modify-write helpers against a scratch file.
+ */
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_UPDATE_PREFS,
+  addSkippedVersion,
+  clearSkippedVersions,
+  loadUpdatePrefs,
+  sanitizeUpdatePrefs,
+  saveUpdatePrefs,
+  updatePrefsPathIn,
+} from "./update-prefs.js";
+
+let dir: string;
+let prefsPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sapiom-update-prefs-"));
+  prefsPath = updatePrefsPathIn(dir);
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("sanitizeUpdatePrefs", () => {
+  it("fills defaults for missing/non-object input", () => {
+    expect(sanitizeUpdatePrefs(undefined)).toEqual(DEFAULT_UPDATE_PREFS);
+    expect(sanitizeUpdatePrefs(null)).toEqual(DEFAULT_UPDATE_PREFS);
+    expect(sanitizeUpdatePrefs("nonsense")).toEqual(DEFAULT_UPDATE_PREFS);
+    expect(sanitizeUpdatePrefs({})).toEqual(DEFAULT_UPDATE_PREFS);
+  });
+
+  it("defaults autoUpdate to true (the toggle ships on) but honors an explicit false", () => {
+    expect(sanitizeUpdatePrefs({}).autoUpdate).toBe(true);
+    expect(sanitizeUpdatePrefs({ autoUpdate: false }).autoUpdate).toBe(false);
+    // A non-boolean is junk, not "off".
+    expect(sanitizeUpdatePrefs({ autoUpdate: "false" }).autoUpdate).toBe(true);
+  });
+
+  it("keeps only non-empty string versions, deduped", () => {
+    expect(
+      sanitizeUpdatePrefs({ skippedVersions: ["1.0.0", "1.0.0", "", 2, null, "2.0.0"] }).skippedVersions,
+    ).toEqual(["1.0.0", "2.0.0"]);
+    expect(sanitizeUpdatePrefs({ skippedVersions: "1.0.0" }).skippedVersions).toEqual([]);
+  });
+});
+
+describe("load / save round-trip", () => {
+  it("returns defaults when the file is absent", async () => {
+    expect(await loadUpdatePrefs(prefsPath)).toEqual(DEFAULT_UPDATE_PREFS);
+  });
+
+  it("returns defaults (never throws) on a corrupt file", async () => {
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["9.9.9"] }, prefsPath);
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(prefsPath, "{ not json");
+    expect(await loadUpdatePrefs(prefsPath)).toEqual(DEFAULT_UPDATE_PREFS);
+  });
+
+  it("persists and reloads both fields", async () => {
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["1.2.3"] }, prefsPath);
+    expect(await loadUpdatePrefs(prefsPath)).toEqual({ autoUpdate: false, skippedVersions: ["1.2.3"] });
+  });
+});
+
+describe("addSkippedVersion", () => {
+  it("appends and dedupes without disturbing autoUpdate", async () => {
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: [] }, prefsPath);
+    await addSkippedVersion("1.0.0", prefsPath);
+    await addSkippedVersion("1.0.0", prefsPath); // dupe — no-op
+    await addSkippedVersion("2.0.0", prefsPath);
+    expect(await loadUpdatePrefs(prefsPath)).toEqual({
+      autoUpdate: false,
+      skippedVersions: ["1.0.0", "2.0.0"],
+    });
+  });
+
+  it("works from a fresh (absent) file", async () => {
+    await addSkippedVersion("0.4.2", prefsPath);
+    expect((await loadUpdatePrefs(prefsPath)).skippedVersions).toEqual(["0.4.2"]);
+  });
+});
+
+describe("clearSkippedVersions", () => {
+  it("empties the list but keeps autoUpdate", async () => {
+    await saveUpdatePrefs({ autoUpdate: true, skippedVersions: ["1.0.0", "2.0.0"] }, prefsPath);
+    await clearSkippedVersions(prefsPath);
+    expect(await loadUpdatePrefs(prefsPath)).toEqual({ autoUpdate: true, skippedVersions: [] });
+  });
+
+  it("does not create a file when there is nothing to clear", async () => {
+    await clearSkippedVersions(prefsPath);
+    expect(existsSync(prefsPath)).toBe(false);
+  });
+});

--- a/packages/harness-desktop/src/main/update-prefs.ts
+++ b/packages/harness-desktop/src/main/update-prefs.ts
@@ -1,0 +1,103 @@
+/**
+ * Persisted, desktop-only update preferences: the "auto-install on quit" toggle
+ * and the set of versions the user chose to skip.
+ *
+ * Deliberately kept free of an `electron` import — like `update-policy.ts`, so it
+ * can be unit-tested without the runtime. The functions take an explicit file
+ * path; the ONE place that needs Electron's per-user dir passes
+ * `updatePrefsPathIn(app.getPath("userData"))` from a caller that already imports
+ * `app` (updater.ts / update-window.ts / index.ts). It mirrors the harness's
+ * `cli/settings.ts` discipline: never throw on read, sanitize on every read AND
+ * write so a hand-edited or older file self-heals instead of needing a migration.
+ *
+ * These live in a desktop-local file rather than the shared `HarnessSettings`
+ * store because updates are a desktop-only concept — `npx @sapiom/harness` has no
+ * updater — so the shared settings type (and its REST/zod schema) stays clean.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export interface UpdatePrefs {
+  /**
+   * When true, a background-downloaded update installs on the next ordinary quit
+   * (`autoUpdater.autoInstallOnAppQuit`). When false, an update is applied ONLY via
+   * the update window's "Restart now" — the "we own the restart" behaviour.
+   */
+  autoUpdate: boolean;
+  /** Versions the user picked "Skip this version" for — never re-offered. */
+  skippedVersions: string[];
+}
+
+export const DEFAULT_UPDATE_PREFS: UpdatePrefs = {
+  // Default ON: a downloaded update installs when the user next quits, so testers
+  // stop sitting on a build whose fix they already have. The window's toggle turns
+  // it off for anyone who wants to own every restart. This intentionally reverses
+  // the updater's former hardcoded `autoInstallOnAppQuit = false` (see updater.ts).
+  autoUpdate: true,
+  skippedVersions: [],
+};
+
+/**
+ * The prefs file inside Electron's per-user `userData` dir. Takes the dir as a
+ * string (not `app`) so this module carries no electron dependency; the caller
+ * supplies `app.getPath("userData")`.
+ */
+export function updatePrefsPathIn(userDataDir: string): string {
+  return path.join(userDataDir, "update-prefs.json");
+}
+
+/**
+ * Coerce arbitrary parsed JSON into a valid `UpdatePrefs`, dropping junk. Applied
+ * on every read and write so a corrupt or older file heals in place. Unknown
+ * fields fall back to defaults; `skippedVersions` is filtered to non-empty strings
+ * and deduped.
+ */
+export function sanitizeUpdatePrefs(raw: unknown): UpdatePrefs {
+  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const skipped = Array.isArray(obj.skippedVersions)
+    ? [...new Set(obj.skippedVersions.filter((v): v is string => typeof v === "string" && v.length > 0))]
+    : [...DEFAULT_UPDATE_PREFS.skippedVersions];
+  return {
+    autoUpdate: typeof obj.autoUpdate === "boolean" ? obj.autoUpdate : DEFAULT_UPDATE_PREFS.autoUpdate,
+    skippedVersions: skipped,
+  };
+}
+
+/**
+ * Never throws: a missing or corrupt file resolves to defaults, exactly as the
+ * harness settings loader does — update prefs are a convenience, not load-bearing.
+ */
+export async function loadUpdatePrefs(prefsPath: string): Promise<UpdatePrefs> {
+  try {
+    return sanitizeUpdatePrefs(JSON.parse(await fs.readFile(prefsPath, "utf-8")));
+  } catch {
+    return { ...DEFAULT_UPDATE_PREFS, skippedVersions: [] };
+  }
+}
+
+export async function saveUpdatePrefs(prefs: UpdatePrefs, prefsPath: string): Promise<void> {
+  const sanitized = sanitizeUpdatePrefs(prefs);
+  await fs.mkdir(path.dirname(prefsPath), { recursive: true });
+  await fs.writeFile(prefsPath, JSON.stringify(sanitized, null, 2) + "\n");
+}
+
+/**
+ * Record a version as skipped (deduped). Read-modify-write so it composes with the
+ * `autoUpdate` toggle rather than clobbering it.
+ */
+export async function addSkippedVersion(version: string, prefsPath: string): Promise<void> {
+  const prefs = await loadUpdatePrefs(prefsPath);
+  if (prefs.skippedVersions.includes(version)) return;
+  await saveUpdatePrefs({ ...prefs, skippedVersions: [...prefs.skippedVersions, version] }, prefsPath);
+}
+
+/**
+ * Clear every skip. An explicit "Check for updates" is the user asking again, so it
+ * un-skips everything — mirroring how `checkForUpdatesNow` clears the per-run
+ * `declined` set. Leaves the file untouched when there is nothing to clear.
+ */
+export async function clearSkippedVersions(prefsPath: string): Promise<void> {
+  const prefs = await loadUpdatePrefs(prefsPath);
+  if (prefs.skippedVersions.length === 0) return;
+  await saveUpdatePrefs({ ...prefs, skippedVersions: [] }, prefsPath);
+}

--- a/packages/harness-desktop/src/main/update-window.ts
+++ b/packages/harness-desktop/src/main/update-window.ts
@@ -1,0 +1,176 @@
+/**
+ * The custom "update ready" window.
+ *
+ * Replaces the native `dialog.showMessageBox` the updater used to raise: an OS
+ * dialog can't be styled, so a genuinely better prompt has to be our own window.
+ * It's built exactly like the setup window (see `windows.ts`) — a frameless card
+ * that loads our own bundled, CSP-locked `update.html`, themed through the
+ * design-system seam — so it reads as Sapiom instead of as a system alert.
+ *
+ * ## Why this is safe (the invariant `ipc.ts` documents)
+ *
+ * The main window must NOT be able to trigger a restart: it shares its origin with
+ * agent-authored content served at `/canvas/:sessionId/*`, so a channel it could
+ * reach, that content could reach too. This window sidesteps that entirely — it is
+ * a SEPARATE, main-process-owned window that loads only `update.html`, carries its
+ * own dedicated preload (no `sapiomDesktop`), and its two channels are gated on the
+ * sender being THIS window's exact `webContents` and registered only while it is
+ * open. No page — SPA or canvas — can reach them.
+ */
+import { BrowserWindow, ipcMain, nativeTheme, type IpcMainInvokeEvent } from "electron";
+import {
+  UPDATE_AUTO_ARG,
+  UPDATE_DECIDE,
+  UPDATE_SET_AUTO,
+  UPDATE_VERSION_ARG,
+  type UpdateChoice,
+} from "./ipc.js";
+import { updateHtmlPath, updatePreloadPath } from "./paths.js";
+
+function log(message: string): void {
+  console.error(`[update-window] ${message}`);
+}
+
+/** Coerce the renderer's answer to a known choice; anything unexpected defers. */
+function toChoice(raw: unknown): UpdateChoice {
+  return raw === "restart" || raw === "skip" ? raw : "later";
+}
+
+/**
+ * The theme the SPA is CURRENTLY showing, read from the parent window's DOM.
+ *
+ * This window's file:// origin can't see the SPA's (http://localhost) localStorage,
+ * so it can't resolve the app's chosen theme the way the SPA does — it would fall
+ * back to the OS and drift out of sync whenever the user picked a non-OS theme. So
+ * ask the SPA window directly for the `data-theme` it already resolved. Best-effort:
+ * a destroyed window or an error falls back to the OS theme (nativeTheme).
+ */
+async function readParentTheme(parent: BrowserWindow): Promise<"dark" | "light" | undefined> {
+  if (parent.isDestroyed()) return undefined;
+  try {
+    const value = await parent.webContents.executeJavaScript(
+      "document.documentElement.dataset.theme",
+      true,
+    );
+    return value === "dark" || value === "light" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface UpdatePromptOptions {
+  version: string;
+  /** Initial state of the "auto-install on quit" toggle. */
+  autoUpdate: boolean;
+  /**
+   * Called when the toggle changes. `updater.ts` supplies this to persist the
+   * preference AND apply it live to `autoUpdater.autoInstallOnAppQuit` (it owns
+   * that reference). Awaited so the renderer's invoke resolves after the write.
+   */
+  onAutoUpdateChange?: (on: boolean) => void | Promise<void>;
+}
+
+/**
+ * Show the update prompt and resolve with the user's choice. Closing the window
+ * (traffic light / Esc / Later) resolves `"later"` — the same defer the old
+ * dialog's `cancelId` meant. Resolves exactly once.
+ */
+export async function showUpdatePrompt(parent: BrowserWindow, opts: UpdatePromptOptions): Promise<UpdateChoice> {
+  // Resolve the app's live theme up front: it drives BOTH the pre-paint background
+  // (below) and the renderer's data-theme (via the loadFile query), so the window
+  // is in sync with the app from the very first frame — not the OS default.
+  const theme = await readParentTheme(parent);
+  const dark = theme ? theme === "dark" : nativeTheme.shouldUseDarkColors;
+  const isMac = process.platform === "darwin";
+  const win = new BrowserWindow({
+    parent,
+    modal: true,
+    width: 560,
+    height: 320,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    show: true,
+    title: "Sapiom",
+    // Same frameless-card treatment as the setup window: on macOS drop the title
+    // bar but keep the (inset) traffic lights so the card is closable/movable;
+    // Windows/Linux keep their native frame. The renderer paints the card surface
+    // (--s1) edge to edge.
+    ...(isMac ? { titleBarStyle: "hiddenInset" as const, trafficLightPosition: { x: 16, y: 16 } } : {}),
+    // Pre-paint in --bg for the RESOLVED theme so there's no flash before the
+    // stylesheet loads. --bg (the app's base background), NOT --s1: the renderer
+    // fills with --bg so the window is the same black as the app (see update.css).
+    // window-background.test.ts pins these hexes to the ds --bg token.
+    backgroundColor: dark ? "#0B0E13" : "#F8F9FA",
+    webPreferences: {
+      preload: updatePreloadPath(),
+      contextIsolation: true,
+      nodeIntegration: false,
+      // ESM preload → sandbox must be off (same constraint as the setup window);
+      // contextIsolation stays on, so the page only ever sees the frozen bridge.
+      sandbox: false,
+      additionalArguments: [
+        `${UPDATE_VERSION_ARG}${opts.version}`,
+        `${UPDATE_AUTO_ARG}${opts.autoUpdate ? "1" : "0"}`,
+      ],
+    },
+  });
+
+  win.webContents.on("preload-error", (_e, preloadPath, error) => {
+    log(`preload failed to load: ${preloadPath}\n${error?.stack ?? error}`);
+  });
+  // This window has no links; deny any window-open and off-page navigation outright.
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+  return new Promise<UpdateChoice>((resolve) => {
+    let settled = false;
+
+    // Removing the handlers is not optional: they are global by channel name, and a
+    // later prompt would throw "second handler for 'update:decide'" if this one left
+    // them registered. removeHandler on an absent channel is a no-op, so this is safe
+    // whether or not the handlers were ever hit.
+    const cleanup = (): void => {
+      ipcMain.removeHandler(UPDATE_DECIDE);
+      ipcMain.removeHandler(UPDATE_SET_AUTO);
+    };
+    const settle = (choice: UpdateChoice): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(choice);
+    };
+
+    // Both handlers fail closed for any sender that is not THIS window's renderer.
+    const fromThisWindow = (event: IpcMainInvokeEvent): boolean => {
+      if (event.sender === win.webContents) return true;
+      log("rejected an update IPC from a non-update-window renderer");
+      return false;
+    };
+
+    // Defensive: clear any stale registration before adding ours (a prior prompt
+    // that somehow didn't clean up would otherwise make handle() throw).
+    cleanup();
+
+    ipcMain.handle(UPDATE_SET_AUTO, async (event, on: unknown): Promise<void> => {
+      if (!fromThisWindow(event)) return;
+      await opts.onAutoUpdateChange?.(on === true);
+    });
+
+    ipcMain.handle(UPDATE_DECIDE, (event, choice: unknown): void => {
+      if (!fromThisWindow(event)) return;
+      settle(toChoice(choice));
+      if (!win.isDestroyed()) win.close();
+    });
+
+    // Closing the window by any means (Later routes through here too, via close())
+    // defers — the same outcome as the old dialog's cancelId. Guarded, so a decision
+    // that closed the window doesn't get overwritten.
+    win.on("closed", () => settle("later"));
+
+    // Hand the resolved theme to the renderer's pre-paint script (it can't read the
+    // SPA's cross-origin localStorage). Omitted when unknown, so the page falls back
+    // to its own resolution.
+    void win.loadFile(updateHtmlPath(), theme ? { query: { theme } } : undefined);
+  });
+}

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -43,6 +43,17 @@ import {
   resolveUpdateChannel,
   shouldEnableUpdater,
 } from "./update-policy.js";
+// The custom "update ready" window that replaced the native offer dialog.
+import { showUpdatePrompt } from "./update-window.js";
+// Persisted, desktop-only update prefs: the auto-install toggle + skipped versions.
+import {
+  DEFAULT_UPDATE_PREFS,
+  addSkippedVersion,
+  clearSkippedVersions,
+  loadUpdatePrefs,
+  saveUpdatePrefs,
+  updatePrefsPathIn,
+} from "./update-prefs.js";
 
 /**
  * How often to look for a new build. Four hours: the app is a long-lived desktop
@@ -177,44 +188,79 @@ function relaunchAfterFailedHandoff(): void {
   app.exit(0);
 }
 
+/** The persisted-prefs file for this install (Electron's per-user userData dir). */
+function updatePrefsFile(): string {
+  return updatePrefsPathIn(app.getPath("userData"));
+}
+
 /**
- * Offer the update, and apply it only if the user agrees.
+ * Persist an "auto-install on quit" toggle change AND apply it live. Passed to the
+ * update window (which holds no autoUpdater reference); the window calls it the
+ * moment the toggle flips, so the change sticks even if the user then just closes
+ * the window rather than pressing a button.
+ */
+async function setAutoUpdatePref(on: boolean): Promise<void> {
+  const prefs = await loadUpdatePrefs(updatePrefsFile());
+  await saveUpdatePrefs({ ...prefs, autoUpdate: on }, updatePrefsFile());
+  if (active) active.autoUpdater.autoInstallOnAppQuit = on;
+  log(`auto-install on quit ${on ? "enabled" : "disabled"} by user`);
+}
+
+/**
+ * Offer the update, and act on the user's choice.
  *
- * A native dialog, not something injected into the page: this fires whenever a
- * background download finishes, and it must work regardless of what the main
- * window happens to be showing. (The SPA's Settings popover has its own,
- * *user-initiated* path — see `checkForUpdatesNow`.)
+ * A custom window (see `update-window.ts`), not something injected into the page:
+ * this fires whenever a background download finishes, and it must work regardless
+ * of what the main window happens to be showing. (The SPA's Settings popover has
+ * its own, *user-initiated* path — see `checkForUpdatesNow`.)
  *
- * Declining is remembered per version FOR THIS RUN only. Re-prompting on every
- * check would nag someone who already said no; forgetting entirely across
- * launches would mean a deferred update is never mentioned again. Prompting once
- * per launch is the middle that needs no extra state on disk — and an explicit
- * "check for updates" clears it, because asking IS undeclining.
+ * Three outcomes:
+ *  - **restart** → apply now.
+ *  - **later** → remembered per version FOR THIS RUN only. Re-prompting on every
+ *    check would nag someone who already said no; forgetting across launches would
+ *    mean a deferred update is never mentioned again. Prompting once per launch is
+ *    the middle that needs no state on disk — and an explicit "check for updates"
+ *    clears it, because asking IS undeclining.
+ *  - **skip** → remembered ACROSS launches (persisted): the user doesn't want this
+ *    version at all. A newer one is still offered; "check for updates" clears skips.
  */
 async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
   const { version } = info;
+  // Skipped versions are never re-offered — checked first, before the per-run
+  // guards, so a skip persisted last launch is honored on this one too.
+  const prefs = await loadUpdatePrefs(updatePrefsFile());
+  if (prefs.skippedVersions.includes(version)) {
+    log(`skipping ${version} (user chose Skip this version)`);
+    return;
+  }
   if (declined.has(version) || promptOpen) return;
   if (deps.mainWindow.isDestroyed()) return;
 
   promptOpen = true;
-  // Held across the apply, not just the dialog: shutdown takes seconds, and
-  // releasing early let a second `update-downloaded` stack another dialog on top
+  // Held across the apply, not just the window: shutdown takes seconds, and
+  // releasing early let a second `update-downloaded` stack another prompt on top
   // of an app that was already installing.
   try {
-    const { response } = await dialog.showMessageBox(deps.mainWindow, {
-      type: "info",
-      buttons: ["Restart now", "Later"],
-      defaultId: 0,
-      cancelId: 1,
-      message: `Sapiom ${version} is ready to install.`,
-      // The session warning is the point of this dialog, not a footnote: the
-      // user may have an agent mid-task, and restarting ends it. Burying that is
-      // how a well-meaning update destroys someone's work.
-      detail:
-        "Restarting will end any running agent sessions. " +
-        "Choose Later to keep working — Sapiom stays on the current version until you restart.",
+    const choice = await showUpdatePrompt(deps.mainWindow, {
+      version,
+      autoUpdate: prefs.autoUpdate,
+      onAutoUpdateChange: setAutoUpdatePref,
     });
-    if (response !== 0) {
+
+    if (choice === "skip") {
+      await addSkippedVersion(version, updatePrefsFile());
+      log(`user skipped ${version}`);
+      // Honor the skip even under auto-install: a staged update would otherwise
+      // install on the next quit. Drop it and stop that for this session — the
+      // pref itself is untouched, so next launch restores it and a manual check
+      // (which clears skips) re-offers.
+      if (pending?.version === version) {
+        pending = null;
+        if (active) active.autoUpdater.autoInstallOnAppQuit = false;
+      }
+      return;
+    }
+    if (choice !== "restart") {
       declined.add(version);
       log(`user deferred ${version}`);
       return;
@@ -224,7 +270,8 @@ async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
     if (!result.ok) {
       // Never silently: the user pressed "Restart now" and nothing happened, so
       // say what and why. Their sessions are still alive in the refuse-up-front
-      // case, which is exactly what the message needs to tell them.
+      // case, which is exactly what the message needs to tell them. The rare
+      // failure stays a native dialog — an OK-only acknowledgement.
       pending = null;
       await dialog.showMessageBox(deps.mainWindow, {
         type: "warning",
@@ -245,8 +292,8 @@ async function offerUpdate(info: UpdateInfo, deps: UpdaterDeps): Promise<void> {
  * scheduled check in three ways, and each one is a thing users notice:
  *  - it REPORTS an outcome. A silent background check is fine; a button that
  *    appears to do nothing is broken.
- *  - it clears the declined set, so someone who chose "Later" can change their
- *    mind without restarting the app.
+ *  - it clears the declined set AND the persisted skip list, so someone who chose
+ *    "Later" or "Skip this version" can change their mind without restarting.
  *  - it answers "downloaded" for an update already waiting, rather than the
  *    literally-true-but-useless "you're up to date".
  *
@@ -261,6 +308,9 @@ export async function checkForUpdatesNow(): Promise<UpdateCheckOutcome> {
   // sets `pending`, so returning early would leave the version declined for the
   // rest of the run and the native prompt would never come back.
   declined.clear();
+  // ...and un-skip: an explicit ask is the user reconsidering, so a version they
+  // chose "Skip this version" for is offered again too.
+  await clearSkippedVersions(updatePrefsFile());
   // Something already downloaded and waiting to be applied: report that instead of
   // asking GitHub again, and RE-RAISE the native prompt. That prompt is the only
   // way to actually apply an update — the SPA has no restart channel, by design —
@@ -373,10 +423,23 @@ function startUpdater(deps: UpdaterDeps): void {
   autoUpdater.channel = decision.channel;
   autoUpdater.allowPrerelease = decision.allowPrerelease;
   autoUpdater.autoDownload = true;
-  // We own the restart (the user asked to be notified, not surprised), so an
-  // ordinary quit must NOT install. Leaving this at its default would apply the
-  // update on quit — silently — which is the behaviour we deliberately declined.
-  autoUpdater.autoInstallOnAppQuit = false;
+  // Whether an ordinary quit installs a downloaded update is now USER-controlled,
+  // via the update window's "Automatically download and install updates" toggle
+  // (persisted in update-prefs). Default ON: a ready update installs on the next
+  // quit — never a surprise mid-session restart, since the running app is only ever
+  // restarted by an explicit "Restart now". This reverses the former hardcoded
+  // `false` ("the behaviour we deliberately declined"), now that the user owns it.
+  // Set the default synchronously (loading prefs is async and the first check is
+  // 30s out), then reconcile with the persisted value; a failed read keeps the
+  // default — prefs are a convenience, never load-bearing.
+  autoUpdater.autoInstallOnAppQuit = DEFAULT_UPDATE_PREFS.autoUpdate;
+  void loadUpdatePrefs(updatePrefsFile())
+    .then((prefs) => {
+      autoUpdater.autoInstallOnAppQuit = prefs.autoUpdate;
+    })
+    .catch(() => {
+      /* keep the default */
+    });
   // Only when forced on from an unpackaged build: read dev-app-update.yml
   // instead of the app-update.yml that only packaging writes.
   if (gate.forced) autoUpdater.forceDevUpdateConfig = true;

--- a/packages/harness-desktop/src/main/window-background.test.ts
+++ b/packages/harness-desktop/src/main/window-background.test.ts
@@ -19,16 +19,24 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const windowsSrc = readFileSync(new URL("./windows.ts", import.meta.url), "utf8");
+const updateWindowSrc = readFileSync(new URL("./update-window.ts", import.meta.url), "utf8");
 const dsNeutral = new URL("../../../harness/web/src/styles/ds-neutral/", import.meta.url);
 const tokensCss = readFileSync(new URL("tokens.css", dsNeutral), "utf8");
 
-/** The setup window's backgroundColor ternary → [darkHex, lightHex]. */
-const bg = windowsSrc.match(
-  /backgroundColor:\s*nativeTheme\.shouldUseDarkColors\s*\?\s*"(#[0-9a-fA-F]{3,8})"\s*:\s*"(#[0-9a-fA-F]{3,8})"/,
-);
+// The condition differs per window (setup uses nativeTheme directly; the update
+// window resolves the app's theme first), so match any `backgroundColor: <cond> ?
+// "#dark" : "#light"` and pin the two hexes to the --s1 token below.
+const BG_TERNARY = /backgroundColor:[^?\n]*\?\s*"(#[0-9a-fA-F]{3,8})"\s*:\s*"(#[0-9a-fA-F]{3,8})"/;
+
+/** Each window's backgroundColor ternary → [darkHex, lightHex]. */
+const bg = windowsSrc.match(BG_TERNARY);
+const updateBg = updateWindowSrc.match(BG_TERNARY);
 
 /** Every `--s1:` hex in document order — tokens.css has [0]=dark block, [1]=light block. */
 const s1 = [...tokensCss.matchAll(/--s1:\s*(#[0-9a-fA-F]{3,8})/g)].map((m) => m[1].toLowerCase());
+/** Every `--bg:` hex in document order — the update window fills with --bg (the app's
+ *  base background), not the raised --s1 the setup window uses. */
+const bgToken = [...tokensCss.matchAll(/--bg:\s*(#[0-9a-fA-F]{3,8})/g)].map((m) => m[1].toLowerCase());
 
 describe("setup window backgroundColor matches the Studio --s1 surface token", () => {
   it("sets a themed pre-paint background at all (no flash)", () => {
@@ -47,5 +55,25 @@ describe("setup window backgroundColor matches the Studio --s1 surface token", (
     // studio.css overrides --bg but NOT --s1, so light --s1 is tokens.css's own
     // light-block value — the surface the renderer paints edge to edge.
     expect(bg![2].toLowerCase()).toBe(s1[1]);
+  });
+});
+
+describe("update window backgroundColor matches the app's --bg base surface token", () => {
+  // The update window fills with --bg (the app's base background) so it reads as the
+  // same black as the app — see update.css — not the raised --s1 the setup window uses.
+  it("sets a themed pre-paint background at all (no flash)", () => {
+    expect(updateBg, "update-window.ts should set backgroundColor from the resolved theme").not.toBeNull();
+  });
+
+  it("tokens.css declares --bg for both themes", () => {
+    expect(bgToken.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("dark background == tokens.css dark --bg", () => {
+    expect(updateBg![1].toLowerCase()).toBe(bgToken[0]);
+  });
+
+  it("light background == tokens.css light --bg", () => {
+    expect(updateBg![2].toLowerCase()).toBe(bgToken[1]);
   });
 });

--- a/packages/harness-desktop/src/preload/update.mts
+++ b/packages/harness-desktop/src/preload/update.mts
@@ -1,0 +1,43 @@
+/**
+ * Preload for the update window. Exposes a tiny, typed bridge (no Node, no raw
+ * `ipcRenderer`) via contextBridge — mirroring the setup preload.
+ *
+ * Unlike the main window's `sapiomDesktop`, this bridge lives ONLY in a window the
+ * main process created and loads only `update.html` into. That containment is what
+ * makes a `choose` channel — which can end running sessions — safe to expose here;
+ * see the note in `ipc.ts`.
+ */
+import { contextBridge, ipcRenderer } from "electron";
+import {
+  UPDATE_AUTO_ARG,
+  UPDATE_DECIDE,
+  UPDATE_SET_AUTO,
+  UPDATE_VERSION_ARG,
+  type UpdateChoice,
+} from "../main/ipc.js";
+
+/** Read a value handed in via `webPreferences.additionalArguments` (see ipc.ts). */
+const argValue = (prefix: string): string =>
+  process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? "";
+
+const api = {
+  /** The version being offered, passed in at window-creation time. */
+  version: argValue(UPDATE_VERSION_ARG),
+  /** Initial state of the "auto-install on quit" toggle. */
+  autoUpdate: argValue(UPDATE_AUTO_ARG) === "1",
+  /**
+   * Persist a toggle change immediately — independent of the eventual button
+   * choice, so flipping it and then just closing the window still keeps the change.
+   */
+  setAutoUpdate(on: boolean): Promise<void> {
+    return ipcRenderer.invoke(UPDATE_SET_AUTO, on) as Promise<void>;
+  },
+  /** Report the user's choice; the main process resolves the prompt and closes. */
+  choose(choice: UpdateChoice): Promise<void> {
+    return ipcRenderer.invoke(UPDATE_DECIDE, choice) as Promise<void>;
+  },
+};
+
+export type UpdateBridge = typeof api;
+
+contextBridge.exposeInMainWorld("sapiomUpdate", api);

--- a/packages/harness-desktop/src/renderer/update.css
+++ b/packages/harness-desktop/src/renderer/update.css
@@ -1,0 +1,323 @@
+/*
+ * Update-window layout + controls.
+ *
+ * Same contract as setup.css: tokens come from the design system (resolved through
+ * the copy-renderer seam), and this file NEVER redefines a design-system token — it
+ * reads them via var() and declares none of its own. It addresses the system tokens
+ * directly (--bg/--s2/--s3/--ink/--ink-muted/--line/--line-2 for surfaces + ink,
+ * --btn/--btn-ink for the primary button, --green for the "on" toggle state) because
+ * this window can't load the SPA's styles.css bridge.
+ *
+ * The window fills with --bg (the app's BASE background), NOT the raised --s1: the
+ * app's own dialogs paint shadcn `bg-background` (= --bg), so filling with --bg makes
+ * this window read as the SAME black as the app rather than a lighter raised card.
+ * Internal separation comes from the raised --s2 (the toggle row, the mark chip).
+ *
+ * Colour discipline matches Studio chrome: neutral ink for the brand lockup and the
+ * primary CTA; green (--green) spent ONLY on the toggle track, where it is a genuine
+ * on/off STATE. The "S" mark is rendered in ink, not its published brand green.
+ */
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+body {
+  font: var(--type-ui) / 1.45 var(--font);
+  -webkit-font-smoothing: antialiased;
+  /* Paint the app's BASE background (--bg) edge to edge — the same surface the app's
+     own dialogs use (shadcn bg-background), so this window is the same black as the
+     app, not a lighter raised card. A frameless macOS window is rounded + shadowed by
+     the OS, so it still reads as a single floating surface. */
+  background: var(--bg);
+  color: var(--ink);
+  display: grid;
+  place-items: center;
+  /* Frameless window has no title bar to drag by, so the body is the drag handle;
+     interactive bits opt out below. */
+  -webkit-app-region: drag;
+}
+
+/* Form controls don't inherit the document font (Chromium's UA sheet pins them to
+   Arial 13.333px); without this the buttons + toggle render in Arial while the card
+   is Geist. Same reset setup.css applies. `inherit` redefines no token. */
+button,
+input {
+  font: inherit;
+  color: inherit;
+}
+
+/* Interactive/selectable elements opt back out of the body drag region, or they
+   can't be clicked. */
+.btn-primary,
+.btn-secondary,
+.toggle-row,
+.toggle-switch {
+  -webkit-app-region: no-drag;
+}
+
+.card {
+  width: 100%;
+  max-width: 520px;
+  padding: 26px 30px;
+  display: flex;
+  flex-direction: column;
+  /* Entrance: a small settle, honoring reduced-motion below. */
+  animation: card-in var(--base) var(--ease) both;
+}
+
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ---- Brand lockup: S-mark chip + wordmark + product + version ---- */
+.brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  margin: 0 0 18px;
+}
+
+/* The neutral chip holding the "S" mark. --s2 fill + hairline, ink glyph. */
+.mark-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--r-sm);
+  background: var(--s2);
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+.brand-mark {
+  display: block;
+  height: 18px;
+  width: auto;
+}
+
+/* The wordmark IS the name, so it is neutral ink. Centered with the chip + text
+   (no baseline descender shift — this lockup is center-aligned, unlike setup's). */
+.brand-logotype {
+  display: block;
+  height: 20px;
+  width: auto;
+  color: var(--ink);
+  transform: none;
+}
+
+/* Lowercase mono product name + version, matching the terminal masthead voice. */
+.brand-product,
+.header-version {
+  font-family: var(--mono);
+  font-size: var(--type-meta);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink-muted);
+}
+.header-version:empty {
+  display: none;
+}
+
+/* ---- Body line ---- */
+.body-line {
+  margin: 0;
+  color: var(--ink);
+  font-size: var(--type-ui);
+  line-height: 1.5;
+}
+
+/* ---- Auto-update toggle row ---- */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp3);
+  margin: 18px 0 22px;
+  padding: 12px 14px;
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--s2) 60%, transparent);
+  border: 1px solid var(--line);
+  cursor: pointer;
+}
+.toggle-label {
+  color: var(--ink);
+  font-size: var(--type-ui);
+}
+
+/* Native checkbox restyled as a pill switch: focusable + Space-toggleable for
+   free, no extra markup. Green track when on is a legit state colour. */
+.toggle-switch {
+  appearance: none;
+  -webkit-appearance: none;
+  flex-shrink: 0;
+  position: relative;
+  width: 40px;
+  height: 22px;
+  border-radius: 9999px;
+  background: var(--s3);
+  border: 1px solid var(--line-2);
+  cursor: pointer;
+  transition:
+    background var(--fast) var(--ease),
+    border-color var(--fast) var(--ease);
+}
+.toggle-switch::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transform: translateY(-50%);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  transition: transform var(--fast) var(--ease);
+}
+.toggle-switch:checked {
+  background: var(--green);
+  border-color: var(--green);
+}
+.toggle-switch:checked::after {
+  transform: translate(18px, -50%);
+}
+.toggle-switch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* ---- Footer: Skip on the left, Later + Restart on the right ---- */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp3);
+}
+.footer-right {
+  display: flex;
+  gap: var(--sp2);
+}
+
+/* ---- Buttons ---- */
+/* The primary CTA — the design system's neutral INK button (--btn/--btn-ink), the
+   same "physical key" treatment as setup.css (crisp Geist label, top inset
+   highlight, soft layered shadow that lifts on hover and presses on click).
+   COLLISION-PROOF: fill/text fall back to --ink / --s1 — the two tokens the card
+   already paints with — so a token layer shipping --btn without --btn-ink degrades
+   to --s1 on --ink rather than vanishing. */
+.btn-primary,
+.btn-secondary {
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 10px;
+  font-family: var(--font);
+  font-weight: 550;
+  font-size: 13.5px;
+  letter-spacing: -0.006em;
+  padding: 9px 18px;
+  min-height: 38px;
+  cursor: pointer;
+  transition:
+    transform var(--fast) var(--ease),
+    background var(--fast) var(--ease),
+    box-shadow var(--fast) var(--ease);
+}
+
+.btn-primary {
+  background: var(--btn, var(--ink));
+  color: var(--btn-ink, var(--s1));
+  border: none;
+  /* Drop shadows stay BLACK on both themes — an --ink-tinted shadow becomes a white
+     glow in dark mode. On dark the white fill carries the elevation. */
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 20%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.22),
+    0 4px 12px -3px rgba(0, 0, 0, 0.3);
+}
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, #fff 24%, transparent),
+    0 2px 4px rgba(0, 0, 0, 0.24),
+    0 10px 22px -6px rgba(0, 0, 0, 0.36);
+}
+.btn-primary:active {
+  transform: translateY(0);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.16),
+    0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px var(--focus-ring),
+    0 4px 12px -3px rgba(0, 0, 0, 0.3);
+}
+
+/* The secondary controls (Skip, Later): neutral outline pills on a translucent
+   surface fill — present but quieter than the ink primary. */
+.btn-secondary {
+  background: color-mix(in srgb, var(--s2) 58%, transparent);
+  color: var(--ink);
+  border: 1px solid var(--line-2);
+}
+.btn-secondary:hover {
+  background: var(--s2);
+  transform: translateY(-1px);
+}
+.btn-secondary:active {
+  transform: translateY(0);
+}
+.btn-secondary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* Motion is decorative here; honor a reduced-motion preference. */
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .btn-primary,
+  .btn-secondary,
+  .toggle-switch,
+  .toggle-switch::after {
+    animation: none;
+    transition: none;
+  }
+  .btn-primary:hover,
+  .btn-secondary:hover,
+  .btn-primary:active,
+  .btn-secondary:active {
+    transform: none;
+  }
+}
+
+/* Forced-colors / high-contrast: hand the buttons + switch to the system palette so
+   labels can never collide with their fill and vanish. */
+@media (forced-colors: active) {
+  .btn-primary,
+  .btn-secondary {
+    background: ButtonFace;
+    color: ButtonText;
+    border: 1px solid ButtonText;
+    box-shadow: none;
+  }
+  .toggle-switch {
+    border: 1px solid ButtonText;
+  }
+  .toggle-switch:checked {
+    background: Highlight;
+  }
+}

--- a/packages/harness-desktop/src/renderer/update.html
+++ b/packages/harness-desktop/src/renderer/update.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<!-- data-product scopes the design-system's "sapiom-studio" preset, exactly as
+     setup.html and the SPA do. It MUST sit on the same element as data-theme
+     (which the script below sets on <html>): studio.css keys the brand on the
+     compound selector [data-product="sapiom-studio"][data-theme="…"], so on <body>
+     light mode would silently lose its brand and its --bg. -->
+<html lang="en" data-product="sapiom-studio">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+    />
+    <title>Sapiom</title>
+    <script>
+      // Set the theme before first paint. The design-system tokens key dark on
+      // [data-theme="dark"], so this window must set the attribute too.
+      //
+      // The app's live theme is handed in by the main process as a `?theme=` query
+      // (see update-window.ts). It has to be — this window's file:// origin can't
+      // read the SPA's (http://localhost) localStorage, so guessing from THIS
+      // origin's storage or the OS would drift out of sync with the app whenever
+      // the user picked a non-OS theme. The query wins; localStorage then OS are
+      // only fallbacks so the window is never unthemed.
+      (function () {
+        var forced = null;
+        try {
+          forced = new URLSearchParams(location.search).get("theme");
+        } catch (_) {}
+        var stored = null;
+        try {
+          stored = localStorage.getItem("sapiom-harness-theme");
+        } catch (_) {}
+        var theme =
+          forced === "light" || forced === "dark"
+            ? forced
+            : stored === "light" || stored === "dark"
+              ? stored
+              : window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
+    <!-- The SAME four design-system files, in the SAME order, as setup.html and the
+         SPA's styles.css: fonts register Geist (before tokens), tokens.css is the
+         source of truth, the named studio.css preset layers Studio on top, then this
+         window's own layout. agent-cloud.css is NEVER linked here — studio.css
+         @imports it, and a later <link> would win on source order and restore the
+         old teal accent. All copied in by scripts/copy-renderer.mjs. -->
+    <link rel="stylesheet" href="./ds-fonts.css" />
+    <link rel="stylesheet" href="./ds-tokens.css" />
+    <link rel="stylesheet" href="./themes/studio.css" />
+    <link rel="stylesheet" href="./update.css" />
+  </head>
+  <body>
+    <main class="card">
+      <!-- The brand lockup. Unlike setup.html (which shows only the wordmark, per
+           the brand rule that mark+wordmark reads as a third logo), this window's
+           agreed design places the "S" mark in a neutral chip beside the wordmark.
+           Both glyphs are inlined in currentColor and themed to ink — the mark is
+           NOT its published brand green here, keeping "green = state only". Paths
+           are the official assets: sapiom-mark.svg and the wordmark (identical to
+           setup.html / BrandLogotype.tsx), inlined so a public clone needs no binary
+           and the CSP needs no img-src. -->
+      <header class="brand-lockup" role="img" aria-label="Sapiom agent.studio">
+        <span class="mark-chip" aria-hidden="true">
+          <svg
+            class="brand-mark"
+            width="18"
+            height="19"
+            viewBox="0 0 115 122"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M105.267 60.7219L98.8902 71.7648L92.1353 83.4669L83.3114 98.7521L70.18 121.491H0L13.1249 98.7521H57.042L72.6274 71.7648L79.0038 60.7219L72.2619 49.0459H98.5247L105.267 60.7219Z"
+              fill="currentColor"
+            />
+            <path
+              d="M114.072 0L100.954 22.7189H57.0694L57.0498 22.6928L57.0368 22.7189L41.8365 49.047L35.0945 60.723L41.471 71.7659H15.2016L8.8252 60.723L15.5671 49.047L21.9631 37.978L30.774 22.7189L43.8923 0H114.072Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <svg
+          class="brand-logotype"
+          style="--brand-logotype-descender: 3.72px"
+          width="82"
+          height="22"
+          viewBox="0 0 89 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M32.1834 7.36578L34.4714 5.81493H36.5941C39.3219 5.81493 41.5567 8.05816 41.5567 10.7996V14.9539C41.5567 17.7234 39.3247 19.9385 36.5941 19.9385H34.4714L32.1834 18.3877V24H29.4277V5.81493H32.1834V7.36578ZM23.7454 7.36578V5.81493H26.5012V19.9385H23.7454V18.3877L21.4574 19.9385H19.3347C16.6069 19.9385 14.3722 17.6953 14.3722 14.9539V10.7996C14.3722 8.03001 16.6041 5.81493 19.3347 5.81493H21.4574L23.7454 7.36578ZM50.2802 17.169H54.0945V19.9385H43.7074V17.169H47.5245V8.58449H43.7074V5.81493H50.2802V17.169ZM73.2556 7.36296L75.5436 5.81212H76.9774C78.4645 5.81212 79.7667 6.60584 80.492 7.79359L81.1557 7.36296L83.4466 5.81212H84.8805C87.1516 5.81212 89 7.66975 89 9.94957V19.9385H86.3199V10.0284C86.3199 9.21495 85.6898 8.58168 84.8805 8.58168H84.3008L81.1585 10.7151V19.9357H78.4001V9.79195C78.2909 9.09675 77.7084 8.58449 76.9802 8.58449H76.4005L73.2556 10.718V19.9385H70.4998V5.81212H73.2556V7.36296ZM64.4479 5.73331C66.3944 5.73331 67.9682 7.31511 67.9682 9.27125V16.2571L64.0923 19.8456L64.0783 19.8569H59.5807C57.6372 19.8569 56.0605 18.2751 56.0605 16.319V9.33316L59.9363 5.74457L59.9504 5.73331H64.4479ZM9.23606 5.81493L11.5549 7.38829V10.7405L8.3539 8.5676H3.91231C2.66607 8.61545 2.63808 10.079 3.62665 10.4618L9.69534 12.3926C11.0284 12.8176 11.9385 14.0616 11.9385 15.4662V16.4907C11.9385 17.5968 11.3925 18.6297 10.4795 19.249L9.65053 19.8119H2.28801L0 18.261V14.9088L3.29339 17.1436H7.53336C7.55015 17.1436 9.29767 17.1859 9.36488 16.0741C9.38729 15.5928 9.12683 15.1059 8.62835 14.9005L2.88732 13.0738C1.16781 12.5249 -0.0476086 10.9515 0.210037 9.16429C0.33886 7.88365 1.34424 5.80931 4.19515 5.83183H4.20356L9.23606 5.82056V5.81493ZM32.1834 10.718V15.0383L35.3284 17.1717H36.5969C37.8096 17.1717 38.8009 16.1754 38.8009 14.9567V10.8024C38.8009 9.58367 37.8096 8.5873 36.5969 8.5873H35.3284L32.1834 10.7208V10.718ZM19.3347 8.58449C18.122 8.58449 17.1307 9.58086 17.1307 10.7996V14.9539C17.1307 16.1726 18.122 17.169 19.3347 17.169H20.6033L23.7454 15.0383V10.718L20.6033 8.58449H19.3347ZM58.7881 10.5378V16.1642C58.7881 16.6764 59.1999 17.0902 59.7096 17.0902H63.0421L65.2377 15.058V9.43168C65.2377 8.91942 64.8261 8.50568 64.3164 8.50568H60.9837L58.7881 10.5378ZM50.283 2.76956H47.2501V0H50.283V2.76956Z"
+            fill="currentColor"
+          />
+        </svg>
+        <span class="brand-product" aria-hidden="true">agent.studio</span>
+        <span class="header-version" id="version-header" aria-hidden="true"></span>
+      </header>
+
+      <p class="body-line">
+        <span id="version-body">A new version</span> is ready to install. Restart ends running agent
+        sessions.
+      </p>
+
+      <label class="toggle-row" for="auto-update">
+        <span class="toggle-label">Automatically download and install updates</span>
+        <input type="checkbox" id="auto-update" class="toggle-switch" role="switch" />
+      </label>
+
+      <footer class="footer">
+        <button id="skip" class="btn-secondary" type="button">Skip this version</button>
+        <div class="footer-right">
+          <button id="later" class="btn-secondary" type="button">Later</button>
+          <button id="restart" class="btn-primary" type="button">Restart now</button>
+        </div>
+      </footer>
+    </main>
+    <script type="module" src="./update.js"></script>
+  </body>
+</html>

--- a/packages/harness-desktop/src/renderer/update.html.test.ts
+++ b/packages/harness-desktop/src/renderer/update.html.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The update window's design-system wiring is the same cross-file contract the
+ * setup window has, and breaks the same silent ways (see setup.html.test.ts): the
+ * window still renders, just in the wrong brand, or with a stylesheet the build
+ * never copied. So this asserts BOTH halves — what the HTML asks for, and what
+ * `scripts/copy-renderer.mjs` puts in dist/renderer.
+ *
+ * Unlike the setup window, this one's agreed design DOES place the "S" mark beside
+ * the wordmark (a lockup setup deliberately avoids), so the brand assertions here
+ * pin the mark+wordmark pair — both inlined in currentColor — rather than forbid
+ * the mark. Text assertions over a DOM, deliberately: this package's vitest run
+ * never imports `electron` (see vitest.config.ts).
+ */
+import { existsSync, readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const html = readFileSync(new URL("./update.html", import.meta.url), "utf8");
+const copyScript = readFileSync(new URL("../../scripts/copy-renderer.mjs", import.meta.url), "utf8");
+
+/** Every linked stylesheet, in document order — the order IS the contract. */
+const stylesheets = [...html.matchAll(/<link rel="stylesheet" href="([^"]+)" \/>/g)].map((m) => m[1]);
+
+describe("update.html design-system wiring", () => {
+  it("scopes the Studio preset on <html>, where data-theme also lives", () => {
+    expect(html).toMatch(/<html lang="en" data-product="sapiom-studio">/);
+  });
+
+  it("links fonts → tokens → studio → own layout, in that order", () => {
+    // The same three design-system files, in the same order, as setup.html and the
+    // SPA's styles.css — then this window's OWN layout last (update.css, not
+    // setup.css), so it can read every token above it.
+    expect(stylesheets).toEqual(["./ds-fonts.css", "./ds-tokens.css", "./themes/studio.css", "./update.css"]);
+  });
+
+  it("never LINKS agent-cloud — studio.css @imports it, and a later link would win", () => {
+    expect(stylesheets.filter((href) => href.includes("agent-cloud"))).toEqual([]);
+  });
+});
+
+describe("update.html brand lockup", () => {
+  // The wordmark's official path head (identical to setup.html / BrandLogotype.tsx)
+  // and the "S" mark's (sapiom-mark.svg). Their opening commands are enough to prove
+  // the REAL assets are inlined, not placeholders.
+  const LOGOTYPE_PATH_HEAD = "M32.1834 7.36578L34.4714 5.81493";
+  const MARK_PATH_HEAD = "M105.267 60.7219L98.8902";
+
+  it("inlines the real Sapiom wordmark, in currentColor", () => {
+    expect(html).toContain('class="brand-logotype"');
+    expect(html).toContain(LOGOTYPE_PATH_HEAD);
+  });
+
+  it("inlines the real 'S' mark beside it, in currentColor (ink, not brand green)", () => {
+    // Inlined (not <img>) so a public clone needs no binary and the CSP no img-src;
+    // currentColor so .brand-mark themes it to ink, keeping green for state only.
+    expect(html).toContain('class="brand-mark"');
+    expect(html).toContain(MARK_PATH_HEAD);
+    // No hardcoded brand-green fill leaked in from the source asset.
+    expect(html).not.toMatch(/fill="#6[bB]/);
+    // Every path in the lockup draws in currentColor.
+    expect([...html.matchAll(/<path\b[^>]*>/g)].every((m) => m[0].includes('fill="currentColor"'))).toBe(true);
+  });
+
+  it("names the app 'Sapiom agent.studio', the same lockup as the SPA header", () => {
+    expect(html).toMatch(/aria-label="Sapiom agent\.studio"/);
+    expect(html).toMatch(/class="brand-product"[^>]*>agent\.studio</);
+  });
+});
+
+describe("update.html controls the renderer + updater rely on", () => {
+  it("carries the version placeholders, the toggle, and all three actions", () => {
+    for (const id of ['id="version-header"', 'id="version-body"', 'id="auto-update"', 'id="skip"', 'id="later"', 'id="restart"']) {
+      expect(html, `update.html is missing ${id}`).toContain(id);
+    }
+  });
+
+  it("loads its module renderer", () => {
+    expect(html).toMatch(/<script type="module" src="\.\/update\.js"><\/script>/);
+  });
+});
+
+describe("copy-renderer.mjs puts every linked file in dist/renderer", () => {
+  it("copies something for each stylesheet update.html links", () => {
+    for (const href of stylesheets) {
+      // "./themes/studio.css" → "themes"; "./update.css" → "update.css".
+      const target = href.replace("./", "").split("/")[0];
+      expect(copyScript, `${href} is linked but nothing copies "${target}"`).toContain(target);
+    }
+  });
+
+  it("copies update.html itself alongside setup.html", () => {
+    expect(copyScript).toContain("update.html");
+  });
+});

--- a/packages/harness-desktop/src/renderer/update.ts
+++ b/packages/harness-desktop/src/renderer/update.ts
@@ -1,0 +1,49 @@
+/**
+ * Update-window renderer. Pure DOM; talks to main only through the
+ * `window.sapiomUpdate` bridge exposed by the preload. Fills in the offered
+ * version, wires the toggle + the three actions, and keeps "Later" as the safe
+ * keyboard default: Esc / Return defer, while restarting — which ends running agent
+ * sessions — is reachable only by an explicit click.
+ */
+import type { UpdateBridge } from "../preload/update.mjs";
+
+declare global {
+  interface Window {
+    sapiomUpdate: UpdateBridge;
+  }
+}
+
+const bridge = window.sapiomUpdate;
+
+const versionHeaderEl = document.getElementById("version-header")!;
+const versionBodyEl = document.getElementById("version-body")!;
+const autoUpdateEl = document.getElementById("auto-update") as HTMLInputElement;
+const skipBtn = document.getElementById("skip") as HTMLButtonElement;
+const laterBtn = document.getElementById("later") as HTMLButtonElement;
+const restartBtn = document.getElementById("restart") as HTMLButtonElement;
+
+// The version, shown in the header (mono) and inline in the body sentence. Falls
+// back to a generic phrase if it wasn't passed (keeps the sentence grammatical).
+versionHeaderEl.textContent = bridge.version;
+versionBodyEl.textContent = bridge.version || "A new version";
+
+// Toggle reflects the persisted preference and writes back immediately on change —
+// independent of which button the user ends on, so closing the window still keeps
+// a toggle change.
+autoUpdateEl.checked = bridge.autoUpdate;
+autoUpdateEl.addEventListener("change", () => {
+  void bridge.setAutoUpdate(autoUpdateEl.checked);
+});
+
+skipBtn.addEventListener("click", () => void bridge.choose("skip"));
+laterBtn.addEventListener("click", () => void bridge.choose("later"));
+restartBtn.addEventListener("click", () => void bridge.choose("restart"));
+
+// Safe default: focus Later, and let Esc defer too.
+laterBtn.focus();
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    void bridge.choose("later");
+  }
+});


### PR DESCRIPTION
## What

Replaces the desktop app's native macOS "update ready" dialog with a custom, on-brand frameless window — matching the agreed mockup. Built the same way as the setup window (bundled, CSP-locked HTML themed through the design-system seam), so it reads as Sapiom instead of a system alert.

## Design
- Sapiom **S-mark chip + wordmark + `agent.studio <version>`** header, a concise "`<version>` is ready to install. Restart ends running agent sessions." line, and an ink **Restart now** primary with secondary **Later** / **Skip this version**.
- Fills the app's `--bg` base surface (the same token the app's own shadcn dialogs paint via `bg-background`), so it's the **same black as the app** — not a lighter raised card.
- **Follows the app's live light/dark theme.** The window's `file://` origin can't read the SPA's (`http://localhost`) theme storage, so the main process reads the SPA window's `data-theme` and passes it in via the `loadFile` query, applied before first paint (no OS-default drift, no flash).

## Behavior
- **Automatically download and install updates** toggle (default **ON**): a downloaded update installs on the next ordinary quit (`autoInstallOnAppQuit`); off keeps prompt-only. This reverses the former hardcoded `autoInstallOnAppQuit = false`, now that the user controls it.
- **Skip this version**: persisted to a desktop-local `update-prefs.json` (userData); never re-offered; a newer version still is; **Check for updates** clears skips.
- **Later** is the safe keyboard default (Esc/Return defer); restarting needs an explicit click.

## Safety
The two new IPC channels are scoped to the update window's own renderer (sender-gated to that exact `webContents`, registered only while it is open), so page/agent content still cannot trigger a restart — preserving the existing "no page-reachable apply-update channel" invariant.

## Testing
- `pnpm --filter @sapiom/harness-desktop build`, `typecheck`, and `test` — **110 tests pass** (new `update.html` contract tests, `update-prefs` unit tests, extended `window-background` pre-paint test pinning the update window to `--bg` and setup to `--s1`).
- Verified visually in both themes and live in the app via a dev-gated preview hook (`SAPIOM_PREVIEW_UPDATE_WINDOW=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)