### PR TITLE
fix(harness): deflake record-archive-wiring pty-kill test

### DIFF
--- a/packages/harness/src/server/record-archive-wiring.test.ts
+++ b/packages/harness/src/server/record-archive-wiring.test.ts
@@ -99,6 +99,18 @@ describe("session record archive wiring", () => {
     expect(res.status).toBe(200);
   }
 
+  /**
+   * The ingest route ACKs before it persists (see ingest.ts: the 200 is sent
+   * and processing runs detached, so a slow server never stalls the agent's
+   * hook pipeline). A resolved hook() therefore doesn't mean the event has
+   * reached events.ndjson — wait for the bytes before acting on "stored".
+   */
+  async function eventsPersisted(needle: string): Promise<void> {
+    await vi.waitFor(async () => {
+      expect(await readFile(eventStorePath, "utf8")).toContain(needle);
+    });
+  }
+
   async function readArchived(harnessSessionId: string): Promise<SessionRecord | null> {
     try {
       return JSON.parse(await readFile(join(recordsRoot, `${harnessSessionId}.json`), "utf8")) as SessionRecord;
@@ -174,6 +186,13 @@ describe("session record archive wiring", () => {
 
     await hook(session.id, "SessionStart", { session_id: "agent-killed", cwd });
     await hook(session.id, "UserPromptSubmit", { prompt: "start something long" });
+
+    // The exit handler folds the archive from events.ndjson exactly once, and
+    // a fold that sees zero turns writes nothing (record-archive.ts) — so if
+    // the kill wins the race against the detached ingest processing, the
+    // archive never appears and no amount of waiting below can recover it.
+    // Killing is only meaningful after the prompt event is on disk.
+    await eventsPersisted("start something long");
 
     // No Stop, no SessionEnd: the agent is killed mid-turn, so the only signal
     // is the session's own transition to "exited".


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [x] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`record-archive-wiring.test.ts > archives a session whose pty was killed
without a SessionEnd hook` is flaky on CI: it failed twice in a row on the
`test (22.x)` job of #605 (a docs-only PR) with
`AssertionError: Target cannot be null or undefined` at the
`archived?.turns` assertion, while passing locally and on `main` at the same
base commit.

Root cause is a race in the test, not in the product. The `/ingest` route
deliberately ACKs with 200 **before** persisting (`server/ingest.ts` sends the
response and runs `processIngest` detached so a slow harness never stalls the
agent's hook pipeline). The test's `hook()` helper treats that 200 as "event
stored" and immediately kills the pty. The session's `exited` handler folds
the archive from `events.ndjson` exactly once, and a fold that sees zero
turns writes nothing (`record-archive.ts` returns null for zero-turn records)
with no retry — so if the kill wins the race against the detached ingest
processing, the archive never appears and the test's 10s `vi.waitFor` times
out deterministically for that run. Fast machines always win the race; loaded
CI runners can lose it.

## Summary and scope

Test-only change to `packages/harness/src/server/record-archive-wiring.test.ts`:

- Adds an `eventsPersisted(needle)` helper that waits until the event bytes
  are actually in `events.ndjson`, with a comment documenting the
  ACK-before-persist behavior of the ingest route.
- The pty-kill test now waits for the `UserPromptSubmit` event to be on disk
  before killing the session, so the one-shot archive fold always has the
  turn to archive.

Out of scope: the ingest route's ACK-before-persist behavior itself (it is
intentional), and the other two tests in the file (their archive trigger is
the `session.end` ingest event, which by construction is appended after the
processing that folds it).

## Related work

Related issue or discussion: N/A — diagnosed on #605 where the flake surfaced
twice (https://github.com/sapiom/sapiom-js/actions/runs/31526911931).

## Validation

```text
# pnpm vitest run src/server/record-archive-wiring.test.ts — 3 passed, run 5 consecutive times, all green
# failure mechanism verified by reading server/ingest.ts (200 sent before detached processIngest),
#   server/index.ts:967 (archive folds once on "exited") and core/record-archive.ts:406
#   (zero-turn fold writes nothing, no retry)
```

### Tests and documentation

This change is itself a test fix; the race and its mechanism are documented
in comments at the helper and at the kill site. No product code changed, so
no further documentation applies.

## Compatibility and release impact

- Breaking or externally visible changes: None — test-only change.
- Changeset: N/A — test-only change; no published package behavior or API
  changed (CONTRIBUTING.md: changesets are not needed for tests).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code diagnosed the CI failure (traced the race through
`server/ingest.ts`, `server/index.ts` and `core/record-archive.ts`), wrote
the test fix, and verified it by running the test file five consecutive
times locally. The diagnosis and fix were reviewed by the maintainer.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
