### PR TITLE
fix(ci): classify trusted PR authors by access

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -92,6 +92,31 @@ jobs:
               return;
             }
 
+            const authorLogin = pullRequest.user?.login;
+            let repositoryPermission;
+            let permissionResolved = false;
+            let permissionLookupFailure = "pull request author is unavailable";
+            if (authorLogin) {
+              try {
+                const { data: repositoryAccess } =
+                  await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner,
+                    repo,
+                    username: authorLogin,
+                  });
+                repositoryPermission = repositoryAccess.permission;
+                permissionResolved = true;
+                permissionLookupFailure = null;
+              } catch (error) {
+                const status =
+                  error && typeof error === "object" && "status" in error
+                    ? error.status
+                    : "unknown";
+                permissionLookupFailure =
+                  `GitHub API status ${status ?? "unknown"}`;
+              }
+            }
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner,
               repo,
@@ -100,10 +125,21 @@ jobs:
             });
             const classification = classifyPullRequest({
               pullRequest,
+              repositoryPermission,
+              permissionResolved,
               files,
               eventAction: process.env.EVENT_ACTION,
               initializeTriage: process.env.INITIALIZE_TRIAGE === "true",
             });
+            if (!classification.repositoryPermissionResolved) {
+              const reason =
+                permissionLookupFailure ??
+                `unexpected permission ${JSON.stringify(repositoryPermission)}`;
+              core.warning(
+                `PR #${pullNumber}: repository permission unresolved (${reason}); ` +
+                  "treating the author as external and requiring manual review",
+              );
+            }
             const currentLabels = pullRequest.labels
               .map((label) =>
                 typeof label === "string" ? label : label.name,

--- a/scripts/pr-label-classifier.mjs
+++ b/scripts/pr-label-classifier.mjs
@@ -12,9 +12,11 @@ export const TYPE_LABELS = Object.freeze(
 );
 
 export const CONTRIBUTOR_LABELS = Object.freeze([
-  "contributor: member",
+  "contributor: trusted",
   "contributor: external",
 ]);
+
+const LEGACY_CONTRIBUTOR_LABELS = Object.freeze(["contributor: member"]);
 
 export const SIZE_LABELS = Object.freeze([
   "size: small",
@@ -25,6 +27,7 @@ export const SIZE_LABELS = Object.freeze([
 
 const CLASSIFICATION_LABELS = Object.freeze([
   ...CONTRIBUTOR_LABELS,
+  ...LEGACY_CONTRIBUTOR_LABELS,
   ...SIZE_LABELS,
   "contribution: incomplete",
   "review: sensitive",
@@ -353,10 +356,23 @@ function isOpaqueFile(file) {
   return file.patch === undefined || file.patch === null;
 }
 
-export function classifyContributor(authorAssociation) {
-  const association = String(authorAssociation ?? "").toUpperCase();
-  return association === "OWNER" || association === "MEMBER"
-    ? "contributor: member"
+const RESOLVED_REPOSITORY_PERMISSIONS = new Set([
+  "admin",
+  "write",
+  "read",
+  "none",
+]);
+
+function normalizeRepositoryPermission(repositoryPermission) {
+  return String(repositoryPermission ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+export function classifyContributor(repositoryPermission) {
+  const permission = normalizeRepositoryPermission(repositoryPermission);
+  return permission === "admin" || permission === "write"
+    ? "contributor: trusted"
     : "contributor: external";
 }
 
@@ -370,11 +386,20 @@ function shouldInitializeTriage(eventAction, initializeTriage) {
 
 export function classifyPullRequest({
   pullRequest,
+  repositoryPermission,
+  permissionResolved = false,
   files,
   eventAction,
   initializeTriage = false,
 }) {
-  const contributorLabel = classifyContributor(pullRequest?.author_association);
+  const normalizedPermission =
+    normalizeRepositoryPermission(repositoryPermission);
+  const repositoryPermissionResolved =
+    permissionResolved === true &&
+    RESOLVED_REPOSITORY_PERMISSIONS.has(normalizedPermission);
+  const contributorLabel = repositoryPermissionResolved
+    ? classifyContributor(normalizedPermission)
+    : "contributor: external";
   const size = calculateReviewSize(files);
   const template = validatePullRequestTemplate(pullRequest?.body);
   const sensitive = files.some(({ filename }) => isSensitivePath(filename));
@@ -383,7 +408,8 @@ export function classifyPullRequest({
   const external = contributorLabel === "contributor: external";
   const manual =
     external &&
-    (!template.complete ||
+    (!repositoryPermissionResolved ||
+      !template.complete ||
       sensitive ||
       size.label === "size: large" ||
       size.label === "size: xlarge" ||
@@ -400,6 +426,7 @@ export function classifyPullRequest({
       external && shouldInitializeTriage(eventAction, initializeTriage),
     desiredLabels: [...desiredLabels].sort((a, b) => a.localeCompare(b)),
     hasOpaqueFile: opaque,
+    repositoryPermissionResolved,
     reviewSize: size.changedLines,
     synchronizeTypeLabels: template.typeIsValid,
     templateReasons: template.reasons,

--- a/scripts/pr-label-classifier.test.mjs
+++ b/scripts/pr-label-classifier.test.mjs
@@ -259,21 +259,19 @@ test("security, AI, and final acknowledgements are enforced", () => {
   assert.equal(disclosedAiDetails.complete, true);
 });
 
-test("only OWNER and MEMBER associations are classified as members", () => {
-  for (const association of ["OWNER", "MEMBER", "owner", "member"]) {
-    assert.equal(classifyContributor(association), "contributor: member");
+test("only write-equivalent repository permissions are trusted", () => {
+  for (const permission of ["admin", "write", "ADMIN", "WRITE"]) {
+    assert.equal(classifyContributor(permission), "contributor: trusted");
   }
 
-  for (const association of [
-    "COLLABORATOR",
-    "CONTRIBUTOR",
-    "FIRST_TIMER",
-    "FIRST_TIME_CONTRIBUTOR",
-    "NONE",
-    "MANNEQUIN",
+  for (const permission of [
+    "read",
+    "none",
+    "triage",
+    "unexpected",
     undefined,
   ]) {
-    assert.equal(classifyContributor(association), "contributor: external");
+    assert.equal(classifyContributor(permission), "contributor: external");
   }
 });
 
@@ -347,9 +345,11 @@ test("sensitive paths cover automation, policy, dependency, and release files", 
 test("external intake gets deterministic type, size, contributor, and triage labels", () => {
   const classification = classifyPullRequest({
     pullRequest: {
-      author_association: "FIRST_TIME_CONTRIBUTOR",
+      author_association: "MEMBER",
       body: pullRequestBody(),
     },
+    repositoryPermission: "read",
+    permissionResolved: true,
     files: [changedFile("packages/core/src/index.ts", 20, 5)],
     eventAction: "opened",
   });
@@ -391,10 +391,11 @@ test("incomplete, sensitive, large, and opaque external PRs route to manual revi
   for (const fixture of cases) {
     const result = classifyPullRequest({
       pullRequest: {
-        author_association: "NONE",
         body: fixture.body,
         changed_files: fixture.changedFiles,
       },
+      repositoryPermission: "read",
+      permissionResolved: true,
       files: fixture.files,
       eventAction: "synchronize",
     });
@@ -402,22 +403,51 @@ test("incomplete, sensitive, large, and opaque external PRs route to manual revi
   }
 });
 
-test("member PRs retain risk metadata without external manual routing", () => {
+test("trusted PRs retain risk metadata without external manual routing", () => {
   const result = classifyPullRequest({
-    pullRequest: { author_association: "MEMBER", body: pullRequestBody() },
-    files: [changedFile(".github/workflows/test.yml", 10)],
+    pullRequest: {
+      author_association: "NONE",
+      body: pullRequestBody({ selectedTypes: [] }),
+    },
+    repositoryPermission: "admin",
+    permissionResolved: true,
+    files: [changedFile(".github/workflows/test.yml", 700)],
     eventAction: "opened",
   });
 
-  assert.ok(result.desiredLabels.includes("contributor: member"));
+  assert.ok(result.desiredLabels.includes("contributor: trusted"));
+  assert.ok(result.desiredLabels.includes("contribution: incomplete"));
   assert.ok(result.desiredLabels.includes("review: sensitive"));
+  assert.ok(result.desiredLabels.includes("size: large"));
   assert.ok(!result.desiredLabels.includes("review: manual"));
   assert.equal(result.addNeedsTriage, false);
 });
 
+test("unresolved repository permissions fail closed to external manual review", () => {
+  for (const fixture of [
+    { repositoryPermission: undefined, permissionResolved: false },
+    { repositoryPermission: "unexpected", permissionResolved: true },
+    { repositoryPermission: "admin", permissionResolved: false },
+  ]) {
+    const result = classifyPullRequest({
+      pullRequest: { body: pullRequestBody() },
+      ...fixture,
+      files: [changedFile("packages/core/src/index.ts", 5)],
+      eventAction: "synchronize",
+    });
+
+    assert.ok(result.desiredLabels.includes("contributor: external"));
+    assert.ok(result.desiredLabels.includes("review: manual"));
+    assert.ok(!result.desiredLabels.includes("contributor: trusted"));
+    assert.equal(result.repositoryPermissionResolved, false);
+  }
+});
+
 test("needs-triage is initialized only on external intake or explicit backfill", () => {
   const input = {
-    pullRequest: { author_association: "NONE", body: pullRequestBody() },
+    pullRequest: { body: pullRequestBody() },
+    repositoryPermission: "read",
+    permissionResolved: true,
     files: [changedFile("packages/core/src/index.ts", 5)],
   };
 
@@ -452,13 +482,16 @@ test("needs-triage is initialized only on external intake or explicit backfill",
 
 test("reconciliation replaces managed labels and preserves maintainer state", () => {
   const classification = classifyPullRequest({
-    pullRequest: { author_association: "MEMBER", body: pullRequestBody() },
+    pullRequest: { body: pullRequestBody() },
+    repositoryPermission: "write",
+    permissionResolved: true,
     files: [changedFile("packages/core/src/index.ts", 5)],
     eventAction: "synchronize",
   });
   const changes = reconcilePullRequestLabels(
     [
       "contributor: external",
+      "contributor: member",
       "size: large",
       "documentation",
       "review: manual",
@@ -469,9 +502,10 @@ test("reconciliation replaces managed labels and preserves maintainer state", ()
     classification,
   );
 
-  assert.deepEqual(changes.add, ["bug", "contributor: member", "size: small"]);
+  assert.deepEqual(changes.add, ["bug", "contributor: trusted", "size: small"]);
   assert.deepEqual(changes.remove, [
     "contributor: external",
+    "contributor: member",
     "documentation",
     "review: manual",
     "size: large",
@@ -481,12 +515,31 @@ test("reconciliation replaces managed labels and preserves maintainer state", ()
   assert.ok(!changes.remove.includes("area: sdk"));
 });
 
+test("reconciliation removes stale trusted access after permission revocation", () => {
+  const classification = classifyPullRequest({
+    pullRequest: { body: pullRequestBody() },
+    repositoryPermission: "read",
+    permissionResolved: true,
+    files: [changedFile("packages/core/src/index.ts", 5)],
+    eventAction: "synchronize",
+  });
+  const changes = reconcilePullRequestLabels(
+    ["contributor: trusted", "size: small", "bug", "help wanted"],
+    classification,
+  );
+
+  assert.deepEqual(changes.add, ["contributor: external"]);
+  assert.deepEqual(changes.remove, ["contributor: trusted"]);
+  assert.ok(!changes.remove.includes("help wanted"));
+});
+
 test("invalid type selection preserves existing type labels", () => {
   const classification = classifyPullRequest({
     pullRequest: {
-      author_association: "NONE",
       body: pullRequestBody({ selectedTypes: [] }),
     },
+    repositoryPermission: "read",
+    permissionResolved: true,
     files: [changedFile("packages/core/src/index.ts", 5)],
     eventAction: "edited",
   });
@@ -538,5 +591,13 @@ test("the privileged workflow stays pinned and never references PR head code or 
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /contents: read/);
   assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /getCollaboratorPermissionLevel/);
+  assert.doesNotMatch(workflow, /author_association/);
   assert.doesNotMatch(workflow, /pull_request\.head|head\.sha|secrets\./);
+
+  const classifier = readFileSync(
+    path.join(ROOT, "scripts", "pr-label-classifier.mjs"),
+    "utf8",
+  );
+  assert.doesNotMatch(classifier, /author_association/);
 });


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The PR labeler currently trusts only `OWNER` and `MEMBER` author associations. Private Sapiom organization membership can make teammates with write or admin repository access appear as collaborators or contributors, so their PRs are incorrectly routed through external-contributor triage and review gates.

## Summary and scope

- Query each PR author's effective `sapiom-js` repository permission using GitHub's collaborator-permission endpoint.
- Treat `admin` and `write` as trusted, and `read` and `none` as external.
- Fail closed to external/manual review when the permission is missing, unexpected, or cannot be resolved.
- Reconcile the new `contributor: trusted` label while removing the legacy `contributor: member` label.
- Cover the permission matrix, failure behavior, access revocation, label migration, and privileged-workflow contract with tests.

Claude review and post-merge label cleanup remain out of scope.

## Related work

Related issue or discussion: [SAP-2562](https://linear.app/sapiom/issue/SAP-2562/sdk-classify-trusted-pr-authors-using-repository-access); related to SAP-2516.

## Validation

```text
pnpm pr-labeler:check — passed (21 tests and Prettier check)
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed (one pre-existing harness warning, zero errors)
pnpm test — passed
git diff --check — passed
```

### Tests and documentation

Expanded the classifier unit and workflow-contract tests for permission-based trust, fail-closed behavior, migration, and revocation. Documentation is N/A because this changes repository automation rather than the public SDK or contributor instructions.

## Compatibility and release impact

- Breaking or externally visible changes: PR metadata changes from `contributor: member` to access-based `contributor: trusted`; there is no SDK API or runtime change.
- Changeset: N/A — no published package changes.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex assisted with the implementation and test updates. I verified the resulting diff manually and ran the focused classifier checks plus the repository build, typecheck, lint, and test suites.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
