### PR TITLE
fix(harness-desktop): use the app icon as the update-window mark

### DIFF
--- a/.changeset/update-window-app-icon.md
+++ b/.changeset/update-window-app-icon.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Update window: use the actual desktop app icon as the brand mark
+
+The redesigned update window showed the SPA's `sapiom-mark.svg` (a different, green mark) in a themed chip. It now shows the app's own `icon.png` — the black rounded-square "S" badge — copied beside the renderer and referenced same-origin, so the window's logo is identical to the dock/installer icon and can't drift from it.

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -78,6 +78,12 @@ for (const file of ["setup.html", "setup.css", "update.html", "update.css"]) {
   await cp(join(srcDir, file), join(outDir, file));
 }
 
+// The update window shows the desktop app icon (the black rounded-square "S" badge)
+// as its brand mark — the SAME asset electron-builder ships as the app/dock icon —
+// so the two can never drift. Copy it beside the renderer so update.html can
+// reference it same-origin (<img src="./icon.png">, covered by img-src 'self').
+await cp(join(root, "assets", "icon.png"), join(outDir, "icon.png"));
+
 const { dir: dsDir, seam } = resolveDesignSystemDir();
 
 // tokens.css is the one file flattened and renamed on the way out (the `ds-`

--- a/packages/harness-desktop/src/renderer/update.css
+++ b/packages/harness-desktop/src/renderer/update.css
@@ -81,7 +81,7 @@ input {
   }
 }
 
