### PR TITLE
docs(claude): release-desktop skill — the version PR is CI-maintained and gates the tag

### DIFF
--- a/.claude/skills/release-desktop/SKILL.md
+++ b/.claude/skills/release-desktop/SKILL.md
@@ -50,7 +50,7 @@ tag, no publish. Useful to smoke a build without releasing.
 
 2. **Merge the PRs to `main`.** Changesets accumulate on `main`.
 
-3. **The version-PR is automatic.** `.github/workflows/release-pr.yml`
+3. **The version-PR is automatic — and self-updating.** `.github/workflows/release-pr.yml`
    (changesets/action@v1, on push to `main`) opens/updates a
    **"chore: version packages"** PR that runs `pnpm run version-packages`
    (= `changeset version` + regenerate the version fallback + `pnpm install
@@ -58,10 +58,26 @@ tag, no publish. Useful to smoke a build without releasing.
    `package.json`, and writes the `CHANGELOG.md`s.
    - You normally do NOT run `changeset version` by hand — let the PR do it. (If
      you must locally: `pnpm run version-packages`.)
+   - **Every push to `main` force-pushes the PR's branch** (`changeset-release/main`)
+     with a fresh run, so a feature PR merged a minute ago is already in it —
+     never edit the version PR by hand and never "update" it manually. If it
+     looks stale, check that the latest `release-pr.yml` run succeeded on main's
+     HEAD SHA (`gh run list --workflow release-pr.yml --limit 1`) rather than
+     touching the branch.
+   - **Expected oddity, not a mistake:** packages that *peer-depend* on a bumped
+     package get a **major** (changesets' default for peer dependents on any
+     minor). This is why `@sapiom/cli` (peer-deps `@sapiom/harness`) jumps a
+     whole major with only "Updated dependencies" in its changelog — 2.0.0 →
+     3.0.0 → 4.0.0 → 5.0.0 all happened this way. Don't "fix" it during a release.
 
-4. **Merge the "chore: version packages" PR.** Now `main` has the bumped
-   `packages/harness-desktop/package.json` version + changelogs. Note the new
-   version, e.g. `0.2.4`.
+4. **Merge the "chore: version packages" PR — the release is BLOCKED until this
+   lands.** The tag in step 5 must equal the version this PR writes, so there is
+   no tagging before it merges. Branch protection requires **1 approving
+   review** (the PR author is the github-actions bot, so any maintainer —
+   including you — can approve): `gh pr review <num> --approve` then
+   `gh pr merge <num> --squash` once CI (CodeQL) is green. Now `main` has the
+   bumped `packages/harness-desktop/package.json` version + changelogs. Note the
+   new version, e.g. `0.2.4`.
 
 5. **Tag and push on `main`** (this is the actual release trigger):
    ```bash
@@ -69,6 +85,13 @@ tag, no publish. Useful to smoke a build without releasing.
    v=$(node -p "require('./packages/harness-desktop/package.json').version")   # e.g. 0.2.4
    git tag "harness-desktop-v$v"          # add a -beta.N suffix for a beta
    git push origin "harness-desktop-v$v"
+   ```
+   From a worktree (don't touch the user's main checkout), the equivalent is
+   tagging main's HEAD directly:
+   ```bash
+   git fetch origin main
+   v=$(git show origin/main:packages/harness-desktop/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+   git tag "harness-desktop-v$v" origin/main && git push origin "harness-desktop-v$v"
    ```
    This starts `desktop-release.yml`: `prepare` (version/channel + tag match) →
    one build job per OS (sign + notarize on macOS) → uploads the installers +


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The `release-desktop` skill described the "chore: version packages" PR but under-specified the part that actually gates a release: that CI force-refreshes that PR on every push to `main` (so it must never be hand-edited or manually "updated"), that it is blocked on one required review and MUST merge before the tag can exist (the tag must equal the version it writes), and that peer-dependent major bumps (`@sapiom/cli`) are changesets' expected behavior rather than something to fix mid-release. All three came up while cutting `harness-desktop-v0.2.8`.

## Summary and scope

Docs-only change to `.claude/skills/release-desktop/SKILL.md`: step 3 gains the self-updating/force-push behavior and how to verify freshness (`gh run list --workflow release-pr.yml`), the peer-dependent-major explanation with the `@sapiom/cli` history as evidence; step 4 is reframed as the release gate with the approve+merge commands; step 5 gains the tag-from-a-worktree variant. No code, workflow, or template changes.

## Related work

Related issue or discussion: N/A — direct docs PR, follows the v0.2.8 release (#590 merge + tag).

## Validation

```text
node scripts/agent-studio-terminology-check.mjs        — pass (401 files)
Local classifier on this PR body (scripts/pr-label-classifier.mjs) — complete: true
Procedure itself validated by executing it: #590 approved/merged, tag
harness-desktop-v0.2.8 pushed, desktop-release.yml run 31511895701 triggered.
```

### Tests and documentation

N/A — the change IS documentation (a repo skill); no code paths to test.

## Compatibility and release impact

- Breaking or externally visible changes: None — internal contributor docs only.
- Changeset: N/A — `.claude/` skill docs are not part of any published package.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Written with Claude Code (Claude Fable 5) while it executed the v0.2.8 release; the added guidance is a record of what that run actually required, verified against `.github/workflows/release-pr.yml` behavior and the `@sapiom/cli` CHANGELOG history.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
