### PR TITLE
docs(readme): point harness-desktop's version cell at GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ deploy/run, and a live canvas for previews.
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [@sapiom/agent-studio](./packages/agent-studio)     | [![npm](https://img.shields.io/npm/v/@sapiom/agent-studio)](https://www.npmjs.com/package/@sapiom/agent-studio)     | Agent Studio launcher — `npx @sapiom/agent-studio@latest`                                       |
 | [@sapiom/harness](./packages/harness)               | [![npm](https://img.shields.io/npm/v/@sapiom/harness)](https://www.npmjs.com/package/@sapiom/harness)               | The Agent Studio implementation — a CLI-launched local web app                                  |
-| [@sapiom/harness-desktop](./packages/harness-desktop) | private                                                                                                            | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
+| [@sapiom/harness-desktop](./packages/harness-desktop) | [GitHub Releases](https://github.com/sapiom/sapiom-js/releases)                                                    | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
 
 ### Runtime internals
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ deploy/run, and a live canvas for previews.
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [@sapiom/agent-studio](./packages/agent-studio)     | [![npm](https://img.shields.io/npm/v/@sapiom/agent-studio)](https://www.npmjs.com/package/@sapiom/agent-studio)     | Agent Studio launcher — `npx @sapiom/agent-studio@latest`                                       |
 | [@sapiom/harness](./packages/harness)               | [![npm](https://img.shields.io/npm/v/@sapiom/harness)](https://www.npmjs.com/package/@sapiom/harness)               | The Agent Studio implementation — a CLI-launched local web app                                  |
-| [@sapiom/harness-desktop](./packages/harness-desktop) | [GitHub Releases](https://github.com/sapiom/sapiom-js/releases)                                                    | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
+| [@sapiom/harness-desktop](./packages/harness-desktop) | [![GitHub release](https://img.shields.io/github/v/release/sapiom/sapiom-js?filter=harness-desktop-v*)](https://github.com/sapiom/sapiom-js/releases) | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
 
 ### Runtime internals
 


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

In the Agent Studio package table added by #605, the `@sapiom/harness-desktop`
row shows `private` in the Version column. That word only describes the npm
`private` field, but in a column of version badges it reads as if the desktop
app itself were unavailable — when it is publicly distributed as signed
installers on GitHub Releases.

## Summary and scope

One-cell README change: the `@sapiom/harness-desktop` Version cell now shows
a shields.io GitHub-release badge filtered to the `harness-desktop-v*` tags
(currently rendering `release: harness-desktop-v0.2.8`), linked to
[GitHub Releases](https://github.com/sapiom/sapiom-js/releases) where the
installers actually live — so the cell indicates the live version the same
way the npm badges in the neighboring rows do. The description ("ships as
signed installers, not to npm") is unchanged. Nothing else in the README is
touched.

## Related work

Related issue or discussion: Follow-up to #605 (merged before this correction
could land on its branch).

## Validation

```text
# pnpm terminology:check — passed (401 files, no stale allowlist entries)
# pnpm provider-copy:check — passed (74 audited files)
# link target https://github.com/sapiom/sapiom-js/releases — existing public releases page
# curl of the shields.io badge URL (filter=harness-desktop-v*) — resolves to "release: harness-desktop-v0.2.8",
#   matching `gh release list` (harness-desktop-v0.2.8 is Latest)
```

### Tests and documentation

N/A — one-line documentation change to the root README; no code or behavior
changed. The README edit is itself the documentation update.

## Compatibility and release impact

- Breaking or externally visible changes: None — README content only.
- Changeset: N/A — documentation-only change to the repo root README; no
  published package's behavior or API changed.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code made the one-cell edit at the maintainer's direction and ran the
repository copy checks (`terminology:check`, `provider-copy:check`). The
wording was reviewed by the maintainer.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