-/* ---- Brand lockup: S-mark chip + wordmark + product + version ---- */
+/* ---- Brand lockup: app-icon badge + wordmark + product + version ---- */
 .brand-lockup {
   display: flex;
   align-items: center;
@@ -89,23 +89,16 @@ input {
   margin: 0 0 18px;
 }
 
-/* The neutral chip holding the "S" mark. --s2 fill + hairline, ink glyph. */
-.mark-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  border-radius: var(--r-sm);
-  background: var(--s2);
-  border: 1px solid var(--line);
-  color: var(--ink);
-}
+/* The desktop app icon (assets/icon.png) — the black rounded-square "S" badge,
+   shown as-is so this window's mark matches the dock/installer icon exactly. The
+   PNG already carries its own rounded corners and fill; theme-independent, like
+   any app icon. --r-sm clips any stray edge pixels from the source margin. */
 .brand-mark {
   display: block;
-  height: 18px;
-  width: auto;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: var(--r-sm);
 }
 
 /* The wordmark IS the name, so it is neutral ink. Centered with the chip + text

--- a/packages/harness-desktop/src/renderer/update.html
+++ b/packages/harness-desktop/src/renderer/update.html
@@ -9,7 +9,7 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self'"
     />
     <title>Sapiom</title>
     <script>
@@ -55,36 +55,15 @@
   </head>
   <body>
     <main class="card">
-      <!-- The brand lockup. Unlike setup.html (which shows only the wordmark, per
-           the brand rule that mark+wordmark reads as a third logo), this window's
-           agreed design places the "S" mark in a neutral chip beside the wordmark.
-           Both glyphs are inlined in currentColor and themed to ink — the mark is
-           NOT its published brand green here, keeping "green = state only". Paths
-           are the official assets: sapiom-mark.svg and the wordmark (identical to
-           setup.html / BrandLogotype.tsx), inlined so a public clone needs no binary
-           and the CSP needs no img-src. -->
+      <!-- The brand lockup: the DESKTOP APP ICON — the black rounded-square "S"
+           badge (assets/icon.png, copied into dist/renderer by
+           scripts/copy-renderer.mjs) — beside the Sapiom wordmark, so this window's
+           mark is IDENTICAL to the app's dock/installer icon rather than a themed
+           redraw. The wordmark stays an inlined currentColor SVG (identical to
+           setup.html / BrandLogotype.tsx). The icon is same-origin, covered by
+           `img-src 'self'` in the CSP above. -->
       <header class="brand-lockup" role="img" aria-label="Sapiom agent.studio">
-        <span class="mark-chip" aria-hidden="true">
-          <svg
-            class="brand-mark"
-            width="18"
-            height="19"
-            viewBox="0 0 115 122"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-            focusable="false"
-          >
-            <path
-              d="M105.267 60.7219L98.8902 71.7648L92.1353 83.4669L83.3114 98.7521L70.18 121.491H0L13.1249 98.7521H57.042L72.6274 71.7648L79.0038 60.7219L72.2619 49.0459H98.5247L105.267 60.7219Z"
-              fill="currentColor"
-            />
-            <path
-              d="M114.072 0L100.954 22.7189H57.0694L57.0498 22.6928L57.0368 22.7189L41.8365 49.047L35.0945 60.723L41.471 71.7659H15.2016L8.8252 60.723L15.5671 49.047L21.9631 37.978L30.774 22.7189L43.8923 0H114.072Z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+        <img class="brand-mark" src="./icon.png" alt="" width="30" height="30" aria-hidden="true" />
         <svg
           class="brand-logotype"
           style="--brand-logotype-descender: 3.72px"

--- a/packages/harness-desktop/src/renderer/update.html.test.ts
+++ b/packages/harness-desktop/src/renderer/update.html.test.ts
@@ -39,26 +39,24 @@ describe("update.html design-system wiring", () => {
 });
 
 describe("update.html brand lockup", () => {
-  // The wordmark's official path head (identical to setup.html / BrandLogotype.tsx)
-  // and the "S" mark's (sapiom-mark.svg). Their opening commands are enough to prove
-  // the REAL assets are inlined, not placeholders.
+  // The wordmark's official path head (identical to setup.html / BrandLogotype.tsx).
   const LOGOTYPE_PATH_HEAD = "M32.1834 7.36578L34.4714 5.81493";
-  const MARK_PATH_HEAD = "M105.267 60.7219L98.8902";
 
   it("inlines the real Sapiom wordmark, in currentColor", () => {
     expect(html).toContain('class="brand-logotype"');
     expect(html).toContain(LOGOTYPE_PATH_HEAD);
+    // The wordmark's path(s) draw in currentColor so .brand-logotype themes it to ink.
+    expect([...html.matchAll(/<path\b[^>]*>/g)].every((m) => m[0].includes('fill="currentColor"'))).toBe(true);
   });
 
-  it("inlines the real 'S' mark beside it, in currentColor (ink, not brand green)", () => {
-    // Inlined (not <img>) so a public clone needs no binary and the CSP no img-src;
-    // currentColor so .brand-mark themes it to ink, keeping green for state only.
-    expect(html).toContain('class="brand-mark"');
-    expect(html).toContain(MARK_PATH_HEAD);
-    // No hardcoded brand-green fill leaked in from the source asset.
-    expect(html).not.toMatch(/fill="#6[bB]/);
-    // Every path in the lockup draws in currentColor.
-    expect([...html.matchAll(/<path\b[^>]*>/g)].every((m) => m[0].includes('fill="currentColor"'))).toBe(true);
+  it("uses the DESKTOP APP ICON as the mark, not a redrawn glyph", () => {
+    // The mark must be the app's own icon.png (the black rounded-square "S" badge)
+    // so it can never drift from the dock/installer icon. Referenced same-origin,
+    // which the CSP must permit.
+    expect(html).toMatch(/<img\b[^>]*class="brand-mark"[^>]*src="\.\/icon\.png"/);
+    expect(html).toMatch(/img-src 'self'/);
+    // The old inlined sapiom-mark glyph (a different, green mark) must be gone.
+    expect(html).not.toContain("M105.267 60.7219");
   });
 
   it("names the app 'Sapiom agent.studio', the same lockup as the SPA header", () => {
@@ -90,5 +88,11 @@ describe("copy-renderer.mjs puts every linked file in dist/renderer", () => {
 
   it("copies update.html itself alongside setup.html", () => {
     expect(copyScript).toContain("update.html");
+  });
+
+  it("copies the desktop app icon the mark references", () => {
+    // update.html <img src="./icon.png"> resolves to dist/renderer/icon.png only if
+    // the build copies it; a missing copy is a silent broken image.
+    expect(copyScript).toContain("icon.png");
   });
 });


### PR DESCRIPTION
Follow-up to #599.

The redesigned update window used the SPA's `sapiom-mark.svg` (a different, green mark) in a themed chip. It now shows the **desktop app's own icon** — the black rounded-square "S" badge (`assets/icon.png`, the same asset electron-builder ships as the app/dock icon) — so the window's logo is identical to the app icon and can't drift from it.

- `copy-renderer.mjs` copies `assets/icon.png` → `dist/renderer/icon.png`.
- `update.html` references it same-origin (`<img src="./icon.png">`), with an explicit `img-src 'self'` added to the CSP.
- Removed the `.mark-chip` + inlined mark SVG; contract tests updated to pin the `<img>` + icon copy and assert the old glyph is gone.

Build + typecheck + **111 tests** pass; verified visually in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)